### PR TITLE
feat(experimentalist): migrate Experimentalist plugin into the monorepo

### DIFF
--- a/plugins/nemo-experimentalist/AGENTS.md
+++ b/plugins/nemo-experimentalist/AGENTS.md
@@ -1,0 +1,80 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+## Conventions
+
+Inherited from the NeMo Platform monorepo that now hosts this plugin:
+
+- Use `uv` exclusively (`uv add`, `uv sync`, `uv run`). No pip/poetry/conda.
+- No `__init__.py` files — use implicit namespace packages.
+- Concrete type hints, not string-based. Don't hide imports under `TYPE_CHECKING`.
+- Lint/format with `uv run ruff check` and `uv run ruff format`.
+- All files need the SPDX header (`Copyright (c) ... NVIDIA CORPORATION & AFFILIATES`, `Apache-2.0`).
+
+## Active migrations
+
+### 2026-07-24: Optimizer renamed to Experimentalist
+
+Ahead of the move into the `nemo-platform` monorepo, the plugin was renamed from
+Optimizer to Experimentalist. Like the Eval Author rename below, this is a
+breaking rename with no compatibility aliases:
+
+- distribution `nemo-optimizer-plugin` → `nemo-experimentalist-plugin`, source
+  path `src/nemo_optimizer_plugin` → `src/nemo_experimentalist_plugin`
+- `OptimizerCLI` → `ExperimentalistCLI`, and both the `nemo.cli` and
+  `nemo.skills` entry-point keys are now `experimentalist`, so the command is
+  `nemo experimentalist ...`
+- the `experiment` verb is now `run`: `nemo experimentalist run`
+- `OPTIMIZER_API_BASE`, `OPTIMIZER_API_KEY`, `OPTIMIZER_{SMART,MID,FAST}_MODEL_NAME`,
+  `OPTIMIZER_MODEL`, `NEMO_OPTIMIZER_E2E`, and `NEMO_OPTIMIZER_RUNTIME_CACHE` are
+  now `EXPERIMENTALIST_*` / `NEMO_EXPERIMENTALIST_*`
+- the dataset cache moved from `~/.cache/nemo-optimizer/` to
+  `~/.cache/nemo-experimentalist/`, so cached datasets re-download once
+
+Two names deliberately did **not** change. `optimizer.yaml` and the
+`.nemo-optimizer/` state directory are a shared contract with
+`nemo-insights-plugin`: `PROFILE_FILENAME` and `discover_profile()` live in
+`nemo_insights_plugin.contracts.profile`, and `nemo insights analyze` writes
+`<profile-dir>/.nemo-optimizer/insights.yaml`, which this plugin reads as the
+default insight. Rename them only in lockstep with a Platform change to that
+contract. `EvolutionaryOptimizer` and `EvolutionaryOptimizerConfig` also keep
+their names — they describe the optimization algorithm, not the product.
+
+The command group is top-level (`nemo experimentalist`) rather than the
+eventual `nemo agents experimentalist`. The platform's `nemo.cli` entry-point
+group is flat — only `nemo.jobs` and `nemo.functions` are dot-scoped — so
+nesting under `nemo agents` needs a Platform-side change first.
+
+### 2026-07-21: Curator renamed to Eval Author
+
+The Curator agent was renamed directly to Eval Author in ASE-643. This is a
+breaking rename with no compatibility aliases or migration layer:
+
+- `nemo_experimentalist_plugin.curator` → `nemo_experimentalist_plugin.eval_author`
+- `Curator`, `CuratorConfig`, and `CuratorResult` → `EvalAuthor`,
+  `EvalAuthorConfig`, and `EvalAuthorResult`
+- `run_curator(...)` and `build_curator_agent(...)` →
+  `run_eval_author(...)` and `build_eval_author_agent(...)`
+- the `curator` optimizer configuration block → `eval_author`
+- Curator-specific artifact paths, cache keys, helpers, tests, and documentation
+  now use `eval_author` / Eval Author terminology
+
+Agents working on in-flight branches that touch these surfaces should rebase
+before resolving conflicts, keep the Eval Author names, and update their code
+instead of restoring Curator imports, configuration, or aliases. The obsolete
+`curator` configuration key is intentionally rejected with a validation error.
+
+## Development environment
+
+- The root `.venv` is the only Experimentalist environment; use the README for the
+  standard `uv` lint, test, and run commands.
+- NeMo Experimentalist consumes Insights produced by the Platform Insights plugin.
+  Configure Platform services, trace storage, and Insights analysis according
+  to the Platform documentation; this repository does not own a service,
+  scheduler, or testbed setup.
+- `nooa` is pinned to a tagged public GitHub release in `pyproject.toml`.
+  Update the tag and lock file together. Keep the Platform-supplied Insights
+  plugin separate.
+- This branch uses merged Platform PR 718 contracts only. After the Platform
+  handoff lands, rebase and repin before adopting any new Platform testbed or
+  installer interfaces.

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -1,0 +1,127 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# NeMo Experimentalist
+
+NeMo Experimentalist is the agent-improvement plugin for
+[NeMo Platform](https://github.com/NVIDIA-NeMo/nemo-platform). It consumes
+Insights produced by the Platform-owned Insights plugin and improves a local
+or Git-backed agent against Harbor-compatible train and validation datasets.
+
+## Install and develop
+
+From the root of this checkout:
+
+```bash
+uv sync
+export NEMO="$PWD/.venv/bin/nemo"
+```
+
+For a NeMo Platform source checkout, use the
+[source-Platform installer](docs/e2e/install-experimentalist-plugin.sh), which keeps
+Platform packages editable while installing both plugins' direct runtime
+dependencies:
+
+```bash
+REPO="$PWD" PLAT=/path/to/nemo-platform bash docs/e2e/install-experimentalist-plugin.sh
+export NEMO=/path/to/nemo-platform/.venv/bin/nemo
+```
+
+The source dependencies are pinned to tagged or immutable revisions in
+`pyproject.toml`. NVIDIA-labs OO Agents (NOOA) is pinned to its public
+GitHub `v0.0.6` release.
+
+## Insight-to-experiment flow
+
+The supported handoff is:
+
+```text
+nemo insights analyze → .nemo-optimizer/insights.yaml or Platform Insight ID
+                    → nemo experimentalist doctor
+                    → nemo experimentalist run
+```
+
+Run `nemo insights analyze` using the Platform Insights plugin and its
+documented trace, workspace, and output options. The producer may write the
+local profile default, `.nemo-optimizer/insights.yaml`, or persist an Insight
+on Platform and report its ID. The Experimentalist does not analyze traces,
+schedule analysis, or host an Insight API.
+
+From an agent directory with an `optimizer.yaml` profile, validate the
+effective inputs:
+
+```bash
+$NEMO experimentalist doctor
+```
+
+## Run the Experimentalist locally
+
+`nemo experimentalist run` runs the local Experimentalist loop. It evaluates
+a baseline agent on Harbor-compatible train and validation datasets, proposes
+candidate mutations, and records its artifacts under the selected experiment
+directory.
+
+Configure the models before running an experiment:
+
+```bash
+export EXPERIMENTALIST_API_BASE=https://inference-api.nvidia.com/v1
+export EXPERIMENTALIST_API_KEY=sk-...
+export EXPERIMENTALIST_SMART_MODEL_NAME=openai/openai/openai/gpt-5.5
+export EXPERIMENTALIST_FAST_MODEL_NAME=openai/openai/openai/gpt-5-mini
+```
+
+### Insight-driven optimization
+
+A single local Insight in `.nemo-optimizer/insights.yaml` is selected by
+default:
+
+```bash
+$NEMO experimentalist run
+```
+
+Use `--insight` to name another local file. Local files can contain one
+Insight object or an `insights` list. A list with multiple entries requires
+`--insight-id`, which accepts an exact ID, exact title, or zero-based index:
+
+```bash
+$NEMO experimentalist run \
+  --insight path/to/insights.yaml \
+  --insight-id 0
+```
+
+For an Insight persisted by Platform, pass its ID with its Platform location:
+
+```bash
+$NEMO experimentalist run \
+  --insight <platform-insight-id> \
+  --workspace <workspace> \
+  --base-url https://<platform-host>
+```
+
+`--agent` may override the baseline agent named by an Insight. The profile
+supplies the task template and the required train and validation datasets; flags
+can override those values.
+
+### Dataset-driven optimization
+
+Use `--no-insight` to bypass both an explicit Insight and the profile-local
+default. Supply a baseline agent when the profile does not provide one:
+
+```bash
+$NEMO experimentalist run \
+  --no-insight \
+  --agent path/to/agent \
+  --train-dataset path/to/train \
+  --validation-dataset path/to/validation \
+  --task-template path/to/task_template
+```
+
+Pass one or more framework skill directories with `--framework-skills` when
+the agent needs framework-specific modification guidance. The checked-in Tau2
+profile demonstrates profile-owned datasets and task template configuration:
+[`examples/tau2-nemo-oo-agent/optimizer.yaml`](examples/tau2-nemo-oo-agent/optimizer.yaml).
+
+Each run writes its local artifacts under `--experiment-dir`, or under
+`.nemo-optimizer/experiments/` beside the governing profile by default.
+
+License: Apache-2.0.

--- a/plugins/nemo-experimentalist/benchmarks/README.md
+++ b/plugins/nemo-experimentalist/benchmarks/README.md
@@ -58,21 +58,21 @@ to both the LangChain AUT and optimizer, using
 Validate provenance and task IDs without Docker or model calls:
 
 ```bash
-uv run python benchmarks/experimentalist/run.py --validate-only
+uv run python benchmarks/run.py --validate-only
 ```
 
 Run the bounded fast benchmark:
 
 ```bash
-uv run python benchmarks/experimentalist/run.py \
-  --config benchmarks/experimentalist/configs/smoke.yaml
+uv run python benchmarks/run.py \
+  --config benchmarks/configs/smoke.yaml
 ```
 
 Run the reproducible quality benchmark:
 
 ```bash
-uv run python benchmarks/experimentalist/run.py \
-  --config benchmarks/experimentalist/configs/quality.yaml
+uv run python benchmarks/run.py \
+  --config benchmarks/configs/quality.yaml
 ```
 
 Both setup and agent execution require network access. The AUT installs a

--- a/plugins/nemo-experimentalist/benchmarks/README.md
+++ b/plugins/nemo-experimentalist/benchmarks/README.md
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Canonical Experimentalist benchmark
+
+This benchmark measures M2 Experimentalist optimization on Harbor's unmodified
+Terminal-Bench 2.1 package. It does not cover M1 Insight → Eval Author behavior
+or Tau2's interactive domains.
+
+## Provenance
+
+The suite uses `terminal-bench/terminal-bench-2-1@6` from Harbor Hub:
+
+- 89 canonical tasks
+- dataset content hash
+  `sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a`
+- Harbor Hub record:
+  <https://hub.harborframework.com/datasets/terminal-bench/terminal-bench-2-1/6>
+
+The repository stores only task IDs. Task definitions are downloaded into a
+local cache and are never vendored here.
+
+The 38/25/26 quality partition and 35/12/12 fast partition came from Gaia's
+`optimization-datasets` commit
+`1b7688ad257dacd1a3267dddb88db6cefdc31376`. The manifest corrects
+`install-windows-3-11` to the canonical ID `install-windows-3.11`. At startup,
+the runner asks Harbor Hub for revision 6, verifies its content hash, and
+asserts that the quality partition covers all 89 canonical IDs exactly once.
+
+## Held-out evaluation
+
+The runner:
+
+1. evaluates the unchanged LangChain baseline on the test split;
+2. gives only train and validation IDs to `run_experimentalist`;
+3. resolves the validation-selected winner from the Experimentalist run;
+4. evaluates that winner on the same test IDs and number of attempts.
+
+Test tasks are not supplied to the optimizer. Failed and missing trials count as
+zero reward in the benchmark summary. Harness errors are reported separately.
+
+`optimizer.evaluator.n_attempts` controls candidate evaluation attempts during
+optimization. Top-level `test_attempts` controls final baseline and winner
+attempts. These settings intentionally remain separate.
+
+## Run
+
+Required credentials:
+
+```bash
+export INFERENCE_API_KEY=...
+```
+
+`EXPERIMENTALIST_API_KEY` may be provided instead. The runner maps either credential
+to both the LangChain AUT and optimizer, using
+`https://inference-api.nvidia.com/v1` unless an API base is explicitly set.
+
+Validate provenance and task IDs without Docker or model calls:
+
+```bash
+uv run python benchmarks/experimentalist/run.py --validate-only
+```
+
+Run the bounded fast benchmark:
+
+```bash
+uv run python benchmarks/experimentalist/run.py \
+  --config benchmarks/experimentalist/configs/smoke.yaml
+```
+
+Run the reproducible quality benchmark:
+
+```bash
+uv run python benchmarks/experimentalist/run.py \
+  --config benchmarks/experimentalist/configs/quality.yaml
+```
+
+Both setup and agent execution require network access. The AUT installs a
+checksum-pinned static `uv`, uv-managed Python 3.12, and dependencies from its
+committed `uv.lock` directly in each canonical task container. It does not need
+the image's system Python, package manager, a sidecar, or a Docker socket.
+
+Pass the same `--output` directory to resume interrupted Harbor jobs. Use a new
+output directory for an intentionally fresh run.
+
+## Artifacts
+
+By default, each run writes under
+`artifacts/experimentalist-benchmarks/<UTC timestamp>/`:
+
+- `summary.json`: dataset and partition revisions, agent digest, model names,
+  complete config, task counts, expected/observed trials, rewards, harness
+  errors, tokens, reported cost, and elapsed time;
+- `heldout-results/heldout-baseline/`: baseline Harbor results;
+- `heldout-results/heldout-winner/`: winner Harbor results;
+- `optimizer/eval-and-optimize/`: Experimentalist candidates, analyses, and
+  train/validation Harbor results.
+
+Harbor result files remain the source of truth. `summary.json` aggregates over
+the full expected test trial count. `cost_usd` is `null` when the selected model
+endpoint does not report monetary cost.

--- a/plugins/nemo-experimentalist/benchmarks/configs/quality.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/configs/quality.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite_partition: quality
+test_attempts: 2
+models:
+  aut: aws/anthropic/claude-haiku-4-5-v1
+  experimentalist_smart: openai/openai/openai/gpt-5.5
+  experimentalist_mid: openai/openai/openai/gpt-5-mini
+  experimentalist_fast: openai/openai/openai/gpt-5-mini
+optimizer:
+  max_rounds: 2
+  min_rounds_before_stopping: 2
+  max_survivors: 2
+  max_candidates: 2
+  max_trajectory_tasks: 6
+  max_train_batch_tasks: 12
+  train_batch_seed: 20260722
+  disable_trajectory_scoring: true
+  evaluator:
+    n_attempts: 2
+    n_concurrent_trials: 2
+    quiet: true
+    agent_setup_timeout_multiplier: 2.0
+    environment_build_timeout_multiplier: 2.0
+  eval_author:
+    max_traces: 10
+    max_validation_repair_attempts: 5

--- a/plugins/nemo-experimentalist/benchmarks/configs/smoke.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/configs/smoke.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite_partition: fast
+test_attempts: 1
+models:
+  aut: aws/anthropic/claude-haiku-4-5-v1
+  experimentalist_smart: openai/openai/openai/gpt-5-mini
+  experimentalist_mid: openai/openai/openai/gpt-5-mini
+  experimentalist_fast: openai/openai/openai/gpt-5-mini
+optimizer:
+  max_rounds: 1
+  min_rounds_before_stopping: 1
+  max_survivors: 1
+  max_candidates: 1
+  max_trajectory_tasks: 2
+  max_train_batch_tasks: 4
+  train_batch_seed: 20260722
+  disable_trajectory_scoring: true
+  disable_convergence_check: true
+  evaluator:
+    n_attempts: 1
+    n_concurrent_trials: 1
+    quiet: true
+    agent_setup_timeout_multiplier: 2.0
+    environment_build_timeout_multiplier: 2.0
+  eval_author:
+    max_traces: 3
+    max_validation_repair_attempts: 2

--- a/plugins/nemo-experimentalist/benchmarks/run.py
+++ b/plugins/nemo-experimentalist/benchmarks/run.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the canonical Terminal-Bench Experimentalist benchmark."""
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, Self
+
+import yaml
+from harbor.registry.client.package import PackageDatasetClient
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import (
+    HarborDataset,
+    HarborEvaluator,
+    HarborEvaluatorConfig,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import (
+    DatasetRef,
+    EvaluationResult,
+    TrialResult,
+    local_path_from_uri,
+)
+from nemo_experimentalist_plugin.resolve import EvolutionaryOptimizerConfig, resolve_dataset
+from pydantic import BaseModel, Field, model_validator
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK_ROOT = Path(__file__).resolve().parent
+DEFAULT_SUITE = BENCHMARK_ROOT / "suites" / "terminal-bench-2.1.yaml"
+DEFAULT_CONFIG = BENCHMARK_ROOT / "configs" / "smoke.yaml"
+DEFAULT_AGENT = PLUGIN_ROOT / "examples" / "terminal-bench-agent"
+DEFAULT_DATASET_CACHE = PLUGIN_ROOT / "tmp" / "benchmark-datasets"
+DEFAULT_RUNTIME_CACHE = PLUGIN_ROOT / "tmp" / "runtime-cache"
+
+
+class CanonicalDatasetSpec(BaseModel):
+    name: str
+    ref: str
+    resolved_ref: str
+    registry_url: str
+    source_url: str
+    expected_task_count: int = Field(gt=0)
+
+    @property
+    def requested_reference(self) -> str:
+        return f"{self.name}@{self.ref}"
+
+
+class SplitSpec(BaseModel):
+    train: list[str]
+    validation: list[str]
+    test: list[str]
+
+    @model_validator(mode="after")
+    def validate_ids(self) -> Self:
+        groups = {"train": self.train, "validation": self.validation, "test": self.test}
+        for name, task_ids in groups.items():
+            if not task_ids or any(not task_id for task_id in task_ids):
+                raise ValueError(f"{name} task IDs must be non-empty strings")
+            if len(task_ids) != len(set(task_ids)):
+                raise ValueError(f"{name} task IDs contain duplicates")
+        all_ids = self.train + self.validation + self.test
+        if len(all_ids) != len(set(all_ids)):
+            raise ValueError("train, validation, and test task IDs must be disjoint")
+        return self
+
+    def all_ids(self) -> list[str]:
+        return self.train + self.validation + self.test
+
+
+class PartitionSource(BaseModel):
+    commit: str
+    note: str
+
+
+class PartitionsSpec(BaseModel):
+    source: PartitionSource
+    quality: SplitSpec
+    fast: SplitSpec
+
+
+class SuiteSpec(BaseModel):
+    schema_version: Literal[1]
+    dataset: CanonicalDatasetSpec
+    partitions: PartitionsSpec
+
+
+class ModelSpec(BaseModel):
+    aut: str
+    experimentalist_smart: str
+    experimentalist_mid: str
+    experimentalist_fast: str
+
+
+class BenchmarkConfig(BaseModel):
+    suite_partition: Literal["fast", "quality"]
+    test_attempts: int = Field(gt=0)
+    models: ModelSpec
+    optimizer: EvolutionaryOptimizerConfig
+
+
+def _load_yaml(path: Path) -> Any:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return payload
+
+
+def load_suite(path: Path) -> SuiteSpec:
+    """Load and validate a suite manifest."""
+    return SuiteSpec.model_validate(_load_yaml(path))
+
+
+def load_benchmark_config(path: Path) -> BenchmarkConfig:
+    """Load and validate a benchmark configuration."""
+    return BenchmarkConfig.model_validate(_load_yaml(path))
+
+
+def validate_canonical_suite(
+    suite: SuiteSpec,
+    *,
+    canonical_task_ids: set[str],
+    resolved_ref: str,
+) -> None:
+    """Verify immutable revision, quality coverage, and all partition IDs."""
+    if resolved_ref != suite.dataset.resolved_ref:
+        raise ValueError(
+            f"Dataset {suite.dataset.requested_reference} resolved to {resolved_ref}, "
+            f"expected {suite.dataset.resolved_ref}"
+        )
+    if len(canonical_task_ids) != suite.dataset.expected_task_count:
+        raise ValueError(
+            f"Canonical dataset has {len(canonical_task_ids)} tasks, expected {suite.dataset.expected_task_count}"
+        )
+    quality_ids = set(suite.partitions.quality.all_ids())
+    if quality_ids != canonical_task_ids:
+        missing = sorted(canonical_task_ids - quality_ids)
+        unknown = sorted(quality_ids - canonical_task_ids)
+        raise ValueError(
+            f"Quality partition does not exactly cover the canonical dataset; missing={missing}, unknown={unknown}"
+        )
+    unknown_fast = sorted(set(suite.partitions.fast.all_ids()) - canonical_task_ids)
+    if unknown_fast:
+        raise ValueError(f"Fast partition contains unknown canonical task IDs: {unknown_fast}")
+
+
+def _configure_models(models: ModelSpec) -> None:
+    api_key = os.environ.get("INFERENCE_API_KEY") or os.environ.get("EXPERIMENTALIST_API_KEY")
+    if not api_key:
+        raise RuntimeError("INFERENCE_API_KEY or EXPERIMENTALIST_API_KEY is required")
+    api_base = os.environ.get("INFERENCE_API_BASE") or os.environ.get("EXPERIMENTALIST_API_BASE")
+    api_base = api_base or "https://inference-api.nvidia.com/v1"
+    os.environ.setdefault("INFERENCE_API_KEY", api_key)
+    os.environ.setdefault("EXPERIMENTALIST_API_KEY", api_key)
+    os.environ.setdefault("INFERENCE_API_BASE", api_base)
+    os.environ.setdefault("EXPERIMENTALIST_API_BASE", api_base)
+    os.environ["AUT_MODEL_NAME"] = models.aut
+    os.environ["EXPERIMENTALIST_SMART_MODEL_NAME"] = models.experimentalist_smart
+    os.environ["EXPERIMENTALIST_MID_MODEL_NAME"] = models.experimentalist_mid
+    os.environ["EXPERIMENTALIST_FAST_MODEL_NAME"] = models.experimentalist_fast
+    os.environ.setdefault("NEMO_EXPERIMENTALIST_RUNTIME_CACHE", str(DEFAULT_RUNTIME_CACHE))
+
+
+def _agent_digest(agent_dir: Path) -> str:
+    digest = hashlib.sha256()
+    excluded = {".git", ".runtime-cache", ".venv", "__pycache__"}
+    files = sorted(
+        path
+        for path in agent_dir.rglob("*")
+        if path.is_file() and not any(part in excluded for part in path.relative_to(agent_dir).parts)
+    )
+    for path in files:
+        digest.update(path.relative_to(agent_dir).as_posix().encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _result_document(trial: TrialResult) -> dict[str, Any] | None:
+    result_ref = trial.resources.get("result")
+    if result_ref is None:
+        return None
+    try:
+        path = local_path_from_uri(result_ref.uri, context="Harbor result")
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _agent_contexts(document: dict[str, Any]) -> list[dict[str, Any]]:
+    direct = document.get("agent_result")
+    if isinstance(direct, dict):
+        return [direct]
+    contexts: list[dict[str, Any]] = []
+    step_results = document.get("step_results")
+    if isinstance(step_results, list):
+        for step in step_results:
+            if isinstance(step, dict) and isinstance(step.get("agent_result"), dict):
+                contexts.append(step["agent_result"])
+    return contexts
+
+
+def summarize_evaluation(
+    result: EvaluationResult,
+    *,
+    task_count: int,
+    attempts: int,
+) -> dict[str, Any]:
+    """Summarize all expected trials, counting missing and failed trials as zero reward."""
+    expected_trials = task_count * attempts
+    reward_sum = 0.0
+    passes = 0
+    harness_errors: list[dict[str, Any]] = []
+    usage = {"input_tokens": 0, "cache_tokens": 0, "output_tokens": 0}
+    costs: list[float] = []
+
+    for trial in result.trials:
+        reward = trial.metrics.get("reward")
+        reward_value = float(reward.value) if reward is not None else 0.0
+        reward_sum += reward_value
+        passes += int(reward_value >= 1.0)
+        if trial.status == "failed" or trial.error is not None:
+            harness_errors.append({"trial": trial.id, "task_id": trial.task_id, "error": trial.error})
+        document = _result_document(trial)
+        if document is None:
+            continue
+        for context in _agent_contexts(document):
+            usage["input_tokens"] += int(context.get("n_input_tokens") or 0)
+            usage["cache_tokens"] += int(context.get("n_cache_tokens") or 0)
+            usage["output_tokens"] += int(context.get("n_output_tokens") or 0)
+            cost = context.get("cost_usd")
+            if isinstance(cost, int | float):
+                costs.append(float(cost))
+
+    missing_trials = max(0, expected_trials - len(result.trials))
+    return {
+        "expected_trials": expected_trials,
+        "observed_trials": len(result.trials),
+        "missing_trials": missing_trials,
+        "passes": passes,
+        "reward_sum": reward_sum,
+        "mean_reward_over_expected": reward_sum / expected_trials,
+        "harness_error_count": len(harness_errors) + missing_trials,
+        "harness_errors": harness_errors,
+        "tokens": usage,
+        "cost_usd": sum(costs) if costs else None,
+    }
+
+
+def summarize_experimentalist_jobs(results_dir: Path) -> dict[str, Any]:
+    """Summarize Harbor job-level results produced during optimization."""
+    jobs: list[dict[str, Any]] = []
+    totals = {
+        "jobs": 0,
+        "trials": 0,
+        "completed_trials": 0,
+        "errored_trials": 0,
+        "input_tokens": 0,
+        "cache_tokens": 0,
+        "output_tokens": 0,
+    }
+    costs: list[float] = []
+    for result_path in sorted(results_dir.glob("*/result.json")):
+        try:
+            payload = json.loads(result_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict) or not isinstance(payload.get("stats"), dict):
+            continue
+        stats = payload["stats"]
+        job = {
+            "name": result_path.parent.name,
+            "trials": int(payload.get("n_total_trials") or 0),
+            "completed_trials": int(stats.get("n_completed_trials") or 0),
+            "errored_trials": int(stats.get("n_errored_trials") or 0),
+            "input_tokens": int(stats.get("n_input_tokens") or 0),
+            "cache_tokens": int(stats.get("n_cache_tokens") or 0),
+            "output_tokens": int(stats.get("n_output_tokens") or 0),
+            "cost_usd": stats.get("cost_usd") if isinstance(stats.get("cost_usd"), int | float) else None,
+            "evals": stats.get("evals") if isinstance(stats.get("evals"), dict) else {},
+        }
+        jobs.append(job)
+        totals["jobs"] += 1
+        for key in (
+            "trials",
+            "completed_trials",
+            "errored_trials",
+            "input_tokens",
+            "cache_tokens",
+            "output_tokens",
+        ):
+            totals[key] += job[key]
+        if job["cost_usd"] is not None:
+            costs.append(float(job["cost_usd"]))
+    return {**totals, "cost_usd": sum(costs) if costs else None, "job_results": jobs}
+
+
+async def _evaluate_heldout(
+    *,
+    label: str,
+    agent_dir: Path,
+    dataset: HarborDataset,
+    run_dir: Path,
+    attempts: int,
+    concurrency: int,
+) -> dict[str, Any]:
+    options = HarborEvaluatorConfig(
+        job_name=f"heldout-{label}",
+        jobs_dir=Path("heldout-results"),
+        n_attempts=attempts,
+        n_concurrent_trials=concurrency,
+        quiet=True,
+        force_rerun=False,
+        agent_setup_timeout_multiplier=2.0,
+        environment_build_timeout_multiplier=2.0,
+    )
+    started = time.monotonic()
+    result = await HarborEvaluator(experiment_dir=run_dir).run(
+        agent=agent_dir,
+        dataset=dataset,
+        options=options,
+    )
+    summary = summarize_evaluation(result, task_count=len(dataset.tasks), attempts=attempts)
+    summary["elapsed_seconds"] = time.monotonic() - started
+    summary["job_name"] = options.job_name
+    return summary
+
+
+async def run_benchmark(args: argparse.Namespace) -> Path:
+    """Execute baseline, optimization, and held-out winner evaluation."""
+    suite = load_suite(args.suite)
+    benchmark_config = load_benchmark_config(args.config)
+    split: SplitSpec = getattr(suite.partitions, benchmark_config.suite_partition)
+
+    package_client = PackageDatasetClient()
+    metadata = await package_client.get_dataset_metadata(suite.dataset.requested_reference)
+    canonical_task_ids = {task.name for task in metadata.task_ids}
+    validate_canonical_suite(suite, canonical_task_ids=canonical_task_ids, resolved_ref=metadata.version)
+
+    if args.validate_only:
+        print(
+            f"Validated {suite.dataset.requested_reference}: {len(canonical_task_ids)} tasks; "
+            f"{benchmark_config.suite_partition} split "
+            f"{len(split.train)}/{len(split.validation)}/{len(split.test)}"
+        )
+        return args.output
+
+    _configure_models(benchmark_config.models)
+    from nemo_experimentalist_plugin.experimentalist.run import run_experimentalist  # noqa: PLC0415
+
+    run_dir = args.output.resolve()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    started_at = datetime.now(UTC)
+    benchmark_started = time.monotonic()
+    dataset_path = Path(
+        await resolve_dataset(
+            suite.dataset.requested_reference,
+            PLUGIN_ROOT,
+            registry_url=suite.dataset.registry_url,
+            cache_dir=args.cache_dir,
+        )
+    )
+    test_ref = DatasetRef(
+        uri=str(dataset_path),
+        metadata={"id": f"{benchmark_config.suite_partition}-test", "task_ids": split.test},
+    )
+    test_dataset = HarborDataset.from_ref(test_ref)
+    baseline_dir = args.agent.resolve()
+
+    baseline = await _evaluate_heldout(
+        label="baseline",
+        agent_dir=baseline_dir,
+        dataset=test_dataset,
+        run_dir=run_dir,
+        attempts=benchmark_config.test_attempts,
+        concurrency=args.test_concurrency,
+    )
+
+    experimentalist_dir = run_dir / "optimizer"
+    experimentalist_summary = await run_experimentalist(
+        agent=str(baseline_dir),
+        agent_spec=str(baseline_dir / "AGENT-SPEC.md"),
+        insight=None,
+        train_dataset=DatasetRef(
+            uri=str(dataset_path),
+            metadata={"id": f"{benchmark_config.suite_partition}-train", "task_ids": split.train},
+        ),
+        validation_dataset=DatasetRef(
+            uri=str(dataset_path),
+            metadata={"id": f"{benchmark_config.suite_partition}-validation", "task_ids": split.validation},
+        ),
+        experiment_dir=experimentalist_dir,
+        workspace="canonical-terminal-bench-2-1",
+        client=None,
+        config=benchmark_config.optimizer,
+        framework_skills_dirs=[PLUGIN_ROOT / "framework-skills" / "langchain-framework"],
+    )
+    run_document = json.loads((experimentalist_dir / "eval-and-optimize" / "run.json").read_text(encoding="utf-8"))
+    winner_label = run_document.get("winner_agent")
+    if not isinstance(winner_label, str) or not winner_label:
+        raise RuntimeError("Experimentalist completed without a selected winner")
+    winner_dir = experimentalist_dir / "eval-and-optimize" / "agents" / winner_label
+    winner = await _evaluate_heldout(
+        label="winner",
+        agent_dir=winner_dir,
+        dataset=test_dataset,
+        run_dir=run_dir,
+        attempts=benchmark_config.test_attempts,
+        concurrency=args.test_concurrency,
+    )
+
+    summary = {
+        "schema_version": 1,
+        "started_at": started_at.isoformat(),
+        "elapsed_seconds": time.monotonic() - benchmark_started,
+        "dataset": {
+            **suite.dataset.model_dump(),
+            "requested_reference": suite.dataset.requested_reference,
+            "materialized_path": str(dataset_path),
+        },
+        "partition": benchmark_config.suite_partition,
+        "task_counts": {
+            "canonical": len(canonical_task_ids),
+            "train": len(split.train),
+            "validation": len(split.validation),
+            "test": len(split.test),
+        },
+        "provenance": {
+            "partition_source": suite.partitions.source.model_dump(),
+            "agent_path": str(baseline_dir),
+            "baseline_agent_sha256": _agent_digest(baseline_dir),
+            "suite_path": str(args.suite.resolve()),
+            "config_path": str(args.config.resolve()),
+        },
+        "models": benchmark_config.models.model_dump(),
+        "config": benchmark_config.model_dump(mode="json"),
+        "baseline": baseline,
+        "optimizer": {
+            "summary": experimentalist_summary,
+            "winner_label": winner_label,
+            "run_path": str(experimentalist_dir / "eval-and-optimize" / "run.json"),
+            "harbor": summarize_experimentalist_jobs(experimentalist_dir / "eval-and-optimize" / "results"),
+        },
+        "winner": winner,
+    }
+    summary_path = run_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    print(summary_path)
+    return summary_path
+
+
+def _default_output() -> Path:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return PLUGIN_ROOT / "artifacts" / "experimentalist-benchmarks" / stamp
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", type=Path, default=DEFAULT_SUITE)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--agent", type=Path, default=DEFAULT_AGENT)
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_DATASET_CACHE)
+    parser.add_argument("--output", type=Path, default=_default_output())
+    parser.add_argument("--test-concurrency", type=int, default=1)
+    parser.add_argument("--validate-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    asyncio.run(run_benchmark(parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/nemo-experimentalist/benchmarks/suites/terminal-bench-2.1.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/terminal-bench-2.1.yaml
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: 1
+dataset:
+  name: terminal-bench/terminal-bench-2-1
+  ref: "6"
+  resolved_ref: sha256:7d7bdc1cbedad549fc1140404bd4dc45e5fd0ea7c4186773687d177ad3a0699a
+  registry_url: https://raw.githubusercontent.com/laude-institute/harbor/main/registry.json
+  source_url: https://hub.harborframework.com/datasets/terminal-bench/terminal-bench-2-1/6
+  expected_task_count: 89
+partitions:
+  source:
+    commit: 1b7688ad257dacd1a3267dddb88db6cefdc31376
+    note: >-
+      The commit above identifies the dataset revision these train/test splits
+      were derived from. Task IDs only; no task content is copied here.
+  quality:
+    train:
+      - adaptive-rejection-sampler
+      - bn-fit-modify
+      - build-pmars
+      - cobol-modernization
+      - code-from-image
+      - constraints-scheduling
+      - count-dataset-tokens
+      - custom-memory-heap-crash
+      - distribution-search
+      - extract-elf
+      - extract-moves-from-video
+      - filter-js-from-html
+      - fix-git
+      - git-leak-recovery
+      - install-windows-3.11
+      - largest-eigenval
+      - mailman
+      - make-doom-for-mips
+      - make-mips-interpreter
+      - model-extraction-relu-logits
+      - mteb-retrieve
+      - multi-source-data-merger
+      - nginx-request-logging
+      - password-recovery
+      - path-tracing-reverse
+      - protein-assembly
+      - pytorch-model-cli
+      - query-optimize
+      - regex-chess
+      - regex-log
+      - reshard-c4-data
+      - rstan-to-pystan
+      - sanitize-git-repo
+      - sparql-university
+      - sqlite-db-truncate
+      - sqlite-with-gcov
+      - torch-tensor-parallelism
+      - write-compressor
+    validation:
+      - break-filter-js-from-html
+      - build-pov-ray
+      - circuit-fibsqrt
+      - configure-git-webserver
+      - db-wal-recovery
+      - dna-assembly
+      - feal-differential-cryptanalysis
+      - financial-document-processor
+      - gpt2-codegolf
+      - headless-terminal
+      - hf-model-inference
+      - kv-store-grpc
+      - large-scale-text-editing
+      - llm-inference-batching-scheduler
+      - modernize-scientific-stack
+      - mteb-leaderboard
+      - overfull-hbox
+      - path-tracing
+      - polyglot-rust-c
+      - portfolio-optimization
+      - pytorch-model-recovery
+      - qemu-alpine-ssh
+      - raman-fitting
+      - torch-pipeline-parallelism
+      - vulnerable-secret
+    test:
+      - build-cython-ext
+      - caffe-cifar-10
+      - cancel-async-tasks
+      - chess-best-move
+      - compile-compcert
+      - crack-7z-hash
+      - dna-insert
+      - feal-linear-cryptanalysis
+      - fix-code-vulnerability
+      - fix-ocaml-gc
+      - gcode-to-text
+      - git-multibranch
+      - log-summary-date-ranges
+      - mcmc-sampling-stan
+      - merge-diff-arc-agi-task
+      - openssl-selfsigned-cert
+      - polyglot-c-py
+      - prove-plus-comm
+      - pypi-server
+      - qemu-startup
+      - sam-cell-seg
+      - schemelike-metacircular-eval
+      - train-fasttext
+      - tune-mjcf
+      - video-processing
+      - winning-avg-corewars
+  fast:
+    train:
+      - break-filter-js-from-html
+      - chess-best-move
+      - cobol-modernization
+      - constraints-scheduling
+      - count-dataset-tokens
+      - custom-memory-heap-crash
+      - dna-insert
+      - extract-elf
+      - filter-js-from-html
+      - gcode-to-text
+      - git-leak-recovery
+      - git-multibranch
+      - headless-terminal
+      - hf-model-inference
+      - kv-store-grpc
+      - large-scale-text-editing
+      - largest-eigenval
+      - merge-diff-arc-agi-task
+      - modernize-scientific-stack
+      - mteb-leaderboard
+      - mteb-retrieve
+      - multi-source-data-merger
+      - nginx-request-logging
+      - polyglot-c-py
+      - prove-plus-comm
+      - qemu-startup
+      - query-optimize
+      - raman-fitting
+      - reshard-c4-data
+      - rstan-to-pystan
+      - sanitize-git-repo
+      - sqlite-db-truncate
+      - tune-mjcf
+      - vulnerable-secret
+      - winning-avg-corewars
+    validation:
+      - adaptive-rejection-sampler
+      - build-pov-ray
+      - caffe-cifar-10
+      - compile-compcert
+      - db-wal-recovery
+      - log-summary-date-ranges
+      - overfull-hbox
+      - pypi-server
+      - pytorch-model-cli
+      - pytorch-model-recovery
+      - regex-log
+      - sqlite-with-gcov
+    test:
+      - build-cython-ext
+      - build-pmars
+      - code-from-image
+      - crack-7z-hash
+      - distribution-search
+      - financial-document-processor
+      - fix-git
+      - mailman
+      - openssl-selfsigned-cert
+      - portfolio-optimization
+      - qemu-alpine-ssh
+      - schemelike-metacircular-eval

--- a/plugins/nemo-experimentalist/examples/terminal-bench-agent/AGENT-SPEC.md
+++ b/plugins/nemo-experimentalist/examples/terminal-bench-agent/AGENT-SPEC.md
@@ -1,0 +1,142 @@
+---
+name: terminal-bench-codeact
+created_timestamp: 2026-06-15T00:00:00+00:00
+author: gdilorenzo@nvidia.com
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+## Role
+
+Solve canonical Terminal-Bench tasks by iteratively executing shell commands in
+the task's main container until the verifier passes.
+
+## Purpose
+
+This agent exists to provide a deliberately plain LangChain baseline for realistic,
+open-ended CLI and systems tasks. It takes a task description and autonomously
+modifies the canonical task environment to produce the expected files and state.
+
+Because Harbor's task verifier validates outputs objectively, the agent must
+produce correct, verifiable results rather than plausible-looking answers.
+
+## Scope
+
+**Audience**: Benchmark evaluators and researchers measuring LLM agent capability on systems/engineering tasks.
+
+**Task categories** (from terminal-bench-ii):
+1. Systems programming — compile, debug, and run C/C++/Rust/OCaml code
+2. Data engineering — process CSV, Parquet, HDF5, and other file formats
+3. ML/AI workflows — train models, run inference, evaluate outputs
+4. Infrastructure/config — set up servers, configure Git, manage databases
+5. Scientific computing — numerical methods, eigensolvers, optimization
+6. Security/CTF — binary analysis, cryptography, reverse engineering
+7. Media processing — video, image, and audio pipelines
+
+**In scope**: Any task that can be solved by running shell commands and writing
+files in a canonical Terminal-Bench Linux container with network access.
+
+**Out of scope**: Tasks requiring unavailable hardware or GUI-only workflows
+with no headless alternative.
+
+## Tools
+
+**execute**: Runs a bounded shell command directly in `/app` and returns its
+exit code, stdout, and stderr. The timeout defaults to 120 seconds and is capped
+at 840 seconds. The agent uses this single tool for file inspection, package
+installation, implementation, and verification.
+
+No external web or search tools are provided. The canonical task container has
+network access, so commands may use its available download tools.
+
+## Model
+
+- **Family/size:** Claude Haiku 4.5 (small/fast)
+- **Gateway model id:** `aws/anthropic/claude-haiku-4-5-v1`
+- **API base:** `https://inference-api.nvidia.com/v1`
+- **Auth:** `INFERENCE_API_KEY` bearer token
+- **Why this choice:** Fast iteration for a plain baseline; many terminal tasks
+  require 10–30 tool calls and latency compounds.
+- **Deployment:** Cloud (NVIDIA inference gateway / AWS Bedrock proxy)
+
+## Framework
+
+LangChain `create_agent` with `ChatOpenAI` and one local shell tool. The agent
+uses the NVIDIA Inference Gateway's OpenAI-compatible endpoint.
+
+## Harness
+
+Harbor imports `harbor_wrapper.py:WrappedAgent`, a `BaseInstalledAgent`.
+The wrapper uploads a pinned static `uv` binary matching the target container,
+installs uv-managed Python 3.12, synchronizes `uv.lock`, and runs the module
+directly in the canonical task container with `/app` as its working directory.
+
+Invocation:
+```bash
+INFERENCE_API_KEY=<key> \
+uv run --project examples/terminal-bench-agent python -m main \
+  --prompt "<task description>"
+```
+
+Harbor runs need no Docker socket, sidecar, system Python, package manager, or
+task-definition modification.
+
+## Behavior
+
+- Begin every task by exploring `/app` to understand available files before writing any solution.
+- Always install missing packages before running code; prefer `pip install -q` and `apt-get install -y -q` to suppress noise.
+- Use single-quoted heredoc delimiters (`<< 'EOF'`) when writing multi-line files to avoid shell variable expansion.
+- Verify the solution by reading or running the expected output file before returning; do not declare success without confirmation.
+- When a command fails, read the error message and adjust rather than retrying the identical command.
+- Prefer idiomatic, minimal solutions over elaborate ones — the test harness checks correctness, not code style.
+- Do not modify test files in `/tests/`; all changes must go to `/app/`.
+- Use `timeout` parameter for compilations (`make`, `cmake`), model training, and any command that could run indefinitely; default 120 s is insufficient for these — pass 600–840 s.
+
+## Success Criteria
+
+- **Task completion**: Harbor's verifier reports reward `1`.
+- **Correctness**: Output files in `/app/` match expected content (exact hash, string match, or tolerance check depending on task).
+- **Robustness**: The agent recovers from package installation failures, compilation errors, and wrong-output first attempts without manual intervention.
+- **Efficiency**: Task solved within the 840 s harness timeout; overly long compilations or training runs must be detected and shortened.
+
+## Evaluation Setup
+
+Evaluated on immutable train, validation, and held-out test subsets of canonical
+`terminal-bench/terminal-bench-2-1@6`. Harbor starts the task's unmodified
+environment and runs its canonical verifier.
+
+Baseline reference: oracle scripts at `solution/solve.sh` demonstrate the expected solution path.
+
+Manual spot-checks use Harbor with `harbor_wrapper.py:WrappedAgent`.
+
+## Change Scope
+
+- System prompt / `solve` docstring: **allowed** (primary lever — task framing, exploration strategy, verification steps)
+- `execute` implementation: **allowed** (timeout and output formatting)
+- uv-managed runtime bootstrap: **not an optimization lever**
+- Model: **allowed** (swap within the NVIDIA inference gateway catalog)
+- Inference parameters (temperature, max_tokens): **allowed**
+- Additional deterministic LangChain tools: **allowed**
+- Task data (`tests/`, `solution/`): **allowed only via oracle fix PRs** — changes here affect benchmark integrity
+- Spec itself: **not allowed** (spec is the contract; only the developer edits it)
+
+## Signals
+
+Priority signals:
+- Mean reward across terminal-bench-ii train and validation sets (target: >0.80).
+- Per-category breakdown (systems, ML, security, etc.) to identify weak spots.
+- Rate of tasks that time out vs. fail on incorrect output — distinguishes speed problems from reasoning problems.
+- Number of `execute` calls per task as a proxy for efficiency.
+
+Ignore:
+- Individual task failures in isolation — single-task debugging belongs in oracle fix PRs, not agent tuning.
+- Latency outside benchmark runs.
+
+## Open Questions
+
+- Whether a larger model (Sonnet) meaningfully improves reward on the hard task
+  tail enough to justify the latency cost in the LangChain loop.
+- Optimal LangChain recursion limit for preventing runaway spending without
+  truncating successful tasks.
+- Whether adding focused read/write tools improves performance over one shell tool.
+- Whether task-category-specific system prompt variations (e.g., extra ML hints for PyTorch tasks) improve recall or just add complexity.

--- a/plugins/nemo-experimentalist/examples/terminal-bench-agent/README.md
+++ b/plugins/nemo-experimentalist/examples/terminal-bench-agent/README.md
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Terminal-Bench LangChain agent
+
+This deliberately small agent runs directly in each canonical Harbor task
+container. Harbor uploads a static `uv` binary, installs uv-managed Python
+3.12, synchronizes the locked dependencies, and invokes `python -m main` with
+`/app` as the working directory.
+
+The agent has one LangChain tool: execute a bounded shell command in `/app`.
+It calls the NVIDIA Inference Gateway using `INFERENCE_API_KEY` and writes
+OpenInference spans in OTLP JSONL format under `/app/traces`; the wrapper also
+publishes them to `/logs/artifacts/traces` for task-authored evaluators.
+
+No Docker socket, sidecar container, system Python, package manager, `curl`, or
+task-definition modification is required.

--- a/plugins/nemo-experimentalist/examples/terminal-bench-agent/agent.py
+++ b/plugins/nemo-experimentalist/examples/terminal-bench-agent/agent.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A deliberately small LangChain coding agent for Terminal-Bench."""
+
+import os
+import signal
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from langchain.agents import create_agent
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.outputs import LLMResult
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.errors import GraphRecursionError
+
+DEFAULT_API_BASE = "https://inference-api.nvidia.com/v1"
+DEFAULT_MODEL = "aws/anthropic/claude-haiku-4-5-v1"
+MAX_COMMAND_OUTPUT_CHARS = 40_000
+SYSTEM_PROMPT = """\
+You are solving a Terminal-Bench task inside its canonical Linux environment.
+The task workspace is /app. Use the execute tool to inspect files, implement
+the solution, and verify it. Do not modify files under /tests. Work directly in
+/app and finish only after checking the result. Missing utilities or language
+runtimes may be installed because network access is available.
+"""
+
+
+def _shell_path() -> str:
+    bash = Path("/bin/bash")
+    return str(bash) if bash.is_file() else "/bin/sh"
+
+
+def _bounded_output(stdout: str, stderr: str, return_code: int) -> str:
+    parts = [f"exit_code={return_code}"]
+    if stdout:
+        parts.append(f"stdout:\n{stdout}")
+    if stderr:
+        parts.append(f"stderr:\n{stderr}")
+    rendered = "\n\n".join(parts)
+    if len(rendered) <= MAX_COMMAND_OUTPUT_CHARS:
+        return rendered
+    omitted = len(rendered) - MAX_COMMAND_OUTPUT_CHARS
+    return f"[... {omitted} earlier characters omitted ...]\n{rendered[-MAX_COMMAND_OUTPUT_CHARS:]}"
+
+
+@tool
+def execute(command: str, timeout_sec: int = 120) -> str:
+    """Execute a shell command in /app and return its exit code, stdout, and stderr."""
+    timeout_sec = max(1, min(timeout_sec, 840))
+    process = subprocess.Popen(
+        [_shell_path(), "-lc", command],
+        cwd="/app",
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_sec)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGKILL)
+        stdout, stderr = process.communicate()
+        stderr = f"{stderr}\ncommand timed out after {timeout_sec} seconds".strip()
+    return _bounded_output(stdout, stderr, process.returncode)
+
+
+class UsageCallback(BaseCallbackHandler):
+    """Accumulate model usage even when the graph reaches its recursion limit."""
+
+    def __init__(self) -> None:
+        self.totals = {"input_tokens": 0, "output_tokens": 0, "cache_read_tokens": 0}
+        self.last_content = ""
+
+    def on_llm_end(self, response: LLMResult, **_kwargs: Any) -> None:
+        for generation_group in response.generations:
+            for generation in generation_group:
+                message = getattr(generation, "message", None)
+                if message is None:
+                    continue
+                content = getattr(message, "content", "")
+                if isinstance(content, str) and content:
+                    self.last_content = content
+                self._add_usage(getattr(message, "usage_metadata", None))
+
+    def _add_usage(self, usage: Any) -> None:
+        if not isinstance(usage, dict):
+            return
+        self.totals["input_tokens"] += int(usage.get("input_tokens") or 0)
+        self.totals["output_tokens"] += int(usage.get("output_tokens") or 0)
+        details = usage.get("input_token_details")
+        if isinstance(details, dict):
+            self.totals["cache_read_tokens"] += int(details.get("cache_read") or 0)
+
+
+async def solve(instruction: str) -> tuple[str, dict[str, int]]:
+    """Run the LangChain tool-calling loop and return its final answer and usage."""
+    api_key = os.environ["INFERENCE_API_KEY"]
+    model = ChatOpenAI(
+        model=os.environ.get("EXPERIMENTALIST_MODEL", DEFAULT_MODEL),
+        base_url=os.environ.get("INFERENCE_API_BASE", DEFAULT_API_BASE),
+        api_key=api_key,
+    )
+    coding_agent = create_agent(
+        model=model,
+        tools=[execute],
+        system_prompt=SYSTEM_PROMPT,
+    )
+    usage = UsageCallback()
+    try:
+        result = await coding_agent.ainvoke(
+            {"messages": [{"role": "user", "content": instruction}]},
+            config={"callbacks": [usage], "recursion_limit": 30},
+        )
+    except GraphRecursionError:
+        answer = usage.last_content or "Stopped after reaching the bounded agent step limit."
+        return answer, usage.totals
+    messages = result["messages"]
+    content = messages[-1].content
+    answer = content if isinstance(content, str) else str(content)
+    return answer, usage.totals

--- a/plugins/nemo-experimentalist/examples/terminal-bench-agent/harbor_wrapper.py
+++ b/plugins/nemo-experimentalist/examples/terminal-bench-agent/harbor_wrapper.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Harbor installed-agent wrapper with an image-independent Python runtime."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shlex
+import shutil
+import tarfile
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import override
+
+from harbor.agents.installed.base import BaseInstalledAgent, with_prompt_template
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+AGENT_DIR = Path(__file__).parent
+PROJECT_FILES = ("agent.py", "main.py", "pyproject.toml", "tracing.py", "uv.lock")
+REMOTE_ROOT = "/installed-agent"
+REMOTE_PROJECT = f"{REMOTE_ROOT}/project"
+REMOTE_UV = f"{REMOTE_ROOT}/bin/uv"
+REMOTE_VENV = f"{REMOTE_ROOT}/venv"
+REMOTE_PYTHON_INSTALLS = f"{REMOTE_ROOT}/python"
+REMOTE_UV_CACHE = f"{REMOTE_ROOT}/uv-cache"
+UV_VERSION = "0.9.5"
+UV_ASSETS: dict[str, tuple[str, str]] = {
+    "aarch64": (
+        "uv-aarch64-unknown-linux-musl.tar.gz",
+        "42b9b83933a289fe9c0e48f4973dee49ce0dfb95e19ea0b525ca0dbca3bce71f",
+    ),
+    "x86_64": (
+        "uv-x86_64-unknown-linux-musl.tar.gz",
+        "3665ffb6c429c31ad6c778ac0489b7746e691acf025cf530b3510b2f9b1660ff",
+    ),
+}
+
+
+def _normalize_architecture(raw: str) -> str:
+    aliases = {
+        "amd64": "x86_64",
+        "arm64": "aarch64",
+        "aarch64": "aarch64",
+        "x86_64": "x86_64",
+    }
+    normalized = aliases.get(raw.strip().lower())
+    if normalized is None:
+        supported = ", ".join(sorted(UV_ASSETS))
+        raise RuntimeError(f"Unsupported task-container architecture {raw!r}; supported: {supported}")
+    return normalized
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as binary_file:
+        for chunk in iter(lambda: binary_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _download_archive(url: str, destination: Path, expected_sha256: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    partial = destination.with_name(f"{destination.name}.{uuid.uuid4().hex}.partial")
+    try:
+        request = urllib.request.Request(url, headers={"User-Agent": "nemo-experimentalist/terminal-bench-agent"})
+        with urllib.request.urlopen(request, timeout=300) as response, partial.open("wb") as output:  # noqa: S310
+            shutil.copyfileobj(response, output)
+        actual_sha256 = _sha256(partial)
+        if actual_sha256 != expected_sha256:
+            raise RuntimeError(
+                f"Downloaded uv archive checksum mismatch: expected {expected_sha256}, got {actual_sha256}"
+            )
+        os.replace(partial, destination)
+    finally:
+        partial.unlink(missing_ok=True)
+
+
+def _cached_uv_binary(architecture: str) -> Path:
+    asset_name, expected_sha256 = UV_ASSETS[architecture]
+    default_cache = Path.cwd() / "tmp" / "runtime-cache"
+    cache_root = Path(os.environ.get("NEMO_EXPERIMENTALIST_RUNTIME_CACHE", default_cache))
+    release_dir = cache_root / f"uv-{UV_VERSION}"
+    archive = release_dir / asset_name
+    if not archive.is_file() or _sha256(archive) != expected_sha256:
+        archive.unlink(missing_ok=True)
+        url = f"https://github.com/astral-sh/uv/releases/download/{UV_VERSION}/{asset_name}"
+        _download_archive(url, archive, expected_sha256)
+
+    binary = release_dir / architecture / "uv"
+    binary.parent.mkdir(parents=True, exist_ok=True)
+    temporary_binary = binary.with_name(f"uv.{uuid.uuid4().hex}.partial")
+    member_name = f"{asset_name.removesuffix('.tar.gz')}/uv"
+    try:
+        with tarfile.open(archive, mode="r:gz") as bundle:
+            member = bundle.getmember(member_name)
+            source = bundle.extractfile(member)
+            if source is None:
+                raise RuntimeError(f"Pinned uv archive does not contain {member_name}")
+            with source, temporary_binary.open("wb") as output:
+                shutil.copyfileobj(source, output)
+        temporary_binary.chmod(0o755)
+        os.replace(temporary_binary, binary)
+    finally:
+        temporary_binary.unlink(missing_ok=True)
+    return binary
+
+
+class WrappedAgent(BaseInstalledAgent):
+    @staticmethod
+    @override
+    def name() -> str:
+        return "nemo-experimentalist-langchain"
+
+    @override
+    def version(self) -> str | None:
+        return "0.1.0"
+
+    @staticmethod
+    async def _target_architecture(environment: BaseEnvironment) -> str:
+        result = await environment.exec("uname -s && uname -m")
+        if result.return_code != 0:
+            raise RuntimeError(f"Could not detect task-container platform: {result.stderr or result.stdout}")
+        lines = (result.stdout or "").splitlines()
+        if len(lines) != 2 or lines[0].strip() != "Linux":
+            raise RuntimeError(f"Terminal-Bench installed agent requires a Linux task container, got {lines!r}")
+        return _normalize_architecture(lines[1])
+
+    @staticmethod
+    def _runtime_env() -> dict[str, str]:
+        return {
+            "UV_CACHE_DIR": REMOTE_UV_CACHE,
+            "UV_HTTP_TIMEOUT": "300",
+            "UV_NO_PROGRESS": "1",
+            "UV_PROJECT_ENVIRONMENT": REMOTE_VENV,
+            "UV_PYTHON_INSTALL_DIR": REMOTE_PYTHON_INSTALLS,
+            "UV_PYTHON_PREFERENCE": "only-managed",
+        }
+
+    @override
+    async def install(self, environment: BaseEnvironment) -> None:
+        """Upload uv and create a locked uv-managed Python environment."""
+        architecture = await self._target_architecture(environment)
+        uv_binary = _cached_uv_binary(architecture)
+        missing = [name for name in PROJECT_FILES if not (AGENT_DIR / name).is_file()]
+        if missing:
+            raise RuntimeError(f"Terminal-Bench agent project is incomplete; missing: {', '.join(missing)}")
+
+        await self.exec_as_root(
+            environment,
+            command=(
+                f"mkdir -p {REMOTE_ROOT}/bin {REMOTE_PROJECT} {REMOTE_VENV} "
+                f"{REMOTE_PYTHON_INSTALLS} {REMOTE_UV_CACHE} && "
+                f"chmod -R a+rwx {REMOTE_ROOT}"
+            ),
+        )
+        await environment.upload_file(uv_binary, REMOTE_UV)
+        for name in PROJECT_FILES:
+            await environment.upload_file(AGENT_DIR / name, f"{REMOTE_PROJECT}/{name}")
+        await self.exec_as_root(
+            environment,
+            command=f"chmod 0755 {REMOTE_UV} && chmod -R a+rX {REMOTE_PROJECT}",
+        )
+        await self.exec_as_agent(
+            environment,
+            command=(
+                f"{REMOTE_UV} python install 3.12 && "
+                f"{REMOTE_UV} sync --project {REMOTE_PROJECT} --frozen --no-dev && "
+                f"{REMOTE_VENV}/bin/python -c "
+                + shlex.quote("import langchain, langchain_openai; print('agent runtime OK')")
+            ),
+            env=self._runtime_env(),
+            timeout_sec=600,
+        )
+
+    def _apply_summary(self, context: AgentContext) -> None:
+        summary_path = self.logs_dir / "summary.json"
+        try:
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        if not isinstance(summary, dict):
+            return
+        answer = summary.get("answer")
+        if isinstance(answer, str):
+            context.metadata = {**(context.metadata or {}), "answer": answer}
+        usage = summary.get("usage")
+        if not isinstance(usage, dict):
+            return
+        input_tokens = usage.get("input_tokens")
+        output_tokens = usage.get("output_tokens")
+        cache_read_tokens = usage.get("cache_read_tokens")
+        if isinstance(input_tokens, int):
+            context.n_input_tokens = input_tokens
+        if isinstance(output_tokens, int):
+            context.n_output_tokens = output_tokens
+        if isinstance(cache_read_tokens, int):
+            context.n_cache_tokens = cache_read_tokens
+
+    @with_prompt_template
+    @override
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        """Run the LangChain module directly in the canonical task container."""
+        api_key = self._get_env("INFERENCE_API_KEY")
+        if not api_key:
+            raise RuntimeError("INFERENCE_API_KEY is required for the Terminal-Bench LangChain agent")
+
+        prompt_path = self.logs_dir / "instruction.txt"
+        prompt_path.write_text(instruction, encoding="utf-8")
+        remote_prompt = f"{REMOTE_ROOT}/instruction.txt"
+        await environment.upload_file(prompt_path, remote_prompt)
+
+        env = {
+            "INFERENCE_API_KEY": api_key,
+            "INFERENCE_API_BASE": self._get_env("INFERENCE_API_BASE") or "https://inference-api.nvidia.com/v1",
+            "PYTHONPATH": REMOTE_PROJECT,
+        }
+        model_name = self.model_name or self._get_env("AUT_MODEL_NAME")
+        if model_name:
+            env["EXPERIMENTALIST_MODEL"] = model_name
+
+        command = (
+            f"{REMOTE_VENV}/bin/python -m main "
+            f"--prompt-file {shlex.quote(remote_prompt)} "
+            "--trace-path /app/traces/trace.jsonl "
+            "--summary-path /logs/agent/summary.json "
+            "> /logs/agent/terminal-bench-agent.txt 2>&1; "
+            "status=$?; "
+            "cat /logs/agent/terminal-bench-agent.txt; "
+            "mkdir -p /logs/artifacts/traces && "
+            "cp -r /app/traces/. /logs/artifacts/traces/ 2>/dev/null || true; "
+            "exit $status"
+        )
+        try:
+            result = await self.exec_as_agent(
+                environment,
+                command=command,
+                env=env,
+                cwd="/app",
+            )
+            context.metadata = {
+                **(context.metadata or {}),
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "returncode": result.return_code,
+            }
+        finally:
+            self._apply_summary(context)

--- a/plugins/nemo-experimentalist/examples/terminal-bench-agent/main.py
+++ b/plugins/nemo-experimentalist/examples/terminal-bench-agent/main.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+
+from agent import solve
+from tracing import setup_tracing
+
+
+async def _run(prompt: str, trace_path: Path, summary_path: Path) -> None:
+    provider = setup_tracing(trace_path)
+    summary: dict[str, object] = {}
+    try:
+        answer, usage = await solve(prompt)
+        summary = {"answer": answer, "usage": usage}
+        print(answer)
+    finally:
+        provider.force_flush(timeout_millis=5_000)
+        provider.shutdown()
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    """Run one Terminal-Bench instruction."""
+    parser = argparse.ArgumentParser()
+    prompt_group = parser.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt")
+    prompt_group.add_argument("--prompt-file", type=Path)
+    parser.add_argument("--trace-path", type=Path, default=Path("/logs/artifacts/traces/trace.jsonl"))
+    parser.add_argument("--summary-path", type=Path, default=Path("/logs/agent/summary.json"))
+    args = parser.parse_args()
+
+    prompt = args.prompt if args.prompt is not None else args.prompt_file.read_text(encoding="utf-8")
+    asyncio.run(_run(prompt, args.trace_path, args.summary_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/nemo-experimentalist/examples/terminal-bench-agent/pyproject.toml
+++ b/plugins/nemo-experimentalist/examples/terminal-bench-agent/pyproject.toml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[project]
+name = "nemo-experimentalist-terminal-bench-agent"
+version = "0.1.0"
+description = "Basic LangChain agent for canonical Terminal-Bench tasks."
+readme = "README.md"
+requires-python = ">=3.12,<3.14"
+dependencies = [
+    "langchain>=1.0,<2.0",
+    "langchain-openai>=1.0,<2.0",
+    "openinference-instrumentation-langchain>=0.1.55",
+    "opentelemetry-exporter-otlp-proto-common>=1.42.1",
+    "opentelemetry-sdk>=1.42.1",
+    "protobuf>=6.0.0",
+]
+
+[tool.uv]
+package = false

--- a/plugins/nemo-experimentalist/examples/terminal-bench-agent/tracing.py
+++ b/plugins/nemo-experimentalist/examples/terminal-bench-agent/tracing.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenInference instrumentation with OTLP JSONL file export."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from google.protobuf.json_format import MessageToDict
+from openinference.instrumentation.langchain import LangChainInstrumentor
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+
+class OtlpJsonlExporter(SpanExporter):
+    """Append OTLP ExportTraceServiceRequest objects to a JSONL file."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text("", encoding="utf-8")
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        try:
+            request = encode_spans(spans)
+            document = MessageToDict(request)
+            with self._path.open("a", encoding="utf-8") as trace_file:
+                trace_file.write(json.dumps(document, separators=(",", ":")) + "\n")
+        except (OSError, TypeError, ValueError):
+            return SpanExportResult.FAILURE
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        return None
+
+
+def setup_tracing(path: Path) -> TracerProvider:
+    """Configure LangChain OpenInference spans before constructing the agent."""
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(OtlpJsonlExporter(path)))
+    trace.set_tracer_provider(provider)
+    LangChainInstrumentor().instrument(tracer_provider=provider)
+    return provider

--- a/plugins/nemo-experimentalist/examples/terminal-bench-agent/uv.lock
+++ b/plugins/nemo-experimentalist/examples/terminal-bench-agent/uv.lock
@@ -1,0 +1,1073 @@
+version = 1
+revision = 3
+requires-python = ">=3.12, <3.14"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
+name = "langchain"
+version = "1.3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
+]
+
+[[package]]
+name = "langchain-core"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpatch" },
+    { name = "langchain-protocol" },
+    { name = "langsmith" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/05/986c4bb148285791eb59994e0b28947bed96cac7f24467079e4274952a37/langchain_core-1.5.0.tar.gz", hash = "sha256:e1fa09d55b354192c8f60dade06a55bd6add2318c822a684555b8d4a30a16143", size = 967401, upload-time = "2026-07-21T03:37:26.48Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/56/5ef7ba14bac95b0344da18c6e8ec108dce0baf5fc054d1117702f92af29d/langchain_core-1.5.0-py3-none-any.whl", hash = "sha256:f122efee35446632b38687119fca33711abbf3b6b555e31156762298fbe78a65", size = 558510, upload-time = "2026-07-21T03:37:24.423Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/fc/d146705e0cf6cf8865d4e873e0551452f94d6520f43fe703594ccdf95763/langchain_openai-1.4.0.tar.gz", hash = "sha256:a3acf6be0937f3970fc9e7f0aae22929c6f117e49128bd62f4d45a64b2587d8b", size = 3261776, upload-time = "2026-07-21T16:09:22.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/6c/f786dfcb6711cb06449041e72b67f7e28fc77a53e2aa16866c4f0002625a/langchain_openai-1.4.0-py3-none-any.whl", hash = "sha256:7a777731fe32a913085ec85bacd5650c3f8422048b65346b63a13b36b1b4a12f", size = 121901, upload-time = "2026-07-21T16:09:21.61Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.2.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/4b/0d1130e26b41a99dcc88353bbe7162a1f255c4db746bd94024268e6af27b/langgraph-1.2.9.tar.gz", hash = "sha256:385f87bc1802c35af7e0aa479278ecba8582d103515eb48256cb2ddcd42d0bd4", size = 722869, upload-time = "2026-07-10T01:30:14.985Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/16/0b8dc48823f1326f3e0c8012a3c07a40da6f194299e2ec080df236287baf/langgraph-1.2.9-py3-none-any.whl", hash = "sha256:c2d98ad94333937922ba04148641c1da2bfe45b5b8e55d7b6dcb0bb2df809e76", size = 247473, upload-time = "2026-07-10T01:30:13.733Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
+    { name = "orjson" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
+]
+
+[[package]]
+name = "langsmith"
+version = "0.10.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+    { name = "websockets" },
+    { name = "xxhash" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/6d/9ad4427662ef131878f0f928d5a9e9913e0dda4b6511bb03e8722f1dee8a/langsmith-0.10.9.tar.gz", hash = "sha256:195bc67c964a6370cb91742ce9fa07ce69bfae47977f0fb3f41d125b3435d03a", size = 4736750, upload-time = "2026-07-20T21:27:13.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/54/509a1eb6b9e5572a4f3f4b087779d240c6b69f3d5247ffa21314f66155d9/langsmith-0.10.9-py3-none-any.whl", hash = "sha256:5e0e8ab0f8df05710809919184495e33c2a7c9a9a5e8861d63dd12c1226d9c79", size = 673326, upload-time = "2026-07-20T21:27:11.889Z" },
+]
+
+[[package]]
+name = "nemo-optimizer-terminal-bench-agent"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "langchain" },
+    { name = "langchain-openai" },
+    { name = "openinference-instrumentation-langchain" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-sdk" },
+    { name = "protobuf" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "langchain", specifier = ">=1.0,<2.0" },
+    { name = "langchain-openai", specifier = ">=1.0,<2.0" },
+    { name = "openinference-instrumentation-langchain", specifier = ">=0.1.55" },
+    { name = "opentelemetry-exporter-otlp-proto-common", specifier = ">=1.42.1" },
+    { name = "opentelemetry-sdk", specifier = ">=1.42.1" },
+    { name = "protobuf", specifier = ">=6.0.0" },
+]
+
+[[package]]
+name = "openai"
+version = "2.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/61/9aeef14de759306e85175126d3d6d56ee4f5072a9512c6c171d58d02a62d/openai-2.47.0.tar.gz", hash = "sha256:4e205548acd4304f235b86202269912e55bc88270b15d2a051fa2b53b90343a6", size = 1089906, upload-time = "2026-07-22T17:47:29.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/69/26b032059273ad798d18fbcdbe369e871181841fd8bcb5caee32b7510039/openai-2.47.0-py3-none-any.whl", hash = "sha256:b3a1a7ad974092427ccb46d89f8852bdb67866680bcabeecc3ff5a3fdd71b15b", size = 1639987, upload-time = "2026-07-22T17:47:27.873Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation"
+version = "0.1.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/cc/62c1175ee7edc2cbdf95b5b73e0b0f305e759d407bf1bc353ff30a763365/openinference_instrumentation-0.1.54.tar.gz", hash = "sha256:9af9817bb38816ed32856fb4cd813c1a5d9f530ab589c3473b37e06cf406ab28", size = 33938, upload-time = "2026-06-30T19:23:15.648Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/e3/c7aa7bb4845e0cfdf477ff87f9a3ec0cd2aa55a34a9f31be84d724cabbb7/openinference_instrumentation-0.1.54-py3-none-any.whl", hash = "sha256:8bc991865c90c804ac9983ef93aa6081a7a2397dd113d3d38b5465cca17892bb", size = 41197, upload-time = "2026-06-30T19:23:14.315Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation-langchain"
+version = "0.1.67"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/02/f381a25a0d11e57f91a90effda4abc484f25598d32a59566205583ca198c/openinference_instrumentation_langchain-0.1.67.tar.gz", hash = "sha256:94bdd348ceacc6657ae7b37f7050fe6289484fb65be9ee51edc2d9c3261a6605", size = 76093, upload-time = "2026-07-01T15:44:22.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/c3/28b6acb7b29ff1c203521087c06d113397f39d04ae502b6f38ebbd29d564/openinference_instrumentation_langchain-0.1.67-py3-none-any.whl", hash = "sha256:2c279640072737359ded51bdf9b82374f44f25f92b2300dde44b3a9e2da8f79f", size = 24833, upload-time = "2026-07-01T15:44:21.74Z" },
+]
+
+[[package]]
+name = "openinference-semantic-conventions"
+version = "0.1.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/51/8ba1182ee86fc79793d5ff2d11e7fdcda10ded2d01f3e46ca6fcf0568213/openinference_semantic_conventions-0.1.30.tar.gz", hash = "sha256:81fece76e09c83789e35c393b8b30523481eeabf1008745b955631a53e3221d9", size = 13391, upload-time = "2026-05-22T21:10:44.065Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/76/5b7e78cf0de38589b821bbe8e9c29c59a6e76edfb980488d0854cbb90f7c/openinference_semantic_conventions-0.1.30-py3-none-any.whl", hash = "sha256:36d946d3f95f699b7c4b12324ae9c1f02d6c7750df11eece56aa159cff430b3d", size = 10911, upload-time = "2026-05-22T21:10:43.04Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864, upload-time = "2026-05-06T15:10:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/6cf69385a58208024fcb8c014e2141b8ce838aba6492b589f8acfff97fab/orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882", size = 135213, upload-time = "2026-05-06T15:10:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994, upload-time = "2026-05-06T15:10:05.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744, upload-time = "2026-05-06T15:10:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127, upload-time = "2026-05-06T15:10:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/dc/7446c538590d55f455647e5f3c61fc33f7108714e7afcffa6a2a033f8350/orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f", size = 148025, upload-time = "2026-05-06T15:10:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/850264ccf6d80f6b174620d30a87f65c9b1490aba33fe6b62798e618cad3/orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470", size = 131606, upload-time = "2026-05-06T15:10:15.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/495470f0e4a18f73fa10b7f6b84b464ec4cc5291c4e0c7c2a6c400bef006/orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624", size = 126736, upload-time = "2026-05-06T15:10:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/b9/d11d7e501ac8fd7d617684423ebb9561e0b998481c1e4cbc0cb212c5d74a/regex-2026.7.19-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2cc3460cedf7579948486eab03bc9ad7089df4d7281c0f47f4afe03e8d13f02d", size = 496778, upload-time = "2026-07-19T00:17:05.677Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a9/a5ab6f312f24318019170dc485d5421fe4f89e43a98640da50d95a8a7041/regex-2026.7.19-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0e9554c8785eac5cffe6300f69a91f58ba72bc88a5f8d661235ad7c6aa5b8ccd", size = 297122, upload-time = "2026-07-19T00:17:07.59Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/63/4cab4d7f2d384a144d420b763d97674cb70619c878ea6fcd7640d0e62143/regex-2026.7.19-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d7da47a0f248977f08e2cb659ff3c17ddc13a4d39b3a7baa0a81bf5b415430f6", size = 292009, upload-time = "2026-07-19T00:17:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/22/85/102a81b218298957d4ea7d2f084fae537a71add9d6ff93c8e67284c5f45e/regex-2026.7.19-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93db40c8de0815baab96a06e08a984bac71f989d13bab789e382158c5d426797", size = 796708, upload-time = "2026-07-19T00:17:11.542Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/dc136af5629938a037cd2b304c12240e132ec92f38be8ff9cc89af2a1f2d/regex-2026.7.19-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:66bd62c59a5427746e8c44becae1d9b99d22fb13f30f492083dfb9ad7c45cc18", size = 865651, upload-time = "2026-07-19T00:17:13.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/75/67402ae3cd9c8c988a4c805d15ee3eef015e7ca4cb112cf3e640fc1f4153/regex-2026.7.19-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1649eb39fcc9ea80c4d2f110fde2b8ab2aef3877b98f02ab9b14e961f418c511", size = 911756, upload-time = "2026-07-19T00:17:15.015Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/8e/096d00c7c480ef2ff4265349b14e2261d4ab787ba1f74e2e80d1c58079c3/regex-2026.7.19-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9dce8ec9695f531a1b8a6f314fd4b393adcccf2ea861db480cdf97a301d01a68", size = 801798, upload-time = "2026-07-19T00:17:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/41/e7ecac6edb5722417f85cc67eaf386322fbe8acf6918ec2fdc37c20dd9d0/regex-2026.7.19-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3080a7fd38ef049bd489e01c970c97dd84ff446a885b0f1f6b26d9b1ad13ce11", size = 776933, upload-time = "2026-07-19T00:17:19.347Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/69/03c9b3f058d66403e0ca2c938696e81d51cd4c6d47ec5265f02f96948d9a/regex-2026.7.19-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1d793a7988e04fcb1e2e135567443d82173225d657419ec09414a9b5a145b986", size = 784338, upload-time = "2026-07-19T00:17:21.057Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f7/b38ab3d43f284afbb618fcd15d0e77eb786ae461ce1f6bc7494619ddc0f2/regex-2026.7.19-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e8b0abe7d870f53ca5143895fef7d1041a0c831a140d3dc2c760dd7ba25d4a8b", size = 860452, upload-time = "2026-07-19T00:17:23.119Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/ff60ef0571121714f3cf9920bc183071e384a10b556d042e0fdb06cc07a5/regex-2026.7.19-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:4e5413bd5f13d3a4e3539ca98f70f75e7fca92518dd7f117f030ebedd10b60cb", size = 765958, upload-time = "2026-07-19T00:17:24.81Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0f/bd34021162c0ab47f9a315bd56cd5642e920c8e5668a75ef6c6a6fca590d/regex-2026.7.19-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:73b133a9e6fb512858e7f065e96f1180aa46646bc74a83aea62f1d314f3dd035", size = 851765, upload-time = "2026-07-19T00:17:26.993Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/20/a2ca43edade0595cccfdc98636739f536d9e26898e7dbddc2b9e98898953/regex-2026.7.19-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dbe6493fbd27321b1d1f2dd4f5c7e5bd4d8b1d7cab7f32fd67db3d0b2ed8248a", size = 789714, upload-time = "2026-07-19T00:17:28.699Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/47/e02db4015d424fc83c00ea0ac8c5e5ec14397943de9abf909d5ce3a25931/regex-2026.7.19-cp312-cp312-win32.whl", hash = "sha256:ddd67571c10869f65a5d7dde536d1e066e306cc90de57d7de4d5f34802428bb5", size = 267157, upload-time = "2026-07-19T00:17:31.051Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8e/c780c131f79b42ed22d1bd7da4096c2c35f813e835acd02ef0f018bd892c/regex-2026.7.19-cp312-cp312-win_amd64.whl", hash = "sha256:e30d40268a28d54ce0437031750497004c22602b8e3ab891f759b795a003b312", size = 277777, upload-time = "2026-07-19T00:17:32.848Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4c/e4d7e086449bdf379d89774bf1f89dc4a41943f3c5a6125a03905b34b5fb/regex-2026.7.19-cp312-cp312-win_arm64.whl", hash = "sha256:de9208bb427130c82a5dbfd104f92c8876fc9559278c880b3002755bbbe9c83d", size = 277136, upload-time = "2026-07-19T00:17:34.803Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/3d/84165e4299ff76f3a40fe1f2abf939e976f693383a08d2beea6af62bd2c1/regex-2026.7.19-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f035d9dc1d25eff9d361456572231c7d27b5ccd473ca7dc0adfce732bd006d40", size = 496552, upload-time = "2026-07-19T00:17:36.808Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/a65293e6e4cf28eb7ee1be5335a5386c40d6742e9f47fafc8fec785e16c7/regex-2026.7.19-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c42572142ed0b9d5d261ba727157c426510da78e20828b66bbb855098b8a4e38", size = 296983, upload-time = "2026-07-19T00:17:38.816Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/2d0564e93d87bc48618360ddca232a2ca612bbdf53ce8465d45ca5ce14ee/regex-2026.7.19-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:40b34dd88658e4fedd2fddbf0275ac970d00614b731357f425722a3ed1983d11", size = 291832, upload-time = "2026-07-19T00:17:40.726Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cd/42dfbabff3dfc9603c501c0e2e2c5adbb09d127b267bf5348de0af338c15/regex-2026.7.19-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c41c63992bf1874cebb6e7f56fd7d3c007924659a604ae3d90e427d40d4fd13", size = 796775, upload-time = "2026-07-19T00:17:42.382Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5d/f6a4839f2b934e3eed5973fd07f5929ee97d4c98939fb275ea23c274ee16/regex-2026.7.19-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d3372064506b94dd2c67c845f2db8062e9e9ba84d04e33cb96d7d33c11fe1ae", size = 865687, upload-time = "2026-07-19T00:17:44.185Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b0/b47d6c36049bc59806a50bd4c86ced70bbe058d787f80281b1d7a9b0e024/regex-2026.7.19-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fce7760bf283405b2c7999cab3da4e72f7deca6396013115e3f7a955db9760da", size = 911962, upload-time = "2026-07-19T00:17:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/ff61f28f9273658cfe23acbbac5217221f6519960ed401e61dfdab12bc35/regex-2026.7.19-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0d702548d89d572b2929879bc883bb7a4c4709efafe4512cadee56c55c9bd15", size = 801817, upload-time = "2026-07-19T00:17:48.25Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bb/8b4f7f26b333f9f79e1b453613c39bb4776f51d38ae66dd0ba31d6b354ca/regex-2026.7.19-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d446c6ac40bb6e05025ccee55b84d80fe9bf8e93010ffc4bb9484f13d498835f", size = 776908, upload-time = "2026-07-19T00:17:50.183Z" },
+    { url = "https://files.pythonhosted.org/packages/09/13/610110fc5921d380516d03c26b652555f08aa0d23ea78a771231873c3638/regex-2026.7.19-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c3501bfa814ab07b5580741f9bf78dfdfe146a04057f82df9e2402d2a975939", size = 784426, upload-time = "2026-07-19T00:17:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f5/1ef9e2a83a5947c57ebff0b377cb5727c3d5ec1992317a320d035cd0dbb6/regex-2026.7.19-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c4585c3e64b4f9e583b4d2683f18f5d5d872b3d71dcf24594b74ecc23602fa96", size = 860600, upload-time = "2026-07-19T00:17:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/02/073af33a3ec149241d11c80acea91e722aa0adbf05addd50f251c4fe89c3/regex-2026.7.19-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:571fde9741eb0ccde23dd4e0c1d50fbae910e901fa7e629faf39b2dda740d220", size = 765950, upload-time = "2026-07-19T00:17:56.041Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a9/d1e9f819dc394a568ef370cd56cf25394e957a2235f8370f23b576e5a475/regex-2026.7.19-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:15b364b9b98d6d2fe1a85034c23a3180ff913f46caddc3895f6fd65186255ccc", size = 851794, upload-time = "2026-07-19T00:17:57.897Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3a/8ae83eda7579feacdf984e71fb9e70635fb6f832eeddca58427ec4fca926/regex-2026.7.19-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffd8893ccc1c2fce6e0d6ca402d716fe1b29db70c7132609a05955e31b2aa8f2", size = 789845, upload-time = "2026-07-19T00:17:59.97Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/c195cbfe5a75fdec64d8f6554fd15237b837919d2c61bdc141d7c807b08b/regex-2026.7.19-cp313-cp313-win32.whl", hash = "sha256:f0fa4fa9c3632d708742baf2282f2055c11d888a790362670a403cbf48a2c404", size = 267135, upload-time = "2026-07-19T00:18:01.958Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/80/a11de8404b7272b70acb45c1c05987cce60b45d5693da2e176f0e390d564/regex-2026.7.19-cp313-cp313-win_amd64.whl", hash = "sha256:d51ffd3427640fa2da6ade574ceba932f210ad095f65fcc450a2b0a0d454868e", size = 277747, upload-time = "2026-07-19T00:18:04.121Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/0f5c8eff1b4f1f3d83276d365fccecf666afcc7d947420943bf394d07adb/regex-2026.7.19-cp313-cp313-win_arm64.whl", hash = "sha256:c670fe7be5b6020b76bc6e8d2196074657e1327595bca93a389e1a76ab130ad8", size = 277129, upload-time = "2026-07-19T00:18:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4c/44b74742052cedda40f9ae469532a037112f7311a36669a891fba8984bb0/regex-2026.7.19-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db47b561c9afd884baa1f96f797c9ca369872c4b65912bc691cfa99e68340af2", size = 501134, upload-time = "2026-07-19T00:18:07.567Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/45/bbd038b5e39ee5613a5a689290145b40058cc152c41de9cc23639d2b9734/regex-2026.7.19-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:65dcd28d3eba2ab7c2fd906485cc301392b47cc2234790d27d4e4814e02cdfda", size = 299418, upload-time = "2026-07-19T00:18:09.38Z" },
+    { url = "https://files.pythonhosted.org/packages/65/38/c5bde94b4cedfd5850d64c3f08222d8e1600e84f6ee71d9b44b4b8163f74/regex-2026.7.19-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f2e7f8e2ab6c2922be02c7ec45185aa5bd771e2e57b95455ee343a44d8130dff", size = 294486, upload-time = "2026-07-19T00:18:11.188Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/2f5e107cb26c960b781967178899daf2787a7ab151844ed3c01d6fc95474/regex-2026.7.19-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe31f28c94402043161876a258a9c6f757cb485905c7614ce8d6cd40e6b7bdc1", size = 811643, upload-time = "2026-07-19T00:18:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d4/a2f963406d7d73a62eed84ba05a258afb6cad1b21aa4517443ce40506b78/regex-2026.7.19-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8f6fa298bb4f7f58a33334406218ba74716e68feddf5e4e54cd5d8082705abf", size = 871081, upload-time = "2026-07-19T00:18:14.733Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a3/44be546340bedb15f13063f5e7fe16793ea4d9ea2e805d09bd174ac27724/regex-2026.7.19-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cc1b2440423a851fad781309dd87843868f4f66a6bcd1ddb9225cf4ec2c84732", size = 917372, upload-time = "2026-07-19T00:18:16.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/e0870b0fd2a40dba0074e4b76e514b21313d37946c9248453e34ec43923e/regex-2026.7.19-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ac59a0900474a52b7c04af8196affc22bd9842acb0950df12f7b813e983609a", size = 816089, upload-time = "2026-07-19T00:18:18.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/27/957e8e22690ad6634572b39b71f130a6105f4d0718bb16849eac00fff147/regex-2026.7.19-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4896db1f4ce0576765b8272aa922df324e0f5b9bb2c3d03044ff32a7234a9aba", size = 785206, upload-time = "2026-07-19T00:18:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a4/186e410941e731037c01166069ab86da9f65e8f8110c18009ccf4bd623ee/regex-2026.7.19-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4e6883a021db30511d9fb8cfb0f222ce1f2c369f7d4d8b0448f449a93ba0bdfc", size = 800431, upload-time = "2026-07-19T00:18:22.716Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9f/e4e10e023d291d64a33e246610b724493bf1ce98e0e59c9b7c837e5acfb7/regex-2026.7.19-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:09523a592938aa9f587fb74467c63ff0cf88fc3df14c82ab0f0517dcf76aaa62", size = 864906, upload-time = "2026-07-19T00:18:24.772Z" },
+    { url = "https://files.pythonhosted.org/packages/24/57/ccb20b6be5f1f52a053d1ba2a8f7a077edb9d918248b8490d7506c6832b3/regex-2026.7.19-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1ebac3474b8589fce2f9b225b650afd61448f7c73a5d0255a10cc6366471aed1", size = 773559, upload-time = "2026-07-19T00:18:27.008Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/82/f3b263cf8fad927dc102891da8502e718b7ff9d19af7a2a07c03865d7188/regex-2026.7.19-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:4a0530bb1b8c1c985e7e2122e2b4d3aedd8a3c21c6bfddae6767c4405668b56e", size = 857739, upload-time = "2026-07-19T00:18:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/1687bd1b6c2aed5e672ccf845fc11557821fe7366d921b50889ea5ce57bf/regex-2026.7.19-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef7eeb108c47ce7bcc9513e51bcb1bf57e8f483d52fce68a8642e3527141ae0", size = 804522, upload-time = "2026-07-19T00:18:31.362Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7c/cc4e7655181b2d9235b704f2c5e19d8eff002bbc437bae59baee0e381aca/regex-2026.7.19-cp313-cp313t-win32.whl", hash = "sha256:64b6ca7391a1395c2638dd5c7456d67bea44fc6c5e8e92c5dc8aa6a8f23292b4", size = 269141, upload-time = "2026-07-19T00:18:33.479Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/14/961b4c7b05a2391c32dbc85e27773076671ef8f97f36cec70fe414734c02/regex-2026.7.19-cp313-cp313t-win_amd64.whl", hash = "sha256:f04b9f56b0e0614c0126be12c2c2d9f8850c1e57af302bd0a63bed379d4af974", size = 280036, upload-time = "2026-07-19T00:18:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/795644550d788ddbb6dc458c95895f8009978ea6d6ea76b005eb3f45e8c9/regex-2026.7.19-cp313-cp313t-win_arm64.whl", hash = "sha256:fcee38cd8e5089d6d4f048ba1233b3ad76e5954f545382180889112ff5cb712d", size = 279394, upload-time = "2026-07-19T00:18:37.454Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.69.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/69/40407dfc835517f058b603dbf37a6df094d8582b015a51eddc988febbcb7/tqdm-4.69.0.tar.gz", hash = "sha256:700c5e85dcd5f009dd6222588a29180a193a748247a5d855b4d67db93d79a53b", size = 792569, upload-time = "2026-07-17T18:09:06.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/21/99a0cdaf54eb35e77623c41b5a2c9472ee4404bba687052791fe2aba6773/tqdm-4.69.0-py3-none-any.whl", hash = "sha256:9979978912be667a6ef21fd5d8abf54e324e63d82f7f43c360792ebc2bc4e622", size = 676680, upload-time = "2026-07-17T18:09:04.172Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uuid-utils"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/91/63938e0e7e7876658e5e40178e7c0735b53527886fe11797a11699c55edd/uuid_utils-0.17.0.tar.gz", hash = "sha256:abb5667a36119019b3fa320c4d10c21ebccfcc87c8a739e6a0056cee7f48dde2", size = 43220, upload-time = "2026-07-09T13:49:58.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/80/a7e685968e3cec99d6fe2fb25d0f5726310e1bba356da68c13dfd8b7d140/uuid_utils-0.17.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9205068badf453d2f0821fd5d340389b4679992d7ff79d4f3e5608996dd1b287", size = 556403, upload-time = "2026-07-09T13:48:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/56/47/3102d93bcb7b0bfe6bede63ff8f221a7f91348e10a37f682773be27c56d9/uuid_utils-0.17.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0fcca4e838af9ac9243b3358d7c14afa4dca286a87781124c272d6c4cad9c968", size = 285608, upload-time = "2026-07-09T13:48:28.769Z" },
+    { url = "https://files.pythonhosted.org/packages/55/fb/d59695f0f8db065b93c63316eaafa05a22d75a0486978a33736c52c646d5/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f3729e839209f3457d0d8b6a35a376fdf65577a5aecaf4cc3587d3305759ba6", size = 319926, upload-time = "2026-07-09T13:48:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/03/62fabcd1e990e07a0e220e8d552af45bc16f107fa8e55c2014a706bb1a1e/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3dac0ad0cd9a2818d1775215365a4e8c2f8ada215529dd26f3f8cceeb67a6988", size = 327172, upload-time = "2026-07-09T13:48:31.187Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/a5081391338b459e2f8d8b12581f00f8caa6317fab510e0e85c18c59e938/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e671b2322ef09106ecb1ca0f4c398b134d5e2c1f80d7a4f3336847a3072c0e94", size = 439075, upload-time = "2026-07-09T13:48:32.295Z" },
+    { url = "https://files.pythonhosted.org/packages/59/30/91795bd01e17a13661280d4899fbf38fb05e3f38e873f9aaec106ec30aa0/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8eb3e5caca8d3a6f72ea4cce024583f989f6f2e9186f98800213fff0176e8bcc", size = 320247, upload-time = "2026-07-09T13:48:33.64Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/11/09102b78303e4eb62069d6d88ef9fd661dc523e8f429e1fd67eaa78a6f44/uuid_utils-0.17.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8b72c2002202038666bf647f9a790906214c7c11cd0d6efef77b7d07bef3034a", size = 344738, upload-time = "2026-07-09T13:48:34.786Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f9/be95bad6954b60328878c3800258f01a6accd24fd75112d13f023462d53f/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4e2ac1c0b56f2c91b6f158e29ed96b1503223fe8aa6e79b1be1dc55bd8a5131c", size = 496845, upload-time = "2026-07-09T13:48:36.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/02/8a19a34e0530d987488a068a71576a236f5c8c746630b870b57f71eb24ef/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6c142bd0cb4dba31c10babe00d59f7ef6460f0ef55eaa9c1a9da270684af996a", size = 603233, upload-time = "2026-07-09T13:48:37.512Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a8/b1abab36ff73b0248d82179816467f6d39a2e80fd64329a895ca94f3508e/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e252db239eb41c32248e096e0d170bce5896a4fd3405556362bc3dd83d912206", size = 561401, upload-time = "2026-07-09T13:48:38.977Z" },
+    { url = "https://files.pythonhosted.org/packages/61/91/70e7b528b351cc03a9ca43e6116371cdde31bb12bcead7ca2ca1367366cc/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:237722b6581bb5b4eb4cefbcbe5c6e2980a440aabe781fbe50ebf1cb71eee4cc", size = 525314, upload-time = "2026-07-09T13:48:40.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/9167e90cf9937d6558f92d022ff3024a69d938a514d9c8faa4080f73b001/uuid_utils-0.17.0-cp312-cp312-win32.whl", hash = "sha256:46a73cacdf512f473a81f65dbf84186e08cfe6e9118fa582b6c6b33a8288a30d", size = 166831, upload-time = "2026-07-09T13:48:41.862Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/7d/0b889654d9ee3413f810cf4685e241285f650d98a4103ac9f3c6bcc95f29/uuid_utils-0.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:e59b60a0a4cb7541480e02090d37dc2df3b72df4c2e776fff64ce3a4e3dd4637", size = 172944, upload-time = "2026-07-09T13:48:42.992Z" },
+    { url = "https://files.pythonhosted.org/packages/be/35/8c6e1bf65e4d400352885dadc656ad6d0af96e89231e3f04686bc2197128/uuid_utils-0.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:d561a4c5747a1e6c7fa7c49a0292e78b4e8c456332caa084fc7abad8de828652", size = 172459, upload-time = "2026-07-09T13:48:44.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/dd/614fb9912157ac0128e6050859ccf06d9f13df9a944a803e8f80f6157e38/uuid_utils-0.17.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d11a7bc1e02da8984d32e6de9e0826c6edac00eac17de270f372bf32f9a0af63", size = 557259, upload-time = "2026-07-09T13:48:45.664Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/d072711704de3d21bec08b6c2f36a215200ca1d5e01a390ea1ac434080a0/uuid_utils-0.17.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7a49f47ac26df3e431c56b825c1bae8e6d3d591fdbb7438c227cc9845a7e3d73", size = 286271, upload-time = "2026-07-09T13:48:47.018Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6d/8a63e5eb2d5a6ba69a6c2036e305075bd6f5a022e7ea25fc6ce0eb7c51d2/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32df1944808877702ceea398c103881c09a679bb672a215e01c2a84231266bf9", size = 320025, upload-time = "2026-07-09T13:48:48.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/bdc2caf9719d9090d7c46043242ae6136cba4f7a7ee384992ab905ad9aa1/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:98c88d3edd08e7245562e9815996dbc6f0bd4745e1c76462f24af5ae4e187dd1", size = 327931, upload-time = "2026-07-09T13:48:49.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/33/9219d09d51ead282b578b2a4e0a515c2cce3ec52076cada8bfb7e35727d5/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a4370089c8b2e42f1db51d76408c7fa8eaa2934bf854d17983d16179c07c098", size = 438537, upload-time = "2026-07-09T13:48:50.842Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/79/e8e0f8b3955f2081c116157119d87659937893242eb834aa170da04d660b/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09a55b7a5ae764985cb46467496a1787678d0a1400356157a080ad95b1a36869", size = 320656, upload-time = "2026-07-09T13:48:52.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/d1ceddc430ff04b6e21704b2030d4438074a2f478b265dab43da957791c1/uuid_utils-0.17.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:56aa6488b931246fae11924e4bd0e2b32677e63945eecb71c29e3c2ca0dc3131", size = 345310, upload-time = "2026-07-09T13:48:54.076Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/62/89438e12f389a843e626b7e37691319a057b3d6b80914609106891faadda/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:309a35f12d99dde19032bc2259cda6431c85eeac0879134dc777cc3087d7e1cb", size = 496771, upload-time = "2026-07-09T13:48:55.365Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d2/eedcd99f522d60e238ead03844f0d51743ba84d33044959e230b756bf212/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:21c79b61ff750abcf057163dd764ccb6196cde7a26cda1b31b45cd97769e03b3", size = 603631, upload-time = "2026-07-09T13:48:56.746Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a8/bb1b38aaddd7243b6e562c6694f499bf094800918316192fd8cb2cdc2620/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4134353bfe3026ddab8e886002dc52bc5a0ab04611aabb0eaae23c32e6e57f64", size = 562008, upload-time = "2026-07-09T13:48:58.241Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/77/5f7ed930dc105e293845c09e4d5bd84076318a12f45a46783e1af64906d7/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7c89359affecebe2e39e6a116d069b363c936511a9572b308402489a26957d89", size = 525527, upload-time = "2026-07-09T13:48:59.784Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/25/1b55697adf6811a6f92cff6340e6b03e31fd6bc51066a5c10698c29b3679/uuid_utils-0.17.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:6a019a31bc4db89a0903a3e4f6b218571f3a6ff0ad4b3d3fe1c8f91a05ff6e3e", size = 97965, upload-time = "2026-07-09T13:49:01.217Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bf/cd729343de4684230be8a966bad7bfc2cf10ce3e643b1189a8b5370dbe35/uuid_utils-0.17.0-cp313-cp313-win32.whl", hash = "sha256:b3131a82d0c7611f0aa480a6d36929e001a3f54ba0fc029a8118a5863cce513c", size = 167316, upload-time = "2026-07-09T13:49:02.354Z" },
+    { url = "https://files.pythonhosted.org/packages/76/f0/e602ae0a1b139a7826e5189b93d91902564def06d5006324fd2faf82c8fc/uuid_utils-0.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:9e311f908d2f842fca4c7dcebc4f10306b8089b204ef04cf6704b4332c9ff6ff", size = 173630, upload-time = "2026-07-09T13:49:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/52/024ebece265b387154115dc4f1d9727174ef82623069f4bec8b7ed7e73f7/uuid_utils-0.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:c351737e2e65497c7200ab4ffb8af97e9f48be6488309abdd265fe08d66ee92f", size = 173214, upload-time = "2026-07-09T13:49:04.836Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/63/71aa56b151a1b28770037a61bd4e461c2619cfc8866a4fcaf1548605e325/xxhash-3.8.1.tar.gz", hash = "sha256:b0de4bf3aa66363552d52c6a89003c479911f12098cd48a53d44a0f7a25f7c46", size = 86223, upload-time = "2026-07-06T10:49:58.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/91/f65c34a7aa7b4e7cf4854f8e6ef3f7ee32ceac41d4f008da0780db0612f6/xxhash-3.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e6e49370822c1f4d8d90e678b06dbcb08b51a026a7c4b55479e7d467f2e813bc", size = 34680, upload-time = "2026-07-06T10:44:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/57/04/b10a245a4c09a9cfa88f8e9ae755029413ad1ac17047f9a61906e5ae0799/xxhash-3.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:220d68130f83f7cc86d6edfdeab176adc73d7200bf3a8ec10c629e8cf605c215", size = 32397, upload-time = "2026-07-06T10:44:42.196Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/75/45ab795b5945b6388583bd75202106af505537935566c15a1577797a0e08/xxhash-3.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d365ee1892c1fa803536f8c6ce21d24b29c9718ec75eb856095c07830f8c478", size = 220549, upload-time = "2026-07-06T10:44:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/13/44/5ba2bd0a14ddf4193fc7d8ec29625f659f22c06d60b28f04bf46305d8330/xxhash-3.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:852bfe059720632e2f16a6a4745e41d20937b2bf2a42a401e2412046bb6971cc", size = 241186, upload-time = "2026-07-06T10:44:45.534Z" },
+    { url = "https://files.pythonhosted.org/packages/23/32/c4147def4d1e4538b906f82731e0ba23424377fc50a7cddd03cd284c8f63/xxhash-3.8.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2f8c25a7061d952de589bd0ea0eaadee32378ff83dd6a677b267f9cd86f401f8", size = 264852, upload-time = "2026-07-06T10:44:47.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/bd/71ed14f4f0318bb7fd7b2ec51999413487fa8da8d41208e84d50d1ef0f98/xxhash-3.8.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:868a8dcaff1a84ba78038e1cef14fc88ccf84d9b4d12ea604696e0693296aa56", size = 242663, upload-time = "2026-07-06T10:44:48.846Z" },
+    { url = "https://files.pythonhosted.org/packages/91/09/70af22c565a8473b3f2ae73f88e7721af281bc4a575236dbd1970c9f76f6/xxhash-3.8.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6536d8677d2fff7e64cd0b98b976df9de7aee0e69590044c2af5f51b76b7a170", size = 473510, upload-time = "2026-07-06T10:44:50.695Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/34db781c8f0cf99c544ca1f2bc2e5bf55426e1eb4ca6de8ea5da56a9f352/xxhash-3.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:82c0cedd280eab2e8291270e6c04894dbc096f8159a39dcf1807429f026ca3cc", size = 220469, upload-time = "2026-07-06T10:44:52.422Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5f/9a184f615fa5a4dce30c01534f62946ce5a11ce40f73785cbd356ccabaa9/xxhash-3.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daa86e4b68221d38e669bb236ba112d0335353829fb627c82e5909e4bbe8694c", size = 310290, upload-time = "2026-07-06T10:44:54.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dc/9b9a9789011ee153723a5eb9e7dd7fcbae2ba9b3fe7a729249ca7c252056/xxhash-3.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2bc7113e6f2b6b3922dd61796ca9f36af09da3773898e7003038dc992fc83b8d", size = 238173, upload-time = "2026-07-06T10:44:55.693Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4d/71c6005ada9dcb608a4e1902e8475ecadb5f3fbfa04e1e244d276a2d0c43/xxhash-3.8.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5eed32dad81d6ba8e62dc7b9ffa0500199385d7810a8dd9d4eafaceb8c6e20bb", size = 269026, upload-time = "2026-07-06T10:44:57.424Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/87/d6c036ba25dfbd9c8633be5aa86fc9474bbb9e2c68212a841d090abe7344/xxhash-3.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:83697b0ea1f10e7f5d8b26a4906fa851393c61546c63839643a2b7fe2d868061", size = 224970, upload-time = "2026-07-06T10:44:59.085Z" },
+    { url = "https://files.pythonhosted.org/packages/48/62/4c1f035a41c5752aa05e195b6c904c07b94fe9061a16de61e72a6e6b135f/xxhash-3.8.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:36fc69160465ae75c6ec4ac9f781bb2aa16ae7ff869e73c26fee85fbb11b9887", size = 240820, upload-time = "2026-07-06T10:45:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/da/14/d39d565069b87e86d21a2af2a31d04db79249d25aa8d5b62959056a89857/xxhash-3.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:445e0f5a31f2f3546ae0895d4811e159518cdc9d824c11419898d40cfadb677e", size = 300619, upload-time = "2026-07-06T10:45:02.716Z" },
+    { url = "https://files.pythonhosted.org/packages/13/22/75467acc887edc8cf71c97ab1708feb3df7a88bda589b9f399765c6387d2/xxhash-3.8.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:dfe0580fbfd5e4af87d0cc52d2044f155d55ebd8c8a93568758a2ea7d8e15975", size = 443267, upload-time = "2026-07-06T10:45:04.653Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b6/1da3baa5fa6ef705e3425fddd382be7dfc4dfba2686df90a20f16e9c7b1b/xxhash-3.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:095e1323fa108be1292c54c86da3ef3c7a7dc015b105a52133973bc07a6ad11a", size = 217338, upload-time = "2026-07-06T10:45:06.304Z" },
+    { url = "https://files.pythonhosted.org/packages/78/dd/b5295a9f97484e7a1c2b283a742ca45e3104991c55a1ef670dde161829ba/xxhash-3.8.1-cp312-cp312-win32.whl", hash = "sha256:bf28f55e427e0483acb1f666bd0d869b6d5e5a716680c216ad7befe3d4cfba2e", size = 31970, upload-time = "2026-07-06T10:45:07.823Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/31/3fa0b807d7e21515cd975e7fe5c039d52ac3e9401a96d6ad68dae6305215/xxhash-3.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:2256e80e4960ee282f63428adb349cb7f8bd8efe4db770d88eb815f4b9860724", size = 32741, upload-time = "2026-07-06T10:45:09.42Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/05/86feada74e239600e6875aa507afb40482a89b92700aa74a92da83bdcb77/xxhash-3.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:9df56e6df96a60590935e22373041cccc91fd55858763dcffb55bf63b3a2b396", size = 29234, upload-time = "2026-07-06T10:45:10.809Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/446bb782cd0d27007a917b5569a08dd73219c3e8d6e459014db104b27bdb/xxhash-3.8.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:3c682fcd96eb4bf64be32a4d95f96107e1588005831bd8a741b324fdda01b913", size = 38562, upload-time = "2026-07-06T10:45:12.425Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ec/c0c45627eaa6be7a5d6117423adf8f7a15b17ee74b4b17072cca5959a225/xxhash-3.8.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:036a024d8b9c01f70782e09ed98d532e76fd23f950ae7154bd950fe94e90ebec", size = 36656, upload-time = "2026-07-06T10:45:13.932Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/94/8324c04cc7597154caaeba6c094e01fbd2e7601d01e7a13eea9f5420e77b/xxhash-3.8.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d6a5c0bce213b23b0166fe0d35bcbbe23ce4b968f257cc7eb6fd57cb8e1e6297", size = 31169, upload-time = "2026-07-06T10:45:15.687Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a4/beb6bb26e1184e126dbe7a5682330214ef54dcfbf882078aa9f4b5428d42/xxhash-3.8.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:5177aa44eddaa97c6ef0cc00c6d540edb64d51781d2f8fb941612ec61a92c9ed", size = 32177, upload-time = "2026-07-06T10:45:17.035Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0f/fc4c92a5a528f839b34b6419b2e53c8597f2a629d5a1f5d721f65bfa1fd6/xxhash-3.8.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7801b7223db017b9c0c9ccf37e44524edb35a1544a1c032add22c061c6af0276", size = 34642, upload-time = "2026-07-06T10:45:18.39Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/58/edbfb141d4000767ac6a9694f8ac0763e2c2e983e65c9e31620ba56e2667/xxhash-3.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e80238259655bf69d7bcd08226a970d7f42605f3157786bfa76dd13472d7fa0", size = 34684, upload-time = "2026-07-06T10:45:20.033Z" },
+    { url = "https://files.pythonhosted.org/packages/07/3f/5072f1f0f5714186f0ac2a0b5a4929ce30d4b845e94886b6c01b6ebda0be/xxhash-3.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bcab50a389cc04d87f90092af78a6adba2ab3deca63175a3344ca83514045315", size = 32401, upload-time = "2026-07-06T10:45:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c7/802ea2f9c2ed59219934d6d65c470d502b1788043eae277a52af8658bda6/xxhash-3.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2489d3a776fa380cb8e71f54c7fda268a9baf3de9b1395093fd280f95735907", size = 220617, upload-time = "2026-07-06T10:45:23.234Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a8/e10488efd31fcb13fcd6acbc6e788f10c6f8e3a0cc4ae3eb89dc19c55a12/xxhash-3.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32ab1e5432690276e71192be7401b55f96db2d0eedea5d44eb1f164505669cc0", size = 241295, upload-time = "2026-07-06T10:45:25.364Z" },
+    { url = "https://files.pythonhosted.org/packages/18/cc/14180b17d44892a631f8ae7323c30bfbb1328efc8209e528a480293528ac/xxhash-3.8.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b30e01a0b97a4bc3f519a4d7a82da3dc53251fb0de5eeea8660dcd4ff094c0c2", size = 264688, upload-time = "2026-07-06T10:45:27.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/72/a14019d0c5f6c41ee407a503036ae32787c91325ca218a96a9b5627be651/xxhash-3.8.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f44275ddb0978b67a58a951501903f04d49335a91f7681c9ce122ecb8ccb329", size = 242740, upload-time = "2026-07-06T10:45:28.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/08/92550e556c6fcfcb96c6a336945eb53a431ed43120ed749636debb16c5cf/xxhash-3.8.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3b87cbd974512c0c5fc7b469c36b2cdc9ee6d76e4ec78bccb2c7184611c49b0", size = 473599, upload-time = "2026-07-06T10:45:30.524Z" },
+    { url = "https://files.pythonhosted.org/packages/29/83/e361d3c1acd1b21e1d489616de6fa4aaf843365d8179f612e3743eac20a9/xxhash-3.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98ee81b4b7f3023c9cb04a78cc67610baffcb5812d92f2096cb5a5efc6f19437", size = 220559, upload-time = "2026-07-06T10:45:32.979Z" },
+    { url = "https://files.pythonhosted.org/packages/05/01/006a4243c2c2a6831827f9999f6d1c23feeef100eb023c1f886022a00bf3/xxhash-3.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2666f059a1588a99267e33605365ed89cea92f424b3522806a9f4bd8ad2e3d62", size = 310383, upload-time = "2026-07-06T10:45:35.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/20/af388e8bf9f9a0f89eeef7d2a1935d176ee1c20bc6adeda05035879379cf/xxhash-3.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0093cf7eeb91b84776e8742113afa4bdf47533d36cf719179aaaf1f56f6f8bf", size = 238228, upload-time = "2026-07-06T10:45:38.02Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6b/4666579a87eebd1744663c404297355fa0658617b015cedfa58810ee7036/xxhash-3.8.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3a800912a2e5e975d4128969d645c4a2a80aa886ccd6c9b1c6f44529e327e8cf", size = 269137, upload-time = "2026-07-06T10:45:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d3/e963a8a46f900a137d91b02144d8ea07a8f812971b138204a3b2f8b8e55c/xxhash-3.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0fe37f72a207223d22a4eddc3149d4298993385aa9daef25c039246ca5a309f3", size = 225068, upload-time = "2026-07-06T10:45:41.718Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/80/9d181dbcde4b0fe48375f48833a5832d4b8cd2b349b15110c92ee472d874/xxhash-3.8.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5db43f249b4be9f99ef4b967863f37094fb40e67effafb78ba4f0356b6396104", size = 240874, upload-time = "2026-07-06T10:45:43.414Z" },
+    { url = "https://files.pythonhosted.org/packages/39/15/ce3ab5a1cd27ead25a5196e55a7284220f6ad6e316da494ffd900b2b600f/xxhash-3.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c4ed42965c2cd9081f011be22f69d0e65d3b6165fe7734072fd0c232840bbd4e", size = 300702, upload-time = "2026-07-06T10:45:45.135Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c0/2281a8ab5f2a62dbf57a23c58a01ccc1d98abf40f71193c8a81f59e759b5/xxhash-3.8.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3557bec8fcb11738a8920eeb68974bc76b75262f6947998d3147954ce0a4b893", size = 443351, upload-time = "2026-07-06T10:45:47.188Z" },
+    { url = "https://files.pythonhosted.org/packages/81/2e/071a58c1a53a52d4f7a3aa0987be0c396dffd40da8204805fe1b130a81f4/xxhash-3.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00de40f3b42240db23a82a5c682b55d7263d84a26a953240c1aee463409660e3", size = 217396, upload-time = "2026-07-06T10:45:48.925Z" },
+    { url = "https://files.pythonhosted.org/packages/68/44/36ab58134badd9d3433fc7b53c4ca8d113d8e807782885628640f8297a4d/xxhash-3.8.1-cp313-cp313-win32.whl", hash = "sha256:b5196cc2574cfec572a5f3fb7cfa5ade27305ae3d06516a082132441aff4c83a", size = 31974, upload-time = "2026-07-06T10:45:50.591Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2a/2a0b84798448e766f7b89ceed073cb0cb5a43fc9ebbacbdea74a38de18e3/xxhash-3.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:538f5f865df6cd8c32dd63158a0e5b4f5dd08d732a7da8b7228a5a0776c8ce55", size = 32739, upload-time = "2026-07-06T10:45:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/60/bb51dbf7c363ff88a7cbd50b7959718219577ef44d7cf255929ffc4a2194/xxhash-3.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:a6617f30641ba0d8baa1635fbefb1dffc5165ec36d26921bd5cee13497cd937a", size = 29239, upload-time = "2026-07-06T10:45:53.714Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d3/827ca123c2ee5443a6aaed3c5dd199237dc2f010e2bebd7ec09ef36f3a5f/xxhash-3.8.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:bfcd82852c62a60e314670a9602de354c4460f8adad916e2e42a20860c7870bc", size = 34964, upload-time = "2026-07-06T10:45:55.535Z" },
+    { url = "https://files.pythonhosted.org/packages/05/67/67ae2a3ccdeb8b8ef025d35aee9edd1d26c3abe5051d47da9286232afbf8/xxhash-3.8.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:08ea2081f5e88615fec8622a9f87fbe21b8ea58d88cfc02163ca11026ee62a92", size = 32697, upload-time = "2026-07-06T10:45:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/38/5a/3d3994346e1f45493679cb5c1ffc2bf454e410e9d1e8a662d253becee91e/xxhash-3.8.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2e32855b6f9e5b18f449e59d45e3d5778bdeb660632ef2693cca267a11246c75", size = 225954, upload-time = "2026-07-06T10:45:58.897Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2c/53169270309b7cd8e05504e07fe123bac053b89d00ac63617faacf0a2ec0/xxhash-3.8.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6e088bd7870775624256a0d84c2a6714afd223b2eeb56b0ca58398e52a32fda", size = 249776, upload-time = "2026-07-06T10:46:00.977Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/5c551d8d592f944506f7c5185e210255c15e672a3c6008c156a1bd9b775e/xxhash-3.8.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:72eb5ae575cc7ae2b23f6f8064a8b10f638c7149819ae9cc6d20ebd4d37a1629", size = 274776, upload-time = "2026-07-06T10:46:02.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/d3a762270cee2d7bcd0e25e28c623e5f3f5c0dc637b66e3e47dd5b0bb3f0/xxhash-3.8.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d0b48cdf690a64cedf7258c3dc9506cc41fc86edd7739c40e3098952265dc068", size = 252056, upload-time = "2026-07-06T10:46:04.688Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/b78e4373b2cb6d1c42af60ea2d7e9146ad0710b239ac7f706d5d31d5bb98/xxhash-3.8.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb9e256a357dfcede7818c6d34e70db2d6b664394803d1de4b6984d2de76c0f1", size = 482108, upload-time = "2026-07-06T10:46:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0d/642d923336ea61a15f8ce64fc7e078729e6e06c3a026e517fa79b2c23b7a/xxhash-3.8.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51f71a6e2ad071e70c937e41fcb6c19f82c3f9f49831eba850ed4a106ffbb647", size = 226739, upload-time = "2026-07-06T10:46:08.598Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0a/a37d6da6427d45a8d23e3ee3a0ca9c9d4a90364849c6637fe2963a755f9b/xxhash-3.8.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4a6443968c4e8dc69967e12776776a5952c119cc1bd94168ad1c5ad667c2be1", size = 319658, upload-time = "2026-07-06T10:46:10.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/51/ebbd40da8a3f1bc53b4b7a9a87f8e28bd95c5f21bc14b8a57860cf367d1b/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:714503083a1f2065c9ad15340dd49ac8a8e948a505a705ffa1750cb951519113", size = 246059, upload-time = "2026-07-06T10:46:12.634Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4c/d9014030147e1f0bb26e7da47aa240dd9ec61c763c573e558111d869f8e1/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:77f74e45a1e5574bbbf80181c8027b3a4c65c2248fffbd557bd596fff13102f9", size = 275535, upload-time = "2026-07-06T10:46:14.614Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/caee2db41fadcd5a25aa4323213f9afec5a8586d4e419241e3d659362bd7/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:4e0e1b0fb0259c1b75d1251ac0bb4d7ab675d36f7a6bf4ba6aa630dae94f9ffa", size = 231292, upload-time = "2026-07-06T10:46:16.452Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/60/f52f08bcdc904c4514ea5c25caa19e9f3214144434a6ff96dc82dc1cbddd/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:10e4393ec33633c2f05ad01869e546ad080b1a18f2650503731f153774608b31", size = 250490, upload-time = "2026-07-06T10:46:18.318Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a0/94dc7ae310838f250669c6ad7168e6d6fca17d49dac1053f06dc232c4a56/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b3ba794c3d885803db6c3116686923f1ec13bc86e621e169a375282b63ea1cc6", size = 309861, upload-time = "2026-07-06T10:46:20.503Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f9/adeead7d0eb28cdfc2832544ea639ffbc6749ccde47a8e228d667459182e/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:57189a69c0891e4818853feaa521c972d22c880a001453addea015f48e3c3398", size = 448739, upload-time = "2026-07-06T10:46:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a4/22ec0e07db57d901c9298ae98aa3cf2be45bafded6f07c13131e85b89032/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d59e71153fe9ff85648d00e18649b07e9b22c797291abb7e27274fa06df8b838", size = 223657, upload-time = "2026-07-06T10:46:24.831Z" },
+    { url = "https://files.pythonhosted.org/packages/94/32/8a9531f37b59e5a013003db7cb7414baf4ce7e0e1268e0d5947cd3d6a2df/xxhash-3.8.1-cp313-cp313t-win32.whl", hash = "sha256:5b96f0024e9840f449bd91b2d005c921a4b666055a0d1b6492463799f32aae22", size = 32377, upload-time = "2026-07-06T10:46:26.86Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/2ca45fd7f671de5f81fc297ef1c95080b40c86ec6be0cc6034b8f7707ac8/xxhash-3.8.1-cp313-cp313t-win_amd64.whl", hash = "sha256:37d5a56c36dcc0b9a87b814cd992598d33863ff683749de6c86081f278d5e629", size = 33274, upload-time = "2026-07-06T10:46:28.39Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/54/20d7163463ddb6438b73a427d1655a77a502cf9b9b0c3ada3599629d9c0a/xxhash-3.8.1-cp313-cp313t-win_arm64.whl", hash = "sha256:6696c8752aded28ff3b16f33ef28ce28fb5d209b80c206746f943199fcf5fd65", size = 29375, upload-time = "2026-07-06T10:46:29.962Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+]

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/SKILL.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/SKILL.md
@@ -1,0 +1,556 @@
+---
+name: langchain-framework
+description: "Guidance for building LLM-powered agents with LangChain, LangGraph, or Deep Agents. Use when building agents with any of these frameworks, implementing tool-calling agents, stateful graph workflows, or multi-step orchestration. Read this skill before writing any LangChain/LangGraph agent code."
+compatibility: Python ≥ 3.10, uv for install, API keys in .env. langchain >= 1.0,<2.0; langgraph >= 1.0,<2.0; langsmith >= 0.3.0; deepagents latest.
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Building Agents with LangChain / LangGraph
+
+> NVIDIA-authored guidance summarizing the public LangChain, LangGraph, and Deep Agents
+> documentation (<https://docs.langchain.com>), which is published by LangChain, Inc. under the
+> MIT license. API names and short usage examples are drawn from those docs; the framework
+> selection guidance, comparisons, and structure are original.
+
+LangChain, LangGraph, and Deep Agents are **layered** frameworks — each builds on the one below:
+
+```
+┌─────────────────────────────────────────┐
+│              Deep Agents                │  ← batteries included: planning, memory, files
+├─────────────────────────────────────────┤
+│               LangGraph                 │  ← orchestration: graphs, loops, state
+├─────────────────────────────────────────┤
+│               LangChain                 │  ← foundation: models, tools, chains
+└─────────────────────────────────────────┘
+```
+
+## Pick Your Framework
+
+| Question | Yes → | No → |
+|----------|-------|------|
+| Need sub-task planning, file management, persistent memory, or on-demand skills? | **Deep Agents** | ↓ |
+| Need loops, branching, human-in-the-loop, or custom state? | **LangGraph** | ↓ |
+| Single-purpose agent with fixed tools? (+ middleware for HITL, retry, PII, etc.) | **LangChain** (`create_agent`) | ↓ |
+| Pure model call or chain with no agent loop? | **LangChain** (LCEL) | — |
+
+## Installation
+
+```bash
+uv add langchain langchain-core langsmith
+
+# Orchestration — only add if you use langgraph.* imports directly or Deep Agents:
+uv add langgraph          # StateGraph, checkpointers, etc.
+uv add deepagents         # Deep Agents (includes LangGraph)
+
+# Model provider — pick yours:
+uv add langchain-anthropic   # Claude (direct) — installed in this environment
+uv add langchain-openai      # GPT or any OpenAI-compatible endpoint — NOT pre-installed; add explicitly
+```
+
+> **Note:** `langchain-openai` is **not installed by default** in this environment. Code examples below that use `ChatOpenAI` require `uv add langchain-openai` first. All code examples work with `langchain-anthropic` out of the box.
+
+Set your API key in `.env`:
+```bash
+ANTHROPIC_API_KEY=<your-key>   # if using langchain-anthropic directly
+# or, for any OpenAI-compatible endpoint (e.g. a custom inference server):
+OPENAI_API_KEY=<your-key>
+LANGSMITH_API_KEY=<your-key>   # optional, for tracing
+```
+
+## Hello World
+
+### LangChain — LCEL chain (pure model call, no agent loop)
+
+```python
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser
+from pydantic import BaseModel
+import os
+
+# Option A: Anthropic directly (langchain-anthropic installed by default)
+from langchain_anthropic import ChatAnthropic
+model = ChatAnthropic(model="claude-sonnet-4-5")
+
+# Option B: OpenAI-compatible endpoint — requires: uv add langchain-openai
+from langchain_openai import ChatOpenAI
+model = ChatOpenAI(
+    model="<model-name>",
+    base_url="<your-endpoint-url>",
+    api_key=os.environ["YOUR_API_KEY"],
+)
+
+# Option 1: plain text output
+chain = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant."),
+    ("human", "{input}"),
+]) | model | StrOutputParser()
+
+print(chain.invoke({"input": "Say hello"}))
+
+# Option 2: structured output
+class Reply(BaseModel):
+    message: str
+
+structured_chain = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant."),
+    ("human", "{input}"),
+]) | model.with_structured_output(Reply)
+
+print(structured_chain.invoke({"input": "Say hello"}))
+```
+
+### LangChain — `create_agent` (single-purpose agent with fixed tools)
+
+```python
+from langchain.agents import create_agent
+from langchain_core.tools import tool
+from datetime import date
+
+@tool
+def get_current_date() -> str:
+    """Get today's date."""
+    return date.today().isoformat()
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-5",   # or a model instance (see above)
+    tools=[get_current_date],
+    system_prompt="You are a helpful assistant.",
+)
+
+result = agent.invoke({"messages": [{"role": "user", "content": "What is today's date?"}]})
+print(result["messages"][-1].content)
+```
+
+**Middleware** — `create_agent` supports a `middleware` list for cross-cutting concerns:
+
+| Middleware | Purpose |
+|---|---|
+| `HumanInTheLoopMiddleware` | Pause for human approval before tool calls |
+| `TodoListMiddleware` | Track sub-tasks with a built-in todo list |
+| `ModelRetryMiddleware` | Retry on model errors |
+| `ToolRetryMiddleware` | Retry on tool call errors |
+| `ModelCallLimitMiddleware` | Cap total LLM calls per run |
+| `SummarizationMiddleware` | Auto-compress context when it grows too long |
+| `PIIMiddleware` | Strip PII from model inputs/outputs |
+
+```python
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware, TodoListMiddleware
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[...],
+    middleware=[HumanInTheLoopMiddleware(), TodoListMiddleware()],
+)
+```
+
+**Per-invocation typed config (`context_schema`)** — pass typed context (user IDs, flags) to nodes without global state:
+
+```python
+from langchain.agents import create_agent
+from pydantic import BaseModel
+
+class UserContext(BaseModel):
+    user_id: str
+    locale: str = "en"
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[...],
+    context_schema=UserContext,
+)
+
+result = agent.invoke(
+    {"messages": [...]},
+    config={"configurable": {"context": UserContext(user_id="u123")}}
+)
+```
+
+See `references/langchain-middleware.md` for full middleware reference.
+
+### LangGraph — `StateGraph` (custom state, loops, branching)
+
+```python
+from langgraph.graph import StateGraph, START, END
+from langchain_core.tools import tool
+from typing import Annotated
+from typing_extensions import TypedDict
+from langgraph.graph.message import add_messages
+from datetime import date
+import os
+
+# Requires: uv add langchain-openai  (or swap for ChatAnthropic)
+from langchain_openai import ChatOpenAI
+model = ChatOpenAI(
+    model="<model-name>",
+    base_url="<your-endpoint-url>",
+    api_key=os.environ["YOUR_API_KEY"],
+)
+
+@tool
+def get_current_date() -> str:
+    """Get today's date."""
+    return date.today().isoformat()
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+model_with_tools = model.bind_tools([get_current_date])
+
+def call_model(state: State) -> State:
+    return {"messages": [model_with_tools.invoke(state["messages"])]}
+
+graph = StateGraph(State)
+graph.add_node("agent", call_model)
+graph.add_edge(START, "agent")
+graph.add_edge("agent", END)
+agent = graph.compile()
+
+result = agent.invoke({"messages": [{"role": "user", "content": "What is today's date?"}]})
+print(result["messages"][-1].content)
+```
+
+### Deep Agents — `create_deep_agent` (planning, files, memory, subagents)
+
+```python
+from deepagents import create_deep_agent
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import MemorySaver
+from datetime import date
+
+@tool
+def get_current_date() -> str:
+    """Get today's date."""
+    return date.today().isoformat()
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[get_current_date],
+    system_prompt="You are a helpful assistant.",
+    checkpointer=MemorySaver(),  # required for deep agents
+)
+
+# thread_id is always required for deep agents
+config = {"configurable": {"thread_id": "session-1"}}
+result = agent.invoke({"messages": [{"role": "user", "content": "What is today's date?"}]}, config=config)
+print(result["messages"][-1].content)
+```
+
+## Core Concepts
+
+### Tools
+
+Tools are Python functions decorated with `@tool`. The docstring is the LLM's description of when and how to call the tool. Pass tools to `create_agent`, `create_deep_agent`, or bind them to a LangGraph model with `bind_tools`.
+
+```python
+from langchain_core.tools import tool
+
+@tool
+def search_files(pattern: str) -> list[str]:
+    """Search for files matching the given glob pattern."""
+    import glob
+    return glob.glob(pattern, recursive=True)
+
+agent = create_agent(model="anthropic:claude-sonnet-4-5", tools=[search_files])
+```
+
+For stateful or resource-sharing tools, use class-based tools or `StructuredTool` for complex input schemas.
+
+---
+
+### System Prompt
+
+Pass `system_prompt=` to `create_agent` or `create_deep_agent` to set the agent's role and constraints:
+
+```python
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[...],
+    system_prompt="You are a precise code reviewer. Always cite line numbers.",
+)
+```
+
+For LCEL chains, set the system message in `ChatPromptTemplate`:
+
+```python
+chain = ChatPromptTemplate.from_messages([
+    ("system", "You are a precise code reviewer. Always cite line numbers."),
+    ("human", "{input}"),
+]) | model | StrOutputParser()
+```
+
+For LangGraph, inject a `SystemMessage` at the start of the state or inside a node.
+
+---
+
+### Agent Types
+
+Choose based on workflow complexity:
+
+| Question | Answer |
+|---|---|
+| Need planning, memory, file management, or on-demand skills? | `create_deep_agent` |
+| Need custom state, loops, branching, or human-in-the-loop? | `StateGraph` (LangGraph) |
+| Single-purpose agent with fixed tools? | `create_agent` |
+| Pure model call or chain? | LCEL (`ChatPromptTemplate | model | parser`) |
+
+```python
+# create_agent — fixed tools, middleware support
+agent = create_agent(model="anthropic:claude-sonnet-4-5", tools=[...])
+
+# StateGraph — custom state and control flow
+graph = StateGraph(State)
+graph.add_node("agent", call_model)
+agent = graph.compile()
+
+# create_deep_agent — planning, memory, subagents, skills
+agent = create_deep_agent(model="...", tools=[...], checkpointer=MemorySaver())
+```
+
+---
+
+### Structured Output
+
+When a method needs to return a specific format, use `.with_structured_output()` rather than describing the format in the system prompt. Structured output is enforced by the model API — it is more reliable than prompt instructions and gives downstream code a typed, predictable value.
+
+```python
+from pydantic import BaseModel
+
+class Analysis(BaseModel):
+    sentiment: str
+    confidence: float
+    topics: list[str]
+
+structured_chain = ChatPromptTemplate.from_messages([
+    ("system", "Analyze the text."),
+    ("human", "{input}"),
+]) | model.with_structured_output(Analysis)
+
+result = structured_chain.invoke({"input": "Great product!"})
+print(result.sentiment)  # validated Analysis instance
+```
+
+Bind the schema in `__init__` so every call on that model instance returns the typed output:
+
+```python
+class MyAgent:
+    def __init__(self):
+        self.llm = ChatNVIDIA(model="meta/llama-3.1-70b-instruct").with_structured_output(MySchema)
+```
+
+---
+
+### Dynamic Prompts
+
+Use template variables in `ChatPromptTemplate` to inject runtime values:
+
+```python
+chain = ChatPromptTemplate.from_messages([
+    ("system", "You are a {role}. Focus on {domain}."),
+    ("human", "{input}"),
+]) | model | StrOutputParser()
+
+result = chain.invoke({"role": "code reviewer", "domain": "security", "input": "..."})
+```
+
+For `create_agent`, pass per-invocation typed config via `context_schema`:
+
+```python
+class RunContext(BaseModel):
+    language: str = "Python"
+    strict_mode: bool = False
+
+agent = create_agent(model="...", tools=[...], context_schema=RunContext)
+result = agent.invoke({...}, config={"configurable": {"context": RunContext(language="Go")}})
+```
+
+---
+
+### Skills
+
+Deep Agents supports skills — callable modules the agent can invoke on demand:
+
+```python
+from deepagents import create_deep_agent, Skill
+
+def read_policy() -> str:
+    return Path("policies/patch.md").read_text()
+
+my_skill = Skill(name="patch-policy", description="Rules for writing correct patches.", fn=read_policy)
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[...],
+    skills=[my_skill],
+    checkpointer=MemorySaver(),
+)
+```
+
+For `create_agent` or plain LangGraph, encode reusable knowledge as additional tools or inject it into the system prompt.
+
+See `references/deep-agents-core.md` for the full skills API.
+
+---
+
+## Advanced Features
+
+### Subagents
+
+Expose a compiled agent as a `@tool` so the parent can delegate to it:
+
+```python
+from langchain_core.tools import tool
+
+child_agent = create_agent(model="anthropic:claude-sonnet-4-5", tools=[...], system_prompt="...")
+
+@tool
+def delegate_to_child(request: str) -> str:
+    """Delegate a focused sub-task to the specialized child agent."""
+    result = child_agent.invoke({"messages": [{"role": "user", "content": request}]})
+    return result["messages"][-1].content
+
+parent_agent = create_agent(model="...", tools=[..., delegate_to_child])
+```
+
+For Deep Agents, see `references/deep-agents-orchestration.md` for the native subagent API.
+
+---
+
+### LLM Configuration
+
+Use a model string shorthand or an explicit instance:
+
+```python
+# String shorthand
+agent = create_agent(model="anthropic:claude-opus-4-7", tools=[...])
+
+# Explicit instance — for custom endpoints
+from langchain_openai import ChatOpenAI
+model = ChatOpenAI(model="...", base_url="...", api_key=os.environ["KEY"])
+agent = create_agent(model=model, tools=[...])
+```
+
+In LangGraph, each node can hold its own model instance for per-step model selection:
+
+```python
+fast_model = ChatOpenAI(model="gpt-5-mini", ...)
+strong_model = ChatOpenAI(model="gpt-5", ...)
+
+def quick_filter(state): return {"messages": [fast_model.invoke(state["messages"])]}
+def deep_patch(state):   return {"messages": [strong_model.invoke(state["messages"])]}
+```
+
+---
+
+### Middleware and Config
+
+Add cross-cutting behavior via the `middleware` list:
+
+```python
+from langchain.agents.middleware import ModelRetryMiddleware, SummarizationMiddleware
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[...],
+    middleware=[ModelRetryMiddleware(max_retries=3), SummarizationMiddleware()],
+)
+```
+
+Available middleware: `HumanInTheLoopMiddleware`, `TodoListMiddleware`, `ModelRetryMiddleware`, `ToolRetryMiddleware`, `ModelCallLimitMiddleware`, `SummarizationMiddleware`, `PIIMiddleware`.
+
+Control LangGraph iteration depth with `recursion_limit`:
+
+```python
+agent = graph.compile(recursion_limit=50)
+```
+
+---
+
+### Persistence
+
+LangGraph checkpointers persist agent state across invocations. Pass `thread_id` to resume a session:
+
+```python
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+checkpointer = MemorySaver()                                    # in-memory, lost on restart
+checkpointer = SqliteSaver.from_conn_string("agent_state.db")  # survives restarts
+
+agent = graph.compile(checkpointer=checkpointer)
+
+config = {"configurable": {"thread_id": "session-1"}}
+result = agent.invoke({"messages": [...]}, config=config)
+```
+
+See `references/langgraph-persistence.md` for time-travel and Store APIs.
+
+---
+
+### MCP Integration
+
+Use MCP (Model Context Protocol) servers as tool sources via `langchain-mcp-adapters`:
+
+```bash
+uv add langchain-mcp-adapters
+```
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+async with MultiServerMCPClient({
+    "my-server": {
+        "url": "https://my-mcp-server.example.com/mcp",
+        "transport": "streamable_http",
+    }
+}) as client:
+    tools = await client.get_tools()
+    agent = create_agent(model="anthropic:claude-sonnet-4-5", tools=tools)
+    result = await agent.ainvoke({"messages": [{"role": "user", "content": "..."}]})
+```
+
+For Managed Deep Agents hosted in LangSmith, MCP servers are registered and credential-managed by the platform. See `references/managed-deep-agents.md` for the hosted path.
+
+---
+
+### Tracing
+
+Wire tracing via OpenInference + OpenTelemetry:
+
+```python
+from openinference.instrumentation.langchain import LangChainInstrumentor
+LangChainInstrumentor().instrument()
+```
+
+For LangSmith, set environment variables before running:
+
+```bash
+LANGSMITH_API_KEY=<your-key>
+LANGCHAIN_TRACING_V2=true
+```
+
+See `references/openinference-tracing.md` for file-based JSONL tracing.
+
+---
+
+## Reference Docs
+
+Load the relevant reference when you need detailed guidance:
+
+| Reference | When to load |
+|-----------|-------------|
+| [references/ecosystem-primer.md](references/ecosystem-primer.md) | Framework selection, env setup, docs navigation |
+| [references/langchain-dependencies.md](references/langchain-dependencies.md) | Package versions, installation, environment setup |
+| [references/langchain-fundamentals.md](references/langchain-fundamentals.md) | `create_agent()`, tool definition, structured output |
+| [references/langchain-middleware.md](references/langchain-middleware.md) | Human-in-the-loop, approval workflows |
+| [references/langchain-rag.md](references/langchain-rag.md) | RAG pipelines, vector stores, document loaders |
+| [references/langgraph-fundamentals.md](references/langgraph-fundamentals.md) | StateGraph, nodes, edges, Send, Command |
+| [references/langgraph-persistence.md](references/langgraph-persistence.md) | Checkpointers, thread_id, time travel, Store |
+| [references/langgraph-human-in-the-loop.md](references/langgraph-human-in-the-loop.md) | `interrupt()`, `Command(resume=...)`, idempotency |
+| [references/langgraph-cli.md](references/langgraph-cli.md) | langgraph CLI: dev, build, deploy, langgraph.json config |
+| [references/deep-agents-core.md](references/deep-agents-core.md) | `create_deep_agent()`, built-in middleware, skills |
+| [references/deep-agents-memory.md](references/deep-agents-memory.md) | State/Store/Filesystem/CompositeBackend |
+| [references/deep-agents-orchestration.md](references/deep-agents-orchestration.md) | Subagents, TodoList, HITL |
+| [references/managed-deep-agents.md](references/managed-deep-agents.md) | LangSmith hosted Deep Agents, deepagents-cli, useStream |
+| [references/openinference-tracing.md](references/openinference-tracing.md) | Wiring file-based tracing via OpenInference + OpenTelemetry SDK |

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/deep-agents-core.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/deep-agents-core.md
@@ -1,0 +1,445 @@
+---
+name: deep-agents-core
+description: "INVOKE THIS SKILL when building ANY Deep Agents application. Covers create_deep_agent(), harness architecture, SKILL.md format, and configuration options."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+Deep Agents are an opinionated agent framework built on LangChain/LangGraph with built-in middleware:
+
+- **Task Planning**: TodoListMiddleware for breaking down complex tasks
+- **Context Management**: Filesystem tools with pluggable backends
+- **Task Delegation**: SubAgent middleware for spawning specialized agents
+- **Long-term Memory**: Persistent storage across threads via Store
+- **Human-in-the-loop**: Approval workflows for sensitive operations
+- **Skills**: On-demand loading of specialized capabilities
+
+The agent harness provides these capabilities automatically - you configure, not implement.
+</overview>
+
+<when-to-use>
+
+| Use Deep Agents When | Use LangChain's create_agent When |
+|---------------------|-----------------------------------|
+| Multi-step tasks requiring planning | Simple, single-purpose tasks |
+| Large context requiring file management | Context fits in a single prompt |
+| Need for specialized subagents | Single agent is sufficient |
+| Persistent memory across sessions | Ephemeral, single-session work |
+
+</when-to-use>
+
+<middleware-selection>
+
+| If you need to... | Middleware | Notes |
+|------------------|------------|-------|
+| Track complex tasks | TodoListMiddleware | Default enabled |
+| Manage file context | FilesystemMiddleware | Configure backend |
+| Delegate work | SubAgentMiddleware | Add custom subagents |
+| Add human approval | HumanInTheLoopMiddleware | Requires checkpointer |
+| Load skills | SkillsMiddleware | Provide skill directories |
+| Access memory | MemoryMiddleware | Requires Store instance |
+
+</middleware-selection>
+
+<ex-basic-agent>
+<python>
+Create a basic deep agent with a custom tool and invoke it with a user message.
+
+```python
+from deepagents import create_deep_agent
+from langchain_core.tools import tool
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the weather for a given city."""
+    return f"It is always sunny in {city}"
+
+agent = create_deep_agent(
+    model="claude-sonnet-4-5",
+    tools=[get_weather],
+    system_prompt="You are a helpful assistant"
+)
+
+config = {"configurable": {"thread_id": "user-123"}}
+result = agent.invoke({
+    "messages": [{"role": "user", "content": "What's the weather in Tokyo?"}]
+}, config=config)
+```
+</python>
+<typescript>
+Create a basic deep agent with a custom tool and invoke it with a user message.
+
+```typescript
+import { createDeepAgent } from "deepagents";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const getWeather = tool(
+  async ({ city }) => `It is always sunny in ${city}`,
+  { name: "get_weather", description: "Get weather for a city", schema: z.object({ city: z.string() }) }
+);
+
+const agent = await createDeepAgent({
+  model: "claude-sonnet-4-5",
+  tools: [getWeather],
+  systemPrompt: "You are a helpful assistant"
+});
+
+const config = { configurable: { thread_id: "user-123" } };
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "What's the weather in Tokyo?" }]
+}, config);
+```
+</typescript>
+</ex-basic-agent>
+
+<ex-full-configuration>
+<python>
+Configure a deep agent with all available options including subagents, skills, and persistence.
+
+```python
+from deepagents import create_deep_agent
+from deepagents.backends import FilesystemBackend
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.store.memory import InMemoryStore
+
+agent = create_deep_agent(
+    name="my-assistant",
+    model="claude-sonnet-4-5",
+    tools=[custom_tool1, custom_tool2],
+    system_prompt="Custom instructions",
+    subagents=[research_agent, code_agent],
+    backend=FilesystemBackend(root_dir=".", virtual_mode=True),
+    interrupt_on={"write_file": True},
+    skills=["./skills/"],
+    checkpointer=MemorySaver(),
+    store=InMemoryStore()
+)
+```
+</python>
+<typescript>
+Configure a deep agent with all available options including subagents, skills, and persistence.
+
+```typescript
+import { createDeepAgent, FilesystemBackend } from "deepagents";
+import { MemorySaver, InMemoryStore } from "@langchain/langgraph";
+
+const agent = await createDeepAgent({
+  name: "my-assistant",
+  model: "claude-sonnet-4-5",
+  tools: [customTool1, customTool2],
+  systemPrompt: "Custom instructions",
+  subagents: [researchAgent, codeAgent],
+  backend: new FilesystemBackend({ rootDir: ".", virtualMode: true }),
+  interruptOn: { write_file: true },
+  skills: ["./skills/"],
+  checkpointer: new MemorySaver(),
+  store: new InMemoryStore()
+});
+```
+</typescript>
+</ex-full-configuration>
+
+<built-in-tools>
+Every deep agent has access to:
+
+1. **Planning**: `write_todos` - Track multi-step tasks
+2. **Filesystem**: `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+3. **Delegation**: `task` - Spawn specialized subagents
+</built-in-tools>
+
+---
+
+## SKILL.md Format
+
+<skill-md-format>
+Skills use **progressive disclosure** - agents only load content when relevant.
+
+### Directory Structure
+
+```
+skills/
+└── my-skill/
+    ├── SKILL.md        # Required: main skill file
+    ├── examples.py     # Optional: supporting files
+    └── templates/      # Optional: templates
+```
+
+### SKILL.md Format
+
+```markdown
+---
+name: my-skill
+description: Clear, specific description of what this skill does
+---
+
+# Skill Name
+
+## Overview
+Brief explanation of the skill's purpose.
+
+## When to Use
+Conditions when this skill applies.
+
+## Instructions
+Step-by-step guidance for the agent.
+```
+</skill-md-format>
+
+<skills-vs-memory>
+
+| Skills | Memory (AGENTS.md) |
+|--------|-------------------|
+| On-demand loading | Always loaded at startup |
+| Task-specific instructions | General preferences |
+| Large documentation | Compact context |
+| SKILL.md in directories | Single AGENTS.md file |
+
+</skills-vs-memory>
+
+<ex-skills-with-filesystem-backend>
+<python>
+Set up an agent with skills directory and filesystem backend for on-demand skill loading.
+
+```python
+from deepagents import create_deep_agent
+from deepagents.backends import FilesystemBackend
+from langgraph.checkpoint.memory import MemorySaver
+
+agent = create_deep_agent(
+    backend=FilesystemBackend(root_dir=".", virtual_mode=True),
+    skills=["./skills/"],
+    checkpointer=MemorySaver()
+)
+
+result = agent.invoke({
+    "messages": [{"role": "user", "content": "Use the python-testing skill"}]
+}, config={"configurable": {"thread_id": "session-1"}})
+```
+</python>
+<typescript>
+Set up an agent with skills directory and filesystem backend for on-demand skill loading.
+
+```typescript
+import { createDeepAgent, FilesystemBackend } from "deepagents";
+import { MemorySaver } from "@langchain/langgraph";
+
+const agent = await createDeepAgent({
+  backend: new FilesystemBackend({ rootDir: ".", virtualMode: true }),
+  skills: ["./skills/"],
+  checkpointer: new MemorySaver()
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Use the python-testing skill" }]
+}, { configurable: { thread_id: "session-1" } });
+```
+</typescript>
+</ex-skills-with-filesystem-backend>
+
+<ex-skills-with-store-backend>
+<python>
+Load skill content into a Store backend for environments without filesystem access.
+
+```python
+from deepagents import create_deep_agent
+from deepagents.backends import StoreBackend
+from deepagents.backends.utils import create_file_data
+from langgraph.store.memory import InMemoryStore
+
+store = InMemoryStore()
+
+# Load skill content into store
+skill_content = """---
+name: python-testing
+description: Best practices for Python testing with pytest
+---
+# Python Testing Skill
+..."""
+
+store.put(
+    namespace=("filesystem",),
+    key="/skills/python-testing/SKILL.md",
+    value=create_file_data(skill_content)
+)
+
+agent = create_deep_agent(
+    backend=lambda rt: StoreBackend(rt),
+    store=store,
+    skills=["/skills/"]
+)
+```
+</python>
+</ex-skills-with-store-backend>
+
+<boundaries>
+
+### What Agents CAN Configure
+
+- Model selection and parameters
+- Additional custom tools
+- System prompt customization
+- Backend storage strategy
+- Which tools require approval
+- Custom subagents with specialized tools
+
+### What Agents CANNOT Configure
+
+- Core middleware removal (TodoList, Filesystem, SubAgent always present)
+- The write_todos, task, or filesystem tool names
+- The SKILL.md frontmatter format
+</boundaries>
+
+<fix-checkpointer-for-interrupts>
+<python>
+Interrupts require a checkpointer.
+
+```python
+# WRONG
+agent = create_deep_agent(interrupt_on={"write_file": True})
+
+# CORRECT
+agent = create_deep_agent(interrupt_on={"write_file": True}, checkpointer=MemorySaver())
+```
+</python>
+<typescript>
+Interrupts require a checkpointer.
+
+```typescript
+// WRONG
+const agent = await createDeepAgent({ interruptOn: { write_file: true } });
+
+// CORRECT
+const agent = await createDeepAgent({ interruptOn: { write_file: true }, checkpointer: new MemorySaver() });
+```
+</typescript>
+</fix-checkpointer-for-interrupts>
+
+<fix-store-for-memory>
+<python>
+StoreBackend requires a Store instance for persistent memory across threads.
+
+```python
+# WRONG
+agent = create_deep_agent(backend=lambda rt: StoreBackend(rt))
+
+# CORRECT
+agent = create_deep_agent(backend=lambda rt: StoreBackend(rt), store=InMemoryStore())
+```
+</python>
+<typescript>
+StoreBackend requires a Store instance for persistent memory across threads.
+
+```typescript
+// WRONG
+const agent = await createDeepAgent({ backend: (config) => new StoreBackend(config) });
+
+// CORRECT
+const agent = await createDeepAgent({ backend: (config) => new StoreBackend(config), store: new InMemoryStore() });
+```
+</typescript>
+</fix-store-for-memory>
+
+<fix-thread-id-for-conversations>
+<python>
+Use consistent thread_id to maintain conversation context across invocations.
+
+```python
+# WRONG: Each invocation is isolated
+agent.invoke({"messages": [{"role": "user", "content": "Hi"}]})
+agent.invoke({"messages": [{"role": "user", "content": "What did I say?"}]})
+
+# CORRECT
+config = {"configurable": {"thread_id": "user-123"}}
+agent.invoke({"messages": [...]}, config=config)
+agent.invoke({"messages": [...]}, config=config)
+```
+</python>
+<typescript>
+Use consistent thread_id to maintain conversation context across invocations.
+
+```typescript
+// WRONG: Each invocation is isolated
+await agent.invoke({ messages: [{ role: "user", content: "Hi" }] });
+await agent.invoke({ messages: [{ role: "user", content: "What did I say?" }] });
+
+// CORRECT
+const config = { configurable: { thread_id: "user-123" } };
+await agent.invoke({ messages: [...] }, config);
+await agent.invoke({ messages: [...] }, config);
+```
+</typescript>
+</fix-thread-id-for-conversations>
+
+<fix-frontmatter-required>
+
+```markdown
+# WRONG: Missing frontmatter in SKILL.md
+# My Skill
+This is my skill...
+
+# CORRECT: Include YAML frontmatter
+---
+name: my-skill
+description: Python testing best practices with pytest fixtures and mocking
+---
+# My Skill
+This is my skill...
+```
+</fix-frontmatter-required>
+
+<fix-backend-for-skills>
+<python>
+Skills require a proper backend to load from the filesystem.
+
+```python
+# WRONG: Skills won't load without proper backend
+agent = create_deep_agent(skills=["./skills/"])
+
+# CORRECT: Use FilesystemBackend for local skills
+agent = create_deep_agent(
+    backend=FilesystemBackend(root_dir=".", virtual_mode=True),
+    skills=["./skills/"]
+)
+```
+</python>
+</fix-backend-for-skills>
+
+<fix-specific-skill-descriptions>
+Use specific descriptions to help agents decide when to use a skill.
+
+```markdown
+# WRONG: Vague description
+---
+name: helper
+description: Helpful skill
+---
+
+# CORRECT: Specific description
+---
+name: python-testing
+description: Python testing best practices with pytest fixtures, mocking, and async patterns
+---
+```
+</fix-specific-skill-descriptions>
+
+<fix-subagent-skills>
+<python>
+Skills are not inherited by subagents - provide them explicitly.
+
+```python
+# WRONG: Custom subagents don't inherit skills
+agent = create_deep_agent(
+    skills=["/main-skills/"],
+    subagents=[{"name": "helper", ...}]  # No skills
+)
+
+# CORRECT: Provide skills explicitly
+agent = create_deep_agent(
+    skills=["/main-skills/"],
+    subagents=[{"name": "helper", "skills": ["/helper-skills/"], ...}]
+)
+```
+</python>
+</fix-subagent-skills>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/deep-agents-memory.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/deep-agents-memory.md
@@ -1,0 +1,323 @@
+---
+name: deep-agents-memory
+description: "INVOKE THIS SKILL when your Deep Agent needs memory, persistence, or filesystem access. Covers StateBackend (ephemeral), StoreBackend (persistent), FilesystemMiddleware, and CompositeBackend for routing."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+Deep Agents use pluggable backends for file operations and memory:
+
+**Short-term (StateBackend)**: Persists within a single thread, lost when thread ends
+**Long-term (StoreBackend)**: Persists across threads and sessions
+**Hybrid (CompositeBackend)**: Route different paths to different backends
+
+FilesystemMiddleware provides tools: `ls`, `read_file`, `write_file`, `edit_file`, `glob`, `grep`
+</overview>
+
+<backend-selection>
+
+| Use Case | Backend | Why |
+|----------|---------|-----|
+| Temporary working files | StateBackend | Default, no setup |
+| Local development CLI | FilesystemBackend | Direct disk access |
+| Cross-session memory | StoreBackend | Persists across threads |
+| Hybrid storage | CompositeBackend | Mix ephemeral + persistent |
+
+</backend-selection>
+
+<ex-default-state-backend>
+<python>
+Default StateBackend stores files ephemerally within a thread.
+
+```python
+from deepagents import create_deep_agent
+
+agent = create_deep_agent()  # Default: StateBackend
+result = agent.invoke({
+    "messages": [{"role": "user", "content": "Write notes to /draft.txt"}]
+}, config={"configurable": {"thread_id": "thread-1"}})
+# /draft.txt is lost when thread ends
+```
+</python>
+<typescript>
+Default StateBackend stores files ephemerally within a thread.
+
+```typescript
+import { createDeepAgent } from "deepagents";
+
+const agent = await createDeepAgent();  // Default: StateBackend
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Write notes to /draft.txt" }]
+}, { configurable: { thread_id: "thread-1" } });
+// /draft.txt is lost when thread ends
+```
+</typescript>
+</ex-default-state-backend>
+
+<ex-composite-backend-for-hybrid>
+<python>
+Configure CompositeBackend to route paths to different storage backends.
+
+```python
+from deepagents import create_deep_agent
+from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+from langgraph.store.memory import InMemoryStore
+
+store = InMemoryStore()
+
+composite_backend = lambda rt: CompositeBackend(
+    default=StateBackend(rt),
+    routes={"/memories/": StoreBackend(rt)}
+)
+
+agent = create_deep_agent(backend=composite_backend, store=store)
+
+# /draft.txt -> ephemeral (StateBackend)
+# /memories/user-prefs.txt -> persistent (StoreBackend)
+```
+</python>
+<typescript>
+Configure CompositeBackend to route paths to different storage backends.
+
+```typescript
+import { createDeepAgent, CompositeBackend, StateBackend, StoreBackend } from "deepagents";
+import { InMemoryStore } from "@langchain/langgraph";
+
+const store = new InMemoryStore();
+
+const agent = await createDeepAgent({
+  backend: (config) => new CompositeBackend(
+    new StateBackend(config),
+    { "/memories/": new StoreBackend(config) }
+  ),
+  store
+});
+
+// /draft.txt -> ephemeral (StateBackend)
+// /memories/user-prefs.txt -> persistent (StoreBackend)
+```
+</typescript>
+</ex-composite-backend-for-hybrid>
+
+<ex-cross-session-memory>
+<python>
+Files in /memories/ persist across threads via StoreBackend routing.
+
+```python
+# Using CompositeBackend from previous example
+config1 = {"configurable": {"thread_id": "thread-1"}}
+agent.invoke({"messages": [{"role": "user", "content": "Save to /memories/style.txt"}]}, config=config1)
+
+config2 = {"configurable": {"thread_id": "thread-2"}}
+agent.invoke({"messages": [{"role": "user", "content": "Read /memories/style.txt"}]}, config=config2)
+# Thread 2 can read file saved by Thread 1
+```
+</python>
+<typescript>
+Files in /memories/ persist across threads via StoreBackend routing.
+
+```typescript
+// Using CompositeBackend from previous example
+const config1 = { configurable: { thread_id: "thread-1" } };
+await agent.invoke({ messages: [{ role: "user", content: "Save to /memories/style.txt" }] }, config1);
+
+const config2 = { configurable: { thread_id: "thread-2" } };
+await agent.invoke({ messages: [{ role: "user", content: "Read /memories/style.txt" }] }, config2);
+// Thread 2 can read file saved by Thread 1
+```
+</typescript>
+</ex-cross-session-memory>
+
+<ex-filesystem-backend-local-dev>
+<python>
+Use FilesystemBackend for local development with real disk access and human-in-the-loop.
+
+```python
+from deepagents import create_deep_agent
+from deepagents.backends import FilesystemBackend
+from langgraph.checkpoint.memory import MemorySaver
+
+agent = create_deep_agent(
+    backend=FilesystemBackend(root_dir=".", virtual_mode=True),  # Restrict access
+    interrupt_on={"write_file": True, "edit_file": True},
+    checkpointer=MemorySaver()
+)
+
+# Agent can read/write actual files on disk
+```
+</python>
+<typescript>
+Use FilesystemBackend for local development with real disk access and human-in-the-loop.
+
+```typescript
+import { createDeepAgent, FilesystemBackend } from "deepagents";
+import { MemorySaver } from "@langchain/langgraph";
+
+const agent = await createDeepAgent({
+  backend: new FilesystemBackend({ rootDir: ".", virtualMode: true }),
+  interruptOn: { write_file: true, edit_file: true },
+  checkpointer: new MemorySaver()
+});
+```
+</typescript>
+
+**Security: Never use FilesystemBackend in web servers - use StateBackend or sandbox instead.**
+</ex-filesystem-backend-local-dev>
+
+<ex-store-in-custom-tools>
+<python>
+Access the store directly in custom tools for long-term memory operations.
+
+```python
+from langchain_core.tools import tool
+from langchain.tools import ToolRuntime
+from langchain.agents import create_agent
+from langgraph.store.memory import InMemoryStore
+
+@tool
+def get_user_preference(key: str, runtime: ToolRuntime) -> str:
+    """Get a user preference from long-term storage."""
+    store = runtime.store
+    result = store.get(("user_prefs",), key)
+    return str(result.value) if result else "Not found"
+
+@tool
+def save_user_preference(key: str, value: str, runtime: ToolRuntime) -> str:
+    """Save a user preference to long-term storage."""
+    store = runtime.store
+    store.put(("user_prefs",), key, {"value": value})
+    return f"Saved {key}={value}"
+
+store = InMemoryStore()
+
+agent = create_agent(
+    model="gpt-4.1",
+    tools=[get_user_preference, save_user_preference],
+    store=store
+)
+```
+</python>
+</ex-store-in-custom-tools>
+
+<boundaries>
+### What Agents CAN Configure
+
+- Backend type and configuration
+- Routing rules for CompositeBackend
+- Root directory for FilesystemBackend
+- Human-in-the-loop for file operations
+
+### What Agents CANNOT Configure
+
+- Tool names (ls, read_file, write_file, edit_file, glob, grep)
+- Access files outside virtual_mode restrictions
+- Cross-thread file access without proper backend setup
+</boundaries>
+
+<fix-storebackend-requires-store>
+<python>
+StoreBackend requires a store instance.
+
+```python
+# WRONG
+agent = create_deep_agent(backend=lambda rt: StoreBackend(rt))
+
+# CORRECT
+agent = create_deep_agent(backend=lambda rt: StoreBackend(rt), store=InMemoryStore())
+```
+</python>
+<typescript>
+StoreBackend requires a store instance.
+
+```typescript
+// WRONG
+const agent = await createDeepAgent({ backend: (c) => new StoreBackend(c) });
+
+// CORRECT
+const agent = await createDeepAgent({ backend: (c) => new StoreBackend(c), store: new InMemoryStore() });
+```
+</typescript>
+</fix-storebackend-requires-store>
+
+<fix-statebackend-files-dont-persist>
+<python>
+StateBackend files are thread-scoped - use same thread_id or StoreBackend for cross-thread access.
+
+```python
+# WRONG: thread-2 can't read file from thread-1
+agent.invoke({"messages": [...]}, config={"configurable": {"thread_id": "thread-1"}})  # Write
+agent.invoke({"messages": [...]}, config={"configurable": {"thread_id": "thread-2"}})  # File not found!
+```
+</python>
+<typescript>
+StateBackend files are thread-scoped - use same thread_id or StoreBackend for cross-thread access.
+
+```typescript
+// WRONG: thread-2 can't read file from thread-1
+await agent.invoke({ messages: [...] }, { configurable: { thread_id: "thread-1" } });  // Write
+await agent.invoke({ messages: [...] }, { configurable: { thread_id: "thread-2" } });  // File not found!
+```
+</typescript>
+</fix-statebackend-files-dont-persist>
+
+<fix-path-prefix-for-persistence>
+<python>
+Path must match CompositeBackend route prefix for persistence.
+
+```python
+# With routes={"/memories/": StoreBackend(rt)}:
+agent.invoke(...)  # /prefs.txt -> ephemeral (no match)
+agent.invoke(...)  # /memories/prefs.txt -> persistent (matches route)
+```
+</python>
+<typescript>
+Path must match CompositeBackend route prefix for persistence.
+
+```typescript
+// With routes: { "/memories/": StoreBackend }:
+await agent.invoke(...);  // /prefs.txt -> ephemeral (no match)
+await agent.invoke(...);  // /memories/prefs.txt -> persistent (matches route)
+```
+</typescript>
+</fix-path-prefix-for-persistence>
+
+<fix-production-store>
+<python>
+Use PostgresStore for production (InMemoryStore lost on restart).
+
+```python
+# WRONG                              # CORRECT
+store = InMemoryStore()              store = PostgresStore(connection_string="postgresql://...")
+```
+</python>
+<typescript>
+Use PostgresStore for production (InMemoryStore lost on restart).
+
+```typescript
+// WRONG                                    // CORRECT
+const store = new InMemoryStore();          const store = new PostgresStore({ connectionString: "..." });
+```
+</typescript>
+</fix-production-store>
+
+<fix-filesystem-backend-needs-virtual-mode>
+<python>
+Enable virtual_mode=True to restrict path access (prevents ../ and ~/ escapes).
+
+```python
+backend = FilesystemBackend(root_dir="/project", virtual_mode=True)  # Secure
+```
+</python>
+</fix-filesystem-backend-needs-virtual-mode>
+
+<fix-longest-prefix-match>
+<python>
+CompositeBackend matches longest prefix first.
+
+```python
+routes = {"/mem/": StoreBackend(rt), "/mem/temp/": StateBackend(rt)}
+# /mem/file.txt -> StoreBackend, /mem/temp/file.txt -> StateBackend (longer match)
+```
+</python>
+</fix-longest-prefix-match>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/deep-agents-orchestration.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/deep-agents-orchestration.md
@@ -1,0 +1,496 @@
+---
+name: deep-agents-orchestration
+description: "INVOKE THIS SKILL when using subagents, task planning, or human approval in Deep Agents. Covers SubAgentMiddleware, TodoList for planning, and HITL interrupts."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+Deep Agents include three orchestration capabilities:
+
+1. **SubAgentMiddleware**: Delegate work via `task` tool to specialized agents
+2. **TodoListMiddleware**: Plan and track tasks via `write_todos` tool
+3. **HumanInTheLoopMiddleware**: Require approval before sensitive operations
+
+All three are automatically included in `create_deep_agent()`.
+</overview>
+
+---
+
+## Subagents (Task Delegation)
+
+<when-to-use-subagents>
+
+| Use Subagents When | Use Main Agent When |
+|-------------------|-------------------|
+| Task needs specialized tools | General-purpose tools sufficient |
+| Want to isolate complex work | Single-step operation |
+| Need clean context for main agent | Context bloat acceptable |
+
+</when-to-use-subagents>
+
+<how-subagents-work>
+Main agent has `task` tool -> creates fresh subagent -> subagent executes autonomously -> returns final report.
+
+**Default subagent**: "general-purpose" - automatically available with same tools/config as main agent.
+</how-subagents-work>
+
+<ex-custom-subagents>
+<python>
+Create a custom "researcher" subagent with specialized tools for academic paper search.
+
+```python
+from deepagents import create_deep_agent
+from langchain_core.tools import tool
+
+@tool
+def search_papers(query: str) -> str:
+    """Search academic papers."""
+    return f"Found 10 papers about {query}"
+
+agent = create_deep_agent(
+    subagents=[
+        {
+            "name": "researcher",
+            "description": "Conduct web research and compile findings",
+            "system_prompt": "Search thoroughly, return concise summary",
+            "tools": [search_papers],
+        }
+    ]
+)
+
+# Main agent delegates: task(agent="researcher", instruction="Research AI trends")
+```
+</python>
+<typescript>
+Create a custom "researcher" subagent with specialized tools for academic paper search.
+
+```typescript
+import { createDeepAgent } from "deepagents";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const searchPapers = tool(
+  async ({ query }) => `Found 10 papers about ${query}`,
+  { name: "search_papers", description: "Search papers", schema: z.object({ query: z.string() }) }
+);
+
+const agent = await createDeepAgent({
+  subagents: [
+    {
+      name: "researcher",
+      description: "Conduct web research and compile findings",
+      systemPrompt: "Search thoroughly, return concise summary",
+      tools: [searchPapers],
+    }
+  ]
+});
+
+// Main agent delegates: task(agent="researcher", instruction="Research AI trends")
+```
+</typescript>
+</ex-custom-subagents>
+
+<ex-subagent-with-hitl>
+<python>
+Configure a subagent with HITL approval for sensitive operations.
+
+```python
+from deepagents import create_deep_agent
+from langgraph.checkpoint.memory import MemorySaver
+
+agent = create_deep_agent(
+    subagents=[
+        {
+            "name": "code-deployer",
+            "description": "Deploy code to production",
+            "system_prompt": "You deploy code after tests pass.",
+            "tools": [run_tests, deploy_to_prod],
+            "interrupt_on": {"deploy_to_prod": True},  # Require approval
+        }
+    ],
+    checkpointer=MemorySaver()  # Required for interrupts
+)
+```
+</python>
+</ex-subagent-with-hitl>
+
+<fix-subagents-are-stateless>
+<python>
+Subagents are stateless - provide complete instructions in a single call.
+
+```python
+# WRONG: Subagents don't remember previous calls
+# task(agent='research', instruction='Find data')
+# task(agent='research', instruction='What did you find?')  # Starts fresh!
+
+# CORRECT: Complete instructions upfront
+# task(agent='research', instruction='Find data on AI, save to /research/, return summary')
+```
+</python>
+<typescript>
+Subagents are stateless - provide complete instructions in a single call.
+
+```typescript
+// WRONG: Subagents don't remember previous calls
+// task research: Find data
+// task research: What did you find?  // Starts fresh!
+
+// CORRECT: Complete instructions upfront
+// task research: Find data on AI, save to /research/, return summary
+```
+</typescript>
+</fix-subagents-are-stateless>
+
+<fix-custom-subagents-dont-inherit-skills>
+<python>
+Custom subagents don't inherit skills from the main agent.
+
+```python
+# WRONG: Custom subagent won't have main agent's skills
+agent = create_deep_agent(
+    skills=["/main-skills/"],
+    subagents=[{"name": "helper", ...}]  # No skills inherited
+)
+
+# CORRECT: Provide skills explicitly (general-purpose subagent DOES inherit)
+agent = create_deep_agent(
+    skills=["/main-skills/"],
+    subagents=[{"name": "helper", "skills": ["/helper-skills/"], ...}]
+)
+```
+</python>
+</fix-custom-subagents-dont-inherit-skills>
+
+---
+
+## TodoList (Task Planning)
+
+<when-to-use-todolist>
+
+| Use TodoList When | Skip TodoList When |
+|------------------|-------------------|
+| Complex multi-step tasks | Simple single-action tasks |
+| Long-running operations | Quick operations (< 3 steps) |
+
+</when-to-use-todolist>
+
+<todolist-tool>
+
+```
+write_todos(todos: list[dict]) -> None
+```
+
+Each todo item has:
+- `content`: Description of the task
+- `status`: One of `"pending"`, `"in_progress"`, `"completed"`
+</todolist-tool>
+
+<ex-todolist-usage>
+<python>
+Invoke an agent that automatically creates a todo list for a multi-step task.
+
+```python
+from deepagents import create_deep_agent
+
+agent = create_deep_agent()  # TodoListMiddleware included by default
+
+result = agent.invoke({
+    "messages": [{"role": "user", "content": "Create a REST API: design models, implement CRUD, add auth, write tests"}]
+}, config={"configurable": {"thread_id": "session-1"}})
+
+# Agent's planning via write_todos:
+# [
+#   {"content": "Design data models", "status": "in_progress"},
+#   {"content": "Implement CRUD endpoints", "status": "pending"},
+#   {"content": "Add authentication", "status": "pending"},
+#   {"content": "Write tests", "status": "pending"}
+# ]
+```
+</python>
+<typescript>
+Invoke an agent that automatically creates a todo list for a multi-step task.
+
+```typescript
+import { createDeepAgent } from "deepagents";
+
+const agent = await createDeepAgent();  // TodoListMiddleware included
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Create a REST API: design models, implement CRUD, add auth, write tests" }]
+}, { configurable: { thread_id: "session-1" } });
+```
+</typescript>
+</ex-todolist-usage>
+
+<ex-access-todo-state>
+<python>
+Access the todo list from the agent's final state after invocation.
+
+```python
+result = agent.invoke({...}, config={"configurable": {"thread_id": "session-1"}})
+
+# Access todo list from final state
+todos = result.get("todos", [])
+for todo in todos:
+    print(f"[{todo['status']}] {todo['content']}")
+```
+</python>
+</ex-access-todo-state>
+
+<fix-todolist-requires-thread-id>
+<python>
+Todo list state requires a thread_id for persistence across invocations.
+
+```python
+# WRONG: Fresh state each time without thread_id
+agent.invoke({"messages": [...]})
+
+# CORRECT: Use thread_id
+config = {"configurable": {"thread_id": "user-session"}}
+agent.invoke({"messages": [...]}, config=config)  # Todos preserved
+```
+</python>
+</fix-todolist-requires-thread-id>
+
+---
+
+## Human-in-the-Loop (Approval Workflows)
+
+<when-to-use-hitl>
+
+| Use HITL When | Skip HITL When |
+|--------------|---------------|
+| High-stakes operations (DB writes, deployments) | Read-only operations |
+| Compliance requires human oversight | Fully automated workflows |
+
+</when-to-use-hitl>
+
+<ex-hitl-setup>
+<python>
+Configure which tools require human approval before execution.
+
+```python
+from deepagents import create_deep_agent
+from langgraph.checkpoint.memory import MemorySaver
+
+agent = create_deep_agent(
+    interrupt_on={
+        "write_file": True,  # All decisions allowed
+        "execute_sql": {"allowed_decisions": ["approve", "reject"]},
+        "read_file": False,  # No interrupts
+    },
+    checkpointer=MemorySaver()  # REQUIRED for interrupts
+)
+```
+</python>
+<typescript>
+Configure which tools require human approval before execution.
+
+```typescript
+import { createDeepAgent } from "deepagents";
+import { MemorySaver } from "@langchain/langgraph";
+
+const agent = await createDeepAgent({
+  interruptOn: {
+    write_file: true,
+    execute_sql: { allowedDecisions: ["approve", "reject"] },
+    read_file: false,
+  },
+  checkpointer: new MemorySaver()  // REQUIRED
+});
+```
+</typescript>
+</ex-hitl-setup>
+
+<ex-approval-workflow>
+<python>
+Complete workflow: trigger an interrupt, check state, approve action, and resume execution.
+
+```python
+from deepagents import create_deep_agent
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Command
+
+agent = create_deep_agent(
+    interrupt_on={"write_file": True},
+    checkpointer=MemorySaver()
+)
+
+config = {"configurable": {"thread_id": "session-1"}}
+
+# Step 1: Agent proposes write_file - execution pauses
+result = agent.invoke({
+    "messages": [{"role": "user", "content": "Write config to /prod.yaml"}]
+}, config=config)
+
+# Step 2: Check for interrupts
+state = agent.get_state(config)
+if state.next:
+    print(f"Pending action")
+
+# Step 3: Approve and resume
+result = agent.invoke(Command(resume={"decisions": [{"type": "approve"}]}), config=config)
+```
+</python>
+<typescript>
+Complete workflow: trigger an interrupt, check state, approve action, and resume execution.
+
+```typescript
+import { createDeepAgent } from "deepagents";
+import { MemorySaver, Command } from "@langchain/langgraph";
+
+const agent = await createDeepAgent({
+  interruptOn: { write_file: true },
+  checkpointer: new MemorySaver()
+});
+
+const config = { configurable: { thread_id: "session-1" } };
+
+// Step 1: Agent proposes write_file - execution pauses
+let result = await agent.invoke({
+  messages: [{ role: "user", content: "Write config to /prod.yaml" }]
+}, config);
+
+// Step 2: Check for interrupts
+const state = await agent.getState(config);
+if (state.next) {
+  console.log("Pending action");
+}
+
+// Step 3: Approve and resume
+result = await agent.invoke(
+  new Command({ resume: { decisions: [{ type: "approve" }] } }), config
+);
+```
+</typescript>
+</ex-approval-workflow>
+
+<ex-reject-with-feedback>
+<python>
+Reject a pending action with feedback, prompting the agent to try a different approach.
+
+```python
+result = agent.invoke(
+    Command(resume={"decisions": [{"type": "reject", "message": "Run tests first"}]}),
+    config=config,
+)
+```
+</python>
+<typescript>
+Reject a pending action with feedback, prompting the agent to try a different approach.
+
+```typescript
+const result = await agent.invoke(
+  new Command({ resume: { decisions: [{ type: "reject", message: "Run tests first" }] } }),
+  config,
+);
+```
+</typescript>
+</ex-reject-with-feedback>
+
+<ex-edit-before-execution>
+<python>
+Edit the proposed action arguments before allowing execution.
+
+```python
+result = agent.invoke(
+    Command(resume={"decisions": [{
+        "type": "edit",
+        "edited_action": {
+            "name": "execute_sql",
+            "args": {"query": "DELETE FROM users WHERE last_login < '2020-01-01' LIMIT 100"},
+        },
+    }]}),
+    config=config,
+)
+```
+</python>
+</ex-edit-before-execution>
+
+<boundaries>
+### What Agents CAN Configure
+
+- Subagent names, tools, models, system prompts
+- Which tools require approval
+- Allowed decision types per tool
+- TodoList content and structure
+
+### What Agents CANNOT Configure
+
+- Tool names (`task`, `write_todos`)
+- HITL protocol (approve/edit/reject structure)
+- Skip checkpointer requirement for interrupts
+- Make subagents stateful (they're ephemeral)
+</boundaries>
+
+<fix-checkpointer-required>
+<python>
+Checkpointer is required when using interrupt_on for HITL workflows.
+
+```python
+# WRONG
+agent = create_deep_agent(interrupt_on={"write_file": True})
+
+# CORRECT
+agent = create_deep_agent(interrupt_on={"write_file": True}, checkpointer=MemorySaver())
+```
+</python>
+<typescript>
+Checkpointer is required when using interruptOn for HITL workflows.
+
+```typescript
+// WRONG
+const agent = await createDeepAgent({ interruptOn: { write_file: true } });
+
+// CORRECT
+const agent = await createDeepAgent({ interruptOn: { write_file: true }, checkpointer: new MemorySaver() });
+```
+</typescript>
+</fix-checkpointer-required>
+
+<fix-thread-id-required-for-resumption>
+<python>
+A consistent thread_id is required to resume interrupted workflows.
+
+```python
+# WRONG: Can't resume without thread_id
+agent.invoke({"messages": [...]})
+
+# CORRECT
+config = {"configurable": {"thread_id": "session-1"}}
+agent.invoke({...}, config=config)
+# Resume with Command using same config
+agent.invoke(Command(resume={"decisions": [{"type": "approve"}]}), config=config)
+```
+</python>
+<typescript>
+A consistent thread_id is required to resume interrupted workflows.
+
+```typescript
+// WRONG: Can't resume without thread_id
+await agent.invoke({ messages: [...] });
+
+// CORRECT
+const config = { configurable: { thread_id: "session-1" } };
+await agent.invoke({ messages: [...] }, config);
+// Resume with Command using same config
+await agent.invoke(new Command({ resume: { decisions: [{ type: "approve" }] } }), config);
+```
+</typescript>
+</fix-thread-id-required-for-resumption>
+
+<fix-interrupt-checks-between-invocations>
+<python>
+Interrupts happen BETWEEN invoke() calls, not mid-execution.
+
+```python
+result = agent.invoke({...}, config=config)       # Step 1: triggers interrupt
+if "__interrupt__" in result:                      # Step 2: check for interrupt
+    result = agent.invoke(                         # Step 3: resume
+        Command(resume={"decisions": [{"type": "approve"}]}),
+        config=config,
+    )
+```
+</python>
+</fix-interrupt-checks-between-invocations>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/ecosystem-primer.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/ecosystem-primer.md
@@ -1,0 +1,193 @@
+---
+name: ecosystem-primer
+description: "INVOKE FIRST for any LangChain / LangGraph / Deep Agents agent building project before consulting other skills or writing any agent code. Required starting point for up to date info on framework selection (LangChain vs LangGraph vs Deep Agents vs hybrid composition), agent patterns, install, environment setup, and which skill to load next."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+LangChain Inc. maintains three layered open-source tools for building agents, plus LangSmith for observability. The stack, top-down:
+
+- **Deep Agents** (top layer, *harness*) — batteries-included toolkit built on LangChain + LangGraph. Ships with planning, file management, subagent spawning, and memory out of the box.
+- **LangGraph** (middle layer, *runtime*) — low-level orchestration for durable execution, custom control flow, and stateful workflows. LangChain agents run on top of LangGraph.
+- **LangChain** (bottom layer, *framework*) — abstractions for models, tools, and the agent loop. Provider-agnostic, easiest to start with.
+- **LangSmith** (cross-cutting) — observability and evaluation platform. Framework-agnostic; always recommended alongside any of the above.
+
+Higher layers depend on lower ones, but you don't need to use lower layers directly. Deep Agents gives you LangGraph's durable execution without writing graph code. LangChain gives you models and tools without managing graph edges.
+</overview>
+
+---
+
+## Step 1 — Choose Your Tool
+
+<decision-table>
+
+Evaluate these conditions in order and stop at the first match:
+
+1. If the task needs planning, file management across a long session, persistent memory, subagent delegation, or on-demand skills → **Deep Agents**
+2. Else, if the task needs custom control flow (deterministic loops, branching logic) → **LangGraph**
+3. Else, if it's a single-purpose agent with a fixed set of tools → **LangChain** (`create_agent` function)
+4. Else, if it's a pure model call, retrieval pipeline, or simple prompt chain with no agent loop → **LangChain** (direct model / chain)
+
+This is your **layer**. BUT you are not done: later in Step 4, you MUST load the layer-specific skill before writing any agent code.
+
+</decision-table>
+
+---
+
+## Tool Profiles
+
+<langchain-profile>
+
+### LangChain — agent framework
+
+**Best for:**
+- Single-purpose agents with a fixed tool set
+- RAG pipelines and document Q&A
+- Model calls, prompt templates, structured output
+
+**Not ideal when:**
+- The agent needs to plan across many steps or manage large context
+- Control flow is conditional, iterative, or parallel
+- State must persist across sessions
+
+All LangChain agents use `create_agent(model, tools=[...])`.
+
+</langchain-profile>
+
+<langgraph-profile>
+
+### LangGraph — agent runtime
+
+**Best for:**
+- Custom control flow — deterministic loops, reflection cycles, parallel fan-out
+- Complex workflows combining deterministic and agentic steps
+- Human-in-the-loop with precise interrupt and resume points
+- State that must survive failures or span long sessions
+
+**Not ideal when:**
+- You want planning, file management, and subagent delegation out of the box (use Deep Agents instead)
+- The workflow is simple enough for a straight tool loop
+
+All LangGraph graphs use `StateGraph(State)` with explicit nodes, edges, and conditional edges.
+
+</langgraph-profile>
+
+<deep-agents-profile>
+
+### Deep Agents — agent harness
+
+**Best for:**
+- Long-running tasks that require planning and decomposition
+- Agents that read, write, and manage files across a session
+- Delegating subtasks to specialized subagents
+- Persistent memory across sessions
+- Loading domain-specific skills on demand
+
+**Not ideal when:**
+- The task is simple enough for a single-purpose agent
+- You need precise hand-crafted control over every graph edge (use LangGraph directly)
+
+All Deep Agents use `create_deep_agent(model, tools=[...])`.
+
+</deep-agents-profile>
+
+---
+
+## Mixing Layers
+
+<mixing-layers>
+
+The tools are layered, so they can be combined in the same project. Common patterns:
+
+- **Deep Agents orchestrator → LangGraph subagent** — when the main agent needs planning and memory but one subtask requires a deterministic graph.
+- **LangGraph graph wrapped as a tool or subagent** — when a specialized pipeline (e.g. RAG, reflection loop) is called by a broader agent.
+
+A compiled LangGraph graph can be registered as a named subagent inside Deep Agents — the orchestrator delegates to it via the `task` tool without knowing its internal structure. LangChain tools and retrievers work freely inside both LangGraph nodes and Deep Agents tools.
+
+</mixing-layers>
+
+---
+
+## Step 2 — Set Environment Variables
+
+Always set these for observability. These are the current LangSmith env var names. Copy them as-is. OLDER NAMES NO LONGER WORK.
+
+<environment-variables>
+LANGSMITH_API_KEY=<your-key>
+LANGSMITH_TRACING=true
+LANGSMITH_PROJECT=<project-name>
+</environment-variables>
+
+Model-provider and tool-specific keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `TAVILY_API_KEY`, etc.) depend on your stack — set them as needed.
+
+---
+
+## Step 3 — How the Docs Work
+
+<docs>
+
+All documentation lives at **docs.langchain.com**, organized into two top-level sections:
+
+- **OSS** — LangChain, LangGraph, Deep Agents. Python (`/oss/python/`) and TypeScript (`/oss/javascript/`) trees in parallel.
+- **LangSmith** — observability, evaluation, deployment, prompt engineering.
+
+Each product has its own page tree: overview → quickstart → how-to guides → reference.
+
+### Canonical landing pages
+
+Start here rather than tree-searching from root (swap `python` → `javascript` for TypeScript):
+
+- **LangChain** — `/oss/python/langchain/overview`
+- **LangGraph** — `/oss/python/langgraph/overview`
+- **Deep Agents** — `/oss/python/deepagents/overview`
+- **LangSmith** — `/langsmith/home` (no language split)
+
+### Accessing docs in an agent context
+
+**If the LangChain Docs MCP server is connected** (`mcp__docs-langchain__*` tools are available), query it directly:
+```bash
+tree /oss/python -L 2                        # explore Python structure
+tree /oss/javascript -L 2                    # parallel TypeScript structure
+cat /oss/python/langchain/quickstart.mdx     # read a specific page
+rg -il "checkpointer" /oss/python/langgraph/ # search by keyword
+```
+
+**If the MCP server is not available**, use the `llms.txt` index:
+1. Fetch `https://docs.langchain.com/llms.txt` — structured list of all pages with descriptions
+2. Identify the 2–4 most relevant pages for the question
+3. Fetch those pages directly for accurate, up-to-date content
+
+> Always prefer fetching live docs over relying on training-data knowledge — these libraries evolve fast and APIs change often.
+
+</docs>
+
+---
+
+## Step 4 — Load the Right Skill Next
+
+Now load the skill below that matches your layer from Step 1. This is required — the layer-specific skill carries the current API; the primer alone does not.
+
+<next-skills>
+
+### LangChain
+
+- **`langchain-fundamentals`** — building any LangChain agent
+- **`langchain-rag`** — adding RAG / vector store retrieval
+- **`langchain-middleware`** — structured output with Pydantic
+- **`langchain-dependencies`** — package versions, installs, or dependency management questions
+
+### LangGraph
+
+- **`langgraph-fundamentals`** — any LangGraph graph
+- **`langgraph-human-in-the-loop`** — human-in-the-loop or approval workflows
+- **`langgraph-persistence`** — state that must survive restarts, or cross-thread memory
+
+### Deep Agents
+
+**Always load `deep-agents-core` first.** Then, as needed:
+
+- **`deep-agents-orchestration`** — subagent delegation or orchestration
+- **`deep-agents-memory`** — cross-session persistent memory
+
+</next-skills>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langchain-dependencies.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langchain-dependencies.md
@@ -1,0 +1,433 @@
+---
+name: langchain-dependencies
+description: "INVOKE THIS SKILL when setting up a new project or when asked about package versions, installation, or dependency management for LangChain, LangGraph, LangSmith, or Deep Agents. Covers required packages, minimum versions, environment requirements, versioning best practices, and common community tool packages for both Python and TypeScript."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+The LangChain ecosystem is split into focused, independently-versioned packages. Understanding which packages you need — and their version constraints — prevents incompatibilities and keeps upgrades predictable.
+
+**Key principles:**
+- **LangChain 1.0 is the current LTS release.** Always start new projects on 1.0+. LangChain 0.3 is legacy maintenance-only — do not use it for new work.
+- **langchain-core** is the shared foundation: always install it explicitly alongside any other package.
+- **langchain-community** (Python only) does NOT follow semantic versioning; pin it conservatively.
+- **LangGraph vs Deep Agents:** choose one orchestration approach based on your use case — they are alternatives, not a required stack (see [Framework Choice](#framework-choice) below).
+- Provider integrations (model, vector store, tools) are installed separately so you only pull in what you use.
+</overview>
+
+---
+
+## Environment Requirements
+
+<environment-requirements>
+
+| Requirement | Python | TypeScript / Node |
+|-------------|--------|-------------------|
+| Runtime minimum | **Python 3.10+** | **Node.js 20+** |
+| LangChain | **1.0+ (LTS)** | **1.0+ (LTS)** |
+| LangSmith SDK | >= 0.3.0 | >= 0.3.0 |
+
+</environment-requirements>
+
+---
+
+## Framework Choice
+
+<framework-choice>
+Pick **one** agent orchestration layer. You do not need both.
+
+| Framework | When to use | Core extra package |
+|-----------|-------------|--------------------|
+| **LangGraph** | Need fine-grained graph control, custom workflows, loops, or branching | `langgraph` / `@langchain/langgraph` |
+| **Deep Agents** | Want batteries-included planning, memory, file context, and skills out of the box | `deepagents` (depends on LangGraph; installs it as a transitive dep) |
+
+Both sit on top of `langchain` + `langchain-core` + `langsmith`.
+</framework-choice>
+
+---
+
+## Core Packages
+
+<python-packages>
+
+### Python — always required
+
+| Package | Role | Min version |
+|---------|------|-------------|
+| `langchain` | Agents, chains, retrieval | 1.0 |
+| `langchain-core` | Base types & interfaces (peer dep) | 1.0 |
+| `langsmith` | Tracing, evaluation, datasets | 0.3.0 |
+
+### Python — orchestration (pick one)
+
+| Package | Use when | Min version |
+|---------|----------|-------------|
+| `langgraph` | Building custom graphs directly | 1.0 |
+| `deepagents` | Using the Deep Agents framework | latest |
+
+### Python — model providers (pick the one(s) you use)
+
+| Package | Provider |
+|---------|----------|
+| `langchain-openai` | OpenAI (GPT-4o, o3, …) |
+| `langchain-anthropic` | Anthropic (Claude) |
+| `langchain-google-genai` | Google (Gemini) |
+| `langchain-mistralai` | Mistral |
+| `langchain-groq` | Groq (fast inference) |
+| `langchain-cohere` | Cohere |
+| `langchain-fireworks` | Fireworks AI |
+| `langchain-together` | Together AI |
+| `langchain-huggingface` | Hugging Face Hub |
+| `langchain-ollama` | Ollama (local models) |
+| `langchain-aws` | AWS Bedrock |
+| `langchain-azure-ai` | Azure AI Foundry |
+
+### Python — common tool & retrieval packages
+
+These packages have tighter compatibility requirements — use the latest available version unless you have a specific reason not to.
+
+| Package | Adds | Notes |
+|---------|------|-------|
+| `langchain-tavily` | Tavily web search (`TavilySearch`) | Dedicated integration package; prefer latest |
+| `langchain-text-splitters` | Text chunking utilities | Semver, keep current |
+| `langchain-community` | 1000+ integrations (fallback) | **NOT semver — pin to minor series** |
+| `faiss-cpu` | FAISS vector store (local) | Via `langchain-community`; use latest |
+| `langchain-chroma` | Chroma vector store | Dedicated integration package; prefer latest |
+| `langchain-pinecone` | Pinecone vector store | Dedicated integration package; prefer latest |
+| `langchain-qdrant` | Qdrant vector store | Dedicated integration package; prefer latest |
+| `langchain-weaviate` | Weaviate vector store | Dedicated integration package; prefer latest |
+| `langsmith[pytest]` | pytest plugin for LangSmith | Requires langsmith >= 0.3.4 |
+
+> **langchain-community stability note:** This package is NOT on semantic versioning. Minor releases can contain breaking changes. Prefer dedicated integration packages (e.g. `langchain-chroma`, `langchain-tavily`) when they exist — they are independently versioned and more stable.
+
+</python-packages>
+
+<typescript-packages>
+
+### TypeScript — always required
+
+| Package | Role | Min version |
+|---------|------|-------------|
+| `@langchain/core` | Base types & interfaces (peer dep) | 1.0 |
+| `langchain` | Agents, chains, retrieval | 1.0 |
+| `langsmith` | Tracing, evaluation, datasets | 0.3.0 |
+
+### TypeScript — orchestration (pick one)
+
+| Package | Use when | Min version |
+|---------|----------|-------------|
+| `@langchain/langgraph` | Building custom graphs directly | 1.0 |
+| `deepagents` | Using the Deep Agents framework | latest |
+
+### TypeScript — model providers (pick the one(s) you use)
+
+| Package | Provider |
+|---------|----------|
+| `@langchain/openai` | OpenAI (GPT-4o, o3, …) |
+| `@langchain/anthropic` | Anthropic (Claude) |
+| `@langchain/google-genai` | Google (Gemini) |
+| `@langchain/mistralai` | Mistral |
+| `@langchain/groq` | Groq (fast inference) |
+| `@langchain/cohere` | Cohere |
+| `@langchain/aws` | AWS Bedrock |
+| `@langchain/azure-openai` | Azure OpenAI |
+| `@langchain/ollama` | Ollama (local models) |
+
+### TypeScript — common tool & retrieval packages
+
+| Package | Adds | Notes |
+|---------|------|-------|
+| `@langchain/tavily` | Tavily web search (`TavilySearch`) | Dedicated integration package; prefer latest |
+| `@langchain/community` | Broad set of community integrations | Use sparingly; prefer dedicated packages |
+| `@langchain/pinecone` | Pinecone vector store | Dedicated integration package; prefer latest |
+| `@langchain/qdrant` | Qdrant vector store | Dedicated integration package; prefer latest |
+| `@langchain/weaviate` | Weaviate vector store | Dedicated integration package; prefer latest |
+
+> **`@langchain/core` must be installed explicitly** in yarn workspaces and monorepos — it is a peer dependency and will not always be hoisted automatically.
+
+</typescript-packages>
+
+---
+
+## Minimal Project Templates
+
+<ex-langgraph-python>
+<python>
+Minimal dependency set for a LangGraph project (provider-agnostic).
+
+```
+# requirements.txt
+langchain>=1.0,<2.0
+langchain-core>=1.0,<2.0
+langgraph>=1.0,<2.0
+langsmith>=0.3.0
+
+# Add your model provider, e.g.:
+# langchain-openai
+# langchain-anthropic
+# langchain-google-genai
+```
+</python>
+</ex-langgraph-python>
+
+<ex-langgraph-typescript>
+<typescript>
+Minimal package.json dependencies for a LangGraph project (provider-agnostic).
+
+```json
+{
+  "dependencies": {
+    "@langchain/core": "^1.0.0",
+    "langchain": "^1.0.0",
+    "@langchain/langgraph": "^1.0.0",
+    "langsmith": "^0.3.0"
+  }
+}
+```
+</typescript>
+</ex-langgraph-typescript>
+
+<ex-deepagents-python>
+<python>
+Minimal dependency set for a Deep Agents project (provider-agnostic).
+
+```
+# requirements.txt
+deepagents            # bundles langgraph internally
+langchain>=1.0,<2.0
+langchain-core>=1.0,<2.0
+langsmith>=0.3.0
+
+# Add your model provider, e.g.:
+# langchain-anthropic
+# langchain-openai
+```
+</python>
+</ex-deepagents-python>
+
+<ex-deepagents-typescript>
+<typescript>
+Minimal package.json dependencies for a Deep Agents project (provider-agnostic).
+
+```json
+{
+  "dependencies": {
+    "deepagents": "latest",
+    "@langchain/core": "^1.0.0",
+    "langchain": "^1.0.0",
+    "langsmith": "^0.3.0"
+  }
+}
+```
+</typescript>
+</ex-deepagents-typescript>
+
+<ex-with-tools-python>
+<python>
+Adding Tavily search and a vector store to a LangGraph project.
+
+```
+# requirements.txt
+langchain>=1.0,<2.0
+langchain-core>=1.0,<2.0
+langgraph>=1.0,<2.0
+langsmith>=0.3.0
+
+# Web search
+langchain-tavily          # use latest; partner package, semver
+
+# Vector store — pick one:
+langchain-chroma          # use latest; partner package, semver
+# langchain-pinecone      # use latest; partner package, semver
+# langchain-qdrant        # use latest; partner package, semver
+
+# Text processing
+langchain-text-splitters  # use latest; semver
+
+# Your model provider:
+# langchain-openai / langchain-anthropic / etc.
+```
+</python>
+</ex-with-tools-python>
+
+<ex-with-tools-typescript>
+<typescript>
+Adding Tavily search and a vector store to a LangGraph project.
+
+```json
+{
+  "dependencies": {
+    "@langchain/core": "^1.0.0",
+    "langchain": "^1.0.0",
+    "@langchain/langgraph": "^1.0.0",
+    "langsmith": "^0.3.0",
+    "@langchain/tavily": "latest",
+    "@langchain/pinecone": "latest"
+  }
+}
+```
+</typescript>
+</ex-with-tools-typescript>
+
+---
+
+## Versioning Policy & Upgrade Strategy
+
+<versioning-policy>
+
+| Package group | Versioning | Safe upgrade strategy |
+|---------------|------------|-----------------------|
+| `langchain`, `langchain-core` | Strict semver (1.0 LTS) | Allow minor: `>=1.0,<2.0` |
+| `langgraph` / `@langchain/langgraph` | Strict semver (v1 LTS) | Allow minor: `>=1.0,<2.0` |
+| `langsmith` | Strict semver | Allow minor: `>=0.3.0` |
+| Dedicated integration packages (e.g. `langchain-tavily`, `langchain-chroma`) | Independently versioned | Allow minor updates; use latest |
+| `langchain-community` | **NOT semver** | Pin exact minor: `>=0.4.0,<0.5.0` |
+| `deepagents` | Follow project releases | Pin to tested version in production |
+
+**Breaking changes only happen in major versions** (1.x → 2.x) for all semver-compliant packages. Deprecated features remain functional across the entire 1.x series with warnings.
+
+**Prefer dedicated integration packages over langchain-community.** When a dedicated package exists (e.g. `langchain-chroma` instead of `langchain-community`'s Chroma integration), use it — dedicated packages are independently versioned and better tested.
+
+**Community tool packages (Tavily, vector stores, etc.) should be kept at latest** unless your project requires a locked environment. These packages frequently release compatibility fixes alongside LangChain/LangGraph updates.
+
+</versioning-policy>
+
+---
+
+## Environment Variables
+
+<environment-variables>
+All keys are read from the environment at runtime. Set only the keys for services you actually use.
+
+```bash
+# LangSmith (always recommended for observability)
+LANGSMITH_API_KEY=<your-key>
+LANGSMITH_PROJECT=<project-name>   # optional, defaults to "default"
+
+# Model provider — set the one(s) you use
+OPENAI_API_KEY=<your-key>
+ANTHROPIC_API_KEY=<your-key>
+GOOGLE_API_KEY=<your-key>
+MISTRAL_API_KEY=<your-key>
+GROQ_API_KEY=<your-key>
+COHERE_API_KEY=<your-key>
+FIREWORKS_API_KEY=<your-key>
+TOGETHER_API_KEY=<your-key>
+HUGGINGFACEHUB_API_TOKEN=<your-key>
+
+# Common tool/retrieval services
+TAVILY_API_KEY=<your-key>          # for Tavily search
+PINECONE_API_KEY=<your-key>        # for Pinecone
+```
+</environment-variables>
+
+---
+
+## Common Mistakes
+
+<fix-legacy-version>
+Never start a new project on LangChain 0.3. It is maintenance-only until December 2026.
+
+```text
+# WRONG: legacy, no new features, security patches only
+langchain>=0.3,<0.4
+
+# CORRECT: LangChain 1.0 LTS
+langchain>=1.0,<2.0
+```
+</fix-legacy-version>
+
+<fix-community-unpinned>
+`langchain-community` can break on minor version bumps — it does not follow semver.
+
+```text
+# WRONG: allows minor-version updates that may be breaking
+langchain-community>=0.4
+
+# CORRECT: pin to exact minor series
+langchain-community>=0.4.0,<0.5.0
+```
+Also consider switching to the equivalent dedicated integration package if one exists (e.g. `langchain-chroma` instead of the community Chroma integration).
+</fix-community-unpinned>
+
+<fix-community-tool-outdated>
+Community tool packages like `langchain-tavily` and vector store integrations release compatibility fixes alongside LangChain updates. Using an old pinned version can cause import errors or broken tool schemas.
+
+```text
+# RISKY: old pin may be incompatible with LangChain 1.0
+langchain-tavily==0.0.1
+
+# BETTER: allow latest within the current major
+langchain-tavily>=0.1
+```
+</fix-community-tool-outdated>
+
+<fix-community-import-deprecated>
+Many tools that used to live in `langchain-community` now have dedicated packages with updated import paths. Always prefer the dedicated package import.
+
+```python
+# WRONG — deprecated community import path
+from langchain_community.tools.tavily_search import TavilySearchResults
+from langchain_community.tools import WikipediaQueryRun
+from langchain_community.vectorstores import Chroma
+from langchain_community.vectorstores import Pinecone
+
+# CORRECT — use dedicated package imports
+from langchain_tavily import TavilySearch                  # pip: langchain-tavily (TavilySearchResults is deprecated)
+from langchain_community.tools import WikipediaQueryRun  # no dedicated pkg yet
+from langchain_chroma import Chroma                       # pip: langchain-chroma
+from langchain_pinecone import PineconeVectorStore        # pip: langchain-pinecone
+```
+
+To find the current canonical import for any integration, search the integrations directory:
+https://python.langchain.com/docs/integrations/tools/
+
+Each entry shows the correct package and import path. If a dedicated package exists, use it — the community path may still work but is considered legacy.
+</fix-community-import-deprecated>
+
+<fix-core-not-installed>
+<typescript>
+`@langchain/core` is a peer dependency — it must be in your package.json, especially in monorepos.
+
+```json
+// WRONG: missing @langchain/core (breaks in yarn workspaces / strict hoisting)
+{
+  "dependencies": {
+    "@langchain/langgraph": "^1.0.0"
+  }
+}
+
+// CORRECT: always list @langchain/core explicitly
+{
+  "dependencies": {
+    "@langchain/core": "^1.0.0",
+    "@langchain/langgraph": "^1.0.0"
+  }
+}
+```
+</typescript>
+</fix-core-not-installed>
+
+<fix-python-version>
+<python>
+Python 3.9 and below are not supported by LangChain 1.0.
+
+```python
+# Verify before installing
+import sys
+assert sys.version_info >= (3, 10), "Python 3.10+ required for LangChain 1.0"
+```
+</python>
+</fix-python-version>
+
+<fix-node-version>
+<typescript>
+Node.js below 20 is not officially supported.
+
+```bash
+# Verify before installing
+node --version   # must be v20.x or higher
+```
+</typescript>
+</fix-node-version>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langchain-fundamentals.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langchain-fundamentals.md
@@ -1,0 +1,414 @@
+---
+name: langchain-fundamentals
+description: Create LangChain agents with create_agent, define tools, and use middleware for human-in-the-loop and error handling.
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<oneliner>
+Build production agents using `create_agent()`, middleware patterns, and the `@tool` decorator / `tool()` function. When creating LangChain agents, you MUST use create_agent(), with middleware for custom flows. All other alternatives are outdated.
+</oneliner>
+
+<create_agent>
+## Creating Agents with create_agent
+
+`create_agent()` is the recommended way to build agents. It handles the agent loop, tool execution, and state management.
+
+### Agent Configuration Options
+
+| Parameter | Purpose | Example |
+|-----------|---------|---------|
+| `model` | LLM to use | `"anthropic:claude-sonnet-4-5"` or model instance |
+| `tools` | List of tools | `[search, calculator]` |
+| `system_prompt` / `systemPrompt` | Agent instructions | `"You are a helpful assistant"` |
+| `checkpointer` | State persistence | `MemorySaver()` |
+| `middleware` | Processing hooks | `[HumanInTheLoopMiddleware]` (Python) / `[humanInTheLoopMiddleware({...})]` (TypeScript) |
+</create_agent>
+
+<ex-basic-agent>
+<python>
+
+```python
+from langchain.agents import create_agent
+from langchain_core.tools import tool
+
+@tool
+def get_weather(location: str) -> str:
+    """Get current weather for a location.
+
+    Args:
+        location: City name
+    """
+    return f"Weather in {location}: Sunny, 72F"
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[get_weather],
+    system_prompt="You are a helpful assistant."
+)
+
+result = agent.invoke({
+    "messages": [{"role": "user", "content": "What's the weather in Paris?"}]
+})
+print(result["messages"][-1].content)
+```
+</python>
+<typescript>
+
+```typescript
+import { createAgent } from "langchain";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const getWeather = tool(
+  async ({ location }) => `Weather in ${location}: Sunny, 72F`,
+  {
+    name: "get_weather",
+    description: "Get current weather for a location.",
+    schema: z.object({ location: z.string().describe("City name") }),
+  }
+);
+
+const agent = createAgent({
+  model: "anthropic:claude-sonnet-4-5",
+  tools: [getWeather],
+  systemPrompt: "You are a helpful assistant.",
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "What's the weather in Paris?" }],
+});
+console.log(result.messages[result.messages.length - 1].content);
+```
+</typescript>
+</ex-basic-agent>
+
+<ex-agent-with-persistence>
+<python>
+Add MemorySaver checkpointer to maintain conversation state across invocations.
+
+```python
+from langchain.agents import create_agent
+from langgraph.checkpoint.memory import MemorySaver
+
+checkpointer = MemorySaver()
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[search],
+    checkpointer=checkpointer,
+)
+
+config = {"configurable": {"thread_id": "user-123"}}
+agent.invoke({"messages": [{"role": "user", "content": "My name is Alice"}]}, config=config)
+result = agent.invoke({"messages": [{"role": "user", "content": "What's my name?"}]}, config=config)
+# Agent remembers: "Your name is Alice"
+```
+</python>
+<typescript>
+Add MemorySaver checkpointer to maintain conversation state across invocations.
+
+```typescript
+import { createAgent } from "langchain";
+import { MemorySaver } from "@langchain/langgraph";
+
+const checkpointer = new MemorySaver();
+
+const agent = createAgent({
+  model: "anthropic:claude-sonnet-4-5",
+  tools: [search],
+  checkpointer,
+});
+
+const config = { configurable: { thread_id: "user-123" } };
+await agent.invoke({ messages: [{ role: "user", content: "My name is Alice" }] }, config);
+const result = await agent.invoke({ messages: [{ role: "user", content: "What's my name?" }] }, config);
+// Agent remembers: "Your name is Alice"
+```
+</typescript>
+</ex-agent-with-persistence>
+
+<tools>
+## Defining Tools
+
+Tools are functions that agents can call. Use the `@tool` decorator (Python) or `tool()` function (TypeScript).
+</tools>
+
+<ex-basic-tool>
+<python>
+
+```python
+from langchain_core.tools import tool
+
+@tool
+def add(a: float, b: float) -> float:
+    """Add two numbers.
+
+    Args:
+        a: First number
+        b: Second number
+    """
+    return a + b
+```
+</python>
+<typescript>
+
+```typescript
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const add = tool(
+  async ({ a, b }) => a + b,
+  {
+    name: "add",
+    description: "Add two numbers.",
+    schema: z.object({
+      a: z.number().describe("First number"),
+      b: z.number().describe("Second number"),
+    }),
+  }
+);
+```
+</typescript>
+</ex-basic-tool>
+
+<middleware>
+## Middleware for Agent Control
+
+Middleware intercepts the agent loop to add human approval, error handling, logging, and more. A deep understanding of middleware is essential for production agents — use `HumanInTheLoopMiddleware` (Python) / `humanInTheLoopMiddleware` (TypeScript) for approval workflows, and `@wrap_tool_call` (Python) / `createMiddleware` (TypeScript) for custom hooks.
+
+Key imports:
+
+```python
+from langchain.agents.middleware import HumanInTheLoopMiddleware, wrap_tool_call
+```
+
+```typescript
+import { humanInTheLoopMiddleware, createMiddleware } from "langchain";
+```
+
+Key patterns:
+- **HITL**: `middleware=[HumanInTheLoopMiddleware(interrupt_on={"dangerous_tool": True})]` — requires `checkpointer` + `thread_id`
+- **Resume after interrupt**: `agent.invoke(Command(resume={"decisions": [{"type": "approve"}]}), config=config)`
+- **Custom middleware**: `@wrap_tool_call` decorator (Python) or `createMiddleware({ wrapToolCall: ... })` (TypeScript)
+</middleware>
+
+<structured_output>
+## Structured Output
+
+Get typed, validated responses from agents using `response_format` or `with_structured_output()`.
+
+<python>
+
+```python
+from langchain.agents import create_agent
+from pydantic import BaseModel, Field
+
+class ContactInfo(BaseModel):
+    name: str
+    email: str
+    phone: str = Field(description="Phone number with area code")
+
+# Option 1: Agent with structured output
+agent = create_agent(model="gpt-4.1", tools=[search], response_format=ContactInfo)
+result = agent.invoke({"messages": [{"role": "user", "content": "Find contact for John"}]})
+print(result["structured_response"])  # ContactInfo(name='John', ...)
+
+# Option 2: Model-level structured output (no agent needed)
+from langchain_openai import ChatOpenAI
+model = ChatOpenAI(model="gpt-4.1")
+structured_model = model.with_structured_output(ContactInfo)
+response = structured_model.invoke("Extract: John, john@example.com, 555-1234")
+# ContactInfo(name='John', email='john@example.com', phone='555-1234')
+```
+</python>
+<typescript>
+
+```typescript
+import { ChatOpenAI } from "@langchain/openai";
+import { z } from "zod";
+
+const ContactInfo = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  phone: z.string().describe("Phone number with area code"),
+});
+
+// Model-level structured output
+const model = new ChatOpenAI({ model: "gpt-4.1" });
+const structuredModel = model.withStructuredOutput(ContactInfo);
+const response = await structuredModel.invoke("Extract: John, john@example.com, 555-1234");
+// { name: 'John', email: 'john@example.com', phone: '555-1234' }
+```
+</typescript>
+</structured_output>
+
+<model_config>
+## Model Configuration
+
+`create_agent` accepts model strings (`"anthropic:claude-sonnet-4-5"`, `"openai:gpt-4.1"`) or model instances for custom settings:
+
+```python
+from langchain_anthropic import ChatAnthropic
+agent = create_agent(model=ChatAnthropic(model="claude-sonnet-4-5", temperature=0), tools=[...])
+```
+</model_config>
+
+
+<fix-missing-tool-description>
+<python>
+Clear descriptions help the agent know when to use each tool.
+
+```python
+# WRONG: Vague or missing description
+@tool
+def bad_tool(input: str) -> str:
+    """Does stuff."""
+    return "result"
+
+# CORRECT: Clear, specific description with Args
+@tool
+def search(query: str) -> str:
+    """Search the web for current information about a topic.
+
+    Use this when you need recent data or facts.
+
+    Args:
+        query: The search query (2-10 words recommended)
+    """
+    return web_search(query)
+```
+</python>
+<typescript>
+Clear descriptions help the agent know when to use each tool.
+
+```typescript
+// WRONG: Vague description
+const badTool = tool(async ({ input }) => "result", {
+  name: "bad_tool",
+  description: "Does stuff.", // Too vague!
+  schema: z.object({ input: z.string() }),
+});
+
+// CORRECT: Clear, specific description
+const search = tool(async ({ query }) => webSearch(query), {
+  name: "search",
+  description: "Search the web for current information about a topic. Use this when you need recent data or facts.",
+  schema: z.object({
+    query: z.string().describe("The search query (2-10 words recommended)"),
+  }),
+});
+```
+</typescript>
+</fix-missing-tool-description>
+
+<fix-no-checkpointer>
+<python>
+Add checkpointer and thread_id for conversation memory across invocations.
+
+```python
+# WRONG: No persistence - agent forgets between calls
+agent = create_agent(model="anthropic:claude-sonnet-4-5", tools=[search])
+agent.invoke({"messages": [{"role": "user", "content": "I'm Bob"}]})
+agent.invoke({"messages": [{"role": "user", "content": "What's my name?"}]})
+# Agent doesn't remember!
+
+# CORRECT: Add checkpointer and thread_id
+from langgraph.checkpoint.memory import MemorySaver
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-5",
+    tools=[search],
+    checkpointer=MemorySaver(),
+)
+config = {"configurable": {"thread_id": "session-1"}}
+agent.invoke({"messages": [{"role": "user", "content": "I'm Bob"}]}, config=config)
+agent.invoke({"messages": [{"role": "user", "content": "What's my name?"}]}, config=config)
+# Agent remembers: "Your name is Bob"
+```
+</python>
+<typescript>
+Add checkpointer and thread_id for conversation memory across invocations.
+
+```typescript
+// WRONG: No persistence
+const agent = createAgent({ model: "anthropic:claude-sonnet-4-5", tools: [search] });
+await agent.invoke({ messages: [{ role: "user", content: "I'm Bob" }] });
+await agent.invoke({ messages: [{ role: "user", content: "What's my name?" }] });
+// Agent doesn't remember!
+
+// CORRECT: Add checkpointer and thread_id
+import { MemorySaver } from "@langchain/langgraph";
+
+const agent = createAgent({
+  model: "anthropic:claude-sonnet-4-5",
+  tools: [search],
+  checkpointer: new MemorySaver(),
+});
+const config = { configurable: { thread_id: "session-1" } };
+await agent.invoke({ messages: [{ role: "user", content: "I'm Bob" }] }, config);
+await agent.invoke({ messages: [{ role: "user", content: "What's my name?" }] }, config);
+// Agent remembers: "Your name is Bob"
+```
+</typescript>
+</fix-no-checkpointer>
+
+<fix-infinite-loop>
+<python>
+Set recursion_limit in the invoke config to prevent runaway agent loops.
+
+```python
+# WRONG: No iteration limit - could loop forever
+result = agent.invoke({"messages": [("user", "Do research")]})
+
+# CORRECT: Set recursion_limit in config
+result = agent.invoke(
+    {"messages": [("user", "Do research")]},
+    config={"recursion_limit": 10},  # Stop after 10 steps
+)
+```
+</python>
+<typescript>
+Set recursionLimit in the invoke config to prevent runaway agent loops.
+
+```typescript
+// WRONG: No iteration limit
+const result = await agent.invoke({ messages: [["user", "Do research"]] });
+
+// CORRECT: Set recursionLimit in config
+const result = await agent.invoke(
+  { messages: [["user", "Do research"]] },
+  { recursionLimit: 10 }, // Stop after 10 steps
+);
+```
+</typescript>
+</fix-infinite-loop>
+
+<fix-accessing-result-wrong>
+<python>
+Access the messages array from the result, not result.content directly.
+
+```python
+# WRONG: Trying to access result.content directly
+result = agent.invoke({"messages": [{"role": "user", "content": "Hello"}]})
+print(result.content)  # AttributeError!
+
+# CORRECT: Access messages from result dict
+result = agent.invoke({"messages": [{"role": "user", "content": "Hello"}]})
+print(result["messages"][-1].content)  # Last message content
+```
+</python>
+<typescript>
+Access the messages array from the result, not result.content directly.
+
+```typescript
+// WRONG: Trying to access result.content directly
+const result = await agent.invoke({ messages: [{ role: "user", content: "Hello" }] });
+console.log(result.content); // undefined!
+
+// CORRECT: Access messages from result object
+const result = await agent.invoke({ messages: [{ role: "user", content: "Hello" }] });
+console.log(result.messages[result.messages.length - 1].content); // Last message content
+```
+</typescript>
+</fix-accessing-result-wrong>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langchain-middleware.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langchain-middleware.md
@@ -1,0 +1,403 @@
+---
+name: langchain-middleware
+description: "INVOKE THIS SKILL when you need human-in-the-loop approval, custom middleware, or structured output. Covers HumanInTheLoopMiddleware for human approval of dangerous tool calls, creating custom middleware with hooks, Command resume patterns, and structured output with Pydantic/Zod."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+Middleware patterns for production LangChain agents:
+
+- **HumanInTheLoopMiddleware** / **humanInTheLoopMiddleware**: Pause before dangerous tool calls for human approval
+- **Custom middleware**: Intercept tool calls for error handling, logging, retry logic
+- **Command resume**: Continue execution after human decisions (approve, edit, reject)
+
+**Requirements:** Checkpointer + thread_id config for all HITL workflows.
+</overview>
+
+---
+
+## Human-in-the-Loop
+
+<ex-basic-hitl-setup>
+<python>
+Set up an agent with HITL middleware that pauses before sending emails for approval.
+
+```python
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langgraph.checkpoint.memory import MemorySaver
+from langchain_core.tools import tool
+
+@tool
+def send_email(to: str, subject: str, body: str) -> str:
+    """Send an email."""
+    return f"Email sent to {to}"
+
+agent = create_agent(
+    model="gpt-4.1",
+    tools=[send_email],
+    checkpointer=MemorySaver(),  # Required for HITL
+    middleware=[
+        HumanInTheLoopMiddleware(
+            interrupt_on={
+                "send_email": {"allowed_decisions": ["approve", "edit", "reject"]},
+            }
+        )
+    ],
+)
+```
+</python>
+<typescript>
+Set up an agent with HITL that pauses before sending emails for human approval.
+
+```typescript
+import { createAgent, humanInTheLoopMiddleware } from "langchain";
+import { MemorySaver } from "@langchain/langgraph";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const sendEmail = tool(
+  async ({ to, subject, body }) => `Email sent to ${to}`,
+  {
+    name: "send_email",
+    description: "Send an email",
+    schema: z.object({ to: z.string(), subject: z.string(), body: z.string() }),
+  }
+);
+
+const agent = createAgent({
+  model: "anthropic:claude-sonnet-4-5",
+  tools: [sendEmail],
+  checkpointer: new MemorySaver(),
+  middleware: [
+    humanInTheLoopMiddleware({
+      interruptOn: { send_email: { allowedDecisions: ["approve", "edit", "reject"] } },
+    }),
+  ],
+});
+```
+</typescript>
+</ex-basic-hitl-setup>
+
+<ex-running-with-interrupts>
+<python>
+Run the agent, detect an interrupt, then resume execution after human approval.
+
+```python
+from langgraph.types import Command
+
+config = {"configurable": {"thread_id": "session-1"}}
+
+# Step 1: Agent runs until it needs to call tool
+result1 = agent.invoke({
+    "messages": [{"role": "user", "content": "Send email to john@example.com"}]
+}, config=config)
+
+# Check for interrupt
+if "__interrupt__" in result1:
+    print(f"Waiting for approval: {result1['__interrupt__']}")
+
+# Step 2: Human approves
+result2 = agent.invoke(
+    Command(resume={"decisions": [{"type": "approve"}]}),
+    config=config
+)
+```
+</python>
+<typescript>
+Run the agent, detect an interrupt, then resume execution after human approval.
+
+```typescript
+import { Command } from "@langchain/langgraph";
+
+const config = { configurable: { thread_id: "session-1" } };
+
+// Step 1: Agent runs until it needs to call tool
+const result1 = await agent.invoke({
+  messages: [{ role: "user", content: "Send email to john@example.com" }]
+}, config);
+
+// Check for interrupt
+if (result1.__interrupt__) {
+  console.log(`Waiting for approval: ${result1.__interrupt__}`);
+}
+
+// Step 2: Human approves
+const result2 = await agent.invoke(
+  new Command({ resume: { decisions: [{ type: "approve" }] } }),
+  config
+);
+```
+</typescript>
+</ex-running-with-interrupts>
+
+<ex-editing-tool-arguments>
+<python>
+Edit the tool arguments before approving when the original values need correction.
+
+```python
+# Human edits the arguments — edited_action must include name + args
+result2 = agent.invoke(
+    Command(resume={
+        "decisions": [{
+            "type": "edit",
+            "edited_action": {
+                "name": "send_email",
+                "args": {
+                    "to": "alice@company.com",  # Fixed email
+                    "subject": "Project Meeting - Updated",
+                    "body": "...",
+                },
+            },
+        }]
+    }),
+    config=config
+)
+```
+</python>
+<typescript>
+Edit the tool arguments before approving when the original values need correction.
+
+```typescript
+// Human edits the arguments — editedAction must include name + args
+const result2 = await agent.invoke(
+  new Command({
+    resume: {
+      decisions: [{
+        type: "edit",
+        editedAction: {
+          name: "send_email",
+          args: {
+            to: "alice@company.com",  // Fixed email
+            subject: "Project Meeting - Updated",
+            body: "...",
+          },
+        },
+      }]
+    }
+  }),
+  config
+);
+```
+</typescript>
+</ex-editing-tool-arguments>
+
+<ex-rejecting-with-feedback>
+<python>
+Reject a tool call and provide feedback explaining why it was rejected.
+
+```python
+# Human rejects
+result2 = agent.invoke(
+    Command(resume={
+        "decisions": [{
+            "type": "reject",
+            "feedback": "Cannot delete customer data without manager approval",
+        }]
+    }),
+    config=config
+)
+```
+</python>
+</ex-rejecting-with-feedback>
+
+<ex-multiple-tools-different-policies>
+<python>
+Configure different HITL policies for each tool based on risk level.
+
+```python
+agent = create_agent(
+    model="gpt-4.1",
+    tools=[send_email, read_email, delete_email],
+    checkpointer=MemorySaver(),
+    middleware=[
+        HumanInTheLoopMiddleware(
+            interrupt_on={
+                "send_email": {"allowed_decisions": ["approve", "edit", "reject"]},
+                "delete_email": {"allowed_decisions": ["approve", "reject"]},  # No edit
+                "read_email": False,  # No HITL for reading
+            }
+        )
+    ],
+)
+```
+</python>
+</ex-multiple-tools-different-policies>
+
+<boundaries>
+### What You CAN Configure
+
+- Which tools require approval (per-tool policies)
+- Allowed decisions per tool (approve, edit, reject)
+- Custom middleware hooks: `before_model`, `after_model`, `wrap_tool_call`, `before_agent`, `after_agent`
+- Tool-specific middleware (apply only to certain tools)
+</boundaries>
+
+---
+
+## Custom Middleware Hooks
+
+Six decorator hooks are available. Two patterns:
+
+- **Wrap hooks** (`wrap_tool_call`, `wrap_model_call`): `(request, handler)` — call `handler(request)` to proceed, or return early to short-circuit.
+- **Before/after hooks** (`before_model`, `after_model`, `before_agent`, `after_agent`): `(state, runtime)` — inspect or modify state. Return `None` or a dict of state updates.
+
+<ex-wrap-tool-call>
+<python>
+`@wrap_tool_call` intercepts tool execution. **Do NOT use `yield`** — it creates a generator and causes `NotImplementedError`.
+
+```python
+from langchain.agents.middleware import wrap_tool_call
+
+@wrap_tool_call
+def retry_middleware(request, handler):
+    for attempt in range(3):
+        try:
+            return handler(request)
+        except Exception:
+            if attempt == 2:
+                raise
+
+@wrap_tool_call
+def guard_middleware(request, handler):
+    if request.tool_call["name"] == "dangerous_tool":
+        return "This tool is disabled"  # short-circuit
+    return handler(request)
+```
+</python>
+<typescript>
+`createMiddleware({ wrapToolCall })` intercepts tool execution.
+
+```typescript
+import { createMiddleware } from "langchain";
+
+const retryMiddleware = createMiddleware({
+  wrapToolCall: async (request, handler) => {
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try { return await handler(request); }
+      catch (e) { if (attempt === 2) throw e; }
+    }
+  },
+});
+```
+</typescript>
+</ex-wrap-tool-call>
+
+<ex-before-after-hooks>
+<python>
+`before_model` / `after_model` / `before_agent` / `after_agent` all share `(state, runtime)` signature.
+
+```python
+from langchain.agents.middleware import before_model, after_model
+
+@before_model
+def log_calls(state, runtime):
+    print(f"Calling model with {len(state['messages'])} messages")
+
+@after_model
+def check_output(state, runtime):
+    print(f"Model responded")
+```
+</python>
+<typescript>
+All before/after hooks share the same `(state, runtime)` signature via `createMiddleware`.
+
+```typescript
+import { createMiddleware } from "langchain";
+
+const loggingMiddleware = createMiddleware({
+  beforeModel: (state, runtime) => {
+    console.log(`Calling model with ${state.messages.length} messages`);
+  },
+  afterModel: (state, runtime) => {
+    console.log("Model responded");
+  },
+});
+```
+</typescript>
+</ex-before-after-hooks>
+
+<boundaries>
+### What You CANNOT Configure
+
+- Interrupt after tool execution (must be before)
+- Skip checkpointer requirement for HITL
+</boundaries>
+
+<fix-missing-checkpointer>
+<python>
+HITL middleware requires a checkpointer to persist state.
+
+```python
+# WRONG
+agent = create_agent(model="gpt-4.1", tools=[send_email], middleware=[HumanInTheLoopMiddleware({...})])
+
+# CORRECT
+agent = create_agent(
+    model="gpt-4.1", tools=[send_email],
+    checkpointer=MemorySaver(),  # Required
+    middleware=[HumanInTheLoopMiddleware({...})]
+)
+```
+</python>
+<typescript>
+HITL requires a checkpointer to persist state.
+
+```typescript
+// WRONG: No checkpointer
+const agent = createAgent({
+  model: "anthropic:claude-sonnet-4-5", tools: [sendEmail],
+  middleware: [humanInTheLoopMiddleware({ interruptOn: { send_email: true } })],
+});
+
+// CORRECT: Add checkpointer
+const agent = createAgent({
+  model: "anthropic:claude-sonnet-4-5", tools: [sendEmail],
+  checkpointer: new MemorySaver(),
+  middleware: [humanInTheLoopMiddleware({ interruptOn: { send_email: true } })],
+});
+```
+</typescript>
+</fix-missing-checkpointer>
+
+<fix-no-thread-id>
+<python>
+Always provide thread_id when using HITL to track conversation state.
+
+```python
+# WRONG
+agent.invoke(input)  # No config!
+
+# CORRECT
+agent.invoke(input, config={"configurable": {"thread_id": "user-123"}})
+```
+</python>
+</fix-no-thread-id>
+
+<fix-wrong-resume-syntax>
+<python>
+Use Command class to resume execution after an interrupt.
+
+```python
+# WRONG
+agent.invoke({"resume": {"decisions": [...]}})
+
+# CORRECT
+from langgraph.types import Command
+agent.invoke(Command(resume={"decisions": [{"type": "approve"}]}), config=config)
+```
+</python>
+<typescript>
+Use Command class to resume execution after an interrupt.
+
+```typescript
+// WRONG
+await agent.invoke({ resume: { decisions: [...] } });
+
+// CORRECT
+import { Command } from "@langchain/langgraph";
+await agent.invoke(new Command({ resume: { decisions: [{ type: "approve" }] } }), config);
+```
+</typescript>
+</fix-wrong-resume-syntax>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langchain-rag.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langchain-rag.md
@@ -1,0 +1,546 @@
+---
+name: langchain-rag
+description: "INVOKE THIS SKILL when building ANY retrieval-augmented generation (RAG) system. Covers document loaders, RecursiveCharacterTextSplitter, embeddings (OpenAI), and vector stores (Chroma, FAISS, Pinecone)."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+Retrieval Augmented Generation (RAG) enhances LLM responses by fetching relevant context from external knowledge sources.
+
+**Pipeline:**
+1. **Index**: Load → Split → Embed → Store
+2. **Retrieve**: Query → Embed → Search → Return docs
+3. **Generate**: Docs + Query → LLM → Response
+
+**Key Components:**
+- **Document Loaders**: Ingest data from files, web, databases
+- **Text Splitters**: Break documents into chunks
+- **Embeddings**: Convert text to vectors
+- **Vector Stores**: Store and search embeddings
+</overview>
+
+<vectorstore-selection>
+
+| Vector Store | Use Case | Persistence |
+|--------------|----------|-------------|
+| **InMemory** | Testing | Memory only |
+| **FAISS** | Local, high performance | Disk |
+| **Chroma** | Development | Disk |
+| **Pinecone** | Production, managed | Cloud |
+
+</vectorstore-selection>
+
+---
+
+## Complete RAG Pipeline
+
+<ex-basic-rag-setup>
+<python>
+End-to-end RAG pipeline: load documents, split into chunks, embed, store, retrieve, and generate a response.
+
+```python
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
+from langchain_community.vectorstores import InMemoryVectorStore
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+from langchain_core.documents import Document
+
+# 1. Load documents
+docs = [
+    Document(page_content="LangChain is a framework for LLM apps.", metadata={}),
+    Document(page_content="RAG = Retrieval Augmented Generation.", metadata={}),
+]
+
+# 2. Split documents
+splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+splits = splitter.split_documents(docs)
+
+# 3. Create embeddings and store
+embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+vectorstore = InMemoryVectorStore.from_documents(splits, embeddings)
+
+# 4. Create retriever
+retriever = vectorstore.as_retriever(search_kwargs={"k": 4})
+
+# 5. Use in RAG
+model = ChatOpenAI(model="gpt-4.1")
+query = "What is RAG?"
+relevant_docs = retriever.invoke(query)
+
+context = "\n\n".join([doc.page_content for doc in relevant_docs])
+response = model.invoke([
+    {"role": "system", "content": f"Use this context:\n\n{context}"},
+    {"role": "user", "content": query},
+])
+```
+</python>
+<typescript>
+End-to-end RAG pipeline: load documents, split into chunks, embed, store, retrieve, and generate a response.
+
+```typescript
+import { ChatOpenAI, OpenAIEmbeddings } from "@langchain/openai";
+import { MemoryVectorStore } from "@langchain/classic/vectorstores/memory";
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+import { Document } from "@langchain/core/documents";
+
+// 1. Load documents
+const docs = [
+  new Document({ pageContent: "LangChain is a framework for LLM apps.", metadata: {} }),
+  new Document({ pageContent: "RAG = Retrieval Augmented Generation.", metadata: {} }),
+];
+
+// 2. Split documents
+const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 500, chunkOverlap: 50 });
+const splits = await splitter.splitDocuments(docs);
+
+// 3. Create embeddings and store
+const embeddings = new OpenAIEmbeddings({ model: "text-embedding-3-small" });
+const vectorstore = await MemoryVectorStore.fromDocuments(splits, embeddings);
+
+// 4. Create retriever
+const retriever = vectorstore.asRetriever({ k: 4 });
+
+// 5. Use in RAG
+const model = new ChatOpenAI({ model: "gpt-4.1" });
+const query = "What is RAG?";
+const relevantDocs = await retriever.invoke(query);
+
+const context = relevantDocs.map(doc => doc.pageContent).join("\n\n");
+const response = await model.invoke([
+  { role: "system", content: `Use this context:\n\n${context}` },
+  { role: "user", content: query },
+]);
+```
+</typescript>
+</ex-basic-rag-setup>
+
+---
+
+## Document Loaders
+
+<ex-loading-pdf>
+<python>
+Load a PDF file and extract each page as a separate document.
+
+```python
+from langchain_community.document_loaders import PyPDFLoader
+
+loader = PyPDFLoader("./document.pdf")
+docs = loader.load()
+print(f"Loaded {len(docs)} pages")
+```
+</python>
+<typescript>
+Load a PDF file and extract each page as a separate document.
+
+```typescript
+import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
+
+const loader = new PDFLoader("./document.pdf");
+const docs = await loader.load();
+console.log(`Loaded ${docs.length} pages`);
+```
+</typescript>
+</ex-loading-pdf>
+
+<ex-loading-web-pages>
+<python>
+Fetch and parse content from a web URL into a document.
+
+```python
+from langchain_community.document_loaders import WebBaseLoader
+
+loader = WebBaseLoader("https://docs.langchain.com")
+docs = loader.load()
+```
+</python>
+<typescript>
+Fetch and parse content from a web URL into a document using Cheerio.
+
+```typescript
+import { CheerioWebBaseLoader } from "@langchain/community/document_loaders/web/cheerio";
+
+const loader = new CheerioWebBaseLoader("https://docs.langchain.com");
+const docs = await loader.load();
+```
+</typescript>
+</ex-loading-web-pages>
+
+<ex-loading-directory>
+<python>
+Load all text files from a directory using a glob pattern.
+
+```python
+from langchain_community.document_loaders import DirectoryLoader, TextLoader
+
+# Load all text files from directory
+loader = DirectoryLoader(
+    "path/to/documents",
+    glob="**/*.txt",  # Pattern for files to load
+    loader_cls=TextLoader
+)
+docs = loader.load()
+```
+</python>
+</ex-loading-directory>
+
+---
+
+## Text Splitting
+
+<ex-text-splitting>
+<python>
+Split documents into chunks using RecursiveCharacterTextSplitter with configurable size and overlap.
+
+```python
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=1000,        # Characters per chunk
+    chunk_overlap=200,      # Overlap for context continuity
+    separators=["\n\n", "\n", " ", ""],  # Split hierarchy
+)
+
+splits = splitter.split_documents(docs)
+```
+</python>
+</ex-text-splitting>
+
+---
+
+## Vector Stores
+
+<ex-chroma-vectorstore>
+<python>
+Create a persistent Chroma vector store and reload it from disk.
+
+```python
+from langchain_chroma import Chroma
+from langchain_openai import OpenAIEmbeddings
+
+vectorstore = Chroma.from_documents(
+    documents=splits,
+    embedding=OpenAIEmbeddings(),
+    persist_directory="./chroma_db",
+    collection_name="my-collection",
+)
+
+# Load existing
+vectorstore = Chroma(
+    persist_directory="./chroma_db",
+    embedding_function=OpenAIEmbeddings(),
+    collection_name="my-collection",
+)
+```
+</python>
+<typescript>
+Create a Chroma vector store connected to a running Chroma server.
+
+```typescript
+import { Chroma } from "@langchain/community/vectorstores/chroma";
+import { OpenAIEmbeddings } from "@langchain/openai";
+
+const vectorstore = await Chroma.fromDocuments(
+  splits,
+  new OpenAIEmbeddings(),
+  { collectionName: "my-collection", url: "http://localhost:8000" }
+);
+```
+</typescript>
+</ex-chroma-vectorstore>
+
+<ex-faiss-vectorstore>
+<python>
+Create a FAISS vector store, save it to disk, and reload it.
+
+```python
+from langchain_community.vectorstores import FAISS
+
+vectorstore = FAISS.from_documents(splits, embeddings)
+vectorstore.save_local("./faiss_index")
+
+# Load (requires allow_dangerous_deserialization)
+loaded = FAISS.load_local(
+    "./faiss_index",
+    embeddings,
+    allow_dangerous_deserialization=True
+)
+```
+</python>
+<typescript>
+Create a FAISS vector store, save it to disk, and reload it.
+
+```typescript
+import { FaissStore } from "@langchain/community/vectorstores/faiss";
+
+const vectorstore = await FaissStore.fromDocuments(splits, embeddings);
+await vectorstore.save("./faiss_index");
+
+const loaded = await FaissStore.load("./faiss_index", embeddings);
+```
+</typescript>
+</ex-faiss-vectorstore>
+
+---
+
+## Retrieval
+
+<ex-similarity-search>
+<python>
+Perform similarity search and retrieve results with relevance scores.
+
+```python
+# Basic search
+results = vectorstore.similarity_search(query, k=5)
+
+# With scores
+results_with_score = vectorstore.similarity_search_with_score(query, k=5)
+for doc, score in results_with_score:
+    print(f"Score: {score}, Content: {doc.page_content}")
+```
+</python>
+<typescript>
+Perform similarity search and retrieve results with relevance scores.
+
+```typescript
+// Basic search
+const results = await vectorstore.similaritySearch(query, 5);
+
+// With scores
+const resultsWithScore = await vectorstore.similaritySearchWithScore(query, 5);
+for (const [doc, score] of resultsWithScore) {
+  console.log(`Score: ${score}, Content: ${doc.pageContent}`);
+}
+```
+</typescript>
+</ex-similarity-search>
+
+<ex-mmr-search>
+<python>
+Use MMR (Maximal Marginal Relevance) to balance relevance and diversity in search results.
+
+```python
+# MMR balances relevance and diversity
+retriever = vectorstore.as_retriever(
+    search_type="mmr",
+    search_kwargs={"fetch_k": 20, "lambda_mult": 0.5, "k": 5},
+)
+```
+</python>
+</ex-mmr-search>
+
+<ex-metadata-filtering>
+<python>
+Add metadata to documents and filter search results by metadata properties.
+
+```python
+# Add metadata when creating documents
+docs = [
+    Document(
+        page_content="Python programming guide",
+        metadata={"language": "python", "topic": "programming"}
+    ),
+]
+
+# Search with filter
+results = vectorstore.similarity_search(
+    "programming",
+    k=5,
+    filter={"language": "python"}  # Only Python docs
+)
+```
+</python>
+</ex-metadata-filtering>
+
+<ex-rag-with-agent>
+<python>
+Create an agent that uses RAG as a tool for answering questions.
+
+```python
+from langchain.agents import create_agent
+from langchain_core.tools import tool
+
+@tool
+def search_docs(query: str) -> str:
+    """Search documentation for relevant information."""
+    docs = retriever.invoke(query)
+    return "\n\n".join([d.page_content for d in docs])
+
+agent = create_agent(
+    model="gpt-4.1",
+    tools=[search_docs],
+)
+
+result = agent.invoke({
+    "messages": [{"role": "user", "content": "How do I create an agent?"}]
+})
+```
+</python>
+<typescript>
+Create an agent that uses RAG as a tool for answering questions.
+
+```typescript
+import { createAgent } from "langchain";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const searchDocs = tool(
+  async (input) => {
+    const docs = await retriever.invoke(input.query);
+    return docs.map(d => d.pageContent).join("\n\n");
+  },
+  {
+    name: "search_docs",
+    description: "Search documentation for relevant information.",
+    schema: z.object({ query: z.string() }),
+  }
+);
+
+const agent = createAgent({
+  model: "gpt-4.1",
+  tools: [searchDocs],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "How do I create an agent?" }],
+});
+```
+</typescript>
+</ex-rag-with-agent>
+
+<boundaries>
+### What You CAN Configure
+
+- Chunk size/overlap
+- Embedding model
+- Number of results (k)
+- Metadata filters
+- Search algorithms: Similarity, MMR
+
+### What You CANNOT Configure
+
+- Embedding dimensions (per model)
+- Mix embeddings from different models in same store
+</boundaries>
+
+<fix-chunk-size>
+<python>
+Chunk size 500-1500 is typically good.
+
+```python
+# WRONG: Too small (loses context) or too large (hits limits)
+splitter = RecursiveCharacterTextSplitter(chunk_size=50)
+splitter = RecursiveCharacterTextSplitter(chunk_size=10000)
+
+# CORRECT
+splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+```
+</python>
+<typescript>
+Chunk size 500-1500 is typically good.
+
+```typescript
+// WRONG: Too small or too large
+const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 50 });
+
+// CORRECT
+const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 1000, chunkOverlap: 200 });
+```
+</typescript>
+</fix-chunk-size>
+
+<fix-chunk-overlap>
+<python>
+Use overlap (10-20% of chunk size) to maintain context at boundaries.
+
+```python
+# WRONG: No overlap - context breaks at boundaries
+splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=0)
+
+# CORRECT: 10-20% overlap
+splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+```
+</python>
+</fix-chunk-overlap>
+
+<fix-persist-vectorstore>
+<python>
+Use persistent vector store instead of in-memory to avoid data loss.
+
+```python
+# WRONG: InMemory - lost on restart
+vectorstore = InMemoryVectorStore.from_documents(docs, embeddings)
+
+# CORRECT
+vectorstore = Chroma.from_documents(docs, embeddings, persist_directory="./chroma_db")
+```
+</python>
+<typescript>
+Use persistent vector store instead of in-memory to avoid data loss.
+
+```typescript
+// WRONG: Memory - lost on restart
+const vectorstore = await MemoryVectorStore.fromDocuments(docs, embeddings);
+
+// CORRECT
+const vectorstore = await Chroma.fromDocuments(docs, embeddings, { collectionName: "my-collection" });
+```
+</typescript>
+</fix-persist-vectorstore>
+
+<fix-consistent-embeddings>
+<python>
+Use the same embedding model for indexing and querying.
+
+```python
+# WRONG: Different embeddings for index and query - incompatible!
+vectorstore = Chroma.from_documents(docs, OpenAIEmbeddings(model="text-embedding-3-small"))
+retriever = vectorstore.as_retriever(embeddings=OpenAIEmbeddings(model="text-embedding-3-large"))
+
+# CORRECT: Same model
+embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+vectorstore = Chroma.from_documents(docs, embeddings)
+retriever = vectorstore.as_retriever()  # Uses same embeddings
+```
+</python>
+<typescript>
+Use the same embedding model for indexing and querying.
+
+```typescript
+const embeddings = new OpenAIEmbeddings({ model: "text-embedding-3-small" });
+const vectorstore = await Chroma.fromDocuments(docs, embeddings);
+const retriever = vectorstore.asRetriever();  // Uses same embeddings
+```
+</typescript>
+</fix-consistent-embeddings>
+
+<fix-faiss-deserialization>
+<python>
+Explicitly allow deserialization when loading FAISS indexes.
+
+```python
+# WRONG: Will raise error
+loaded_store = FAISS.load_local("./faiss_index", embeddings)
+
+# CORRECT
+loaded_store = FAISS.load_local("./faiss_index", embeddings, allow_dangerous_deserialization=True)
+```
+</python>
+</fix-faiss-deserialization>
+
+<fix-dimension-mismatch>
+<python>
+Ensure embedding dimensions match the vector store index dimensions.
+
+```python
+# WRONG: Index has 1536 dimensions but using 512-dim embeddings
+pc.create_index(name="idx", dimension=1536, metric="cosine")
+vectorstore = PineconeVectorStore.from_documents(
+    docs, OpenAIEmbeddings(model="text-embedding-3-small", dimensions=512), index=pc.Index("idx")
+)  # Error: dimension mismatch!
+
+# CORRECT: Match dimensions
+embeddings = OpenAIEmbeddings()  # Default 1536
+```
+</python>
+</fix-dimension-mismatch>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langgraph-cli.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langgraph-cli.md
@@ -1,0 +1,248 @@
+---
+name: langgraph-cli
+description: "INVOKE THIS SKILL when using the langgraph CLI to scaffold, develop, build, or deploy LangGraph applications. Covers langgraph new, dev, build, up, deploy, and langgraph.json configuration."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+The `langgraph` CLI manages the full lifecycle of LangGraph applications — from scaffolding a new project to deploying it to LangGraph Platform (LangSmith Deployments).
+
+Key commands:
+- **`langgraph new`** — Scaffold a project from a template
+- **`langgraph dev`** — Run locally with hot reload (no Docker)
+- **`langgraph build`** — Build a Docker image
+- **`langgraph up`** — Launch locally via Docker Compose
+- **`langgraph deploy`** — Ship to LangGraph Platform
+- **`langgraph dockerfile`** — Generate a Dockerfile
+
+All commands (except `new`) read from a `langgraph.json` config file in the project root.
+</overview>
+
+## When to use
+
+Use this skill when the user wants to:
+- Scaffold a new LangGraph project
+- Run a local development or production-like server
+- Build or deploy a LangGraph application
+- Understand or edit `langgraph.json` configuration
+- Manage LangSmith Deployments (list, delete, view logs)
+
+## Installation
+
+```bash
+# Python
+pip install 'langgraph-cli[inmem]'   # includes langgraph dev support
+pip install langgraph-cli             # without dev server (build/up/deploy only)
+
+# if using UV as package manager
+uv add "langgraph-cli[inmem]"       # includes langgraph dev support
+uv add langgraph-cli                # without dev server (build/up/deploy only)
+
+# JavaScript
+npx @langchain/langgraph-cli         # use on demand
+npm install -g @langchain/langgraph-cli  # install globally (available as langgraphjs)
+```
+
+## Commands
+
+### `langgraph new [PATH]`
+
+Scaffold a new project from a template.
+
+```bash
+langgraph new                          # interactive template selection
+langgraph new ./my-agent               # create in specific directory
+langgraph new --template agent-python  # skip prompt, use template directly
+```
+
+Available templates: `deep-agent-python`, `deep-agent-js`, `agent-python`, `new-langgraph-project-python`, `new-langgraph-project-js`
+
+### `langgraph dev`
+
+Run a local development server with hot reloading. No Docker required.
+
+```bash
+langgraph dev                              # default: localhost:2024
+langgraph dev --port 8000                  # custom port
+langgraph dev --config ./langgraph.json    # explicit config path
+langgraph dev --no-reload                  # disable hot reload
+langgraph dev --no-browser                 # don't auto-open LangGraph Studio
+langgraph dev --host 0.0.0.0              # bind to all interfaces (trusted networks only)
+langgraph dev --tunnel                     # expose via Cloudflare tunnel for remote access
+langgraph dev --debug-port 5678            # enable remote debugger (requires debugpy)
+langgraph dev --n-jobs-per-worker 20       # max concurrent jobs per worker (default: 10)
+```
+
+### `langgraph build`
+
+Build a Docker image for the LangGraph API server.
+
+```bash
+langgraph build -t my-image                # required: tag the image
+langgraph build -t my-image --no-pull      # use locally-built base images
+langgraph build -t my-image -c langgraph.json  # explicit config
+langgraph build -t my-image --base-image langchain/langgraph-server:0.2.18  # pin base version
+```
+
+### `langgraph up`
+
+Launch the LangGraph API server via Docker Compose (includes Postgres).
+
+```bash
+langgraph up                               # default port 8123
+langgraph up --port 8000                   # custom port
+langgraph up --watch                       # restart on file changes
+langgraph up --recreate                    # force fresh build (useful for pre-deploy validation)
+langgraph up --postgres-uri postgresql://...  # external Postgres
+langgraph up --no-pull                     # use local images (after langgraph build)
+langgraph up --image my-image              # skip build, use pre-built image
+langgraph up -d docker-compose.yml         # add extra Docker services
+langgraph up --debugger-port 8124          # serve debugger UI
+langgraph up --wait                        # block until services are healthy
+```
+
+### `langgraph deploy`
+
+Build and deploy to LangGraph Platform (LangSmith Deployments). Requires Docker. On Apple Silicon (M1/M2/M3), Docker Buildx is also required for cross-compiling to `linux/amd64`.
+
+```bash
+langgraph deploy                           # deploy, name defaults to directory name
+langgraph deploy --name my-agent           # explicit deployment name
+langgraph deploy --deployment-type prod    # production deployment (default: dev)
+langgraph deploy --tag v1.2.0              # custom image tag (default: latest)
+langgraph deploy --deployment-id <id>      # update an existing deployment by ID
+langgraph deploy --config ./langgraph.json # explicit config path
+langgraph deploy --no-wait                 # don't wait for deployment status
+langgraph deploy --verbose                 # show detailed server logs
+```
+
+Prereq: `LANGSMITH_API_KEY` in environment or `.env`.
+
+`langgraph deploy` also accepts build flags: `--base-image`, `--pull`/`--no-pull`.
+
+#### `langgraph deploy list`
+
+```bash
+langgraph deploy list                      # list all deployments
+langgraph deploy list --name-contains bot  # filter by name
+```
+
+#### `langgraph deploy delete`
+
+```bash
+langgraph deploy delete <deployment-id>          # interactive confirmation
+langgraph deploy delete <deployment-id> --force  # skip confirmation
+```
+
+#### `langgraph deploy logs`
+
+```bash
+langgraph deploy logs                                  # runtime logs, last 100
+langgraph deploy logs --name my-agent                  # by deployment name
+langgraph deploy logs --deployment-id <id>             # by deployment ID
+langgraph deploy logs --type build                     # build logs instead of runtime
+langgraph deploy logs -f                               # follow/stream logs
+langgraph deploy logs --level error                    # filter by level (debug|info|warning|error|critical)
+langgraph deploy logs -q "timeout"                     # search filter
+langgraph deploy logs --limit 500                      # more entries
+langgraph deploy logs --start-time 2026-03-08T00:00:00Z  # time range
+```
+
+### `langgraph dockerfile <SAVE_PATH>`
+
+Generate a Dockerfile (and optionally Docker Compose files) without building.
+
+```bash
+langgraph dockerfile ./Dockerfile                      # generate Dockerfile
+langgraph dockerfile ./Dockerfile --add-docker-compose # also generate compose + .env + .dockerignore
+```
+
+## `langgraph.json` reference
+
+The configuration file used by all CLI commands (`dev`, `build`, `up`, `deploy`). Defaults to `langgraph.json` in the current directory.
+
+### Minimal config (Python)
+
+```json
+{
+    "dependencies": ["."],
+    "graphs": {
+        "agent": "./my_agent/agent.py:graph"
+    },
+    "env": "./.env"
+}
+```
+
+### Minimal config (JavaScript)
+
+```json
+{
+    "dependencies": ["."],
+    "graphs": {
+        "agent": "./src/agent.js:graph"
+    },
+    "env": "./.env"
+}
+```
+
+### Full config with all keys
+
+```json
+{
+    "dependencies": [".", "langchain_openai", "./local_package"],
+    "graphs": {
+        "agent": "./my_agent/agent.py:graph",
+        "retriever": "./my_agent/rag.py:rag_graph"
+    },
+    "env": "./.env",
+    "python_version": "3.12",
+    "pip_config_file": "./pip.conf",
+    "dockerfile_lines": [
+        "RUN apt-get update && apt-get install -y ffmpeg"
+    ]
+}
+```
+
+### Key reference
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `dependencies` | Yes | Array of dependencies. `"."` looks for local packages via `pyproject.toml`, `setup.py`, `requirements.txt`, or `package.json`. Can also be paths to subdirectories (`"./my_pkg"`) or package names (`"langchain_openai"`). |
+| `graphs` | Yes | Mapping of graph ID to path. Format: `./path/to/file.py:variable` (Python) or `./path/to/file.js:function` (JS). The variable must be a `CompiledGraph` or a function returning one. Multiple graphs supported. |
+| `env` | No | Path to a `.env` file (string) OR an inline mapping of env var names to values (object). Used by `langgraph dev` and `langgraph up` locally. `langgraph deploy` reads from this file and adds the variables as deployment secrets. |
+| `python_version` | No | `"3.11"`, `"3.12"`, or `"3.13"`. Defaults to `"3.11"`. |
+| `node_version` | No | Node.js version for JS projects. |
+| `pip_config_file` | No | Path to a pip config file for custom package indexes. |
+| `dockerfile_lines` | No | Array of additional Dockerfile lines appended after the base image import. Use for system packages, binaries, or custom setup. |
+
+## Typical workflow
+
+1. **Scaffold** — `langgraph new` to create a project from a template.
+2. **Configure** — Edit `langgraph.json`: set dependencies, point `graphs` at your compiled graph(s), add `.env`.
+3. **Develop** — `langgraph dev` for rapid local iteration with hot reload (no Docker, port 2024).
+4. **Validate** — `langgraph up --recreate` to test in a production-like Docker stack (port 8123, includes Postgres).
+5. **Deploy** — `langgraph deploy` to ship to LangGraph Platform (LangSmith Deployments).
+6. **Monitor** — `langgraph deploy logs -f` to tail runtime logs; `--type build` for build logs.
+
+## `langgraph dev` vs `langgraph up`
+
+| Feature | `langgraph dev` | `langgraph up` |
+|---------|----------------|----------------|
+| Docker required | No | Yes |
+| Install | `pip install 'langgraph-cli[inmem]'` | `pip install langgraph-cli` |
+| Primary use | Rapid development & testing | Production-like validation |
+| State persistence | In-memory / pickled to local dir | PostgreSQL |
+| Hot reloading | Yes (default) | Optional (`--watch`) |
+| Default port | 2024 | 8123 |
+| Resource usage | Lightweight | Heavier (Docker containers for server, Postgres, Redis) |
+| IDE debugging | Built-in DAP support (`--debug-port`) | Container debugging |
+
+## Gotchas
+
+- **`langgraph deploy` requires Docker** — On Apple Silicon (M1/M2/M3), Docker Buildx is also required for cross-compiling to `linux/amd64`.
+- **`langgraph deploy` can only update its own deployments** — Deployments created through the LangSmith UI or GitHub integration cannot be updated with `langgraph deploy`. Use the UI for those.
+- **`dependencies` must include all packages** — The `dependencies` array in `langgraph.json` must point to where your package config lives (e.g., `"."` for root). The actual packages are resolved from `pyproject.toml`, `requirements.txt`, or `package.json` at that location.
+- **`langgraph dev` runs without Docker** — It runs directly in your environment. If your code depends on system packages (e.g., `ffmpeg`), they must be installed locally. Use `langgraph up` to validate Docker builds.
+- **JavaScript CLI** — Use `npx @langchain/langgraph-cli <command>` (or `langgraphjs` if installed globally via `npm install -g @langchain/langgraph-cli`).
+- **API key** — `LANGSMITH_API_KEY` is required for `langgraph deploy`. For `langgraph dev`, it is optional — the server runs without it, but you won't get traces in LangSmith. Can also be set via `LANGGRAPH_HOST_API_KEY` or `LANGCHAIN_API_KEY`.

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langgraph-fundamentals.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langgraph-fundamentals.md
@@ -1,0 +1,934 @@
+---
+name: langgraph-fundamentals
+description: "INVOKE THIS SKILL when writing ANY LangGraph code. Covers StateGraph, state schemas, nodes, edges, Command, Send, invoke, streaming, and error handling."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+LangGraph models agent workflows as **directed graphs**:
+
+- **StateGraph**: Main class for building stateful graphs
+- **Nodes**: Functions that perform work and update state
+- **Edges**: Define execution order (static or conditional)
+- **START/END**: Special nodes marking entry and exit points
+- **State with Reducers**: Control how state updates are merged
+
+Graphs must be `compile()`d before execution.
+</overview>
+
+<design-methodology>
+
+### Designing a LangGraph application
+
+Follow these 5 steps when building a new graph:
+
+1. **Map out discrete steps** — sketch a flowchart of your workflow. Each step becomes a node.
+2. **Identify what each step does** — categorize nodes: LLM step, data step, action step, or user input step. For each, determine static context (prompt), dynamic context (from state), retry strategy, and desired outcome.
+3. **Design your state** — state is shared memory for all nodes. Store raw data, format prompts on-demand inside nodes.
+4. **Build your nodes** — implement each step as a function that takes state and returns partial updates.
+5. **Wire it together** — connect nodes with edges, add conditional routing, compile with a checkpointer if needed.
+
+</design-methodology>
+
+<when-to-use-langgraph>
+
+| Use LangGraph When | Use Alternatives When |
+|-------------------|----------------------|
+| Need fine-grained control over agent orchestration | Quick prototyping → LangChain agents |
+| Building complex workflows with branching/loops | Simple stateless workflows → LangChain direct |
+| Require human-in-the-loop, persistence | Batteries-included features → Deep Agents |
+
+</when-to-use-langgraph>
+
+---
+
+## State Management
+
+<state-update-strategies>
+
+| Need | Solution | Example |
+|------|----------|---------|
+| Overwrite value | No reducer (default) | Simple fields like counters |
+| Append to list | Reducer (operator.add / concat) | Message history, logs |
+| Custom logic | Custom reducer function | Complex merging |
+
+</state-update-strategies>
+
+<ex-state-with-reducer>
+<python>
+Define state schema with reducers for accumulating lists and summing integers.
+
+```python
+from typing_extensions import TypedDict, Annotated
+import operator
+
+class State(TypedDict):
+    name: str  # Default: overwrites on update
+    messages: Annotated[list, operator.add]  # Appends to list
+    total: Annotated[int, operator.add]  # Sums integers
+```
+</python>
+<typescript>
+Use StateSchema with ReducedValue for accumulating arrays.
+
+```typescript
+import { StateSchema, ReducedValue, MessagesValue } from "@langchain/langgraph";
+import { z } from "zod";
+
+const State = new StateSchema({
+  name: z.string(),  // Default: overwrites
+  messages: MessagesValue,  // Built-in for messages
+  items: new ReducedValue(
+    z.array(z.string()).default(() => []),
+    { reducer: (current, update) => current.concat(update) }
+  ),
+});
+```
+</typescript>
+</ex-state-with-reducer>
+
+<fix-forgot-reducer-for-list>
+<python>
+Without a reducer, returning a list overwrites previous values.
+
+```python
+# WRONG: List will be OVERWRITTEN
+class State(TypedDict):
+    messages: list  # No reducer!
+
+# Node 1 returns: {"messages": ["A"]}
+# Node 2 returns: {"messages": ["B"]}
+# Final: {"messages": ["B"]}  # "A" is LOST!
+
+# CORRECT: Use Annotated with operator.add
+from typing import Annotated
+import operator
+
+class State(TypedDict):
+    messages: Annotated[list, operator.add]
+# Final: {"messages": ["A", "B"]}
+```
+</python>
+<typescript>
+Without ReducedValue, arrays are overwritten not appended.
+
+```typescript
+// WRONG: Array will be overwritten
+const State = new StateSchema({
+  items: z.array(z.string()),  // No reducer!
+});
+// Node 1: { items: ["A"] }, Node 2: { items: ["B"] }
+// Final: { items: ["B"] }  // A is lost!
+
+// CORRECT: Use ReducedValue
+const State = new StateSchema({
+  items: new ReducedValue(
+    z.array(z.string()).default(() => []),
+    { reducer: (current, update) => current.concat(update) }
+  ),
+});
+// Final: { items: ["A", "B"] }
+```
+</typescript>
+</fix-forgot-reducer-for-list>
+
+<fix-state-must-return-dict>
+<python>
+Nodes must return partial updates, not mutate and return full state.
+
+```python
+# WRONG: Returning entire state object
+def my_node(state: State) -> State:
+    state["field"] = "updated"
+    return state  # Don't mutate and return!
+
+# CORRECT: Return dict with only the updates
+def my_node(state: State) -> dict:
+    return {"field": "updated"}
+```
+</python>
+<typescript>
+Return partial updates only, not the full state object.
+
+```typescript
+// WRONG: Returning entire state
+const myNode = async (state: typeof State.State) => {
+  state.field = "updated";
+  return state;  // Don't do this!
+};
+
+// CORRECT: Return partial updates
+const myNode = async (state: typeof State.State) => {
+  return { field: "updated" };
+};
+```
+</typescript>
+</fix-state-must-return-dict>
+
+---
+
+## Nodes
+
+<node-function-signatures>
+
+Node functions accept these arguments:
+
+<python>
+
+| Signature | When to Use |
+|-----------|-------------|
+| `def node(state: State)` | Simple sync nodes that only need state |
+| `async def node(state: State)` | Node does I/O (LLM calls, DB, HTTP) — use with `ainvoke`/`astream` |
+| `def node(state: State, config: RunnableConfig)` | Need thread_id, tags, or configurable values |
+| `async def node(state: State, config: RunnableConfig)` | Async + configurable values |
+| `def node(state: State, runtime: Runtime[Context])` | Need runtime context, store, or stream_writer |
+
+```python
+from langchain_core.runnables import RunnableConfig
+from langgraph.runtime import Runtime
+
+def plain_node(state: State):
+    return {"results": "done"}
+
+async def async_node(state: State):
+    """Use async def when calling LLMs, external APIs, or other coroutines."""
+    result = await some_llm_call(state["query"])
+    return {"results": result}
+
+def node_with_config(state: State, config: RunnableConfig):
+    thread_id = config["configurable"]["thread_id"]
+    return {"results": f"Thread: {thread_id}"}
+
+async def async_node_with_config(state: State, config: RunnableConfig):
+    thread_id = config["configurable"]["thread_id"]
+    result = await some_llm_call(state["query"])
+    return {"results": result}
+
+def node_with_runtime(state: State, runtime: Runtime[Context]):
+    user_id = runtime.context.user_id
+    return {"results": f"User: {user_id}"}
+```
+
+> **Note:** If any node is `async def`, use `await graph.ainvoke(...)` / `async for chunk in graph.astream(...)` to run the graph. LangGraph supports both sync and async execution paths — the async path is required when nodes perform I/O.
+</python>
+<typescript>
+
+| Signature | When to Use |
+|-----------|-------------|
+| `(state) => {...}` | Simple nodes that only need state |
+| `(state, config) => {...}` | Need thread_id, tags, or configurable values |
+
+```typescript
+import { GraphNode, StateSchema } from "@langchain/langgraph";
+
+const plainNode: GraphNode<typeof State> = (state) => {
+  return { results: "done" };
+};
+
+const nodeWithConfig: GraphNode<typeof State> = (state, config) => {
+  const threadId = config?.configurable?.thread_id;
+  return { results: `Thread: ${threadId}` };
+};
+```
+</typescript>
+
+</node-function-signatures>
+
+---
+
+## Edges
+
+<edge-type-selection>
+
+| Need | Edge Type | When to Use |
+|------|-----------|-------------|
+| Always go to same node | `add_edge()` | Fixed, deterministic flow |
+| Route based on state | `add_conditional_edges()` | Dynamic branching |
+| Update state AND route | `Command` | Combine logic in single node |
+| Fan-out to multiple nodes | `Send` | Parallel processing with dynamic inputs |
+
+</edge-type-selection>
+
+<ex-basic-graph>
+<python>
+Simple two-node graph with linear edges.
+
+```python
+from langgraph.graph import StateGraph, START, END
+from typing_extensions import TypedDict
+
+class State(TypedDict):
+    input: str
+    output: str
+
+def process_input(state: State) -> dict:
+    return {"output": f"Processed: {state['input']}"}
+
+def finalize(state: State) -> dict:
+    return {"output": state["output"].upper()}
+
+graph = (
+    StateGraph(State)
+    .add_node("process", process_input)
+    .add_node("finalize", finalize)
+    .add_edge(START, "process")
+    .add_edge("process", "finalize")
+    .add_edge("finalize", END)
+    .compile()
+)
+
+result = graph.invoke({"input": "hello"})
+print(result["output"])  # "PROCESSED: HELLO"
+```
+</python>
+<typescript>
+Chain nodes with addEdge and compile before invoking.
+
+```typescript
+import { StateGraph, StateSchema, START, END } from "@langchain/langgraph";
+import { z } from "zod";
+
+const State = new StateSchema({
+  input: z.string(),
+  output: z.string().default(""),
+});
+
+const processInput = async (state: typeof State.State) => {
+  return { output: `Processed: ${state.input}` };
+};
+
+const finalize = async (state: typeof State.State) => {
+  return { output: state.output.toUpperCase() };
+};
+
+const graph = new StateGraph(State)
+  .addNode("process", processInput)
+  .addNode("finalize", finalize)
+  .addEdge(START, "process")
+  .addEdge("process", "finalize")
+  .addEdge("finalize", END)
+  .compile();
+
+const result = await graph.invoke({ input: "hello" });
+console.log(result.output);  // "PROCESSED: HELLO"
+```
+</typescript>
+</ex-basic-graph>
+
+<ex-conditional-edges>
+<python>
+Route to different nodes based on state with conditional edges.
+
+```python
+from typing import Literal
+from langgraph.graph import StateGraph, START, END
+
+class State(TypedDict):
+    query: str
+    route: str
+    result: str
+
+def classify(state: State) -> dict:
+    if "weather" in state["query"].lower():
+        return {"route": "weather"}
+    return {"route": "general"}
+
+def route_query(state: State) -> Literal["weather", "general"]:
+    return state["route"]
+
+graph = (
+    StateGraph(State)
+    .add_node("classify", classify)
+    .add_node("weather", lambda s: {"result": "Sunny, 72F"})
+    .add_node("general", lambda s: {"result": "General response"})
+    .add_edge(START, "classify")
+    .add_conditional_edges("classify", route_query, ["weather", "general"])
+    .add_edge("weather", END)
+    .add_edge("general", END)
+    .compile()
+)
+```
+</python>
+<typescript>
+addConditionalEdges routes based on function return value.
+
+```typescript
+import { StateGraph, StateSchema, START, END } from "@langchain/langgraph";
+import { z } from "zod";
+
+const State = new StateSchema({
+  query: z.string(),
+  route: z.string().default(""),
+  result: z.string().default(""),
+});
+
+const classify = async (state: typeof State.State) => {
+  if (state.query.toLowerCase().includes("weather")) {
+    return { route: "weather" };
+  }
+  return { route: "general" };
+};
+
+const routeQuery = (state: typeof State.State) => state.route;
+
+const graph = new StateGraph(State)
+  .addNode("classify", classify)
+  .addNode("weather", async () => ({ result: "Sunny, 72F" }))
+  .addNode("general", async () => ({ result: "General response" }))
+  .addEdge(START, "classify")
+  .addConditionalEdges("classify", routeQuery, ["weather", "general"])
+  .addEdge("weather", END)
+  .addEdge("general", END)
+  .compile();
+```
+</typescript>
+</ex-conditional-edges>
+
+---
+
+## Command
+
+Command combines state updates and routing in a single return value. Fields:
+- **`update`**: State updates to apply (like returning a dict from a node)
+- **`goto`**: Node name(s) to navigate to next
+- **`resume`**: Value to resume after `interrupt()` — see human-in-the-loop skill
+
+<ex-command-state-and-routing>
+<python>
+Command lets you update state AND choose next node in one return.
+
+```python
+from langgraph.types import Command
+from typing import Literal
+
+class State(TypedDict):
+    count: int
+    result: str
+
+def node_a(state: State) -> Command[Literal["node_b", "node_c"]]:
+    """Update state AND decide next node in one return."""
+    new_count = state["count"] + 1
+    if new_count > 5:
+        return Command(update={"count": new_count}, goto="node_c")
+    return Command(update={"count": new_count}, goto="node_b")
+
+graph = (
+    StateGraph(State)
+    .add_node("node_a", node_a)
+    .add_node("node_b", lambda s: {"result": "B"})
+    .add_node("node_c", lambda s: {"result": "C"})
+    .add_edge(START, "node_a")
+    .add_edge("node_b", END)
+    .add_edge("node_c", END)
+    .compile()
+)
+```
+</python>
+<typescript>
+Return Command with update and goto to combine state change with routing.
+
+```typescript
+import { StateGraph, StateSchema, START, END, Command } from "@langchain/langgraph";
+import { z } from "zod";
+
+const State = new StateSchema({
+  count: z.number().default(0),
+  result: z.string().default(""),
+});
+
+const nodeA = async (state: typeof State.State) => {
+  const newCount = state.count + 1;
+  if (newCount > 5) {
+    return new Command({ update: { count: newCount }, goto: "node_c" });
+  }
+  return new Command({ update: { count: newCount }, goto: "node_b" });
+};
+
+const graph = new StateGraph(State)
+  .addNode("node_a", nodeA, { ends: ["node_b", "node_c"] })
+  .addNode("node_b", async () => ({ result: "B" }))
+  .addNode("node_c", async () => ({ result: "C" }))
+  .addEdge(START, "node_a")
+  .addEdge("node_b", END)
+  .addEdge("node_c", END)
+  .compile();
+```
+</typescript>
+</ex-command-state-and-routing>
+
+<command-return-type-annotations>
+
+**Python**: Use `Command[Literal["node_a", "node_b"]]` as the return type annotation to declare valid goto destinations.
+
+**TypeScript**: Pass `{ ends: ["node_a", "node_b"] }` as the third argument to `addNode` to declare valid goto destinations.
+
+</command-return-type-annotations>
+
+<warning-command-static-edges>
+
+**Warning**: `Command` only adds **dynamic** edges — static edges defined with `add_edge` / `addEdge` still execute. If `node_a` returns `Command(goto="node_c")` and you also have `graph.add_edge("node_a", "node_b")`, **both** `node_b` and `node_c` will run.
+
+</warning-command-static-edges>
+
+---
+
+## Send API
+
+Fan-out with `Send`: return `[Send("worker", {...})]` from a conditional edge to spawn parallel workers. Requires a reducer on the results field.
+
+<ex-orchestrator-worker>
+<python>
+Fan out tasks to parallel workers using the Send API and aggregate results.
+
+```python
+from langgraph.types import Send
+from typing import Annotated
+import operator
+
+class OrchestratorState(TypedDict):
+    tasks: list[str]
+    results: Annotated[list, operator.add]
+    summary: str
+
+def orchestrator(state: OrchestratorState):
+    """Fan out tasks to workers."""
+    return [Send("worker", {"task": task}) for task in state["tasks"]]
+
+def worker(state: dict) -> dict:
+    return {"results": [f"Completed: {state['task']}"]}
+
+def synthesize(state: OrchestratorState) -> dict:
+    return {"summary": f"Processed {len(state['results'])} tasks"}
+
+graph = (
+    StateGraph(OrchestratorState)
+    .add_node("worker", worker)
+    .add_node("synthesize", synthesize)
+    .add_conditional_edges(START, orchestrator, ["worker"])
+    .add_edge("worker", "synthesize")
+    .add_edge("synthesize", END)
+    .compile()
+)
+
+result = graph.invoke({"tasks": ["Task A", "Task B", "Task C"]})
+```
+</python>
+<typescript>
+Fan out tasks to parallel workers using the Send API and aggregate results.
+
+```typescript
+import { Send, StateGraph, StateSchema, ReducedValue, START, END } from "@langchain/langgraph";
+import { z } from "zod";
+
+const State = new StateSchema({
+  tasks: z.array(z.string()),
+  results: new ReducedValue(
+    z.array(z.string()).default(() => []),
+    { reducer: (curr, upd) => curr.concat(upd) }
+  ),
+  summary: z.string().default(""),
+});
+
+const orchestrator = (state: typeof State.State) => {
+  return state.tasks.map((task) => new Send("worker", { task }));
+};
+
+const worker = async (state: { task: string }) => {
+  return { results: [`Completed: ${state.task}`] };
+};
+
+const synthesize = async (state: typeof State.State) => {
+  return { summary: `Processed ${state.results.length} tasks` };
+};
+
+const graph = new StateGraph(State)
+  .addNode("worker", worker)
+  .addNode("synthesize", synthesize)
+  .addConditionalEdges(START, orchestrator, ["worker"])
+  .addEdge("worker", "synthesize")
+  .addEdge("synthesize", END)
+  .compile();
+```
+</typescript>
+</ex-orchestrator-worker>
+
+<fix-send-accumulator>
+<python>
+Use a reducer to accumulate parallel worker results (otherwise last worker overwrites).
+
+```python
+# WRONG: No reducer - last worker overwrites
+class State(TypedDict):
+    results: list
+
+# CORRECT
+class State(TypedDict):
+    results: Annotated[list, operator.add]  # Accumulates
+```
+</python>
+<typescript>
+Use ReducedValue to accumulate parallel worker results.
+
+```typescript
+// WRONG: No reducer
+const State = new StateSchema({ results: z.array(z.string()) });
+
+// CORRECT
+const State = new StateSchema({
+  results: new ReducedValue(z.array(z.string()).default(() => []), { reducer: (curr, upd) => curr.concat(upd) }),
+});
+```
+</typescript>
+</fix-send-accumulator>
+
+---
+
+## Running Graphs: Invoke and Stream
+
+<invoke-basics>
+
+Call `graph.invoke(input, config)` (sync) or `await graph.ainvoke(input, config)` (async) to run a graph to completion and return the final state. Use `ainvoke` when any node is `async def` or when the graph is called from an async context (e.g., inside another async node or a NAT adapter).
+
+<python>
+
+```python
+# Sync — use when all nodes are sync def
+result = graph.invoke({"input": "hello"})
+result = graph.invoke({"input": "hello"}, {"configurable": {"thread_id": "1"}})
+
+# Async — required when any node is async def, or called from async context
+result = await graph.ainvoke({"input": "hello"})
+result = await graph.ainvoke({"input": "hello"}, {"configurable": {"thread_id": "1"}})
+
+# Async streaming — iterate over state snapshots
+async for chunk in graph.astream({"input": "hello"}, stream_mode="values"):
+    print(chunk)  # full state after each node
+```
+</python>
+<typescript>
+
+```typescript
+const result = await graph.invoke({ input: "hello" });
+// With config
+const result = await graph.invoke({ input: "hello" }, { configurable: { thread_id: "1" } });
+```
+</typescript>
+
+</invoke-basics>
+
+<stream-mode-selection>
+
+| Mode | What it Streams | Use Case |
+|------|----------------|----------|
+| `values` | Full state after each step | Monitor complete state |
+| `updates` | State deltas | Track incremental updates |
+| `messages` | LLM tokens + metadata | Chat UIs |
+| `custom` | User-defined data | Progress indicators |
+
+</stream-mode-selection>
+
+<ex-stream-llm-tokens>
+<python>
+Stream LLM tokens in real-time for chat UI display.
+
+```python
+for chunk in graph.stream(
+    {"messages": [HumanMessage("Hello")]},
+    stream_mode="messages"
+):
+    token, metadata = chunk
+    if hasattr(token, "content"):
+        print(token.content, end="", flush=True)
+```
+</python>
+<typescript>
+Stream LLM tokens in real-time for chat UI display.
+
+```typescript
+for await (const chunk of graph.stream(
+  { messages: [new HumanMessage("Hello")] },
+  { streamMode: "messages" }
+)) {
+  const [token, metadata] = chunk;
+  if (token.content) {
+    process.stdout.write(token.content);
+  }
+}
+```
+</typescript>
+</ex-stream-llm-tokens>
+
+<ex-stream-custom-data>
+<python>
+Emit custom progress updates from within nodes using the stream writer.
+
+```python
+from langgraph.config import get_stream_writer
+
+def my_node(state):
+    writer = get_stream_writer()
+    writer("Processing step 1...")
+    # Do work
+    writer("Complete!")
+    return {"result": "done"}
+
+for chunk in graph.stream({"data": "test"}, stream_mode="custom"):
+    print(chunk)
+```
+</python>
+<typescript>
+Emit custom progress updates from within nodes using the stream writer.
+
+```typescript
+import { getWriter } from "@langchain/langgraph";
+
+const myNode = async (state: typeof State.State) => {
+  const writer = getWriter();
+  writer("Processing step 1...");
+  // Do work
+  writer("Complete!");
+  return { result: "done" };
+};
+
+for await (const chunk of graph.stream({ data: "test" }, { streamMode: "custom" })) {
+  console.log(chunk);
+}
+```
+</typescript>
+</ex-stream-custom-data>
+
+---
+
+## Error Handling
+
+Match the error type to the right handler:
+
+<error-handling-table>
+
+| Error Type | Who Fixes | Strategy | Example |
+|---|---|---|---|
+| Transient (network, rate limits) | System | `RetryPolicy(max_attempts=3)` | `add_node(..., retry_policy=...)` |
+| LLM-recoverable (tool failures) | LLM | `ToolNode(tools, handle_tool_errors=True)` | Error returned as ToolMessage |
+| User-fixable (missing info) | Human | `interrupt({"message": ...})` | Collect missing data (see HITL skill) |
+| Unexpected | Developer | Let bubble up | `raise` |
+
+</error-handling-table>
+
+<ex-retry-policy>
+<python>
+Use RetryPolicy for transient errors (network issues, rate limits).
+
+```python
+from langgraph.types import RetryPolicy
+
+workflow.add_node(
+    "search_documentation",
+    search_documentation,
+    retry_policy=RetryPolicy(max_attempts=3, initial_interval=1.0)
+)
+```
+</python>
+<typescript>
+Use retryPolicy for transient errors.
+
+```typescript
+workflow.addNode(
+  "searchDocumentation",
+  searchDocumentation,
+  {
+    retryPolicy: { maxAttempts: 3, initialInterval: 1.0 },
+  },
+);
+```
+</typescript>
+</ex-retry-policy>
+
+<ex-tool-node-error-handling>
+<python>
+Use ToolNode from langgraph.prebuilt to handle tool execution and errors. When handle_tool_errors=True, errors are returned as ToolMessages so the LLM can recover.
+
+```python
+from langgraph.prebuilt import ToolNode
+
+tool_node = ToolNode(tools, handle_tool_errors=True)
+
+workflow.add_node("tools", tool_node)
+```
+</python>
+<typescript>
+Use ToolNode from @langchain/langgraph/prebuilt to handle tool execution and errors. When handleToolErrors is true, errors are returned as ToolMessages so the LLM can recover.
+
+```typescript
+import { ToolNode } from "@langchain/langgraph/prebuilt";
+
+const toolNode = new ToolNode(tools, { handleToolErrors: true });
+
+workflow.addNode("tools", toolNode);
+```
+</typescript>
+</ex-tool-node-error-handling>
+
+---
+
+## Common Fixes
+
+<fix-compile-before-execution>
+<python>
+Must compile() to get executable graph.
+
+```python
+# WRONG
+builder.invoke({"input": "test"})  # AttributeError!
+
+# CORRECT
+graph = builder.compile()
+graph.invoke({"input": "test"})
+```
+</python>
+<typescript>
+Must compile() to get executable graph.
+
+```typescript
+// WRONG
+await builder.invoke({ input: "test" });
+
+// CORRECT
+const graph = builder.compile();
+await graph.invoke({ input: "test" });
+```
+</typescript>
+</fix-compile-before-execution>
+
+<fix-infinite-loop-needs-exit>
+<python>
+Provide conditional path to END to avoid infinite loops.
+
+```python
+# WRONG: Loops forever
+builder.add_edge("node_a", "node_b")
+builder.add_edge("node_b", "node_a")
+
+# CORRECT
+def should_continue(state):
+    return END if state["count"] > 10 else "node_b"
+builder.add_conditional_edges("node_a", should_continue)
+```
+</python>
+<typescript>
+Use conditional edges with END return to break loops.
+
+```typescript
+// WRONG: Loops forever
+builder.addEdge("node_a", "node_b").addEdge("node_b", "node_a");
+
+// CORRECT
+builder.addConditionalEdges("node_a", (state) => state.count > 10 ? END : "node_b");
+```
+</typescript>
+</fix-infinite-loop-needs-exit>
+
+<fix-common-mistakes>
+Other common mistakes:
+
+```python
+# Router must return names of nodes that exist in the graph
+builder.add_node("my_node", func)  # Add node BEFORE referencing in edges
+builder.add_conditional_edges("node_a", router, ["my_node"])
+
+# Command return type needs Literal for routing destinations (Python)
+def node_a(state) -> Command[Literal["node_b", "node_c"]]:
+    return Command(goto="node_b")
+
+# START is entry-only - cannot route back to it
+builder.add_edge("node_a", START)  # WRONG!
+builder.add_edge("node_a", "entry")  # Use a named entry node instead
+
+# Reducer expects matching types
+return {"items": ["item"]}  # List for list reducer, not a string
+
+# set_entry_point / set_finish_point are equivalent to add_edge(START/END):
+workflow.set_entry_point("my_node")       # same as add_edge(START, "my_node")
+workflow.set_finish_point("my_node")      # same as add_edge("my_node", END)
+# Both APIs are valid; prefer add_edge(START/END, ...) in new code.
+```
+
+```typescript
+// Always await graph.invoke() - it returns a Promise
+const result = await graph.invoke({ input: "test" });
+
+// TS Command nodes need { ends } to declare routing destinations
+builder.addNode("router", routerFn, { ends: ["node_b", "node_c"] });
+```
+</fix-common-mistakes>
+
+<nested-graph-pattern>
+
+### Nested Graph Pattern (Adapter Wrapper)
+
+Use when adapting an existing `CompiledStateGraph` to a different state schema — for example, wrapping a domain-specific graph to satisfy an external state contract (e.g., a `messages`-keyed interface).
+
+```python
+from typing import Annotated
+import operator
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.state import CompiledStateGraph
+
+# Outer state satisfies the external contract
+class WrapperState(TypedDict, total=False):
+    messages: Annotated[list[BaseMessage], operator.add]
+
+# Inner state is domain-specific
+class InnerState(TypedDict):
+    query: str
+    answer: str
+
+def create_inner_graph() -> CompiledStateGraph:
+    # ... define inner nodes/edges
+    return builder.compile()
+
+# Single adapter node: translate outer → inner → outer
+async def _adapter_node(state: WrapperState) -> WrapperState:
+    # Extract input from outer state
+    messages = state.get("messages") or []
+    query = next(
+        (str(getattr(m, "content", "")) for m in reversed(messages) if isinstance(m, HumanMessage)),
+        "",
+    )
+    # Invoke inner graph
+    result = await create_inner_graph().ainvoke(InnerState(query=query, answer=""))
+    # Map result back to outer contract
+    return {"messages": [AIMessage(content=result["answer"])]}
+
+def _build_wrapper() -> StateGraph:
+    builder = StateGraph(WrapperState)
+    builder.add_node("run_inner", _adapter_node)
+    builder.add_edge(START, "run_inner")
+    builder.add_edge("run_inner", END)
+    return builder
+
+# Eager compile — simpler, graph constructed at import time
+agent: CompiledStateGraph = _build_wrapper().compile()
+
+# Lazy factory — graph constructed per request; use when parameterization is needed
+def agent_factory(_config: RunnableConfig) -> CompiledStateGraph:
+    return _build_wrapper().compile()
+```
+
+**Key points:**
+- The inner `CompiledStateGraph` is invoked via `await inner.ainvoke(inner_state)` inside an async node.
+- Keep the outer graph minimal (single adapter node) — all logic stays in the inner graph.
+- Expose inner intermediate state fields in the outer state for observability when needed.
+
+</nested-graph-pattern>
+
+<boundaries>
+### What You Should NOT Do
+
+- Mutate state directly — always return partial update dicts from nodes
+- Route back to START — it's entry-only; use a named node instead
+- Forget reducers on list fields — without one, last write wins
+- Mix static edges with Command goto without understanding both will execute
+</boundaries>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langgraph-human-in-the-loop.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langgraph-human-in-the-loop.md
@@ -1,0 +1,551 @@
+---
+name: langgraph-human-in-the-loop
+description: "INVOKE THIS SKILL when implementing human-in-the-loop patterns, pausing for approval, or handling errors in LangGraph. Covers interrupt(), Command(resume=...), approval/validation workflows, and the 4-tier error handling strategy."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+LangGraph's human-in-the-loop patterns let you pause graph execution, surface data to users, and resume with their input:
+
+- **`interrupt(value)`** — pauses execution, surfaces a value to the caller
+- **`Command(resume=value)`** — resumes execution, providing the value back to `interrupt()`
+- **Checkpointer** — required to save state while paused
+- **Thread ID** — required to identify which paused execution to resume
+</overview>
+
+---
+
+## Requirements
+
+Three things are required for interrupts to work:
+
+1. **Checkpointer** — compile with `checkpointer=InMemorySaver()` (dev) or `PostgresSaver` (prod)
+2. **Thread ID** — pass `{"configurable": {"thread_id": "..."}}` to every `invoke`/`stream` call
+3. **JSON-serializable payload** — the value passed to `interrupt()` must be JSON-serializable
+
+---
+
+## Basic Interrupt + Resume
+
+`interrupt(value)` pauses the graph. The value surfaces in the result under `__interrupt__`. `Command(resume=value)` resumes — the resume value becomes the return value of `interrupt()`.
+
+**Critical**: when the graph resumes, the node restarts from the **beginning** — all code before `interrupt()` re-runs.
+
+<ex-basic-interrupt-resume>
+<python>
+Pause execution for human review and resume with Command.
+
+```python
+from langgraph.types import interrupt, Command
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import StateGraph, START, END
+from typing_extensions import TypedDict
+
+class State(TypedDict):
+    approved: bool
+
+def approval_node(state: State):
+    # Pause and ask for approval
+    approved = interrupt("Do you approve this action?")
+    # When resumed, Command(resume=...) returns that value here
+    return {"approved": approved}
+
+checkpointer = InMemorySaver()
+graph = (
+    StateGraph(State)
+    .add_node("approval", approval_node)
+    .add_edge(START, "approval")
+    .add_edge("approval", END)
+    .compile(checkpointer=checkpointer)
+)
+
+config = {"configurable": {"thread_id": "thread-1"}}
+
+# Initial run — hits interrupt and pauses
+result = graph.invoke({"approved": False}, config)
+print(result["__interrupt__"])
+# [Interrupt(value='Do you approve this action?')]
+
+# Resume with the human's response
+result = graph.invoke(Command(resume=True), config)
+print(result["approved"])  # True
+```
+</python>
+<typescript>
+Pause execution for human review and resume with Command.
+
+```typescript
+import { interrupt, Command, MemorySaver, StateGraph, StateSchema, START, END } from "@langchain/langgraph";
+import { z } from "zod";
+
+const State = new StateSchema({
+  approved: z.boolean().default(false),
+});
+
+const approvalNode = async (state: typeof State.State) => {
+  // Pause and ask for approval
+  const approved = interrupt("Do you approve this action?");
+  // When resumed, Command({ resume }) returns that value here
+  return { approved };
+};
+
+const checkpointer = new MemorySaver();
+const graph = new StateGraph(State)
+  .addNode("approval", approvalNode)
+  .addEdge(START, "approval")
+  .addEdge("approval", END)
+  .compile({ checkpointer });
+
+const config = { configurable: { thread_id: "thread-1" } };
+
+// Initial run — hits interrupt and pauses
+let result = await graph.invoke({ approved: false }, config);
+console.log(result.__interrupt__);
+// [{ value: 'Do you approve this action?', ... }]
+
+// Resume with the human's response
+result = await graph.invoke(new Command({ resume: true }), config);
+console.log(result.approved);  // true
+```
+</typescript>
+</ex-basic-interrupt-resume>
+
+---
+
+## Approval Workflow
+
+A common pattern: interrupt to show a draft, then route based on the human's decision.
+
+<ex-approval-workflow>
+<python>
+Interrupt for human review, then route to send or end based on the decision.
+
+```python
+from langgraph.types import interrupt, Command
+from langgraph.graph import StateGraph, START, END
+from typing import Literal
+from typing_extensions import TypedDict
+
+class EmailAgentState(TypedDict):
+    email_content: str
+    draft_response: str
+    classification: dict
+
+def human_review(state: EmailAgentState) -> Command[Literal["send_reply", "__end__"]]:
+    """Pause for human review using interrupt and route based on decision."""
+    classification = state.get("classification", {})
+
+    # interrupt() must come first — any code before it will re-run on resume
+    human_decision = interrupt({
+        "email_id": state.get("email_content", ""),
+        "draft_response": state.get("draft_response", ""),
+        "urgency": classification.get("urgency"),
+        "action": "Please review and approve/edit this response"
+    })
+
+    # Process the human's decision
+    if human_decision.get("approved"):
+        return Command(
+            update={"draft_response": human_decision.get("edited_response", state.get("draft_response", ""))},
+            goto="send_reply"
+        )
+    else:
+        # Rejection — human will handle directly
+        return Command(update={}, goto=END)
+```
+</python>
+<typescript>
+Interrupt for human review, then route to send or end based on the decision.
+
+```typescript
+import { interrupt, Command, END, GraphNode } from "@langchain/langgraph";
+
+const humanReview: GraphNode<typeof EmailAgentState> = async (state) => {
+  const classification = state.classification!;
+
+  // interrupt() must come first — any code before it will re-run on resume
+  const humanDecision = interrupt({
+    emailId: state.emailContent,
+    draftResponse: state.responseText,
+    urgency: classification.urgency,
+    action: "Please review and approve/edit this response",
+  });
+
+  // Process the human's decision
+  if (humanDecision.approved) {
+    return new Command({
+      update: { responseText: humanDecision.editedResponse || state.responseText },
+      goto: "sendReply",
+    });
+  } else {
+    return new Command({ update: {}, goto: END });
+  }
+};
+```
+</typescript>
+</ex-approval-workflow>
+
+---
+
+## Validation Loop
+
+Use `interrupt()` in a loop to validate human input and re-prompt if invalid.
+
+<ex-validation-loop>
+<python>
+Validate human input in a loop, re-prompting until valid.
+
+```python
+from langgraph.types import interrupt
+
+def get_age_node(state):
+    prompt = "What is your age?"
+
+    while True:
+        answer = interrupt(prompt)
+
+        # Validate the input
+        if isinstance(answer, int) and answer > 0:
+            break
+        else:
+            # Invalid input — ask again with a more specific prompt
+            prompt = f"'{answer}' is not a valid age. Please enter a positive number."
+
+    return {"age": answer}
+```
+
+Each `Command(resume=...)` call provides the next answer. If invalid, the loop re-interrupts with a clearer message.
+
+```python
+config = {"configurable": {"thread_id": "form-1"}}
+first = graph.invoke({"age": None}, config)
+# __interrupt__: "What is your age?"
+
+retry = graph.invoke(Command(resume="thirty"), config)
+# __interrupt__: "'thirty' is not a valid age..."
+
+final = graph.invoke(Command(resume=30), config)
+print(final["age"])  # 30
+```
+</python>
+<typescript>
+Validate human input in a loop, re-prompting until valid.
+
+```typescript
+import { interrupt } from "@langchain/langgraph";
+
+const getAgeNode = (state: typeof State.State) => {
+  let prompt = "What is your age?";
+
+  while (true) {
+    const answer = interrupt(prompt);
+
+    // Validate the input
+    if (typeof answer === "number" && answer > 0) {
+      return { age: answer };
+    } else {
+      // Invalid input — ask again with a more specific prompt
+      prompt = `'${answer}' is not a valid age. Please enter a positive number.`;
+    }
+  }
+};
+```
+</typescript>
+</ex-validation-loop>
+
+---
+
+## Multiple Interrupts
+
+When parallel branches each call `interrupt()`, resume all of them in a single invocation by mapping each interrupt ID to its resume value.
+
+<ex-multiple-interrupts>
+<python>
+Resume multiple parallel interrupts by mapping interrupt IDs to values.
+
+```python
+from typing import Annotated, TypedDict
+import operator
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import START, END, StateGraph
+from langgraph.types import Command, interrupt
+
+class State(TypedDict):
+    vals: Annotated[list[str], operator.add]
+
+def node_a(state):
+    answer = interrupt("question_a")
+    return {"vals": [f"a:{answer}"]}
+
+def node_b(state):
+    answer = interrupt("question_b")
+    return {"vals": [f"b:{answer}"]}
+
+graph = (
+    StateGraph(State)
+    .add_node("a", node_a)
+    .add_node("b", node_b)
+    .add_edge(START, "a")
+    .add_edge(START, "b")
+    .add_edge("a", END)
+    .add_edge("b", END)
+    .compile(checkpointer=InMemorySaver())
+)
+
+config = {"configurable": {"thread_id": "1"}}
+
+# Both parallel nodes hit interrupt() and pause
+result = graph.invoke({"vals": []}, config)
+# result["__interrupt__"] contains both Interrupt objects with IDs
+
+# Resume all pending interrupts at once using a map of id -> value
+resume_map = {
+    i.id: f"answer for {i.value}"
+    for i in result["__interrupt__"]
+}
+result = graph.invoke(Command(resume=resume_map), config)
+# result["vals"] = ["a:answer for question_a", "b:answer for question_b"]
+```
+</python>
+<typescript>
+Resume multiple parallel interrupts by mapping interrupt IDs to values.
+
+```typescript
+import { Command, END, MemorySaver, START, StateGraph, interrupt, isInterrupted, INTERRUPT, Annotation } from "@langchain/langgraph";
+
+const State = Annotation.Root({
+  vals: Annotation<string[]>({
+    reducer: (left, right) => left.concat(Array.isArray(right) ? right : [right]),
+    default: () => [],
+  }),
+});
+
+function nodeA(_state: typeof State.State) {
+  const answer = interrupt("question_a") as string;
+  return { vals: [`a:${answer}`] };
+}
+
+function nodeB(_state: typeof State.State) {
+  const answer = interrupt("question_b") as string;
+  return { vals: [`b:${answer}`] };
+}
+
+const graph = new StateGraph(State)
+  .addNode("a", nodeA)
+  .addNode("b", nodeB)
+  .addEdge(START, "a")
+  .addEdge(START, "b")
+  .addEdge("a", END)
+  .addEdge("b", END)
+  .compile({ checkpointer: new MemorySaver() });
+
+const config = { configurable: { thread_id: "1" } };
+
+const interruptedResult = await graph.invoke({ vals: [] }, config);
+
+// Resume all pending interrupts at once
+const resumeMap: Record<string, string> = {};
+if (isInterrupted(interruptedResult)) {
+  for (const i of interruptedResult[INTERRUPT]) {
+    if (i.id != null) {
+      resumeMap[i.id] = `answer for ${i.value}`;
+    }
+  }
+}
+const result = await graph.invoke(new Command({ resume: resumeMap }), config);
+// result.vals = ["a:answer for question_a", "b:answer for question_b"]
+```
+</typescript>
+</ex-multiple-interrupts>
+
+User-fixable errors use `interrupt()` to pause and collect missing data — that's the pattern covered by this skill. For the full 4-tier error handling strategy (RetryPolicy, Command error loops, etc.), see the **fundamentals** skill.
+
+---
+
+## Side Effects Before Interrupt Must Be Idempotent
+
+When the graph resumes, the node restarts from the **beginning** — ALL code before `interrupt()` re-runs. In subgraphs, BOTH the parent node and the subgraph node re-execute.
+
+<idempotency-rules>
+
+**Do:**
+- Use **upsert** (not insert) operations before `interrupt()`
+- Use **check-before-create** patterns
+- Place side effects **after** `interrupt()` when possible
+- Separate side effects into their own nodes
+
+**Don't:**
+- Create new records before `interrupt()` — duplicates on each resume
+- Append to lists before `interrupt()` — duplicate entries on each resume
+
+</idempotency-rules>
+
+<ex-idempotent-patterns>
+<python>
+Idempotent operations before interrupt vs non-idempotent (wrong).
+
+```python
+# GOOD: Upsert is idempotent — safe before interrupt
+def node_a(state: State):
+    db.upsert_user(user_id=state["user_id"], status="pending_approval")
+    approved = interrupt("Approve this change?")
+    return {"approved": approved}
+
+# GOOD: Side effect AFTER interrupt — only runs once
+def node_a(state: State):
+    approved = interrupt("Approve this change?")
+    if approved:
+        db.create_audit_log(user_id=state["user_id"], action="approved")
+    return {"approved": approved}
+
+# BAD: Insert creates duplicates on each resume!
+def node_a(state: State):
+    audit_id = db.create_audit_log({  # Runs again on resume!
+        "user_id": state["user_id"],
+        "action": "pending_approval",
+    })
+    approved = interrupt("Approve this change?")
+    return {"approved": approved}
+```
+</python>
+<typescript>
+Idempotent operations before interrupt vs non-idempotent (wrong).
+
+```typescript
+// GOOD: Upsert is idempotent — safe before interrupt
+const nodeA = async (state: typeof State.State) => {
+  await db.upsertUser({ userId: state.userId, status: "pending_approval" });
+  const approved = interrupt("Approve this change?");
+  return { approved };
+};
+
+// GOOD: Side effect AFTER interrupt — only runs once
+const nodeA = async (state: typeof State.State) => {
+  const approved = interrupt("Approve this change?");
+  if (approved) {
+    await db.createAuditLog({ userId: state.userId, action: "approved" });
+  }
+  return { approved };
+};
+
+// BAD: Insert creates duplicates on each resume!
+const nodeA = async (state: typeof State.State) => {
+  await db.createAuditLog({  // Runs again on resume!
+    userId: state.userId,
+    action: "pending_approval",
+  });
+  const approved = interrupt("Approve this change?");
+  return { approved };
+};
+```
+</typescript>
+</ex-idempotent-patterns>
+
+<subgraph-interrupt-re-execution>
+
+### Subgraph re-execution on resume
+
+When a subgraph contains an `interrupt()`, resuming re-executes BOTH the parent node (that invoked the subgraph) AND the subgraph node (that called `interrupt()`):
+
+<python>
+
+```python
+def node_in_parent_graph(state: State):
+    some_code()  # <-- Re-executes on resume
+    subgraph_result = subgraph.invoke(some_input)
+    # ...
+
+def node_in_subgraph(state: State):
+    some_other_code()  # <-- Also re-executes on resume
+    result = interrupt("What's your name?")
+    # ...
+```
+</python>
+<typescript>
+
+```typescript
+async function nodeInParentGraph(state: State) {
+  someCode();  // <-- Re-executes on resume
+  const subgraphResult = await subgraph.invoke(someInput);
+  // ...
+}
+
+async function nodeInSubgraph(state: State) {
+  someOtherCode();  // <-- Also re-executes on resume
+  const result = interrupt("What's your name?");
+  // ...
+}
+```
+</typescript>
+</subgraph-interrupt-re-execution>
+
+---
+
+## Command(resume) Warning
+
+`Command(resume=...)` is the **only** Command pattern intended as input to `invoke()`/`stream()`. Do NOT pass `Command(update=...)` as input — it resumes from the latest checkpoint and the graph appears stuck. See the fundamentals skill for the full antipattern explanation.
+
+---
+
+## Fixes
+
+<fix-checkpointer-required-for-interrupts>
+<python>
+Checkpointer required for interrupt functionality.
+
+```python
+# WRONG
+graph = builder.compile()
+
+# CORRECT
+graph = builder.compile(checkpointer=InMemorySaver())
+```
+</python>
+<typescript>
+Checkpointer required for interrupt functionality.
+
+```typescript
+// WRONG
+const graph = builder.compile();
+
+// CORRECT
+const graph = builder.compile({ checkpointer: new MemorySaver() });
+```
+</typescript>
+</fix-checkpointer-required-for-interrupts>
+
+<fix-resume-with-command>
+<python>
+Use Command to resume from an interrupt (regular dict restarts graph).
+
+```python
+# WRONG
+graph.invoke({"resume_data": "approve"}, config)
+
+# CORRECT
+graph.invoke(Command(resume="approve"), config)
+```
+</python>
+<typescript>
+Use Command to resume from an interrupt (regular object restarts graph).
+
+```typescript
+// WRONG
+await graph.invoke({ resumeData: "approve" }, config);
+
+// CORRECT
+await graph.invoke(new Command({ resume: "approve" }), config);
+```
+</typescript>
+</fix-resume-with-command>
+
+<boundaries>
+### What You Should NOT Do
+
+- Use interrupts without a checkpointer — will fail
+- Resume without the same thread_id — creates a new thread instead of resuming
+- Pass `Command(update=...)` as invoke input — graph appears stuck (use plain dict)
+- Perform non-idempotent side effects before `interrupt()` — creates duplicates on resume
+- Assume code before `interrupt()` only runs once — it re-runs every resume
+</boundaries>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langgraph-persistence.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/langgraph-persistence.md
@@ -1,0 +1,587 @@
+---
+name: langgraph-persistence
+description: "INVOKE THIS SKILL when your LangGraph needs to persist state, remember conversations, travel through history, or configure subgraph checkpointer scoping. Covers checkpointers, thread_id, time travel, Store, and subgraph persistence modes."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+<overview>
+LangGraph's persistence layer enables durable execution by checkpointing graph state:
+
+- **Checkpointer**: Saves/loads graph state at every super-step
+- **Thread ID**: Identifies separate checkpoint sequences (conversations)
+- **Store**: Cross-thread memory for user preferences, facts
+
+**Two memory types:**
+- **Short-term** (checkpointer): Thread-scoped conversation history
+- **Long-term** (store): Cross-thread user preferences, facts
+</overview>
+
+<checkpointer-selection>
+
+| Checkpointer | Use Case | Production Ready |
+|--------------|----------|------------------|
+| `InMemorySaver` | Testing, development | No |
+| `SqliteSaver` | Local development | Partial |
+| `PostgresSaver` | Production | Yes |
+
+</checkpointer-selection>
+
+---
+
+## Checkpointer Setup
+
+<ex-basic-persistence>
+<python>
+Set up a basic graph with in-memory checkpointing and thread-based state persistence.
+
+```python
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.graph import StateGraph, START, END
+from typing_extensions import TypedDict, Annotated
+import operator
+
+class State(TypedDict):
+    messages: Annotated[list, operator.add]
+
+def add_message(state: State) -> dict:
+    return {"messages": ["Bot response"]}
+
+checkpointer = InMemorySaver()
+
+graph = (
+    StateGraph(State)
+    .add_node("respond", add_message)
+    .add_edge(START, "respond")
+    .add_edge("respond", END)
+    .compile(checkpointer=checkpointer)  # Pass at compile time
+)
+
+# ALWAYS provide thread_id
+config = {"configurable": {"thread_id": "conversation-1"}}
+
+result1 = graph.invoke({"messages": ["Hello"]}, config)
+print(len(result1["messages"]))  # 2
+
+result2 = graph.invoke({"messages": ["How are you?"]}, config)
+print(len(result2["messages"]))  # 4 (previous + new)
+```
+</python>
+<typescript>
+Set up a basic graph with in-memory checkpointing and thread-based state persistence.
+
+```typescript
+import { MemorySaver, StateGraph, StateSchema, MessagesValue, START, END } from "@langchain/langgraph";
+import { HumanMessage } from "@langchain/core/messages";
+
+const State = new StateSchema({ messages: MessagesValue });
+
+const addMessage = async (state: typeof State.State) => {
+  return { messages: [{ role: "assistant", content: "Bot response" }] };
+};
+
+const checkpointer = new MemorySaver();
+
+const graph = new StateGraph(State)
+  .addNode("respond", addMessage)
+  .addEdge(START, "respond")
+  .addEdge("respond", END)
+  .compile({ checkpointer });
+
+// ALWAYS provide thread_id
+const config = { configurable: { thread_id: "conversation-1" } };
+
+const result1 = await graph.invoke({ messages: [new HumanMessage("Hello")] }, config);
+console.log(result1.messages.length);  // 2
+
+const result2 = await graph.invoke({ messages: [new HumanMessage("How are you?")] }, config);
+console.log(result2.messages.length);  // 4 (previous + new)
+```
+</typescript>
+</ex-basic-persistence>
+
+<ex-production-postgres>
+<python>
+Configure PostgreSQL-backed checkpointing for production deployments.
+
+```python
+import os
+from langgraph.checkpoint.postgres import PostgresSaver
+
+# Run once during deployment (not at application startup):
+#   PostgresSaver.from_conn_string(os.environ["DATABASE_URL"]).setup()
+
+with PostgresSaver.from_conn_string(os.environ["DATABASE_URL"]) as checkpointer:
+    graph = builder.compile(checkpointer=checkpointer)
+```
+</python>
+<typescript>
+Configure PostgreSQL-backed checkpointing for production deployments.
+
+```typescript
+import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
+
+// Run once during deployment (not at application startup):
+//   await PostgresSaver.fromConnString(process.env.DATABASE_URL!).setup();
+
+const checkpointer = PostgresSaver.fromConnString(process.env.DATABASE_URL!);
+const graph = builder.compile({ checkpointer });
+```
+</typescript>
+</ex-production-postgres>
+
+---
+
+## Thread Management
+
+<ex-separate-threads>
+<python>
+Demonstrate isolated state between different thread IDs.
+
+```python
+# Different threads maintain separate state
+alice_config = {"configurable": {"thread_id": "user-alice"}}
+bob_config = {"configurable": {"thread_id": "user-bob"}}
+
+graph.invoke({"messages": ["Hi from Alice"]}, alice_config)
+graph.invoke({"messages": ["Hi from Bob"]}, bob_config)
+
+# Alice's state is isolated from Bob's
+```
+</python>
+<typescript>
+Demonstrate isolated state between different thread IDs.
+
+```typescript
+// Different threads maintain separate state
+const aliceConfig = { configurable: { thread_id: "user-alice" } };
+const bobConfig = { configurable: { thread_id: "user-bob" } };
+
+await graph.invoke({ messages: [new HumanMessage("Hi from Alice")] }, aliceConfig);
+await graph.invoke({ messages: [new HumanMessage("Hi from Bob")] }, bobConfig);
+
+// Alice's state is isolated from Bob's
+```
+</typescript>
+</ex-separate-threads>
+
+---
+
+## State History & Time Travel
+
+<ex-resume-from-checkpoint>
+<python>
+Time travel: browse checkpoint history and replay or fork from a past state.
+
+```python
+config = {"configurable": {"thread_id": "session-1"}}
+
+result = graph.invoke({"messages": ["start"]}, config)
+
+# Browse checkpoint history
+states = list(graph.get_state_history(config))
+
+# Replay from a past checkpoint
+past = states[-2]
+result = graph.invoke(None, past.config)  # None = resume from checkpoint
+
+# Or fork: update state at a past checkpoint, then resume
+fork_config = graph.update_state(past.config, {"messages": ["edited"]})
+result = graph.invoke(None, fork_config)
+```
+</python>
+<typescript>
+Time travel: browse checkpoint history and replay or fork from a past state.
+
+```typescript
+const config = { configurable: { thread_id: "session-1" } };
+
+const result = await graph.invoke({ messages: ["start"] }, config);
+
+// Browse checkpoint history (async iterable, collect to array)
+const states: Awaited<ReturnType<typeof graph.getState>>[] = [];
+for await (const state of graph.getStateHistory(config)) {
+  states.push(state);
+}
+
+// Replay from a past checkpoint
+const past = states[states.length - 2];
+const replayed = await graph.invoke(null, past.config);  // null = resume from checkpoint
+
+// Or fork: update state at a past checkpoint, then resume
+const forkConfig = await graph.updateState(past.config, { messages: ["edited"] });
+const forked = await graph.invoke(null, forkConfig);
+```
+</typescript>
+</ex-resume-from-checkpoint>
+
+<ex-update-state>
+<python>
+Manually update graph state before resuming execution.
+
+```python
+config = {"configurable": {"thread_id": "session-1"}}
+
+# Modify state before resuming
+graph.update_state(config, {"data": "manually_updated"})
+
+# Resume with updated state
+result = graph.invoke(None, config)
+```
+</python>
+<typescript>
+Manually update graph state before resuming execution.
+
+```typescript
+const config = { configurable: { thread_id: "session-1" } };
+
+// Modify state before resuming
+await graph.updateState(config, { data: "manually_updated" });
+
+// Resume with updated state
+const result = await graph.invoke(null, config);
+```
+</typescript>
+</ex-update-state>
+
+---
+
+## Subgraph Checkpointer Scoping
+
+When compiling a subgraph, the `checkpointer` parameter controls persistence behavior. This is critical for subgraphs that use interrupts, need multi-turn memory, or run in parallel.
+
+<subgraph-checkpointer-scoping-table>
+
+| Feature | `checkpointer=False` | `None` (default) | `True` |
+|---|---|---|---|
+| Interrupts (HITL) | No | Yes | Yes |
+| Multi-turn memory | No | No | Yes |
+| Multiple calls (different subgraphs) | Yes | Yes | Warning (namespace conflicts possible) |
+| Multiple calls (same subgraph) | Yes | Yes | No |
+| State inspection | No | Warning (current invocation only) | Yes |
+
+</subgraph-checkpointer-scoping-table>
+
+<subgraph-checkpointer-when-to-use>
+
+### When to use each mode
+
+- **`checkpointer=False`** — Subgraph doesn't need interrupts or persistence. Simplest option, no checkpoint overhead.
+- **`None` (default / omit `checkpointer`)** — Subgraph needs `interrupt()` but not multi-turn memory. Each invocation starts fresh but can pause/resume. Parallel execution works because each invocation gets a unique namespace.
+- **`checkpointer=True`** — Subgraph needs to remember state across invocations (multi-turn conversations). Each call picks up where the last left off.
+
+</subgraph-checkpointer-when-to-use>
+
+<warning-stateful-subgraphs-parallel>
+
+**Warning**: Stateful subgraphs (`checkpointer=True`) do NOT support calling the same subgraph instance multiple times within a single node — the calls write to the same checkpoint namespace and conflict.
+
+</warning-stateful-subgraphs-parallel>
+
+<ex-subgraph-checkpointer-modes>
+<python>
+Choose the right checkpointer mode for your subgraph.
+
+```python
+# No interrupts needed — opt out of checkpointing
+subgraph = subgraph_builder.compile(checkpointer=False)
+
+# Need interrupts but not cross-invocation persistence (default)
+subgraph = subgraph_builder.compile()
+
+# Need cross-invocation persistence (stateful)
+subgraph = subgraph_builder.compile(checkpointer=True)
+```
+</python>
+<typescript>
+Choose the right checkpointer mode for your subgraph.
+
+```typescript
+// No interrupts needed — opt out of checkpointing
+const subgraph = subgraphBuilder.compile({ checkpointer: false });
+
+// Need interrupts but not cross-invocation persistence (default)
+const subgraph = subgraphBuilder.compile();
+
+// Need cross-invocation persistence (stateful)
+const subgraph = subgraphBuilder.compile({ checkpointer: true });
+```
+</typescript>
+</ex-subgraph-checkpointer-modes>
+
+<parallel-subgraph-namespacing>
+
+### Parallel subgraph namespacing
+
+When multiple **different** stateful subgraphs run in parallel, wrap each in its own `StateGraph` with a unique node name for stable namespace isolation:
+
+<python>
+
+```python
+from langgraph.graph import MessagesState, StateGraph
+
+def create_sub_agent(model, *, name, **kwargs):
+    """Wrap an agent with a unique node name for namespace isolation."""
+    agent = create_agent(model=model, name=name, **kwargs)
+    return (
+        StateGraph(MessagesState)
+        .add_node(name, agent)  # unique name -> stable namespace
+        .add_edge("__start__", name)
+        .compile()
+    )
+
+fruit_agent = create_sub_agent(
+    "gpt-4.1-mini", name="fruit_agent",
+    tools=[fruit_info], prompt="...", checkpointer=True,
+)
+veggie_agent = create_sub_agent(
+    "gpt-4.1-mini", name="veggie_agent",
+    tools=[veggie_info], prompt="...", checkpointer=True,
+)
+```
+</python>
+<typescript>
+
+```typescript
+import { StateGraph, StateSchema, MessagesValue, START } from "@langchain/langgraph";
+
+function createSubAgent(model: string, { name, ...kwargs }: { name: string; [key: string]: any }) {
+  const agent = createAgent({ model, name, ...kwargs });
+  return new StateGraph(new StateSchema({ messages: MessagesValue }))
+    .addNode(name, agent)  // unique name -> stable namespace
+    .addEdge(START, name)
+    .compile();
+}
+
+const fruitAgent = createSubAgent("gpt-4.1-mini", {
+  name: "fruit_agent", tools: [fruitInfo], prompt: "...", checkpointer: true,
+});
+const veggieAgent = createSubAgent("gpt-4.1-mini", {
+  name: "veggie_agent", tools: [veggieInfo], prompt: "...", checkpointer: true,
+});
+```
+</typescript>
+
+Note: Subgraphs added as nodes (via `add_node`) already get name-based namespaces automatically and don't need this wrapper.
+
+</parallel-subgraph-namespacing>
+
+---
+
+## Long-Term Memory (Store)
+
+<ex-long-term-memory-store>
+<python>
+Use a Store for cross-thread memory to share user preferences across conversations.
+
+```python
+from langgraph.store.memory import InMemoryStore
+
+store = InMemoryStore()
+
+# Save user preference (available across ALL threads)
+store.put(("alice", "preferences"), "language", {"preference": "short responses"})
+
+# Node with store — access via runtime
+from langgraph.runtime import Runtime
+
+def respond(state, runtime: Runtime):
+    prefs = runtime.store.get((state["user_id"], "preferences"), "language")
+    return {"response": f"Using preference: {prefs.value}"}
+
+# Compile with BOTH checkpointer and store
+graph = builder.compile(checkpointer=checkpointer, store=store)
+
+# Both threads access same long-term memory
+graph.invoke({"user_id": "alice"}, {"configurable": {"thread_id": "thread-1"}})
+graph.invoke({"user_id": "alice"}, {"configurable": {"thread_id": "thread-2"}})  # Same preferences!
+```
+</python>
+<typescript>
+Use a Store for cross-thread memory to share user preferences across conversations.
+
+```typescript
+import { MemoryStore } from "@langchain/langgraph";
+
+const store = new MemoryStore();
+
+// Save user preference (available across ALL threads)
+await store.put(["alice", "preferences"], "language", { preference: "short responses" });
+
+// Node with store — access via runtime
+const respond = async (state: typeof State.State, runtime: any) => {
+  const item = await runtime.store?.get(["alice", "preferences"], "language");
+  return { response: `Using preference: ${item?.value?.preference}` };
+};
+
+// Compile with BOTH checkpointer and store
+const graph = builder.compile({ checkpointer, store });
+
+// Both threads access same long-term memory
+await graph.invoke({ userId: "alice" }, { configurable: { thread_id: "thread-1" } });
+await graph.invoke({ userId: "alice" }, { configurable: { thread_id: "thread-2" } });  // Same preferences!
+```
+</typescript>
+</ex-long-term-memory-store>
+
+<ex-store-operations>
+<python>
+Basic store operations: put, get, search, and delete.
+
+```python
+from langgraph.store.memory import InMemoryStore
+
+store = InMemoryStore()
+
+store.put(("user-123", "facts"), "location", {"city": "San Francisco"})  # Put
+item = store.get(("user-123", "facts"), "location")  # Get
+results = store.search(("user-123", "facts"), filter={"city": "San Francisco"})  # Search
+store.delete(("user-123", "facts"), "location")  # Delete
+```
+</python>
+</ex-store-operations>
+
+---
+
+## Fixes
+
+<fix-thread-id-required>
+<python>
+Always provide thread_id in config to enable state persistence.
+
+```python
+# WRONG: No thread_id - state NOT persisted!
+graph.invoke({"messages": ["Hello"]})
+graph.invoke({"messages": ["What did I say?"]})  # Doesn't remember!
+
+# CORRECT: Always provide thread_id
+config = {"configurable": {"thread_id": "session-1"}}
+graph.invoke({"messages": ["Hello"]}, config)
+graph.invoke({"messages": ["What did I say?"]}, config)  # Remembers!
+```
+</python>
+<typescript>
+Always provide thread_id in config to enable state persistence.
+
+```typescript
+// WRONG: No thread_id - state NOT persisted!
+await graph.invoke({ messages: [new HumanMessage("Hello")] });
+await graph.invoke({ messages: [new HumanMessage("What did I say?")] });  // Doesn't remember!
+
+// CORRECT: Always provide thread_id
+const config = { configurable: { thread_id: "session-1" } };
+await graph.invoke({ messages: [new HumanMessage("Hello")] }, config);
+await graph.invoke({ messages: [new HumanMessage("What did I say?")] }, config);  // Remembers!
+```
+</typescript>
+</fix-thread-id-required>
+
+
+<fix-inmemory-not-for-production>
+<python>
+Use PostgresSaver instead of InMemorySaver for production persistence.
+
+```python
+# WRONG: Data lost on process restart
+checkpointer = InMemorySaver()  # In-memory only!
+
+# CORRECT: Use persistent storage for production
+from langgraph.checkpoint.postgres import PostgresSaver
+with PostgresSaver.from_conn_string("postgresql://...") as checkpointer:
+    checkpointer.setup()  # only needed on first use to create tables
+    graph = builder.compile(checkpointer=checkpointer)
+```
+</python>
+<typescript>
+Use PostgresSaver instead of MemorySaver for production persistence.
+
+```typescript
+// WRONG: Data lost on process restart
+const checkpointer = new MemorySaver();  // In-memory only!
+
+// CORRECT: Use persistent storage for production
+import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
+const checkpointer = PostgresSaver.fromConnString("postgresql://...");
+await checkpointer.setup(); // only needed on first use to create tables
+```
+</typescript>
+</fix-inmemory-not-for-production>
+
+
+<fix-update-state-with-reducers>
+<python>
+Use Overwrite to replace state values instead of passing through reducers.
+
+```python
+from langgraph.types import Overwrite
+
+# State with reducer: items: Annotated[list, operator.add]
+# Current state: {"items": ["A", "B"]}
+
+# update_state PASSES THROUGH reducers
+graph.update_state(config, {"items": ["C"]})  # Result: ["A", "B", "C"] - Appended!
+
+# To REPLACE instead, use Overwrite
+graph.update_state(config, {"items": Overwrite(["C"])})  # Result: ["C"] - Replaced
+```
+</python>
+<typescript>
+Use Overwrite to replace state values instead of passing through reducers.
+
+```typescript
+import { Overwrite } from "@langchain/langgraph";
+
+// State with reducer: items uses concat reducer
+// Current state: { items: ["A", "B"] }
+
+// updateState PASSES THROUGH reducers
+await graph.updateState(config, { items: ["C"] });  // Result: ["A", "B", "C"] - Appended!
+
+// To REPLACE instead, use Overwrite
+await graph.updateState(config, { items: new Overwrite(["C"]) });  // Result: ["C"] - Replaced
+```
+</typescript>
+</fix-update-state-with-reducers>
+
+<fix-store-injection>
+<python>
+Access store via the Runtime object in graph nodes.
+
+```python
+# WRONG: Store not available in node
+def my_node(state):
+    store.put(...)  # NameError! store not defined
+
+# CORRECT: Access store via runtime
+from langgraph.runtime import Runtime
+
+def my_node(state, runtime: Runtime):
+    runtime.store.put(...)  # Correct store instance
+```
+</python>
+<typescript>
+Access store via runtime parameter in graph nodes.
+
+```typescript
+// WRONG: Store not available in node
+const myNode = async (state) => {
+  store.put(...);  // ReferenceError!
+};
+
+// CORRECT: Access store via runtime
+const myNode = async (state, runtime) => {
+  await runtime.store?.put(...);  // Correct store instance
+};
+```
+</typescript>
+</fix-store-injection>
+
+<boundaries>
+### What You Should NOT Do
+
+- Use `InMemorySaver` in production — data lost on restart; use `PostgresSaver`
+- Forget `thread_id` — state won't persist without it
+- Expect `update_state` to bypass reducers — it passes through them; use `Overwrite` to replace
+- Run the same stateful subgraph (`checkpointer=True`) in parallel within one node — namespace conflict
+- Access store directly in a node — use `runtime.store` via the `Runtime` param
+</boundaries>

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/managed-deep-agents.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/managed-deep-agents.md
@@ -32,7 +32,7 @@ Use this skill when the user wants to:
 
 ```bash
 uv tool install "deepagents-cli>=0.2.2"
-pip install managed-deepagents
+uv add managed-deepagents
 npm install @langchain/managed-deepagents @langchain/react
 ```
 

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/managed-deep-agents.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/managed-deep-agents.md
@@ -1,0 +1,565 @@
+---
+name: managed-deep-agents
+description: "INVOKE THIS SKILL when creating, deploying, running, or operating Managed Deep Agents in LangSmith. Covers deepagents-cli, the Python and TypeScript SDKs, React useStream, REST fallbacks, MCP tools, interrupts, backends, and the managed agent file tree."
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Managed Deep Agents
+
+## Overview
+
+Managed Deep Agents is a hosted runtime for creating, running, and operating Deep Agents in LangSmith. It packages the operational layer around the open-source Deep Agents harness: a versioned Context Hub agent repo, durable threads, streamed runs, MCP credential storage, managed files, and optional LangSmith sandboxes.
+
+Use the Managed Deep Agents path when the user wants LangSmith to host and operate the agent. For self-hosted deployments, custom application routes, or the full Agent Server API surface, use a standard LangSmith Deployment via [[langgraph-cli]] instead.
+
+## When to use
+
+Use this skill when the user wants to:
+
+- Deploy a Managed Deep Agent from local project files.
+- Create or update a Managed Deep Agent from Python, TypeScript, or REST.
+- Run an agent on a durable thread and stream output.
+- Build a React chat UI with `@langchain/react` `useStream`.
+- Register MCP servers, list MCP tools, or configure tool interrupts.
+- Choose between Managed Deep Agents and a self-hosted LangSmith Deployment.
+
+## Prerequisites
+
+- Managed Deep Agents preview access in the target LangSmith workspace.
+- A LangSmith API key for that workspace.
+- One of the supported clients:
+
+```bash
+uv tool install "deepagents-cli>=0.2.2"
+pip install managed-deepagents
+npm install @langchain/managed-deepagents @langchain/react
+```
+
+Set the API key in the shell or server environment:
+
+```bash
+export LANGSMITH_API_KEY="<LANGSMITH_API_KEY>"
+```
+
+The SDKs default to `https://api.smith.langchain.com/v1/deepagents`. To use a different compatible endpoint, set `LANGSMITH_ENDPOINT` or pass `api_url` / `apiUrl` in the client.
+
+For direct REST examples, set:
+
+```bash
+export DEEPAGENTS_BASE_URL="https://api.smith.langchain.com/v1/deepagents"
+```
+
+All REST requests authenticate with:
+
+```text
+X-Api-Key: <LANGSMITH_API_KEY>
+```
+
+Never expose a long-lived LangSmith API key in browser code. For browser apps, route requests through your own backend or provide a custom `fetch` implementation that proxies requests server-side.
+
+## Choose an interface
+
+| Interface | Use for |
+| --- | --- |
+| `deepagents-cli>=0.2.2` | Normal project-file workflow: scaffold, edit files, deploy, manage MCP servers. |
+| Python SDK `managed-deepagents` | Server-side Python automation, tests, scripts, services, and streaming. |
+| TypeScript SDK `@langchain/managed-deepagents` | Server-side TypeScript automation and LangGraph-compatible streaming. |
+| React `useStream` | Chat UIs that should let LangGraph own thread/run/projection state. |
+| REST `/v1/deepagents` | Low-level fallback when a client does not expose a field yet. |
+
+Prefer the CLI for local agent projects. Prefer the SDKs for application code. Use REST only when you need exact request control.
+
+## Resource groups
+
+| Group | Purpose |
+| --- | --- |
+| Agents | Create, list, get, update, clone, delete, and health-check Managed Deep Agents. |
+| Threads | Create, list, search, count, inspect, update, and delete durable thread state. |
+| Runs | Start and stream runs on a thread. |
+| MCP servers | Register, list, update, delete, and connect MCP servers. |
+| MCP tools | List tools exposed by a registered MCP server for `tools.json`. |
+| Auth sessions | Start and inspect OAuth authorization sessions. |
+
+## Project file tree
+
+The CLI uses a local project directory and deploys it into the managed Context Hub agent repo.
+
+```text
+my-agent/
+  agent.json
+  AGENTS.md
+  tools.json
+  skills/<name>/SKILL.md
+  subagents/<name>/agent.json
+  subagents/<name>/AGENTS.md
+  subagents/<name>/tools.json
+```
+
+| File / directory | Purpose |
+| --- | --- |
+| `agent.json` | Agent name, description, model, backend, permissions, and optional target `agent_id`. |
+| `AGENTS.md` | Main agent instructions. |
+| `tools.json` | MCP-backed tools plus `interrupt_config`. |
+| `skills/` | Reusable instructions and files the agent can load. |
+| `subagents/` | Delegated worker definitions and optional subagent-scoped tools. |
+
+At runtime, the agent can read and write managed files, including memory files created by the Deep Agents harness.
+
+## Backends
+
+New projects should use the canonical backend names from `deepagents-cli>=0.2.2`.
+
+Use `state` when the agent does not need sandbox-specific backend behavior:
+
+```json
+{
+  "backend": {
+    "type": "state"
+  }
+}
+```
+
+Use `sandbox` when the agent needs a LangSmith sandbox for code execution, filesystem work, or long-running tasks:
+
+```json
+{
+  "backend": {
+    "type": "sandbox",
+    "sandbox_config": {
+      "scope": "thread",
+      "policy_ids": ["policy-id"],
+      "idle_ttl_seconds": 900,
+      "delete_after_stop_seconds": 300
+    }
+  }
+}
+```
+
+`sandbox_config.scope` must be `thread` or `agent`.
+
+## CLI workflow
+
+Use the CLI for most deploy workflows.
+
+```bash
+deepagents init research-assistant
+cd research-assistant
+```
+
+Edit `agent.json`:
+
+```json
+{
+  "name": "research-assistant",
+  "description": "Research assistant that can search the web and summarize sources.",
+  "model": "openai:gpt-5.5",
+  "backend": {
+    "type": "state"
+  }
+}
+```
+
+Edit `AGENTS.md` with the main instructions, then deploy:
+
+```bash
+deepagents deploy
+```
+
+Useful CLI commands:
+
+| Command | Use |
+| --- | --- |
+| `deepagents --version` | Confirm `deepagents-cli>=0.2.2`. |
+| `deepagents deploy --dry-run` | Print the agent payload and managed file tree without deploying. |
+| `deepagents agents list` | List Managed Deep Agents in the workspace. |
+| `deepagents agents get <agent_id> --include-files` | Inspect an agent and its managed files. |
+| `deepagents mcp-servers add --url URL --name NAME` | Register a static-header MCP server. |
+| `deepagents mcp-servers add --url URL --auth-type oauth --connect` | Register and connect an OAuth MCP server. |
+| `deepagents mcp-servers tools <id\|name\|url>` | List tools and print a paste-ready `tools.json` snippet. |
+| `deepagents mcp-servers connect <id\|name\|url>` | Complete OAuth for a registered OAuth MCP server. |
+
+For shared repositories, put the target `agent_id` in `agent.json`; the CLI asks for confirmation before updating that remote agent. Use `--yes` only when the target is intentional.
+
+## MCP tools
+
+Tools are configured with a `tools` array and an `interrupt_config` map. The same shape is used in `tools.json` and inline SDK/REST create or update payloads.
+
+```json
+{
+  "tools": [
+    {
+      "name": "read_url_content",
+      "mcp_server_url": "https://example.com/mcp",
+      "mcp_server_name": "my-tools",
+      "display_name": "read_url_content"
+    }
+  ],
+  "interrupt_config": {
+    "https://example.com/mcp::read_url_content": false
+  }
+}
+```
+
+- `tools[].mcp_server_url` must match a registered workspace MCP server URL.
+- `tools[].name` is the tool name exposed by the MCP server, not the workspace MCP-server display name.
+- Use `deepagents mcp-servers tools <server>` or the SDK tool-listing methods to confirm exact tool names.
+- `interrupt_config` keys use `{mcp_server_url}::{tool_name}`. Additional `::` parts are accepted for compatibility, but do not rely on them for new configs.
+- Set the interrupt value to `true` to require human approval before the tool runs.
+
+Python SDK tool listing:
+
+```python
+from managed_deepagents import Client
+
+with Client() as client:
+    tools = client.mcp_servers.list_tools(
+        url="https://example.com/mcp",
+        force_refresh=True,
+    )
+    print(tools["tools"])
+```
+
+TypeScript SDK tool listing:
+
+```ts
+import { Client } from "@langchain/managed-deepagents";
+
+const client = new Client({ apiKey: process.env.LANGSMITH_API_KEY });
+const tools = await client.mcpServers.listTools({
+  url: "https://example.com/mcp",
+  forceRefresh: true,
+});
+console.log(tools.tools);
+```
+
+## Python SDK workflow
+
+Use the Python SDK for server-side automation and streaming.
+
+```python
+from managed_deepagents import Client
+
+with Client() as client:
+    agent = client.agents.create(
+        name="research-assistant",
+        description="Research assistant that can search the web and summarize sources.",
+        model="openai:gpt-5.5",
+        backend={"type": "state"},
+        instructions=(
+            "You are a careful research assistant. Search for sources, "
+            "keep notes, and return concise answers with citations."
+        ),
+    )
+
+    thread = client.threads.create(
+        agent_id=agent["id"],
+        options={
+            "test_run": False,
+            "skip_memory_write_protection": False,
+        },
+    )
+
+    for event in client.threads.stream(
+        thread["id"],
+        agent_id=agent["id"],
+        messages=[
+            {
+                "role": "user",
+                "content": "Research recent approaches to agent memory and summarize the main tradeoffs.",
+            }
+        ],
+        stream_mode=["values", "updates", "messages-tuple"],
+        stream_subgraphs=True,
+        user_timezone="America/Los_Angeles",
+    ):
+        print(event.event, event.data)
+```
+
+Async Python clients are available as `AsyncClient` with matching resource names.
+
+## TypeScript SDK workflow
+
+Use the TypeScript SDK for server-side automation and LangGraph-compatible streaming.
+
+```ts
+import { Client } from "@langchain/managed-deepagents";
+
+const client = new Client({
+  apiKey: process.env.LANGSMITH_API_KEY,
+});
+
+const agent = await client.agents.create({
+  name: "research-assistant",
+  description: "Research assistant that can search the web and summarize sources.",
+  model: "openai:gpt-5.5",
+  backend: { type: "state" },
+  instructions:
+    "You are a careful research assistant. Search for sources, keep notes, and return concise answers with citations.",
+});
+
+const thread = await client.threads.create({
+  agent_id: agent.id,
+  options: {
+    test_run: false,
+    skip_memory_write_protection: false,
+  },
+});
+
+const langGraphClient = client.getLangGraphClient({ agentId: agent.id });
+const stream = langGraphClient.runs.stream(thread.id, agent.id, {
+  input: {
+    messages: [
+      {
+        role: "user",
+        content:
+          "Research recent approaches to agent memory and summarize the main tradeoffs.",
+      },
+    ],
+  },
+  streamMode: ["values", "updates", "messages-tuple"],
+  streamSubgraphs: true,
+});
+
+for await (const event of stream) {
+  console.log(event.event, event.data);
+}
+```
+
+The adapter translates LangGraph SDK request fields into Managed Deep Agents routes, headers, and payload fields.
+
+## React `useStream`
+
+For React applications, use the TypeScript SDK's LangGraph client adapter with `@langchain/react`. `useStream` owns the thread, run, and state projection behavior while the Managed Deep Agents SDK handles auth, routes, and payload translation.
+
+```tsx
+import { Client } from "@langchain/managed-deepagents";
+import { useStream } from "@langchain/react";
+
+const agentId = "<agent_id>";
+
+const managedDeepAgents = new Client({
+  // Server-only or browser-safe proxy configuration.
+  // Do not ship LANGSMITH_API_KEY to browser clients.
+  apiKey: process.env.LANGSMITH_API_KEY,
+});
+
+const client = managedDeepAgents.getLangGraphClient({ agentId });
+
+export function ManagedDeepAgentStream() {
+  const stream = useStream({
+    client,
+    assistantId: agentId,
+    fetchStateHistory: false,
+  });
+
+  return (
+    <section>
+      <button
+        type="button"
+        disabled={stream.isLoading}
+        onClick={() => {
+          void stream.submit({
+            messages: [
+              { role: "user", content: "Write a short status update." },
+            ],
+          });
+        }}
+      >
+        Run agent
+      </button>
+
+      {stream.messages.map((message, index) => (
+        <p key={message.id ?? index}>{String(message.content)}</p>
+      ))}
+    </section>
+  );
+}
+```
+
+`stream.submit({ messages })` is the correct UI-level shape. The SDK adapter rewrites it to the Managed Deep Agents stream route as `input.messages`.
+
+## REST fallback
+
+Use REST when a client does not expose a field yet or when debugging raw payloads. Prefer SDK helpers in normal application code.
+
+Create an agent:
+
+```python
+import os
+import httpx
+
+BASE_URL = os.environ["DEEPAGENTS_BASE_URL"]
+HEADERS = {"X-Api-Key": os.environ["LANGSMITH_API_KEY"]}
+
+response = httpx.post(
+    f"{BASE_URL}/agents",
+    headers=HEADERS,
+    json={
+        "name": "research-assistant",
+        "description": "Research assistant that can search the web and summarize sources.",
+        "runtime": {"model": {"model_id": "openai:gpt-5.5"}},
+        "backend": {"type": "state"},
+        "instructions": (
+            "You are a careful research assistant. Search for sources, "
+            "keep notes, and return concise answers with citations."
+        ),
+    },
+)
+response.raise_for_status()
+agent_id = response.json()["id"]
+```
+
+Create a thread:
+
+```python
+response = httpx.post(
+    f"{BASE_URL}/threads",
+    headers=HEADERS,
+    json={
+        "agent_id": agent_id,
+        "options": {
+            "test_run": False,
+            "skip_memory_write_protection": False,
+        },
+    },
+)
+response.raise_for_status()
+thread_id = response.json()["id"]
+```
+
+Stream a run:
+
+```python
+payload = {
+    "agent_id": agent_id,
+    "input": {
+        "messages": [
+            {
+                "role": "user",
+                "content": "Research recent approaches to agent memory and summarize the main tradeoffs.",
+            }
+        ]
+    },
+    "stream_mode": ["values", "updates", "messages-tuple"],
+    "stream_subgraphs": True,
+    "user_timezone": "America/Los_Angeles",
+}
+
+with httpx.stream(
+    "POST",
+    f"{BASE_URL}/threads/{thread_id}/runs/stream",
+    headers={**HEADERS, "Accept": "text/event-stream"},
+    json=payload,
+    timeout=None,
+) as response:
+    response.raise_for_status()
+    for line in response.iter_lines():
+        if line:
+            print(line)
+```
+
+Set `Accept: text/event-stream` for raw REST streaming. `stream_mode` accepts LangGraph stream modes such as `values`, `updates`, and `messages-tuple`. `stream_subgraphs: true` emits subagent events as well as parent events.
+
+## Human-in-the-loop interrupts
+
+When `interrupt_config` flags a tool with `true`, the run pauses before the tool executes and emits an interrupt payload inside a `values` or `updates` event:
+
+```json
+{
+  "__interrupt__": [
+    {
+      "value": {
+        "action_requests": [
+          {
+            "name": "read_url_content",
+            "args": { "url": "https://example.com" },
+            "description": "Tool execution requires approval"
+          }
+        ],
+        "review_configs": [
+          {
+            "action_name": "read_url_content",
+            "allowed_decisions": ["approve", "edit", "reject", "respond"]
+          }
+        ]
+      },
+      "id": "interrupt-id"
+    }
+  ]
+}
+```
+
+The stream closes after the interrupt is emitted. To act on it, post a follow-up run with `command.resume` on the same thread.
+
+Python SDK resume:
+
+```python
+for event in client.threads.stream(
+    thread_id,
+    agent_id=agent_id,
+    messages=[{"role": "system", "content": ""}],
+    command={"resume": {"decisions": [{"type": "approve"}]}},
+    stream_mode=["values", "updates", "messages-tuple"],
+    stream_subgraphs=True,
+):
+    print(event.event, event.data)
+```
+
+REST resume:
+
+```python
+payload = {
+    "agent_id": agent_id,
+    "input": {"messages": [{"role": "system", "content": ""}]},
+    "command": {
+        "resume": {
+            "decisions": [{"type": "approve"}]
+        }
+    },
+    "stream_mode": ["values", "updates", "messages-tuple"],
+    "stream_subgraphs": True,
+}
+```
+
+The resume value must be the HITL response object `{"decisions": [...]}`, not a bare decision list. Send exactly one decision per `action_request`, in the same order.
+
+| Decision | Shape | Effect |
+| --- | --- | --- |
+| Approve | `{"type": "approve"}` | Run the tool with the proposed args. |
+| Edit | `{"type": "edit", "edited_action": {"name": "...", "args": {...}}}` | Run the tool with modified name/args. |
+| Reject | `{"type": "reject", "message": "..."}` | Block the tool and return an error `ToolMessage` to the model. |
+| Respond | `{"type": "respond", "message": "..."}` | Skip the tool and return a synthetic successful tool reply. |
+
+Each decision `type` must be allowed by the matching `review_configs[i].allowed_decisions`.
+
+### Resolve interrupt endpoint
+
+`POST /v1/deepagents/threads/{thread_id}/resolve-interrupt` takes no body and returns `204`. It terminates the paused run at the interrupt; it is not an approve shortcut. Use `command.resume` on `/runs/stream` for approve, edit, reject, or respond decisions.
+
+## When NOT to use Managed Deep Agents
+
+Use a standard LangSmith Deployment via [[langgraph-cli]] (`langgraph deploy`) instead when you need:
+
+- Custom application code or custom routes around the agent.
+- Advanced authentication around your own app server.
+- The full Agent Server API surface.
+- Stronger isolation controls or maximum scalability.
+- A region other than supported LangSmith Cloud regions, or self-hosted/Hybrid.
+
+## Gotchas
+
+- **Use `deepagents-cli>=0.2.2`** - older CLI versions generate stale backend names.
+- **Use canonical backends** - new examples should use `state` or `sandbox` with `sandbox_config.scope`.
+- **REST stream payloads use `input.messages`** - SDK helpers accept `messages` and normalize the request body.
+- **Do not ship API keys to browsers** - proxy browser requests through your backend or custom `fetch`.
+- **`PATCH` can replace nested fields wholesale** - when updating tools, pass the full desired tool set.
+- **Tool names must match MCP tool names** - if `tools[].name` is wrong, the model will not see the tool.
+- **List tools before wiring `tools.json`** - use the CLI or SDK tool-listing methods to avoid name mismatches.
+- **Resume interrupts with `command.resume = {"decisions": [...]}`** - a bare list is invalid.
+- **Resume runs still need a non-empty message list** - use `[ {"role": "system", "content": ""} ]` as a no-op message when needed.
+- **`resolve-interrupt` cancels/finalizes** - it does not approve a pending action.
+- **Model IDs should include provider prefix** - use `openai:gpt-5.5`, not a bare model name.
+- **MCP credentials are sensitive** - avoid logging headers or raw credential payloads.
+- **Deleting an agent does not delete its threads** - track and clean up threads explicitly.
+- **API stability** - `/v1/deepagents` is still evolving; prefer SDK and CLI surfaces for user-facing workflows.

--- a/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/openinference-tracing.md
+++ b/plugins/nemo-experimentalist/framework-skills/langchain-framework/references/openinference-tracing.md
@@ -1,0 +1,115 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# OpenInference tracing for LangChain
+
+Wire LangChain spans to a JSONL file using [OpenInference](https://github.com/Arize-ai/openinference) instrumentation on top of an OpenTelemetry SDK tracer provider. OpenInference defines cross-framework semantic conventions for LLM observability (`openinference.span.kind`, `llm.input_messages.*`, `tool.name`, …); the `openinference-instrumentation-langchain` package auto-instruments LangChain to emit those attributes on every LLM, tool, and chain span.
+
+## When to use
+
+- Debugging a multi-step agent: inspect every LLM and tool call after the run.
+- Producing structured trace files for downstream tooling.
+- Running the agent inside an evaluation harness that collects per-trial traces from disk.
+
+## Install
+
+```bash
+uv add openinference-instrumentation-langchain opentelemetry-sdk
+```
+
+## Wire it into `main.py`
+
+Set up the tracer **before** constructing any LangChain object (model, tools, agent). Spans created during construction won't be captured otherwise.
+
+```python
+from pathlib import Path
+
+from openinference.instrumentation.langchain import LangChainInstrumentor
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import (
+    SimpleSpanProcessor,
+    SpanExporter,
+    SpanExportResult,
+)
+
+
+class _FileSpanExporter(SpanExporter):
+    """Append one ReadableSpan.to_json() per line to a JSONL file."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text("")  # truncate at start of each run
+
+    def export(self, spans) -> SpanExportResult:
+        try:
+            with self._path.open("a", encoding="utf-8") as f:
+                for span in spans:
+                    f.write(span.to_json(indent=None) + "\n")
+            return SpanExportResult.SUCCESS
+        except Exception:
+            return SpanExportResult.FAILURE
+
+    def shutdown(self) -> None:
+        return None
+
+
+def setup_tracing(trace_path: str | Path) -> TracerProvider:
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(_FileSpanExporter(trace_path)))
+    trace.set_tracer_provider(provider)
+    LangChainInstrumentor().instrument(tracer_provider=provider)
+    return provider
+```
+
+Call it early in `main()` and force a flush before exit. Put the flush/shutdown — and any post-run trace conversion — inside `finally` so they run even when the agent raises (recursion limit, tool errors, etc.):
+
+```python
+def main() -> None:
+    provider = setup_tracing("traces/run.jsonl")
+    try:
+        # ... build model / tools / agent and run ...
+        ...
+    finally:
+        provider.force_flush(timeout_millis=5000)
+        provider.shutdown()
+```
+
+## Why `SimpleSpanProcessor`
+
+`SimpleSpanProcessor` exports each span synchronously when it ends. For a single-shot agent run this is reliable and order-preserving — no risk of losing spans if the process exits before a background batch flushes. `BatchSpanProcessor` is preferable in long-running services where throughput matters; for one-off agent runs it's not worth the failure mode.
+
+## Output format
+
+Each line of the JSONL file is one `ReadableSpan.to_json()`:
+
+```json
+{"name": "ChatOpenAI", "context": {"trace_id": "0x...", "span_id": "0x..."}, "kind": "SpanKind.INTERNAL", "parent_id": "0x...", "start_time": "...", "end_time": "...", "status": {"status_code": "OK"}, "attributes": {"openinference.span.kind": "LLM", "llm.model_name": "...", "llm.input_messages.0.message.role": "system", "llm.input_messages.0.message.content": "...", "llm.output_messages.0.message.role": "assistant", "llm.output_messages.0.message.content": "...", "input.value": "...", "output.value": "..."}, "events": [], "links": [], "resource": {...}}
+```
+
+OpenInference attributes you'll see most often:
+
+| Attribute | Meaning |
+|---|---|
+| `openinference.span.kind` | One of `AGENT`, `CHAIN`, `LLM`, `TOOL`, `RETRIEVER`, `EMBEDDING` |
+| `input.value`, `output.value` | Serialized inputs/outputs of the span |
+| `llm.model_name`, `llm.provider` | Model identification on LLM spans |
+| `llm.input_messages.{i}.message.role`, `…content` | Each prompt message, indexed |
+| `llm.output_messages.{i}.message.role`, `…content` | Each model output message |
+| `llm.token_count.prompt`, `…completion`, `…total` | Token usage on LLM spans |
+| `tool.name`, `tool.description` | Tool identification on TOOL spans |
+
+## Privacy controls
+
+OpenInference includes message content by default. To redact, set environment variables before `instrument()` runs:
+
+- `OPENINFERENCE_HIDE_INPUTS=true` — drop `input.value` and `llm.input_messages.*`
+- `OPENINFERENCE_HIDE_OUTPUTS=true` — drop `output.value` and `llm.output_messages.*`
+- `OPENINFERENCE_HIDE_LLM_INVOCATION_PARAMETERS=true` — drop sampling params
+
+## Common pitfalls
+
+- **Instrumenting after construction**: if `setup_tracing()` runs after `create_agent(...)` or `ChatOpenAI(...)`, spans from those objects aren't captured. Always set up tracing first.
+- **Forgetting to flush**: even with `SimpleSpanProcessor`, calling `provider.shutdown()` (or `force_flush()`) before exit ensures any in-flight async work completes. Without it, you may see truncated files when running under `asyncio`.
+- **Multiple tracer providers**: do not call `trace.set_tracer_provider()` more than once. If your agent imports a library that also configures tracing, decide which one wins and configure only that.

--- a/plugins/nemo-experimentalist/framework-skills/nooa/SKILL.md
+++ b/plugins/nemo-experimentalist/framework-skills/nooa/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: nooa
+description: Build, modify, debug, or optimize agents using NVIDIA-labs OO Agents (NOOA). Use for nooa.Agent subclasses, ellipsis generation methods, CodeAct or Predict strategies, ShellTools, Skill/TextSkill, context and persistence, MCP, tracing, middleware, channels, or trace analysis.
+compatibility: Python >= 3.12,<3.14; uv; nooa v0.0.6
+metadata:
+  upstream: https://github.com/NVIDIA-NeMo/labs-OO-Agents
+  revision: v0.0.6
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# NVIDIA-labs OO Agents (NOOA)
+
+Use the `nooa` package and namespace pinned in this repository.
+
+For detailed framework guidance, consult the immutable upstream `v0.0.6`
+skills:
+https://github.com/NVIDIA-NeMo/labs-OO-Agents/tree/v0.0.6/skills
+
+Before changing framework behavior, inspect the pinned implementation or the
+matching upstream skill instead of guessing. In Optimizer:
+
+- Call `super().__init__()` before attaching tools or skills.
+- Use `GuardedShellTools` where workspace access must remain restricted.
+- Hide internal skill registries with `spec(self, "skills", hidden=True)`.
+- Keep the explicit `orjson==3.11.9` workaround required by the v0.0.6
+  LiteLLM tool-call path.
+
+## Verification
+
+Use the repository root `.venv` and the README's standard `uv` workflow. Run:
+
+```bash
+uv run --frozen pytest -q <focused migration tests>
+uv run --frozen ruff check .
+uv run --frozen ruff format --check .
+uv run --frozen pyright
+```
+
+Then run the changed agent end to end with its configured model.

--- a/plugins/nemo-experimentalist/pyproject.toml
+++ b/plugins/nemo-experimentalist/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "nemo-experimentalist-plugin"
+version = "0.1.0"
+description = "NeMo Experimentalist plugin for NeMo Platform."
+# The plugin itself needs 3.12 (so do nooa and harbor), but a workspace member cannot
+# raise its floor above the workspace's without dragging every other package up with it.
+# The floor is declared here and enforced by the markers below plus the `experimentalist`
+# dependency group in the workspace root.
+requires-python = ">=3.11,<3.14"
+dependencies = [
+    "pydantic>=2",
+    "httpx",
+    "harbor>=0.16 ; python_full_version >= '3.12'",
+    "opentelemetry-proto>=1.42.1",
+    "protobuf>=6.0.0",
+    "nooa ; python_full_version >= '3.12'",
+    "pyyaml>=6.0.3",
+    "nemo-insights-plugin",
+    "nemo-platform",
+    "nemo-platform-plugin",
+    "tomlkit>=0.13.3",
+]
+
+[project.entry-points."nemo.cli"]
+experimentalist = "nemo_experimentalist_plugin.cli:ExperimentalistCLI"
+
+[project.entry-points."nemo.skills"]
+experimentalist = "nemo_experimentalist_plugin.skills:skills_dir"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nemo_experimentalist_plugin"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/assets/models.yaml
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/assets/models.yaml
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Curated model catalog for OptimizeModelCapability.
+# Keep one entry per underlying model. Duplicate route aliases, such as
+# nvcf/nvidia/* aliases for nvidia/nvidia/* models, are intentionally omitted.
+default_endpoint: https://inference-api.nvidia.com/v1
+default_api_key_env: NVIDIA_INTERNAL_API_KEY
+id_field: model_id
+# Models may define endpoint and api_key_env overrides. If omitted, use the defaults above.
+models:
+  - model_id: azure/openai/gpt-5.5
+    provider: OpenAI
+    range: frontier_strong_reasoning
+    notes: Flagship GPT.
+  - model_id: azure/openai/gpt-5.4
+    provider: OpenAI
+    range: frontier_strong_reasoning
+    notes: Strong general-purpose GPT.
+  - model_id: nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1
+    provider: NVIDIA
+    range: frontier_strong_reasoning
+    notes: Largest Nemotron; strong open-weight reasoning.
+  - model_id: nvidia/nvidia/nemotron-3-ultra
+    provider: NVIDIA
+    range: frontier_strong_reasoning
+    notes: Current Nemotron Ultra.
+  - model_id: nvidia/nvidia/nemotron-3-super-v3
+    provider: NVIDIA
+    range: frontier_strong_reasoning
+    notes: Open-weight, strong instruction-following.
+  - model_id: nvidia/nvidia/nemotron-3-super-preview
+    provider: NVIDIA
+    range: frontier_strong_reasoning
+    notes: Preview Nemotron Super.
+  - model_id: nvidia/minimaxai/minimax-m2.7
+    provider: MiniMax
+    range: frontier_strong_reasoning
+    notes: Strong reasoning and coding model.
+  - model_id: azure/openai/gpt-5
+    provider: OpenAI
+    range: mid_tier_balanced
+    notes: Balanced GPT.
+  - model_id: azure/openai/gpt-4.1
+    provider: OpenAI
+    range: mid_tier_balanced
+    notes: Proven mid-tier GPT.
+  - model_id: nvidia/meta/llama-3.3-70b-instruct
+    provider: Meta
+    range: mid_tier_balanced
+    notes: Strong open-weight 70B.
+  - model_id: nvidia/nvidia/llama-3.3-nemotron-super-49b-v1
+    provider: NVIDIA
+    range: mid_tier_balanced
+    notes: Nemotron Super 49B.
+  - model_id: nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5
+    provider: NVIDIA
+    range: mid_tier_balanced
+    notes: Good reasoning-to-cost ratio.
+  - model_id: nvidia/qwen/qwen3-5-397b-a17b
+    provider: Qwen
+    range: mid_tier_balanced
+    notes: Large MoE, only 17B active parameters.
+  - model_id: nvidia/deepseek-ai/deepseek-v4-pro
+    provider: DeepSeek
+    range: mid_tier_balanced
+    notes: Strong reasoning.
+  - model_id: nvidia/minimaxai/minimax-m2.5
+    provider: MiniMax
+    range: mid_tier_balanced
+    notes: Balanced MiniMax model.
+  - model_id: nvidia/google/gemma-4-31b-it
+    provider: Google
+    range: mid_tier_balanced
+    notes: Strong open-weight 31B.
+  - model_id: azure/openai/gpt-5-mini
+    provider: OpenAI
+    range: fast_cheap
+    notes: Small, fast GPT.
+  - model_id: azure/openai/gpt-4.1-mini
+    provider: OpenAI
+    range: fast_cheap
+    notes: Cheap, proven GPT.
+  - model_id: nvidia/nvidia/nemotron-nano-31b-v3
+    provider: NVIDIA
+    range: fast_cheap
+    notes: Fast open-weight model.
+  - model_id: nvidia/nvidia/nemotron-nano-30b-v3
+    provider: NVIDIA
+    range: fast_cheap
+    notes: Fast open-weight 30B.
+  - model_id: nvidia/nvidia/nemotron-nano-9b-v2
+    provider: NVIDIA
+    range: fast_cheap
+    notes: Smallest Nemotron; lowest cost.
+  - model_id: nvidia/qwen/qwen3.5-9b
+    provider: Qwen
+    range: fast_cheap
+    notes: Small, fast open-weight model.
+  - model_id: nvidia/deepseek-ai/deepseek-v4-flash
+    provider: DeepSeek
+    range: fast_cheap
+    notes: Fast reasoning at low cost.
+  - model_id: nvidia/meta/llama-3.1-8b-instruct
+    provider: Meta
+    range: fast_cheap
+    notes: Tiny, very fast.
+  - model_id: azure/openai/o3
+    provider: OpenAI
+    range: reasoning_specialized
+    notes: Strong reasoning model.
+  - model_id: azure/openai/o4-mini
+    provider: OpenAI
+    range: reasoning_specialized
+    notes: Fast reasoning model.
+  - model_id: nvidia/moonshotai/kimi-k2.6
+    provider: Moonshot
+    range: reasoning_specialized
+    notes: Strong open-weight reasoning.
+  - model_id: nvidia/nvidia/Nemotron-3-Nano-30B-A3B
+    provider: NVIDIA
+    range: reasoning_specialized
+    notes: Nemotron Nano A3B reasoning.
+  - model_id: nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning
+    provider: NVIDIA
+    range: reasoning_specialized
+    notes: Open-weight reasoning.
+  - model_id: nvidia/nvidia/nemotron-nano-12b-v2-vl
+    provider: NVIDIA
+    range: multimodal
+    notes: Vision-language, small and fast.
+  - model_id: nvidia/meta/llama-3.2-11b-vision-instruct
+    provider: Meta
+    range: multimodal
+    notes: Vision-language 11B.

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/cli.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/cli.py
@@ -1,0 +1,524 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimentalist plugin CLI — ``nemo experimentalist ...`` subcommands."""
+
+import asyncio
+import os
+import uuid
+from collections.abc import MutableMapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import ClassVar, Literal
+from urllib.parse import urlsplit
+
+import typer
+import yaml
+from nemo_experimentalist_plugin.client import make_client
+from nemo_experimentalist_plugin.preflight import (
+    Probes,
+    check_artifacts,
+    check_datasets,
+    check_environment,
+    check_profile,
+)
+from nemo_experimentalist_plugin.profile import AgentProfile, load_profile
+from nemo_experimentalist_plugin.resolve import (
+    ResolveError,
+    build_effective_experiment_plan,
+    resolve_effective_insight,
+    resolve_experiment_inputs,
+)
+from nemo_insights_plugin.contracts.checks import (
+    CheckResult,
+    advisories,
+    format_report,
+    required_failures,
+)
+from nemo_insights_plugin.contracts.profile import (
+    EnvFileError,
+    ProfileError,
+    discover_profile,
+    load_env_file,
+    resolve_base_url,
+)
+from nemo_platform_plugin.cli import NemoCLI
+
+DEFAULT_WORKSPACE = "default"
+
+_PREFLIGHT_PROBES: Probes | None = None  # test seam; None → real probes
+
+# Lazily imported in the experiment command: importing experimentalist.run reaches model
+# construction that requires EXPERIMENTALIST_API_* env at import time, and this module
+# must import env-less so `nemo experimentalist doctor` can diagnose the missing creds.
+# Tests monkeypatch this global with a recorder, which bypasses the lazy import.
+run_experimentalist = None
+
+# TODO: Add remote train/validation dataset support when remote experiment mode is implemented.
+
+
+def _default_experiment_dir(profile: AgentProfile | None) -> Path:
+    if profile is None:
+        experiments_root = Path("tmp")
+    else:
+        experiments_root = profile.profile_dir / ".nemo-optimizer" / "experiments"
+    experiments_root.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(tz=UTC).strftime("%Y%m%d-%H%M%S")
+    while True:
+        candidate = experiments_root / f"{timestamp}-{uuid.uuid4().hex}"
+        try:
+            candidate.mkdir(exist_ok=False)
+        except FileExistsError:
+            continue
+        return candidate
+
+
+class ExperimentalistCLI(NemoCLI):
+    """``nemo experimentalist ...`` subcommands."""
+
+    name: ClassVar[str] = "experimentalist"
+    description: ClassVar[str] = "NeMo Experimentalist commands."
+
+    def get_cli(self) -> typer.Typer:
+        app = typer.Typer(help=self.description, no_args_is_help=True)
+
+        @app.callback()
+        def _root() -> None:
+            """Force subcommand dispatch even when only one verb is registered."""
+
+        @app.command("run")
+        def run(
+            agent: str | None = typer.Option(
+                None,
+                "--agent",
+                help=(
+                    "Baseline agent: a local directory or a git URL with an optional ref "
+                    "(e.g. ssh://git@host/group/repo.git@main). Optional in Mode 1 (the insight "
+                    "supplies the agent) and overrides the insight's agent when given. A git "
+                    "source records provenance and enables --config storage.publish_winner to open a "
+                    "draft PR/MR for the winner against that ref."
+                ),
+            ),
+            agent_spec: str | None = typer.Option(
+                None,
+                "--agent-spec",
+                help="URI of a markdown file describing the agent under test (its spec).",
+            ),
+            insight: str | None = typer.Option(
+                None,
+                "--insight",
+                help=(
+                    "Insight for Mode 1: a local insight file OR a platform insight id "
+                    "(surfaced in Studio). A path that exists on disk is read locally; "
+                    "otherwise it is fetched from the platform. Default: "
+                    "<profile-dir>/.nemo-optimizer/insights.yaml when it exists (where "
+                    "`nemo insights analyze` writes by default)."
+                ),
+            ),
+            insight_id: str | None = typer.Option(
+                None,
+                "--insight-id",
+                help=(
+                    "Selector for a local multi-insight file: exact id/title first; "
+                    "if none matches, a decimal value is a zero-based index."
+                ),
+            ),
+            no_insight: bool = typer.Option(
+                False,
+                "--no-insight",
+                help="Disable insight use (Mode 2), including the shared profile insight file.",
+            ),
+            profile_path: Path | None = typer.Option(
+                None,
+                "--profile",
+                help="Path to optimizer.yaml. Default: discovered by walking up from the cwd.",
+                exists=True,
+                dir_okay=False,
+                readable=True,
+            ),
+            train_dataset: str | None = typer.Option(
+                None,
+                "--train-dataset",
+                help="Train dataset: local path or harbor registry ref. Falls back to the profile.",
+            ),
+            validation_dataset: str | None = typer.Option(
+                None,
+                "--validation-dataset",
+                help="Validation dataset: local path or harbor registry ref. Falls back to the profile.",
+            ),
+            task_template: str | None = typer.Option(
+                None,
+                "--task-template",
+                help="Evaluator-specific task-template URI. Required with --insight.",
+            ),
+            experiment_dir: Path | None = typer.Option(
+                None,
+                "--experiment-dir",
+                "--output",
+                "--experiments-output",
+                "-o",
+                help=(
+                    "Local experiment directory; writes eval-and-optimize/ here. "
+                    "Default: <profile-dir>/.nemo-optimizer/experiments/<timestamp> "
+                    "when a profile governs the run, else ./tmp."
+                ),
+                file_okay=False,
+                dir_okay=True,
+            ),
+            mode: Literal["local", "remote"] = typer.Option(
+                "local",
+                "--mode",
+                help="Mode of the optimizer run.",
+            ),
+            workspace: str | None = typer.Option(
+                None,
+                "--workspace",
+                help="Intake/NMP workspace for traces and run/candidate metadata. Falls back to the profile.",
+            ),
+            base_url: str | None = typer.Option(
+                None,
+                "--base-url",
+                help=(
+                    "Base URL of the running NMP instance. Default: NMP_BASE_URL "
+                    "(shell or profile-dir .env), else http://localhost:8080."
+                ),
+                envvar="NMP_BASE_URL",
+            ),
+            config: Path | None = typer.Option(
+                None,
+                "--config",
+                help="YAML or JSON configuration for the optimizer run.",
+                exists=True,
+                file_okay=True,
+                dir_okay=False,
+                readable=True,
+            ),
+            framework_skills: list[Path] = typer.Option(
+                [],
+                "--framework-skills",
+                help="Path to a directory of framework skills to load into the optimizer agents. May be specified multiple times.",
+                exists=True,
+                file_okay=False,
+                dir_okay=True,
+                readable=True,
+            ),
+        ) -> None:
+            """Run offline optimization for a baseline agent (local dir or git source)."""
+
+            if no_insight and (insight is not None or insight_id is not None):
+                typer.echo("--no-insight cannot be combined with --insight or --insight-id", err=True)
+                raise typer.Exit(code=1)
+            if mode == "remote":
+                typer.echo("Remote mode is not implemented yet", err=True)
+                raise typer.Exit(code=1)
+
+            async def _flow() -> str:
+                """Resolve inputs (profile + flags) and run the Experimentalist."""
+                profile, profile_load_error = _load_profile_or_error(profile_path)
+                # Resolved AFTER the profile-dir .env load so an NMP_BASE_URL set there
+                # takes effect; typer's envvar/flag binding (shell) wins.
+                base_url_resolved = resolve_base_url(base_url)
+                effective_insight = resolve_effective_insight(
+                    profile=profile,
+                    insight=insight,
+                    insight_id=insight_id,
+                    disabled=no_insight,
+                )
+                if no_insight:
+                    typer.echo("Insight disabled: --no-insight (Mode 2)", err=True)
+                elif effective_insight.is_profile_default:
+                    # `nemo insights analyze` writes here by default: the verbs connect flag-free.
+                    typer.echo(
+                        f"Insight file: {effective_insight.ref} (default; pass --insight to override)",
+                        err=True,
+                    )
+                _announce_credential_defaults()
+                # Phase 1 — cheap environment checks BEFORE resolution: certain failures
+                # (missing creds, docker down, harbor absent) surface as the grouped
+                # report before any dataset download or the loop-chain import (which
+                # itself requires EXPERIMENTALIST_API_* env) can preempt them. check_profile is
+                # doctor-only on purpose: flags may fully specify the run, and resolution
+                # reports missing inputs with the skeleton.
+                _preflight_or_exit(
+                    check_environment(
+                        profile=profile,
+                        insight=effective_insight.ref,
+                        insight_id=effective_insight.selector,
+                        base_url=base_url_resolved,
+                        enforce_insight_agent=agent is None,
+                        probes=_PREFLIGHT_PROBES,
+                    )
+                )
+                config_payload = _load_config_payload(config)
+                try:
+                    plan = build_effective_experiment_plan(
+                        profile=profile,
+                        agent=agent,
+                        agent_spec=agent_spec,
+                        insight=effective_insight.ref,
+                        insight_id=effective_insight.selector,
+                        no_insight=no_insight,
+                        train_dataset=train_dataset,
+                        validation_dataset=validation_dataset,
+                        task_template=task_template,
+                        workspace=workspace,
+                        config_payload=config_payload,
+                        framework_skills=framework_skills or None,
+                    )
+                except ResolveError as exc:
+                    if profile_load_error is not None:
+                        raise ResolveError(f"{profile_load_error}\n{exc}") from None
+                    raise
+                if profile_load_error is not None:
+                    typer.echo(f"⚠ ignoring unusable optimizer.yaml: {profile_load_error}", err=True)
+                # Phase 2 validates effective source/template/storage before
+                # creating an output directory or downloading datasets.
+                _preflight_or_exit(
+                    check_artifacts(
+                        profile,
+                        task_template=plan.task_template,
+                        agent_source=plan.agent,
+                        storage=plan.config.storage.model_dump(),
+                        require_template=plan.insight is not None,
+                        probes=_PREFLIGHT_PROBES,
+                    )
+                )
+                if experiment_dir is None:
+                    experiment_dir_resolved = _default_experiment_dir(profile)
+                    typer.echo(f"Experiment dir: {experiment_dir_resolved}", err=True)
+                else:
+                    experiment_dir_resolved = experiment_dir
+                inputs = await resolve_experiment_inputs(
+                    profile=profile,
+                    scratch_dir=experiment_dir_resolved / "resolved",
+                    plan=plan,
+                )
+                global run_experimentalist
+                if run_experimentalist is None:
+                    from nemo_experimentalist_plugin.experimentalist.run import (
+                        run_experimentalist as _run_experimentalist,  # noqa: PLC0415
+                    )
+
+                    run_experimentalist = _run_experimentalist
+                client = make_client(base_url_resolved)
+                try:
+                    return await run_experimentalist(
+                        agent=inputs.agent,
+                        agent_spec=inputs.agent_spec,
+                        insight=inputs.insight,
+                        train_dataset=inputs.train_dataset,
+                        validation_dataset=inputs.validation_dataset,
+                        task_template=inputs.task_template,
+                        experiment_dir=experiment_dir_resolved,
+                        workspace=inputs.workspace,
+                        client=client,
+                        config=inputs.config,
+                        mode=mode,
+                        framework_skills_dirs=inputs.framework_skills_dirs,
+                    )
+                finally:
+                    await client.close()
+
+            try:
+                output_text = asyncio.run(_flow())
+            except (OSError, ValueError, yaml.YAMLError) as exc:
+                typer.echo(str(exc), err=True)
+                raise typer.Exit(code=1) from None
+            typer.echo(output_text)
+
+        @app.command("doctor")
+        def doctor(
+            insight: str | None = typer.Option(None, "--insight", help="Optional insight ref to verify."),
+            insight_id: str | None = typer.Option(
+                None,
+                "--insight-id",
+                help="Select an exact id/title or zero-based index from a local multi-insight file.",
+            ),
+            profile_path: Path | None = typer.Option(None, "--profile", help="Path to optimizer.yaml."),
+            base_url: str | None = typer.Option(
+                None,
+                "--base-url",
+                help=(
+                    "Base URL of the running NMP instance. Default: NMP_BASE_URL "
+                    "(shell or profile-dir .env), else http://localhost:8080."
+                ),
+                envvar="NMP_BASE_URL",
+            ),
+        ) -> None:
+            """Diagnose Experimentalist setup: profile, artifacts, credentials, platform, runtime."""
+            found = profile_path or discover_profile()
+            profile_obj, profile_error = None, None
+            env_results: list[CheckResult] = []
+            if found is not None:
+                try:
+                    profile_obj = load_profile(found)
+                except ProfileError as exc:
+                    profile_error = str(exc)
+                try:
+                    _announce_env_file(found.parent)
+                except EnvFileError as exc:
+                    env_results.append(
+                        CheckResult(
+                            name="profile-env",
+                            group="profile",
+                            status="fail",
+                            severity="required",
+                            message=str(exc),
+                            hint="check that the file is readable UTF-8 text, or remove the broken .env file",
+                        )
+                    )
+            base_url_resolved = resolve_base_url(base_url)
+            _announce_credential_defaults()
+            insight_results: list[CheckResult] = []
+            try:
+                effective_insight = resolve_effective_insight(
+                    profile=profile_obj,
+                    insight=insight,
+                    insight_id=insight_id,
+                )
+            except ResolveError as exc:
+                effective_insight = None
+                insight_results.append(
+                    CheckResult(
+                        name="insight-resolution",
+                        group="platform",
+                        status="fail",
+                        severity="required",
+                        message=str(exc),
+                    )
+                )
+            plan = None
+            plan_results: list[CheckResult] = []
+            if profile_obj is not None and effective_insight is not None:
+                try:
+                    plan = build_effective_experiment_plan(
+                        profile=profile_obj,
+                        insight=effective_insight.ref,
+                        insight_id=effective_insight.selector,
+                    )
+                except ResolveError as exc:
+                    plan_results.append(
+                        CheckResult(
+                            name="experiment-plan",
+                            group="profile",
+                            status="fail",
+                            severity="required",
+                            message=str(exc),
+                            hint="fix optimizer.yaml or its referenced agent_spec/experiment_config",
+                        )
+                    )
+            results = check_profile(profile_obj, profile_error) + env_results + plan_results + insight_results
+            results += check_environment(
+                profile=profile_obj,
+                insight=effective_insight.ref if effective_insight is not None else None,
+                insight_id=effective_insight.selector if effective_insight is not None else None,
+                base_url=base_url_resolved,
+                probes=_PREFLIGHT_PROBES,
+            )
+            if profile_obj is not None:
+                if plan is not None:
+                    results += check_artifacts(
+                        profile_obj,
+                        task_template=plan.task_template,
+                        agent_source=plan.agent,
+                        storage=plan.config.storage.model_dump(),
+                        require_template=plan.insight is not None,
+                        probes=_PREFLIGHT_PROBES,
+                    )
+                results += check_datasets(profile_obj)
+            typer.echo(format_report(results))
+            if required_failures(results):
+                raise typer.Exit(code=1)
+
+        return app
+
+
+def _load_profile_or_error(profile_path: Path | None) -> tuple[AgentProfile | None, str | None]:
+    """Load the explicit or discovered profile; announce a discovered one.
+
+    An explicitly named ``--profile`` must load (ProfileError propagates). A
+    discovered optimizer.yaml that fails to load is returned as an error
+    string — it may be a malformed or foreign file, and flags can still fully
+    specify the run. A successfully discovered profile is echoed to stderr so
+    a stray parent-directory optimizer.yaml can never silently govern a run.
+    """
+    found = profile_path or discover_profile()
+    if found is None:
+        return None, None
+    try:
+        profile = load_profile(found)
+    except ProfileError as exc:
+        if profile_path is not None:
+            raise
+        _announce_env_file(found.parent)
+        return None, str(exc)
+    if profile_path is None:
+        typer.echo(f"Using profile: {found} (agent: {profile.agent})", err=True)
+    _announce_env_file(found.parent)
+    return profile, None
+
+
+def _announce_env_file(profile_dir: Path) -> None:
+    """Load ``<profile_dir>/.env`` into the process env (set keys win) and say so."""
+    env_path = profile_dir / ".env"
+    loaded = load_env_file(env_path)
+    if loaded:
+        typer.echo(f"Loaded .env from {env_path} ({len(loaded)} vars)", err=True)
+
+
+_GATEWAY_BASE = "https://inference-api.nvidia.com/v1"
+_GATEWAY_HOST = "inference-api.nvidia.com"
+
+
+def _is_gateway_base(value: str) -> bool:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return False
+    return parsed.scheme == "https" and parsed.hostname == _GATEWAY_HOST
+
+
+def _apply_credential_defaults(env: MutableMapping[str, str] = os.environ) -> list[str]:
+    """Fill gateway-shaped credential gaps; returns what was applied.
+
+    ``EXPERIMENTALIST_API_BASE`` defaults to the NVIDIA Inference Gateway, and when
+    the effective base IS the gateway, ``INFERENCE_API_KEY`` can power the
+    experimentalist too. A custom base never inherits the gateway key.
+    """
+    applied: list[str] = []
+    if not env.get("EXPERIMENTALIST_API_BASE", "").strip():
+        env["EXPERIMENTALIST_API_BASE"] = _GATEWAY_BASE
+        applied.append(f"EXPERIMENTALIST_API_BASE={_GATEWAY_BASE}")
+    if _is_gateway_base(env["EXPERIMENTALIST_API_BASE"]):
+        inference = env.get("INFERENCE_API_KEY", "").strip()
+        optimizer = env.get("EXPERIMENTALIST_API_KEY", "").strip()
+        if inference and not optimizer:
+            env["EXPERIMENTALIST_API_KEY"] = inference
+            applied.append("EXPERIMENTALIST_API_KEY=INFERENCE_API_KEY")
+    return applied
+
+
+def _announce_credential_defaults() -> None:
+    applied = _apply_credential_defaults()
+    if applied:
+        typer.echo("Credential defaults: " + ", ".join(applied), err=True)
+
+
+def _load_config_payload(config: Path | None) -> dict | None:
+    """Read a --config file; an explicitly passed empty file is an error, not
+    a silent fallback to the profile's experiment_config."""
+    if config is None:
+        return None
+    payload = yaml.safe_load(config.read_text(encoding="utf-8"))
+    if payload is None:
+        raise ValueError(f"--config {config} is empty; remove the flag or add settings to the file")
+    return payload
+
+
+def _preflight_or_exit(results: list[CheckResult]) -> None:
+    """Auto-run gate: hard-error on required failures, warn on advisories."""
+    if required_failures(results):
+        typer.echo(format_report(results), err=True)
+        raise typer.Exit(code=1)
+    for warning in advisories(results):
+        typer.echo(f"⚠ {warning.message}" + (f" ({warning.hint})" if warning.hint else ""), err=True)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/client.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/client.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared NeMo Platform SDK client construction for Insight consumers.
+
+Auth lives in the active ``nemo auth login`` context in
+``~/.config/nmp/config.yaml``. The SDK only wires up that context (and the
+transparent OIDC token refresh that comes with it) when it runs its config
+bootstrap. Passing ``base_url`` *alone* puts the SDK in "direct mode", which
+skips the bootstrap and injects **no** auth headers — fine for an
+unauthenticated local ``nemo services run``, but it 401s against a remote
+deployment. To authenticate against a remote URL we must trigger the bootstrap
+(by also passing ``config_path``) so the explicit ``base_url`` is combined with
+the context's credentials.
+
+Every Platform Insight consumer takes ``base_url`` from its workflow context,
+so this helper is the one place that branch lives.
+"""
+
+from urllib.parse import urlparse
+
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform.config.config import Config
+
+# Loopback hosts are served by an unauthenticated local platform; attaching
+# (and refreshing) OAuth tokens there is both unnecessary and a failure mode
+# when the cached token is stale and OIDC discovery against localhost fails.
+LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", "0.0.0.0"})
+
+
+def make_client(base_url: str | None) -> AsyncNeMoPlatform:
+    """Construct an :class:`AsyncNeMoPlatform` honoring an optional ``base_url``.
+
+    - No ``base_url``: use the active nmp context for both URL and auth.
+    - Loopback ``base_url``: direct mode (local platform is unauthenticated).
+    - Remote ``base_url`` with an nmp config present: combine the URL with the
+      context's auth so the SDK injects and refreshes a Bearer token.
+    - Remote ``base_url`` without an nmp config: direct mode (no credentials to
+      use; the request will surface a clear auth error).
+    """
+    if not base_url:
+        return AsyncNeMoPlatform()
+
+    host = (urlparse(base_url).hostname or "").lower()
+    config_path = Config.get_default_config_path()
+    if host in LOOPBACK_HOSTS or not config_path.exists():
+        return AsyncNeMoPlatform(base_url=base_url)
+
+    return AsyncNeMoPlatform(base_url=base_url, config_path=config_path)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/entities.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/entities.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimentalist plugin entity definitions — stored in the NeMo Platform entity store."""
+
+from typing import Any, Literal, Sequence
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import TrialResult
+from nemo_platform_plugin.entity import NemoEntity
+from pydantic import ConfigDict, Field, model_validator
+
+
+class ExperimentRun(NemoEntity, entity_type="experiment_run"):
+    """Tracks a single Experimentalist optimization run end-to-end.
+
+    Enables resumability and listing all runs for an insight. Created when a
+    run starts, updated on each round, and finalized (with summary and
+    winner) when the run completes or fails.
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    # --- immutable: set at creation, never updated ---
+    agent: str = Field(frozen=True, description="Name or path of the agent under test.")
+    insight: str | None = Field(
+        frozen=True,
+        default=None,
+        description=(
+            "Id of the Insight this run is optimizing against, or a local "
+            "filesystem path to the insight fixture when running offline. "
+            "None for Mode 2 (dataset-driven) runs."
+        ),
+    )
+    config_snapshot: dict[str, Any] = Field(
+        frozen=True,
+        default_factory=dict,
+        description="EvolutionaryOptimizerConfig fields at run creation time.",
+    )
+    # --- mutable: updated throughout the run lifecycle ---
+    status: Literal["running", "completed", "failed"] = Field(
+        default="running",
+        description="Lifecycle status of this optimization run.",
+    )
+    rounds_completed: int = Field(
+        default=0,
+        description="Number of full optimization rounds completed so far.",
+    )
+    winner_agent: str | None = Field(
+        default=None,
+        description=(
+            "Entity id of the winning Candidate, or a local filesystem path "
+            "to the agent directory when running offline; set on completion."
+        ),
+    )
+    summary: str | None = Field(
+        default=None,
+        description="Human-readable summary of the run; filled by persist_result.",
+    )
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _restore_id_from_json(cls, data: Any, handler: Any) -> "ExperimentRun":
+        """Restore computed field ``id`` when deserializing from JSON.
+
+        The ``id`` property is a computed field backed by private ``_id``. It serializes
+        to JSON but ``model_validate`` ignores computed fields during deserialization,
+        so the private ``_id`` must be restored from the serialized ``"id"`` key.
+        Without this, resumed runs lose their identity and projection names collapse.
+        """
+        if isinstance(data, dict) and "id" in data:
+            # Pydantic wraps the dict during validation, extract the raw data
+            instance = handler(data)
+            instance._id = data["id"]  # type: ignore[attr-defined]
+            return instance
+        return handler(data)
+
+
+class Candidate(NemoEntity, entity_type="candidate"):
+    """A candidate agent version produced during an Experimentalist run.
+
+    Lives in the entity store so candidates are queryable, resumable, and
+    survive the local working directory being deleted.  ``run_id`` groups all
+    candidates for a single ExperimentRun.
+
+    Like every entity in this plugin, a Candidate's durable identity is its
+    store-assigned ``id`` (``name`` is left for the store to auto-slug).
+    ``label`` is the run-scoped handle ("agent-0", "agent-1", ...) used for the
+    working directory, evolution-tree key, and ``ancestor`` references; it is
+    unique within a run, not globally.
+
+    ``artifacts`` is a runtime-only dict (excluded from serialization) that
+    the loop uses to attach transient objects (e.g. agent directory paths)
+    without polluting the persisted record.
+    """
+
+    workspace: str = Field(
+        default="default",
+        description="NeMo Platform workspace this candidate belongs to.",
+    )
+    run_id: str = Field(
+        ...,
+        description="ExperimentRun entity id that this candidate belongs to.",
+    )
+    label: str = Field(
+        ...,
+        description=(
+            "Run-scoped handle for this candidate (e.g. 'agent-0'): the working "
+            "directory name, evolution-tree key, and target of ``ancestor`` "
+            "references. Unique within a run, not globally — the store-assigned "
+            "``id`` is the durable identity."
+        ),
+    )
+    ancestor: str | None = Field(
+        default=None,
+        description="Parent Candidate ``label``. None means this is the baseline (round 0).",
+    )
+    round: int = Field(description="Optimization round that produced this candidate. 0 = baseline.")
+    optimization: str = Field(
+        description=(
+            "Graph-level description of the architecture change that produced this candidate "
+            "(nodes added/removed/modified, edges changed, prompts rewritten). "
+            "No source file paths or line numbers."
+        ),
+    )
+    optimization_type: str | None = Field(
+        default=None,
+        description="OptimizationType literal that categorizes the change.",
+    )
+    task_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Task ids the Proposer flagged as most exercising this candidate's root "
+            "cause; the coder uses them to validate the fix during subproblem refinement."
+        ),
+    )
+    train_reward: dict[str, float] | None = Field(
+        default=None,
+        description="Multi-dimensional reward on the training split.",
+    )
+    train_reward_details: Sequence[TrialResult] | None = Field(
+        default=None,
+        description="Train split trial results from the last evaluation run.",
+    )
+    validation_reward: dict[str, float] | None = Field(
+        default=None,
+        description="Multi-dimensional reward on the validation split.",
+    )
+    validation_reward_details: Sequence[TrialResult] | None = Field(
+        default=None,
+        description="Validation split trial results from the last evaluation run.",
+    )
+    validation_trajectory_reward: dict[str, float] | None = Field(
+        default=None,
+        description="Validation trajectory reward: aggregate + per-node scores.",
+    )
+    validation_trajectory_reward_details: dict[str, Any] | None = Field(
+        default=None,
+        description="Validation trajectory reward details: node_id → task_id → {reward, explanation}.",
+    )
+    killed_round: int | None = Field(
+        default=None,
+        description="Round in which this candidate was eliminated. None means still alive.",
+    )
+    artifacts: dict[str, Any] = Field(
+        default_factory=dict,
+        exclude=True,
+        description="Runtime-only artifacts (not persisted to the entity store).",
+    )
+
+    def __repr__(self) -> str:
+        parts = [f"Candidate(label={self.label!r}, round={self.round}"]
+        if self.ancestor is not None:
+            parts.append(f", ancestor={self.ancestor!r}")
+        parts.append(f", optimization={self.optimization!r}")
+        if self.optimization_type is not None:
+            parts.append(f", optimization_type={self.optimization_type!r}")
+        if self.train_reward:
+            scores = ", ".join(f"{k}={v:.3f}" for k, v in self.train_reward.items())
+            parts.append(f", train_reward={{{scores}}}")
+        if self.validation_reward:
+            scores = ", ".join(f"{k}={v:.3f}" for k, v in self.validation_reward.items())
+            parts.append(f", validation_reward={{{scores}}}")
+        if self.killed_round is not None:
+            parts.append(f", killed_round={self.killed_round}")
+        parts.append(")")
+        return "".join(parts)
+
+    def slim(self) -> "Candidate":
+        """Return a copy without per-trial detail fields (safe to pass to LLM methods)."""
+        return self.model_copy(
+            update={
+                "train_reward_details": None,
+                "validation_reward_details": None,
+                "validation_trajectory_reward_details": None,
+            }
+        )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/README.md
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/README.md
@@ -1,0 +1,101 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Eval Author
+
+The top-level `nemo_experimentalist_plugin.eval_author` package is the canonical Eval Author
+implementation. It turns an Experimentalist Insight and its production trace refs into
+evaluator dataset changes, creating or augmenting regression signals that
+capture the failure mode before optimization begins.
+
+Experimentalist is a consumer of this package: its insight mode imports and
+runs the top-level Eval Author before beginning optimization.
+
+## Current Files
+
+- `agent.py` defines the canonical `EvalAuthor` agent.
+- `materialization.py` stages, validates, and publishes Insight suites.
+- `models.py` defines the lightweight `EvalAuthorConfig` and `EvalAuthorResult` models.
+- `run.py` defines `run_eval_author(...)`, a reusable orchestration function for
+  Python callers.
+- `config.yaml` is a default run preset for future CLI or job wiring.
+
+## Configuration
+
+`config.yaml` is not loaded automatically yet. A future entrypoint should read
+the file, overlay caller-provided values, and validate the nested `eval_author`
+block with `EvalAuthorConfig`.
+
+The preset includes the run inputs needed by `run_eval_author(...)`:
+
+- `insight`: local Insight file path or platform Insight id.
+- `agent`: optional agent source override. If omitted, the Insight's agent is used.
+- `train_dataset`: evaluator training dataset URI.
+- `validation_dataset`: evaluator validation dataset URI.
+- `task_template`: local or `fileset://` evaluator task template URI for production traces.
+- `experiment_dir`: local Eval Author working directory.
+- `workspace`, `base_url`, `mode`, and `evaluator_type`: platform and evaluator routing.
+- `eval_author.max_summary_tokens` and `eval_author.max_traces`: agent tuning parameters.
+
+## Materialized Insight Suite
+
+For an Insight with trace references, Eval Author copies and fills one local Harbor
+task template per trace beneath its experiment working directory:
+
+```text
+eval-and-optimize/eval_author/<insight-slug>/insight-suite/
+```
+
+Each Eval Author invocation fills a fresh candidate suite from the current template
+and traces. The complete suite is Harbor-validated locally, promoted to the
+experiment-local working copy with backup-and-restore failure handling, and
+uploaded to a newly created NeMo Platform Fileset. Eval Author verifies the remote
+file inventory before returning.
+An incomplete Fileset is deleted if upload or verification fails; Filesets from
+earlier successful invocations are never modified or reused.
+
+Task-template inputs may be local paths, `file://` URIs, or NeMo Platform
+`fileset://<workspace>/<fileset>` references. Fileset-backed templates are
+downloaded into the experiment-local staging directory before Harbor parses
+them. The staged template is refreshed on every invocation rather than reused.
+
+`EvalAuthorResult.insight_suite` contains a durable `DatasetRef` whose URI uses the
+`fileset://<workspace>/<fileset>` form. Downstream agents may store and pass that
+reference without understanding its storage. A component that needs Harbor's
+local filesystem layout must hydrate the Fileset into its own working directory
+before calling `HarborDataset.from_path`.
+
+## Intended Invocation
+
+Until a CLI or platform job is wired, Python callers can invoke the runner
+directly:
+
+```python
+import asyncio
+from pathlib import Path
+
+from nemo_experimentalist_plugin.eval_author.models import EvalAuthorConfig
+from nemo_experimentalist_plugin.eval_author.run import run_eval_author
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+
+
+async def main() -> None:
+    result = await run_eval_author(
+        insight="insight-id",
+        train_dataset=DatasetRef(uri="path/to/train"),
+        validation_dataset=DatasetRef(uri="path/to/validation"),
+        task_template=DatasetRef(uri="path/to/template"),
+        experiment_dir=Path("tmp/eval_author"),
+        workspace="default",
+        base_url="http://localhost:8080",
+        config=EvalAuthorConfig(),
+    )
+    print(result.summary)
+
+
+asyncio.run(main())
+```
+
+No standalone Eval Author CLI is implemented yet.

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/agent.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/agent.py
@@ -1,0 +1,403 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical first-level Eval Author agent.
+
+Experimentalist consumes this implementation to curate evaluator datasets
+before beginning insight-driven optimization.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from nemo_experimentalist_plugin.eval_author.materialization import InsightSuite
+from nemo_experimentalist_plugin.eval_author.models import EvalAuthorConfig, EvalAuthorResult
+from nemo_experimentalist_plugin.experimentalist.components import cache
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import (
+    Dataset,
+    DatasetValidationError,
+    Task,
+    TrialResult,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import ResourceRef
+from nemo_experimentalist_plugin.experimentalist.components.model_config import get_fast_model, get_smart_model
+from nemo_experimentalist_plugin.experimentalist.components.tools import GuardedShellTools
+from nemo_experimentalist_plugin.experimentalist.components.trace_analyzer import (
+    Diagnostic,
+    TraceAnalyzer,
+    TraceAnalyzerConfig,
+)
+from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import (
+    SearchResult,
+    SessionData,
+    SessionSummary,
+    TraceExplorer,
+    TurnInfo,
+)
+from nemo_insights_plugin.entities import Insight
+from nemo_platform import AsyncNeMoPlatform
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc
+from nooa.agents import TokenBudgetSummarizer
+from nooa.config import CodeActConfig
+from nooa.config.summarizer_config import TokenBudgetConfig
+from nooa.tools import TodoManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EvalAuthorDatasetValidationFailure:
+    """Validation failure for one Eval Author dataset split."""
+
+    split: str
+    error: DatasetValidationError
+
+
+class EvalAuthorDatasetValidationError(DatasetValidationError):
+    """Validation failures from datasets returned by the Eval Author."""
+
+    def __init__(self, failures: list[EvalAuthorDatasetValidationFailure]) -> None:
+        self.failures = tuple(failures)
+        details = "\n".join(f"{failure.split} dataset:\n{failure.error}" for failure in failures)
+        super().__init__(f"Eval Author dataset validation failed:\n{details}")
+
+
+async def _validate_eval_author_result(result: EvalAuthorResult) -> None:
+    """Validate both Eval Author output splits and aggregate authoring failures."""
+    failures: list[EvalAuthorDatasetValidationFailure] = []
+    for split, dataset in (("train", result.train_dataset), ("validation", result.validation_dataset)):
+        try:
+            await dataset.validate()
+        except DatasetValidationError as exc:
+            failures.append(EvalAuthorDatasetValidationFailure(split=split, error=exc))
+
+    if failures:
+        first_failure = failures[0]
+        raise EvalAuthorDatasetValidationError(failures) from first_failure.error
+
+
+class EvalAuthor(Agent, llm=get_smart_model()):
+    """Insights are failure modes of an agent in production.
+
+    The role of the Eval Author is to create or augment the evaluation suite in such a way that it can be used to detect the failure mode.
+    This suite will be used for optimization and regression testing.
+    """
+
+    def __init__(self, experiment_dir: Path, config: EvalAuthorConfig | None = None, **kwargs: Any) -> None:
+        """Initialize the Eval Author for the given experiment directory.
+
+        Args:
+            experiment_dir: Absolute path to the experiment root.
+            config: Tuning parameters; defaults to ``EvalAuthorConfig()``.
+            **kwargs: Forwarded to ``Agent.__init__``.
+        """
+        super().__init__(**kwargs)
+        self._config = config or EvalAuthorConfig()
+        self.experiment_dir = experiment_dir
+        self.shell = GuardedShellTools(cwd=experiment_dir)
+        self.todos = TodoManager()
+        self.context["trace_documentation"] = doc(
+            TraceExplorer,
+            SessionSummary,
+            TurnInfo,
+            SessionData,
+            SearchResult,
+            inline_depth=2,
+        )
+        TokenBudgetSummarizer.install(
+            self,
+            llm=get_fast_model(),
+            config=TokenBudgetConfig(max_tokens=self._config.max_summary_tokens),
+        )
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=15, cell_timeout=60.0)))
+    async def discover_runner(self, dataset: Dataset) -> str:
+        """Discover how this dataset's evaluation runner works.
+
+        ``self.context["dataset_documentation"]`` contains the full API reference
+        for this dataset type — read it first.
+
+        Then read a few task directories from the dataset (resolve ``task.uri``
+        from ``dataset.list_tasks()`` to get the on-disk path) and inspect
+        the actual files.
+
+        Return a concise summary of the conventions observed (file layout,
+        how to write add metrics).
+        """  # noqa: D413
+        ...
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=60, cell_timeout=3600.0)))
+    async def augment_dataset(
+        self,
+        insight: Insight,
+        diagnostics: list[tuple[str, Diagnostic]],
+        train_dataset: Dataset,
+        validation_dataset: Dataset,
+        runner_conventions: str,
+        validation_feedback: str | None = None,
+    ) -> EvalAuthorResult:
+        """Augment existing dataset tasks with evaluation metrics that capture the insight.
+
+        Args:
+            insight: The insight whose failure mode the tasks should detect.
+            diagnostics: Per-trace ``(trace_ref, Diagnostic)`` pairs for concrete evidence.
+            train_dataset: The train dataset to augment for optimization feedback.
+            validation_dataset: The validation dataset to augment for scoring.
+            runner_conventions: Summary of how this dataset's runner works (from ``discover_runner``).
+                Use this as the authoritative reference for what artifacts exist at
+                evaluation runtime, how tasks are structured, and how to add metrics.
+            validation_feedback: Actionable failures from mandatory validation of
+                the previous augmentation attempt. If provided, repair every reported
+                file before returning.
+
+        Refer to ``self.context["dataset_documentation"]`` for the dataset-specific API
+        and metric authoring conventions (file layout, how to add/remove/modify a metric).
+
+        **Scope: every task in both datasets**
+
+        Add the metric to every task in ``train_dataset`` and ``validation_dataset``.
+        A metric is only useful as a suite-wide signal, not a per-sample patch.
+
+        **Validate while authoring**
+
+        After every verifier edit, call ``await train_dataset.validate()`` and
+        ``await validation_dataset.validate()``. These validation tools perform
+        evaluator-specific static checks without launching trials or executing verifier
+        code. If either raises ``DatasetValidationError``, use its task, path, and source
+        location diagnostics to repair the files, then call the tools again. Do not return
+        until both datasets pass validation. If ``validation_feedback`` is provided, it
+        means the previous result failed the mandatory validation performed by the caller;
+        fix all reported failures and revalidate both datasets.
+
+        **Metric quality**
+
+        Focus the metric on the root cause, not the surface symptom.  Prefer graded
+        partial scores over binary 0/1 whenever the evidence supports measuring severity,
+        frequency, or progress toward the desired behavior.  Use binary scores only when
+        the behavior is genuinely all-or-nothing.  For LLM judges: instruct the judge to
+        return calibrated partial-credit floats with a short rationale, not pass/fail.
+
+        **Metric scale — higher is always better, never use raw counts**
+
+        Every metric value must be a float in ``[0.0, 1.0]`` where ``1.0`` means perfect
+        and ``0.0`` means complete failure.  Raw counts (error_count, call_count, …) are
+        forbidden as metric values — they have no upper bound and make optimization
+        direction ambiguous.  Convert counts to rates or invert them:
+
+        - Error rate → ``max(0.0, 1.0 - errors / total_calls)``
+        - Presence of a behavior → ``1.0`` if present, ``0.0`` if absent
+        - Partial credit → fraction of required steps completed correctly
+
+        Example: the symptom is that the agent fails to return X when a customer asks for Y.
+        The root cause is that the agent does not retrieve the full set of relevant database
+        objects for Y, so X is missing from its context.  Measure whether the agent retrieves
+        all required objects, not merely whether X appears in the final answer.
+
+        Return an ``EvalAuthorResult(train_dataset=..., validation_dataset=..., summary=...)``
+        with the same dataset objects and a summary of what was added.
+        """  # noqa: D413
+        ...
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=20, cell_timeout=60.0)))
+    async def fill_task_template(
+        self,
+        trace_ref: str,
+        task_template: Task,
+        client: AsyncNeMoPlatform,
+        workspace: str,
+    ) -> Task:
+        """Fill a pre-staged task template with values from a production trace.
+
+        Steps:
+        1. Read the staged task directory at ``task_template.uri`` (file:// URI).
+           The caller has already copied the template to its durable candidate path;
+           edit this directory in place and do not copy or rename it.
+        2. Fetch the trace via ``client`` and populate the template's placeholders
+           with values from the trace (instruction, environment config, etc.).
+           Leave unfillable placeholders as-is.
+        3. Keep ``task.toml`` parseable and keep ``[task] name`` in ``org/name``
+           format. The caller will deterministically finalize the name and provenance.
+        4. Return a Task whose ``uri`` still points at the staged directory.
+
+        Args:
+            trace_ref: Production trace identifier.
+            task_template: Pre-staged task copy; resolve its directory from ``task_template.uri``.
+            client: NeMo Platform client for fetching the trace.
+            workspace: Workspace the trace belongs to.
+        """
+        ...
+
+    def _trace_trial(
+        self,
+        insight: Insight,
+        task: Task,
+        trace_ref: str,
+        index: int,
+        insight_id: str,
+    ) -> TrialResult:
+        """Return TrialResult wrapper for an insight production trace."""
+        return TrialResult(
+            id=f"insight-trace-{index}",
+            task_id=task.id,
+            status="completed",
+            trace=ResourceRef(uri=f"intake://{trace_ref}", description="Production trace attached to the insight."),
+            metadata={
+                "source": "insight",
+                "trace_ref": trace_ref,
+                "insight_id": insight_id,
+            },
+        )
+
+    async def run(
+        self,
+        insight: Insight,
+        agent_path: Path,
+        task_template: Task,
+        train_dataset: Dataset,
+        validation_dataset: Dataset,
+        *,
+        client: AsyncNeMoPlatform,
+    ) -> EvalAuthorResult:
+        """Curate an evaluation suite and always close the owned shell session."""
+        try:
+            return await self._run(
+                insight=insight,
+                agent_path=agent_path,
+                task_template=task_template,
+                train_dataset=train_dataset,
+                validation_dataset=validation_dataset,
+                client=client,
+            )
+        finally:
+            await self.shell.close()
+
+    async def _run(
+        self,
+        insight: Insight,
+        agent_path: Path,
+        task_template: Task,
+        train_dataset: Dataset,
+        validation_dataset: Dataset,
+        *,
+        client: AsyncNeMoPlatform,
+    ) -> EvalAuthorResult:
+        """Curate an evaluation suite from an Insight and its production traces.
+
+        Args:
+            insight: The Insight to investigate with relevant traces.
+            agent_path: Agent root, relative to ``experiment_dir`` or absolute.
+            task_template: Parsed evaluator task containing explicit placeholders.
+            train_dataset: The train dataset to augment.
+            validation_dataset: The validation dataset to augment.
+            client: Existing NeMo Platform client used for Intake requests.
+        """
+        resolved_agent = self.experiment_dir / agent_path
+        insight_id = insight.id
+        if not insight_id:
+            raise ValueError("Eval Author requires a persisted Insight with a durable id")
+        refs = insight.trace_refs[: self._config.max_traces]
+
+        if not refs:
+            return EvalAuthorResult(
+                train_dataset=train_dataset,
+                validation_dataset=validation_dataset,
+                summary="No trace refs on insight — nothing to analyze.",
+            )
+
+        insight_suite = InsightSuite(
+            experiment_dir=self.experiment_dir,
+            insight_id=insight_id,
+            task_template=task_template,
+        )
+        try:
+            staged_tasks = insight_suite.stage(refs)
+            for staged in staged_tasks:
+                await self.fill_task_template(staged.trace_ref, staged.task, client, insight.workspace)
+                insight_suite.validate(staged)
+            materialized_dataset = insight_suite.promote_local(refs, staged_tasks)
+        except BaseException:
+            insight_suite.discard()
+            raise
+        tasks = list(materialized_dataset.list_tasks())
+        trials = [
+            self._trace_trial(insight, task, ref, index, insight_id)
+            for index, (task, ref) in enumerate(zip(tasks, refs, strict=True), start=1)
+        ]
+        diagnostics: list[tuple[str, Diagnostic]] = []
+        analyzer_config = TraceAnalyzerConfig(max_summary_tokens=self._config.max_summary_tokens)
+        analyzers = [TraceAnalyzer(experiment_dir=self.experiment_dir, config=analyzer_config) for _ in trials]
+        raw_diagnostics: list[Diagnostic | BaseException] = list(
+            await asyncio.gather(
+                *[
+                    analyzer.run(
+                        trial=trial,
+                        task=task,
+                        agent_path=resolved_agent,
+                        insight=insight,
+                        client=client,
+                        workspace=insight.workspace,
+                    )
+                    for analyzer, trial, task in zip(analyzers, trials, tasks, strict=True)
+                ],
+                return_exceptions=True,
+            )
+        )
+        analysis_statuses: dict[str, tuple[str, str | None]] = {}
+        for task, ref, result in zip(tasks, refs, raw_diagnostics, strict=True):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, BaseException):
+                logger.warning("Trace analysis failed for %s: %s", ref, result)
+                analysis_statuses[task.id] = ("failed", str(result))
+                continue
+            cache.store(self.experiment_dir, cache.task_hash(f"eval_author:{ref}"), result)
+            diagnostics.append((ref, result))
+            analysis_statuses[task.id] = ("completed", None)
+        insight_suite.record_analysis(analysis_statuses)
+        insight_suite_ref = await insight_suite.publish_fileset(client, insight.workspace)
+
+        self.context["dataset_documentation"] = doc(type(train_dataset), inline_depth=1)
+        runner_conventions = await self.discover_runner(train_dataset)
+        result = await self.augment_dataset(
+            insight,
+            diagnostics,
+            train_dataset,
+            validation_dataset,
+            runner_conventions,
+        )
+        for repair_attempt in range(self._config.max_validation_repair_attempts + 1):
+            try:
+                await _validate_eval_author_result(result)
+            except DatasetValidationError as exc:
+                if repair_attempt >= self._config.max_validation_repair_attempts:
+                    raise
+                logger.warning(
+                    "Eval Author dataset validation failed; requesting repair attempt %d/%d: %s",
+                    repair_attempt + 1,
+                    self._config.max_validation_repair_attempts,
+                    exc,
+                )
+                result = await self.augment_dataset(
+                    insight,
+                    diagnostics,
+                    result.train_dataset,
+                    result.validation_dataset,
+                    runner_conventions,
+                    validation_feedback=str(exc),
+                )
+            else:
+                return result.model_copy(update={"insight_suite": insight_suite_ref})
+
+        raise AssertionError("unreachable")
+
+
+def build_eval_author_agent(
+    experiment_dir: Path,
+    config: EvalAuthorConfig | None = None,
+) -> EvalAuthor:
+    """Build and return a configured top-level Eval Author agent."""
+    return EvalAuthor(experiment_dir=experiment_dir, config=config)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/config.yaml
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/config.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Default top-level Eval Author run preset.
+#
+# This file is intentionally not loaded automatically yet. Future CLI or job
+# entrypoints can read it, overlay user-provided values, and validate the
+# "eval_author" block with EvalAuthorConfig.
+
+workspace: default
+base_url: http://localhost:8080
+mode: local
+evaluator_type: harbor
+
+# Required per run.
+insight: ""
+agent: null
+train_dataset: ""
+validation_dataset: ""
+task_template: ""
+experiment_dir: tmp/eval_author
+
+eval_author:
+  max_summary_tokens: 80000
+  max_traces: 10

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/materialization.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/materialization.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic persistence for Eval Author-built Harbor insight suites."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from uuid import uuid4
+
+import tomlkit
+from harbor.models.task.task import Task as HarborTask
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import HarborDataset
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import (
+    DatasetRef,
+    Task,
+    local_path_from_uri,
+)
+from nemo_platform import AsyncNeMoPlatform
+
+_MANIFEST_SCHEMA_VERSION = 1
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(value: str, *, fallback: str, max_length: int = 48) -> str:
+    slug = _SLUG_RE.sub("-", value.lower()).strip("-")[:max_length].rstrip("-")
+    return slug or fallback
+
+
+def _digest(value: str, length: int = 10) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:length]
+
+
+@dataclass(frozen=True, slots=True)
+class StagedInsightTask:
+    """One copied task template waiting to be filled and validated."""
+
+    index: int
+    trace_ref: str
+    slug: str
+    path: Path
+    task: Task
+
+
+class InsightSuite:
+    """Build and publish one persisted Harbor dataset for an Insight."""
+
+    def __init__(self, *, experiment_dir: Path, insight_id: str, task_template: Task) -> None:
+        """Initialize deterministic paths and template provenance for a suite."""
+        if not insight_id:
+            raise ValueError("Insight id is required to materialize an insight suite")
+        if not task_template.uri:
+            raise ValueError("Task template URI is required to materialize an insight suite")
+
+        self.insight_id = insight_id
+        self.template_dir = local_path_from_uri(
+            task_template.uri,
+            context="Eval Author task template",
+        ).resolve()
+        if not self.template_dir.is_dir():
+            raise ValueError(f"Eval Author task template is not a directory: {self.template_dir}")
+        self.template_uri = self.template_dir.as_uri()
+        insight_slug = f"{_slug(insight_id, fallback='insight')}-{_digest(insight_id)}"
+        self.root = experiment_dir.resolve() / "eval-and-optimize" / "eval_author" / insight_slug
+        self.suite_dir = self.root / "insight-suite"
+        self._candidate_root: Path | None = None
+        self._candidate_suite: Path | None = None
+
+    @staticmethod
+    def task_slug(index: int, trace_ref: str) -> str:
+        """Return a stable, collision-resistant directory name for one trace occurrence."""
+        return f"{index:03d}-{_slug(trace_ref, fallback='trace')}-{_digest(trace_ref)}"
+
+    def stage(self, trace_refs: list[str]) -> list[StagedInsightTask]:
+        """Copy one template per trace into an isolated candidate suite."""
+        if self._candidate_root is not None:
+            raise RuntimeError("Insight suite staging has already started")
+        self._candidate_root = self.root / "work" / f"candidate-{uuid4().hex}"
+        self._candidate_suite = self._candidate_root / "insight-suite"
+        self._candidate_suite.mkdir(parents=True)
+
+        staged: list[StagedInsightTask] = []
+        for index, trace_ref in enumerate(trace_refs, start=1):
+            slug = self.task_slug(index, trace_ref)
+            task_dir = self._candidate_suite / slug
+            shutil.copytree(self.template_dir, task_dir)
+            task = list(HarborDataset.from_path(task_dir).list_tasks())[0]
+            staged.append(StagedInsightTask(index=index, trace_ref=trace_ref, slug=slug, path=task_dir, task=task))
+        return staged
+
+    def discard(self) -> None:
+        """Remove an unpublished candidate suite and reset its staging state."""
+        if self._candidate_root is not None and self._candidate_root.exists():
+            shutil.rmtree(self._candidate_root)
+        self._candidate_root = None
+        self._candidate_suite = None
+
+    def validate(self, staged: StagedInsightTask) -> None:
+        """Stamp deterministic identity and provenance, then validate with Harbor."""
+        toml_path = staged.path / "task.toml"
+        document = tomlkit.parse(toml_path.read_text(encoding="utf-8"))
+        task_table = document.get("task")
+        if task_table is None:
+            raise ValueError(f"Materialized task has no [task] table: {toml_path}")
+        raw_name = task_table.get("name")
+        if not isinstance(raw_name, str) or "/" not in raw_name:
+            raise ValueError(f"Materialized task [task].name must use org/name format: {raw_name!r}")
+        organization, short_name = raw_name.rsplit("/", 1)
+        base_name = short_name.split("__", 1)[0]
+        task_table["name"] = f"{organization}/{base_name}__{staged.slug}"
+
+        metadata = document.get("metadata")
+        if metadata is None:
+            metadata = tomlkit.table()
+            document["metadata"] = metadata
+        provenance = metadata.get("nemo_experimentalist")
+        if provenance is None:
+            provenance = tomlkit.table()
+            metadata["nemo_experimentalist"] = provenance
+        provenance["source_trace_ref"] = staged.trace_ref
+        provenance["insight_id"] = self.insight_id
+        toml_path.write_text(tomlkit.dumps(document), encoding="utf-8")
+
+        instruction_path = staged.path / "instruction.md"
+        if not instruction_path.is_file() or not instruction_path.read_text(encoding="utf-8").strip():
+            raise ValueError(f"Materialized task instruction is missing or empty: {instruction_path}")
+        for directory_name in ("environment", "tests"):
+            directory = staged.path / directory_name
+            if not directory.is_dir():
+                raise ValueError(f"Materialized task is missing required {directory_name}/ directory: {directory}")
+        HarborTask(staged.path)
+
+    def promote_local(self, trace_refs: list[str], staged_tasks: list[StagedInsightTask]) -> HarborDataset:
+        """Promote the validated candidate to the experiment-local working copy."""
+        if self._candidate_root is None or self._candidate_suite is None:
+            raise RuntimeError("Insight suite has not been staged")
+
+        manifest = {
+            "schema_version": _MANIFEST_SCHEMA_VERSION,
+            "insight_id": self.insight_id,
+            "trace_refs": trace_refs,
+            "task_template": {"uri": self.template_uri},
+            "tasks": [
+                {
+                    "index": task.index,
+                    "path": task.slug,
+                    "source_trace_ref": task.trace_ref,
+                    "analysis": {"status": "pending"},
+                }
+                for task in staged_tasks
+            ],
+        }
+        (self._candidate_suite / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+        self.root.mkdir(parents=True, exist_ok=True)
+        backup = self.root / f".insight-suite-backup-{uuid4().hex}"
+        had_existing = self.suite_dir.exists()
+        if had_existing:
+            os.replace(self.suite_dir, backup)
+        try:
+            os.replace(self._candidate_suite, self.suite_dir)
+            dataset = HarborDataset.from_path(
+                self.suite_dir,
+                dataset_id=f"insight-{_digest(self.insight_id, 12)}",
+            )
+            for task in dataset.list_tasks():
+                HarborTask(local_path_from_uri(task.uri, context="Materialized Harbor task"))
+        except BaseException as exc:
+            try:
+                if had_existing and backup.exists():
+                    if self.suite_dir.exists():
+                        shutil.rmtree(self.suite_dir)
+                    os.replace(backup, self.suite_dir)
+                elif self.suite_dir.exists():
+                    shutil.rmtree(self.suite_dir)
+                self.discard()
+            except BaseException as rollback_exc:
+                rollback_exc.add_note(f"Local Insight suite promotion also failed before rollback: {exc!r}")
+                raise rollback_exc from exc
+            raise
+
+        if backup.exists():
+            shutil.rmtree(backup)
+        self.discard()
+        return dataset
+
+    def record_analysis(self, statuses: dict[str, tuple[str, str | None]]) -> None:
+        """Persist per-task analysis outcomes without changing suite membership."""
+        manifest_path = self.suite_dir / "manifest.json"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        for task in manifest["tasks"]:
+            status, error = statuses.get(task["path"], ("pending", None))
+            task["analysis"] = {"status": status}
+            if error is not None:
+                task["analysis"]["error"] = error
+        pending_path = manifest_path.with_suffix(".json.pending")
+        pending_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        os.replace(pending_path, manifest_path)
+
+    async def publish_fileset(self, client: AsyncNeMoPlatform, workspace: str) -> DatasetRef:
+        """Upload the complete local suite to a fresh NeMo Platform Fileset."""
+        fileset_name = (
+            f"nemo-experimentalist-insight-{_slug(self.insight_id, fallback='insight', max_length=80)}-{uuid4().hex}"
+        )
+        fileset = await client.files.filesets.create(
+            workspace=workspace,
+            name=fileset_name,
+            description="Eval Author-built Harbor tasks materialized from Insight production traces.",
+            purpose="dataset",
+        )
+        try:
+            await client.files.upload(
+                local_path=f"{self.suite_dir}{os.sep}",
+                fileset=fileset.name,
+                workspace=workspace,
+            )
+            local_files = {
+                path.relative_to(self.suite_dir).as_posix(): path.stat().st_size
+                for path in self.suite_dir.rglob("*")
+                if path.is_file()
+            }
+            uploaded = await client.files.list(fileset=fileset.name, workspace=workspace)
+            remote_files = {file.path: file.size for file in uploaded.data}
+            if remote_files != local_files:
+                raise RuntimeError(
+                    f"Uploaded Insight suite Fileset {fileset.name!r} does not match the validated local suite"
+                )
+        except BaseException as exc:
+            try:
+                await client.files.filesets.delete(fileset.name, workspace=workspace)
+            except BaseException as cleanup_exc:
+                cleanup_exc.add_note(f"Fileset publication also failed before cleanup: {exc!r}")
+                raise cleanup_exc from exc
+            raise
+
+        return DatasetRef(
+            uri=f"fileset://{workspace}/{fileset.name}",
+            description="Eval Author-built Harbor tasks materialized from Insight production traces.",
+            metadata={
+                "id": f"insight-{_digest(self.insight_id, 12)}",
+                "insight_id": self.insight_id,
+                "fileset_id": fileset.id,
+                "fileset_name": fileset.name,
+                "workspace": workspace,
+            },
+        )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/models.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/models.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared models for the top-level Eval Author."""
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import Dataset, DatasetRef
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EvalAuthorConfig(BaseModel):
+    """Tuning parameters for the Eval Author agent."""
+
+    max_summary_tokens: int = Field(
+        default=80_000,
+        description="Max tokens the token-budget summarizer may use.",
+    )
+    max_traces: int = Field(
+        default=10,
+        description="Max trace refs from the insight to analyze in depth.",
+    )
+    max_validation_repair_attempts: int = Field(
+        default=5,
+        ge=0,
+        le=10,
+        description="Max Eval Author repair attempts after mandatory dataset validation fails.",
+    )
+
+
+class EvalAuthorResult(BaseModel):
+    """Output of one Eval Author run."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    train_dataset: Dataset
+    validation_dataset: Dataset
+    insight_suite: DatasetRef | None = Field(
+        default=None,
+        description="NeMo Platform Fileset reference to tasks materialized from the Insight's production traces.",
+    )
+    summary: str

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/run.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/eval_author/run.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable optimizer Eval Author run orchestration."""
+
+import importlib
+from pathlib import Path
+from typing import Literal, Protocol, cast
+
+from nemo_experimentalist_plugin.client import make_client
+from nemo_experimentalist_plugin.eval_author.models import EvalAuthorConfig, EvalAuthorResult
+from nemo_experimentalist_plugin.experimentalist.components.dataset_staging import stage_task_template
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import Dataset, Task
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import EvaluatorType
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.factory import DatasetFactory
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import (
+    make_experimentalist_backend,
+)
+from nemo_insights_plugin.entities import Insight
+from nemo_platform import AsyncNeMoPlatform
+
+
+class _LiteLLMModule(Protocol):
+    drop_params: bool
+
+
+class _EvalAuthorAgent(Protocol):
+    async def run(
+        self,
+        insight: Insight,
+        agent_path: Path,
+        task_template: Task,
+        train_dataset: Dataset,
+        validation_dataset: Dataset,
+        *,
+        client: AsyncNeMoPlatform,
+    ) -> EvalAuthorResult: ...
+
+
+async def run_eval_author(
+    *,
+    insight: Path | str,
+    train_dataset: DatasetRef,
+    validation_dataset: DatasetRef,
+    task_template: DatasetRef,
+    experiment_dir: Path,
+    workspace: str,
+    base_url: str | None,
+    config: EvalAuthorConfig,
+    agent: Path | str | None = None,
+    evaluator_type: EvaluatorType = "harbor",
+    mode: Literal["local", "remote"] = "local",
+) -> EvalAuthorResult:
+    """Build and run the Eval Author against an Insight and evaluator datasets.
+
+    Args:
+        insight: Local Insight file path or platform insight id.
+        train_dataset: Evaluator dataset reference for training.
+        validation_dataset: Evaluator dataset reference for validation.
+        task_template: Local or Fileset-backed evaluator task template used for production traces.
+        experiment_dir: Working directory for Eval Author artifacts.
+        workspace: Platform workspace.
+        base_url: Platform base URL. ``None`` uses the active platform context.
+        config: Eval Author tuning parameters.
+        agent: Optional agent source override. When absent, the Insight's agent is used.
+        evaluator_type: Evaluator adapter used to parse datasets and task template.
+        mode: Backend mode. Currently uses the same backend factory as Experimentalist.
+
+    Returns:
+        Typed Eval Author output containing the train dataset, validation dataset, and summary.
+    """
+    _enable_litellm_drop_params()
+
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    experiment_dir = experiment_dir.resolve()
+    insight = insight.resolve() if isinstance(insight, Path) else insight
+
+    client = make_client(base_url)
+    try:
+        backend = make_experimentalist_backend(
+            client=client,
+            experiments_output=str(experiment_dir),
+            mode=mode,
+        )
+        resolved_insight = await backend.get_insight(workspace=workspace, insight_id=str(insight))
+        agent_ref = agent if agent is not None else resolved_insight.agent
+        agent_path = experiment_dir / "eval_author" / "source-agent"
+        await backend.get_agent_code(workspace=workspace, agent=agent_ref, dest=agent_path)
+
+        dataset_factory = DatasetFactory()
+        staged_task_template = await stage_task_template(
+            experiment_dir,
+            task_template,
+            client=client,
+            workspace=workspace,
+        )
+        eval_author = build_eval_author_agent(
+            experiment_dir=experiment_dir,
+            config=config,
+        )
+        return await eval_author.run(
+            insight=resolved_insight,
+            agent_path=agent_path,
+            task_template=dataset_factory.build_task_template(evaluator_type, staged_task_template),
+            train_dataset=dataset_factory.build_dataset(evaluator_type, train_dataset),
+            validation_dataset=dataset_factory.build_dataset(evaluator_type, validation_dataset),
+            client=client,
+        )
+    finally:
+        await client.close()
+
+
+def build_eval_author_agent(*, experiment_dir: Path, config: EvalAuthorConfig) -> _EvalAuthorAgent:
+    """Build the LLM-backed Eval Author agent lazily."""
+    from nemo_experimentalist_plugin.eval_author.agent import build_eval_author_agent as _build_eval_author_agent
+
+    return _build_eval_author_agent(experiment_dir=experiment_dir, config=config)
+
+
+def _enable_litellm_drop_params() -> None:
+    """Let LiteLLM omit unsupported model parameters when it is installed."""
+    try:
+        litellm = cast(_LiteLLMModule, importlib.import_module("litellm"))
+    except ModuleNotFoundError:
+        return
+    litellm.drop_params = True

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/__init__.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/agent.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/agent.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimentalist agent factory."""
+
+from pathlib import Path
+
+from nemo_experimentalist_plugin.experimentalist.components.loop import (
+    EvolutionaryOptimizer,
+    EvolutionaryOptimizerConfig,
+)
+
+
+def build_experimentalist_agent(
+    working_dir: Path,
+    config: EvolutionaryOptimizerConfig | None = None,
+    framework_skills_dirs: list[Path] | None = None,
+) -> EvolutionaryOptimizer:
+    """Build and return a configured :class:`EvolutionaryOptimizer`.
+
+    Args:
+        working_dir: Local temp directory hydrated from the agent's fileset
+            before the run starts. The optimizer reads/writes all intermediate
+            artifacts here.
+        config: Optional optimizer config. When None the optimizer uses its
+            built-in defaults.
+        framework_skills_dirs: Optional list of directories containing framework
+            skills to load into all optimizer agents.
+    """
+    return EvolutionaryOptimizer(
+        working_dir=working_dir, config=config, framework_skills_dirs=framework_skills_dirs or []
+    )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/__init__.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
@@ -1,0 +1,705 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast  # noqa: F401
+import asyncio  # noqa: F401
+import json  # noqa: F401
+import logging
+import os  # noqa: F401
+import re  # noqa: F401
+from collections import Counter, defaultdict  # noqa: F401
+from pathlib import Path
+from typing import Any, Literal, Sequence
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import (
+    Dataset,
+    EvaluationResult,
+    Task,
+    TrialResult,
+)
+from nemo_platform import AsyncNeMoPlatform
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc, spec
+from nooa.agents import TokenBudgetSummarizer
+from nooa.config import CodeActConfig
+from nooa.config.summarizer_config import TokenBudgetConfig
+from nooa.skill_registry import SkillRegistry
+from nooa.tools import Match, TodoManager
+from pydantic import BaseModel, Field
+
+from . import cache
+from .model_config import get_fast_model, get_smart_model
+from .rationalizer import Rationale, Rationalizer, RationalizerConfig  # noqa: F401
+from .tools import GuardedShellTools
+from .trace_analyzer import Diagnostic, TraceAnalyzer, TraceAnalyzerConfig  # noqa: F401
+from .trace_explorer import TraceExplorer  # noqa: F401
+from .util import load_framework_skills
+
+
+class AnalyzerConfig(BaseModel):
+    """Configure tuning parameters for AgentAnalyzer."""
+
+    max_summary_tokens: int = Field(
+        default=80_000,
+        description="Max tokens the token-budget summarizer may use.",
+    )
+    max_trials: int = Field(
+        default=5,
+        description="Max number of failing trials to analyze in depth per agent per round.",
+    )
+    max_divergent_pairs: int = Field(
+        default=3,
+        description="Max peer divergence pairs to narrate in the comparison report.",
+    )
+    rationalizer: RationalizerConfig = Field(
+        default_factory=RationalizerConfig,
+        description="Config forwarded to each Rationalizer instance spawned during analysis.",
+    )
+    trace_analyzer: TraceAnalyzerConfig = Field(
+        default_factory=TraceAnalyzerConfig,
+        description="Config forwarded to each TraceAnalyzer instance spawned during analysis.",
+    )
+
+
+class SystematicFailure(BaseModel):
+    """Represent a failure pattern that recurs across multiple tasks with the same root cause."""
+
+    root_cause: str
+    affected_tasks: list[str]
+    pattern: str
+
+
+class MechanicalError(BaseModel):
+    """Represent an infrastructure or tooling failure not attributable to agent logic."""
+
+    task_id: str
+    issue_type: Literal["environment", "infrastructure", "evaluation", "tool"]
+    description: str
+
+
+class FailureClassification(BaseModel):
+    """Group failures into systematic patterns and one-off mechanical errors."""
+
+    systematic: list[SystematicFailure]
+    mechanical: list[MechanicalError]
+
+    def __repr__(self) -> str:
+        """Return markdown-formatted string representation.
+
+        Returns:
+            str: Markdown representation of failure classification.
+
+        """
+        lines = ["## Failure Classification"]
+        lines.append("\n### Systematic Failures")
+        for f in self.systematic:
+            lines.append(f"- **{f.root_cause}** (tasks: {', '.join(f.affected_tasks)})")
+            lines.append(f"  {f.pattern}")
+        if not self.systematic:
+            lines.append("None identified.")
+        lines.append("\n### Mechanical Errors")
+        for e in self.mechanical:
+            lines.append(f"- [{e.issue_type}] {e.task_id}: {e.description}")
+        if not self.mechanical:
+            lines.append("None identified.")
+        return "\n".join(lines)
+
+
+class DivergentTrial(BaseModel):
+    """Represent a task where one agent outperformed another with divergence analysis."""
+
+    task_id: str
+    winner: str
+    loser: str
+    divergence_point: str
+    winner_insight: str
+    loser_blind_spot: str
+    transferable_lesson: str
+
+    def __repr__(self) -> str:
+        """Return markdown-formatted string representation.
+
+        Returns:
+            str: Markdown representation of divergent trial.
+
+        """
+        return (
+            f"#### {self.task_id} — winner: {self.winner}, loser: {self.loser}\n"
+            f"Divergence: {self.divergence_point}\n"
+            f"Winner insight: {self.winner_insight}\n"
+            f"Loser blind spot: {self.loser_blind_spot}\n"
+            f"Lesson: {self.transferable_lesson}"
+        )
+
+
+class ComplementaryPattern(BaseModel):
+    """Represent a task set where different agents have complementary pass/fail patterns."""
+
+    agents: list[str]
+    description: str
+
+
+class PeerComparison(BaseModel):
+    """Represent comparison results between an agent and its peers, including divergences."""
+
+    divergent_trials: list[DivergentTrial]
+    complementary_patterns: list[ComplementaryPattern]
+
+    def __repr__(self) -> str:
+        """Return markdown-formatted string representation.
+
+        Returns:
+            str: Markdown representation of peer comparison.
+
+        """
+        lines = ["## Peer Comparison"]
+        lines.append("\n### Divergent Trials")
+        for t in self.divergent_trials:
+            lines.append(repr(t))
+        if not self.divergent_trials:
+            lines.append("None found.")
+        lines.append("\n### Complementary Patterns")
+        for p in self.complementary_patterns:
+            lines.append(f"- {', '.join(p.agents)}: {p.description}")
+        if not self.complementary_patterns:
+            lines.append("None identified.")
+        return "\n\n".join(lines)
+
+
+class TrialAnalysis(BaseModel):
+    """Represent a single trial's trace analysis result paired with its metrics."""
+
+    task_id: str
+    trial_id: str
+    metrics: dict[str, float]
+    diagnostic: Diagnostic
+
+    def __repr__(self) -> str:
+        """Return markdown-formatted string representation.
+
+        Returns:
+            str: Markdown representation of trial analysis.
+
+        """
+        metrics = ", ".join(f"{name}: {value:.3f}" for name, value in self.metrics.items()) or "no metrics"
+        lines = [f"### {self.task_id} / {self.trial_id} ({metrics})"]
+        lines.append(f"Outcome: {self.diagnostic.outcome}")
+        lines.append(f"Summary: {self.diagnostic.summary}")
+        if self.diagnostic.failure_point is not None:
+            lines.append(f"Failure point: span {self.diagnostic.failure_point}")
+        lines.append(f"Root cause: {self.diagnostic.root_cause}")
+        return "\n".join(lines)
+
+
+class AgentAnalysis(BaseModel):
+    """Represent full analysis output for one agent: trials, failure classes, and peer comparisons."""
+
+    agent_id: str
+    aggregate_metrics: dict[str, float]
+    trial_analyses: list[TrialAnalysis]
+    failure_classification: FailureClassification
+    peer_comparison: PeerComparison
+
+    def __repr__(self) -> str:
+        """Return markdown-formatted string representation.
+
+        Returns:
+            str: Markdown representation of agent analysis.
+
+        """
+        metrics = ", ".join(f"{name}: {value:.3f}" for name, value in self.aggregate_metrics.items()) or "no metrics"
+        sections = [f"# Agent Analysis: {self.agent_id} ({metrics})"]
+        sections.append("## Per-Trial Traces\n" + "\n\n".join(repr(t) for t in self.trial_analyses))
+        sections.append(repr(self.failure_classification))
+        sections.append(repr(self.peer_comparison))
+        return "\n\n".join(sections)
+
+
+class AgentAnalyzer(Agent, llm=get_smart_model()):
+    """Analyze an agent's trace and failure patterns for a single optimization round."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        config: AnalyzerConfig | None = None,
+        framework_skills_dirs: list[Path] | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize the analyzer for the given workspace.
+
+        Args:
+            workspace: Absolute path to the eval-and-optimize workspace root.
+            config: Tuning parameters; defaults to ``AnalyzerConfig()`` if ``None``.
+            framework_skills_dirs: Optional list of directories containing framework skills to load.
+            **kwargs: Forwarded to ``Agent.__init__``.
+
+        """
+        super().__init__(**kwargs)
+        self._config = config or AnalyzerConfig()
+        self._workspace_path = workspace
+        self._framework_skills_dirs: list[Path] = framework_skills_dirs or []
+        self.shell = GuardedShellTools(cwd=workspace)
+        self.todos = TodoManager()
+        self.context["file_match"] = doc(Match)
+        self.skills: SkillRegistry = SkillRegistry(self)
+        spec(self, "skills", hidden=True)
+        load_framework_skills(self.skills, self._framework_skills_dirs)
+        TokenBudgetSummarizer.install(
+            self,
+            llm=get_fast_model(),
+            config=TokenBudgetConfig(max_tokens=self._config.max_summary_tokens),
+        )
+
+    @strategy(
+        CodeActStrategy(config=CodeActConfig(max_iterations=20, cell_timeout=3600.0)),
+        llm=get_fast_model(),
+    )
+    async def select_trials(
+        self,
+        agent_id: str,
+        dataset: Dataset,
+        evaluation: EvaluationResult,
+    ) -> Sequence[TrialResult]:
+        """Pick which trials to analyze in depth. Return their TrialResult objects.
+
+        Args:
+            agent_id: The agent to analyze.
+            dataset: The dataset to analyze.
+            evaluation: The evaluation result to analyze.
+
+        Returns:
+            Sequence[TrialResult]: The selected trials.
+
+        ## Step 1: Get task and trial objects
+
+        ```python
+        tasks_by_id = {task.id: task for task in dataset.list_tasks()}
+        trials = list(evaluation.trials)
+        ```
+
+        ## Step 2: Inspect metrics, outputs, resources, and errors
+
+        ```python
+        trial_metrics = [trial.metrics for trial in trials]
+        trial_outputs = [trial.outputs for trial in trials]
+        trial_resources = [trial.resources for trial in trials]
+        trial_errors = [trial.error for trial in trials]
+        ```
+
+        ## Step 3: Triage — pick up to {self._config.max_trials} trials
+
+        Prefer trials where:
+        - status/error indicates the evaluator did not complete cleanly
+        - one or more numeric metric values are below the task's expected passing
+          value
+        - the trace reference is missing or unloadable
+        - outputs/resources suggest repeated failures across task ids
+
+        Metric names are evaluator-defined. Do not assume particular metric
+        names, result directories, private checks, or split paths.
+
+        ## Step 4: Return TrialResult objects
+
+        ```python
+        return selected_trials
+        ```
+        """
+        ...
+
+    @strategy(
+        CodeActStrategy(config=CodeActConfig(max_iterations=30, cell_timeout=3600.0)),
+        llm=get_fast_model(),
+    )
+    async def classify_failures(
+        self,
+        agent_id: str,
+        diagnoses: list[Diagnostic],
+        trials: Sequence[TrialResult],
+    ) -> FailureClassification:
+        """Classify diagnoses into systematic vs. one-off and agent vs. mechanical failures.
+
+        **Systematic vs. one-off**: a failure is systematic when ≥2 trials share the same
+        root cause. One-offs are worth noting but should not drive hypotheses. Group the
+        diagnoses by root_cause similarity and label each group accordingly.
+
+        **Agent logic vs. mechanical errors**: some failures are not the agent's fault —
+        infrastructure issues such as missing packages, network errors, evaluator bugs, API
+        rate limits, or ambiguous ground truth. Cross-reference each diagnosis against
+        `trials`: use `status`, `metrics`, `outputs`, `resources`, `error`, and
+        `metadata`. Do not assume result folders, score files, private check
+        outputs, or artifact manifests exist. Decide whether the failure is
+        an agent logic error (optimizable) or a mechanical error (needs an infra
+        fix). Do not penalise the agent for mechanical errors.
+
+        Return a FailureClassification with:
+        - `systematic`: list of SystematicFailure (root_cause, affected_tasks, pattern)
+        - `mechanical`: list of MechanicalError (task_id, issue_type, description)
+
+        """
+        ...
+
+    async def compare_with_peers(
+        self,
+        agent_id: str,
+        evaluation: EvaluationResult,
+        diagnoses: list[Diagnostic],
+        peer_evaluations: dict[str, EvaluationResult] | None = None,
+    ) -> PeerComparison:
+        """Compare this agent to peers and return divergent trials and complementary patterns.
+
+        Args:
+            agent_id: The agent to compare against its peers.
+            evaluation: Evaluation result for the focal agent.
+            diagnoses: Per-trial diagnostics for this agent (used by the narration step).
+            peer_evaluations: Optional peer evaluation results keyed by agent id.
+
+        Returns:
+            PeerComparison: divergent trial narratives and complementary failure patterns.
+
+        """
+        if not peer_evaluations:
+            return PeerComparison(divergent_trials=[], complementary_patterns=[])
+
+        top_divergent = self._select_divergent_pairs(
+            agent_id,
+            evaluation,
+            peer_evaluations,
+            k=self._config.max_divergent_pairs,
+        )
+        complementary_raw = self._find_complementary_failures(agent_id, evaluation, peer_evaluations)
+
+        return await self._narrate_peer_comparison(agent_id, top_divergent, complementary_raw, diagnoses)
+
+    def _select_divergent_pairs(
+        self,
+        agent_id: str,
+        evaluation: EvaluationResult,
+        peer_evaluations: dict[str, EvaluationResult],
+        k: int = 3,
+    ) -> list[dict[str, Any]]:
+        """Pick top-k divergent (peer, task) pairs ordered by absolute score delta.
+
+        Args:
+            agent_id: The focal agent to compare against each peer.
+            evaluation: Evaluation result for the focal agent.
+            peer_evaluations: Peer evaluation results keyed by agent id.
+            k: Maximum number of pairs to return.
+
+        Returns:
+            list[dict[str, Any]]: up to k dicts each with keys ``task_id``,
+            ``winner``, ``loser``, ``winner_metrics``, ``loser_metrics`` (per-metric
+            means), ``delta`` (L1 magnitude of the per-metric difference),
+            ``breakdown_delta`` (per-metric winner minus loser), ``winner_trace_ref``,
+            ``loser_trace_ref`` (``None`` when unavailable).
+
+        """
+        pairs: list[dict[str, Any]] = []
+        focal_means = self._task_metric_means(evaluation)
+        focal_traces = self._task_trace_refs(evaluation)
+        for peer, peer_evaluation in peer_evaluations.items():
+            peer_means = self._task_metric_means(peer_evaluation)
+            peer_traces = self._task_trace_refs(peer_evaluation)
+            for task_id in sorted(set(focal_means) & set(peer_means)):
+                fm = focal_means[task_id]
+                pm = peer_means[task_id]
+                focal_delta = {m: fm.get(m, 0.0) - pm.get(m, 0.0) for m in sorted(set(fm) | set(pm))}
+                magnitude = sum(abs(v) for v in focal_delta.values())
+                if magnitude == 0.0:
+                    continue
+                wins = sum(1 for v in focal_delta.values() if v > 0)
+                losses = sum(1 for v in focal_delta.values() if v < 0)
+                focal_is_winner = wins > losses or (wins == losses and sum(focal_delta.values()) >= 0)
+                winner = agent_id if focal_is_winner else peer
+                loser = peer if focal_is_winner else agent_id
+                sign = 1.0 if focal_is_winner else -1.0
+                pairs.append(
+                    {
+                        "task_id": task_id,
+                        "winner": winner,
+                        "loser": loser,
+                        "winner_metrics": fm if focal_is_winner else pm,
+                        "loser_metrics": pm if focal_is_winner else fm,
+                        "delta": magnitude,
+                        "breakdown_delta": {m: sign * d for m, d in focal_delta.items()},
+                        "winner_trace_ref": (focal_traces if focal_is_winner else peer_traces).get(task_id),
+                        "loser_trace_ref": (peer_traces if focal_is_winner else focal_traces).get(task_id),
+                    }
+                )
+        pairs.sort(key=lambda p: -p["delta"])
+        return pairs[:k]
+
+    def _task_trace_refs(self, evaluation: EvaluationResult) -> dict[str, str]:
+        """Return the first trace URI per task id."""
+        refs: dict[str, str] = {}
+        for trial in evaluation.trials:
+            if trial.trace is not None and trial.task_id not in refs:
+                refs[trial.task_id] = trial.trace.uri
+        return refs
+
+    def _task_metric_means(self, evaluation: EvaluationResult) -> dict[str, dict[str, float]]:
+        """Return average value per metric name, keyed by task id."""
+        per_task: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+        for trial in evaluation.trials:
+            for metric_name, metric in trial.metrics.items():
+                per_task[trial.task_id][metric_name].append(float(metric.value))
+        return {
+            task_id: {name: sum(values) / len(values) for name, values in metrics.items()}
+            for task_id, metrics in per_task.items()
+        }
+
+    def _find_complementary_failures(
+        self,
+        agent_id: str,
+        evaluation: EvaluationResult,
+        peer_evaluations: dict[str, EvaluationResult],
+    ) -> dict[str, dict[str, dict[str, list[str]]]]:
+        """Find tasks where agents split on leaders vs. trailers, per metric.
+
+        Leadership is relative and metric-agnostic: on each metric the agents
+        holding the best mean value are leaders, the rest are trailers. A task
+        is reported only when at least one metric splits the agents.
+        """
+        all_means = {agent_id: self._task_metric_means(evaluation)}
+        all_means.update({peer: self._task_metric_means(pe) for peer, pe in peer_evaluations.items()})
+
+        task_ids: set[str] = set()
+        for means in all_means.values():
+            task_ids.update(means)
+
+        complementary: dict[str, dict[str, dict[str, list[str]]]] = {}
+        for task_id in sorted(task_ids):
+            metric_names: set[str] = set()
+            for means in all_means.values():
+                metric_names.update(means.get(task_id, {}))
+            per_metric: dict[str, dict[str, list[str]]] = {}
+            for metric in sorted(metric_names):
+                values = {
+                    agent: means[task_id][metric]
+                    for agent, means in all_means.items()
+                    if metric in means.get(task_id, {})
+                }
+                if len(values) < 2 or min(values.values()) == max(values.values()):
+                    continue
+                best = max(values.values())
+                per_metric[metric] = {
+                    "leaders": sorted(agent for agent, value in values.items() if value == best),
+                    "trailers": sorted(agent for agent, value in values.items() if value < best),
+                }
+            if per_metric:
+                complementary[task_id] = per_metric
+        return complementary
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=40, cell_timeout=3600.0)))
+    async def _narrate_peer_comparison(
+        self,
+        agent_id: str,
+        top_divergent: list[dict[str, Any]],
+        complementary_raw: dict[str, dict[str, dict[str, list[str]]]],
+        diagnoses: list[Diagnostic],
+    ) -> PeerComparison:
+        """Write the DivergentTrial and ComplementaryPattern narratives from pre-computed data.
+
+        ## Inputs
+
+        `top_divergent` is a list of up to 3 dicts, each with:
+          - `task_id`, `winner`, `loser`
+          - `winner_metrics`, `loser_metrics`: per-metric mean values for each agent
+          - `delta`: L1 magnitude of the per-metric difference (ranking signal)
+          - `breakdown_delta`: per-metric (winner - loser); positive means the
+            winner did better on that dimension
+          - `winner_trace_ref`, `loser_trace_ref`: trace URIs if the evaluator emits
+            traces, otherwise None
+
+        `complementary_raw` is
+        `{task_id: {metric: {"leaders": [agents], "trailers": [agents]}}}`
+        — per-metric splits between the best-scoring agents and the rest.
+
+        ## For each divergent pair
+
+        Produce one DivergentTrial:
+          - `task_id`, `winner`, `loser` come from the input dict
+          - If both `winner_trace_ref` and `loser_trace_ref` are non-None:
+            use TraceExplorer on both to find the earliest turn where reasoning
+            diverged. The `breakdown_delta` tells you which dimensions matter
+            most (e.g., big insight delta → focus on the moment the loser
+            stopped going deeper). Fill in `divergence_point`, `winner_insight`,
+            `loser_blind_spot`, `transferable_lesson` from what you see.
+          - If either trace ref is None: infer divergence from `breakdown_delta`
+            and available metric differences.
+            Note in the narrative that this is breakdown-inferred (no trace
+            comparison was possible).
+
+        Always emit a DivergentTrial — missing traces is the worse signal, not a
+        reason to skip the pair.
+
+        ## For complementary patterns
+
+        Group tasks by which agents lead/trail on each metric. Flag:
+          - pairs of agents whose trailing sets are disjoint across metrics (high
+            ensemble potential)
+          - agents that lead on a metric where higher-scoring peers trail
+          - unexpected weaknesses (an agent trailing on a metric it usually leads)
+
+        Build ComplementaryPattern entries with `agents` (the agent set involved)
+        and `description` (one or two sentences naming the pattern).
+
+        If `complementary_raw` is empty, return an empty `complementary_patterns` list.
+
+        Return a PeerComparison.
+        """
+        ...
+
+    def _agent_id_and_path(self, agent: Path | str) -> tuple[str, Path]:
+        """Return stable agent id and local path for analyzer calls."""
+        if isinstance(agent, Path):
+            return agent.name, agent
+        return agent, self._workspace_path / "eval-and-optimize" / "agents" / agent
+
+    def _tasks_by_id(self, dataset: Dataset) -> dict[str, Task]:
+        """Return dataset tasks keyed by id."""
+        return {task.id: task for task in dataset.list_tasks()}
+
+    async def run(
+        self,
+        agent: Path | str,
+        dataset: Dataset,
+        evaluation: EvaluationResult,
+        round: int | None = None,  # noqa: A002
+        peer_evaluations: dict[str, EvaluationResult] | None = None,
+        client: AsyncNeMoPlatform | None = None,
+        nmp_workspace: str | None = None,
+        agent_spec: Path | None = None,
+    ) -> AgentAnalysis:
+        """Run the full analysis pipeline for one agent in one optimization round.
+
+        Args:
+            agent: The agent path or stable agent id to analyze.
+            dataset: The dataset to analyze.
+            evaluation: The evaluation result to analyze.
+            round: Current optimization round number, if available.
+            peer_evaluations: Optional peer evaluation results keyed by agent id.
+            client: NeMo Platform client used to load ``intake://`` trial traces.
+                When ``None``, Intake traces cannot be loaded and are skipped.
+            nmp_workspace: NeMo Platform (Intake) workspace *name* — the request
+                context for ``intake://`` trace lookups. Distinct from the
+                constructor's ``workspace: Path`` (the filesystem eval dir).
+
+        Returns:
+            AgentAnalysis: per-trial diagnostics, failure classification, and peer
+            comparison for the given agent.
+
+        """
+        agent_id, agent_path = self._agent_id_and_path(agent)
+        round_key = f":round:{round}" if round is not None else ""
+        # Fold intake availability into the key: when no client/workspace is
+        # supplied, intake:// trial traces are skipped and the analysis is
+        # trace-starved. Keying on availability prevents such a degraded result
+        # from being replayed on a later run that *can* load those traces.
+        intake_key = ":intake:1" if client is not None and nmp_workspace is not None else ":intake:0"
+        cache_key = cache.agent_hash(f"{agent_id}:evaluation:{evaluation.id}{round_key}{intake_key}")
+        cached = cache.load(self._workspace_path, cache_key, AgentAnalysis)
+        if cached is not None:
+            return cached
+
+        trials = await self.select_trials(agent_id, dataset, evaluation)
+        tasks_by_id = self._tasks_by_id(dataset)
+
+        missing_task_diagnostics: dict[str, Diagnostic] = {}
+        trial_tasks: list[tuple[TrialResult, Task]] = []
+        for trial in trials:
+            task = tasks_by_id.get(trial.task_id)
+            if task is None:
+                missing_task_diagnostics[trial.id] = Diagnostic(
+                    outcome="FAILURE",
+                    summary=f"Trial {trial.id} references missing task {trial.task_id!r}.",
+                    failure_point=None,
+                    root_cause="evaluation_result_references_unknown_task",
+                )
+                continue
+            trial_tasks.append((trial, task))
+
+        unique_tasks = {task.id: task for _, task in trial_tasks}
+        rationales_list = await asyncio.gather(
+            *[
+                Rationalizer(
+                    workspace=self._workspace_path,
+                    config=self._config.rationalizer,
+                    framework_skills_dirs=self._framework_skills_dirs,
+                ).run(task, agent_spec=agent_spec)
+                for task in unique_tasks.values()
+            ],
+            return_exceptions=True,
+        )
+        rationales: dict[str, Rationale] = {}
+        for task_id, result in zip(unique_tasks, rationales_list, strict=True):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, BaseException):
+                logging.getLogger(__name__).warning(f"Rationalizer failed for {agent_id}/{task_id}: {result}")
+                continue
+            rationales[task_id] = result
+
+        diagnoses_list = await asyncio.gather(
+            *[
+                TraceAnalyzer(
+                    experiment_dir=self._workspace_path,
+                    config=self._config.trace_analyzer,
+                    framework_skills_dirs=self._framework_skills_dirs,
+                ).run(
+                    trial=trial,
+                    task=task,
+                    agent_path=agent_path,
+                    rationale=rationales.get(task.id),
+                    client=client,
+                    workspace=nmp_workspace,
+                )
+                for trial, task in trial_tasks
+            ],
+            return_exceptions=True,
+        )
+        diagnostics_by_trial_id = dict(missing_task_diagnostics)
+        for (trial, _), result in zip(trial_tasks, diagnoses_list, strict=True):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, BaseException):
+                logging.getLogger(__name__).warning(
+                    "TraceAnalyzer failed for %s/%s: %s",
+                    agent_id,
+                    trial.task_id,
+                    result,
+                )
+                diagnostics_by_trial_id[trial.id] = Diagnostic(
+                    outcome="FAILURE",
+                    summary=f"Trace analysis failed: {result}",
+                    failure_point=None,
+                    root_cause="analysis_error",
+                )
+                continue
+            diagnostics_by_trial_id[trial.id] = result
+
+        trial_analyses = [
+            TrialAnalysis(
+                task_id=trial.task_id,
+                trial_id=trial.id,
+                metrics={name: float(metric.value) for name, metric in trial.metrics.items()},
+                diagnostic=diagnostics_by_trial_id[trial.id],
+            )
+            for trial in trials
+            if trial.id in diagnostics_by_trial_id
+        ]
+        diagnoses = [analysis.diagnostic for analysis in trial_analyses]
+
+        classification, comparison = await asyncio.gather(
+            self.classify_failures(agent_id, diagnoses, trials),
+            self.compare_with_peers(agent_id, evaluation, diagnoses, peer_evaluations),
+        )
+
+        analysis_out = AgentAnalysis(
+            agent_id=agent_id,
+            aggregate_metrics={name: float(value) for name, value in evaluation.aggregate_metrics.items()},
+            trial_analyses=trial_analyses,
+            failure_classification=classification,
+            peer_comparison=comparison,
+        )
+        cache.store(self._workspace_path, cache_key, analysis_out)
+        return analysis_out

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/cache.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/cache.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import TypeVar
+from uuid import uuid4
+
+from pydantic import BaseModel, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+# PEP 695 syntax would read better, but the workspace lints against Python 3.11.
+T = TypeVar("T", bound=BaseModel)
+
+
+def task_hash(task_name: str) -> str:
+    """Return a namespaced sha256 hex digest for a task key.
+
+    Args:
+        task_name: the task identifier to hash.
+
+    Returns:
+        str: a ``task-<hex>`` prefixed digest string.
+
+    """
+    digest = hashlib.sha256(task_name.encode()).hexdigest()
+    return f"task-{digest}"
+
+
+def agent_hash(agent_id: str) -> str:
+    """Return a namespaced sha256 hex digest for an agent key.
+
+    Args:
+        agent_id: the agent identifier to hash.
+
+    Returns:
+        str: an ``agent-<hex>`` prefixed digest string.
+
+    """
+    digest = hashlib.sha256(agent_id.encode()).hexdigest()
+    return f"agent-{digest}"
+
+
+def trace_hash(trace_path: str | Path) -> str:
+    """Return a namespaced sha256 hex digest of a trace file's contents.
+
+    Args:
+        trace_path: path to the trace file to hash.
+
+    Returns:
+        str: a ``trace-<hex>`` prefixed digest string.
+
+    """
+    h = hashlib.sha256()
+    with open(trace_path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    digest = h.hexdigest()
+    return f"trace-{digest}"
+
+
+def _cache_path(workspace: Path, key: str) -> Path:
+    return workspace / "eval-and-optimize" / "cache" / f"{key}.json"
+
+
+def load(workspace: Path, key: str, model: type[T]) -> T | None:
+    """Return a previously-stored model instance for this key, or None.
+
+    Args:
+        workspace: root workspace directory containing the cache.
+        key: cache key returned by one of the ``*_hash`` functions.
+        model: Pydantic model class used to deserialise the stored payload.
+
+    Returns:
+        T | None: the deserialised model instance, or None if the entry is
+            missing, unreadable, or fails validation.
+
+    """
+    path = _cache_path(workspace, key)
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, ValueError) as exc:
+        _logger.warning(f"Cache read failed at {path}: {exc} -- ignoring")
+        return None
+    try:
+        return model.model_validate(payload)
+    except ValidationError as exc:
+        _logger.warning(f"Cache payload at {path} does not validate against {model.__name__}: {exc} -- ignoring")
+        return None
+
+
+def store(workspace: Path, key: str, value: BaseModel) -> None:
+    """Persist a model instance under the given key, overwriting any prior entry.
+
+    Args:
+        workspace: root workspace directory containing the cache.
+        key: cache key returned by one of the ``*_hash`` functions.
+        value: Pydantic model instance to serialise and store.
+
+    """
+    path = _cache_path(workspace, key)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = value.model_dump(mode="json")
+    tmp = path.parent / f"{path.name}.{uuid4().hex}.tmp"
+    try:
+        tmp.write_text(json.dumps(payload, indent=2))
+        tmp.replace(path)
+    except OSError as exc:
+        _logger.warning(f"Cache write failed for key {key}: {exc} -- skipping")
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/cards.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/cards.py
@@ -1,0 +1,1596 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+from nooa import Skill
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class ModelCatalogEntry(BaseModel):
+    """One curated model choice for OptimizeModelCapability."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    model_id: str = Field(
+        min_length=1,
+        description="Model identifier.",
+    )
+    provider: str = Field(
+        min_length=1,
+        description="Model provider.",
+    )
+    range: str = Field(
+        min_length=1,
+        description="Capability or cost range.",
+    )
+    notes: str = Field(
+        min_length=1,
+        description="Short model notes.",
+    )
+    endpoint: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional endpoint override. Uses default_endpoint when omitted.",
+    )
+    api_key_env: str | None = Field(
+        default=None,
+        min_length=1,
+        description="Optional API key environment variable override. Uses default_api_key_env when omitted.",
+    )
+
+
+class ModelCatalog(BaseModel):
+    """Schema for assets/models.yaml."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    default_endpoint: str = Field(
+        min_length=1,
+        description="Default inference endpoint.",
+    )
+    default_api_key_env: str = Field(
+        min_length=1,
+        description="Default API key environment variable.",
+    )
+    id_field: str = Field(
+        pattern="^model_id$",
+        description="Model identifier field name.",
+    )
+    models: list[ModelCatalogEntry] = Field(
+        min_length=1,
+        description="Curated model entries.",
+    )
+
+    @model_validator(mode="after")
+    def model_ids_are_unique(self) -> "ModelCatalog":
+        """Validate that all model_id values in the catalog are unique.
+
+        Returns:
+            ModelCatalog: the validated catalog instance.
+
+        Raises:
+            ValueError: if any model_id appears more than once.
+
+        """
+        seen: set[str] = set()
+        duplicates: set[str] = set()
+        for model in self.models:
+            if model.model_id in seen:
+                duplicates.add(model.model_id)
+            seen.add(model.model_id)
+
+        if duplicates:
+            duplicate_list = ", ".join(sorted(duplicates))
+            raise ValueError(f"Duplicate model_id values: {duplicate_list}")
+        return self
+
+
+class OptimizeArchitecture(Skill):
+    """Use when the agent's structure is the bottleneck — context overflow causes earlier conclusions to be forgotten, a single method mixes separable concerns, or missing phase boundaries let the agent skip steps. Covers add_subagent, remove_subagent, split_method, merge_method.
+
+    # Optimization Card: Architecture
+
+    ## When to Use
+
+    Use this card when traces show the agent's **structure is the bottleneck**, not its knowledge or reasoning:
+
+    - A single method is doing issue parsing + bug localization + patch writing — and loses earlier conclusions by the end
+    - A phase is ended prematurely because the agent is not forced to complete it by phase boundaries
+    - Context overflow: patch written at turn N contradicts the bug location identified at turn 2 because earlier context was compressed
+    - A task decomposes into genuinely separable concerns that each need their own tool access, model, or reasoning chain
+    - Multiple methods each paraphrase the previous output without adding new reasoning (consolidation needed)
+    - The agent produces correct intermediate results but incorrect final patches due to information overload
+
+    **Key diagnostic**: Errors are inconsistent — the agent solves the same issue correctly sometimes and incorrectly other times with no change in inputs. This is a context/structure problem, not a knowledge problem.
+
+    ## When NOT to Use
+
+    - Agent reasons incorrectly in a structured way → use `opt-reasoning` (fix the logic, not the structure)
+    - Agent skips operations → use `opt-execution`
+    - Rules are wrong → use `opt-domain-knowledge`
+
+    ---
+
+    ## Core Pattern
+
+    Architecture fixes restructure **how methods are organized and connected**. The public entrypoint remains programmatic. The change is in how LLM-driven sub-methods are decomposed — splitting into subagents, splitting methods at phase boundaries, or collapsing redundant methods.
+
+    ---
+
+    ## Approaches
+
+    ### Approach 1: Add a Subagent
+
+    **When**: A method is doing multiple separable tasks that each need their own context, tool access, or reasoning chain.
+
+    **Optimization type**: `add_subagent`
+
+    **How**: Extract the concern into a separate `Agent` subclass. The parent delegates to it and consumes its structured output. **The subagent must have its own tools** — passing a callback is insufficient.
+
+    **Code example** — extracting issue triage into a dedicated subagent so the main agent focuses on patching:
+
+    ```python
+    class IssueTriager(Agent):
+        '''Subagent specialized in parsing GitHub issues into structured bug reports.'''
+        search = CodeSearchTool()
+
+        async def triage(self, issue: str, repo: str) -> BugReport:
+            '''Parse the issue and identify the affected area.
+
+            Steps:
+            1. Extract the symptom and expected vs. actual behavior from the issue text
+            2. Identify the module or function likely responsible
+            3. Search the repo for the symbol mentioned in the issue
+            4. Return a BugReport — do not write a patch here.
+            '''
+            ...
+
+
+    class SWEAgent(Agent):
+        '''Main agent — delegates issue parsing, focuses on patch writing and verification.'''
+        run_tests = RunTestsTool()
+        triager   = IssueTriager()   # subagent as attribute
+
+        async def _write_and_verify(
+            self, bug_report: BugReport, test_results: dict
+        ) -> Patch:
+            '''Write and verify a patch given pre-triaged bug report and test results.
+
+            bug_report: structured output from IssueTriager (pre-fetched).
+            test_results: pre-run test output (pre-fetched).
+            Do not re-triage or re-run tests — use what's passed in.
+            '''
+            ...
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            '''Solve the GitHub issue.'''
+            bug_report   = await self.triager.triage(issue, repo)  # subagent
+            test_results = self.run_tests(repo)                    # concrete
+            return await self._write_and_verify(bug_report, test_results)
+    ```
+
+    **When NOT to add a subagent**: if the concern can be handled by a deterministic method or a new reasoning step. Subagents add latency — reserve them for genuinely separable multi-step concerns.
+
+    ---
+
+    ### Approach 2: Split a Method
+
+    **When**: A single stochastic method combines multiple phases that each produce intermediate conclusions, and the agent loses track of early conclusions by the final step.
+
+    **Optimization type**: `split_method`
+
+    **How**: Split at natural phase boundaries. Each phase produces a typed output consumed by the next. Wire the split into the public entrypoint's Python body.
+
+    **Code example** — splitting a monolithic solve into localization + patch writing:
+
+    ```python
+    class SWEAgent(Agent):
+
+        def collect_repo_structure(self, repo: str) -> dict: ...   # concrete
+
+        async def _locate_bug(
+            self, issue: str, repo_structure: dict
+        ) -> BugLocation:
+            '''Locate the bug from the issue and repo structure.
+
+            Return all candidate locations including contradictory evidence.
+            Do NOT write a patch — only locate and return evidence.
+            '''
+            ...
+
+        async def _write_patch(
+            self, issue: str, bug_location: BugLocation
+        ) -> Patch:
+            '''Write a patch for the located bug.
+
+            Do NOT re-locate. Work only from bug_location.
+            Apply the output format from the skill file.
+            '''
+            ...
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            '''Solve the GitHub issue.'''
+            structure    = self.collect_repo_structure(repo)
+            bug_location = await self._locate_bug(issue, structure)
+            return await self._write_patch(issue, bug_location)
+    ```
+
+    **Split boundary rules**:
+    - Split at the boundary between *fact gathering* and *reasoning*, or between *reasoning* and *patch generation*
+    - Each phase must produce a reusable typed output — not a free-form string
+    - Do NOT split a focused method — splitting adds latency without benefit
+
+    ---
+
+    ### Approach 3: Merge Methods
+
+    **When**: Multiple sequential stochastic methods each paraphrase the previous output without adding new reasoning, bloating context and diluting signal.
+
+    **Optimization type**: `merge_method`
+
+    **How**: Identify methods whose output is structurally identical to their input (just reformatted). Merge into one method that does the combined work. Update the entrypoint accordingly.
+
+    **Code example** — eliminating a redundant summarization step between localization and patching:
+
+    ```python
+    # Before: _summarize_location just reformats _locate_bug output without adding reasoning
+    async def _locate_bug(self, issue: str, structure: dict) -> BugLocation: ...
+    async def _summarize_location(self, loc: BugLocation) -> str: ...   # redundant
+    async def _write_patch(self, summary: str) -> Patch: ...
+
+    # After: _locate_bug feeds _write_patch directly
+    async def _locate_bug(self, issue: str, structure: dict) -> BugLocation: ...
+    async def _write_patch(self, issue: str, bug_location: BugLocation) -> Patch: ...
+
+    # Entrypoint updates to match
+    async def solve(self, issue: str, repo: str) -> Patch:
+        structure    = self.collect_repo_structure(repo)
+        bug_location = await self._locate_bug(issue, structure)
+        return await self._write_patch(issue, bug_location)
+    ```
+
+    ---
+
+    ### Approach 4: Remove a Subagent
+
+    **When**: A subagent adds latency and complexity without measurable accuracy gain. The parent could do the work inline without context overflow.
+
+    **Optimization type**: `remove_subagent`
+
+    **How**: Collapse the subagent's tools and behavior into the parent agent. Move the subagent's tool access and relevant prompt content into the parent. Remove the subagent if no other caller uses it.
+
+    **Code example** — collapsing a trivial triage subagent back into the parent:
+
+    ```python
+    # Before: IssueTriager subagent just extracts keywords — doesn't need its own context
+    class IssueTriager(Agent):
+        async def triage(self, issue: str) -> dict:
+            '''Extract key terms from issue.'''
+            ...
+
+    class SWEAgent(Agent):
+        triager = IssueTriager()
+        async def solve(self, issue: str, repo: str) -> Patch:
+            keywords = await self.triager.triage(issue)
+            return await self._write_patch(issue, keywords)
+
+    # After: triage is a deterministic method on the parent — no subagent overhead
+    class SWEAgent(Agent):
+        def extract_keywords(self, issue: str) -> dict:
+            '''Extract key terms from issue text.'''
+            import re
+            return {"terms": re.findall(r'`([^`]+)`', issue)}
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            keywords = self.extract_keywords(issue)
+            return await self._write_patch(issue, keywords)
+    ```
+
+    **When to remove vs. keep**: If removing causes context overflow or inconsistent results, keep the subagent. Remove only when the task is simple enough for a single method + tool call.
+
+    ---
+
+    ## Success Criteria
+
+    A good architecture fix:
+    - Reduces "contradicts earlier conclusion" errors in traces
+    - Each method/subagent has a **single clear responsibility** readable from its name alone
+    - Intermediate outputs are **typed structs** — not free-form strings
+    - Performance improves on tasks that previously showed inconsistent results
+    - Does not add subagents/splits that increase latency without measurable accuracy gain
+    """
+
+
+class OptimizeReasoning(Skill):
+    """Use when the agent retrieves the right data and has the right rules but draws the wrong conclusion — it conflates distinct concepts, skips implicit inference steps, or its chain of reasoning is plausible but logically flawed. Covers edit_method (steps/logic), add_method, remove_method, split_method, make_method_abstract.
+
+    # Optimization Card: Reasoning
+
+    ## When to Use
+
+    Use this card when traces show the agent **has the right data and the right rules but reasons incorrectly**:
+
+    - Agent found the right file but patched the wrong function within it
+    - Agent conflated two distinct concepts (e.g. "test fails" = "bug is in the test" rather than in the code under test)
+    - Agent skipped an implicit reasoning step that was never made explicit
+    - Agent's chain of reasoning is plausible but logically flawed
+    - A method does multiple things at once and loses track of one of them
+    - The same reasoning error recurs across different issues with different inputs
+
+    **Key diagnostic**: The trace shows correct data retrieval — the failure is in the inference step. More data won't help. Clearer step-by-step reasoning structure will.
+
+    ## When NOT to Use
+
+    - Agent skips steps it knows it should take → use `opt-execution`
+    - Agent reasons correctly but from a wrong domain rule → use `opt-domain-knowledge`
+    - The reasoning load is too high for one method → use `opt-architecture`
+
+    ---
+
+    ## Core Pattern
+
+    Reasoning fixes restructure the **private stochastic method** (`_locate_bug`, `_write_patch`, etc.) — the method defined by its method prompt, implemented by the LLM at runtime. The orchestration entrypoint stays unchanged. The fix makes implicit reasoning steps explicit, breaks conflations into separate questions, or adds a new stochastic method for a missing phase.
+
+    ---
+
+    ## Approaches
+
+    ### Approach 1: Make an Implicit Reasoning Step Explicit
+
+    **When**: The agent conflates two concepts or skips an implicit inference. The fix is adding an explicit intermediate conclusion step to the stochastic method's prompt.
+
+    **Optimization type**: `edit_method`
+
+    **How**: Break the conflation by requiring the LLM to answer sub-questions explicitly and separately before drawing the final conclusion.
+
+    **Code example** — fixing conflation of "test fails" with "bug is in the test file":
+
+    ```python
+    async def _locate_bug(self, issue: str, test_results: dict) -> BugLocation:
+        '''Locate the source of the bug described in issue given test results.
+
+        ## Root Cause Localization (answer each question separately)
+
+        Before concluding where the bug is, answer these in sequence — do NOT merge them:
+
+        Q1: Which test(s) are failing?
+        → Check test_results["failed"]. Answer: list the failing test names.
+
+        Q2: What is each failing test actually testing?
+        → Read the test body. Identify the function or class under test.
+          Answer: the production symbol being tested, NOT the test file.
+
+        Q3: Is the failure caused by wrong test logic, or wrong production code?
+        → Check if the test assertion matches the documented behavior in the issue.
+          If the test expectation is correct and production code produces the wrong value:
+          bug is in production code.
+          If the test expectation is wrong: bug is in the test.
+
+        Only conclude "bug is in test file" if Q3 shows the test expectation is wrong.
+        Failing test → bug in test is the most common wrong inference — always check Q2 and Q3.
+        '''
+        ...
+    ```
+
+    ---
+
+    ### Approach 2: Fix the method contract
+
+    **When**: A method reasons correctly but hands downstream callers output they can't
+    reliably consume — free-form text where a caller expects specific fields, or an
+    untyped value that varies run to run. The symptom is a *contract* problem, not a
+    reasoning problem: the method's logic may be fine; only its output shape is wrong.
+    Reach for this instead of adding a soft "please include X" constraint to the prompt.
+
+    **Optimization type**: `edit_method`
+
+    **How**: Change the method's return type annotation to a typed struct and update its
+    prompt to require that format. Then update the outgoing edge label in the architecture
+    diagram to reflect the new contract. This is a **signature change**, not a prompt
+    reasoning edit.
+
+    **Code example** — fixing a method that returns raw text to return a typed result:
+
+    ```python
+    from pydantic import BaseModel
+
+    class AnalysisResult(BaseModel):
+        conclusion: str       # the primary finding
+        confidence: str       # "high" | "medium" | "low"
+        evidence: list[str]   # supporting observations
+
+    class SWEAgent(Agent):
+
+        async def _analyze(self, data: dict) -> AnalysisResult:
+            '''Analyze the data and return a structured finding.
+
+            Return an AnalysisResult with:
+            - conclusion: the primary finding, one sentence
+            - confidence: "high" if evidence is unambiguous, "low" if uncertain
+            - evidence: list of supporting observations from the data
+
+            Do NOT return raw text — structure the output into the fields above.
+            '''
+            ...
+    ```
+
+    **Architecture diagram update** — change the edge label to make the contract explicit:
+
+    ```
+    _analyze* -->|result: AnalysisResult| _write_patch*
+    ```
+
+    **When NOT to use**: If the method's reasoning logic is also wrong (wrong inference, conflated
+    concepts), combine this with Approach 1 or 3 as needed. If the caller is the problem (can't
+    handle structured input), fix the caller instead.
+
+    ---
+
+    ### Approach 3: Add a New Reasoning Method
+
+    **When**: The agent is missing an entire reasoning phase — a distinct analytical concern that needs its own context and typed output, not just a step within an existing method.
+
+    **Optimization type**: `add_method`
+
+    **How**: Add a new private stochastic method that produces a structured intermediate output. The downstream method consumes that output instead of re-deriving it. Wire it into the public entrypoint's Python body.
+
+    **Code example** — adding a dedicated reproduction phase before patch writing:
+
+    ```python
+    class SWEAgent(Agent):
+
+        async def _reproduce(
+            self, issue: str, repo_structure: dict, test_results: dict
+        ) -> ReproductionResult:
+            '''Determine whether the issue is reproduced by current test failures.
+
+            Evaluate in three layers:
+            1. Symptom match: do the failing tests match the behavior described in the issue?
+            2. Scope: is the failure isolated to the area described, or is it broader?
+            3. Confidence: is this a reliable reproduction or an unrelated pre-existing failure?
+
+            Return a ReproductionResult with:
+            - reproduced: True | False | "partial"
+            - failing_tests: list of test names that reproduce the issue
+            - confidence: "high" | "medium" | "low"
+            - notes: any observations that affect patch strategy
+            '''
+            ...
+
+        async def _write_patch(
+            self, issue: str, reproduction: ReproductionResult
+        ) -> Patch:
+            '''Write a patch that resolves the issue.
+
+            Do NOT re-run tests or re-reproduce — trust the reproduction result.
+            Focus on fixing the production code identified in reproduction.failing_tests.
+            '''
+            ...
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            '''Solve the GitHub issue.'''
+            structure    = self.collect_repo_structure(repo)
+            test_results = self.run_test_suite(repo)
+            reproduction = await self._reproduce(issue, structure, test_results)
+            return await self._write_patch(issue, reproduction)
+    ```
+
+    ---
+
+    ### Approach 4: Split a Method That Does Too Much
+
+    **When**: A single stochastic method combines evidence interpretation + intermediate reasoning + final classification, causing the LLM to lose earlier conclusions by the final step.
+
+    **Optimization type**: `split_method`
+
+    **How**: Split at natural phase boundaries. Each phase receives only what it needs and produces a typed output. Wire the split into the public entrypoint's Python body.
+
+    **Code example** — splitting `_solve()` into bug location + patch writing:
+
+    ```python
+    class SWEAgent(Agent):
+
+        def collect_repo_structure(self, repo: str) -> dict: ...   # concrete
+
+        async def _locate_bug(
+            self, issue: str, repo_structure: dict, test_results: dict
+        ) -> BugLocation:
+            '''Locate the bug from the issue description and test results.
+
+            Report all candidate locations including uncertain ones.
+            Do NOT write a patch — only locate and return evidence.
+            '''
+            ...
+
+        async def _write_patch(
+            self, issue: str, bug_location: BugLocation
+        ) -> Patch:
+            '''Write a patch that fixes the located bug.
+
+            Do NOT re-locate. Work only from bug_location.
+            The patch must change the file and function identified in bug_location.
+            '''
+            ...
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            '''Solve the GitHub issue.'''
+            structure    = self.collect_repo_structure(repo)
+            test_results = self.run_test_suite(repo)
+            bug_location = await self._locate_bug(issue, structure, test_results)
+            return await self._write_patch(issue, bug_location)
+    ```
+
+    **When to split vs. edit**: If the method is short and the error is about conflation, prefer `edit_method`. Split when the trace shows early conclusions disappearing by the final step.
+
+    ---
+
+    ### Approach 5: Remove a Redundant Reasoning Method
+
+    **When**: A stochastic method paraphrases the previous output without adding new reasoning, or a reasoning phase was added but traces show it always produces the same conclusion regardless of input.
+
+    **Optimization type**: `remove_method`
+
+    **How**: Remove the method and update the entrypoint to skip that phase. Pass the upstream output directly to the downstream consumer.
+
+    **Code example** — removing a validation step that always rubber-stamps the previous output:
+
+    ```python
+    # Before: _validate_location just restates _locate_bug output without adding reasoning
+    async def _locate_bug(self, issue: str, structure: dict) -> BugLocation: ...
+    async def _validate_location(self, loc: BugLocation) -> BugLocation: ...  # always returns loc unchanged
+    async def _write_patch(self, issue: str, loc: BugLocation) -> Patch: ...
+
+    async def solve(self, issue: str, repo: str) -> Patch:
+        structure = self.collect_repo_structure(repo)
+        loc = await self._locate_bug(issue, structure)
+        validated = await self._validate_location(loc)  # wasted step
+        return await self._write_patch(issue, validated)
+
+    # After: _locate_bug feeds _write_patch directly
+    async def _locate_bug(self, issue: str, structure: dict) -> BugLocation: ...
+    async def _write_patch(self, issue: str, loc: BugLocation) -> Patch: ...
+
+    async def solve(self, issue: str, repo: str) -> Patch:
+        structure = self.collect_repo_structure(repo)
+        loc = await self._locate_bug(issue, structure)
+        return await self._write_patch(issue, loc)
+    ```
+
+    **When to remove vs. keep**: If removing the method causes downstream errors because it was doing useful transformation (even subtle), keep it. Remove only when traces show the method's output is structurally identical to its input across multiple tasks.
+
+    ---
+
+    ### Approach 6: Convert a Concrete Method to an Stochastic Method
+
+    **When**: A deterministic method uses brittle heuristics (regex, keyword matching, hardcoded thresholds) that fail on novel inputs. The task requires judgment, not pattern matching — but the current implementation is hardcoded Python.
+
+    **Optimization type**: `make_method_abstract`
+
+    **How**: Replace the concrete method with a stochastic method. Move the intent into a prompt with structured reasoning steps. The public entrypoint calls the new stochastic method where it previously called the concrete one.
+
+    **Code example** — converting a regex-based classifier that misclassifies edge cases:
+
+    ```python
+    # Before: concrete method — brittle regex can't handle ambiguous issue descriptions
+    class SWEAgent(Agent):
+
+        def classify_issue(self, issue: str) -> str:
+            '''Classify issue type by keyword matching.'''
+            if "crash" in issue.lower() or "traceback" in issue.lower():
+                return "crash"
+            if "slow" in issue.lower() or "timeout" in issue.lower():
+                return "performance"
+            return "bug"
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            issue_type = self.classify_issue(issue)  # hardcoded
+            return await self._write_patch(issue, issue_type)
+
+    # After: LLM method — handles ambiguous and novel descriptions
+    class SWEAgent(Agent):
+
+        async def _classify_issue(self, issue: str) -> IssueClassification:
+            '''Classify the issue into one of: crash, performance, regression, bug.
+
+            Read the full issue text. Determine:
+            1. Is there an explicit stack trace or "raises" keyword? → crash
+            2. Does the issue describe degraded speed, timeouts, or resource exhaustion? → performance
+            3. Does the issue say "used to work" or reference a prior version? → regression
+            4. Otherwise → bug
+
+            Return the classification and a one-sentence justification.
+            '''
+            ...
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            classification = await self._classify_issue(issue)  # LLM handles ambiguity
+            return await self._write_patch(issue, classification)
+    ```
+
+    **When to convert vs. keep concrete**: If the operation is truly deterministic (parsing structured output, running a command, filtering by exact match), keep it concrete. Convert only when traces show the hardcoded logic fails on inputs that require judgment.
+
+    ---
+
+    ## Success Criteria
+
+    A good reasoning fix:
+    - Eliminates a **specific logical error** visible in the trace — not "improves reasoning generally"
+    - The intermediate conclusion is explicitly formed and visible in the trace
+    - The error does not reappear when the same logical scenario occurs with different inputs
+    - Does not add steps that increase latency without measurable accuracy gain
+    """
+
+
+class OptimizeExecution(Skill):
+    """Use when the agent knows what to do but skips or inconsistently performs a deterministic operation — the same prompt instruction has been added multiple rounds without fixing the failure, or a mechanical step works on train but fails on novel inputs. Covers add_concrete_method, remove_concrete_method, add_tool, remove_tool, edit_concrete_method, make_method_concrete.
+
+    # Optimization Card: Execution
+
+    ## When to Use
+
+    Use this card when traces show the agent **knows what it should do but doesn't reliably do it**:
+
+    - Agent was instructed to run an operation but skipped it on some inputs
+    - A method was added to the architecture but the LLM never calls it
+    - The same prompt instruction has been added multiple rounds without fixing the failure
+    - Agent executes a deterministic operation inconsistently — correct on train, wrong on novel inputs
+    - The operation is purely mechanical: parsing, querying, filtering, enumerating — no reasoning required
+
+    **Key diagnostic**: If you have added an instruction "call X" or "run Y" and the agent still skips it on novel cases, adding it to the method prompt again will not work. The fix is enforcing the call in Python.
+
+    ## When NOT to Use
+
+    - Agent runs the operation but interprets results incorrectly → use `opt-reasoning`
+    - Agent lacks the domain rule to know *what* to check → use `opt-domain-knowledge`
+    - The operation requires reasoning to decide whether to run → use `opt-reasoning` or `opt-architecture`
+
+    ---
+
+    ## Core Pattern
+
+    The public method is **programmatic** (has a Python body). It calls deterministic sub-methods unconditionally, then delegates reasoning to a **private stochastic method** (`_locate_and_fix`, `_classify`, etc.) that receives the pre-fetched data.
+
+    ```python
+    class SWEAgent(Agent):
+
+        # Deterministic sub-method — always runs, LLM cannot skip
+        async def collect_repo_structure(self, repo: str) -> dict:
+            '''Deterministically collect file tree and test suite locations.'''
+            files = await self.shell.run(f"find {repo} -name '*.py' | head -200")
+            tests = await self.shell.run(f"find {repo} -name 'test_*.py' -o -name '*_test.py'")
+            return {"files": files.splitlines(), "tests": tests.splitlines()}
+
+        # Private LLM method — implements reasoning, receives pre-fetched data
+        async def _locate_and_fix(self, issue: str, repo_structure: dict) -> Patch:
+            '''Locate the bug described in issue and write a patch.
+
+            repo_structure contains: files (list of .py paths), tests (list of test paths).
+            Use these fields directly — do not re-scan the repo.
+            '''
+            ...
+
+        # Public entrypoint — programmatic, enforces sub-calls in Python body
+        async def solve(self, issue: str, repo: str) -> Patch:
+            '''Solve the GitHub issue by locating and patching the bug.'''
+            structure = await self.collect_repo_structure(repo)  # enforced in Python
+            return await self._locate_and_fix(issue, structure)
+    ```
+
+    **Why this works**: `solve()` has a Python body — the LLM doesn't decide whether to call sub-steps. `collect_repo_structure()` always runs. The LLM only implements `_locate_and_fix()`, which receives the data it needs.
+
+    ---
+
+    ## Approaches
+
+    ### Approach 1: Add a Concrete Sub-Method
+
+    **When**: A deterministic operation is currently described in a method prompt but the LLM skips it. Extract it as a deterministic method and call it from the public method's Python body.
+
+    **Optimization type**: `add_concrete_method`
+
+    **Steps**:
+    1. Implement the operation as a deterministic `def` method
+    2. Make the public method programmatic (give it a Python body)
+    3. Call the sub-method from that body
+    4. Pass the result to a new private LLM `_<method>()` for reasoning
+
+    **Code example** — adding test output parsing that the LLM kept skipping despite method prompt instructions:
+
+    ```python
+    class SWEAgent(Agent):
+
+        async def run_test_suite(self, repo: str, test_file: str) -> dict:
+            '''Run the specified test file and return structured output.'''
+            raw = await self.shell.run(f"cd {repo} && python -m pytest {test_file} -v 2>&1")
+            passed, failed = [], []
+            for line in raw.splitlines():
+                if " PASSED" in line:
+                    passed.append(line.strip())
+                elif " FAILED" in line or " ERROR" in line:
+                    failed.append(line.strip())
+            return {"passed": passed, "failed": failed, "raw": raw}
+
+        async def _verify_patch(self, patch: Patch, test_results: dict) -> VerificationResult:
+            '''Assess whether the patch fixes the issue given pre-run test results.
+
+            test_results: {"passed": [...], "failed": [...], "raw": str}
+            Use these directly — do not re-run tests.
+            '''
+            ...
+
+        async def verify(self, repo: str, patch: Patch, test_file: str) -> VerificationResult:
+            '''Verify that patch fixes the issue.'''
+            test_results = await self.run_test_suite(repo, test_file)  # enforced in Python
+            return await self._verify_patch(patch, test_results)
+    ```
+
+    ---
+
+    ### Approach 2: Add a Tool and Call It Unconditionally
+
+    **When**: The agent needs an external capability it lacks. Wire the tool call into the public method's Python body so it always runs.
+
+    **Optimization type**: `add_tool`
+
+    **Code example** — adding a code search tool that the agent was approximating by reading files manually:
+
+    ```python
+    class CodeSearchTool:
+        '''Search for a symbol or pattern across all Python files in a repo.'''
+        def __call__(self, repo: str, pattern: str) -> list[dict]:
+            import subprocess, json
+            result = subprocess.run(
+                ["grep", "-rn", "--include=*.py", "-l", pattern, repo],
+                capture_output=True, text=True
+            )
+            return [{"file": f} for f in result.stdout.splitlines() if f]
+
+
+    class SWEAgent(Agent):
+        search = CodeSearchTool()
+
+        async def _write_patch(self, issue: str, symbol_locations: list[dict]) -> Patch:
+            '''Write a patch for the issue given pre-located symbol sites.
+
+            symbol_locations: list of {"file": str} dicts.
+            Read only these files — do not search again.
+            '''
+            ...
+
+        async def solve(self, issue: str, repo: str, symbol: str) -> Patch:
+            '''Solve the issue by finding and patching the relevant symbol.'''
+            locations = self.search(repo, symbol)   # always runs
+            return await self._write_patch(issue, locations)
+    ```
+
+    ---
+
+    ### Approach 3: Fix a Broken Concrete Method
+
+    **When**: A deterministic method exists and is already called from the Python body, but has wrong logic or silent failures.
+
+    **Optimization type**: `edit_concrete_method`
+
+    **Code example** — fix a test parser that silently drops failures reported on multi-line output:
+
+    ```python
+    # Before — misses FAILED lines that follow a traceback (not immediately after test name)
+    def parse_test_output(self, raw: str) -> dict:
+        failed = [l for l in raw.splitlines() if "FAILED" in l and "::" in l]
+        return {"failed": failed}
+
+    # After — collects all FAILED markers regardless of surrounding context
+    def parse_test_output(self, raw: str) -> dict:
+        failed = []
+        for line in raw.splitlines():
+            line = line.strip()
+            if line.startswith("FAILED") or ("FAILED" in line and "::" in line):
+                failed.append(line)
+        return {"failed": failed}
+    ```
+
+    ---
+
+    ### Approach 4: Remove an Unused Deterministic Method
+
+    **When**: A deterministic helper is never called in traces, or its logic is now handled elsewhere (by another method or tool).
+
+    **Optimization type**: `remove_concrete_method`
+
+    **How**: Remove the method definition and any calls to it in the entrypoint's Python body. Verify traces still show correct behavior without it.
+
+    **Code example** — removing a helper that was superseded by a tool:
+
+    ```python
+    # Before: manual file counting helper, but CodeSearchTool now handles this
+    def count_python_files(self, repo: str) -> int:
+        '''Count .py files in repo.'''
+        return len(glob.glob(f"{repo}/**/*.py", recursive=True))
+
+    # After: remove the helper, use self.search directly in the entrypoint
+    ```
+
+    ---
+
+    ### Approach 5: Remove an Unused Tool
+
+    **When**: A tool attribute is never invoked in traces, or the agent consistently calls it but ignores the result, or it returns misleading output that confuses the LLM.
+
+    **Optimization type**: `remove_tool`
+
+    **How**: Remove the tool attribute and any references in method prompts or Python bodies. If a method's Python body called the tool unconditionally, update that body to skip the call.
+
+    **Code example** — removing a linter tool that the agent never uses productively:
+
+    ```python
+    # Before: linter tool added in round 2, but traces show agent ignores lint output
+    class SWEAgent(Agent):
+        linter = LintTool()  # never produces actionable signal
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            lint_output = self.linter(repo)  # wasted call
+            return await self._write_patch(issue, lint_output)
+
+    # After: remove the tool, pass what the agent actually needs
+    class SWEAgent(Agent):
+        async def solve(self, issue: str, repo: str) -> Patch:
+            structure = self.collect_repo_structure(repo)
+            return await self._write_patch(issue, structure)
+    ```
+
+    ---
+
+    ### Approach 6: Convert an Stochastic Method to a Concrete Method
+
+    **When**: A stochastic method performs a purely deterministic operation — parsing, filtering, formatting, string extraction — where the output is fully determined by the input with no judgment needed. The LLM wastes tokens and introduces inconsistency on what should be a mechanical step.
+
+    **Optimization type**: `make_method_concrete`
+
+    **How**: Replace the `async def` stochastic method with a concrete `def` that implements the same logic in Python. Call it from the public entrypoint's Python body so it always runs identically.
+
+    **Code example** — converting a stochastic method that extracts test names from pytest output into a deterministic parser:
+
+    ```python
+    # Before: LLM method — wastes tokens parsing structured output, sometimes misses entries
+    class SWEAgent(Agent):
+
+        async def _extract_failing_tests(self, raw_output: str) -> list[str]:
+            '''Extract the names of failing tests from pytest output.
+
+            Look for lines containing FAILED and extract the test name after '::'.
+            Return a list of fully qualified test names.
+            '''
+            ...
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            raw = await self.shell.run(f"cd {repo} && python -m pytest -v 2>&1")
+            failing = await self._extract_failing_tests(raw)  # LLM parses structured text
+            return await self._write_patch(issue, failing)
+
+    # After: concrete method — deterministic, zero tokens, never misses a line
+    class SWEAgent(Agent):
+
+        def extract_failing_tests(self, raw_output: str) -> list[str]:
+            '''Parse failing test names from pytest -v output.'''
+            failing = []
+            for line in raw_output.splitlines():
+                line = line.strip()
+                if "FAILED" in line and "::" in line:
+                    # Extract "path/test_file.py::test_name" before the FAILED marker
+                    parts = line.split(" ")
+                    for part in parts:
+                        if "::" in part:
+                            failing.append(part)
+                            break
+            return failing
+
+        async def solve(self, issue: str, repo: str) -> Patch:
+            raw = await self.shell.run(f"cd {repo} && python -m pytest -v 2>&1")
+            failing = self.extract_failing_tests(raw)  # deterministic, enforced in Python
+            return await self._write_patch(issue, failing)
+    ```
+
+    **When to convert vs. keep as stochastic**: If the output depends on understanding natural language, ambiguous input, or requires judgment — keep it as a stochastic method. Convert only when the transformation is mechanical and fully specifiable in code.
+
+    ---
+
+    ## Success Criteria
+
+    A good execution fix:
+    - The public method has a **Python body** that calls deterministic sub-methods before delegating to `_<method>()`
+    - Deterministic operations run **unconditionally** — the LLM receives results as arguments, not instructions
+    - The trace shows every deterministic method firing on every task, including ones previously skipped
+    - If the LLM still skips an operation after the fix, the fix is still prompt-based — move the call into Python
+    """
+
+
+class OptimizeDomainKnowledge(Skill):
+    """Use when the agent applies the wrong domain rule, misclassifies because of a missing taxonomy entry, or reasons coherently from a wrong premise — the reasoning chain is logical but starts from incorrect knowledge. Covers edit_skill, add_skill, remove_skill, edit_method (rules section).
+
+    # Optimization Card: Domain Knowledge
+
+    ## When to Use
+
+    Use this card when traces show the agent **has the right information but applies the wrong rule**:
+
+    - Agent correctly locates the bug but patches the wrong layer (e.g. patches the caller instead of the implementation)
+    - Agent applies a rule meant for a different issue type
+    - Agent lacks a taxonomy entry for the specific failure mode
+    - The same misclassification pattern appears across multiple issues with different inputs
+    - Agent's reasoning is internally consistent but starts from a wrong premise
+
+    **Key diagnostic**: The reasoning chain is coherent, but it starts from a wrong or missing rule. More execution steps won't help — the agent needs the right knowledge.
+
+    ## When NOT to Use
+
+    - Agent has the right rule but doesn't consistently apply it → use `opt-execution`
+    - Agent's reasoning process is flawed (correct rules, wrong logic) → use `opt-reasoning`
+    - The knowledge gap requires a new reasoning phase → use `opt-architecture`
+
+    ---
+
+    ## Core Pattern
+
+    Domain knowledge fixes go into the **skill module** (shared, versioned, independent of method structure) or into the method's prompt as a rules section. They do not change the Python execution flow — that's `opt-execution`.
+
+    **Do NOT embed dataset-specific cases into the skill.** Skills must encode generalizable rules (decision tables, classification taxonomies, process steps) — never facts about specific inputs, libraries, or CVEs from the training data. That is memorization, not domain knowledge.
+    ---
+
+    ## Approaches
+
+    ### Approach 1: Edit the Skill File
+
+    **When**: The gap is in the shared domain skill — a wrong classification rule, missing taxonomy entry, or incomplete decision table. Fixing it propagates to all methods that load the skill.
+
+    **Optimization type**: `edit_skill`
+
+    **How**: Open the agent's skill module and add or correct the rule. Be specific — vague rules get ignored. Include concrete examples with correct outcomes. Consult the framework skill to find the correct skill location and format for the target framework.
+
+    **Code example** — adding a missing patch location rule that caused systematic wrong-layer fixes:
+
+    ```markdown
+    ## Patch Location Policy (MANDATORY)
+
+    When the bug is in a utility called by multiple callers, patch the utility — not the callers:
+
+    | Bug location | Wrong fix | Correct fix |
+    |---|---|---|
+    | `utils/parser.py` raises ValueError | Add try/except in every caller | Fix the parser to not raise |
+    | `db/connection.py` leaks connections | Close connection at each call site | Fix connection lifecycle in `db/connection.py` |
+    | `auth/token.py` returns wrong expiry | Adjust expiry at each consumer | Fix expiry logic in `auth/token.py` |
+
+    Patching callers instead of the source is a **layering violation** — it leaves the bug in place and masks it.
+    ```
+
+    **Code example** — adding a missing issue type for flaky tests:
+
+    ```markdown
+    ## Issue Classification
+
+    Issues fall into one of four types. Classification determines where to look for the bug:
+
+    | Type | Signal in issue text | Where to look |
+    |---|---|---|
+    | `regression` | "used to work", "worked in v<X>" | git log for the breaking commit |
+    | `flaky_test` | "fails intermittently", "CI sometimes" | test isolation, shared state, timing |
+    | `wrong_output` | "returns X but should return Y" | logic in the computation path |
+    | `crash` | "raises", "exception", "traceback" | the stack trace entry points |
+
+    Do not apply `wrong_output` debugging strategy to `flaky_test` issues — they require different tools.
+    ```
+
+    ---
+
+    ### Approach 2: Add a New Skill File
+
+    **When**: The agent lacks an entire knowledge domain that needs its own versioned skill — too large or orthogonal for a section in an existing skill.
+
+    **Optimization type**: `add_skill`
+
+    **How**: Create a new skill module with a focused scope, then wire it into the agent using the framework's skill attachment mechanism.
+
+    **Example skill content** (framework-neutral markdown):
+
+    ```markdown
+    # Test Framework Identification
+
+    Repos use different test runners. Running with the wrong command silently passes when tests aren't discovered.
+
+    ## Detection
+
+    1. Check `pyproject.toml` or `setup.cfg` for `[tool.pytest]`, `[tool.unittest]`, or `testpaths`
+    2. Check for `pytest.ini` or `tox.ini`
+    3. Presence of `conftest.py` → pytest
+    4. Presence of `unittest.TestCase` subclasses with no pytest config → unittest
+    ```
+
+    **Wiring the skill** — the mechanism depends on the framework. Read the framework skill before wiring to find the correct attachment pattern.
+
+    **Example** (consult the framework skill for the correct location and API):
+    ```python
+    self.test_framework = TextSkill(path="skills/test-framework")
+    ```
+
+    ---
+
+    ### Approach 3: Add a Rules Section to the Method Docstring
+
+    **When**: The knowledge gap is specific to one method's decision logic and is too narrow for the shared skill. The rule is about how *this method* should interpret its inputs.
+
+    **Optimization type**: `edit_method`
+
+    **How**: Add a named "Rules" or "Policy" section to the method's prompt. Keep it targeted — if the rule applies broadly, use `edit_skill` instead.
+
+    **Code example** — adding a test-only change policy to the patch classification method:
+
+    ```python
+    async def _classify_patch(self, patch: Patch, issue: str) -> PatchResult:
+        '''Classify whether the patch correctly addresses the issue.
+
+        ## Test-Only Change Policy
+        A patch that only modifies test files (paths matching `test_*.py`, `*_test.py`,
+        or files under `tests/`) does NOT fix the underlying bug.
+        Classify as `incomplete` if no production source file was changed.
+
+        Apply this rule when:
+        - All changed files are under test directories
+        - No module outside `tests/` was modified
+
+        Do NOT apply when the issue explicitly asks to add a missing test — in that case,
+        a test-only patch is correct.
+        '''
+        ...
+    ```
+
+    ---
+
+    ### Approach 4: Remove a Confusing Skill
+
+    **When**: A skill file contradicts method prompts, introduces rules the agent misapplies, or adds noise that dilutes more important rules. Traces show the agent citing skill rules incorrectly or applying them to wrong contexts.
+
+    **Optimization type**: `remove_skill`
+
+    **How**: Detach the skill from the agent and un-wire it from the agent. If some rules are still needed, migrate them into the relevant method prompt where they'll have narrower scope before detaching.
+
+    **Example** — the diagnostic and the detachment:
+
+    ```
+    # The skill says: "Always classify network-reachable code as HIGH severity"
+    # But the method prompt says: "Classify based on actual exploit path,
+    # not reachability alone" — the agent oscillates between the two rules.
+    # Fix: keep the method-level rule (more nuanced) and detach the skill.
+    ```
+
+    Remove the skill attachment from the agent's initialisation (the exact API depends on the framework — consult the framework skill) and delete or move the skill file so it cannot be re-loaded through a future scan or import.
+
+    **Example** — removing a skill attachment (consult the framework skill for the correct API and file location):
+    ```python
+    # Remove the skill attribute from __init__ and delete the skill files
+    # self.confusing_skill = TextSkill(path="skills/confusing-skill")  ← delete this line
+    ```
+
+    **When to remove vs. edit**: If the skill has a mix of correct and incorrect rules, prefer `edit_skill` to fix the bad rules. Remove only when the entire skill is a net negative — confusing more than helping.
+
+    ---
+
+    ## Success Criteria
+
+    A good domain knowledge fix:
+    - Adds a **concrete, verifiable rule** — not a vague instruction like "be more careful"
+    - Includes an example of correct vs. incorrect application
+    - The failure pattern does not reappear on held-out tasks after the fix
+    - Does not contradict existing rules in the skill — check for conflicts before adding
+    - For `add_skill` / `remove_skill`: the attachment step actually ran. After the change, the skill is reachable by the agent at runtime (loaded, injected, or otherwise accessible) — a skill file on disk that nothing loads or imports is not a fix.
+    """
+
+
+class OptimizeModelCapability(Skill):
+    """Use when prompt, code, and architecture improvements have plateaued, or the agent has correct instructions and architecture but is unable to follow them — the current model is too weak for complex tasks, too expensive for simple steps, or config limits (iterations, timeouts) cut the agent off mid-task. Covers edit_llm, add_llm, remove_llm, edit_config.
+
+    # Optimization Card: Tuning
+
+    ## When to Use
+
+    Use this card **only after prompt, code, and architecture improvements have plateaued**:
+
+    - Agent has correct prompts and architecture but fails on complex reasoning that a stronger model would handle
+    - Agent has correct instructions and architecture but is unable to follow them reliably
+    - Agent uses an expensive model for a simple filtering step where a cheaper model would suffice
+    - Agent hits iteration limits or timeouts — traces show it was cut off mid-task
+    - Multiple LLMs exist but one is unused or consistently inferior
+
+    **Key diagnostic**: The trace shows correct architecture, prompts, and instructions. The agent understands what it should do but cannot follow through reliably; the failure is about model capability (too weak for the task) or execution limits (ran out of time/iterations).
+
+    ## When NOT to Use
+
+    - Agent has wrong reasoning logic → use `opt-reasoning`
+    - Agent skips operations → use `opt-execution`
+    - Agent lacks domain rules → use `opt-domain-knowledge`
+    - Agent's structure is the bottleneck → use `opt-architecture`
+
+    ---
+
+    ## Approaches
+
+    ### Approach 1: Swap the Model on an Existing LLM
+
+    **When**: The agent's current model is too weak for complex reasoning tasks, or too expensive for simple tasks. Try ONLY after prompt/code improvements plateau.
+
+    **Optimization type**: `edit_llm`
+
+    **How**: Change the model identifier on an existing LLM attribute. Always use models from the curated model catalog — never invent model IDs. Test on the same tasks to verify the swap helps.
+
+    #### Available Models
+
+    Use the `model_id` field with `get_llm_client()`.
+    Candidate agents should use only model IDs listed in `assets/models.yaml`;
+    do not invent provider/model IDs outside that catalog.
+
+    To inspect the catalog from the optimizer Coder, run:
+
+    ```python
+    catalog = self.optimize.optimize_model_capability.read_model_catalog()
+    models = catalog.models
+    ```
+
+    The YAML contains one entry per underlying model with `model_id`, `provider`,
+    `range`, and `notes`. The catalog defines `default_endpoint` and
+    `default_api_key_env`; model entries may define `endpoint` and `api_key_env`
+    overrides, and if they omit either field, use the corresponding catalog
+    default. Duplicate provider route aliases are intentionally omitted so tuning
+    choices are not split across equivalent IDs. If editing an LLM model id, also
+    call `available_model_ids = await self.list_available_models()` first and
+    choose a catalog model that is currently available.
+
+    > **Tip**: The full live catalog can be queried at runtime — `requests.get("https://inference-api.nvidia.com/v1/models", headers={"Authorization": f"Bearer {key}"})`. `assets/models.yaml` is a curated subset.
+
+    **Code example** — upgrading from a fast model to a stronger one for classification:
+
+    ```python
+    from nooa.unifiedllm import get_llm_client
+
+    class SWEAgent(Agent):
+        # Before — a small model struggles with nuanced classification
+        classifier_llm = get_llm_client("azure/openai/gpt-5-mini")
+
+        # After — a stronger open-weight model handles the edge cases
+        classifier_llm = get_llm_client("azure/openai/gpt-5.5")
+    ```
+
+    **When NOT to swap**: If the agent fails on simple, unambiguous tasks — the model isn't the problem. If accuracy is already high on train but low on validation — the model is fine, the prompt is overfitting.
+
+    ---
+
+    ### Approach 2: Add a Second LLM
+
+    **When**: A sub-task needs a different model — either because it needs stronger reasoning, or because a cheaper/faster model suffices and the expensive one is wasted. This can be done **per-method** (same agent, different LLM for one method) or **via a subagent** (separate context).
+
+    **Optimization type**: `add_llm`
+
+    #### Option A: Per-Method LLM Override
+
+    **When**: The method shares the parent agent's context but needs a different model. No context isolation needed.
+
+    **How**: Assign a dedicated LLM to a specific method using the `llm=` parameter on the method decorator or attribute.
+
+    **Code example** — a cheap model for a simple filtering method, strong model for everything else:
+
+    ```python
+    from nooa.unifiedllm import get_llm_client
+
+    fast_llm = get_llm_client("azure/openai/gpt-5-mini")
+
+    class SWEAgent(Agent):
+        '''Main agent uses the default strong model. _quick_filter uses a fast model.'''
+
+        async def _quick_filter(self, candidates: list[dict], llm=fast_llm) -> list[dict]:
+            '''Discard obviously irrelevant candidates. Speed matters more than depth.'''
+            ...
+
+        async def _deep_classify(self, candidate: dict) -> dict:
+            '''Deep classification — uses the agent's default (strong) model.'''
+            ...
+
+        async def run(self, candidates: list[dict]) -> list[dict]:
+            filtered = await self._quick_filter(candidates)
+            return [await self._deep_classify(c) for c in filtered]
+    ```
+
+    #### Option B: Dedicated Subagent
+
+    **When**: The sub-task needs both a different model AND its own context — the subagent sees only what you pass it, not the parent's full history.
+
+    **How**: Create a separate agent class with its own LLM. The parent delegates to it.
+
+    **Code example** — a fast filter subagent with separate context, strong main agent for final classification:
+
+    ```python
+    from nooa.unifiedllm import get_llm_client
+
+    fast_llm = get_llm_client("azure/openai/gpt-5-mini")
+
+    class FilterAgent(Agent, llm=fast_llm):
+        '''Quick pre-filter for candidates. Sees only the candidate batch, not the full analysis context.'''
+
+        async def filter(self, candidates: list[dict]) -> list[dict]:
+            '''Discard obviously irrelevant candidates. Speed matters more than depth.'''
+            ...
+
+    class SWEAgent(Agent):
+        '''Main agent — strong model for deep classification.'''
+
+        def __init__(self):
+            super().__init__()
+            self.filter_agent = FilterAgent()
+
+        async def run(self, candidates: list[dict]) -> list[dict]:
+            filtered = await self.filter_agent.filter(candidates)
+            return [await self._classify(c) for c in filtered]
+
+        async def _classify(self, candidate: dict) -> dict:
+            '''Deep classification of a single candidate.'''
+            ...
+    ```
+
+    **When to use per-method vs. subagent**: Per-method is simpler — use it when the method just needs a different model. Use a subagent when you also need context isolation (the sub-task shouldn't see the parent's full conversation).
+
+    ---
+
+    ### Approach 3: Remove a Redundant LLM
+
+    **When**: Multiple LLMs exist but one is unused, or two methods share the same model and there's no reason to keep them separate.
+
+    **Optimization type**: `remove_llm`
+
+    **How**: Consolidate to a single LLM. Remove the extra attribute and update any methods that referenced it.
+
+    **Code example** — consolidating after a filtering step was removed:
+
+    ```python
+    from nooa.unifiedllm import get_llm_client
+
+    # Before: filter_llm was added for _filter_candidates, but that method was merged into _classify
+    class SWEAgent(Agent):
+        filter_llm = get_llm_client("azure/openai/gpt-5-mini")  # orphaned — no method uses it
+
+    # After: remove the unused LLM
+    class SWEAgent(Agent):
+        # Only the agent-level default LLM remains
+        ...
+    ```
+
+    **When to remove**: If traces show both LLMs produce equivalent results, or the cheaper model was added for a step that was later merged or removed.
+
+    ---
+
+    ### Approach 4: Tune Config Attributes
+
+    **When**: The agent hits execution limits — traces show it was cut off mid-task, or it completes but with too few iterations to reason properly.
+
+    **Optimization type**: `edit_config`
+
+    **How**: Adjust `max_iterations`, timeouts, or similar execution bounds. Only when traces confirm the agent is cut off mid-task, not when it's reasoning poorly within the allotted steps.
+
+    **Code example** — increasing iteration limit because traces show the agent running out mid-analysis:
+
+    ```python
+    class SWEAgent(Agent):
+        # Before — agent consistently hits 30-iteration cap during complex tasks
+        config = {"max_iterations": 30}
+
+        # After — enough headroom for multi-step analysis
+        config = {"max_iterations": 60}
+    ```
+
+    **Warning signs this is the WRONG fix**:
+    - Agent completes well within the limit but produces wrong output → reasoning/knowledge problem
+    - Agent uses many iterations but most are wasted on retries → fix the retry logic instead
+    - Increasing the limit doesn't change the outcome → the limit wasn't the bottleneck
+
+    ---
+
+    ## Success Criteria
+
+    A good tuning fix:
+    - Only applied AFTER prompt/code/architecture improvements plateau
+    - Model swap produces measurable accuracy gain on previously-failing tasks
+    - Config change allows the agent to complete tasks it was previously cut off on
+    - Does not increase cost/latency without measurable accuracy benefit
+    - Cheaper model substitutions maintain accuracy while reducing cost
+    """
+
+    def __init__(self, model_catalog_path: Path | None = None, **kwargs: Any):
+        """Initialize the card with an optional model catalog override."""
+        super().__init__(**kwargs)
+        self._model_catalog_path = model_catalog_path
+
+    def read_model_catalog(self) -> ModelCatalog:
+        """Return the validated model catalog from ``assets/models.yaml``.
+
+        Returns:
+            ModelCatalog: the parsed and validated catalog of available models.
+
+        Raises:
+            FileNotFoundError: if ``assets/models.yaml`` does not exist.
+            ValidationError: if the YAML does not conform to the ModelCatalog schema.
+
+        """
+        if self._model_catalog_path is not None:
+            raw_catalog = self._model_catalog_path.read_text()
+        else:
+            catalog_ref = resources.files("nemo_experimentalist_plugin").joinpath("assets/models.yaml")
+            try:
+                raw_catalog = catalog_ref.read_text()
+            except FileNotFoundError:
+                catalog_path = Path(__file__).resolve().parents[2] / "assets" / "models.yaml"
+                raw_catalog = catalog_path.read_text()
+        return ModelCatalog.model_validate(yaml.safe_load(raw_catalog))
+
+
+class Fix(Skill):
+    """Use when the agent crashes or produces degraded output due to a mechanical defect — truncation errors, wrong config limits, missing imports, broken paths, or unhandled exceptions. Not a reasoning or strategy problem; the code itself is broken. Covers edit_config, edit_concrete_method.
+
+    # Optimization Card: Fix
+
+    ## When to Use
+
+    The agent crashes or produces degraded output due to a **mechanical defect** — not
+    a reasoning or strategy problem. The code is broken in a way any developer would fix
+    on sight:
+
+    - Truncation or size limit exceeded (prompt too large for configured limit)
+    - Wrong config parameters on a method or class (limits, timeouts, retries)
+    - Missing or incorrect decorator parameters
+    - `sys.exit()` on a recoverable error instead of graceful degradation
+    - Output written to wrong path or wrong format
+    - Missing error handling around external service calls
+    - Import errors, typos in method names, wrong variable references
+
+    **Key diagnostic**: The trace shows an exception, an error message, or
+    output that is structurally wrong (wrong path, wrong schema). The agent's reasoning
+    logic is irrelevant — the code itself is broken.
+
+    ## When NOT to Use
+
+    - Agent reasons incorrectly → use `opt-reasoning`
+    - Agent skips operations → use `opt-execution`
+    - Agent lacks domain rules → use `opt-domain-knowledge`
+    - Agent's structure is the bottleneck → use `opt-architecture`
+    - Model too weak for the task → use `opt-model-capability`
+
+    ---
+
+    ## Approaches
+
+    ### Approach 1: Fix Config Limits
+
+    **When**: Agent crashes with truncation or size limit errors. The input is within
+    the model's context window but exceeds a framework-imposed config limit.
+
+    **Optimization type**: `edit_config`
+
+    **How**: Raise the relevant limit on the class or method. Read the error message —
+    it tells you the parameter name and current value. Common limits:
+    - Per-block character limit (truncates input before the LLM sees it)
+    - Per-parameter character limit (rejects large method arguments)
+    - Iteration limits (cuts off the agent mid-task)
+    - Timeout limits
+
+    **When NOT to fix config**: If the input is genuinely too large for the model's context
+    window — truncate or summarize the data instead of raising the limit.
+
+    ---
+
+    ### Approach 2: Fix Error Handling
+
+    **When**: Agent calls `sys.exit()`, raises unhandled exceptions, or silently drops
+    data on recoverable errors.
+
+    **Optimization type**: `edit_concrete_method`
+
+    **Code example** — replacing fatal exit with graceful fallback:
+
+    ```python
+    # Before — crashes when scraping fails
+    if not sources:
+        sys.exit(1)
+
+    # After — falls back to search snippets
+    if not scraped_sources:
+        sources = [{"content": r["snippet"], ...} for r in search_results if r.get("snippet")]
+    ```
+
+    ---
+
+    ### Approach 3: Fix Output Path/Schema
+
+    **When**: Agent writes output to the wrong location or in the wrong format.
+    The verifier expects a specific path and schema.
+
+    **Optimization type**: `edit_concrete_method`
+
+    **How**: Inspect the dataset file list and verifier files to find the
+    expected path, schema, service state, or side effect, then fix the agent's
+    output/finalization code to match.
+
+    ---
+
+    ## Success Criteria
+
+    A good fix:
+    - Eliminates the crash or error — the agent completes the task
+    - Is mechanical — doesn't change reasoning strategy
+    - Addresses the root cause, not a symptom (e.g., raise the limit vs. suppress the error)
+    - Can be verified by re-running the same task that triggered the failure
+    """
+
+
+class Optimize(Skill):
+    """Top-level optimization skill — progressive disclosure index. Start here when proposing improvements. Routes to the specific optimization card based on the root cause diagnosis.
+
+    # Optimization Skill Index
+
+    ## Core concepts
+
+    An agent is a graph of components. Each component is a lever — identifying which one is the
+    bottleneck determines which optimization to apply:
+
+    | Component | What it is | What can go wrong | Cards that target it |
+    | --------- | ---------- | ----------------- | -------------------- |
+    | **Method prompt** | The instruction that shapes what a stochastic method does | Wrong reasoning, missing rules, conflated responsibilities | `optimize_reasoning`, `optimize_domain_knowledge` |
+    | **Method** | A deterministic callable at agent disposal | Agent skips it, brittle heuristics fail | `optimize_execution`, `fix` |
+    | **Stochastic method** | A callable implemented by the LLM at runtime | Wrong conclusion, lost context, mixed concerns | `optimize_reasoning`, `optimize_domain_knowledge` |
+    | **Subagent** | Another agent the component delegates work to | Unnecessary latency, context overflow, wrong decomposition | `optimize_architecture` |
+    | **Model config** | Which LLM and with what parameters | Model too weak/expensive, context or rate limits hit | `optimize_capability`, `fix` |
+    | **Skills** | Domain knowledge and methods the agent can draw on | Missing rules, outdated knowledge, wrong scope | `optimize_domain_knowledge` |
+
+    Based on the framework of choice, the components look different.
+    Some popular frameworks example:
+
+    **NeMo OO Agents**
+
+    ```python
+    from nooa import Agent, TextSkill
+    from nooa.unifiedllm import get_llm_client
+
+    llm = get_llm_client("aws/anthropic/claude-haiku-4-5-v1")  # model config
+
+    class ResearchAgent(Agent, llm=llm):
+        '''You are a research assistant.'''  # system prompt
+
+        def __init__(self):
+            super().__init__()
+            self.rules = TextSkill(path=".claude/skills/domain-rules")  # skill
+
+        async def search(self, query: str) -> list[str]:      # deterministic method
+            return http_search(query)
+
+        async def summarize(self, hits: list[str]) -> str:    # stochastic method (LLM)
+            '''Summarize the search hits into a concise paragraph.''' # method prompt
+            ...
+
+        async def run(self, question: str) -> str:            # stochastic method (LLM)
+            '''Answer the question by searching and summarizing.''' # method prompt
+            ...
+    ```
+
+    **LangGraph / LangChain**
+
+    ```python
+    from langgraph.graph import StateGraph, START, END
+    from langchain_core.tools import tool
+    from langchain_openai import ChatOpenAI
+
+    model = ChatOpenAI(model="gpt-4o", temperature=0)    # model config
+
+    @tool
+    def search(query: str) -> list[str]:                  # deterministic method
+        return http_search(query)
+
+    def call_model(state):                                # stochastic method (LLM node)
+        prompt = "You are a research assistant. Answer questions precisely."  # method prompt
+        messages = [{"role": "system", "content": prompt}] + list(state["messages"])
+        return {"messages": [model.bind_tools([search]).invoke(messages)]}
+
+    graph = StateGraph(State)
+    graph.add_node("agent", call_model)
+    graph.add_edge(START, "agent")
+    ```
+
+    **Deep Agents (LangChain)**
+
+    ```python
+    from langchain_nvidia_ai_endpoints import create_deep_agent
+    from langchain_core.tools import tool
+    from langchain_openai import ChatOpenAI
+
+    summarize_llm = ChatOpenAI(model="gpt-4o-mini")       # model config (per-tool)
+
+    @tool
+    def search(query: str) -> list[str]:                  # deterministic method
+        return http_search(query)
+
+    @tool
+    def summarize(hits: list[str]) -> str:                # stochastic method (LLM)
+        prompt = "Summarize the search hits into a concise paragraph."  # method prompt
+        return summarize_llm.invoke([
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": str(hits)},
+        ]).content
+
+    agent = create_deep_agent(
+        model="anthropic:claude-sonnet-4-5",              # model config
+        tools=[search, summarize],                        # methods
+        system_prompt="Answer questions precisely.",      # system prompt
+        skills=["domain-rules"],                          # skills
+    )
+    ```
+
+    Understand how each framework defines the components and the relationships between them.
+
+    ---
+
+    When proposing an improvement, **diagnose the root cause first**, then load the matching card.
+
+    ## Decision Tree
+
+    Each numbered entry names a card available as an attribute on this skill —
+    load the card for the detailed approach.
+
+    0. **Does the agent crash?**
+       → Card `fix` — fix the mechanical defect: raise a config limit, fix a path, add error handling.
+       Covers: `edit_config`, `edit_concrete_method`
+
+    1. **Does the agent skip or inconsistently perform a deterministic operation?**
+       → Card `optimize_execution` — move the call into Python so the LLM can't skip it.
+       Covers: `add_concrete_method`, `remove_concrete_method`, `add_tool`, `remove_tool`, `edit_concrete_method`, `make_method_concrete`
+
+    2. **Does the agent have the right data but draw the wrong conclusion, conflate concepts, or produce unstructured output that callers cannot parse?**
+       → Card `optimize_reasoning` — make implicit reasoning steps explicit, fix untyped output contracts, split overloaded methods, convert brittle concrete logic to LLM reasoning.
+       Covers: `edit_method` (steps/logic, output signature), `add_method`, `remove_method`, `split_method`, `make_method_abstract`
+
+    3. **Does the agent reason correctly but from a wrong or missing domain rule?**
+       → Card `optimize_domain_knowledge` — fix the skill module or add domain rules to the method's prompt.
+       Covers: `edit_skill`, `add_skill`, `remove_skill`, `edit_method` (rules section)
+
+    4. **Is the agent's structure the bottleneck — context overflow, separable concerns in one method?**
+       → Card `optimize_architecture` — restructure methods, add/remove subagents, merge redundant steps.
+       Covers: `add_subagent`, `remove_subagent`, `split_method`, `merge_method`
+
+    5. **Has tuning plateaued — is the model too weak, too expensive, or are config limits too restrictive?**
+       → Card `optimize_model_capability` — swap models, add/remove LLMs, adjust config limits.
+       Covers: `edit_llm`, `add_llm`, `remove_llm`, `edit_config`
+
+    ## Quick Reference
+
+    | Symptom | Card | Key Diagnostic |
+    |---------|------|----------------|
+    | Crash, truncation error, framework limit | `fix` | Exception or error message in trace, agent never completes |
+    | Skips operations despite instructions | `optimize_execution` | Same instruction added multiple rounds without effect |
+    | LLM does purely mechanical work (parsing, filtering) | `optimize_execution` | Method output is fully determined by input, no judgment needed |
+    | Right data, wrong conclusion | `optimize_reasoning` | Trace shows correct retrieval, flawed inference |
+    | Untyped method output, callers can't parse | `optimize_reasoning` | Method returns `str`; downstream nodes receive inconsistent blobs |
+    | Hardcoded logic fails on novel inputs | `optimize_reasoning` | Concrete method uses brittle heuristics that need judgment |
+    | Coherent reasoning from wrong premise | `optimize_domain_knowledge` | Reasoning chain is logical but starts from wrong rule |
+    | Inconsistent errors across same inputs | `optimize_architecture` | Context/structure problem, not knowledge |
+    | Correct prompts but model too weak, too expensive, or limits hit | `optimize_model_capability` | Prompt/code/architecture improvements plateaued; traces show capability or config limit gap |
+
+    ## Usage
+
+    Pick the matching card from the decision tree above, then read the card
+    via `doc(card)` for detailed approaches, code examples, and success criteria.
+    """
+
+    def __init__(self, model_catalog_path: Path | None = None, **kwargs: Any):
+        """Initialize the Optimize skill and register all sub-skill cards."""
+        super().__init__(**kwargs)
+        self.fix = Fix()
+        self.optimize_architecture = OptimizeArchitecture()
+        self.optimize_reasoning = OptimizeReasoning()
+        self.optimize_execution = OptimizeExecution()
+        self.optimize_domain_knowledge = OptimizeDomainKnowledge()
+        self.optimize_model_capability = OptimizeModelCapability(model_catalog_path=model_catalog_path)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/coder.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/coder.py
@@ -1,0 +1,1107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast  # noqa: D100, F401
+import json
+import os  # noqa: F401
+import random
+import re  # noqa: F401
+import shutil
+from collections import Counter, defaultdict  # noqa: F401
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import httpx
+from nemo_experimentalist_plugin.entities import Candidate
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc, spec
+from nooa.agents import TokenBudgetSummarizer
+from nooa.config import CodeActConfig
+from nooa.config.summarizer_config import TokenBudgetConfig
+from nooa.skill import Skill
+from nooa.skill_registry import SkillRegistry
+from nooa.tools import Match, TodoManager
+from pydantic import BaseModel, Field
+
+from .cards import Optimize
+from .evaluator import Dataset, EvaluationResult, Evaluator, EvaluatorConfig, Task, TrialResult
+from .model_config import get_fast_model, get_mid_model, get_smart_model
+from .tools import GuardedShellTools
+from .util import load_framework_skills
+
+
+class CoderConfig(BaseModel):
+    """Store tuning parameters for Coder optimization."""
+
+    max_summary_tokens: int = Field(
+        default=80_000,
+        description="Max tokens the token-budget summarizer may use.",
+    )
+    max_fix_attempts: int = Field(
+        default=2,
+        description="Max LLM repair iterations inside integration_check before giving up on a candidate.",
+    )
+    timeout_model_list_secs: float = Field(
+        default=10.0,
+        description="HTTP timeout in seconds when fetching the list of available LLM models.",
+    )
+    model_catalog_path: Path | None = Field(
+        default=None,
+        description="Optional YAML model catalog path overriding the packaged assets/models.yaml.",
+    )
+
+
+class IntegrationCheckFailed(RuntimeError):
+    """Signal that a candidate cannot pass the integration check within the allotted repair budget."""
+
+
+class ArchitectureSkill(Skill):
+    """Guide to writing architecture documentation for an agent.
+
+    An architecture documentation file is a human- and LLM-readable snapshot of an agent's diagram,
+    written as a mermaid class diagram. The optimizer reads it to understand what can be changed and
+    proposes improvements targeting specific degrees of freedom.
+
+    ---
+
+    ## Core concepts
+
+    An agent is a graph of components. Regardless of framework, every agent has:
+
+    | Concept | What it is |
+    | ------- | ---------- |
+    | **Prompt** | The string, template, or policy object that shapes what the LLM is asked |
+    | **Method** | A callable the agent invokes to interact with the world (search, SQL, API, bash, files, etc.). A tool at agent disposal. |
+    | **Stochastic Method** | A callable the agent invokes to interact with the world using a LLM (e.g. a tool that uses a LLM). A tool at agent disposal. |
+    | **Subagent** | Another agent/executor instance the component delegates work to (e.g. a planner agent) |
+    | **Model config** | Which LLM model and with what parameters (temperature, max_tokens, etc.) |
+    | **Skills** | A collection of methods and knowledge that the agent can use to interact with the world |
+    | **Association arrows** | The arrows that connect the components in the diagram |
+
+
+    Based on the framework of choice, the components look different.
+    Some popular frameworks example:
+
+    **NeMo OO Agents**
+
+    ```python
+    from nooa import Agent, TextSkill
+    from nooa.unifiedllm import get_llm_client
+
+    llm = get_llm_client("aws/anthropic/claude-haiku-4-5-v1")  # model config
+
+    class ResearchAgent(Agent, llm=llm):
+        '''You are a research assistant.'''  # system prompt
+
+        def __init__(self):
+            super().__init__()
+            self.rules = TextSkill(path=".claude/skills/domain-rules")  # skill
+
+        async def search(self, query: str) -> list[str]:      # deterministic method
+            return http_search(query)
+
+        async def summarize(self, hits: list[str]) -> str:    # stochastic method (LLM)
+            '''Summarize the search hits into a concise paragraph.'''  # method prompt
+            ...
+
+        async def run(self, question: str) -> str:            # stochastic method (LLM)
+            '''Answer the question by searching and summarizing.'''  # method prompt
+            ...
+    ```
+
+    **LangGraph / LangChain**
+
+    ```python
+    from langgraph.graph import StateGraph, START, END
+    from langchain_core.tools import tool
+    from langchain_openai import ChatOpenAI
+
+    model = ChatOpenAI(model="gpt-4o", temperature=0)    # model config
+
+    @tool
+    def search(query: str) -> list[str]:                  # deterministic method
+        return http_search(query)
+
+    def call_model(state):                                # stochastic method (LLM node)
+        prompt = "You are a research assistant. Answer questions precisely."  # method prompt
+        messages = [{"role": "system", "content": prompt}] + list(state["messages"])
+        return {"messages": [model.bind_tools([search]).invoke(messages)]}
+
+    graph = StateGraph(State)
+    graph.add_node("agent", call_model)
+    graph.add_edge(START, "agent")
+    ```
+
+    **Deep Agents (LangChain)**
+
+    ```python
+    from langchain_nvidia_ai_endpoints import create_deep_agent
+    from langchain_core.tools import tool
+    from langchain_openai import ChatOpenAI
+
+    summarize_llm = ChatOpenAI(model="gpt-4o-mini")       # model config (per-tool)
+
+    @tool
+    def search(query: str) -> list[str]:                  # deterministic method
+        return http_search(query)
+
+    @tool
+    def summarize(hits: list[str]) -> str:                # stochastic method (LLM)
+        prompt = "Summarize the search hits into a concise paragraph."  # method prompt
+        return summarize_llm.invoke([
+            {"role": "system", "content": prompt},
+            {"role": "user", "content": str(hits)},
+        ]).content
+
+    agent = create_deep_agent(
+        model="anthropic:claude-sonnet-4-5",              # model config
+        tools=[search, summarize],                        # methods
+        system_prompt="Answer questions precisely.",      # system prompt
+        skills=["domain-rules"],                          # skills
+    )
+    ```
+
+    Understand how each framework defines the components and the relationships between them.
+
+    ---
+
+    ## Scope — what to include and what to exclude
+
+    The diagram must contain ONLY components the optimizer can improve. Include and exclude strictly:
+
+    **Include:**
+    - All components listed above (agents, subagents, methods, tools, skills, prompts, etc.)
+    - Default configuration (models being used, tool configurations, etc.)
+
+
+    **Exclude — do not diagram these:**
+    - Any infrastructure code (e.g. web framework, database, logging, monitoring, feature-flag plumbing, etc.) around the agent.
+    - Non default configuration (e.g. tool configurations, model configurations, etc.)
+    - Anything that's not strictly called by the agent (e.g. code that is not part of the agent's logic, such as setup code, testing code, etc.)
+    - Legacy paths or non default paths that are not exercised in the current evaluation
+
+    **Default path tracing:** When the entrypoint dispatches based on a feature flag or if/else,
+    follow only the actively exercised branch based on the entrypoint. Check for flags, env variables and default runner.
+
+    When in doubt: if the optimizer changing this component would not affect agent behavior on the task, exclude it.
+
+    ---
+
+    ## Format
+
+    `architecture.md` has two sections: a **Mermaid flowchart** and a **prompts** appendix.
+
+    ### Section 1 — Mermaid flowchart
+
+    > **Mental model, not a code transcript.** The diagram is a friendly visualization of agent
+    > topology — it is meant to be readable by humans and useful to the optimizer, not a one-to-one
+    > copy of implementation details. For example, a dict of tool callables
+    > (`self.TOOLS = {'search': search_fn}`) may be shown as individual method nodes because that
+    > conveys the logical structure more clearly. What matters is capturing *what the agent can do
+    > and how components relate*, not mirroring every syntactic choice in the source.
+    > It is meant to be an execution overview of the agent, not a detailed code transcript.
+
+    A mermaid `flowchart TD`. Every node is one of four types:
+
+    **Node shapes:**
+
+    Use `<br/>` for line breaks inside node labels — `\n` is not valid Mermaid syntax.
+
+    | Node type | Mermaid syntax | When to use |
+    | --------- | -------------- | ----------- |
+    | Agent | `id{{"Name<br/>model: model-id<br/>system: <truncated><br/>skills: s1 · s2"}}` | The agent itself — hexagon. Omit `skills:` line if none. |
+    | Method | `id["name<br/>in:  arg: Type<br/>out: ReturnType"]` | Deterministic callable with real logic (dispatch, transform, branch) — no LLM involved. Rectangle. Pure `await`-sequence methods are invisible — see rule below. |
+    | Stochastic method | `id(["name*<br/>in:  arg: Type<br/>out: ReturnType<br/>prompt: <truncated>"])` | LLM-driven callable. Stadium shape. Append `<br/>model: override` only when the method overrides the agent's default model. |
+    | Subagent | `subgraph AgentName["AgentName · model: model-id · system: <truncated>"]` ... `end` | Delegates work to another agent. Use a Mermaid subgraph containing the subagent's method nodes. |
+
+    Truncate long strings to ~60 chars with `...` — the prompts appendix holds verbatim content.
+
+    **Arrow types:**
+
+    | Arrow | Meaning |
+    | ----- | ------- |
+    | `A --> B` | Forced path: A always invokes B — enforced by code (explicit `await self.B()`, `graph.add_edge`, etc.) |
+    | `A -.-> B` | Optional path: A may invoke B — the LLM decides at runtime |
+
+    **Critical rule:** prompt-instructed sequences are dashed, not solid. A stochastic method's
+    prompt may say "always call X then Y" but the LLM may still deviate — only Python code or
+    graph edges that unconditionally invoke a method justify a solid arrow.
+
+    **Sequence vs fan-out:** When an orchestrator method calls A then B then C in code, draw a
+    chain `run --> A --> B --> C`, not a fan-out `run --> A`, `run --> B`, `run --> C`. The arrow
+    shows execution sequence, not just who owns whom.
+
+    **Tool access:** If a method (class or other callable) is accessible from a stochastic method, draw a dashed arrow FROM
+    that method TO the method. A method (class or other callable) is accessible if it is reachable from that method at runtime
+    — e.g. `self.shell`, a module-level instance, or a closure variable. Accessibility, not call
+    frequency, determines the arrow.
+
+    **Invisible sequencers:** If a method's body consists entirely of `await` calls to other
+    methods in sequence, omit it from the diagram. The diagram IS the graph that method builds.
+    The agent hexagon connects directly to the first step in the chain.
+
+    **Labeled solid arrows:** Label every solid arrow with the data flowing between steps:
+    `A -->|param: Type| B`. If one step's output flows to multiple downstream steps, draw a
+    labeled arrow for each downstream node. Dashed arrows are not labeled — LLM-decided data
+    flow is not deterministic.
+
+    **Mermaid edge label quoting:** If a label contains `[`, `]`, `<`, or `>`, wrap the entire
+    label in double quotes: `A -->|"list[T]"| B`. Plain `|param: Type|` is fine when no special
+    characters are present.
+
+    Node labels use `<br/>` for line breaks. Each node type has a fixed field order:
+
+    **Agent / Subagent fields** (include only fields that apply):
+    ```
+    AgentName
+    model: <model-id>
+    system: <first ~60 chars of system prompt>...
+    skills: skill1 · skill2
+    ```
+
+    **Method fields** (deterministic — no LLM, rectangle `[...]`):
+    ```
+    method_name
+    in:  param1: Type, param2: Type
+    out: ReturnType
+    ```
+
+    **Stochastic method fields** (LLM-driven, stadium `([...])`, always ends with `*`):
+    ```
+    method_name*
+    in:  param1: Type, param2: Type
+    out: ReturnType
+    prompt: <first ~60 chars>...
+    model: <override-id>       ← only when different from agent default
+    temperature: N             ← only when explicitly set non-default
+    max_tokens: N              ← only when explicitly set non-default
+    ```
+
+    ---
+
+    **Example 1 — NeMo OO: agent with skills, LLM tool dispatch**
+
+    Demonstrates: agent hexagon with skills, stochastic methods, tool nodes,
+    solid entrypoint from framework, all LLM-driven calls dashed.
+
+    ```python
+    class MyAgent(Agent, llm=get_smart_model()):
+        '''You are a research assistant.'''
+
+        def __init__(self):
+            self.shell = ShellTools()
+            self.domain = TextSkill(path=".claude/skills/domain.md")
+
+        async def solve_task(self, task_input: str) -> str:
+            '''Solve the task using available tools.'''
+            ...
+
+        async def summarize(self, text: str) -> str:
+            '''Summarize the text into a concise paragraph.'''
+            ...
+    ```
+
+    ```mermaid
+    flowchart TD
+        MyAgent{{"MyAgent<br/>model: claude-opus-4-5<br/>system: You are a research assistant.<br/>skills: domain"}}
+
+        shell["ShellTools<br/>in: command: str, path: str, content: str<br/>out: ShellResult | Match"]
+        solve_task(["solve_task*<br/>in:  task_input: str<br/>out: str<br/>prompt: Solve the task using available tools."])
+        summarize(["summarize*<br/>in:  text: str<br/>out: str<br/>prompt: Summarize the text into a concise paragraph."])
+
+        MyAgent --> solve_task
+        solve_task -.-> summarize
+        solve_task -.-> shell
+        summarize -.-> shell
+    ```
+
+    `MyAgent --> solve_task` solid: framework calls `solve_task` as the entrypoint in code.
+    Everything else dashed: the LLM inside `solve_task` freely decides what to call.
+    Both `solve_task` and `summarize` get dashed tool arrows — every stochastic method can use tools.
+
+    ---
+
+    **Example 2 — LangGraph: hard-wired graph edges, deterministic node, tool choice**
+
+    Demonstrates: `add_edge` produces solid arrows, deterministic method (rectangle, no LLM),
+    dashed tool choice when dispatch depends on runtime state.
+
+    ```python
+    SYSTEM = "You are a planner. Break the query into sub-steps."
+
+    class PlannerAgent:
+        def __init__(self):
+            self.llm = ChatNVIDIA(model="meta/llama-3.1-70b-instruct")
+            self.TOOLS = {"search": search_tool, "sql": sql_tool}
+
+        def create_plan(self, state: AgentState) -> AgentState:
+            # LLM call
+            ...
+
+        def execute_step(self, state: AgentState) -> AgentState:
+            # deterministic dispatch — reads state["plan"][0]["tool"], no LLM
+            result = self.TOOLS[state["plan"][0]["tool"]](state["plan"][0]["input"])
+            state["result"] = result
+            return state
+
+        def generate_final_answer(self, state: AgentState) -> AgentState:
+            # LLM call
+            ...
+
+        def create_graph(self):
+            graph = StateGraph(AgentState)
+            graph.add_edge("plan", "execute")    # hard-wired
+            graph.add_edge("execute", "answer")  # hard-wired
+            return graph.compile()
+    ```
+
+    ```mermaid
+    flowchart TD
+        PlannerAgent{{"PlannerAgent<br/>model: meta/llama-3.1-70b-instruct<br/>system: You are a planner. Break the query into sub-steps."}}
+
+        create_plan(["create_plan*<br/>in:  state: AgentState<br/>out: AgentState<br/>prompt: You are a planner. Break the query into sub-steps."])
+        execute_step["execute_step<br/>in:  state: AgentState<br/>out: AgentState"]
+        generate_final_answer(["generate_final_answer*<br/>in:  state: AgentState<br/>out: AgentState<br/>prompt: Summarize: {state[result]}"])
+        search["search_tool<br/>in:  query: str<br/>out: list[str]"]
+        sql["sql_tool<br/>in:  query: str<br/>out: str"]
+
+        PlannerAgent --> create_plan
+        create_plan --> execute_step
+        execute_step -.-> search
+        execute_step -.-> sql
+        execute_step --> generate_final_answer
+    ```
+
+    Solid arrows: `add_edge` calls in Python code. `execute_step` is a rectangle (no LLM).
+    Dashed to tools: `execute_step` reads `state["plan"][0]["tool"]` at runtime — either tool.
+
+    ---
+
+    **Example 3 — Code-enforced sequence with model override and generation params**
+
+    Demonstrates: explicit Python `await` chain produces solid arrows; stochastic method
+    with a different model and non-default temperature; deterministic orchestrator method.
+
+    ```python
+    class WriterAgent(Agent, llm=get_smart_model()):
+        '''You are a writing assistant. Draft and refine content.'''
+
+        def __init__(self):
+            self.style = TextSkill(path=".claude/skills/style.md")
+            self.tone  = TextSkill(path=".claude/skills/tone.md")
+
+        async def draft(self, brief: str) -> str:
+            '''Write a first draft from the brief.'''
+            ...
+
+        @strategy(PredictStrategy(), llm=get_fast_model(), temperature=0.0)
+        async def critique(self, draft: str) -> str:
+            '''List exactly three weaknesses in the draft. Be terse.'''
+            ...
+
+        async def revise(self, draft: str, notes: str) -> str:
+            '''Revise the draft to address every critique note.'''
+            ...
+
+        async def run(self, brief: str) -> str:
+            # explicit await chain — deterministic Python, not LLM-driven
+            draft  = await self.draft(brief)
+            notes  = await self.critique(draft)
+            return await self.revise(draft, notes)
+    ```
+
+    ```mermaid
+    flowchart TD
+        WriterAgent{{"WriterAgent<br/>model: claude-opus-4-5<br/>system: You are a writing assistant. Draft and refine content.<br/>skills: style · tone"}}
+
+        draft(["draft*<br/>in:  brief: str<br/>out: str<br/>prompt: Write a first draft from the brief."])
+        critique(["critique*<br/>in:  draft: str<br/>out: str<br/>prompt: List exactly three weaknesses in the draft. Be terse.<br/>model: claude-haiku-4-5<br/>temperature: 0.0"])
+        revise(["revise*<br/>in:  draft: str, notes: str<br/>out: str<br/>prompt: Revise the draft to address every critique note."])
+
+        WriterAgent -->|brief: str| draft
+        draft -->|draft: str| critique
+        draft -->|draft: str| revise
+        critique -->|notes: str| revise
+    ```
+
+    `run` is invisible — it is a pure `await`-sequence method, so the diagram encodes what it builds.
+    `WriterAgent` connects directly to `draft`, the first step, labeled with the input type.
+    `draft` fans to both `critique` and `revise` because both consume its output.
+    `critique` carries `model:` and `temperature:` because both differ from the agent default.
+
+    ---
+
+    **Example 4 — Multi-agent: subagent as nested subgraph, execution chain**
+
+    Demonstrates: subagent as a Mermaid `subgraph` containing its method nodes, execution
+    sequence as a chain (not fan-out), every stochastic method gets dashed arrows to all tools.
+
+    ```python
+    class Orchestrator(Agent, llm=get_smart_model()):
+        '''You are an optimization orchestrator.'''
+
+        def __init__(self):
+            self.shell = GuardedShellTools(...)
+            self.analyzer = AnalyzerAgent(...)
+
+        async def propose_improvements(self, analysis: str) -> list[Improvement]:
+            '''Propose candidate improvements based on the analysis.'''
+            ...
+
+        async def implement_improvement(self, candidate: Candidate) -> None:
+            '''Implement the proposed improvement in agent source.'''
+            ...
+
+        async def run(self, dataset: Dataset) -> None:
+            analysis = await self.analyzer.analyze_trace(...)  # explicit subagent call
+            proposal = await self.propose_improvements(analysis)
+            await self.implement_improvement(proposal)
+    ```
+
+    ```mermaid
+    flowchart TD
+        Orchestrator{{"Orchestrator<br/>model: claude-opus-4-5<br/>system: You are an optimization orchestrator."}}
+
+        shell["GuardedShellTools<br/>in: command: str, path: str, content: str<br/>out: ShellResult | Match"]
+        propose(["propose_improvements*<br/>in:  analysis: str<br/>out: list[Improvement]<br/>prompt: Propose candidate improvements based on the analysis."])
+        implement(["implement_improvement*<br/>in:  candidate: Candidate<br/>out: None<br/>prompt: Implement the proposed improvement in agent source."])
+
+        subgraph AnalyzerAgent["AnalyzerAgent · model: claude-haiku-4-5 · system: You are a trace analyzer. Identify failure patterns..."]
+            analyze_trace(["analyze_trace*<br/>in:  trace_path: str<br/>out: str<br/>prompt: Analyze the trace and identify failure patterns."])
+        end
+
+        Orchestrator -->|dataset: Dataset| analyze_trace
+        analyze_trace -->|analysis: str| propose
+        propose -->|candidate: Candidate| implement
+        propose -.-> shell
+        implement -.-> shell
+    ```
+
+    `run` is invisible — pure `await`-sequence method, the diagram encodes what it builds.
+    `Orchestrator` connects directly to `analyze_trace` (first step) with the input data label.
+    Solid labeled chain shows exact data contracts between steps — the optimizer knows what breaks if types change.
+    Every stochastic method (`propose`, `implement`) gets dashed arrows to all tools Orchestrator owns.
+
+    ---
+
+    **Example 5 — Types and Prompts appendix** (for PlannerAgent from Example 2):
+
+    `AgentState` appears in every arrow label and node signature — the optimizer needs its fields
+    to propose schema changes. `str`, `list` etc. are primitives and need no entry.
+
+    ```markdown
+    ## Types
+
+    ### AgentState
+    - query: str
+    - plan: list
+    - result: str
+
+    ## Prompts
+
+    ### PlannerAgent.create_plan
+    You are a planner. Break the query into sub-steps.
+
+    {state[query]}
+
+    ### PlannerAgent.generate_final_answer
+    Summarize {state[result]}
+    ```
+
+    ### Section 2 — Types
+
+    Full definitions of every non-primitive custom type that appears in the diagram — in `in:`,
+    `out:`, or arrow labels. Primitive types (`str`, `int`, `bool`, `float`, `list[str]`, etc.)
+    are self-explanatory and do not need an entry. Include every `TypedDict`, `dataclass`,
+    `Pydantic model`, or named type that the optimizer would need to understand in order to
+    propose a schema change.
+
+    ```markdown
+    ## Types
+
+    ### TypeName
+    - field1: Type
+    - field2: Type
+    - field3: Type | None
+    ```
+
+    ### Section 3 — Prompts
+
+    Full verbatim content of every prompt found in the codebase — system prompts, user prompts,
+    prompt templates, and prompt-returning methods. This is the primary optimization target.
+
+    ```markdown
+    ## Prompts
+
+    ### ClassName.method_name  (or  module.CONSTANT_NAME)
+    <full prompt string or method body, verbatim>
+
+    ### ClassName.other_method
+    <full prompt string or method body, verbatim>
+    ```
+
+    Include:
+    - Every prompt that is passed to an LLM that can be acted upon or modified by someone coding the agent.
+
+    ---
+
+    ## AGENT-SPEC.md — read first if it exists
+
+    An `AGENT-SPEC.md` (or `AGENT_SPEC.md`) in the workspace is a durable contract written by the
+    agent's author. When present, read it before any source file. It is authoritative on the scope of the agent.
+
+    It helps discern what is agent-pertinent and what is not.
+    If AGENT-SPEC.md is absent, infer all of the above from source code.
+
+    ---
+
+    ## Writing architecture.md
+
+    1. Check for documentation (specs, readmes) and read it first if present. Understand the scope of the agent.
+    2. Read the agent's source `.py` files, starting from the entrypoint, following imports. Use the spec's framework and harness to anchor what you're looking for.
+    3. Apply the Scope rules above: include only agent components, tools, skills, and prompts. Do not include anything that's infrastructure around it, evaluation code, storage code, etc.
+       Only include default paths. If a user has to change configs to use this path, it should not be included.
+    4. Collect key imports and write the diagram note.
+    5. If the file already EXISTS (it is seeded from the ancestor for every non-baseline agent),
+       edit it IN PLACE: apply only the minimal delta for the one change being documented and
+       preserve everything else verbatim — same section order, Mermaid dialect, node-shape syntax,
+       wording, and type-annotation style. Do **not** re-render or restyle unchanged content.
+    6. Only when the file does NOT already exist, author it from scratch: write the diagram, then
+       the prompts appendix (verbatim content of all prompt strings found).
+
+    """
+
+
+class Coder(Agent, llm=get_smart_model()):
+    """Create and modify agent source code as part of the optimization loop."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        config: CoderConfig | None = None,
+        framework_skills_dirs: list[Path] | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize the coder for the given workspace."""
+        super().__init__(**kwargs)
+        self._config = config or CoderConfig()
+        self._workspace_path = workspace.resolve()
+        self.shell = GuardedShellTools(cwd=self._workspace_path)
+        self.todos = TodoManager()
+        self.context["file_match"] = doc(Match)
+
+        self.skills: SkillRegistry = SkillRegistry(self)
+        spec(self, "skills", hidden=True)
+        load_framework_skills(self.skills, framework_skills_dirs or [])
+        self.skills.register("ext.architecture_skill", ArchitectureSkill())
+        # Attach the optimization-card index so apply_change / wire_up_change
+        # can consult the card matching candidate.optimization_type. Without
+        # this, the Coder only sees the proposer's prose and the framework
+        # skill -- the optimize cards never reach it (gitlab #148).
+        self.optimize = Optimize(model_catalog_path=self._config.model_catalog_path)
+        self.skills.register("ext.optimize", self.optimize)
+        self.skills.activate(["cmd.*", "ext.*"])
+        self._models_cache: list[str] | None = None
+        TokenBudgetSummarizer.install(
+            self,
+            llm=get_fast_model(),
+            config=TokenBudgetConfig(max_tokens=self._config.max_summary_tokens),
+        )
+
+    async def list_available_models(self) -> list[str]:
+        """Fetch available LLM model IDs from the configured inference API.
+
+        Results are cached in memory for the lifetime of this instance.
+
+        Returns:
+            list[str]: model ID strings as returned by the API.
+
+        Raises:
+            ValueError: if EXPERIMENTALIST_API_BASE or EXPERIMENTALIST_API_KEY is not set.
+            httpx.HTTPStatusError: if the API returned a non-2xx response.
+            httpx.RequestError: if there was a network or connection failure.
+
+        """
+        if self._models_cache is not None:
+            return self._models_cache
+
+        async with httpx.AsyncClient() as client:
+            api_base = os.environ.get("EXPERIMENTALIST_API_BASE")
+            api_key = os.environ.get("EXPERIMENTALIST_API_KEY")
+            if api_base is None or api_key is None:
+                raise ValueError("EXPERIMENTALIST_API_BASE and EXPERIMENTALIST_API_KEY must be set")
+
+            resp = await client.get(
+                f"{api_base}/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=self._config.timeout_model_list_secs,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+        rows = data.get("data", [])
+        if not isinstance(rows, list):
+            raise ValueError("Invalid /models response: expected data to be a list")
+        models = [
+            model_id
+            for row in rows
+            if isinstance(row, dict) and isinstance(model_id := row.get("id"), str) and model_id
+        ]
+        if not models:
+            raise ValueError("No model ids found in /models response")
+        self._models_cache = models
+        return models
+
+    async def run(
+        self,
+        candidate: Candidate,
+        dataset: Dataset,
+        evaluator: Evaluator,
+        evaluator_options: EvaluatorConfig | None = None,
+        source_path: str | None = None,
+        entrypoint: str | None = None,
+    ) -> None:
+        """Implement the improvement described in candidate and verify it integrates cleanly.
+
+        Args:
+            candidate: The agent variant to implement. Identifies the agent directory,
+                carries the optimization description, and links to its ancestor.
+            dataset: The dataset to use for the evaluation.
+            evaluator: The evaluator to use for the evaluation.
+            evaluator_options: The options to pass to the evaluator.
+            source_path: The path to the agent source code, relative to the agent directory.
+            entrypoint: The file that the evaluation harness invokes to run the agent, relative to the agent directory.
+
+        Raises:
+            RuntimeError: if no training tasks are available for integration_check.
+            IntegrationCheckFailed: if the candidate cannot pass a smoke eval after the
+                bounded number of fix attempts.
+
+        """
+        await self.apply_change(candidate)
+        await self.wire_up_change(candidate)
+        await self.run_pyright(candidate.name)
+        await self.optimize_subproblem(candidate, dataset, evaluator, evaluator_options)
+        await self.run_pyright(candidate.name)
+        if not await self.integration_check(candidate, dataset, evaluator, evaluator_options):
+            raise IntegrationCheckFailed(f"{candidate.name} smoke eval failed after fix attempts")
+        if candidate.ancestor:
+            ancestor_arch = (
+                self._workspace_path / "eval-and-optimize" / "agents" / candidate.ancestor / "architecture.md"
+            )
+            candidate_arch = self._workspace_path / "eval-and-optimize" / "agents" / candidate.name / "architecture.md"
+            if ancestor_arch.exists() and not candidate_arch.exists():
+                shutil.copy2(ancestor_arch, candidate_arch)
+        await self.create_architecture_doc(candidate.name, source_path=source_path, entrypoint=entrypoint)
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=50, cell_timeout=3600.0)))
+    async def apply_change(self, candidate: Candidate) -> None:
+        """Apply the ONE change from candidate.optimization.
+
+        Args:
+        - candidate (Candidate): the agent variant being built. Identifies
+          which agent directory to modify, describes the change to apply, and
+          carries lineage info from its ancestor
+
+        ## Pre-staged destination — DO NOT re-copy from the ancestor
+        The destination directory ``agents/{candidate.id}/`` has ALREADY been
+        populated by the framework with a copy of the ancestor's source files
+        (everything except generated framework artifacts: ``metadata.json`` and
+        ``architecture.md``). Runtime harness files are inherited when present
+        but are not part of the agent behavior being optimized.
+        Open and modify files in place. You do NOT need to copy anything in.
+
+        ## Required reading before editing
+        - The framework skill — how to write agents in the target framework (NeMo OO, LangChain, etc.).
+        - The optimization card for this change. First run `print(doc(self.optimize))`
+          to see the decision tree mapping optimization types to cards. Find which
+          card covers `candidate.optimization_type` (e.g. `add_concrete_method` is
+          covered by `optimize_execution`), then load that card's details with
+          `print(doc(self.optimize.optimize_execution))`. The card lists approved approaches,
+          code examples, and success criteria.
+        - If the change involves methods that handle large inputs (scraped pages,
+          documents, search results), read `print(doc(self.processing_large_data))`
+          for chunking patterns that avoid `max_param_chars` truncation errors.
+
+        ## Constraints
+        - Make one change matching candidate.optimization
+        - No hardcoded knowledge (keyword lists, lookup tables, if/elif on task-specific strings). This applies to BOTH code AND skill edits: skill additions must improve generalizable methodology (process steps, classification rules, evidence requirements), never add dataset-specific facts about specific libraries, frameworks, CVEs, or package internals — that is memorization of training data, not domain knowledge.
+        - NEVER read from, copy from, or overwrite files in any OTHER agent
+          directory (``agents/agent-N/`` for N != candidate.id). The pre-staged
+          files in your own directory are the only source you should edit.
+        - NEVER modify ``metadata.json`` in any agent directory. It is owned by
+          the framework and carries the correct agent id, lineage, and scores.
+        - VERIFY INTEGRATION: In the integration test, check traces to confirm new code is actually
+          called by the agent. Code that exists but isn't invoked is useless.
+        - If the change involves editing an LLM model id, call
+          `models = await self.list_available_models()` first and pick one of the
+          returned ids. Do NOT invent or abbreviate model ids.
+        """
+        ...
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=50, cell_timeout=3600.0)))
+    async def wire_up_change(self, candidate: Candidate) -> None:
+        """Wire up the change to the agent such that it is called by the agent. Load the framework skill and use it to understand how to wire up the change.
+
+        Args:
+        - candidate (Candidate): the agent variant being built. Identifies
+          which agent directory to modify, describes the change to apply, and
+          carries lineage info from its ancestor
+
+        Consult `doc(self.optimize)` to find which card covers
+        `candidate.optimization_type`, then read that card via
+        `doc(self.optimize.optimize_<type>)` for what "wired" means in the target framework.
+        (e.g. for `add_skill` covered by `optimize_domain_knowledge`, the new skill
+        must be reachable by the agent at runtime — a file that is never imported or
+        registered is not wired, regardless of framework).
+        """
+        ...
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=200, cell_timeout=3600.0)))
+    async def optimize_subproblem(
+        self,
+        candidate: Candidate,
+        dataset: Dataset,
+        evaluator: Evaluator,
+        evaluator_options: EvaluatorConfig | None = None,
+    ) -> None:
+        """Validate and iteratively refine the subproblem fix until the agent's behavior improves.
+
+        Args:
+        - candidate (Candidate): the agent variant being built. Identifies
+          which agent directory to modify, describes the change to apply, and
+          carries lineage info from its ancestor
+        - dataset (Dataset): The dataset to use for the evaluation.
+        - evaluator (Evaluator): The evaluator to use for the evaluation.
+        - evaluator_options (EvaluatorConfig): The options to pass to the evaluator.
+
+        ## Workflow
+
+        1. **Pick test tasks**:
+           - **Target tasks**: use `candidate.task_ids` — the tasks the Proposer flagged as
+             most directly exercising this candidate's root cause. The fix must improve these.
+             Only if `candidate.task_ids` is empty, fall back to picking 2-3 representative
+             tasks that exercise the subproblem yourself.
+           - **Regression tasks**: also pick 2-3 tasks the ancestor/baseline already handled
+             correctly and that are unrelated to this subproblem. The fix must NOT regress
+             these — they guard against the change breaking previously-working behavior.
+           - Consider `candidate.optimization` to understand what was changed
+
+        2. **Isolate the subproblem**:
+           - Read the agent's architecture.md to understand the agent's behavior
+           - Read the optimization card for `candidate.optimization_type` to understand what was changed
+           - Read `candidate.optimization` to understand the specific subproblem being fixed
+           - Run the subproblem fix on the tasks and inspect the results.
+             E.g. if the subproblem was the behavior of a single method, call that method on the tasks
+             and inspect the results. If it was a single tool, run that tool directly.
+             Always prefer isolated calls for speed; only run a full smoke eval if needed.
+
+           Example: Adding a new method to the agent to create unit tests.
+
+            ```python
+            class SWEAgent(Agent):
+                async def create_unit_tests(self, issue: str, repo: str) -> str:
+                    '''Create unit tests for the issue.'''
+                    return "Unit tests created."
+
+            ### Test
+            task_description = ...
+            repo = ...
+            print(SweAgent().create_unit_tests(task_description, repo))
+            ```
+
+        3. **Reason about whether the behavior improved**:
+           - Compare what you observe to what the fix was supposed to achieve
+           - Look for concrete evidence in traces and outputs
+
+           **Example**: Subproblem = "agent prematurely concludes without thorough analysis"
+           - Fix applied: increased minimum reasoning steps before concluding
+           - What to check: Does the trace show multiple reasoning/analysis tool calls?
+           - Verdict: subproblem is fixed only if BOTH hold — the target tasks now show the
+             improved behavior AND the regression tasks still behave as they did on the baseline
+             (no regression). If both → you're done.
+           - If no: identify specifically what's still wrong — either the target isn't fixed
+             ("train-005 still has only 1 reasoning call") or a regression task broke
+             ("train-012 was passing but now fails").
+
+        4. **If not fixed** (max 3 iterations):
+           - Make targeted changes to the agent source based on what you observed
+           - Repeat from step 2 with the same tasks (for consistency)
+
+        5. **Done** - no cleanup needed
+
+        ## Key principle
+
+        You're validating **behavior change**, not just correctness. The subproblem is about
+        how the agent acts (thoroughness, reasoning depth, tool usage patterns, report quality).
+        Use the traces as evidence of whether the agent's behavior actually improved.
+
+        """
+        ...
+
+    async def integration_check(
+        self,
+        candidate: Candidate,
+        dataset: Dataset,
+        evaluator: Evaluator,
+        evaluator_options: EvaluatorConfig | None = None,
+        max_fix_attempts: int | None = None,
+    ) -> bool:
+        """Smoke-test the candidate and attempt bounded LLM repairs if it fails.
+
+        Args:
+            candidate: The agent variant to smoke-test.
+            dataset: The dataset to use for the evaluation.
+            evaluator: The evaluator to use for the evaluation.
+            evaluator_options: The options to pass to the evaluator.
+            max_fix_attempts: Maximum repair iterations; defaults to
+                ``self._config.max_fix_attempts``.
+
+        Returns:
+            bool: True if the candidate passes the smoke eval, False otherwise.
+
+        Raises:
+            RuntimeError: if no training tasks are available.
+
+        """
+        _max_fix_attempts = max_fix_attempts if max_fix_attempts is not None else self._config.max_fix_attempts
+
+        all_tasks = list(dataset.list_tasks())
+        if not all_tasks:
+            raise RuntimeError("No tasks available for integration_check")
+        # One task to keep smoke wall time low; seeded by candidate.name so retries hit the same task.
+        tasks = [random.Random(candidate.name).choice(all_tasks)]
+        for attempt in range(_max_fix_attempts + 1):
+            evaluation = await self.run_smoke_eval(candidate.name, tasks, dataset, evaluator, evaluator_options)
+            if self._is_smoke_results_healthy(evaluation, tasks):
+                return True
+            if attempt < _max_fix_attempts:
+                await self._fix_runtime_issues(candidate, evaluation)
+        return False
+
+    def _is_smoke_results_healthy(self, evaluation: EvaluationResult, tasks: Sequence[Task]) -> bool:
+        """Return True if each selected task has a completed trial without evaluator error.
+
+        Args:
+            evaluation: Smoke evaluation result.
+            tasks: Tasks included in the smoke evaluation.
+
+        Returns:
+            bool: True if all tasks produced at least one clean trial.
+
+        """
+        trials_by_task: dict[str, list[TrialResult]] = defaultdict(list)
+        for trial in evaluation.trials:
+            trials_by_task[trial.task_id].append(trial)
+
+        for task in tasks:
+            trials = trials_by_task.get(task.id, [])
+            if not trials:
+                return False
+            if not any(self._trial_runtime_healthy(trial) for trial in trials):
+                return False
+        return True
+
+    def _trial_runtime_healthy(self, trial: TrialResult) -> bool:
+        """Return True if evaluator status/error indicates runtime success."""
+        if trial.error is not None:
+            return False
+        return trial.status == "completed"
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=50, cell_timeout=3600.0)))
+    async def _fix_runtime_issues(self, candidate: Candidate, evaluation: EvaluationResult) -> None:
+        """Diagnose and repair runtime failures surfaced by the most recent smoke eval.
+
+        Args:
+        - candidate (Candidate): the agent variant being repaired. Identifies
+          which agent directory to modify, describes the change that was applied,
+          and carries lineage info from its ancestor
+        - evaluation (EvaluationResult): the smoke evaluation result. Use its
+          trials, metrics, outputs, resources, errors, and metadata as failure evidence.
+
+        The orchestrator (`integration_check`) just ran `run_smoke_eval` and the
+        deterministic health check returned False. Your job is to read the failure
+        evidence and edit the agent source so the next smoke eval will pass. Do NOT
+        re-run smoke eval yourself — the orchestrator does it.
+
+        ## Failure context (read in this order)
+
+        For each trial in `evaluation.trials`:
+        1. `trial.status` and `trial.error` — crash, timeout, or evaluator-owned
+           failure details.
+        2. `trial.outputs` — agent-visible output values or referenced output files.
+        3. `trial.resources` — logs, traces, manifests, or artifact references made
+           visible by the evaluator.
+        4. `trial.metrics` — numeric evaluator results. Names are evaluator-defined.
+        5. `trial.metadata` — adapter facts that help locate or interpret evidence.
+
+        Read ResourceRef descriptions and metadata before opening referenced files.
+        Do not assume any particular directory layout or artifact filename.
+
+        ## What to fix
+
+        Edit files in `eval-and-optimize/agents/{candidate.id}/` — the same files
+        `apply_change` and `wire_up_change` produced. Common runtime failure modes
+        and their fixes:
+
+        - **TypeError / wrong signature** — tool/function called with bad kwargs.
+          Match the call to the definition.
+        - **NameError / ImportError** — the change references a symbol that doesn't
+          exist or removed an import. Add the import or revert the reference.
+        - **KeyError on env var / config** — the change added a config read without
+          a default or `.env` entry. Use `os.environ.get(..., default)` or revert.
+        - **Evaluator failure, no exception** — the agent ran but failed task checks.
+          Read visible outputs/resources to identify the missing file, wrong schema,
+          bad side effect, service failure, or incorrect final value. Required
+          artifact paths are task-defined; do not assume a generic `output.*`.
+        - **Tool that no longer exists is being called** — a tool was removed but
+          a call site wasn't updated. Update the call site.
+
+        ## Constraints
+
+        - Do NOT modify `metadata.json`.
+        - Do NOT touch optimizer infrastructure: `init_structure.py`,
+          `optimize_agent.py`, anything under `.claude/skills/`.
+        - Do NOT call `run_smoke_eval` — the orchestrator re-runs it after you finish.
+        - Make the minimum edit that fixes the failure. Don't introduce new behavior.
+        """
+        ...
+
+    async def run_pyright(self, agent_id: str) -> str:
+        """Run pyright on the agent's directory and return diagnostic lines.
+
+        Args:
+            agent_id: The agent directory under eval-and-optimize/agents/ to check.
+
+        Returns:
+            str: newline-separated error and warning lines, or an empty string
+                if pyright reports no issues.
+
+        """
+        r = await self.shell.run(f"pyright --outputjson eval-and-optimize/agents/{agent_id} 2>/dev/null || true")
+        output = (r.stdout or "").strip()
+        try:
+            data = json.loads(output)
+            diags = data.get("generalDiagnostics", [])
+            if not diags:
+                return ""
+            lines = []
+            for d in diags:
+                if d.get("severity") in ("error", "warning"):
+                    file_ = d.get("file", "")
+                    rule = d.get("rule", "")
+                    msg = d.get("message", "")
+                    rng = d.get("range", {}).get("start", {})
+                    line_no = rng.get("line", "?")
+                    lines.append(f"{file_}:{line_no}: {d['severity']}: {msg} ({rule})")
+            return "\n".join(lines)
+        except Exception:
+            return output
+
+    async def run_smoke_eval(
+        self,
+        agent_id: str,
+        tasks: Sequence[Task],
+        dataset: Dataset,
+        evaluator: Evaluator,
+        evaluator_options: EvaluatorConfig | None = None,
+    ) -> EvaluationResult:
+        """Run smoke evaluation against a specific subset of tasks.
+
+        Args:
+            agent_id: The agent directory under eval-and-optimize/agents/ to evaluate.
+            tasks: Non-empty task objects to evaluate.
+            dataset: The dataset to use for the evaluation.
+            evaluator: The evaluator to use for the evaluation.
+            evaluator_options: The options to pass to the evaluator.
+
+        Returns:
+            EvaluationResult: smoke evaluation result.
+
+        Raises:
+            ValueError: if ``tasks`` is empty.
+
+        """
+        if not tasks:
+            raise ValueError("run_smoke_eval requires at least one task")
+
+        smoke_dataset = dataset.subset([task.id for task in tasks])
+        base_options = evaluator_options if evaluator_options is not None else evaluator.options
+        smoke_options = base_options.model_copy(update={"force_rerun": True})
+        agent_path = self._workspace_path / "eval-and-optimize" / "agents" / agent_id
+        return await evaluator.run(
+            agent=agent_path,
+            dataset=smoke_dataset,
+            options=smoke_options,
+        )
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=50, cell_timeout=3600.0)), llm=get_mid_model())
+    async def create_architecture_doc(
+        self, agent_id: str, source_path: str | None = None, entrypoint: str | None = None
+    ) -> None:
+        """Update (or, only if absent, create) architecture.md for the given agent.
+
+        Args:
+        - agent_id (str): identifies which agent directory under {self._workspace_path}/eval-and-optimize/agents/ to document
+        - source_path (str | None): directory containing the agent source code, relative to the
+          agent directory (e.g. "app/"). Read .py files from here when following imports.
+          When absent, infer the source root from AGENT-SPEC.md or the directory structure.
+        - entrypoint (str | None): the file that the evaluation harness invokes to run the agent,
+          relative to the agent directory (e.g. "harbor/runner.py"). Start reading here to
+          determine the call chain and identify the default execution path before reading
+          source_path. When absent, infer from AGENT-SPEC.md or the directory structure.
+
+        Load the agent-architecture skill and use it to document the agent.
+
+        ## Edit in place — do NOT regenerate from scratch
+        For any candidate with an ancestor, the framework has ALREADY seeded
+        {self._workspace_path}/eval-and-optimize/agents/{agent_id}/architecture.md with a
+        byte-for-byte copy of the ancestor's architecture.md. Open the existing file and edit it
+        in place to reflect the FINAL state of the candidate source (after all automated repairs),
+        not just its originally declared change. Compare the final source against the ancestor and
+        capture every resulting difference — nodes, edges, prompts, and type definitions — as a
+        MINIMAL, targeted delta:
+
+        - Preserve the existing document verbatim wherever the code did not change — same section
+          order and headings, same Mermaid dialect and node-shape syntax, same wording, spacing,
+          and type-annotation style. Do NOT restyle, reflow, re-title, re-render, or "improve" any
+          part the change did not touch.
+        - Edit ONLY the lines the final source differs from the ancestor: a node added/removed/
+          modified, an edge rerouted, an affected custom type definition, or a prompt string that
+          changed. If a node or type was already drawn a certain way in the ancestor's file, keep
+          drawing it that way.
+        - A reviewer diffing this file against the ancestor's must see only the real architectural
+          delta. Spurious formatting churn (different Mermaid dialect, added prose, re-cased type
+          names, reordered sections) hides the actual change and is a defect.
+
+        ## Steps
+
+        1. Read the entrypoint {entrypoint} to identify the default execution path — which feature
+           flag value is default, which if/else branch runs in production. The entrypoint itself
+           is infrastructure and must NOT appear in the diagram. Use it only to determine scope.
+           Then read source files under {source_path}, following only imports reachable from the
+           default path. If entrypoint is None, infer it from AGENT-SPEC.md or the directory.
+           Apply the scope rules from the architecture skill:
+           include only agent components (agents, stochastic methods, deterministic methods, tools),
+           exclude the entrypoint/harness itself, evaluation code, test data, and infrastructure.
+
+        2. Diff your understanding of the current source against the EXISTING architecture.md and
+           apply the minimal edit that brings it up to date. Pay special attention to prompt strings
+           (Section 3), which change frequently: copy them verbatim from source definitions, not
+           call sites. A reader must understand what the LLM is asked to do without opening any
+           source file.
+
+        3. ONLY if architecture.md does not already exist (e.g. a baseline agent with no ancestor),
+           author it from scratch using the node shapes and arrow conventions from the architecture
+           skill exactly:
+           - Agent hexagon {{}} for each agent
+           - Stochastic method stadium ([]) with * suffix for every method that calls an LLM
+           - Deterministic method rectangle [] for methods with real logic but no LLM
+           - Dashed arrows -.-> for LLM-decided calls; solid arrows --> for code-enforced calls
+           - Labeled solid arrows -->|param: Type| next showing data contracts
+           - Section 2: Types — definitions of all non-primitive custom types used in the diagram
+           - Section 3: Prompts — verbatim prompt strings the LLM will read (instruction sentences,
+             role descriptions, template content). Copy from source definitions, not call sites.
+        """
+        ...

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/dataset_staging.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/dataset_staging.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experiment-local staging and hydration for Eval Author inputs."""
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef, local_path_from_uri
+from nemo_platform import AsyncNeMoPlatform
+
+
+@dataclass(frozen=True, slots=True)
+class _StagedEvalAuthorInputs:
+    """Staged Eval Author references returned by this module's factory."""
+
+    train_dataset: DatasetRef
+    validation_dataset: DatasetRef
+    task_template: DatasetRef
+
+
+def _local_directory(ref: DatasetRef) -> Path:
+    path = local_path_from_uri(ref.uri, context="Eval Author input").resolve()
+    if not path.is_dir():
+        raise ValueError(f"Eval Author input is not a directory: {path}")
+    return path
+
+
+def _stage(ref: DatasetRef, destination: Path) -> DatasetRef:
+    if not destination.exists():
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(_local_directory(ref), destination)
+    return ref.model_copy(update={"uri": str(destination)})
+
+
+async def stage_task_template(
+    experiment_dir: Path,
+    task_template: DatasetRef,
+    *,
+    client: AsyncNeMoPlatform,
+    workspace: str,
+) -> DatasetRef:
+    """Refresh a local or Fileset-backed task template in experiment-local staging."""
+    destination = experiment_dir.resolve() / "dataset" / "task-template"
+    source = None
+    if urlparse(task_template.uri).scheme != "fileset":
+        source = _local_directory(task_template)
+        if source == destination:
+            return task_template.model_copy(update={"uri": str(destination)})
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        if not destination.is_dir():
+            raise ValueError(f"Eval Author task template staging path is not a directory: {destination}")
+        shutil.rmtree(destination)
+
+    if urlparse(task_template.uri).scheme == "fileset":
+        try:
+            await client.files.download(
+                remote_path=task_template.uri,
+                local_path=str(destination),
+                workspace=workspace,
+            )
+        except BaseException:
+            if destination.exists():
+                shutil.rmtree(destination)
+            raise
+        if not destination.is_dir() or not any(path.is_file() for path in destination.rglob("*")):
+            if destination.exists():
+                shutil.rmtree(destination)
+            raise ValueError(f"Eval Author Fileset task template contains no files: {task_template.uri}")
+    else:
+        assert source is not None
+        shutil.copytree(source, destination)
+
+    return task_template.model_copy(update={"uri": str(destination)})
+
+
+async def stage_eval_author_inputs(
+    experiment_dir: Path,
+    *,
+    train_dataset: DatasetRef,
+    validation_dataset: DatasetRef,
+    task_template: DatasetRef,
+    client: AsyncNeMoPlatform,
+    workspace: str,
+) -> _StagedEvalAuthorInputs:
+    """Stage mutable Eval Author inputs beneath the experiment directory."""
+    dataset_dir = experiment_dir.resolve() / "dataset"
+    return _StagedEvalAuthorInputs(
+        train_dataset=_stage(train_dataset, dataset_dir / "train"),
+        validation_dataset=_stage(validation_dataset, dataset_dir / "validation"),
+        task_template=await stage_task_template(
+            experiment_dir,
+            task_template,
+            client=client,
+            workspace=workspace,
+        ),
+    )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/__init__.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/__init__.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import (
+    Evaluator,
+    EvaluatorConfig,
+    EvaluatorType,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import (
+    CommandSpec,
+    Dataset,
+    DatasetRef,
+    DatasetValidationError,
+    DataValue,
+    DependencyRuntime,
+    EvaluationResult,
+    MetricResult,
+    MetricSpec,
+    MetricValue,
+    ResourceRef,
+    Task,
+    TrialResult,
+    TrialStatus,
+    local_path_from_uri,
+)
+
+__all__ = [
+    "CommandSpec",
+    "DataValue",
+    "Dataset",
+    "DatasetRef",
+    "DatasetValidationError",
+    "DependencyRuntime",
+    "EvaluationResult",
+    "Evaluator",
+    "EvaluatorConfig",
+    "EvaluatorType",
+    "MetricResult",
+    "MetricSpec",
+    "MetricValue",
+    "ResourceRef",
+    "Task",
+    "TrialResult",
+    "TrialStatus",
+    "local_path_from_uri",
+]

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/base.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/base.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evaluator interfaces."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import (
+    Dataset,
+    EvaluationResult,
+    TrialResult,
+)
+from pydantic import BaseModel, ConfigDict, Field
+
+EvaluatorType: TypeAlias = Literal["harbor"]
+
+
+class EvaluatorConfig(BaseModel):
+    """Configuration for evaluator run."""
+
+    model_config = ConfigDict(extra="allow")
+    force_rerun: bool = Field(
+        default=False,
+        description="Force the evaluator to run even if there is already a result for this agent and dataset.",
+    )
+
+
+class Evaluator(ABC):
+    """Abstract base class for concrete evaluators."""
+
+    evaluator_type: EvaluatorType
+
+    def __init__(self, options: EvaluatorConfig, experiment_dir: Path | None = None) -> None:
+        self.options = options
+        self.experiment_dir = experiment_dir
+
+    async def aggregate_results(self, results: Sequence[TrialResult]) -> dict[str, float | int]:
+        """
+        Aggregate evaluation results from multiple runs.
+
+        Defaults to averaging each metric across all trials, treating trials that
+        did not emit a metric (e.g. failed trials) as contributing 0. The denominator
+        is always ``len(results)``, not the number of trials that reported each metric,
+        so failure counts against the aggregate score.
+
+        Args:
+            results(Sequence[TrialResult]): List of trial results to aggregate.
+
+        Returns:
+            dict[str, float | int]: Aggregated metric values keyed by metric name.
+        """
+        if not results:
+            return {}
+
+        completed = [r for r in results if r.status != "failed"]
+        if not completed:
+            return {}
+
+        expected_metrics = set(completed[0].metrics.keys())
+        for result in completed[1:]:
+            if set(result.metrics.keys()) != expected_metrics:
+                missing = expected_metrics - set(result.metrics.keys())
+                extra = set(result.metrics.keys()) - expected_metrics
+                raise ValueError(f"Inconsistent metrics across trials. Missing: {missing}, extra: {extra}")
+
+        aggregate_metrics: dict[str, float | int] = {}
+        for result in completed:
+            for metric_name, metric_result in result.metrics.items():
+                if metric_name not in aggregate_metrics:
+                    aggregate_metrics[metric_name] = metric_result.value
+                else:
+                    aggregate_metrics[metric_name] += metric_result.value
+
+        for metric_name in aggregate_metrics:
+            aggregate_metrics[metric_name] = aggregate_metrics[metric_name] / len(completed)
+        return aggregate_metrics
+
+    async def run(
+        self,
+        agent: Path,
+        dataset: Dataset,
+        options: EvaluatorConfig | dict | None = None,
+    ) -> EvaluationResult:
+        """
+        Run an evaluation and return a domain result.
+
+        Args:
+            agent(Path): Path to the agent directory.
+            dataset(Dataset): Dataset to evaluate.
+            options(EvaluatorConfig | dict | None): Additional options to pass to the evaluator.
+                Overrides the evaluator's default options. Dicts are coerced via
+                model_validate against the evaluator's default options type.
+
+        Returns:
+            EvaluationResult: Evaluation result.
+        """
+        if options is None:
+            options = self.options
+        elif isinstance(options, dict):
+            options = type(self.options).model_validate({**self.options.model_dump(), **options})
+        trials = await self._run(agent, dataset, options)
+        aggregate_metrics = await self.aggregate_results(trials)
+        return EvaluationResult(
+            id=f"{agent.name}-{dataset.id}",
+            trials=trials,
+            aggregate_metrics=aggregate_metrics,
+            metadata={},
+        )
+
+    @abstractmethod
+    async def _run(self, agent: Path, dataset: Dataset, options: EvaluatorConfig) -> Sequence[TrialResult]:
+        """Run the evaluator and return a list of trial results.
+
+        Args:
+            agent(Path): Path to the agent directory.
+            dataset(Dataset): Dataset to evaluate.
+            options(EvaluatorConfig): Options to pass to the evaluator.
+
+        Returns:
+            Sequence[TrialResult]: List of trial results.
+
+        Raises:
+            ValueError: If the agent or dataset is not provided.
+        """
+        ...

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/factory.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/factory.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Factories for evaluator-specific datasets and evaluators."""
+
+from pathlib import Path
+from typing import Any
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import (
+    Evaluator,
+    EvaluatorConfig,
+    EvaluatorType,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import (
+    HarborDataset,
+    HarborEvaluator,
+    HarborEvaluatorConfig,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import Dataset, DatasetRef, Task
+
+_SUPPORTED_EVALUATOR_TYPES = {
+    "harbor": (HarborDataset, HarborEvaluator, HarborEvaluatorConfig),
+}
+
+
+class DatasetFactory:
+    """Build evaluator-compatible Dataset objects from source references."""
+
+    def __init__(
+        self,
+        supported_evaluator_types: dict[EvaluatorType, tuple[type[Dataset], type[Evaluator], type[EvaluatorConfig]]]
+        | None = None,
+    ) -> None:
+        self.supported_evaluator_types = supported_evaluator_types or _SUPPORTED_EVALUATOR_TYPES
+
+    def build_dataset(self, evaluator_type: EvaluatorType, dataset_ref: DatasetRef) -> Dataset:
+        """Build a Dataset for the selected evaluator type.
+
+        Args:
+            evaluator_type(EvaluatorType): The type of evaluator to build the dataset for.
+            dataset_ref(DatasetRef): The reference to the dataset to build.
+
+        Returns:
+            Dataset: The built dataset.
+
+        Raises:
+            ValueError: If the evaluator type or dataset reference is not provided or if the evaluator type is not supported.
+        """
+        if not evaluator_type or not dataset_ref:
+            raise ValueError("Evaluator type and dataset reference are required")
+
+        if evaluator_type not in self.supported_evaluator_types:
+            raise ValueError(f"Unsupported evaluator type: {evaluator_type}")
+        return self.supported_evaluator_types[evaluator_type][0].from_ref(dataset_ref)
+
+    def build_task_template(self, evaluator_type: EvaluatorType, template_ref: DatasetRef) -> Task:
+        """Parse an evaluator-specific template directory as one task.
+
+        Args:
+            evaluator_type(EvaluatorType): The type of evaluator to build the task template for.
+            template_ref(DatasetRef): The reference to the template directory to build.
+                A template directory is a directory that contains a single task template containing placeholder values for the task.
+
+        Returns:
+            Task: The built task.
+        """
+        tasks = list(self.build_dataset(evaluator_type, template_ref).list_tasks())
+        if len(tasks) != 1:
+            raise ValueError(f"Task template must contain exactly one {evaluator_type} task; found {len(tasks)}")
+        return tasks[0]
+
+
+class EvaluatorFactory:
+    """Build concrete evaluators from evaluator type."""
+
+    def build_evaluator(
+        self,
+        evaluator_type: EvaluatorType,
+        config: EvaluatorConfig | dict[str, Any],
+        *,
+        experiment_dir: Path | None = None,
+    ) -> Evaluator:
+        """Build an Evaluator for the selected evaluator type.
+
+        Args:
+            evaluator_type(EvaluatorType): The type of evaluator to build.
+            config(EvaluatorConfig | dict[str, Any]): The configuration for the evaluator.
+            experiment_dir(Path | None): The directory to store the experiment results.
+
+        Returns:
+            Evaluator: The built evaluator.
+
+        Raises:
+            ValueError: If the evaluator type is not supported.
+            TypeError: If the evaluator config is not an EvaluatorConfig or dict.
+        """
+        if evaluator_type in _SUPPORTED_EVALUATOR_TYPES:
+            if isinstance(config, EvaluatorConfig):
+                config = config.model_dump()
+            elif not isinstance(config, dict):
+                raise TypeError(f"{evaluator_type.capitalize()} evaluator config must be an EvaluatorConfig or dict")
+            evaluator_config = _SUPPORTED_EVALUATOR_TYPES[evaluator_type][2].model_validate(config)
+            return _SUPPORTED_EVALUATOR_TYPES[evaluator_type][1](
+                options=evaluator_config, experiment_dir=experiment_dir
+            )
+
+        raise ValueError(f"Unsupported evaluator type: {evaluator_type}")

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
@@ -1,0 +1,1328 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Harbor dataset adapter for evaluator-domain task objects."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import importlib.machinery
+import json
+import logging
+import os
+import re
+import shutil
+import sys
+import tempfile
+import tomllib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType, TracebackType
+from typing import Any, TypeAlias, TypedDict
+from uuid import uuid4
+
+from harbor.constants import MAIN_SERVICE_NAME
+from harbor.environments.base import BaseEnvironment
+from harbor.environments.factory import EnvironmentFactory
+from harbor.job import DatasetConfig, Job, JobConfig
+from harbor.models.environment_type import EnvironmentType
+from harbor.models.job.config import AgentConfig, ArtifactConfig, RetryConfig
+from harbor.models.task.task import Task as HarborTaskModel
+from harbor.models.trial.config import ServiceVolumeConfig
+from harbor.models.trial.paths import EnvironmentPaths, TrialPaths
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import (
+    Evaluator,
+    EvaluatorConfig,
+    EvaluatorType,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import (
+    Dataset,
+    DatasetRef,
+    DatasetValidationError,
+    DataValue,
+    DependencyRuntime,
+    MetricResult,
+    MetricSpec,
+    ResourceRef,
+    Task,
+    TrialResult,
+    local_path_from_uri,
+    run_dependency_command,
+    subset_dataset_id,
+)
+from pydantic import Field
+
+
+class HarborResourceSpec(TypedDict):
+    """Known Harbor task file or directory."""
+
+    name: str
+    description: str
+
+
+TreeResourceSpec: TypeAlias = tuple[HarborResourceSpec, str, tuple[str, ...]]
+
+_HARBOR_CONFIG_FILENAME: HarborResourceSpec = {
+    "name": "task.toml",
+    "description": "Harbor task configuration file.",
+}
+_INSTRUCTION_FILENAME: HarborResourceSpec = {
+    "name": "instruction.md",
+    "description": "Task instruction shown to the benchmark agent.",
+}
+_README_FILENAMES = ("README.md", "readme.md")
+_ENVIRONMENT_DIRNAME: HarborResourceSpec = {
+    "name": "environment",
+    "description": (
+        "Harbor task environment directory. Contains the container definition and supporting files Harbor uses "
+        "to create the task environment, such as Dockerfile, docker-compose.yaml, singularity-compose.yaml, "
+        "and dependency files."
+    ),
+}
+_VERIFIER_DIRNAME: HarborResourceSpec = {
+    "name": "tests",
+    "description": (
+        "Harbor verifier tests directory. Harbor copies this directory into the task environment at /tests "
+        "after the agent phase, discovers test.{sh,ps1,cmd,bat}, and expects rewards under /logs/verifier "
+        "as reward.txt or reward.json."
+    ),
+}
+_ORACLE_DIRNAME: HarborResourceSpec = {
+    "name": "solution",
+    "description": (
+        "Harbor oracle solution directory. Harbor's OracleAgent copies this directory into the task environment "
+        "at /solution and discovers solve.{sh,ps1,cmd,bat} as the reference solution script."
+    ),
+}
+_STEPS_DIRNAME: HarborResourceSpec = {
+    "name": "steps",
+    "description": (
+        "Harbor multi-step task directory. Contains one subdirectory per [[steps]] entry; each step can provide "
+        "instruction.md plus step-specific tests/ and solution/ directories that Harbor uses like the top-level "
+        "verifier and oracle directories."
+    ),
+}
+_TASK_TREE_RESOURCES: tuple[TreeResourceSpec, ...] = (
+    (_ENVIRONMENT_DIRNAME, "environment_dir", ()),
+    (_VERIFIER_DIRNAME, "verifier_dir", ("test",)),
+    (_ORACLE_DIRNAME, "oracle_dir", ()),
+    (_STEPS_DIRNAME, "steps_dir", ()),
+)
+_TRACE_ARTIFACT_SOURCE = "/app/traces"
+_TRACE_ARTIFACT_DESTINATION = "traces"
+_SHELL_SYNTAX_TIMEOUT_SEC = 10.0
+_AGENT_IMPORT_ROOT = "_nemo_experimentalist_eval_agents"
+_IDENTIFIER_RE = re.compile(r"\W+")
+_TRIAL_LOG_DESCRIPTIONS = {
+    "agent/oracle.txt": "Oracle-agent log captured when Harbor runs the reference solution.",
+    "agent/setup/stdout.txt": "Agent setup stdout captured while Harbor uploads the agent and installs dependencies.",
+    "exception.txt": "Exception traceback captured by Harbor for a failed trial.",
+    "trial.log": "Harbor trial orchestration log covering environment setup, agent execution, verifier execution, artifact collection, and cleanup.",
+    "verifier/reward.json": "Verifier reward JSON written under /logs/verifier. Harbor parses numeric entries from this file as trial metrics.",
+    "verifier/reward.txt": "Verifier scalar reward file written under /logs/verifier. Harbor parses this file as the reward metric.",
+    "verifier/test-stderr.txt": "Verifier stderr captured while Harbor runs the task tests from the /tests directory.",
+    "verifier/test-stdout.txt": "Verifier stdout captured while Harbor runs the task tests from the /tests directory.",
+}
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HarborVerifierValidationFailure:
+    """Syntax failure found in one task's Harbor verifier."""
+
+    task_id: str
+    path: Path
+    error: str
+    line: int | None = None
+    column: int | None = None
+
+
+class HarborVerifierValidationError(DatasetValidationError):
+    """Aggregated Harbor verifier syntax failures."""
+
+    def __init__(self, failures: Sequence[HarborVerifierValidationFailure]) -> None:
+        self.failures = tuple(failures)
+        details = "\n".join(f"- {self._format_failure(failure)}" for failure in self.failures)
+        super().__init__(f"Harbor verifier preflight validation failed:\n{details}")
+
+    @staticmethod
+    def _format_failure(failure: HarborVerifierValidationFailure) -> str:
+        location = str(failure.path)
+        if failure.line is not None:
+            location = f"{location}:{failure.line}"
+            if failure.column is not None:
+                location = f"{location}:{failure.column}"
+        return f"task {failure.task_id!r}: {location}: {failure.error}"
+
+
+@dataclass(frozen=True)
+class _VerifierSyntaxFailure:
+    """Content-addressed verifier syntax failure."""
+
+    error: str
+    line: int | None = None
+    column: int | None = None
+
+
+class HarborEvaluatorConfig(EvaluatorConfig):
+    """Configuration for Harbor evaluator."""
+
+    job_name: str | None = Field(
+        default=None, description="Name of the job to run. If not provided, a default name will be generated."
+    )
+    jobs_dir: Path = Field(
+        default=Path("eval-and-optimize") / "results",
+        description="Directory to store job results, resolved relative to the experiment directory.",
+    )
+    n_attempts: int = Field(default=1)
+    n_concurrent_trials: int = Field(default=os.cpu_count() or 4)
+    quiet: bool = Field(default=False)
+    verifier_timeout_multiplier: float | None = Field(default=1.0)
+    agent_timeout_multiplier: float | None = Field(default=1.0)
+    agent_setup_timeout_multiplier: float | None = Field(default=1.0)
+    environment_build_timeout_multiplier: float | None = Field(default=1.0)
+    artifacts: list[str] = Field(default=[])
+    retry: RetryConfig = Field(default=RetryConfig(exclude_exceptions=set()))
+    import_path: str = Field(default="harbor_wrapper:WrappedAgent")
+    trace_dir: str = Field(default=_TRACE_ARTIFACT_SOURCE)
+
+
+class HarborDependencyRuntime(DependencyRuntime):
+    """Harbor API-backed task environment runtime."""
+
+    task_path: ResourceRef
+    environment_type: str = "docker"
+    force_build: bool = True
+    delete: bool = True
+    run_healthcheck: bool = True
+    build_timeout_sec: int | None = None
+
+    def context(self) -> HarborDependencyContext:
+        """Return Harbor-specific dependency context."""
+        return HarborDependencyContext(self)
+
+
+class HarborDependencyContext:
+    """Async context manager that starts and stops Harbor task dependencies."""
+
+    def __init__(self, runtime: HarborDependencyRuntime) -> None:
+        self._runtime = runtime
+        self._environment: BaseEnvironment | None = None
+        self._temp_dir: tempfile.TemporaryDirectory[str] | None = None
+
+    async def __aenter__(self) -> DependencyRuntime:
+        """Start Harbor dependencies and return the entered runtime."""
+        try:
+            await self._start_harbor_runtime()
+            if self._runtime.readiness is not None:
+                await run_dependency_command(self._runtime.readiness, "readiness")
+        except BaseException:
+            try:
+                await self._stop_started_runtime()
+            except Exception as stop_exc:
+                logger.warning("Harbor dependency cleanup failed during startup error: %s", stop_exc)
+            raise
+        return self._runtime
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Stop Harbor dependencies after the wrapped block completes."""
+        try:
+            await self._stop_started_runtime()
+        except Exception as stop_exc:
+            if exc_type is None:
+                raise
+            logger.warning("Harbor dependency cleanup failed (original error suppressed): %s", stop_exc)
+        return False
+
+    async def _start_harbor_runtime(self) -> None:
+        task_path = local_path_from_uri(self._runtime.task_path.uri, context="Harbor task reference").resolve()
+        harbor_task = HarborTaskModel(task_path)
+        context_id = uuid4()
+        session_id = f"{harbor_task.short_name}__{context_id.hex[:12]}__env"
+        temp_dir = tempfile.TemporaryDirectory(prefix="nemo-harbor-deps-")
+        trial_paths = TrialPaths(Path(temp_dir.name))
+        trial_paths.mkdir()
+
+        env_paths = EnvironmentPaths.for_os(harbor_task.config.environment.os)
+        main_artifacts_dir = trial_paths.host_artifact_path(MAIN_SERVICE_NAME, env_paths.artifacts_dir.as_posix())
+        main_artifacts_dir.mkdir(parents=True, exist_ok=True)
+        mounts = [
+            ServiceVolumeConfig(
+                type="bind",
+                source=trial_paths.verifier_dir.resolve().absolute().as_posix(),
+                target=str(env_paths.verifier_dir),
+            ),
+            ServiceVolumeConfig(
+                type="bind",
+                source=trial_paths.agent_dir.resolve().absolute().as_posix(),
+                target=str(env_paths.agent_dir),
+            ),
+            ServiceVolumeConfig(
+                type="bind",
+                source=main_artifacts_dir.resolve().absolute().as_posix(),
+                target=str(env_paths.artifacts_dir),
+            ),
+        ]
+        if harbor_task.paths.tests_dir.is_dir():
+            mounts.append(
+                ServiceVolumeConfig(
+                    type="bind",
+                    source=harbor_task.paths.tests_dir.resolve().absolute().as_posix(),
+                    target=str(env_paths.tests_dir),
+                    read_only=True,
+                )
+            )
+        environment = EnvironmentFactory.create_environment(
+            EnvironmentType(self._runtime.environment_type),
+            environment_dir=harbor_task.paths.environment_dir,
+            environment_name=harbor_task.short_name,
+            session_id=session_id,
+            trial_paths=trial_paths,
+            task_env_config=harbor_task.config.environment,
+            mounts=mounts,
+        )
+        environment.context_id = context_id
+        self._temp_dir = temp_dir
+        self._environment = environment
+
+        if environment.capabilities.mounted:
+            trial_paths.chmod_dir()
+            _chmod_path_chain(main_artifacts_dir, trial_paths.artifacts_dir)
+
+        await asyncio.wait_for(
+            environment.start(force_build=self._runtime.force_build),
+            timeout=self._runtime.build_timeout_sec,
+        )
+        if self._runtime.run_healthcheck and harbor_task.config.environment.healthcheck is not None:
+            await environment.run_healthcheck()
+
+        self._runtime.metadata.update(
+            {
+                "harbor_task_path": str(task_path),
+                "harbor_trial_dir": str(trial_paths.trial_dir),
+                "harbor_environment_session_id": session_id,
+            }
+        )
+
+    async def _stop_started_runtime(self) -> None:
+        stop_error: Exception | None = None
+        if self._environment is not None:
+            try:
+                await self._environment.stop(delete=self._runtime.delete)
+            except Exception as exc:
+                stop_error = exc
+            finally:
+                self._environment = None
+
+        if self._runtime.stop is not None:
+            try:
+                await run_dependency_command(self._runtime.stop, "stop")
+            except Exception as exc:
+                if stop_error is None:
+                    stop_error = exc
+
+        if self._temp_dir is not None:
+            self._temp_dir.cleanup()
+            self._temp_dir = None
+        if stop_error is not None:
+            raise stop_error
+
+
+def _chmod_path_chain(path: Path, stop_at: Path) -> None:
+    current = path
+    while True:
+        current.chmod(0o777)
+        if current == stop_at:
+            break
+        current = current.parent
+
+
+HarborDataValue: TypeAlias = DataValue | ResourceRef
+
+
+def _safe_identifier(value: str) -> str:
+    identifier = _IDENTIFIER_RE.sub("_", value).strip("_")
+    if not identifier:
+        identifier = "path"
+    if not identifier[0].isalpha() and identifier[0] != "_":
+        identifier = f"_{identifier}"
+    return identifier
+
+
+def _agent_import_package(agent_path: Path) -> str:
+    path_parts = [_safe_identifier(part) for part in agent_path.parts if part not in {"", agent_path.anchor}]
+    tail = path_parts[-6:] or ["agent"]
+    digest = hashlib.sha256(str(agent_path).encode("utf-8")).hexdigest()[:12]
+    tail[-1] = f"{tail[-1]}_{digest}"
+    return ".".join([_AGENT_IMPORT_ROOT, *tail])
+
+
+def _ensure_package(name: str, search_path: Path | None = None) -> None:
+    parts = name.split(".")
+    for idx in range(1, len(parts) + 1):
+        package_name = ".".join(parts[:idx])
+        package = sys.modules.get(package_name)
+        if package is None:
+            package = ModuleType(package_name)
+            package.__package__ = package_name
+            package.__spec__ = importlib.machinery.ModuleSpec(package_name, loader=None, is_package=True)
+            package.__path__ = []  # type: ignore[attr-defined]
+            sys.modules[package_name] = package
+            if idx > 1:
+                parent_name = ".".join(parts[: idx - 1])
+                setattr(sys.modules[parent_name], parts[idx - 1], package)
+        if search_path is not None and idx == len(parts):
+            package.__path__ = [str(search_path)]  # type: ignore[attr-defined]
+
+
+def _scoped_import_path(agent_path: Path, import_path: str) -> tuple[str, str]:
+    module_name, separator, attribute = import_path.partition(":")
+    module_name = module_name.strip().lstrip(".")
+    if not module_name:
+        raise ValueError("import_path module is required")
+
+    package_name = _agent_import_package(agent_path)
+    _ensure_package(package_name, search_path=agent_path)
+    scoped = f"{package_name}.{module_name}"
+    if separator:
+        scoped = f"{scoped}:{attribute}"
+    return scoped, package_name
+
+
+def _cleanup_scoped_imports(package_name: str) -> None:
+    package = sys.modules.get(package_name)
+    for module_name in list(sys.modules):
+        if module_name == package_name or module_name.startswith(f"{package_name}."):
+            sys.modules.pop(module_name, None)
+    parent_name, _, child_name = package_name.rpartition(".")
+    parent = sys.modules.get(parent_name)
+    if parent is not None and getattr(parent, child_name, None) is package:
+        delattr(parent, child_name)
+    parts = package_name.split(".")
+    for idx in range(len(parts) - 1, 0, -1):
+        module_name = ".".join(parts[:idx])
+        if any(name.startswith(f"{module_name}.") for name in sys.modules):
+            break
+        package = sys.modules.pop(module_name, None)
+        parent_name, _, child_name = module_name.rpartition(".")
+        parent = sys.modules.get(parent_name)
+        if parent is not None and getattr(parent, child_name, None) is package:
+            delattr(parent, child_name)
+
+
+def _resolve_verifier_dir(task_dir: Path, config: dict[str, Any]) -> Path:
+    verifier_config = config.get("verifier")
+    if isinstance(verifier_config, dict):
+        configured_dir = verifier_config.get("directory")
+        if isinstance(configured_dir, str) and configured_dir.strip():
+            path = Path(configured_dir).expanduser()
+            return path if path.is_absolute() else task_dir / path
+
+    for dirname in (_VERIFIER_DIRNAME["name"], "test"):
+        verifier_dir = task_dir / dirname
+        if verifier_dir.is_dir():
+            return verifier_dir
+    return task_dir / _VERIFIER_DIRNAME["name"]
+
+
+def _python_syntax_failure(source: str, path: Path) -> _VerifierSyntaxFailure | None:
+    try:
+        compile(source, str(path), "exec")
+    except SyntaxError as exc:
+        return _VerifierSyntaxFailure(
+            error=f"{type(exc).__name__}: {exc.msg}",
+            line=exc.lineno,
+            column=exc.offset,
+        )
+    except RecursionError as exc:
+        return _VerifierSyntaxFailure(error=f"{type(exc).__name__}: {exc}")
+    return None
+
+
+async def _shell_syntax_failure(source: str) -> _VerifierSyntaxFailure | None:
+    bash_path = shutil.which("bash", path=os.defpath)
+    if bash_path is None:
+        raise FileNotFoundError("bash executable not found on the system path")
+    process = await asyncio.create_subprocess_exec(
+        bash_path,
+        "--noprofile",
+        "--norc",
+        "-n",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={"LC_ALL": "C", "PATH": os.defpath, "SHELLOPTS": "noexec"},
+    )
+    try:
+        _, stderr = await asyncio.wait_for(
+            process.communicate(source.encode("utf-8")),
+            timeout=_SHELL_SYNTAX_TIMEOUT_SEC,
+        )
+    except (TimeoutError, asyncio.CancelledError):
+        if process.returncode is None:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                pass
+        await process.communicate()
+        raise
+    if process.returncode == 0:
+        return None
+
+    error = stderr.decode("utf-8", errors="replace").strip() or f"bash -n exited with status {process.returncode}"
+    line_match = re.search(r"\bline (\d+):", error)
+    return _VerifierSyntaxFailure(
+        error=error,
+        line=int(line_match.group(1)) if line_match else None,
+    )
+
+
+def _harbor_metric_spec(ref: ResourceRef | None, task_name: str | None = None) -> MetricSpec:
+    description = "Harbor verifier reward emitted for this task."
+    if task_name:
+        description = f"Harbor verifier reward emitted for {task_name}."
+    return MetricSpec(name="reward", description=description, ref=ref)
+
+
+def _trial_metric_spec(trial_dir: Path, trial_data: dict[str, Any]) -> MetricSpec:
+    task_dir = _trial_task_path(trial_data)
+
+    ref = None
+    if task_dir is not None:
+        for verifier_dirname in (_VERIFIER_DIRNAME["name"], "test"):
+            verifier_dir = task_dir / verifier_dirname
+            if verifier_dir.is_dir():
+                ref = ResourceRef(
+                    uri=verifier_dir.resolve().as_uri(),
+                    description=_VERIFIER_DIRNAME["description"],
+                )
+                break
+    if ref is None and (trial_dir / "verifier").is_dir():
+        verifier_output_dir = trial_dir / "verifier"
+        ref = ResourceRef(
+            uri=verifier_output_dir.resolve().as_uri(),
+            description=(
+                "Harbor verifier output directory. In the task environment this is mounted at /logs/verifier "
+                "and stores verifier logs and reward files."
+            ),
+        )
+
+    task_name = trial_data.get("task_name")
+    return _harbor_metric_spec(ref, task_name if isinstance(task_name, str) else None)
+
+
+def _trial_task_path(trial_data: dict[str, Any]) -> Path | None:
+    config = trial_data.get("config")
+    if isinstance(config, dict):
+        task_config = config.get("task")
+        if isinstance(task_config, dict) and isinstance(task_config.get("path"), str):
+            return Path(task_config["path"]).expanduser()
+
+    task_ref = trial_data.get("task_id")
+    if isinstance(task_ref, dict) and isinstance(task_ref.get("path"), str):
+        return Path(task_ref["path"]).expanduser()
+    return None
+
+
+def _resolve_trial_task_id(
+    trial_name: str,
+    trial_data: dict[str, Any],
+    task_map: dict[str, Task],
+) -> str:
+    task_path = _trial_task_path(trial_data)
+    if task_path is not None:
+        resolved_path = task_path.resolve()
+        for task in task_map.values():
+            if not task.uri:
+                continue
+            try:
+                if local_path_from_uri(task.uri, context="Harbor task reference").resolve() == resolved_path:
+                    return task.id
+            except ValueError:
+                continue
+        if task_path.name in task_map:
+            return task_path.name
+
+    task_name = trial_data.get("task_name")
+    if isinstance(task_name, str) and task_name:
+        task_id = task_name.split("/")[-1]
+    else:
+        task_id = trial_name.rsplit("__", 1)[0]
+    if task_id in task_map:
+        return task_id
+
+    trial_base = trial_name.rsplit("__", 1)[0]
+    if trial_base in task_map:
+        return trial_base
+
+    return task_id
+
+
+def _trial_attempt(trial_name: str) -> int | None:
+    suffix = trial_name.rsplit("__", 1)[-1]
+    if suffix.isdigit():
+        return int(suffix)
+    return None
+
+
+def _is_trial_log_path(relative_path: str) -> bool:
+    if relative_path in _TRIAL_LOG_DESCRIPTIONS:
+        return True
+    parts = relative_path.split("/")
+    return len(parts) == 3 and parts[0] == "agent" and parts[1].startswith("command-") and parts[2] == "stdout.txt"
+
+
+def _with_trace_artifact(artifacts: Sequence[str | ArtifactConfig], trace_source: str) -> list[str | ArtifactConfig]:
+    for artifact in artifacts:
+        if isinstance(artifact, ArtifactConfig):
+            if artifact.source == trace_source or artifact.destination == _TRACE_ARTIFACT_DESTINATION:
+                return list(artifacts)
+        elif isinstance(artifact, str) and artifact in {trace_source, _TRACE_ARTIFACT_DESTINATION}:
+            return list(artifacts)
+
+    trace_artifact = ArtifactConfig(source=trace_source, destination=_TRACE_ARTIFACT_DESTINATION)
+    return [trace_artifact, *artifacts]
+
+
+def _trial_error(exception_info: Any) -> dict[str, DataValue] | None:
+    if exception_info is None:
+        return None
+    if not isinstance(exception_info, dict):
+        return {"exception_info": exception_info}
+
+    error: dict[str, DataValue] = {}
+    if "exception_type" in exception_info:
+        error["type"] = exception_info["exception_type"]
+    if "exception_message" in exception_info:
+        error["message"] = exception_info["exception_message"]
+    if "exception_traceback" in exception_info:
+        error["traceback"] = exception_info["exception_traceback"]
+    return error or {"exception_info": exception_info}
+
+
+def _reward_values_from_file(path: Path) -> dict[str, Any]:
+    if path.suffix == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    return {"reward": path.read_text(encoding="utf-8").strip()}
+
+
+def _trial_reward_values(trial_dir: Path, trial_data: dict[str, Any]) -> dict[str, Any]:
+    verifier_result = trial_data.get("verifier_result")
+    if isinstance(verifier_result, dict):
+        rewards = verifier_result.get("rewards")
+        if isinstance(rewards, dict):
+            return rewards
+
+    reward_paths = (
+        trial_dir / "verifier" / "reward.json",
+        trial_dir / "verifier" / "reward.txt",
+        trial_dir / "reward.json",
+        trial_dir / "reward.txt",
+    )
+    for path in reward_paths:
+        if path.is_file():
+            return _reward_values_from_file(path)
+    return {}
+
+
+def _trial_metrics(trial_dir: Path, trial_data: dict[str, Any], spec: MetricSpec) -> dict[str, MetricResult]:
+    values = _trial_reward_values(trial_dir, trial_data)
+    metrics: dict[str, MetricResult] = {}
+    for name, value in values.items():
+        try:
+            metric_value = float(value)
+        except (TypeError, ValueError):
+            continue
+        metrics[name] = MetricResult(name=name, value=metric_value, spec=spec)
+    return metrics
+
+
+def _trial_resources(trial_dir: Path) -> tuple[dict[str, ResourceRef], ResourceRef | None]:
+    resources: dict[str, ResourceRef] = {
+        "trial_dir": ResourceRef(
+            uri=trial_dir.resolve().as_uri(),
+            description=(
+                "Harbor trial output directory for one task attempt. Contains config.json, result.json, "
+                "trial.log, agent logs, verifier logs, and collected artifacts."
+            ),
+        )
+    }
+    trace_ref = None
+
+    for path in sorted(candidate for candidate in trial_dir.rglob("*") if candidate.is_file()):
+        relative_path = path.relative_to(trial_dir).as_posix()
+        uri = path.resolve().as_uri()
+        if relative_path == "config.json":
+            resources["config"] = ResourceRef(
+                uri=uri,
+                description=(
+                    "Harbor trial configuration snapshot. Records the task, agent, environment, verifier, "
+                    "artifact collection, and job id used for this attempt."
+                ),
+            )
+        elif relative_path == "result.json":
+            resources["result"] = ResourceRef(
+                uri=uri,
+                description=(
+                    "Harbor trial result JSON. Contains task and trial identifiers, agent info, verifier rewards, "
+                    "exception info, phase timings, and token or cost usage."
+                ),
+            )
+        elif path.suffix == ".jsonl" and "traces" in Path(relative_path).parts[:-1]:
+            trace_relative_path = relative_path.removeprefix("artifacts/")
+            description = f"Agent execution trace JSONL for {trace_relative_path}."
+            trace_ref = trace_ref or ResourceRef(uri=uri, description=description)
+            resources[f"trace:{trace_relative_path}"] = ResourceRef(uri=uri, description=description)
+        elif _is_trial_log_path(relative_path):
+            description = _TRIAL_LOG_DESCRIPTIONS.get(relative_path)
+            if description is None and relative_path.startswith("agent/command-"):
+                description = "Agent command stdout captured while Harbor runs the benchmark agent."
+            description = description or f"Harbor trial log {relative_path}."
+            resources[f"log:{relative_path}"] = ResourceRef(
+                uri=uri,
+                description=description,
+            )
+        elif relative_path.startswith("artifacts/"):
+            artifact_relative_path = relative_path.removeprefix("artifacts/")
+            description = f"Collected Harbor artifact {artifact_relative_path}."
+            if artifact_relative_path == "manifest.json":
+                description = (
+                    "Harbor artifact manifest. Lists collected artifact files and the environment paths they were "
+                    "copied from."
+                )
+            resources[f"artifact:{artifact_relative_path}"] = ResourceRef(
+                uri=uri,
+                description=description,
+            )
+        else:
+            resources[f"artifact:{relative_path}"] = ResourceRef(
+                uri=uri,
+                description=f"Collected Harbor artifact {relative_path}.",
+            )
+
+    return resources, trace_ref
+
+
+class HarborDataset(Dataset):
+    """Harbor task collection mapped onto generic evaluator-domain objects.
+
+    ## Navigating the dataset
+
+    ``dataset.source.uri`` — ``file://`` URI of the dataset root.
+    Iterate tasks with ``dataset.list_tasks()``.  Each ``Task`` exposes:
+
+    - ``task.id``  — subdirectory name (e.g. ``"tau2-airline-13"``)
+    - ``task.uri`` — ``file://`` URI of the task root directory
+
+    Resolve a ``file://`` URI to a ``pathlib.Path``:
+
+    .. code-block:: python
+
+        from pathlib import Path
+        from urllib.parse import unquote, urlparse
+
+        task_dir = Path(unquote(urlparse(task.uri).path))
+        dataset_root = Path(unquote(urlparse(dataset.source.uri).path))
+
+    ## Task directory layout
+
+    ::
+
+        <task-id>/
+          task.toml       # task config
+          instruction.md  # agent prompt
+          tests/
+            test.sh       # verifier entry point (may be empty on live datasets)
+          environment/    # container definition
+          solution/       # optional oracle
+
+    ## How to modify instructions
+
+    Edit the ``instruction.md`` file in the task directory.
+
+    ## How to modify the solution
+
+    The entry point for the agent is the ``solve.sh`` script in the ``solution/`` directory.
+    It is executed in the task environment and can modify it.
+
+    The verifier script will run after the solve.sh script.
+
+    ## How to add, remove, or modify a metric
+
+    Metrics are defined by what ``tests/test.sh`` writes to ``/logs/verifier/``
+    inside the container.  To change the metrics for a task, edit or replace
+    that script.
+
+    **How it runs:** after the agent finishes, Harbor copies ``tests/`` into the
+    container at ``/tests`` and executes ``tests/test.sh``.  The script can read:
+
+    - ``/logs/artifacts/traces/`` — **primary signal source**: OTLP trace files
+      written by the agent as ``*.jsonl``.  Each line is an
+      ``ExportTraceServiceRequest`` JSON object.  Spans live under
+      ``resourceSpans[].scopeSpans[].spans[]``.  Span attributes are a list of
+      ``{"key": str, "value": {"stringValue": str}}``.  Error spans carry
+      ``error.type`` and ``error.message`` attributes.  Tool calls, LLM inputs/outputs,
+      and execution results are all recorded here as structured spans — prefer this
+      over raw log files for reliable, parseable signal.  Resolve the path via
+      ``os.environ.get("TRACE_DIR", "/logs/artifacts/traces")`` so the script is
+      testable locally.
+    - ``/logs/agent/``    — raw agent process output (stdout/stderr, unstructured).
+      Use only when the OTLP traces don't capture what you need.
+    - ``/tests/``         — any helper files you place in ``tests/``
+
+    and must write to:
+
+    - ``/logs/verifier/reward.json`` — flat JSON object; **every value must be a
+      plain number** (int or float).  Harbor calls ``float(value)`` on each entry
+      and silently drops non-numeric values (nested objects, booleans, strings).
+
+    Correct format::
+
+        {"reward": 0.8, "my_metric": 1.0}
+
+    **To add a new metric** — write it as an additional key in ``reward.json``::
+
+        {"reward": 0.8, "my_metric": 1.0, "another_metric": 0.5}
+
+    **To remove a metric** — omit its key from the JSON object.
+
+    **To modify the scoring logic** — edit the ``test.sh`` script body.
+
+    **Preferred pattern — separate script files**
+
+    Write each metric as a standalone Python file in ``tests/`` (e.g.
+    ``tests/check_my_metric.py``) and call it from ``test.sh``.  This avoids
+    shell-escaping issues with heredocs and makes each script independently
+    testable.
+
+    ``tests/check_my_metric.py``:
+
+    .. code-block:: python
+
+        #!/usr/bin/env python3
+        # Measures: <describe what this script measures>
+        import json, pathlib, sys
+
+        AGENT_DIR = pathlib.Path("/logs/agent")
+        OUT = pathlib.Path("/logs/verifier/metric_my_metric.json")
+
+        # Inspect AGENT_DIR for the behavior to measure.
+        score = 1.0
+        # ... compute score from files in AGENT_DIR ...
+
+        OUT.write_text(json.dumps({"my_metric": score}))
+        print(f"my_metric={score}", file=sys.stderr)  # captured in verifier stderr
+
+    ``tests/test.sh``:
+
+    .. code-block:: bash
+
+        #!/usr/bin/env bash
+        set -euo pipefail
+        mkdir -p /logs/verifier
+        SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+        # Run each metric script and collect its output.
+        python3 "$SCRIPT_DIR/check_my_metric.py"
+
+        # Merge all metric_*.json files into reward.json.
+        python3 "$SCRIPT_DIR/merge_metrics.py"
+
+    ``tests/merge_metrics.py`` (reusable across tasks):
+
+    .. code-block:: python
+
+        #!/usr/bin/env python3
+        import json, glob, pathlib
+
+        result = {}
+        for f in sorted(glob.glob("/logs/verifier/metric_*.json")):
+            result.update(json.load(open(f)))
+        pathlib.Path("/logs/verifier/reward.json").write_text(json.dumps(result))
+
+    **LLM judge — ``tests/check_judge.py``**:
+
+    .. code-block:: python
+
+        #!/usr/bin/env python3
+        # Judge: scores agent response against the task instruction via LLM.
+        import json, pathlib, sys, openai
+
+        AGENT_DIR = pathlib.Path("/logs/agent")
+        OUT = pathlib.Path("/logs/verifier/metric_judge.json")
+
+        agent_log = AGENT_DIR / "agent_log.jsonl"
+        turns = [json.loads(l) for l in agent_log.read_text().splitlines() if l.strip()]
+        agent_response = next(
+            (t["content"] for t in reversed(turns) if t.get("role") == "assistant"), ""
+        )
+        instruction = pathlib.Path("/tests/instruction.md").read_text()
+
+        # OPENAI_API_KEY injected via task.toml [verifier] env = { OPENAI_API_KEY = "sk-..." }
+        client = openai.OpenAI()
+        verdict = client.chat.completions.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": (
+                    "You are a strict evaluator. "
+                    'Reply with JSON: {"score": <0.0-1.0>, "reason": "<one sentence>"}.'
+                )},
+                {"role": "user", "content": (
+                    f"Instruction:\n{instruction}\n\nAgent response:\n{agent_response}\n\n"
+                    "Score 1.0 if fully satisfied, 0.0 if not."
+                )},
+            ],
+            response_format={"type": "json_object"},
+        )
+        result = json.loads(verdict.choices[0].message.content)
+        score = float(result["score"])
+        print(f"judge_score={score} reason={result.get('reason','')}", file=sys.stderr)
+        OUT.write_text(json.dumps({"judge_score": score}))
+
+    ``tests/test.sh`` calls it the same way as any other metric script::
+
+        python3 "$SCRIPT_DIR/check_judge.py"
+        python3 "$SCRIPT_DIR/merge_metrics.py"
+
+    Live datasets ship with an empty ``test.sh`` — replace it entirely with the
+    pattern above.
+
+    ## Augmenting a dataset in place
+
+    Edit task directories on disk — do **not** copy them elsewhere.
+
+    .. code-block:: python
+
+        for task in dataset.list_tasks():
+            task_dir = Path(unquote(urlparse(task.uri).path))
+            test_sh = task_dir / "tests" / "test.sh"
+            test_sh.parent.mkdir(exist_ok=True)
+            test_sh.write_text(check_script, encoding="utf-8")
+            test_sh.chmod(0o755)
+    """
+
+    def __init__(
+        self,
+        id: str,
+        source: ResourceRef | None = None,
+        tasks: Sequence[Task] | None = None,
+        metadata: dict[str, DataValue] | None = None,
+    ) -> None:
+        super().__init__(
+            id=id,
+            source=source,
+            tasks=list(tasks or []),
+            metadata=metadata or {},
+        )
+
+    @classmethod
+    def from_ref(cls, ref: DatasetRef, **options: Any) -> HarborDataset:
+        """Build a Harbor dataset from a local dataset reference."""
+        dataset_path = local_path_from_uri(ref.uri, context="Harbor dataset reference")
+        dataset_id = ref.metadata.get("id")
+        if dataset_id is not None and not isinstance(dataset_id, str):
+            raise ValueError("Harbor dataset ref metadata field 'id' must be a string")
+        task_ids = cls._task_ids_from_metadata(ref.metadata.get("task_ids"))
+        dataset = cls.from_path(
+            dataset_path,
+            dataset_id=dataset_id,
+            **options,
+        )
+        return dataset.subset(task_ids) if task_ids is not None else dataset
+
+    @staticmethod
+    def _task_ids_from_metadata(value: DataValue) -> list[str] | None:
+        """Validate an optional ordered task-id selection from DatasetRef metadata."""
+        if value is None:
+            return None
+        if not isinstance(value, list) or not value:
+            raise ValueError("Harbor dataset ref metadata field 'task_ids' must be a non-empty list of strings")
+        if any(not isinstance(task_id, str) or not task_id for task_id in value):
+            raise ValueError("Harbor dataset ref metadata field 'task_ids' must be a non-empty list of strings")
+        if len(set(value)) != len(value):
+            raise ValueError("Harbor dataset ref metadata field 'task_ids' must not contain duplicates")
+        return value
+
+    @classmethod
+    def from_path(
+        cls,
+        dataset_path: Path,
+        *,
+        dataset_id: str | None = None,
+        **_ignored_options: Any,
+    ) -> HarborDataset:
+        """Build a Harbor dataset from a local Harbor task collection."""
+        dataset_path = dataset_path.expanduser().resolve()
+        if not dataset_path.exists():
+            raise FileNotFoundError(f"Harbor dataset path not found: {dataset_path}")
+        if not dataset_path.is_dir():
+            raise ValueError(f"Harbor dataset path is not a directory: {dataset_path}")
+
+        task_dirs = cls._find_task_dirs(dataset_path)
+        if not task_dirs:
+            raise ValueError(f"Harbor dataset path contains no Harbor task directories: {dataset_path}")
+
+        tasks = [cls._from_task_dir(task_dir) for task_dir in task_dirs]
+        return cls(
+            id=dataset_id or dataset_path.name,
+            source=ResourceRef(
+                uri=dataset_path.resolve().as_uri(),
+                description="Harbor dataset root directory.",
+            ),
+            tasks=tasks,
+        )
+
+    @staticmethod
+    def _find_task_dirs(dataset_path: Path) -> list[Path]:
+        if dataset_path.is_dir() and (dataset_path / "task.toml").exists():
+            return [dataset_path]
+        return sorted(
+            path
+            for path in dataset_path.iterdir()
+            if path.is_dir() and path.name != "task_template" and (path / "task.toml").exists()
+        )
+
+    @classmethod
+    def _from_task_dir(cls, task_dir: Path) -> Task:
+        config = tomllib.loads((task_dir / "task.toml").read_text(encoding="utf-8"))
+        inputs: dict[str, HarborDataValue] = {}
+        resources: dict[str, ResourceRef] = {}
+
+        cls._add_instruction_inputs(task_dir, config, inputs, resources)
+        if config:
+            inputs["config"] = config
+
+        cls._add_readme_inputs(task_dir, inputs, resources)
+        cls._add_known_resources(task_dir, config, resources)
+
+        return Task(
+            uri=task_dir.resolve().as_uri(),
+            description="Harbor task root directory.",
+            id=task_dir.name,
+            inputs=inputs,
+            resources=resources,
+            metric_specs=cls._task_metric_specs(task_dir, config),
+            dependencies=cls._dependency_runtime(task_dir, config),
+        )
+
+    @classmethod
+    def _add_instruction_inputs(
+        cls,
+        task_dir: Path,
+        config: dict[str, Any],
+        inputs: dict[str, HarborDataValue],
+        resources: dict[str, ResourceRef],
+    ) -> None:
+        instruction_path = task_dir / _INSTRUCTION_FILENAME["name"]
+        if instruction_path.exists():
+            inputs["instruction"] = instruction_path.read_text(encoding="utf-8")
+            resources["instruction"] = ResourceRef(
+                uri=instruction_path.resolve().as_uri(),
+                description=_INSTRUCTION_FILENAME["description"],
+            )
+
+        step_inputs = cls._step_inputs(task_dir, config, resources)
+        if step_inputs:
+            inputs["steps"] = step_inputs
+            if "instruction" not in inputs:
+                inputs["instruction"] = "\n\n---\n\n".join(
+                    f"## Step {index + 1}: {step['name']}\n\n{step['instruction']}"
+                    for index, step in enumerate(step_inputs)
+                    if isinstance(step.get("instruction"), str)
+                )
+
+    @staticmethod
+    def _step_inputs(
+        task_dir: Path,
+        config: dict[str, Any],
+        resources: dict[str, ResourceRef],
+    ) -> list[dict[str, Any]]:
+        step_inputs: list[dict[str, Any]] = []
+        steps_dir = task_dir / _STEPS_DIRNAME["name"]
+        steps = config.get("steps")
+        if not isinstance(steps, list):
+            return step_inputs
+
+        for index, step in enumerate(step for step in steps if isinstance(step, dict)):
+            name = step.get("name")
+            if not isinstance(name, str) or not name:
+                continue
+            instruction_path = steps_dir / name / _INSTRUCTION_FILENAME["name"]
+            instruction = None
+            if instruction_path.exists():
+                instruction = instruction_path.read_text(encoding="utf-8").rstrip()
+                resources[f"step_{index + 1}_instruction"] = ResourceRef(
+                    uri=instruction_path.resolve().as_uri(),
+                    description=f"Instruction for Harbor task step {name}.",
+                )
+            step_inputs.append(
+                {
+                    "name": name,
+                    "instruction": instruction,
+                    "config": step,
+                }
+            )
+        return step_inputs
+
+    @staticmethod
+    def _add_readme_inputs(
+        task_dir: Path,
+        inputs: dict[str, HarborDataValue],
+        resources: dict[str, ResourceRef],
+    ) -> None:
+        # Match against the directory listing rather than Path.exists(): on a
+        # case-insensitive filesystem every candidate spelling "exists", which would
+        # emit a URI whose casing does not match the file actually on disk.
+        try:
+            present = {entry.name for entry in task_dir.iterdir()}
+        except OSError:
+            return
+        for name in _README_FILENAMES:
+            if name not in present:
+                continue
+            ref = ResourceRef(
+                uri=(task_dir / name).resolve().as_uri(),
+                description="Task README.",
+            )
+            inputs["readme"] = ref
+            resources["readme"] = ref
+            return
+
+    @staticmethod
+    def _add_known_resources(
+        task_dir: Path,
+        config: dict[str, Any],
+        resources: dict[str, ResourceRef],
+    ) -> None:
+        resources["task_dir"] = ResourceRef(
+            uri=task_dir.resolve().as_uri(),
+            description="Harbor task root directory.",
+        )
+
+        config_path = task_dir / _HARBOR_CONFIG_FILENAME["name"]
+        if config_path.is_file():
+            resources["task_config"] = ResourceRef(
+                uri=config_path.resolve().as_uri(),
+                description=_HARBOR_CONFIG_FILENAME["description"],
+            )
+
+        for spec, key, aliases in _TASK_TREE_RESOURCES:
+            if key == "verifier_dir":
+                verifier_dir = _resolve_verifier_dir(task_dir, config)
+                if verifier_dir.is_dir():
+                    resources[key] = ResourceRef(
+                        uri=verifier_dir.resolve().as_uri(),
+                        description=spec["description"],
+                    )
+                continue
+            for name in (spec["name"], *aliases):
+                path = task_dir / name
+                if path.is_dir():
+                    resources[key] = ResourceRef(
+                        uri=path.resolve().as_uri(),
+                        description=spec["description"],
+                    )
+                    break
+
+    @staticmethod
+    def _task_metric_specs(task_dir: Path, config: dict[str, Any]) -> dict[str, MetricSpec]:
+        task_config = config.get("task")
+        task_name = None
+        if isinstance(task_config, dict) and isinstance(task_config.get("name"), str):
+            task_name = task_config["name"]
+        ref = None
+        verifier_dir = _resolve_verifier_dir(task_dir, config)
+        if verifier_dir.is_dir():
+            ref = ResourceRef(
+                uri=verifier_dir.resolve().as_uri(),
+                description=_VERIFIER_DIRNAME["description"],
+            )
+
+        return {"reward": _harbor_metric_spec(ref, task_name)}
+
+    @staticmethod
+    def _dependency_runtime(task_dir: Path, config: dict[str, Any]) -> DependencyRuntime:
+        environment_config = config.get("environment") if isinstance(config, dict) else None
+        build_timeout = None
+        if isinstance(environment_config, dict):
+            raw_timeout = environment_config.get("build_timeout_sec")
+            if isinstance(raw_timeout, int | float):
+                build_timeout = int(raw_timeout)
+        return HarborDependencyRuntime(
+            task_path=ResourceRef(
+                uri=task_dir.resolve().as_uri(),
+                description="Harbor task directory to start via Harbor EnvironmentFactory.",
+            ),
+            force_build=True,
+            build_timeout_sec=build_timeout,
+        )
+
+    def list_tasks(self) -> Sequence[Task]:
+        """Return Harbor tasks."""
+        return list(self.tasks)
+
+    def get_task(self, task_id: str) -> Task:
+        """Return a Harbor task by id."""
+        for task in self.list_tasks():
+            if task.id == task_id:
+                return task
+        raise ValueError(f"Task id not found in Harbor dataset {self.id!r}: {task_id}")
+
+    async def validate(self) -> None:
+        """Validate selected task verifier syntax without executing verifier code."""
+        failures: list[HarborVerifierValidationFailure] = []
+        cache: dict[tuple[str, str], _VerifierSyntaxFailure | None] = {}
+
+        for task in self.list_tasks():
+            if not task.uri:
+                raise ValueError(f"Harbor task {task.id!r} URI is required for verifier validation")
+            task_dir = local_path_from_uri(task.uri, context="Harbor task reference").resolve()
+            config_path = task_dir / _HARBOR_CONFIG_FILENAME["name"]
+            config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            verifier_dir = _resolve_verifier_dir(task_dir, config)
+            if not verifier_dir.is_dir():
+                continue
+
+            verifier_paths = sorted(path for path in verifier_dir.rglob("*.py") if path.is_file())
+            shell_entrypoint = verifier_dir / "test.sh"
+            if shell_entrypoint.is_file():
+                verifier_paths.append(shell_entrypoint)
+
+            for path in verifier_paths:
+                source = path.read_text(encoding="utf-8")
+                verifier_type = "shell" if path == shell_entrypoint else "python"
+                cache_key = (verifier_type, hashlib.sha256(source.encode("utf-8")).hexdigest())
+                syntax_failure = cache.get(cache_key)
+                if cache_key not in cache:
+                    if verifier_type == "shell":
+                        syntax_failure = await _shell_syntax_failure(source)
+                    else:
+                        syntax_failure = _python_syntax_failure(source, path)
+                    cache[cache_key] = syntax_failure
+
+                if syntax_failure is not None:
+                    failures.append(
+                        HarborVerifierValidationFailure(
+                            task_id=task.id,
+                            path=path.resolve(),
+                            error=syntax_failure.error,
+                            line=syntax_failure.line,
+                            column=syntax_failure.column,
+                        )
+                    )
+
+        if failures:
+            raise HarborVerifierValidationError(failures)
+
+    def subset(self, task_ids: Sequence[str]) -> HarborDataset:
+        """Return a Harbor dataset containing selected task ids."""
+        selected_ids = set(task_ids)
+        tasks = [task for task in self.list_tasks() if task.id in selected_ids]
+        missing = selected_ids - {task.id for task in tasks}
+        if missing:
+            missing_text = ", ".join(sorted(missing))
+            raise ValueError(f"Task id(s) not found in Harbor dataset {self.id!r}: {missing_text}")
+        return HarborDataset(
+            id=subset_dataset_id(self.id, [task.id for task in tasks]),
+            source=self.source,
+            tasks=tasks,
+            metadata=dict(self.metadata),
+        )
+
+
+class HarborEvaluator(Evaluator):
+    """Run Harbor evaluations and return parsed reward payloads."""
+
+    evaluator_type: EvaluatorType = "harbor"
+
+    def __init__(self, options: HarborEvaluatorConfig | None = None, experiment_dir: Path | None = None) -> None:
+        super().__init__(options or HarborEvaluatorConfig(), experiment_dir=experiment_dir)
+
+    async def _run(self, agent: Path, dataset: Dataset, options: HarborEvaluatorConfig) -> Sequence[TrialResult]:
+        if not isinstance(dataset, HarborDataset):
+            raise ValueError("Dataset must be a Harbor dataset")
+
+        if dataset.source is None:
+            raise ValueError("Harbor dataset source is required")
+        dataset_path = local_path_from_uri(dataset.source.uri, context="Harbor dataset reference").resolve()
+
+        options_dict = options.model_dump()
+        experiment_dir = self.experiment_dir or Path.cwd()
+        options_dict["jobs_dir"] = experiment_dir / options.jobs_dir
+        options_dict["job_name"] = options.job_name or f"{agent.name}-{dataset.id}"
+        import_path: str = options_dict.pop("import_path")
+        trace_dir: str = options_dict.pop("trace_dir", _TRACE_ARTIFACT_SOURCE)
+        options_dict["artifacts"] = _with_trace_artifact(options_dict.get("artifacts") or [], trace_dir)
+        force_rerun: bool = options_dict.pop("force_rerun", False)
+
+        agent_path = agent.expanduser().resolve()
+
+        if not agent_path.is_dir():
+            raise FileNotFoundError(f"Harbor agent path not found: {agent_path}")
+
+        await dataset.validate()
+
+        scoped_import_path, scoped_package = _scoped_import_path(agent_path, import_path)
+        agents_config = [AgentConfig(import_path=scoped_import_path)]
+        datasets_config = [DatasetConfig(path=dataset_path, task_names=[task.id for task in dataset.tasks])]
+        job_config = JobConfig(**options_dict, agents=agents_config, datasets=datasets_config)
+        if force_rerun:
+            job_dir = job_config.jobs_dir / job_config.job_name
+            if job_dir.exists():
+                shutil.rmtree(job_dir)
+
+        try:
+            job = await Job.create(job_config)
+            await job.run()
+        finally:
+            _cleanup_scoped_imports(scoped_package)
+
+        trials = await self._trials_from_dir(job.job_dir, dataset.tasks)
+        return trials
+
+    async def _trials_from_dir(self, job_dir: Path, tasks: Sequence[Task]) -> Sequence[TrialResult]:
+        task_map = {task.id: task for task in tasks}
+        trials: list[TrialResult] = []
+        for trial_dir in sorted(path for path in job_dir.iterdir() if path.is_dir()):
+            result_path = trial_dir / "result.json"
+            if not result_path.is_file():
+                continue
+
+            trial_data = json.loads(result_path.read_text(encoding="utf-8"))
+            trial_id = trial_data.get("trial_name")
+            if not isinstance(trial_id, str) or not trial_id:
+                trial_id = trial_dir.name
+
+            task_id = _resolve_trial_task_id(trial_id, trial_data, task_map)
+            task = task_map.get(task_id)
+            metric_spec = task.metric_specs["reward"] if task is not None and "reward" in task.metric_specs else None
+            if metric_spec is not None and metric_spec.ref is None:
+                metric_spec = None
+            metric_spec = metric_spec or _trial_metric_spec(trial_dir, trial_data)
+
+            exception_info = trial_data.get("exception_info")
+            resources, trace = _trial_resources(trial_dir)
+
+            trials.append(
+                TrialResult(
+                    id=trial_id,
+                    task_id=task_id,
+                    attempt=_trial_attempt(trial_id),
+                    status="completed" if exception_info is None else "failed",
+                    error=_trial_error(exception_info),
+                    trace=trace,
+                    outputs={},
+                    resources=resources,
+                    metrics=_trial_metrics(trial_dir, trial_data, metric_spec),
+                )
+            )
+        return trials

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/models.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/models.py
@@ -1,0 +1,340 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared models for evaluator inputs, outputs, resources, and dependencies."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+import shlex
+from abc import ABC
+from collections.abc import Sequence
+from contextlib import AbstractAsyncContextManager
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Literal, TypeAlias
+from urllib.parse import unquote, urlparse
+
+from pydantic import BaseModel, Field, SerializeAsAny
+
+DataValue: TypeAlias = str | int | float | bool | dict[str, Any] | list[Any] | None
+MetricValue: TypeAlias = float | int
+TrialStatus: TypeAlias = Literal["completed", "failed"]
+
+
+class DatasetValidationError(ValueError):
+    """Dataset content failed evaluator-specific authoring validation."""
+
+
+def local_path_from_uri(uri: str, *, context: str = "Resource") -> Path:
+    """Convert a plain path or local file URI to a path on Python 3.12+."""
+    parsed = urlparse(uri)
+    if parsed.scheme not in ("", "file"):
+        raise ValueError(f"{context} must be a local path or file URI, got URI scheme {parsed.scheme!r}: {uri}")
+    if parsed.scheme == "file" and parsed.netloc not in ("", "localhost"):
+        raise ValueError(f"{context} file URI must be local, got: {uri}")
+    raw_path = parsed.path if parsed.scheme == "file" else uri
+    return Path(unquote(raw_path)).expanduser()
+
+
+def subset_dataset_id(dataset_id: str, task_ids: Sequence[str]) -> str:
+    """Return deterministic dataset id for a selected task subset.
+
+    Args:
+        dataset_id (str): The dataset id to subset.
+        task_ids (Sequence[str]): The task ids to subset the dataset by.
+
+    Returns:
+        str: A deterministic dataset id for the selected task subset.
+    """
+    digest = hashlib.sha256("\n".join(task_ids).encode("utf-8")).hexdigest()[:12]
+    return f"{dataset_id}-subset-{len(task_ids)}-{digest}"
+
+
+class ResourceRef(BaseModel):
+    """Lazy reference to a local, remote, or evaluator-native resource."""
+
+    uri: str = Field(description="Portable locator: file, remote URL, or evaluator-native URI.")
+    description: str = Field(default="", description="Human-readable description of the resource.")
+    metadata: dict[str, DataValue] = Field(default_factory=dict, description="Small serializable resource facts.")
+
+
+class CommandSpec(BaseModel):
+    """Runnable command description for dependency setup."""
+
+    argv: list[str] = Field(description="Command arguments.")
+    cwd: ResourceRef | None = Field(default=None, description="Working directory for the command.")
+    env: dict[str, str] = Field(default_factory=dict, description="Environment variables for the command.")
+    timeout_sec: int | None = Field(default=None, description="Timeout for the command in seconds.")
+    metadata: dict[str, DataValue] = Field(default_factory=dict, description="Metadata for the command.")
+
+
+class DependencyRuntime(BaseModel):
+    """Commands that describe how to start task dependencies."""
+
+    start: CommandSpec | None = Field(default=None, description="Command to start the dependencies.")
+    stop: CommandSpec | None = Field(default=None, description="Command to stop the dependencies.")
+    readiness: CommandSpec | None = Field(
+        default=None, description="Command to check the readiness of the dependencies."
+    )
+    metadata: dict[str, DataValue] = Field(default_factory=dict, description="Metadata for the dependencies.")
+
+    def context(self) -> AbstractAsyncContextManager[DependencyRuntime | None]:
+        """Return dependency context for this runtime."""
+        return DependencyContext(self)
+
+
+async def run_dependency_command(spec: CommandSpec, phase: str) -> None:
+    """Run a dependency command.
+
+    Args:
+        spec (CommandSpec): The command spec to run.
+        phase (str): The phase of the dependency command.
+
+    """
+    if not spec.argv:
+        raise ValueError(f"Dependency {phase} command has empty argv")
+
+    cwd = local_path_from_uri(spec.cwd.uri, context="Command cwd") if spec.cwd is not None else None
+    env = os.environ.copy()
+    env.update(spec.env)
+
+    process = await asyncio.create_subprocess_exec(
+        *spec.argv,
+        cwd=cwd,
+        env=env,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=spec.timeout_sec)
+    except TimeoutError as exc:
+        process.kill()
+        await process.wait()
+        command = shlex.join(spec.argv)
+        raise TimeoutError(f"Dependency {phase} command timed out after {spec.timeout_sec}s: {command}") from exc
+
+    if process.returncode == 0:
+        return
+
+    command = shlex.join(spec.argv)
+    stdout_text = stdout.decode(errors="replace").strip()
+    stderr_text = stderr.decode(errors="replace").strip()
+    raise RuntimeError(
+        f"Dependency {phase} command failed with exit code {process.returncode}: {command}\n"
+        f"stdout:\n{stdout_text}\n"
+        f"stderr:\n{stderr_text}"
+    )
+
+
+class DependencyContext:
+    """Async context manager that starts and stops command dependencies."""
+
+    def __init__(self, runtime: DependencyRuntime | None) -> None:
+        self._runtime = runtime
+
+    async def __aenter__(self) -> DependencyRuntime | None:
+        """Start dependencies and return the runtime that was entered."""
+        if self._runtime is None:
+            return None
+        try:
+            if self._runtime.start is None:
+                raise ValueError("DependencyRuntime requires start")
+            await run_dependency_command(self._runtime.start, "start")
+
+            if self._runtime.readiness is not None:
+                await run_dependency_command(self._runtime.readiness, "readiness")
+        except BaseException:
+            try:
+                await self._stop_started_runtime()
+            except Exception:
+                pass
+            raise
+        return self._runtime
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        """Stop dependencies after the wrapped analysis block completes."""
+        if self._runtime is None:
+            return False
+        try:
+            await self._stop_started_runtime()
+        except Exception:
+            if exc_type is None:
+                raise
+        return False
+
+    async def _stop_started_runtime(self) -> None:
+        """Stop the started runtime."""
+        stop_error: Exception | None = None
+        if self._runtime is not None and self._runtime.stop is not None:
+            try:
+                await run_dependency_command(self._runtime.stop, "stop")
+            except Exception as exc:
+                if stop_error is None:
+                    stop_error = exc
+
+        if stop_error is not None:
+            raise stop_error
+
+
+class MetricSpec(BaseModel):
+    """Metric definition expected from evaluator output."""
+
+    name: str = Field(description="Stable metric identifier, such as 'reward' or 'accuracy'.")
+    description: str = Field(description="Human-readable meaning of the metric.")
+    ref: ResourceRef | None = Field(default=None, description="Reference to the metric definition.")
+
+
+class MetricResult(BaseModel):
+    """Numeric metric value with provenance metadata."""
+
+    name: str = Field(description="Name of the metric.")
+    value: MetricValue = Field(description="Numeric metric value.")
+    spec: MetricSpec | None = Field(default=None, description="Metric spec for the metric.")
+    metadata: dict[str, DataValue] = Field(
+        default_factory=dict,
+        description="Metric provenance or aggregation details.",
+    )
+
+
+class Task(BaseModel):
+    """One task input item."""
+
+    uri: str = Field(default="", description="Portable locator for the task itself.")
+    description: str = Field(default="", description="Human-readable description of the task reference.")
+    id: str = Field(description="Stable task identifier within the dataset.")
+    inputs: dict[str, DataValue | ResourceRef] = Field(default_factory=dict, description="Named inputs for the task.")
+    resources: dict[str, ResourceRef] = Field(default_factory=dict, description="Named resources for the task.")
+    metric_specs: dict[str, MetricSpec] = Field(default_factory=dict, description="Named metric specs for the task.")
+    dependencies: SerializeAsAny[DependencyRuntime] | None = Field(
+        default=None,
+        description="Dependencies for the task.",
+    )
+    metadata: dict[str, DataValue] = Field(default_factory=dict, description="Metadata for the task.")
+
+    def start_deps(self) -> AbstractAsyncContextManager[DependencyRuntime | None]:
+        """Return an async context manager for this task's dependency runtime.
+
+        Returns:
+            AbstractAsyncContextManager[DependencyRuntime | None]: An async context manager for this task's dependency runtime.
+        """
+        if self.dependencies is None:
+            return DependencyContext(None)
+        return self.dependencies.context()
+
+
+class Dataset(ABC):
+    """Collection of tasks."""
+
+    def __init__(
+        self,
+        id: str,
+        source: ResourceRef | None = None,
+        tasks: Sequence[Task] | None = None,
+        metadata: dict[str, DataValue] | None = None,
+    ) -> None:
+        self.id = id
+        self.source = source
+        self.tasks = list(tasks or [])
+        self.metadata = dict(metadata or {})
+
+    def list_tasks(self) -> Sequence[Task]:
+        """Return all tasks in the dataset.
+
+        Returns:
+            Sequence[Task]: A sequence of Task objects in the dataset.
+        """
+        return list(self.tasks)
+
+    async def validate(self) -> None:
+        """Validate authored dataset content without running evaluation trials.
+
+        Evaluator-specific datasets override this method with safe, static
+        checks that dataset authors can call repeatedly while editing.
+
+        Raises:
+            DatasetValidationError: If authored dataset content is invalid.
+        """
+
+    def subset(self, task_ids: Sequence[str]) -> Dataset:
+        """Return a dataset containing selected task ids.
+
+        Args:
+            task_ids (Sequence[str]): The task ids to subset the dataset by.
+
+        Returns:
+            Dataset: A dataset containing the selected task ids.
+        """
+        selected_ids = set(task_ids)
+        tasks = [task for task in self.list_tasks() if task.id in selected_ids]
+        missing = selected_ids - {task.id for task in tasks}
+        if missing:
+            missing_text = ", ".join(sorted(missing))
+            raise ValueError(f"Task id(s) not found in dataset {self.id!r}: {missing_text}")
+        return self.__class__(
+            id=subset_dataset_id(self.id, [task.id for task in tasks]),
+            source=self.source,
+            tasks=tasks,
+            metadata=self.metadata,
+        )
+
+    @classmethod
+    def from_ref(cls, ref: DatasetRef) -> Dataset:
+        """Create a Dataset from a DatasetRef.
+
+        Parses the DatasetRef and returns a Dataset object based on the type of the DatasetRef.
+
+        Args:
+            ref (DatasetRef): The DatasetRef to parse.
+
+        Returns:
+            Dataset: A Dataset object based on the type of the DatasetRef.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+
+class TrialResult(BaseModel):
+    """One task execution by one agent attempt."""
+
+    id: str = Field(description="Stable trial identifier within the evaluation run.")
+    task_id: str = Field(description="Stable task identifier within the dataset.")
+    attempt: int | None = Field(default=None, description="Attempt index when multiple attempts are run.")
+    status: TrialStatus = Field(description="Execution status of the trial.")
+    trace: ResourceRef | None = Field(default=None, description="Local or Intake trace reference for analyzers.")
+    outputs: dict[str, DataValue | ResourceRef] = Field(
+        default_factory=dict,
+        description="Named outputs for the trial.",
+    )
+    resources: dict[str, ResourceRef] = Field(default_factory=dict, description="Named resources for the trial.")
+    metrics: dict[str, MetricResult] = Field(default_factory=dict, description="Named metrics for the trial.")
+    error: dict[str, DataValue] | None = Field(default=None, description="Error details for the trial.")
+    metadata: dict[str, DataValue] = Field(
+        default_factory=dict,
+        description="Metadata for the trial.",
+    )
+
+
+class EvaluationResult(BaseModel):
+    """Evaluator run output consumed by optimizer and downstream analyzers."""
+
+    id: str = Field(description="Stable identifier for one evaluator run.")
+    aggregate_metrics: dict[str, float | int] = Field(
+        default_factory=dict,
+        description="Run-level metric summaries.",
+    )
+    trials: Sequence[TrialResult] = Field(default_factory=list, description="Trials produced by this run.")
+    metadata: dict[str, DataValue] = Field(
+        default_factory=dict,
+        description="Metadata for the evaluation run.",
+    )
+
+
+class DatasetRef(ResourceRef):
+    """Source handle used to build evaluator-specific Dataset objects."""

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/goal_tree.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/goal_tree.py
@@ -1,0 +1,545 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import Dataset
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc, spec
+from nooa.agents import TokenBudgetSummarizer
+from nooa.config import CodeActConfig
+from nooa.config.summarizer_config import TokenBudgetConfig
+from nooa.skill_registry import SkillRegistry
+from nooa.tools import Match, ShellTools, TodoManager
+from pydantic import BaseModel, Field, model_validator
+
+from .model_config import get_fast_model
+from .tools import WorkspaceTool
+from .util import load_framework_skills
+
+
+class GoalTreeConfig(BaseModel):
+    """Configuration for goal tree generation and validation.
+
+    Enforces hierarchical depth and node count constraints during tree generation.
+    """
+
+    max_depth: int = Field(default=3, gt=0, description="Maximum tree depth allowed")
+    max_initial_depth: int = Field(
+        default=2,
+        gt=0,
+        description="Maximum depth for initial tree generation",
+    )
+    min_initial_nodes: int = Field(
+        default=3,
+        gt=0,
+        description="Minimum nodes required in initial tree",
+    )
+    max_initial_nodes: int = Field(
+        default=4,
+        gt=0,
+        description="Maximum nodes allowed in initial tree",
+    )
+
+    @model_validator(mode="after")
+    def validate_constraints(self) -> GoalTreeConfig:
+        """Validate that depth and node constraints are internally consistent.
+
+        Returns:
+            GoalTreeConfig: the validated config instance.
+
+        Raises:
+            ValueError: if ``max_initial_depth`` exceeds ``max_depth`` or
+                ``min_initial_nodes`` exceeds ``max_initial_nodes``.
+
+        """
+        if self.max_initial_depth > self.max_depth:
+            raise ValueError(f"max_initial_depth ({self.max_initial_depth}) cannot exceed max_depth ({self.max_depth})")
+        if self.min_initial_nodes > self.max_initial_nodes:
+            raise ValueError(
+                f"min_initial_nodes ({self.min_initial_nodes}) cannot exceed "
+                f"max_initial_nodes ({self.max_initial_nodes})"
+            )
+        return self
+
+    def validate_tree(self, tree: GoalTree) -> GoalTree:
+        """Validate a goal tree against this config's constraints.
+
+        Args:
+            tree: The goal tree to validate.
+
+        Returns:
+            GoalTree: the validated tree, unchanged.
+
+        Raises:
+            ValueError: if the tree violates depth or node count constraints.
+
+        """
+
+        def visit(node: GoalNode, depth: int) -> None:
+            if depth > self.max_depth:
+                raise ValueError(f"goal tree exceeds max depth {self.max_depth} at node {node.id!r}")
+            if node.added_at_generation is None and depth > self.max_initial_depth:
+                raise ValueError(
+                    f"initial goal tree nodes exceed max depth {self.max_initial_depth} at node {node.id!r}"
+                )
+            for child in node.children:
+                visit(child, depth + 1)
+
+        visit(tree.root, depth=1)
+        initial_nodes = [node for node in tree._iter_nodes() if node.added_at_generation is None]
+        if not (self.min_initial_nodes <= len(initial_nodes) <= self.max_initial_nodes):
+            raise ValueError(
+                f"initial goal tree must have {self.min_initial_nodes}-"
+                f"{self.max_initial_nodes} nodes, got {len(initial_nodes)}"
+            )
+        return tree
+
+
+class GoalNode(BaseModel):
+    """A single node in the goal tree with a weighted objective and optional children."""
+
+    id: str = Field(description="Stable kebab-case identifier, unique within the tree.")
+    goal: str = Field(description="One sentence stating the observable behavior this node scores.")
+    weight: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Weight within parent. Children weights sum to 1.0.",
+    )
+    children: list[GoalNode] = Field(default_factory=list)
+
+    added_at_generation: int | None = None
+    added_because: str | None = None
+    added_by: str | None = None
+
+
+class GoalTree(BaseModel):
+    """A hierarchical rubric describing the sub-capabilities required to complete a task."""
+
+    task_id: str = Field(description="Identifier of the task this tree scores.")
+    generated_at: str = Field(
+        default_factory=lambda: datetime.now(UTC).isoformat(),
+        description="ISO 8601 UTC timestamp when this tree was generated.",
+    )
+    frozen: bool = Field(default=True)
+    root: GoalNode
+
+    @model_validator(mode="after")
+    def validate_structure(self) -> GoalTree:
+        """Validate tree structural invariants.
+
+        Invariants:
+          - Root weight is 1.0.
+          - Children weights at each non-leaf node sum to 1.0 (within 1e-3).
+          - Node IDs are unique across the tree.
+
+        Returns:
+            GoalTree: the validated tree instance.
+
+        Raises:
+            ValueError: if root weight is not 1.0, any node ID is duplicated,
+                any node has an empty goal, or sibling weights do not sum to 1.0.
+
+        """
+        if abs(self.root.weight - 1.0) > 1e-3:
+            raise ValueError(f"root weight must be 1.0, got {self.root.weight}")
+
+        seen_ids: set[str] = set()
+
+        def visit(node: GoalNode) -> None:
+            if node.id in seen_ids:
+                raise ValueError(f"duplicate node id {node.id!r}")
+            seen_ids.add(node.id)
+            if not node.goal.strip():
+                raise ValueError(f"node {node.id!r} has empty goal")
+            if node.children:
+                child_weight_sum = sum(c.weight for c in node.children)
+                if abs(child_weight_sum - 1.0) > 1e-3:
+                    raise ValueError(
+                        f"children of {node.id!r} have weights summing to {child_weight_sum:.3f}; expected 1.0"
+                    )
+            for child in node.children:
+                visit(child)
+
+        visit(self.root)
+        return self
+
+    def _iter_nodes(self) -> list[GoalNode]:
+        """Return all nodes in the tree in depth-first order.
+
+        Returns:
+            list[GoalNode]: all nodes from root to leaves, depth-first.
+
+        """
+
+        def visit(node: GoalNode) -> list[GoalNode]:
+            return [node, *[desc for child in node.children for desc in visit(child)]]
+
+        return visit(self.root)
+
+    def to_json(self) -> str:
+        """Return the goal tree serialized as a JSON string.
+
+        Returns:
+            str: a pretty-printed JSON representation of this tree.
+
+        """
+        return json.dumps(self.model_dump(), indent=2)
+
+    @classmethod
+    def from_path(
+        cls,
+        path: Path,
+        config: GoalTreeConfig | None = None,
+    ) -> GoalTree:
+        """Load and validate a goal tree from a JSON file.
+
+        Args:
+            path: Path to the goal tree JSON file.
+            config: Configuration with validation constraints. If None, uses defaults.
+
+        Returns:
+            GoalTree: the loaded and validated goal tree.
+
+        Raises:
+            FileNotFoundError: if ``path`` does not exist.
+            ValueError: if the JSON fails validation or violates config constraints.
+
+        """
+        if config is None:
+            config = GoalTreeConfig()
+        tree = cls.model_validate(json.loads(path.read_text()))
+        return config.validate_tree(tree)
+
+
+def traverse_tree(node: GoalNode) -> list[GoalNode]:
+    """Return all leaf nodes reachable from the given node (depth-first).
+
+    Args:
+        node: the root of the subtree to traverse.
+
+    Returns:
+        list[GoalNode]: leaf nodes in depth-first order.
+
+    """
+    if not node.children:
+        return [node]
+    leaves: list[GoalNode] = []
+    for child in node.children:
+        leaves.extend(traverse_tree(child))
+    return leaves
+
+
+def leaf_weights_by_id(node: GoalNode, cumulative_weight: float = 1.0) -> dict[str, float]:
+    """Return a mapping of leaf node IDs to their cumulative path weights.
+
+    Args:
+        node: the root of the subtree to process.
+        cumulative_weight: accumulated weight from ancestor nodes; defaults to 1.0.
+
+    Returns:
+        dict[str, float]: mapping from leaf node ID to its cumulative path weight.
+
+    """
+    node_weight = cumulative_weight * node.weight
+    if not node.children:
+        return {node.id: node_weight}
+    weights: dict[str, float] = {}
+    for child in node.children:
+        weights.update(leaf_weights_by_id(child, node_weight))
+    return weights
+
+
+def find_node(root: GoalNode, node_id: str) -> GoalNode | None:
+    """Return the first node with the given ID, or None if not found.
+
+    Args:
+        root: the root node to search from.
+        node_id: the node ID to locate.
+
+    Returns:
+        GoalNode | None: the matching node, or None if not present in the subtree.
+
+    """
+    if root.id == node_id:
+        return root
+    for child in root.children:
+        found = find_node(child, node_id)
+        if found:
+            return found
+    return None
+
+
+# Standard Pydantic v2 pattern for recursive models
+GoalNode.model_rebuild()
+
+
+class GoalTreeGenerator(Agent, llm=get_fast_model()):
+    """Generates the goal tree consumed by the trajectory scorer.
+
+    The generator MUST NOT see the agent's implementation, harbor wrapper, or any
+    prior trace. It works only from scoring-side context (use case description,
+    verifier behavior, sample ground truth), so the tree describes what the *task*
+    requires rather than what the *current implementation* does.
+    """
+
+    def __init__(
+        self, workspace: Path, config: GoalTreeConfig, framework_skills_dirs: list[Path] | None = None, **kwargs: Any
+    ):
+        """Initialize the goal tree generator.
+
+        Args:
+            workspace: the root directory containing use-case data and skills.
+            config: the constraints and validation rules for generated trees.
+            framework_skills_dirs: Optional list of directories containing framework skills to load.
+            **kwargs: additional arguments passed to the parent Agent.
+
+        """
+        super().__init__(**kwargs)
+        self._config = config
+        self._workspace_path = workspace.resolve()
+
+        self.shell = ShellTools(cwd=str(workspace))
+        self.workspace = WorkspaceTool(workspace=workspace)
+        self.todos = TodoManager()
+        self.context["file_match"] = doc(Match)
+        self.skills: SkillRegistry = SkillRegistry(self)
+        spec(self, "skills", hidden=True)
+        load_framework_skills(self.skills, framework_skills_dirs or [])
+        TokenBudgetSummarizer.install(self, llm=get_fast_model(), config=TokenBudgetConfig(max_tokens=80_000))
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=40, cell_timeout=3600.0)))
+    async def _generate(self, dataset: Dataset, agent_spec: Path | None = None) -> GoalTree:  # pyright: ignore[reportReturnType]
+        """Generate a hierarchical goal tree describing what a successful agent run looks like.
+
+        # Inputs you should consult
+
+        - `AGENT-SPEC.md` in the workspace root. Read it via self.shell. This is the
+          canonical description of the domain and what the agent is being asked to do.
+        - 3 to 5 examples from the dataset. Use task inputs, visible
+          resources, and metric specs to understand the task shape and scoring surface.
+
+        # Inputs you MUST NOT consult
+
+        - The agent's source code, harbor_wrapper.py, dind_environment.py, or any file under
+          eval-and-optimize/agents/. The tree describes what the *task* requires, not what
+          the *current implementation* does. Mirroring the implementation penalises
+          candidates that deviate, defeating the purpose of trajectory scoring.
+        - Any trace from a prior run (eval-and-optimize/results/).
+
+        # Tree shape — phases, not outcome dimensions
+
+        Produce a compact GoalTree that obeys the numeric limit arguments passed to
+        this call:
+        - total depth must be at most {self._config.max_initial_depth} for initial nodes.
+        - total initial node count must be between {self._config.min_initial_nodes}
+          and {self._config.max_initial_nodes}, including the root.
+        - absolute depth must be at most {self._config.max_depth}.
+
+        **Critical**: structure the children of root as **sequential execution phases** of a
+        correct agent run, not as dimensions of the final output. The purpose is dense partial
+        rewards for long traces: an agent that completes phases 1-2 of 3 but fails at phase 3
+        should receive meaningful partial credit. Outcome-only nodes (label match, explanation quality) make
+        this impossible because they award zero until the final answer is produced.
+
+        - Root: one statement of the overall task goal. Weight = 1.0.
+        - Children of root: the ordered execution stages a
+          correct run passes through. Each phase is observable mid-trace (tool calls made,
+          intermediate data retrieved, intermediate conclusions written). Assign weights
+          proportional to how much of the task's difficulty the phase represents. They MUST
+          sum to 1.0.
+        - Do not add grandchildren unless {self._config.max_initial_depth} allows them and
+          the extra structure is necessary. Every leaf should be scoreable from the trace.
+
+        # Minimize nodes, maximize signal
+
+        **Hard rule**: initial NODE count must stay within {self._config.min_initial_nodes}
+        and {self._config.max_initial_nodes}, including the root.
+
+        ## Signal test — apply to every proposed leaf
+
+        Before keeping a leaf, ask: *"Would two agent variants on this task plausibly score
+        differently on this criterion?"* If every plausibly-implemented agent will trivially
+        pass (or trivially fail) the criterion, the leaf has zero signal — DROP IT.
+
+        ## Anti-patterns — do NOT emit these leaves
+
+        - **"Agent parses its input"** / "agent reads the --prompt CLI argument" / "agent
+          parses the research question". Any agent that runs at all passes this; any agent
+          that doesn't run produces no trace at all. Zero signal.
+        - **"Agent writes the required final artifact"** / "the expected file exists
+          after the run". The verifier already checks terminal artifact existence,
+          schema, service state, or final answer validity. A separate leaf adds
+          little unless it captures a meaningful intermediate step toward that artifact.
+        - **"Agent does N X times"** - avoid hard constraints on the number of X.
+
+        ## Good leaf examples
+
+        Leaves should be where *judgment* differentiates agents:
+
+        - "Agent's follow-up search queries refine or expand on the initial round (judged by
+          whether the queries target gaps in the initial sources, not by mere string
+          inequality)." → genuinely needs LLM judgment.
+        - "Agent's report cites high-authority sources (academic, official documentation,
+          peer-reviewed venues) over marketing/SEO content." → needs source-quality
+          judgment.
+        - "Agent's intermediate evidence-gathering output addresses the specific aspect
+          required by the question, not just the topic keywords." → distinguishes broad vs
+          focused research.
+        - Do not duplicate the verifier's checks.
+
+        Example phase decomposition for a research-and-classify task:
+          1. gather-intelligence   — retrieve CVE advisory, SBOM, relevant docs
+                                     → intermediate artifact: evidence notes file
+          2. verify-and-assess     — confirm component presence and reachability
+                                     → intermediate artifact: assessment summary
+          3. synthesize-verdict    — derive status and label from the evidence
+
+        Every node MUST have a non-empty goal that can be judged from observable trace
+        events and filesystem artifacts:
+
+        - Trace tool calls: "Retrieve the CVE advisory and package metadata before judging reachability."
+        - Intermediate artifacts: "Write evidence notes before producing the final classification."
+        - Terminal artifacts: "Produce a final report that parses as the expected schema."
+        - Intermediate data logged: "Record the retrieved version before deciding affectedness."
+
+        Avoid goals that require reading the agent's mind ("the agent intended to...") or
+        that can only be evaluated after the final answer exists ("status matches ground truth").
+        If you cannot describe a goal in observable mid-trace or filesystem terms, drop the
+        node.
+
+        # Hidden verifier boundary
+
+        The verifier files you read are for rubric design only. They are often hidden from
+        the task agent during Harbor/Terminal-Bench execution. Therefore:
+
+        - Do NOT create a phase that requires the agent to read, find, list, inspect, run,
+          execute, or invoke the resources of the task.
+        - Do NOT assume the agent can see hidden expected outputs or benchmark tests.
+        - If a useful phase involves checking work, phrase it as agent-visible validation:
+          local commands, visible tests, program invocations, service probes, output-file
+          reads, or artifact/schema checks derived from the prompt and visible workspace.
+        - Use hidden verifier details only to choose better observable proxies, such as
+          "run the implemented converter on visible sample input and inspect the output
+          format" rather than "run the verifier".
+
+        # IDs
+
+        Use kebab-case identifiers stable across the run (e.g. "parse-input",
+        "reason-about-cues", "emit-schema"). They appear in metadata.json and selection logs,
+        so prefer descriptive over short.
+
+        # Output
+
+        Return a GoalTree(task_id=task_id, root=GoalNode(...)). The framework validates
+        weights, depth, initial node count, and ID uniqueness; invalid trees are rejected and the call retries.
+        """
+        ...
+
+    async def generate(
+        self,
+        dataset: Dataset,
+        agent_spec: Path | None = None,
+    ) -> GoalTree:
+        """Generate and validate a goal tree. Caller is responsible for persistence.
+
+        Returns:
+            GoalTree: a freshly generated, structurally valid goal tree.
+
+        """
+        tree = await self._generate(dataset, agent_spec=agent_spec)
+        validated_tree = GoalTree.model_validate(tree.model_dump())
+        return self._config.validate_tree(validated_tree)
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=40, cell_timeout=1800.0)))
+    async def _update(
+        self,
+        dataset: Dataset,
+        goal_tree: GoalTree,
+        analysis: str,
+        round_num: int,
+        agent_spec: Path | None = None,
+    ) -> GoalTree:  # pyright: ignore[reportReturnType]
+        """Propose a reweighted goal tree informed by a round of agent analysis.
+
+        # What you receive
+
+        - `goal_tree`: the current frozen rubric. Inspect `goal_tree.root` and its
+          children to understand what sub-capabilities are already measured.
+        - `analysis`: the merged round analysis markdown. It contains the
+          population-level Root Causes, Failure Patterns, and Mechanical Errors
+          sections. Use systematic Root Causes as context for what went wrong,
+          not as a checklist of nodes to add.
+        - `round_num`: the current generation number. Any newly added node MUST
+          set `added_at_generation=round_num` and `added_by="analyzer"`.
+
+        # What to look for
+
+        Start from selection and analysis utility, not root-cause coverage. Ask:
+        "Is there one additional partial-reward signal that would materially help
+        distinguish promising candidates, explain outcome/trajectory disagreements,
+        or preserve a useful branch in the next selection step?"
+
+        Prefer returning the tree unchanged when the existing nodes already give
+        enough steering signal.
+
+        # Constraints
+
+        - Add at most **one** new leaf per call. Pick only the highest-leverage
+          missing partial reward. Do not add one node per root cause.
+        - Only add nodes for **systematic** failures (≥2 tasks). One-offs are noise.
+        - Each new node must map to an **observable** goal (tool call present,
+          output field exists, file written) — never "the agent understood X".
+        - Do not duplicate existing nodes. Check all existing node IDs and goals
+          before adding.
+        - Keep the change minimal. Prefer a narrow leaf under the closest existing
+          phase over a broad new top-level phase.
+        - Return the **entire updated tree**, not just the new node. You MUST
+          reweight every affected sibling set yourself so every non-leaf node's
+          child weights sum to exactly 1.0. If you add a top-level phase, reweight
+          all root children. If you add a child under a leaf, that new child is the
+          only child and must have weight 1.0.
+        - Preserve every existing node's id, goal, added_at_generation,
+          added_because, added_by, and parent. You may change existing node
+          weights only to make room for the new node.
+        - Total depth must stay within {self._config.max_depth}.
+        - If no missing steering signal exists, return the input tree unchanged.
+
+        # Output
+
+        Return a complete GoalTree. The framework validates weights, depth, and
+        ID uniqueness; invalid trees are rejected and the call retries.
+        """
+        self.context["current_goal_tree"] = goal_tree.to_json()
+        self.context["round_analysis"] = analysis
+        self.context["round_num"] = round_num
+        ...
+
+    async def update(
+        self,
+        goal_tree: GoalTree,
+        analysis: str,
+        round_num: int,
+        dataset: Dataset,
+        agent_spec: Path | None = None,
+    ) -> GoalTree:
+        """Produce an updated, validated goal tree. Caller is responsible for persistence.
+
+        Args:
+            goal_tree: the current goal tree to refine.
+            analysis: round analysis markdown used to inform reweighting.
+            round_num: the current generation number, stamped on any new nodes.
+            agent_spec: optional path to a materialized agent-spec file.
+
+        Returns:
+            GoalTree: the updated, structurally valid goal tree.
+
+        """
+        tree = await self._update(dataset, goal_tree, analysis, round_num, agent_spec=agent_spec)
+        validated_tree = GoalTree.model_validate(tree.model_dump())
+        return self._config.validate_tree(validated_tree)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/holdout_utils.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/holdout_utils.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+HELD_OUT_SPLITS = frozenset({"validation"})
+HELD_OUT_STORAGE_DIR = ".aad-heldout"
+
+# Path tokens GuardedShellTools refuses: a tripwire for direct shell access while a
+# split is briefly restored for scoring. Relocation is the main obfuscation layer.
+DEFAULT_BLOCKED_PATHS: tuple[str, ...] = (
+    HELD_OUT_STORAGE_DIR,
+    *(f"dataset/{s}" for s in sorted(HELD_OUT_SPLITS)),
+)
+
+BLOCKED_MESSAGE = (
+    "blocked: the validation split is held out for scoring only. "
+    "Its contents are off-limits; diagnose and fix using the train split."
+)
+
+
+class HeldOutAccessError(PermissionError):
+    """Raised when held-out split contents or debugging artifacts are requested."""
+
+
+def heldout_storage_root(workspace: Path) -> Path:
+    """Return the workspace-local directory used to store held-out splits.
+
+    Args:
+        workspace: absolute path to the eval-and-optimize workspace root.
+
+    Returns:
+        Path: the hidden storage directory for held-out splits.
+
+    """
+    workspace = Path(workspace).resolve()
+    return workspace / HELD_OUT_STORAGE_DIR
+
+
+def _split_paths(workspace: Path, split: str) -> tuple[Path, Path]:
+    """Return the ``(visible, hidden)`` locations for ``split``."""
+    workspace = Path(workspace).resolve()
+    return workspace / "dataset" / split, heldout_storage_root(workspace) / split
+
+
+def _move(src: Path, dst: Path, split: str) -> None:
+    """Delete any existing ``dst``, then rename ``src`` to ``dst``."""
+    if dst.exists():
+        shutil.rmtree(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.rename(dst)
+
+
+def ensure_heldout_hidden(workspace: Path, *, splits: frozenset[str] = HELD_OUT_SPLITS) -> None:
+    """Move any visible held-out splits into hidden storage.
+
+    Idempotent — safe to call before every optimizer phase.
+
+    Args:
+        workspace: absolute path to the eval-and-optimize workspace root.
+        splits: set of split names to hide; defaults to ``HELD_OUT_SPLITS``.
+
+    """
+    for split in splits:
+        visible, hidden = _split_paths(workspace, split)
+        if visible.exists():
+            _move(visible, hidden, split)
+
+
+def restore_heldout_splits(workspace: Path, *, splits: frozenset[str] = HELD_OUT_SPLITS) -> None:
+    """Restore hidden held-out splits back into ``dataset/``.
+
+    Args:
+        workspace: absolute path to the eval-and-optimize workspace root.
+        splits: set of split names to restore; defaults to ``HELD_OUT_SPLITS``.
+
+    """
+    for split in splits:
+        visible, hidden = _split_paths(workspace, split)
+        if hidden.exists():
+            _move(hidden, visible, split)
+    _prune_empty_storage(workspace)
+
+
+def _prune_empty_storage(workspace: Path) -> None:
+    """Remove the hidden storage dir if empty."""
+    root = heldout_storage_root(workspace)
+    try:
+        root.rmdir()
+    except OSError:
+        pass

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
@@ -1,0 +1,1674 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Evolutionary optimization loop — ported from AAD ``optimizer/optimize_agent.py``.
+
+The public entry point is :class:`EvolutionaryOptimizer`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import fnmatch
+import json
+import logging
+import random
+import shutil
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Literal, cast, get_args
+
+from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun
+from nemo_experimentalist_plugin.eval_author.agent import EvalAuthor
+from nemo_experimentalist_plugin.experimentalist.components.analyzer import AgentAnalyzer, AnalyzerConfig
+from nemo_experimentalist_plugin.experimentalist.components.coder import Coder, CoderConfig
+from nemo_experimentalist_plugin.experimentalist.components.dataset_staging import stage_eval_author_inputs
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import (
+    Dataset,
+    EvaluationResult,
+    Evaluator,
+    TrialResult,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.factory import DatasetFactory, EvaluatorFactory
+from nemo_experimentalist_plugin.experimentalist.components.goal_tree import (
+    GoalTree,
+    GoalTreeConfig,
+    GoalTreeGenerator,
+    leaf_weights_by_id,
+    traverse_tree,
+)
+from nemo_experimentalist_plugin.experimentalist.components.holdout_utils import (
+    ensure_heldout_hidden,
+    restore_heldout_splits,
+)
+from nemo_experimentalist_plugin.experimentalist.components.model_config import (
+    get_fast_model,
+    get_smart_model,
+)
+from nemo_experimentalist_plugin.experimentalist.components.models import (
+    EvolutionTree,
+    OptimizationType,
+    pareto_front,
+    pareto_sort,
+)
+from nemo_experimentalist_plugin.experimentalist.components.proposer import Improvement, Proposer, ProposerConfig
+from nemo_experimentalist_plugin.experimentalist.components.terminator import Terminator
+from nemo_experimentalist_plugin.experimentalist.components.tools import (
+    GuardedShellTools,
+    WorkspaceTool,
+)
+from nemo_experimentalist_plugin.experimentalist.components.trace_scorer import (
+    GroupLeafScorer,
+)
+from nemo_experimentalist_plugin.experimentalist.deps import ExperimentalistDeps
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import (
+    ExperimentalistBackend,
+)
+from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
+from nemo_experimentalist_plugin.resolve import EvolutionaryOptimizerConfig
+from nemo_platform import AsyncNeMoPlatform
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc, spec
+from nooa.agents import TokenBudgetSummarizer
+from nooa.config import CodeActConfig
+from nooa.config.summarizer_config import TokenBudgetConfig
+from nooa.skill import Skill
+from nooa.skill_registry import SkillRegistry
+from nooa.tools import Match
+
+from .util import load_framework_skills
+
+logger = logging.getLogger(__name__)
+
+
+_BASELINE_AGENT_LABEL = "agent-0"
+
+_EXCLUDE_DIRS = {
+    "eval-and-optimize",
+    "__pycache__",
+    ".git",
+    ".runtime-cache",
+    ".claude",
+    ".uv",
+    ".venv",
+    "artifacts",
+    "dataset",
+    "scratch",
+}
+_EXCLUDE_GLOBS = {"*traces*", "*eval-and-optimize_*"}
+
+
+def _warn_persistence_failure(operation: Literal["archive", "publish"], candidate: str, exc: Exception) -> None:
+    """Log best-effort persistence failure context."""
+    logger.warning(
+        "[PERSISTENCE] %s failed for candidate %s; continuing: %s",
+        operation,
+        candidate,
+        exc,
+    )
+
+
+def _ignore_patterns(directory: str, contents: list[str]) -> set[str]:
+    ignored = set()
+    for name in contents:
+        if name in _EXCLUDE_DIRS:
+            ignored.add(name)
+        elif any(fnmatch.fnmatch(name, pattern) for pattern in _EXCLUDE_GLOBS):
+            ignored.add(name)
+    return ignored
+
+
+def _coerce_optimization_type(optimization_type: str | None) -> OptimizationType | None:
+    if optimization_type in get_args(OptimizationType):
+        return cast(OptimizationType, optimization_type)
+    return None
+
+
+def _trajectory_detail_from_reward(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        reward_val = value.get("reward", value.get("score", 0.0))
+        explanation = value.get("reason") or value.get("explanation") or ""
+    else:
+        reward_val = getattr(value, "reward", getattr(value, "score", value))
+        explanation = getattr(value, "reason", "") or getattr(value, "explanation", "")
+    detail: dict[str, Any] = {"reward": float(reward_val)}
+    if explanation:
+        detail["explanation"] = str(explanation)
+    return detail
+
+
+def _complete_trace_groups(
+    traces_by_task: dict[str, dict[str, TrialResult]], agent_ids: list[str]
+) -> dict[str, dict[str, TrialResult]]:
+    required_agents = set(agent_ids)
+    return {
+        task_id: by_agent
+        for task_id, by_agent in traces_by_task.items()
+        if set(by_agent) == required_agents and all(by_agent[aid] for aid in required_agents)
+    }
+
+
+class AnalysisSkill(Skill):
+    """Standard format for the per-round analysis file the optimizer writes each round.
+
+    The round analysis merges every agent's per-agent analysis into one markdown file
+    (``eval-and-optimize/analysis/round-N.md``). It is the record a human or the next
+    round reads to understand what happened: which agents lead on which reward
+    dimensions, where they diverge, and which failures are systematic vs mechanical.
+    Follow this format exactly and fill every section with real data from the per-agent
+    analyses and metadata — no placeholders.
+
+    ---
+
+    ```markdown
+    # Round N Analysis
+
+    ## Rewards
+
+    **Show every dimension as its own column** so agents with different strengths are visible
+    and easier to reason about for merging. An agent may have lower values on some dimensions
+    but higher on others — that's a candidate to merge with a complementary agent.
+
+    Train Reward:
+    | Agent | <dim1> | <dim2> | <dim3> | ... | Ancestor | vs. Ancestor |
+    | ----- | ------ | ------ | ------ | --- | -------- | ------------ |
+    | agent-3 | 0.61 | 0.72 | 0.51 | ... | agent-0 | +0.16 |
+    | agent-1 | 0.58 | 0.68 | 0.48 | ... | agent-0 | +0.13 |
+    | agent-0 | 0.45 | 0.55 | 0.40 | ... | --- | baseline |
+
+    Validation Reward:
+    | Agent | <dim1> | <dim2> | <dim3> | ... | Ancestor | vs. Ancestor |
+    | ----- | ------ | ------ | ------ | --- | -------- | ------------ |
+    | agent-3 | 0.51 | 0.62 | 0.44 | ... | agent-0 | -0.10 |
+    | agent-1 | 0.48 | 0.58 | 0.41 | ... | agent-0 | -0.10 |
+    | agent-0 | 0.45 | 0.55 | 0.40 | ... | --- | baseline |
+
+    [Columns are the actual reward dimension keys from metadata. Order by any dimension that
+    helps comparison — no dimension is privileged.]
+
+    ## Trajectory Rewards
+
+    Trajectory rewards measure intermediate step quality (goal-tree subgoal rollup).
+    Read from metadata:
+
+    ```python
+    candidate = self.workspace.get_metadata(agent_id)
+    traj = candidate.validation_trajectory_reward or {}
+    # e.g. {"aggregate": 0.74, "parse-cli-input": 0.31, "search-web-sources": 0.78}
+    details = candidate.validation_trajectory_reward_details or {}
+    # details[node_id][task_id] = {"reward": 0.7, "explanation": "..."}
+    ```
+
+    | Agent | <step1> | <step2> | ... | aggregate |
+    | ----- | ------- | ------- | --- | --------- |
+    | agent-3 | 0.45 | 0.85 | ... | 0.78 |
+    | agent-1 | 0.32 | 0.90 | ... | 0.75 |
+    | agent-0 | 0.31 | 0.78 | ... | 0.74 |
+
+    [Omit if `validation_trajectory_reward` is absent or empty. Show the `aggregate` key as the overall column
+    and each node_id entry as its node column.
+    When a trajectory reward explains a selection tradeoff or outcome-reward disagreement,
+    quote/paraphrase the relevant `validation_trajectory_reward_details` explanation.]
+
+    ## Divergent Trial Analysis
+
+    For each agent pair with divergent results:
+
+    ### agent-A vs agent-B
+
+    | Task | agent-A | agent-B | Winner's Key Insight |
+    |------|---------|---------|----------------------|
+    | task-003 | ✓ 1.0 | ✗ 0.0 | Checked container type before classifying |
+    | task-007 | ✗ 0.0 | ✓ 1.0 | Verified code reachability not just presence |
+
+    **Divergence Pattern**: agent-A excels at X, agent-B excels at Y.
+    **Transferable Insight**: agent-B's reachability check could be added to agent-A.
+
+    ## Complementary Failures
+
+    Agent pairs with complementary strengths (each passes tasks the other fails):
+
+    - **agent-A + agent-B**: 5 complementary tasks (ensemble would score 0.85 vs 0.65/0.70 individual)
+    - **agent-C + agent-D**: 2 complementary tasks
+
+    ## Failure Patterns
+    For each systematic failure pattern (≥2 tasks), describe:
+    - Root cause description (in your own words, as specific as the evidence allows)
+    - How many tasks affected (e.g. "5/8 tasks")
+    - Concrete example: task name, what agent did, what it should have done
+    - Trace evidence: session + turn + direct quote from the trace
+
+    Example:
+    - **Agent interprets "net revenue" as "gross revenue"** (4/7 tasks): In task `q3-analysis`,
+      turn 3: agent wrote "I'll use total_sales which represents net revenue" — but total_sales
+      is pre-discount. Root cause confirmed via trace.search("net revenue") returning 0 matches
+      before the wrong computation.
+      **agent-2 passes this task** by explicitly checking the column metadata for "net" vs "gross".
+
+    ## Root Causes
+    For each root cause, answer these three questions explicitly:
+    1. **What** specifically did the agent do wrong? (concrete action or output)
+    2. **Why** did it do that? (missing knowledge, wrong assumption, context issue, code bug)
+    3. **What would fix it?** (the minimal change that addresses the root cause directly)
+    4. **Which agents don't have this root cause?** — and what's different about them
+
+    Do NOT write vague statements like "the agent misunderstood the task" without
+    specifying what it misunderstood and why. Do NOT write "improve the prompt" without
+    specifying what information is missing and where in the agent's reasoning it would help.
+
+    ## Mechanical/Infrastructure Errors
+
+    Errors that are NOT agent logic problems — fix these on the infrastructure side:
+
+    | Task | Error Type | Issue | Suggested Fix |
+    |------|------------|-------|---------------|
+    | task-005 | environment | `ModuleNotFoundError: cryptography` | Add to container requirements |
+    | task-012 | timeout | Agent hit 5min limit mid-analysis | Increase task timeout to 10min |
+    | task-018 | dataset | Ground truth expects format X but instruction says Y | Fix instruction.md |
+    | task-023 | api | CVE server returned 503 | Add retry logic to cve-server |
+    | task-001 | config | `max_iterations` set to 100 | Increase `max_iterations` to 1000 |
+
+    **Do NOT optimize agents to work around these issues.** Report them for infra fixes.
+
+    Common mechanical error categories:
+    - **config**: wrong config parameters, missing config, config limits exceeded
+    - **environment**: missing packages, wrong versions, container config
+    - **timeout**: legitimate work cut short by time limits
+    - **dataset**: incorrect ground truth, ambiguous instructions, missing fixtures
+    - **api/service**: external service failures, rate limits, network issues
+    - **scorer**: evaluation bug, wrong expected format, edge case not handled
+
+    **What qualifies as a mechanical error:**
+    - Crashes or `sys.exit` on recoverable errors (e.g., scraping fails → exit instead of fallback)
+    - Wrong output path, missing required fields, schema violations
+    - Unhandled exceptions that silently discard valid data
+    - Missing error handling where failure is expected (network calls, file I/O)
+    - Misconfigured agent, llms, config, etc.
+
+    **What is NOT a mechanical error** (use root cause analysis + improvements instead):
+    - Shallow reasoning, poor query strategy, suboptimal architecture
+    - The code works but produces low-quality output
+    ```
+
+    Fill in every section with real data from the per-agent analyses. No placeholders.
+    Return the complete markdown content as a string — the caller writes it to disk.
+    """
+
+
+class EvolutionaryOptimizer(Agent, llm=get_smart_model()):
+    """The Experimentalist's deterministic Pareto optimization loop.
+
+    Orchestrates the baseline → [convergence-check → select → train-eval →
+    analyze → propose → implement → record → validation-eval] cycle across
+    rounds, mirroring the AAD ``EvolutionaryOptimizer``.
+    """
+
+    def __init__(
+        self,
+        working_dir: Path,
+        config: EvolutionaryOptimizerConfig | None = None,
+        framework_skills_dirs: list[Path] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.working_dir = working_dir.resolve()
+        self.config = config or EvolutionaryOptimizerConfig()
+        self._config = self.config
+        self._workspace_path = self.working_dir
+        self._framework_skills_dirs: list[Path] = framework_skills_dirs or []
+        self.terminator = Terminator()
+        self.shell = GuardedShellTools(cwd=self.working_dir)
+        self.workspace = WorkspaceTool(workspace=self.working_dir)
+        self.context["file_match"] = doc(Match)
+        self.context["workspace_tool_documentation"] = doc(WorkspaceTool)
+        self.skills: SkillRegistry = SkillRegistry(self)
+        spec(self, "skills", hidden=True)
+        load_framework_skills(self.skills, self._framework_skills_dirs)
+        self.skills.register("ext.analysis_skill", AnalysisSkill())
+        self.skills.activate(["cmd.*", "ext.*"])
+        TokenBudgetSummarizer.install(
+            self,
+            llm=get_fast_model(),
+            config=TokenBudgetConfig(max_tokens=self.config.max_summary_tokens),
+        )
+
+    @staticmethod
+    def _coder_config(config: EvolutionaryOptimizerConfig) -> CoderConfig:
+        coder_config = CoderConfig.model_validate(config.coder.model_dump())
+        if config.model_catalog_path is None or coder_config.model_catalog_path is not None:
+            return coder_config
+        return coder_config.model_copy(update={"model_catalog_path": config.model_catalog_path})
+
+    @staticmethod
+    def _goal_tree_config(config: EvolutionaryOptimizerConfig) -> GoalTreeConfig:
+        return GoalTreeConfig.model_validate(config.goal_config.model_dump())
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    async def run(self, deps: ExperimentalistDeps) -> ExperimentalistResult:
+        """Run optimization and always close the owned shell session."""
+        try:
+            return await self._run(deps)
+        finally:
+            await self.shell.close()
+
+    async def _run(self, deps: ExperimentalistDeps) -> ExperimentalistResult:
+        """Run the Pareto evolutionary optimization loop.
+
+        Args:
+            deps: Per-run dependencies (workspace, insight_id, dataset,
+                backend, optional config override).
+
+        Returns:
+            An :class:`ExperimentalistResult` committed to the entity store
+            via ``backend.persist_result()``.
+        """
+        if deps.backend is None:
+            raise ValueError("deps.backend must be set before calling run()")
+        backend = deps.backend
+        workspace = deps.workspace
+        config = deps.config if deps.config is not None else self.config
+
+        # ---- Preflight: fail fast when persistence is enabled but git is missing.
+        if (config.storage.archive_candidates or config.storage.publish_winner) and shutil.which("git") is None:
+            raise ValueError(
+                "Candidate persistence is enabled (storage.archive_candidates/publish_winner) "
+                "but 'git' is not on PATH, so nothing can be persisted. Install git, or disable "
+                "storage to run without persistence."
+            )
+
+        # ---- Working directory structure ---------------------------------
+        agents_dir, analysis_dir, results_dir = self._init_structure()
+        evaluator_factory = EvaluatorFactory()
+        evaluator = evaluator_factory.build_evaluator(
+            deps.evaluator_type,
+            config.evaluator,
+            experiment_dir=self.working_dir,
+        )
+        dataset_factory = DatasetFactory()
+
+        train_dataset_ref = deps.train_dataset
+        validation_dataset_ref = deps.validation_dataset
+        task_template_ref = deps.task_template
+        if deps.insight is not None:
+            if task_template_ref is None:
+                raise ValueError("Task template is required for insight trace analysis")
+            if backend.client is None:
+                raise ValueError("Platform client is required for insight task template loading")
+            staged_inputs = await stage_eval_author_inputs(
+                self.working_dir,
+                train_dataset=train_dataset_ref,
+                validation_dataset=validation_dataset_ref,
+                task_template=task_template_ref,
+                client=backend.client,
+                workspace=workspace,
+            )
+            train_dataset_ref = staged_inputs.train_dataset
+            validation_dataset_ref = staged_inputs.validation_dataset
+            task_template_ref = staged_inputs.task_template
+
+        # ---- Resolve datasets to evaluator-domain objects -----------------
+        train_eval_dataset = dataset_factory.build_dataset(
+            deps.evaluator_type,
+            train_dataset_ref,
+        )
+
+        validation_eval_dataset = dataset_factory.build_dataset(
+            deps.evaluator_type,
+            validation_dataset_ref,
+        )
+
+        # ---- Resolve insight (Mode 1) vs local agent (Mode 2) -----------
+        insight = (
+            await backend.get_insight(workspace=workspace, insight_id=str(deps.insight))
+            if deps.insight is not None
+            else None
+        )
+        agent_ref: str | Path | None = deps.agent
+        if agent_ref is None and insight is not None:
+            agent_ref = insight.agent
+        if agent_ref is None:
+            raise ValueError("Insight or agent is required")
+
+        agent_path = self.working_dir / "eval-and-optimize" / "source-agent"
+        await backend.get_agent_code(
+            workspace=workspace,
+            agent=agent_ref,
+            dest=agent_path,
+            clone_depth=config.source.clone_depth,
+        )
+        agent_name = str(agent_ref)
+
+        agent_spec_path: Path | None = None
+        if deps.agent_spec is not None:
+            agent_spec_path = await backend.get_agent_spec(
+                workspace=workspace,
+                spec=deps.agent_spec,
+                dest=self.working_dir / "AGENT-SPEC.md",
+            )
+
+        if insight is not None:
+            insight_ref: str = str(deps.insight)
+            # run the eval_author
+            if backend.client is None:
+                raise ValueError("Platform client is required for insight trace loading")
+            assert task_template_ref is not None
+            eval_author = EvalAuthor(experiment_dir=self.working_dir, config=config.eval_author)
+            eval_author_result = await eval_author.run(
+                insight=insight,
+                agent_path=agent_path,
+                task_template=dataset_factory.build_task_template(deps.evaluator_type, task_template_ref),
+                train_dataset=train_eval_dataset,
+                validation_dataset=validation_eval_dataset,
+                client=backend.client,
+            )
+            train_eval_dataset = eval_author_result.train_dataset
+            validation_eval_dataset = eval_author_result.validation_dataset
+        else:
+            # Mode 2: local agent directory as baseline, no insight required.
+            insight = None
+            insight_ref = ""
+
+        # ---- Resume or fresh start ---------------------------------------
+        if (round_num := self._detect_last_round()) is not None:
+            logger.info(f"[RESUME] round {round_num}")
+            self._delete_all_artifacts(from_round=round_num)
+            evolution_tree = EvolutionTree.from_dir(agents_dir)
+            candidates: list[Candidate] = list(evolution_tree.survivors(round_num))
+            run_entity = self._load_run_entity() or await self._create_experiment_run(
+                workspace=workspace,
+                backend=backend,
+                agent_name=agent_name or None,
+                agent_path=agent_path,
+                insight_ref=insight_ref or None,
+                config=config,
+            )
+        else:
+            round_num = 0
+            logger.info("phase=baseline round=0")
+            run_entity = await self._create_experiment_run(
+                workspace=workspace,
+                backend=backend,
+                agent_name=agent_name or None,
+                agent_path=agent_path,
+                insight_ref=insight_ref or None,
+                config=config,
+            )
+
+            try:
+                # ---- Fetch + build baseline agent (agent-0) --------------
+                baseline = await self._create_baseline_agent(
+                    workspace=workspace,
+                    backend=backend,
+                    agents_dir=agents_dir,
+                    agent_name=agent_name,
+                    agent_path=agent_path,
+                    run_id=run_entity.id or "",
+                    config=config,
+                )
+                await self._update_candidate(
+                    baseline,
+                    workspace=workspace,
+                    backend=backend,
+                    run_id=run_entity.id or "",
+                )
+                evolution_tree = EvolutionTree.from_dir(agents_dir)
+                candidates = list(evolution_tree.survivors(0))
+
+                # ---- Baseline validation evaluation (round 0) ------------
+                validation_candidate_results = await self._evaluate_validation_candidates(
+                    dataset=validation_eval_dataset,
+                    evaluator=evaluator,
+                    candidates=candidates,
+                )
+                validation_result = validation_candidate_results[candidates[0].label]
+                await backend.persist_evaluation(
+                    workspace=workspace,
+                    result=validation_result,
+                    candidate=candidates[0],
+                    split="validation",
+                )
+                await self._update_candidate(
+                    candidates[0],
+                    updates={
+                        "validation_reward": validation_result.aggregate_metrics,
+                        "validation_reward_details": validation_result.trials,
+                    },
+                    workspace=workspace,
+                    backend=backend,
+                    run_id=run_entity.id or "",
+                )
+            except Exception:
+                run_entity.status = "failed"
+                await backend.update_run(workspace=workspace, run=run_entity)
+                raise
+
+        run_id = run_entity.id or ""
+
+        # ---- Initial goal tree (idempotent) ------------------------------
+        await self._generate_initial_goal_tree(
+            dataset=train_eval_dataset,
+            disable_trajectory_scoring=config.disable_trajectory_scoring,
+            config=config,
+            agent_spec_path=agent_spec_path,
+        )
+
+        phase: Literal["exploration", "exploitation"] = "exploration" if round_num % 2 == 0 else "exploitation"
+
+        # ---- Pareto optimization loop (shared by fresh start and resume) --
+        try:
+            while True:
+                prior_analysis = (
+                    await self._load_round_analysis(analysis_dir=analysis_dir, round_num=round_num - 1)
+                    if round_num > 0
+                    else None
+                )
+                decision = await self.terminator.run(
+                    round_num=round_num,
+                    evolution_tree=evolution_tree,
+                    prior_analysis=prior_analysis,
+                    config=config,
+                )
+                if decision.stop:
+                    logger.info(f"phase=terminate reason={decision.reason}")
+                    break
+
+                survivors = (
+                    await self._select_survivors([c.slim() for c in candidates], k=config.max_survivors)
+                    if len(candidates) > 1
+                    else list(candidates)
+                )
+                survivor_labels = {s.label for s in survivors}
+                killed = [c for c in candidates if c.label not in survivor_labels]
+                for candidate in killed:
+                    await self._update_candidate(
+                        candidate,
+                        workspace=workspace,
+                        backend=backend,
+                        run_id=run_id,
+                        updates={"killed_round": round_num},
+                    )
+
+                train_candidate_results = await self._evaluate_train_candidates(
+                    dataset=train_eval_dataset,
+                    evaluator=evaluator,
+                    survivors=survivors,
+                    round_num=round_num,
+                    max_train_batch_tasks=config.max_train_batch_tasks,
+                    train_batch_seed=config.train_batch_seed,
+                )
+                for survivor in survivors:
+                    if survivor.label in train_candidate_results:
+                        await backend.persist_evaluation(
+                            workspace=workspace,
+                            result=train_candidate_results[survivor.label],
+                            candidate=survivor,
+                            split="train",
+                        )
+                        await self._update_candidate(
+                            survivor,
+                            workspace=workspace,
+                            backend=backend,
+                            run_id=run_id,
+                            updates={
+                                "train_reward": train_candidate_results[survivor.label].aggregate_metrics,
+                                "train_reward_details": train_candidate_results[survivor.label].trials,
+                            },
+                        )
+                analysis = await self._analyze_round(
+                    analysis_dir=analysis_dir,
+                    dataset=train_eval_dataset,
+                    evaluations=train_candidate_results,
+                    survivors=[c.slim() for c in survivors],
+                    round_num=round_num,
+                    config=config,
+                    client=backend.client,
+                    nmp_workspace=workspace,
+                    agent_spec_path=agent_spec_path,
+                )
+                await self._update_goal_tree(
+                    analysis_dir=analysis_dir,
+                    round_num=round_num,
+                    analysis=analysis,
+                    dataset=train_eval_dataset,
+                    config=config,
+                    agent_spec_path=agent_spec_path,
+                )
+
+                improvements = await self._propose_improvements(
+                    workspace=workspace,
+                    backend=backend,
+                    analysis=analysis,
+                    evolution_tree=evolution_tree,
+                    round_num=round_num,
+                    phase=phase,
+                    config=config,
+                )
+                new_candidates = [
+                    self._create_agent(
+                        agents_dir=agents_dir,
+                        improvement=imp,
+                        round_num=round_num + 1,
+                        run_id=run_entity.id or "",
+                    )
+                    for imp in improvements
+                ]
+                # Persist metadata.json before Coder runs so snapshot can read it.
+                for candidate in new_candidates:
+                    await self._update_candidate(
+                        candidate,
+                        workspace=workspace,
+                        backend=backend,
+                        run_id=run_entity.id or "",
+                    )
+                new_candidates = await self._implement_candidates(
+                    workspace=workspace,
+                    backend=backend,
+                    dataset=train_eval_dataset,
+                    evaluator=evaluator,
+                    candidates=new_candidates,
+                    config=config,
+                )
+                for candidate in new_candidates:
+                    await self._update_candidate(
+                        candidate,
+                        workspace=workspace,
+                        backend=backend,
+                        run_id=run_id,
+                    )
+                for c in new_candidates:
+                    evolution_tree.add(c)
+
+                candidates = survivors + new_candidates
+                round_num += 1
+                phase = "exploration" if round_num % 2 == 0 else "exploitation"
+
+                validation_candidate_results = await self._evaluate_validation_candidates(
+                    dataset=validation_eval_dataset,
+                    evaluator=evaluator,
+                    candidates=candidates,
+                )
+                for candidate in candidates:
+                    if candidate.label in validation_candidate_results:
+                        await backend.persist_evaluation(
+                            workspace=workspace,
+                            result=validation_candidate_results[candidate.label],
+                            candidate=candidate,
+                            split="validation",
+                        )
+                        await self._update_candidate(
+                            candidate,
+                            workspace=workspace,
+                            backend=backend,
+                            run_id=run_id,
+                            updates={
+                                "validation_reward": validation_candidate_results[candidate.label].aggregate_metrics,
+                                "validation_reward_details": validation_candidate_results[candidate.label].trials,
+                            },
+                        )
+                if not config.disable_trajectory_scoring:
+                    trajectory_results = await self._reward_trajectories(
+                        workspace=workspace,
+                        backend=backend,
+                        dataset=validation_eval_dataset,
+                        candidates=candidates,
+                        config=config,
+                        client=backend.client,
+                    )
+                    for candidate in candidates:
+                        if candidate.label in trajectory_results:
+                            await self._update_candidate(
+                                candidate,
+                                workspace=workspace,
+                                backend=backend,
+                                run_id=run_id,
+                                updates={
+                                    "validation_trajectory_reward": trajectory_results[candidate.label]["reward"],
+                                    "validation_trajectory_reward_details": trajectory_results[candidate.label][
+                                        "details"
+                                    ],
+                                },
+                            )
+
+                if config.storage.archive_candidates:
+                    for candidate in new_candidates:
+                        try:
+                            await backend.archive_candidate(workspace=workspace, candidate=candidate)
+                        except Exception as exc:  # noqa: BLE001 - archival must never fail the run
+                            _warn_persistence_failure("archive", candidate.label, exc)
+
+                run_entity.rounds_completed = round_num
+                await backend.update_run(workspace=workspace, run=run_entity)
+
+        except Exception:
+            run_entity.status = "failed"
+            await backend.update_run(workspace=workspace, run=run_entity)
+            raise
+
+        # ---- Finalize ----------------------------------------------------
+        winner_entity = await self._finalize(
+            workspace=workspace,
+            backend=backend,
+            agents_dir=agents_dir,
+            run_entity=run_entity,
+            evolution_tree=evolution_tree,
+            agent_name=agent_name,
+        )
+
+        result = ExperimentalistResult(
+            summary=self._render_summary(rounds_completed=round_num, winner=winner_entity),
+            run_id=run_id,
+            rounds_completed=round_num,
+            winner=winner_entity,
+        )
+
+        # Persist the terminal result
+        await backend.persist_result(workspace=workspace, result=result)
+
+        # Publish the winner as a draft PR/MR
+        if config.storage.publish_winner and winner_entity is not None and winner_entity.round != 0:
+            try:
+                url = await backend.publish_candidate(workspace=workspace, candidate=winner_entity)
+                if url:
+                    logger.info(f"[TERMINATOR] opened draft PR/MR for winner {winner_entity.label}: {url}")
+            except Exception as exc:  # noqa: BLE001 - publishing must never fail the run
+                _warn_persistence_failure("publish", winner_entity.label, exc)
+        return result
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=100, cell_timeout=3600.0)))
+    async def select_diverse_survivors(self, ranked: list[Candidate], k: int) -> list[Candidate]:  # pyright: ignore[reportReturnType]
+        """Choose up to k survivors from Pareto-ranked candidates.
+
+        ``ranked`` is already Pareto-sorted using outcome and trajectory scores:
+        front 0 (non-dominated) first, then front 1, etc. Inside a front,
+        candidates are incomparable, so prefer agents with distinct architecture
+        changes, complementary task coverage, and different trajectory strengths.
+
+        To avoid getting stuck on the same agents round after round:
+        1. Always include at least 1 candidate that was newly created this round. Look up
+           `self.workspace.get_metadata(c.name)["round"]` for each candidate; new candidates
+           are the ones whose round equals the max round across `ranked`.
+        2. Prefer candidates with different optimization_type values or that address different root causes.
+        3. If all new candidates sit on a worse Pareto front, still include the best new candidate.
+
+        ## MANDATORY: Prefer agents with complementary strengths
+
+        Read each candidate's per-dimension validation rewards from metadata and
+        prefer a set whose strong dimensions cover each other (one agent leads on
+        dimensions where another trails):
+
+        ```python
+        rewards = {c.id: self.workspace.get_metadata(c.name).validation_reward or {} for c in ranked}
+        ```
+
+        Between 1 to 3 survivors per round.
+        Return the selected subset, preserving the input's Pareto-front order.
+        """
+        ...
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=100, cell_timeout=3600.0)))
+    async def merge_analysis(
+        self,
+        agent_ids: list[Candidate],
+        round: int,
+        per_agent_analyses: list[str],  # noqa: A002
+    ) -> str:  # pyright: ignore[reportReturnType]
+        """Merge per-agent analyses, compare agents, and write the round analysis file.
+
+        ## Step 1: Compare agents at reward level
+
+        Read each agent's per-dimension train rewards from metadata:
+
+        ```python
+        rewards = {c.id: self.workspace.get_metadata(c.name).train_reward or {} for c in agent_ids}
+        ```
+
+        - Compare siblings: which optimization strategy worked better this round?
+        - Compare to ancestors: did the change actually fix the targeted root cause?
+
+        ## Step 2: Analyze divergent and complementary patterns
+
+        Using the per-dimension rewards above, identify where agents diverge (one
+        leads, another trails on a dimension) and where their strengths are
+        complementary. Ground observations in the per-agent analyses passed in.
+
+        ## Step 3: Build the round analysis markdown
+
+        First, discover reward dimensions from metadata:
+        ```python
+        candidate = self.workspace.get_metadata(agent_ids[0].name).slim()
+        train_reward = candidate.train_reward or {}
+        dim_keys = sorted(train_reward.keys())
+        ```
+
+        Follow the `ext.analysis_skill` format exactly for every section (Rewards table,
+        Trajectory Rewards, Divergent Trial Analysis, Complementary Failures, Failure
+        Patterns, Root Causes, Mechanical/Infrastructure Errors).
+
+        Fill in every section with real data. No placeholders.
+        Return the complete markdown content as a string.
+        """
+        ...
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=100, cell_timeout=3600.0)))
+    async def write_final_report(self, best_agent_id: str) -> None:  # pyright: ignore[reportReturnType]
+        """Write the final optimization report to eval-and-optimize/OPTIMIZATION.md.
+
+        ## MANDATORY: use self.workspace — DO NOT ls / cat / find manually
+
+        ```python
+        agent_ids = self.workspace.list_agents()
+        candidate = self.workspace.get_metadata(agent_id).slim()
+        analysis  = self.workspace.read_analysis_file(n)
+        ```
+
+        ## Steps
+        1. Collect metadata for every agent.
+        2. Read round analysis files.
+        3. Build the lineage tree by following ancestor chains.
+        4. Write eval-and-optimize/OPTIMIZATION.md with format:
+           - Summary (baseline vs best rewards, rounds completed, total agents)
+           - Reward Breakdown table (one row per agent, per-dimension columns)
+           - Lineage Tree (ASCII tree with rewards and optimization type)
+           - Round-by-Round Analysis
+           - Optimization Insights
+
+        Fill in every section with real data. Every agent must appear in the lineage tree.
+        Mark the best agent with * BEST.
+        """
+        ...
+
+    # ------------------------------------------------------------------
+    # Private helpers — concrete (no LLM, no evaluator)
+    # ------------------------------------------------------------------
+
+    def _init_structure(self) -> tuple[Path, Path, Path]:
+        """Create the eval-and-optimize workspace directories; return (agents_dir, analysis_dir, results_dir)."""
+        agents_dir = self.working_dir / "eval-and-optimize" / "agents"
+        analysis_dir = self.working_dir / "eval-and-optimize" / "analysis"
+        results_dir = self.working_dir / "eval-and-optimize" / "results"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        analysis_dir.mkdir(parents=True, exist_ok=True)
+        results_dir.mkdir(parents=True, exist_ok=True)
+        return agents_dir, analysis_dir, results_dir
+
+    def _load_run_entity(self) -> ExperimentRun | None:
+        """Read run.json from the workspace; return None if absent or unparseable."""
+        run_path = self.working_dir / "eval-and-optimize" / "run.json"
+        if not run_path.exists():
+            return None
+        try:
+            data = json.loads(run_path.read_text())
+            # ExperimentRun._restore_id_from_json validator handles id restoration
+            return ExperimentRun.model_validate(data)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"[RESUME] Could not parse run.json: {exc}")
+            return None
+
+    def _detect_last_round(self) -> int | None:
+        """Return the last completed round by scanning analysis files, or None if starting fresh."""
+        analysis_dir = self.working_dir / "eval-and-optimize" / "analysis"
+        if not analysis_dir.exists():
+            return None
+        rounds = []
+        for f in analysis_dir.glob("round-*.md"):
+            try:
+                rounds.append(int(f.stem.split("-")[1]))
+            except (IndexError, ValueError):
+                continue
+        return max(rounds) if rounds else None
+
+    def _delete_all_artifacts(self, from_round: int) -> None:
+        """Delete agents and analysis files created after *from_round*.
+
+        Rolls back any partial work so the loop can cleanly re-enter at
+        the start of ``from_round + 1``.  Also clears stale ``killed_round``
+        markers on surviving agents whose killer round was itself rolled back.
+        """
+        agents_dir = self.working_dir / "eval-and-optimize" / "agents"
+        results_dir = self.working_dir / "eval-and-optimize" / "results"
+        analysis_dir = self.working_dir / "eval-and-optimize" / "analysis"
+        smoke_dataset_dir = self.working_dir / "eval-and-optimize" / "smoke-dataset"
+        smoke_results_dir = self.working_dir / "eval-and-optimize" / "smoke-results"
+
+        for agent_dir in sorted(agents_dir.iterdir()):
+            if not (
+                agent_dir.is_dir() and agent_dir.name.startswith("agent-") and agent_dir.name.split("-")[1].isdigit()
+            ):
+                continue
+            meta_path = agent_dir / "metadata.json"
+            if not meta_path.exists():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            if (meta.get("round") or 0) > from_round:
+                shutil.rmtree(agent_dir)
+                for suffix in ("-train", "-validation"):
+                    rd = results_dir / f"{agent_dir.name}{suffix}"
+                    if rd.exists():
+                        shutil.rmtree(rd)
+                for rd in (
+                    smoke_results_dir / agent_dir.name,
+                    smoke_dataset_dir / agent_dir.name,
+                ):
+                    if rd.exists():
+                        shutil.rmtree(rd)
+
+        # Clear stale killed_round markers whose killer round was rolled back.
+        for agent_dir in sorted(agents_dir.iterdir()):
+            if not (
+                agent_dir.is_dir() and agent_dir.name.startswith("agent-") and agent_dir.name.split("-")[1].isdigit()
+            ):
+                continue
+            meta_path = agent_dir / "metadata.json"
+            if not meta_path.exists():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            killed = meta.get("killed_round")
+            if killed is not None and killed > from_round:
+                meta["killed_round"] = None
+                meta_path.write_text(json.dumps(meta, indent=2))
+
+        for pattern in ("round-*.md", "round-*-goal.json"):
+            for f in analysis_dir.glob(pattern):
+                try:
+                    n = int(f.stem.split("-")[1])
+                except (IndexError, ValueError):
+                    continue
+                if n > from_round:
+                    f.unlink()
+
+    async def _create_baseline_agent(
+        self,
+        *,
+        workspace: str,
+        backend: ExperimentalistBackend,
+        agents_dir: Path,
+        agent_name: str | None,
+        agent_path: Path | None,
+        run_id: str,
+        config: EvolutionaryOptimizerConfig,
+    ) -> Candidate:
+        """Materialize the source agent into ``agents_dir/agent-0`` and return the baseline candidate.
+
+        An explicit ``--agent`` (``agent_path``, a local dir or a git clone) takes
+        precedence and is copied directly; otherwise the code is fetched by the
+        insight's agent name via ``backend.get_agent_code``. Skips the copy when the
+        directory already exists (resume case).
+        """
+        baseline_dir = agents_dir / _BASELINE_AGENT_LABEL
+        if not baseline_dir.exists():
+            if agent_path is not None:
+                shutil.copytree(agent_path, baseline_dir, ignore=_ignore_patterns)
+            elif agent_name:
+                await backend.get_agent_code(workspace=workspace, agent=agent_name, dest=baseline_dir)
+        await self._generate_architecture_doc(agent_dir=baseline_dir, config=config)
+        candidate = Candidate(
+            name=_BASELINE_AGENT_LABEL,
+            label=_BASELINE_AGENT_LABEL,
+            workspace=workspace,
+            run_id=run_id,
+            ancestor=None,
+            round=0,
+            optimization="baseline",
+        )
+        return candidate
+
+    def _create_agent(
+        self,
+        *,
+        agents_dir: Path,
+        improvement: Improvement,
+        round_num: int,
+        run_id: str,
+    ) -> Candidate:
+        """Copy the ancestor directory to a new ``agent-N`` directory and return the candidate."""
+        next_label = self._next_agent_label(agents_dir)
+        ancestor_dir = agents_dir / improvement.ancestor
+        candidate_dir = agents_dir / next_label
+        generated_files = {
+            "architecture.md",
+        }
+
+        def _ignore_agent_meta(directory: str, contents: list[str]) -> set[str]:
+            ignored = _ignore_patterns(directory, contents)
+            if Path(directory).resolve() != ancestor_dir.resolve():
+                return ignored
+            return ignored | {name for name in contents if name == "metadata.json" or name in generated_files}
+
+        if ancestor_dir.is_dir():
+            shutil.copytree(ancestor_dir, candidate_dir, ignore=_ignore_agent_meta)
+        else:
+            candidate_dir.mkdir(parents=True, exist_ok=True)
+        opt_type = _coerce_optimization_type(improvement.optimization_type)
+        candidate = Candidate(
+            name=next_label,
+            label=next_label,
+            ancestor=improvement.ancestor,
+            round=round_num,
+            optimization=improvement.optimization,
+            optimization_type=opt_type,
+            task_ids=improvement.task_ids,
+            run_id=run_id,
+        )
+        return candidate
+
+    def _next_agent_label(self, agents_dir: Path) -> str:
+        """Return the next sequential ``agent-N`` label based on existing directories."""
+        nums = [
+            int(d.name.split("-")[1])
+            for d in agents_dir.iterdir()
+            if d.is_dir() and d.name.startswith("agent-") and d.name.split("-")[1].isdigit()
+        ]
+        return f"agent-{max(nums, default=-1) + 1}"
+
+    async def _load_round_analysis(
+        self,
+        *,
+        analysis_dir: Path,
+        round_num: int,
+    ) -> str | None:
+        """Return the cached analysis markdown for *round_num*, or None if absent."""
+        path = analysis_dir / f"round-{round_num}.md"
+        return path.read_text() if path.exists() else None
+
+    async def _update_candidate(
+        self,
+        candidate: Candidate,
+        *,
+        workspace: str,
+        backend: ExperimentalistBackend,
+        run_id: str,
+        updates: dict[str, Any] | None = None,
+    ) -> None:
+        """Sync candidates to the entity store.
+
+        Fills in ``workspace`` and ``run_id`` from the call-site context
+        (which is authoritative) before persisting.  On first persist the
+        backend assigns a store id (``_id``); on subsequent calls it updates
+        the existing record.
+        """
+        candidate.workspace = workspace
+        candidate.run_id = run_id
+        if updates is not None:
+            for key, value in updates.items():
+                setattr(candidate, key, value)
+        if candidate.id:
+            await backend.update_candidate(workspace=workspace, candidate=candidate)
+        else:
+            result = await backend.create_candidate(workspace=workspace, candidate=candidate)
+            candidate._id = result._id  # type: ignore[attr-defined]
+
+    def _goal_tree_path(self, round_num: int) -> Path:
+        return self.working_dir / "eval-and-optimize" / "analysis" / f"round-{round_num}-goal.json"
+
+    def _latest_goal_tree_path(self) -> Path | None:
+        analysis_dir = self.working_dir / "eval-and-optimize" / "analysis"
+        best: tuple[int, Path] | None = None
+        for p in analysis_dir.glob("round-*-goal.json"):
+            try:
+                n = int(p.stem.split("-")[1])
+            except (IndexError, ValueError):
+                continue
+            if best is None or n > best[0]:
+                best = (n, p)
+        return best[1] if best else None
+
+    def _load_goal_tree(
+        self,
+        path: Path,
+        goal_config: GoalTreeConfig,
+        context: str,
+    ) -> GoalTree | None:
+        try:
+            return GoalTree.from_path(path, config=goal_config)
+        except (OSError, ValueError) as exc:
+            logger.warning(f"[TRAJ] Failed to load {context} goal tree {path}: {exc}")
+            return None
+
+    def _format_evolution_table(self, evolution_tree: EvolutionTree) -> str:
+        if not evolution_tree.nodes:
+            return "(none yet — this is the first round)"
+        return evolution_tree.to_markdown_table()
+
+    def _copy_best_to_workspace(self, agent_id: str) -> None:
+        src = self.working_dir / "eval-and-optimize" / "agents" / agent_id
+        skip_names = {
+            "metadata.json",
+            "harbor_wrapper.py",
+            "dind_environment.py",
+            "architecture.md",
+        }
+        for entry in src.iterdir():
+            if entry.name in skip_names:
+                continue
+            dst = self.working_dir / entry.name
+            if entry.is_dir():
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(entry, dst)
+            else:
+                shutil.copy2(entry, dst)
+
+    def _snapshot_metadata(self, candidate_name: str) -> str | None:
+        """Read and return the metadata.json content for a candidate, or None if absent."""
+        path = self.working_dir / "eval-and-optimize" / "agents" / candidate_name / "metadata.json"
+        try:
+            return path.read_text()
+        except OSError:
+            return None
+
+    def _restore_metadata(self, candidate_name: str, content: str | None) -> None:
+        """Restore metadata.json for a candidate to a previously snapshotted content."""
+        if content is None:
+            return
+        path = self.working_dir / "eval-and-optimize" / "agents" / candidate_name / "metadata.json"
+        try:
+            path.write_text(content)
+        except OSError:
+            pass
+
+    async def _evaluate_agent(
+        self,
+        candidate: Candidate,
+        dataset: Dataset,
+        evaluator: Evaluator,
+        task_ids: list[str] | None = None,
+    ) -> tuple[Candidate, EvaluationResult]:
+        """Run evaluator for one candidate and return the candidate/result pair."""
+        eval_dataset = dataset.subset(task_ids) if task_ids is not None else dataset
+        # Force a unique job name per candidate so concurrent candidates don't
+        # collide on the same results directory when the user sets a fixed job_name.
+        options_dict = evaluator.options.model_dump()
+        options_dict["job_name"] = f"{candidate.label}-{eval_dataset.id}"
+        per_candidate_options = type(evaluator.options).model_validate(options_dict)
+        result = await evaluator.run(
+            agent=self.working_dir / "eval-and-optimize" / "agents" / candidate.label,
+            dataset=eval_dataset,
+            options=per_candidate_options,
+        )
+        return (candidate, result)
+
+    # ------------------------------------------------------------------
+    # Private step methods — implementations
+    # ------------------------------------------------------------------
+
+    async def _create_experiment_run(
+        self,
+        *,
+        workspace: str,
+        backend: ExperimentalistBackend,
+        agent_name: str | None,
+        agent_path: Path | None,
+        insight_ref: str | None,
+        config: EvolutionaryOptimizerConfig,
+    ) -> ExperimentRun:
+        """Create an ExperimentRun entity; return it with its store-assigned id."""
+        run = ExperimentRun(
+            workspace=workspace,
+            agent=agent_name or str(agent_path or ""),
+            insight=insight_ref,
+            config_snapshot=config.model_dump(mode="json"),
+            status="running",
+            rounds_completed=0,
+        )
+        return await backend.create_run(workspace=workspace, run=run)
+
+    async def _generate_architecture_doc(
+        self,
+        *,
+        agent_dir: Path,
+        config: EvolutionaryOptimizerConfig,
+    ) -> None:
+        """Generate ``architecture.md`` for *agent_dir* via Coder."""
+        if (agent_dir / "architecture.md").exists():
+            return
+        agent_id = agent_dir.name
+        await Coder(
+            workspace=self.working_dir,
+            config=self._coder_config(config),
+            framework_skills_dirs=self._framework_skills_dirs,
+        ).create_architecture_doc(
+            agent_id,
+            source_path=config.source.source_path,
+            entrypoint=config.source.entrypoint,
+        )
+
+    async def _evaluate_validation_candidates(
+        self,
+        *,
+        dataset: Dataset,
+        evaluator: Evaluator,
+        candidates: list[Candidate],
+    ) -> dict[str, EvaluationResult]:
+        """Evaluate candidates on the validation split; skip any that already have a reward."""
+        pending = [c for c in candidates if c.validation_reward is None]
+        if not pending:
+            return {}
+        if pending:
+            splits = frozenset({"validation"})
+            restore_heldout_splits(self.working_dir, splits=splits)
+            try:
+                candidate_results = await asyncio.gather(
+                    *[
+                        self._evaluate_agent(
+                            c,
+                            dataset,
+                            evaluator,
+                        )
+                        for c in pending
+                    ]
+                )
+            finally:
+                ensure_heldout_hidden(self.working_dir, splits=splits)
+        return {
+            candidate_result[0].label: candidate_result[1]
+            for candidate_result in candidate_results
+            if candidate_result is not None
+        }
+
+    async def _generate_initial_goal_tree(
+        self,
+        *,
+        dataset: Dataset,
+        disable_trajectory_scoring: bool,
+        config: EvolutionaryOptimizerConfig,
+        agent_spec_path: Path | None = None,
+    ) -> None:
+        """Generate and persist the round-0 goal tree if it does not already exist."""
+        if disable_trajectory_scoring:
+            return
+        tree_path = self._goal_tree_path(0)
+        if tree_path.exists():
+            return
+        try:
+            tree = await GoalTreeGenerator(
+                workspace=self.working_dir,
+                config=self._goal_tree_config(config),
+                framework_skills_dirs=self._framework_skills_dirs,
+            ).generate(dataset, agent_spec=agent_spec_path)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"[TRAJ] Failed to generate initial goal tree; continuing without trajectory scoring: {exc}")
+            return
+        tree_path.parent.mkdir(parents=True, exist_ok=True)
+        tree_path.write_text(tree.to_json())
+
+    async def _select_survivors(
+        self,
+        candidates: list[Candidate],
+        k: int,
+    ) -> list[Candidate]:
+        """Return the top-k Pareto-optimal and architecturally diverse candidates."""
+        ranked = pareto_sort(candidates, lambda c: c.validation_reward or {})
+        return await self.select_diverse_survivors(ranked, k)
+
+    async def _evaluate_train_candidates(
+        self,
+        *,
+        dataset: Dataset,
+        evaluator: Evaluator,
+        max_train_batch_tasks: int | None,
+        train_batch_seed: int,
+        survivors: list[Candidate],
+        round_num: int,
+    ) -> dict[str, EvaluationResult]:
+        """Evaluate survivors on the train split.
+
+        In full-dataset mode (``max_train_batch_tasks is None``) the eval set is
+        identical every round, so a survivor's cached ``train_reward`` is reused and
+        only survivors without one are evaluated. In batch mode the sampled batch
+        changes per round, so cached rewards are not comparable within a round: every
+        survivor is re-evaluated on the same freshly sampled batch.
+        """
+        if max_train_batch_tasks is None:
+            # Full-dataset mode: the eval set is identical every round, so evaluate only
+            # survivors that lack a reward and reuse each survivor's cached train reward.
+            pending = [s for s in survivors if s.train_reward is None]
+            evaluated: list[tuple[Candidate, EvaluationResult]] = []
+            if pending:
+                evaluated = await asyncio.gather(*[self._evaluate_agent(c, dataset, evaluator) for c in pending])
+            results = {candidate.label: result for candidate, result in evaluated}
+            for survivor in survivors:
+                if survivor.label in results:
+                    continue
+                if survivor.train_reward is None and survivor.train_reward_details is None:
+                    continue
+                results[survivor.label] = EvaluationResult(
+                    id=f"{survivor.label}-train",
+                    aggregate_metrics=survivor.train_reward or {},
+                    trials=list(survivor.train_reward_details or []),
+                )
+            return results
+
+        # Batch mode: the sampled batch changes per round, so a cached reward computed on
+        # a different task set is not comparable within a round. Re-evaluate every survivor
+        # on the same freshly sampled batch instead of reusing cached rewards.
+        if max_train_batch_tasks <= 0:
+            raise ValueError("max_train_batch_tasks must be positive or None")
+        all_task_ids = sorted(task.id for task in dataset.list_tasks())
+        if not all_task_ids:
+            raise ValueError(f"No train tasks found in dataset {dataset.id!r}")
+        rng = random.Random(train_batch_seed + round_num)
+        batch_size = min(max_train_batch_tasks, len(all_task_ids))
+        task_ids = sorted(rng.sample(all_task_ids, batch_size))
+        evaluated = await asyncio.gather(
+            *[self._evaluate_agent(c, dataset, evaluator, task_ids=task_ids) for c in survivors]
+        )
+        return {candidate.label: result for candidate, result in evaluated}
+
+    async def _analyze_round(
+        self,
+        *,
+        analysis_dir: Path,
+        dataset: Dataset,
+        evaluations: dict[str, EvaluationResult],
+        survivors: list[Candidate],
+        round_num: int,
+        config: EvolutionaryOptimizerConfig,
+        client: AsyncNeMoPlatform | None = None,
+        nmp_workspace: str | None = None,
+        agent_spec_path: Path | None = None,
+    ) -> str:
+        """Run AgentAnalyzer per survivor, merge analyses, persist to disk.
+
+        ``client`` and ``nmp_workspace`` are threaded into each ``AgentAnalyzer``
+        so its ``TraceAnalyzer`` can load ``intake://`` trial traces; when
+        ``None`` those traces are skipped (local ``file://`` traces still load).
+
+        Returns the merged analysis markdown string.
+        """
+        analysis_path = analysis_dir / f"round-{round_num}.md"
+        if analysis_path.exists():
+            return analysis_path.read_text()
+
+        per_agent = await asyncio.gather(
+            *[
+                AgentAnalyzer(
+                    workspace=self.working_dir,
+                    config=AnalyzerConfig.model_validate(config.analyzer.model_dump()),
+                    framework_skills_dirs=self._framework_skills_dirs,
+                ).run(
+                    agent=s.label,
+                    dataset=dataset,
+                    evaluation=evaluations[s.label],
+                    round=round_num,
+                    peer_evaluations={k: v for k, v in evaluations.items() if k != s.label},
+                    client=client,
+                    nmp_workspace=nmp_workspace,
+                    agent_spec=agent_spec_path,
+                )
+                for s in survivors
+            ]
+        )
+        analysis = await self.merge_analysis(survivors, round_num, [str(a) for a in per_agent])
+        analysis_path.parent.mkdir(parents=True, exist_ok=True)
+        analysis_path.write_text(analysis)
+        return analysis
+
+    async def _update_goal_tree(
+        self,
+        *,
+        analysis_dir: Path,
+        round_num: int,
+        analysis: str,
+        dataset: Dataset,
+        config: EvolutionaryOptimizerConfig,
+        agent_spec_path: Path | None = None,
+    ) -> None:
+        """Refine and persist the goal tree for round *round_num* + 1."""
+        next_goal_path = self._goal_tree_path(round_num + 1)
+        if next_goal_path.exists():
+            return
+        goal_tree_path = self._latest_goal_tree_path()
+        if goal_tree_path is None:
+            return
+        goal_config = self._goal_tree_config(config)
+        goal_tree = self._load_goal_tree(goal_tree_path, goal_config, context="analysis")
+        if goal_tree is None:
+            return
+        generator = GoalTreeGenerator(
+            workspace=self.working_dir, config=goal_config, framework_skills_dirs=self._framework_skills_dirs
+        )
+        updated_tree = await generator.update(goal_tree, analysis, round_num, dataset, agent_spec=agent_spec_path)
+        next_goal_path.parent.mkdir(parents=True, exist_ok=True)
+        next_goal_path.write_text(updated_tree.to_json())
+
+    async def _propose_improvements(
+        self,
+        *,
+        workspace: str,
+        backend: ExperimentalistBackend,
+        analysis: str,
+        evolution_tree: EvolutionTree,
+        round_num: int,
+        phase: Literal["exploration", "exploitation"],
+        config: EvolutionaryOptimizerConfig,
+    ) -> list[Improvement]:
+        """Run Proposer; return up to ``config.max_candidates`` Improvements."""
+        proposer = Proposer(
+            workspace=self.working_dir,
+            config=ProposerConfig.model_validate(config.proposer.model_dump()),
+            framework_skills_dirs=self._framework_skills_dirs,
+        )
+        return await proposer.run(
+            analysis=analysis,
+            evolution_history=self._format_evolution_table(evolution_tree),
+            evolution_tree=evolution_tree,
+            round_num=round_num,
+            phase=phase,
+            max_candidates=config.max_candidates,
+        )
+
+    async def _implement_candidates(
+        self,
+        *,
+        workspace: str,
+        backend: ExperimentalistBackend,
+        dataset: Dataset,
+        evaluator: Evaluator,
+        candidates: list[Candidate],
+        config: EvolutionaryOptimizerConfig,
+    ) -> list[Candidate]:
+        """Apply proposed changes to each candidate via Coder; return the updated candidates."""
+        snapshots = {c.name: self._snapshot_metadata(c.name) for c in candidates}
+        try:
+            results = await asyncio.gather(
+                *[
+                    Coder(
+                        workspace=self.working_dir,
+                        config=self._coder_config(config),
+                        framework_skills_dirs=self._framework_skills_dirs,
+                    ).run(
+                        c,
+                        dataset,
+                        evaluator,
+                        source_path=config.source.source_path,
+                        entrypoint=config.source.entrypoint,
+                    )
+                    for c in candidates
+                ],
+                return_exceptions=True,
+            )
+        finally:
+            for c in candidates:
+                self._restore_metadata(c.name, snapshots[c.name])
+        failed = {c.name for c, r in zip(candidates, results, strict=True) if isinstance(r, Exception)}
+        # Persist a killed marker on failed candidates so a later resume via
+        # EvolutionTree.from_dir does not resurrect them as active survivors
+        # (a node is a survivor exactly when killed_round is None).
+        for candidate in candidates:
+            if candidate.name not in failed:
+                continue
+            logger.warning(f"Impl failed: {candidate.name}")
+            await self._update_candidate(
+                candidate,
+                workspace=workspace,
+                backend=backend,
+                run_id=candidate.run_id,
+                updates={"killed_round": candidate.round},
+            )
+        return [c for c in candidates if c.name not in failed]
+
+    async def _reward_trajectories(
+        self,
+        *,
+        workspace: str,
+        backend: ExperimentalistBackend,
+        dataset: Dataset,
+        candidates: list[Candidate],
+        config: EvolutionaryOptimizerConfig,
+        client: AsyncNeMoPlatform | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        """Score candidates against the goal tree; return trajectory results keyed by candidate label."""
+        tree_path = self._latest_goal_tree_path()
+        if tree_path is None:
+            logger.info("[TRAJ] No goal tree found, skipping trajectory scoring")
+            return {}
+
+        goal_tree = self._load_goal_tree(tree_path, self._goal_tree_config(config), context="trajectory scoring")
+        if goal_tree is None:
+            logger.info("[TRAJ] Invalid goal tree, skipping trajectory scoring")
+            return {}
+
+        pending = [c.label for c in candidates]
+        if len(pending) == 1:
+            logger.info("[TRAJ] Only one agent to score, skipping GRA")
+            return {}
+
+        logger.info(f"[TRAJ] Scoring {len(pending)} agents using GRA")
+
+        nodes = traverse_tree(goal_tree.root)
+        node_weights = leaf_weights_by_id(goal_tree.root)
+        traces_by_task: dict[str, dict[str, TrialResult]] = {}
+        for candidate in candidates:
+            if candidate.validation_reward is None and candidate.validation_reward_details is None:
+                continue
+            for trial in candidate.validation_reward_details or []:
+                if trial.trace is None:
+                    continue
+                traces_by_task.setdefault(trial.task_id, {}).setdefault(candidate.label, trial)
+
+        # Only require agents that actually contributed traces; a candidate with no
+        # traces at all (e.g. its validation run failed entirely) must not cause every
+        # task to be dropped from scoring.
+        agents_with_traces = {label for task_traces in traces_by_task.values() for label in task_traces}
+        if len(agents_with_traces) < 2:
+            logger.info("[TRAJ] Fewer than two agents have traces, skipping trajectory scoring")
+            return {}
+        complete_traces = _complete_trace_groups(traces_by_task, list(agents_with_traces))
+        dropped = len(traces_by_task) - len(complete_traces)
+        if dropped:
+            logger.info(f"[TRAJ] Skipping {dropped} tasks missing traces for one or more agents")
+        traces_by_task = complete_traces
+
+        task_names = sorted(traces_by_task)
+        total_tasks = len(task_names)
+        max_tasks = config.max_trajectory_tasks
+        if max_tasks and total_tasks > max_tasks:
+            task_names = task_names[:max_tasks]
+            traces_by_task = {t: traces_by_task[t] for t in task_names}
+            logger.info(f"[TRAJ] Selected first {max_tasks}/{total_tasks} complete tasks")
+
+        if not traces_by_task:
+            logger.info("[TRAJ] No complete trace groups found, skipping")
+            return {}
+
+        scores_by_node_trial_agent: dict[str, dict[str, dict[str, dict[str, Any]]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+        keys = [(node.id, task_id) for node in nodes for task_id in traces_by_task]
+        logger.info(f"[TRAJ] Starting {len(keys)} GRA scoring tasks...")
+
+        scorer = GroupLeafScorer(workspace=self.working_dir, client=client, nmp_workspace=workspace)
+        scoring_results = await asyncio.gather(
+            *[scorer.run(node, traces_by_task[task_id], dataset) for node in nodes for task_id in traces_by_task]
+        )
+        logger.info("[TRAJ] Scoring completed")
+        for (node_id, task_id), group_scores in zip(keys, scoring_results, strict=True):
+            for aid, gs in group_scores.items():
+                scores_by_node_trial_agent[node_id][task_id][aid] = _trajectory_detail_from_reward(gs)
+
+        trajectory_results: dict[str, dict[str, Any]] = {}
+        for aid in pending:
+            details: dict[str, dict[str, dict[str, Any]]] = {}
+            for node in nodes:
+                details[node.id] = {
+                    tid: by_agent[aid]
+                    for tid, by_agent in scores_by_node_trial_agent[node.id].items()
+                    if aid in by_agent
+                }
+            node_means = {
+                node.id: sum(item["reward"] for item in details[node.id].values()) / len(details[node.id])
+                for node in nodes
+                if details[node.id]
+            }
+            trajectory_reward = sum(node_weights[node.id] * node_means.get(node.id, 0.0) for node in nodes)
+            trajectory_results[aid] = {
+                "details": details,
+                "reward": {
+                    "aggregate": trajectory_reward,
+                    **node_means,
+                },
+            }
+            logger.info(f"[TRAJ] {aid}: trajectory_reward={trajectory_reward:.3f}")
+
+        return trajectory_results
+
+    async def _finalize(
+        self,
+        *,
+        workspace: str,
+        backend: ExperimentalistBackend,
+        agents_dir: Path,
+        run_entity: ExperimentRun,
+        evolution_tree: EvolutionTree,
+        agent_name: str,
+    ) -> Candidate | None:
+        """Select the winner, copy to workspace root, write final report."""
+        # Only survivors that actually have a validation reward are eligible winners.
+        scored = [n for n in evolution_tree.nodes.values() if n.is_survivor and n.val_reward]
+        front = pareto_front(scored, lambda n: n.val_reward) if scored else []
+        best_id = front[0].label if front else None
+
+        restore_heldout_splits(self.working_dir)
+
+        if best_id is None:
+            logger.warning("[FINAL] no candidates to finalize")
+            run_entity.status = "completed"
+            await backend.update_run(workspace=workspace, run=run_entity)
+            return None
+
+        evolution_tree.mark_best(best_id)
+        self._copy_best_to_workspace(best_id)
+
+        try:
+            await self.write_final_report(best_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(f"[FINAL] Failed to write final report: {exc}")
+
+        run_entity.status = "completed"
+        run_entity.winner_agent = best_id
+        await backend.update_run(workspace=workspace, run=run_entity)
+
+        return evolution_tree.nodes[best_id].candidate
+
+    def _render_summary(
+        self,
+        rounds_completed: int,
+        winner: Candidate | None,
+    ) -> str:
+        """Render a human-readable summary of the run outcome."""
+        winner_str = winner.name if winner else "none"
+        val_reward = ""
+        if winner:
+            vr = getattr(winner, "validation_reward", None)
+            if vr:
+                val_reward = f", validation_reward={vr}"
+        return f"Optimization complete: {rounds_completed} round(s) completed, winner={winner_str}{val_reward}"

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/model_config.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/model_config.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import functools
+import os
+from urllib.parse import urlparse
+
+from nooa.unifiedllm import CompletionClient
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} must be set")
+    return value
+
+
+def _optional_env(name: str, default: str) -> str:
+    return os.environ.get(name, "").strip() or default
+
+
+@functools.cache
+def get_smart_model() -> CompletionClient:
+    """Return the cached smart (high-capability) LLM client configured from environment variables.
+
+    Returns:
+        CompletionClient: the singleton smart-model client.
+
+    Raises:
+        ValueError: if ``EXPERIMENTALIST_API_BASE`` or ``EXPERIMENTALIST_API_KEY`` are unset or empty.
+
+    """
+    api_base = _required_env("EXPERIMENTALIST_API_BASE")
+    api_key = _required_env("EXPERIMENTALIST_API_KEY")
+    name = _optional_env("EXPERIMENTALIST_SMART_MODEL_NAME", "openai/openai/openai/gpt-5.5")
+    return CompletionClient(name, api_base=api_base, api_key=api_key)
+
+
+@functools.cache
+def get_mid_model() -> CompletionClient:
+    """Return the cached mid-tier LLM client configured from environment variables.
+
+    Returns:
+        CompletionClient: the singleton mid-model client.
+
+    Raises:
+        ValueError: if ``EXPERIMENTALIST_API_BASE`` or ``EXPERIMENTALIST_API_KEY`` are unset or empty.
+
+    """
+    api_base = _required_env("EXPERIMENTALIST_API_BASE")
+    api_key = _required_env("EXPERIMENTALIST_API_KEY")
+    name = _optional_env("EXPERIMENTALIST_MID_MODEL_NAME", "openai/gcp/google/gemini-3.5-flash")
+    return CompletionClient(name, api_base=api_base, api_key=api_key)
+
+
+@functools.cache
+def get_fast_model() -> CompletionClient:
+    """Return the cached fast (low-latency) LLM client configured from environment variables.
+
+    Returns:
+        CompletionClient: the singleton fast-model client.
+
+    Raises:
+        ValueError: if ``EXPERIMENTALIST_API_BASE`` or ``EXPERIMENTALIST_API_KEY`` are unset or empty.
+
+    """
+    api_base = _required_env("EXPERIMENTALIST_API_BASE")
+    api_key = _required_env("EXPERIMENTALIST_API_KEY")
+    name = _optional_env("EXPERIMENTALIST_FAST_MODEL_NAME", "openai/openai/openai/gpt-5-mini")
+    return CompletionClient(name, api_base=api_base, api_key=api_key)
+
+
+def _mask_key(value: str) -> str:
+    if len(value) <= 4:
+        return "*" * len(value)
+    return f"*****{value[-4:]}"
+
+
+def _sanitize_url(url: str) -> str:
+    """Strip userinfo, query, and fragment so credentials never leak via the log banner."""
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"{parsed.scheme}://{host}{port}{parsed.path}"
+
+
+def log_model_config() -> str:
+    """Return a formatted string summarising the current optimizer model configuration.
+
+    Returns:
+        str: a multi-line summary of smart model, fast model, API base, and masked API key.
+
+    """
+    smart = _optional_env("EXPERIMENTALIST_SMART_MODEL_NAME", "openai/openai/openai/gpt-5.5")
+    mid = _optional_env("EXPERIMENTALIST_MID_MODEL_NAME", "openai/gcp/google/gemini-3.5-flash")
+    fast = _optional_env("EXPERIMENTALIST_FAST_MODEL_NAME", "openai/openai/openai/gpt-5-mini")
+    api_base = _required_env("EXPERIMENTALIST_API_BASE")
+    api_key = _required_env("EXPERIMENTALIST_API_KEY")
+    return (
+        "Experimentalist model config:\n"
+        f"  smart model: {smart}\n"
+        f"  mid model:   {mid}\n"
+        f"  fast model:  {fast}\n"
+        f"  api base:    {_sanitize_url(api_base)}\n"
+        f"  api key:     {_mask_key(api_key)}"
+    )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/models.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/models.py
@@ -1,0 +1,313 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Core data models for the Experimentalist's optimization loop.
+
+Ported from AAD ``skills/eval-and-optimize-base/scripts/optimizer/models.py``.
+Pure data — no platform dependencies — shared vocabulary between the loop,
+analyzer, proposer, coder, and evaluator.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import Literal, TypeVar
+
+from nemo_experimentalist_plugin.entities import Candidate
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Pareto utilities
+# ---------------------------------------------------------------------------
+
+T = TypeVar("T")
+
+
+def _dominates(a: dict[str, float], b: dict[str, float]) -> bool:
+    """Return True iff *a* Pareto-dominates *b* on every shared dimension."""
+    if not a or not b or a.keys() != b.keys():
+        return False
+    return all(a[k] >= b[k] for k in a) and any(a[k] > b[k] for k in a)
+
+
+def pareto_front(
+    items: Iterable[T],
+    reward_of: Callable[[T], dict[str, float]],
+) -> list[T]:
+    """Return the non-dominated subset of *items*.
+
+    Items with empty rewards are kept (incomparable, not dominated).
+    """
+    items = list(items)
+    rewards = [reward_of(i) for i in items]
+    front: list[T] = []
+    for i, item in enumerate(items):
+        if any(_dominates(rewards[j], rewards[i]) for j in range(len(items)) if j != i):
+            continue
+        front.append(item)
+    return front
+
+
+def pareto_sort(
+    items: Iterable[T],
+    reward_of: Callable[[T], dict[str, float]],
+) -> list[T]:
+    """Sort by non-domination rank (front 0 first, then front 1, …)."""
+    remaining = list(items)
+    out: list[T] = []
+    while remaining:
+        front = pareto_front(remaining, reward_of)
+        out.extend(front)
+        front_ids = {id(x) for x in front}
+        remaining = [x for x in remaining if id(x) not in front_ids]
+    return out
+
+
+# ---------------------------------------------------------------------------
+# OptimizationType
+# ---------------------------------------------------------------------------
+
+OptimizationType = Literal[
+    # Edit existing elements
+    "edit_method",
+    "edit_concrete_method",
+    "edit_skill",
+    "edit_llm",
+    "edit_config",
+    # Add new elements
+    "add_method",
+    "add_concrete_method",
+    "add_subagent",
+    "add_tool",
+    "add_llm",
+    "add_skill",
+    # Remove elements
+    "remove_method",
+    "remove_concrete_method",
+    "remove_subagent",
+    "remove_tool",
+    "remove_llm",
+    "remove_skill",
+    # Structural transforms
+    "split_method",
+    "merge_method",
+    # Method nature conversions
+    "make_method_concrete",
+    "make_method_abstract",
+]
+
+
+# ---------------------------------------------------------------------------
+# Candidate helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_reward(reward: dict[str, float]) -> str:
+    if not reward:
+        return "-"
+    keys = ["aggregate"] if "aggregate" in reward else []
+    keys.extend(k for k in sorted(reward) if k != "aggregate")
+    return " ".join(f"{k}={reward[k]:.2f}" for k in keys)
+
+
+# ---------------------------------------------------------------------------
+# EvolutionNode
+# ---------------------------------------------------------------------------
+
+
+class EvolutionNode(BaseModel):
+    """One node in the evolution tree, representing one Candidate."""
+
+    candidate: Candidate
+    is_best: bool = False
+
+    @property
+    def label(self) -> str:
+        return self.candidate.label
+
+    @property
+    def ancestor(self) -> str | None:
+        return self.candidate.ancestor
+
+    @property
+    def round(self) -> int:
+        return self.candidate.round
+
+    @property
+    def optimization_type(self) -> str | None:
+        return self.candidate.optimization_type
+
+    @property
+    def optimization(self) -> str:
+        return self.candidate.optimization
+
+    @property
+    def train_reward(self) -> dict[str, float]:
+        return self.candidate.train_reward or {}
+
+    @property
+    def val_reward(self) -> dict[str, float]:
+        return self.candidate.validation_reward or {}
+
+    @property
+    def trajectory_reward(self) -> dict[str, float]:
+        return self.candidate.validation_trajectory_reward or {}
+
+    @property
+    def is_survivor(self) -> bool:
+        return self.candidate.killed_round is None
+
+    @property
+    def reward_str(self) -> str:
+        parts = []
+        if self.train_reward:
+            parts.append(f"tr[{_format_reward(self.train_reward)}]")
+        if self.val_reward:
+            parts.append(f"val[{_format_reward(self.val_reward)}]")
+        if self.trajectory_reward:
+            parts.append(f"traj[{_format_reward(self.trajectory_reward)}]")
+        return " ".join(parts) if parts else "no rewards"
+
+
+# ---------------------------------------------------------------------------
+# EvolutionTree
+# ---------------------------------------------------------------------------
+
+
+class EvolutionTree:
+    """Tracks agent lineage and improvements across optimization rounds."""
+
+    def __init__(self) -> None:
+        self.nodes: dict[str, EvolutionNode] = {}
+        self._children: dict[str, list[str]] = {}
+
+    @classmethod
+    def from_dir(cls, agents_dir: Path) -> EvolutionTree:
+        """Rebuild the full tree from agent directories on disk."""
+        tree = cls()
+        if not agents_dir.exists():
+            return tree
+        for agent_dir in sorted(agents_dir.iterdir()):
+            meta_path = agent_dir / "metadata.json"
+            if not agent_dir.is_dir() or not meta_path.exists():
+                continue
+            try:
+                meta = json.loads(meta_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            candidate = Candidate.model_validate(meta)
+            entity_id = meta.get("id", "")
+            if entity_id:
+                candidate._id = entity_id  # type: ignore[attr-defined]
+            tree.add(candidate)
+        return tree
+
+    def survivors(self, max_round: int | None = None) -> list[Candidate]:
+        """Return alive candidates up to *max_round* (or all if None)."""
+        return [
+            n.candidate for n in self.nodes.values() if n.is_survivor and (max_round is None or n.round <= max_round)
+        ]
+
+    def add(self, candidate: Candidate) -> EvolutionNode:
+        """Add or update a candidate in the tree."""
+        if candidate.label in self.nodes:
+            node = self.nodes[candidate.label]
+            node.candidate = candidate
+            return node
+        node = EvolutionNode(candidate=candidate)
+        self.nodes[candidate.label] = node
+        parent_key = candidate.ancestor or "__root__"
+        self._children.setdefault(parent_key, []).append(candidate.label)
+        return node
+
+    def mark_best(self, label: str) -> None:
+        """Designate the node with *label* as the best, clearing all other best flags."""
+        for node in self.nodes.values():
+            node.is_best = False
+        if label in self.nodes:
+            self.nodes[label].is_best = True
+
+    def get_best(self) -> list[EvolutionNode]:
+        """Return the Pareto-optimal nodes by validation reward."""
+        scored = [n for n in self.nodes.values() if n.val_reward]
+        if not scored:
+            return []
+        return pareto_front(scored, lambda n: n.val_reward)
+
+    def to_markdown_table(self) -> str:
+        """Export as a markdown table with all score dimensions as columns."""
+        train_keys: set[str] = set()
+        val_keys: set[str] = set()
+        traj_keys: set[str] = set()
+        for n in self.nodes.values():
+            train_keys.update(n.train_reward.keys())
+            val_keys.update(n.val_reward.keys())
+            traj_keys.update(n.trajectory_reward.keys())
+        train_cols = sorted(train_keys)
+        val_cols = sorted(val_keys)
+        traj_cols = sorted(traj_keys)
+
+        fixed = ["round", "agent", "ancestor", "type"]
+        all_cols = (
+            fixed
+            + [f"train:{k}" for k in train_cols]
+            + [f"val:{k}" for k in val_cols]
+            + [f"traj:{k}" for k in traj_cols]
+            + ["optimization"]
+        )
+        header = "| " + " | ".join(all_cols) + " |"
+        sep = "| " + " | ".join("---" for _ in all_cols) + " |"
+        lines = [header, sep]
+
+        for label in sorted(
+            self.nodes.keys(),
+            key=lambda x: int(x.split("-")[1]) if x.split("-")[-1].isdigit() else 0,
+        ):
+            n = self.nodes[label]
+            train_vals = [f"{n.train_reward[k]:.2f}" if k in n.train_reward else "-" for k in train_cols]
+            val_vals = [f"{n.val_reward[k]:.2f}" if k in n.val_reward else "-" for k in val_cols]
+            traj_vals = [f"{n.trajectory_reward[k]:.2f}" if k in n.trajectory_reward else "-" for k in traj_cols]
+            opt = (n.optimization or "")[:50].replace("\n", " ")
+            cells = [
+                str(n.round),
+                n.label,
+                n.ancestor or "-",
+                n.optimization_type or "-",
+            ]
+            cells += [*train_vals, *val_vals, *traj_vals, opt]
+            lines.append("| " + " | ".join(cells) + " |")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        if not self.nodes:
+            return "EvolutionTree(empty)"
+        lines = ["EvolutionTree:"]
+        roots = sorted(set(self._children.get("__root__", []) + self._children.get("baseline", [])))
+        if not roots:
+            roots = [nid for nid, n in self.nodes.items() if n.ancestor is None or n.ancestor not in self.nodes]
+        for i, root_id in enumerate(sorted(roots)):
+            lines.extend(self._build_tree_lines(root_id, "", i == len(roots) - 1))
+        return "\n".join(lines)
+
+    def _render_node(self, node: EvolutionNode) -> str:
+        opt_type = f"[{node.optimization_type}]" if node.optimization_type else ""
+        opt_desc = (node.optimization or "")[:40].replace("\n", " ")
+        if opt_desc and len(node.optimization) > 40:
+            opt_desc += "..."
+        markers = (" *BEST*" if node.is_best else "") + (" [S]" if node.is_survivor else "")
+        return f"{node.label} ({node.reward_str}){markers} {opt_type} {opt_desc}".strip()
+
+    def _build_tree_lines(self, label: str, prefix: str = "", is_last: bool = True) -> list[str]:
+        lines = []
+        node = self.nodes.get(label)
+        if not node:
+            return lines
+        connector = "└── " if is_last else "├── "
+        lines.append(prefix + connector + self._render_node(node))
+        children = self._children.get(label, [])
+        child_prefix = prefix + ("    " if is_last else "│   ")
+        for i, child_id in enumerate(sorted(children)):
+            lines.extend(self._build_tree_lines(child_id, child_prefix, i == len(children) - 1))
+        return lines

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/proposer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/proposer.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from typing import Any, Literal, get_args
+
+from nemo_experimentalist_plugin.experimentalist.components.models import (
+    EvolutionTree,
+    OptimizationType,
+)
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc, spec
+from nooa.agents import TokenBudgetSummarizer
+from nooa.config import CodeActConfig
+from nooa.config.summarizer_config import TokenBudgetConfig
+from nooa.skill_registry import SkillRegistry
+from pydantic import BaseModel, Field
+
+from .cards import Optimize
+from .model_config import get_fast_model, get_smart_model
+from .tools import WorkspaceTool
+from .util import load_framework_skills
+
+
+class Improvement(BaseModel):
+    """A proposed single-change improvement for a specific ancestor agent."""
+
+    ancestor: str
+    root_cause: str = Field(
+        min_length=1,
+        description=(
+            "The diagnosed cause of poor performance from the analysis — WHY the agent fails, "
+            "not what would fix it. Must complete: 'The agent underperforms because...' "
+            "Do not mention the proposed change or any remedy here."
+        ),
+    )
+    optimization: str = Field(
+        min_length=1,
+        description=(
+            "Graph-level description of the change in terms of the architecture diagram: "
+            "which node is added, removed, or modified; which edge changes; which prompt is rewritten. "
+            "Must NOT reference source file paths, line numbers, or implementation details."
+        ),
+    )
+    optimization_type: OptimizationType
+    task_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Task ids from the analysis that most directly exercise this root cause — "
+            "the concrete tasks the agent fails (or barely passes) for this reason. "
+            "The coder uses these to validate the fix, so pick tasks whose failure "
+            "evidence in the analysis is caused by `root_cause`. 2-3 is typical."
+        ),
+    )
+
+
+class ProposerConfig(BaseModel):
+    """Configuration for Proposer tuning parameters."""
+
+    max_summary_tokens: int = Field(
+        default=80_000,
+        description="Max tokens the token-budget summarizer may use.",
+    )
+
+
+class Proposer(Agent, llm=get_smart_model()):
+    """Propose the next round's isolated optimization candidates."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        config: ProposerConfig | None = None,
+        framework_skills_dirs: list[Path] | None = None,
+        **kwargs: Any,
+    ):
+        super().__init__(**kwargs)
+        self._config = config or ProposerConfig()
+        self._workspace_path = workspace.resolve()
+        self.workspace = WorkspaceTool(workspace=self._workspace_path)
+        self.context["workspace_tool_documentation"] = doc(WorkspaceTool)
+
+        self.skills: SkillRegistry = SkillRegistry(self)
+        spec(self, "skills", hidden=True)
+        load_framework_skills(self.skills, framework_skills_dirs or [])
+
+        self.optimize = Optimize()
+        TokenBudgetSummarizer.install(
+            self,
+            llm=get_fast_model(),
+            config=TokenBudgetConfig(max_tokens=self._config.max_summary_tokens),
+        )
+
+    async def run(
+        self,
+        analysis: str,
+        evolution_history: str,
+        evolution_tree: EvolutionTree,
+        round_num: int,
+        phase: Literal["exploration", "exploitation"],
+        max_candidates: int,
+    ) -> list[Improvement]:
+        """Return up to max_candidates targeted improvement proposals.
+
+        Args:
+            analysis: merged round analysis markdown with root causes already enumerated.
+            evolution_history: markdown table of prior rounds for context.
+            evolution_tree: live tree used to derive survivors and tried optimization types.
+            round_num: current optimization round number; used to filter survivors.
+            phase: "exploration" for novel directions, "exploitation" to refine the best.
+            max_candidates: maximum number of Improvement objects to return.
+
+        Returns:
+            list[Improvement]: up to max_candidates targeted improvement proposals.
+
+        """
+        all_types = set(get_args(OptimizationType))
+        tried_types = sorted(
+            {
+                n.optimization_type
+                for n in evolution_tree.nodes.values()
+                if n.optimization_type and n.optimization_type in all_types
+            }
+        )
+        available_types = sorted(all_types - set(tried_types))
+        proposal_survivors = evolution_tree.survivors(round_num)
+
+        agents_dir = self._workspace_path / "eval-and-optimize" / "agents"
+        survivor_context: list[dict[str, Any]] = []
+        for s in proposal_survivors:
+            arch_path = agents_dir / s.label / "architecture.md"
+            try:
+                arch_text = arch_path.read_text()
+            except OSError:
+                arch_text = f"(architecture.md missing for {s.label})"
+            try:
+                candidate = self.workspace.get_metadata(s.label)
+                meta = candidate.slim().model_dump(exclude={"artifacts"})
+            except Exception:  # noqa: BLE001
+                meta = {}
+            survivor_context.append(
+                {
+                    "id": s.label,
+                    "reward": s.validation_reward or {},
+                    "trajectory_reward": s.validation_trajectory_reward or {},
+                    "metadata": meta,
+                    "architecture": arch_text,
+                }
+            )
+
+        improvements = await self._run_with_context(
+            analysis=analysis,
+            evolution_history=evolution_history,
+            tried_types=tried_types,
+            available_types=available_types,
+            survivors=survivor_context,
+            cards_index=doc(self.optimize),
+            phase=phase,
+            max_candidates=max_candidates,
+        )
+        self._validate_improvements(
+            improvements=improvements,
+            max_candidates=max_candidates,
+            allowed_types=set(available_types) or all_types,
+        )
+        return improvements
+
+    @staticmethod
+    def _validate_improvements(
+        *,
+        improvements: list[Improvement],
+        max_candidates: int,
+        allowed_types: set[str],
+    ) -> None:
+        if not improvements:
+            raise ValueError("Proposer returned no improvements")
+        if len(improvements) > max_candidates:
+            raise ValueError(f"Proposer returned {len(improvements)} improvements; maximum is {max_candidates}")
+        seen_types: set[str] = set()
+        seen_descriptions: set[str] = set()
+        for improvement in improvements:
+            optimization_type = improvement.optimization_type
+            if optimization_type not in allowed_types:
+                raise ValueError(
+                    f"Proposer returned disallowed optimization_type "
+                    f"{optimization_type!r}; allowed: {sorted(allowed_types)}"
+                )
+            if optimization_type in seen_types:
+                raise ValueError(f"Proposer returned duplicate optimization_type {optimization_type!r}")
+            seen_types.add(optimization_type)
+
+            description = improvement.optimization.strip()
+            if description in seen_descriptions:
+                raise ValueError(f"Proposer returned duplicate optimization text: {description!r}")
+            seen_descriptions.add(description)
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=20, cell_timeout=3600.0)))
+    async def _run_with_context(
+        self,
+        analysis: str,
+        evolution_history: str,
+        tried_types: list[str],
+        available_types: list[str],
+        survivors: list[dict[str, Any]],
+        cards_index: str,
+        phase: Literal["exploration", "exploitation"],
+        max_candidates: int,
+    ) -> list[Improvement]:
+        """Pick up to `max_candidates` targeted improvements grounded in root causes.
+
+        Args:
+        - analysis (str): round analysis with root causes already enumerated
+        - evolution_history (str): markdown table of prior rounds, for context
+        - tried_types (list[str]): optimization_types already attempted — AVOID these
+        - available_types (list[str]): types not yet tried — PICK FROM THESE
+        - survivors (list[dict]): each {id, reward, trajectory_reward, metadata,
+          architecture}; these are your branching candidates with their architecture.md
+          already loaded
+        - cards_index (str): pre-rendered `doc(self.optimize)` showing the card index.
+          Load a specific card on demand via `print(doc(self.optimize.<name>))`.
+        - phase (Literal): "exploration" = novel directions; "exploitation" = improve current best
+        - max_candidates (int): max number of Improvements to return (typically 3)
+
+        Returns:
+        - list[Improvement]: up to `max_candidates` Improvements.
+
+        ## Working level
+        You are a graph-level architect. Reason exclusively from the architecture
+        diagrams in `survivors[*].architecture` — do NOT read source files or
+        inspect implementation details. Your job is to identify WHAT changes at
+        the diagram level, not HOW it is implemented in code.
+
+        ## Per-improvement requirements
+        For each Improvement you propose:
+        1. Identify ONE root cause from the analysis: the specific reason the agent
+           underperforms, stated as a diagnosis ("The agent fails because X is absent /
+           misconfigured / too vague"). Do NOT include the proposed remedy here — that
+           belongs in `optimization`. If you cannot articulate the failure cause
+           independently of the fix, drop the hypothesis.
+        2. Pick the ancestor from `survivors` most affected by that root cause.
+        3. Load the matching card with `doc(self.optimize.<name>)` and pick ONE
+           optimization_type from `available_types` that the card covers.
+        4. Read the ancestor's architecture diagram (in `survivors[*].architecture`)
+           to understand the current graph shape. If the change touches a skill,
+           find it in the diagram — do NOT open source files.
+        5. Write `root_cause` (pure diagnosis — why the agent fails, no remedy)
+           and `optimization` (the graph-level change that addresses it). These
+           must be independently readable: `root_cause` explains the failure,
+           `optimization` describes the diagram delta (node added/removed/modified,
+           edge changed, prompt rewritten). No file paths, no line numbers, no
+           code snippets in either field.
+        6. Set `task_ids` to the tasks in the analysis whose failure evidence is
+           caused by this `root_cause` — the concrete tasks the coder should use to
+           validate the fix. Pick 2-3 tasks the ancestor actually fails (or barely
+           passes) for this reason; do not pad with unrelated passing tasks.
+
+        ## Branching rules
+        - Branch from any survivor — usually the top scorer, but a lower-scoring
+          ancestor is the right base when it uniquely passes tasks the top scorer fails.
+        - If two survivors have complementary failures (each passes what the other
+          fails), propose a cross-pollination improvement that merges their approaches.
+
+        ## Phase
+        - exploration: novel directions, even speculative ones
+        - exploitation: refine the current best survivor. When the obvious targeted
+          improvements have already been tried, do NOT stop — pick the best untried
+          direction from `available_types` and explore it.
+
+        ## MANDATORY
+        - Return between 1 and max_candidates Improvements. NEVER return [].
+        - Each Improvement.optimization_type MUST be in `available_types`. If
+          `available_types` is empty, pick the least-tried type from the tried set.
+        - Each improvement in a round should target a different degree of freedom;
+          two improvements touching the same axis are only allowed when no other
+          viable direction exists.
+        - Each Improvement must make exactly ONE targeted change. Do not bundle
+          prompt edits with code edits, config changes with tool additions, cleanup
+          with behavior changes, or multiple unrelated fixes in one candidate.
+        - `optimization` MUST be a graph-level description. Reject any draft that
+          names a source file, a line number, or any code construct.
+        """
+        ...

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/rationalizer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/rationalizer.py
@@ -1,0 +1,724 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast  # noqa: F401
+import json  # noqa: F401
+import os  # noqa: F401
+import re  # noqa: F401
+from collections import Counter, defaultdict  # noqa: F401
+from pathlib import Path
+from typing import Any
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import Task
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DependencyRuntime
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc, spec
+from nooa.agents import TokenBudgetSummarizer
+from nooa.config import CodeActConfig
+from nooa.config.summarizer_config import TokenBudgetConfig
+from nooa.skill_registry import SkillRegistry
+from nooa.tools import Match, TodoManager
+from pydantic import BaseModel, Field
+
+from . import cache
+from .model_config import get_fast_model, get_smart_model
+from .tools import GuardedShellTools
+from .util import load_framework_skills
+
+
+class RationaleStep(BaseModel):
+    """One reasoning step in a task rationale."""
+
+    thought: str
+    action: str
+    observation: str = ""
+
+
+class Rationale(BaseModel):
+    """Task-level context produced by the Rationalizer before trace analysis."""
+
+    task_name: str
+    steps: list[RationaleStep] = Field(default_factory=list)
+
+
+class RationalizerConfig(BaseModel):
+    """Configuration for Rationalizer tuning parameters."""
+
+    max_summary_tokens: int = Field(
+        default=80_000,
+        description="Max tokens the token-budget summarizer may use.",
+    )
+
+
+class Rationalizer(Agent, llm=get_smart_model()):
+    """Your role is to bootstrap the reference reasoning trace.
+
+    You are the bootstrapping reasoner for trace analysis. Your output is
+    the "golden path" that lets trace analyzer compare a failed agent run
+    against what a competent task agent should have discovered, in order,
+    from visible evidence.
+
+    You are not the evaluator and you are not the benchmark agent. You may
+    use evaluator-private material to uncover the correct causal path, but
+    your returned rationale must teach trace analyzer the public reasoning
+    trajectory a task agent could have followed.
+
+    Your job has two distinct phases:
+
+    1. Privileged debugging: use private references and the live runtime to
+        understand what a passing run requires.
+    2. Public trace reconstruction: return the shortest faithful sequence
+        of actions that a normal task agent could have taken from the task
+        instruction and visible runtime alone.
+
+    The returned ``Rationale.steps`` are phase 2 only. They are not a log of
+    every privileged thing you did as the Rationalizer.
+    """
+
+    def __init__(
+        self,
+        workspace: Path,
+        config: RationalizerConfig | None = None,
+        framework_skills_dirs: list[Path] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the Rationalizer with workspace path and optional config.
+
+        Args:
+            workspace: Absolute path to the eval-and-optimize workspace root.
+            config: Tuning parameters; defaults to ``RationalizerConfig()`` if ``None``.
+            framework_skills_dirs: Optional list of directories containing framework skills to load.
+            **kwargs: Forwarded to ``Agent.__init__``.
+
+        """
+        super().__init__(**kwargs)
+        self._config = config or RationalizerConfig()
+        self._workspace_path = workspace
+        self.shell = GuardedShellTools(cwd=workspace)
+        self.todos = TodoManager()
+        self.context["file_match"] = doc(Match)
+
+        self.skills: SkillRegistry = SkillRegistry(self)
+        spec(self, "skills", hidden=True)
+        load_framework_skills(self.skills, framework_skills_dirs or [])
+        TokenBudgetSummarizer.install(
+            self,
+            llm=get_fast_model(),
+            config=TokenBudgetConfig(max_tokens=self._config.max_summary_tokens),
+        )
+
+    async def run(self, task: Task, agent_spec: Path | None = None) -> Rationale:
+        """Generate a correct reasoning trace for the task.
+
+        Args:
+            task: The evaluator task to rationalize.
+            agent_spec: optional path to a materialized agent-spec file.
+
+        Returns:
+            Rationale: minimal chain-of-thought steps a correct agent would follow.
+
+        """
+        spec_digest = ""
+        if agent_spec is not None and agent_spec.exists():
+            import hashlib
+
+            spec_digest = hashlib.sha256(agent_spec.read_bytes()).hexdigest()[:16]
+        key = cache.task_hash(f"{task.id}:{spec_digest}")
+        cached = cache.load(self._workspace_path, key, Rationale)
+        if cached is not None:
+            return cached
+        async with task.start_deps() as runtime:
+            rationale = await self.solve(task, runtime, agent_spec=agent_spec)
+            rationale = await self.verify(task, runtime, rationale, agent_spec=agent_spec)
+            cache.store(self._workspace_path, key, rationale)
+        return rationale
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=30, cell_timeout=120.0)))
+    async def verify(
+        self, task: Task, runtime: DependencyRuntime | None, rationale: Rationale, agent_spec: Path | None = None
+    ) -> Rationale:  # pyright: ignore[reportReturnType]
+        """Execute the rationale against the live task runtime and augment until it scores 100%.
+
+        Args:
+            task: Evaluator task being rationalized.
+            runtime: Dependency runtime to use for re-running actions.
+            rationale: Draft rationale to verify.
+            agent_spec: Optional path to a materialized agent-spec file; read
+                as private context before executing (same as in ``solve()``).
+
+        Returns:
+            Rationale that, when followed exactly, produces a fully passing task run.
+
+        ## Goal
+
+        Execute the draft rationale's steps in the live task runtime. If the
+        task does not pass after following those steps, identify what is missing
+        and add the missing steps to the rationale. Repeat until the task passes.
+
+        The returned rationale must be self-sufficient: a task agent following
+        it step-by-step, with no other context, must achieve a full score.
+
+        ## Runtime — already live
+
+        The ``runtime`` parameter is the ALREADY-STARTED task dependency
+        context. All task services are live. **NEVER call ``task.start_deps()``
+        inside this method** — it creates a new isolated context that resets
+        all conversation and service state to zero.
+
+        ## Step 0 — Build the scoring checklist
+
+        Before executing, discover every criterion the task scores against.
+        Use private references, task tests, rubrics, and runtime introspection
+        to enumerate all requirements: required outputs, required behaviors,
+        required values, thresholds, schemas, and any judge criteria.
+
+        This checklist drives Steps 1 and 2. Use private material here for
+        discovery, but do not include private inspection as a task-agent step
+        in the final returned rationale.
+
+        ## Step 1 — Execute the rationale and measure the score
+
+        Run each action in the draft rationale against the live runtime in order.
+        Replace each stored observation with the actual raw output from the real
+        execution (truncated to 600 chars). Do NOT summarize or paraphrase.
+
+        After executing all steps, run the task's scoring mechanism (test suite,
+        evaluator check, output validation, or judge) to measure the current score.
+
+        For each step also check:
+
+        **Observation accuracy** — does the real execution output match what was
+        stored? An empty or near-empty observation (fewer than 20 characters) is
+        always wrong — the action was never re-executed after the private phase.
+        Re-run it now and store the verbatim output. If the stored observation is
+        a clean structured summary with no noise, it was fabricated. Real tool
+        output contains irrelevant lines, raw blobs, and truncated content.
+        Replace it with the verbatim real output.
+
+        **Traceability** — every specific value used in a step (named entity,
+        URL, identifier, statistic, date, or domain-specific term) must appear
+        verbatim in the task instruction OR in a prior step's real observation.
+        If a value appears with no prior source, insert a step before it that
+        fetches that value from the live runtime.
+
+        **Next-step support** — does the real observation contain the values
+        that the following step's thought claims to derive from it? If not,
+        correct the thought or insert an intermediate step.
+
+        ## Step 2 — Augment until the task passes
+
+        If the score after Step 1 is not maxed out, identify every failing check
+        from the scoring checklist and add the steps needed to satisfy them.
+
+        For each failing check:
+        - Add a new step (or steps) that produces the required output, state
+          change, or value via a real tool call — not from LLM memory.
+        - The observation must contain the actual result from the live runtime.
+        - The step must be expressed as a task-agent-visible action: something
+          the AUT could do from its instruction and live environment alone.
+          If the failing check came from a private test or reference solution,
+          translate it into an equivalent public action (run the visible program,
+          inspect the produced artifact, probe the exposed service).
+
+        After augmenting, re-run the scoring mechanism. Repeat until all checks
+        pass. A rationale that does not produce a passing run is incomplete.
+
+        ## Return
+
+        ```python
+        from nemo_experimentalist_plugin.experimentalist.components.rationalizer import (
+            Rationale,
+            RationaleStep,
+        )
+        Rationale(task_name=task.id, steps=revised_steps)
+        ```
+
+        """
+        ...
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=50, cell_timeout=3600.0)))
+    async def solve(self, task: Task, runtime: DependencyRuntime | None, agent_spec: Path | None = None) -> Rationale:  # pyright: ignore[reportReturnType]
+        """Solve the task and record each action as a RationaleStep as you go.
+
+        Args:
+            task: Evaluator task to solve.
+            runtime: Dependency runtime to use for solving the task.
+
+        Returns:
+            Rationale whose steps are the actual execution trace.
+
+
+        ## Agent spec — private context, never a rationale step
+
+        If ``agent_spec`` is not None, read it as private setup before writing
+        any steps. This is Rationalizer-only context — the AUT never reads its
+        own spec at runtime, so do NOT include this as a ``RationaleStep``:
+
+        ```python
+        if agent_spec is not None and agent_spec.exists():
+            spec_text = agent_spec.read_text()
+            print(spec_text[:3000])
+        ```
+
+        Use it to understand the agent's scope and goal: what problem it
+        solves, what a correct outcome looks like, what success criteria it is
+        held to, and what tools it has available. Ground your rationale in
+        that understanding, but every step in ``Rationale.steps`` must be an
+        action the AUT itself takes from its task instruction and live
+        environment — not rationalizer setup work.
+
+        ## Spec-given facts are pre-known — do not rediscover or justify them
+
+        Everything the agent spec states is a GIVEN the AUT already possesses:
+        the tools it has and their calling conventions, the schema, the I/O
+        format and output path, how to reach the runtime (container, endpoint,
+        credentials), and any fixed domain terminology. The spec IS the agent's
+        equipment — the AUT does not discover it at runtime, so the rationale
+        must NOT contain steps that rediscover or re-derive it.
+
+        Concretely, do NOT emit steps that:
+        - locate or identify the runtime container / endpoint (the access
+          method is spec-given),
+        - grep the app source for helper/tool function names or signatures,
+        - inspect files to learn the schema, table/column names, or the
+          expected response category/format.
+
+        These are not AUT actions — they are the rationalizer re-proving what
+        the spec already told the agent, and they add pure noise. Start the
+        trace from the first step that consumes genuinely unknown, task-specific
+        information (the live query result, the actual data, the count). Only
+        facts NOT in the spec — the values the AUT must obtain from the live
+        environment for this specific task — require a grounding observation.
+
+        ## Output contract — write from the AUT's perspective
+
+        ``Rationale.steps`` is a first-person trace narrated by the Agent Under
+        Test (AUT), not by you. Every ``thought``, ``action``, and
+        ``observation`` is written as if the AUT is the subject:
+
+        - ``thought``: what the AUT reasons at this point, given only what it
+          has seen so far (task instruction + prior observations).
+        - ``action``: a concrete step the AUT takes — reading a file, running
+          a command, calling a tool, writing an output artifact.
+        - ``observation``: the raw output the AUT receives from that action.
+
+        The AUT's first step is always reading or interpreting the task
+        instruction. It has no access to private references, hidden tests,
+        evaluator metadata, or the agent spec you read above. Do not include
+        any step the AUT could not have taken from its task instruction and
+        live environment alone.
+
+        Your job is to privately solve the task (using all your privileged
+        access), then reconstruct the steps as the AUT would have taken them.
+        The rationalizer's own setup work — reading the agent spec, inspecting
+        private references, running hidden checks — never appears in the steps.
+
+        ## Why reconstruct, not replay
+
+        Do NOT return a log of what you personally did as the Rationalizer.
+        Privately solve the task first to understand what steps are necessary,
+        then write the steps from the AUT's point of view. This reconstruction
+        must be faithful: every value in an ``action`` must be derivable from
+        the task instruction or a prior ``observation`` — no fabricated leaps.
+
+        ## Data structure
+
+        Initialize once at the start:
+
+        ```python
+        from nemo_experimentalist_plugin.experimentalist.components.rationalizer import (
+            Rationale,
+            RationaleStep,
+        )
+        steps = []
+        ```
+
+        Before every tool call, write the reasoning into ``thought`` and the
+        concrete action into ``action``. After the call returns, append the step
+        immediately:
+
+        ```python
+        thought = (
+            "Task instructions say the article title is 'A Review of AR Applications "
+            "for History Education' — this is a known sub-field. I need the paper's "
+            "reference list to find the primary studies."
+        )
+        action = "Search Semantic Scholar for 'Challenor Ma 2019 AR history education review'."
+        result = await self.shell.run('python3 -c "..."')   # actual tool call
+        steps.append(RationaleStep(
+            thought=thought,
+            action=action,
+            observation=str(result)[:600],
+        ))
+        ```
+
+        At the very end return:
+
+        ```python
+        Rationale(task_name=task.id, steps=steps)
+        ```
+
+        ## Thought rule — AUT voice, quote the trigger
+
+        Write each ``thought`` as the AUT reasoning from what it has seen.
+        It must name the exact value or signal from the PRIOR step's
+        ``observation`` (or from the task instruction for step 1) that caused
+        this action. Quote it verbatim.
+
+        The ``action`` field states the concrete step the AUT takes next.
+
+        Example: "The instruction observation says output_path='/results/answer.json'.
+        I need to create '/results/' before writing."; action: "Create '/results/' and write the output."
+
+        Never write generic motivation like "need more data." Never write from
+        the rationalizer's perspective ("I read the agent spec and learned...").
+
+        ## Traceability rule — values must be earned
+
+        Any specific value in a `thought` or `action` — a named entity, URL,
+        identifier, query term, or domain-specific fact — must either appear
+        verbatim in the task instructions OR have been produced by a prior step's
+        `observation`. If a value appears in an action without being returned by
+        an earlier observation, that is a bug.
+
+        **Active gate — check before writing each thought:** Scan the thought for
+        every specific value. For each one, locate where it appears in the task
+        instruction text or in a prior step's observation text. If you cannot
+        point to the exact source, remove it or add a prior step that fetches it.
+
+        ## Observation verbatim rule — raw output only
+
+        Every observation must be the actual, unmodified output of the tool call,
+        truncated to fit. Never paraphrase, interpret, or summarize into the
+        observation field.
+
+        **If the observation looks like any of the following, it is fabricated —
+        re-run the action and store the real output instead:**
+        - A clean numbered list with tidy category labels and no noise
+        - A structured set of key-value pairs with no irrelevant lines
+        - Output that conveniently matches the expected answer with no artifacts
+        - A tidy summary paragraph with no raw tool output visible
+
+        Real tool output is noisy: it contains extra whitespace, irrelevant lines,
+        raw JSON blobs, HTTP headers, truncated sentences, and values that don't
+        yet tell you anything. That noise is the signal that the observation is real.
+
+        ## Depth mandate — exhaust every dimension *required by the task goal*
+
+        When the task goal requires knowing ALL instances of something — all
+        vulnerabilities, all affected packages, all search results, all
+        matching records — finding one is a starting point, not a conclusion.
+        Exhaust the required space before concluding.
+
+        **This mandate applies to information the task goal depends on.** It
+        does NOT mean enumerating every piece of data encountered along the
+        way. If the task is to complete an action (book a reservation, fix a
+        bug, write a file), only gather the data that action requires. Do not
+        inspect unrelated environment state just because it appears in a
+        response.
+
+        **Patterns that signal shallow analysis — each is a bug:**
+        - The task requires finding all instances of X → stopped after finding one.
+        - Ran one search query for a required fact → did not verify at the primary source.
+        - Drew a conclusion from absence without a direct negative check.
+        - Observation is a clean structured summary → fabricated, must re-run.
+
+        ## Derivation mandate — earn the substance, not just the surface values
+
+        Traceability covers more than surface values (names, URLs, ids). Every
+        *substantive claim the final artifact or conclusion depends on* must be
+        derived from a real observation, never asserted from prior knowledge:
+        mechanisms, design decisions, domain facts, version boundaries, ABIs,
+        schemas, policy consequences, and what a component actually does at
+        runtime.
+
+        If you already "know" the answer from training, treat that as the
+        strongest signal that you must derive it from a tool call anyway. The
+        trace's entire value is showing HOW a fact was discovered from the live
+        environment; a confident assertion the model happened to get right
+        teaches nothing and is often subtly wrong. Go to the primary source —
+        inspect the artifact, dump the header, read the config, enumerate the
+        instances, probe the service, scrape the page — instead of substituting
+        a plausible recollection.
+
+        **A required output with many parts is many requirements, not one.**
+        When the deliverable spans multiple named dimensions, each dimension
+        needs its own grounding step; do not produce the whole artifact from a
+        single lead. If a section of the final artifact has no supporting
+        observation behind it, it was written from memory and is a bug.
+
+        **For the decisive artifact or verdict, enumerate the candidate space.**
+        Do not conclude from the first instance you find or the first hypothesis
+        that fits. Enumerate every candidate that could change the answer, and
+        rule out the alternatives with a direct observation before concluding.
+
+        ## How to reverse-engineer the correct solution
+
+        **Pre-step 0: Privately understand the target**
+
+        Before writing final steps, privately inspect the task references and
+        live runtime enough to understand the passing behavior. Build a concrete
+        checklist of required artifacts, state changes, outputs, schemas, and
+        edge cases.
+
+        All of this is Rationalizer setup work. Do not include it in the final
+        ``Rationale.steps`` unless the task agent itself would run the same
+        command. The rationale should start from the first public action the
+        task agent can take from its instruction and visible runtime.
+
+        **Runtime boundary — critical**
+
+        The ``runtime`` parameter passed to this method is the ALREADY-STARTED
+        task dependency context. All task services (MCP servers, containers,
+        endpoints) are live and reachable right now.
+
+        **NEVER call ``task.start_deps()`` inside this method.** Doing so
+        creates a NEW isolated context that resets all conversation and service
+        state to zero — destroying any progress made in the existing runtime.
+        Use the ``runtime`` parameter directly to reach the task environment.
+
+        The AUT executes inside the task's runtime environment, which is set up
+        by ``task.start_deps()``. That environment may inject environment
+        variables, start services, or expose endpoints that the AUT uses.
+        Inspect ``task.inputs``, ``task.resources``, and any env vars the
+        runtime injects to discover how to reach it — do not assume any
+        specific mechanism (container, process, HTTP service, etc.).
+
+        The rationalizer's ``self.shell`` runs on the host. It can reach the
+        task's runtime only through whatever interface the runtime exposes
+        (e.g. env vars pointing to endpoints or exec wrappers). Never execute
+        host-side commands and record their output as if they were the AUT's
+        in-runtime experience — the paths, permissions, and tools available
+        on the host differ from those in the task runtime.
+
+        Never include in rationale steps:
+        - Paths or commands that only work on the rationalizer host, not in
+          the AUT's runtime environment
+        - Errors produced by running AUT-targeted commands on the host
+        - Private fixture reads from the host filesystem
+
+        **Step 1: Read the task instruction — always first**
+
+        The AUT's very first action is always reading its primary instruction
+        from the live runtime. Access it via ``task.inputs``, ``task.resources``,
+        or the runtime environment — not from host fixture paths. Do not write
+        its content from memory. Store the raw output as the observation.
+
+        From that observation, extract and record:
+        - The required output(s): artifact paths, formats, schemas, or answer shape.
+        - Every distinct requirement the instruction names — what to produce, what
+          to cover, what constitutes success. List them explicitly; they drive Step 3.
+        - The success criteria or evaluation rubric if stated.
+
+        Do not proceed to Step 2 until these are grounded in a real observation.
+
+        **Step 2: Inspect the visible environment**
+
+        Inspect configuration files, environment variables, available services,
+        sample data, or any other runtime state the AUT has access to.
+        These observations explain why each later action is necessary.
+
+        Limit this to task-specific unknowns NOT already given by the spec. Do
+        not add steps that rediscover spec-given facts (schema, tool names and
+        signatures, runtime access method, output format) — see "Spec-given
+        facts are pre-known" above. If the only thing a would-be Step 2 does is
+        re-confirm what the spec states, drop it and go straight to executing.
+
+        **Step 3: Execute — one step per distinct requirement**
+
+        For each distinct requirement identified in Step 1, make a dedicated step.
+        Do not collapse independent operations into a single combined call. Each
+        requirement gets its own targeted action and its own observation.
+
+        Use the tools and environment variables described in the agent spec —
+        read the spec to discover their names and calling conventions; do not
+        assume them. If the task runtime exposes services or endpoints, probe them.
+
+        Each result may point to further work. Follow every lead: fetch what is
+        referenced, verify what is claimed, check every dependency. After each
+        discovery, apply the depth mandate: ask what else might exist and check
+        before moving on. Keep following the chain until every requirement from
+        Step 1 is covered by a real observation.
+
+        NEVER generate facts from LLM memory. If a call fails, retry with a
+        different query — do not substitute invented content.
+
+        **Before implementing a complex artifact**, each unknown it depends on
+        is a separate grounding step — format, interfaces, constraints,
+        behavioral dependencies. Do not merge reconnaissance into the
+        implementation step; derive each unknown from the live environment
+        rather than asserting it from training knowledge. The implementation
+        step's thought must cite the specific values from preceding observations
+        it relies on.
+
+        **Follow the task to the runtime's natural conclusion.** Privately
+        knowing the answer is not the same as delivering it. The AUT must
+        communicate findings, apply policy, and write outputs — then wait for
+        the runtime's response before concluding. Only a terminal signal from
+        the runtime itself (a final score, an explicit stop, a closed stream)
+        ends the trace. Do not call the termination tool until that signal
+        arrives.
+
+        **Failed execution rule**: If a code cell exits with a non-zero code,
+        raises an exception, or returns only an error/traceback, that step
+        FAILED. The observation must record the error verbatim. The following
+        step's thought must acknowledge the failure and describe the fix —
+        never reference data the failed call was supposed to produce. A thought
+        that cites a value from a step whose observation is an error message is
+        a grounding violation.
+
+        **Step 4: Filter the returned steps**
+
+        Omit setup steps the task agent does not take (reading private reference
+        files, reading a private reference solution, reading experimentalist-only
+        metadata, inspecting held-out ground truth, starting setup wrappers).
+        Start from the first real task action the agent could take from the
+        instruction and available environment.
+
+        If you used private checks to check your work, convert that into an
+        equivalent public validation step before returning. Bad returned step:
+        "copy tests and run `/tests/test_outputs.py`." Good returned step:
+        "instantiate the class and exercise the visible methods that the task
+        instruction requires, then inspect their stdout/files."
+
+        **Step 5: Completeness gate — before returning**
+
+        Before returning, run this checklist against your steps:
+
+        - The task instruction was read from the live runtime in Step 1 — its
+          content appears verbatim in that step's observation.
+        - Every distinct requirement from the instruction has dedicated steps;
+          none were collapsed into a single combined call.
+        - Every claim in the final conclusion is backed by a verbatim
+          observation from a real tool call, not from reasoning alone.
+        - Every specific value in every thought can be pointed to in a prior
+          observation or the instruction text — no values from LLM memory.
+        - No step's thought references data from a prior step whose observation
+          is an error message or empty — that data was never actually retrieved.
+        - For every instance found (package, file, service, config value),
+          you checked whether other instances exist before concluding.
+        - No observation is empty or near-empty (< 20 chars) — if it is, re-run the action.
+        - No observation is a clean pre-parsed summary — all are raw output.
+        - No step contains a path or error that only makes sense on the
+          rationalizer host — all actions and observations reflect what
+          the AUT sees inside the task's runtime environment.
+        - No step references private evaluator infrastructure — test scripts,
+          hidden ground-truth files, oracle paths, or rationalizer setup work
+          that the AUT could not reach from its task instruction alone.
+        - No step rediscovers a spec-given fact — no container/endpoint
+          identification, no grepping for tool/helper names, no inspecting the
+          schema or expected output format. Those are pre-known; the trace
+          starts from the first genuinely task-specific action.
+        - If a visible test runner exists, it was executed and its output recorded.
+        - Removing any step would leave the next step's thought unjustified.
+
+        If any item fails, add the missing steps before returning.
+
+        **Step 6: Return**
+
+        ```python
+        Rationale(task_name=task.id, steps=steps)
+        ```
+
+        ## Worked example
+
+        The following synthetic example illustrates every rule above applied
+        together. It is NOT a real task — it is a format reference only.
+
+        **Scenario**: ``task.inputs["instruction"]`` says "Parse ``input.csv``,
+        compute the median of column ``price``, write the result to ``out/result.txt``."
+        The runtime exposes a bash-accessible environment with the input file.
+
+        ```python
+        steps = []
+
+        # ── Step 1: read the instruction from task.inputs ───────────────────
+        instruction = str(task.inputs.get("instruction", ""))
+        steps.append(RationaleStep(
+            thought=(
+                "The task instruction is the only public starting point. "
+                "Reading it from the live runtime grounds every subsequent "
+                "path and requirement in a real observation."
+            ),
+            action="Read the task instruction.",
+            observation=instruction[:600],
+        ))
+
+        # ── Step 2: inspect the runtime environment ──────────────────────────
+        # Discover available files/services via task.resources and env vars
+        # injected by task.start_deps() — mechanism depends on the task type.
+        result = await self.shell.run("ls -la input.csv && head -3 input.csv")
+        steps.append(RationaleStep(
+            thought=(
+                "The instruction names `input.csv` and column `price`. "
+                "Previewing the file confirms it exists and reveals the "
+                "actual header row before computing."
+            ),
+            action="Preview `input.csv` to confirm schema.",
+            observation=str(result)[:600],
+        ))
+
+        # ── Step 3: first attempt fails — record error, do NOT cite its data ─
+        result = await self.shell.run(
+            "python3 -c \""
+            "import csv, statistics; "
+            "rows = list(csv.DictReader(open('input.csv'))); "
+            "print(statistics.median(float(r['price']) for r in rows))\""
+        )
+        steps.append(RationaleStep(
+            thought=(
+                "The header preview showed columns `id,price,qty`. "
+                "Compute the median of `price` using the confirmed column name."
+            ),
+            action="Compute median of `price` column.",
+            observation=str(result)[:600],  # e.g. "ValueError: could not convert..."
+        ))
+
+        # ── Step 4: fix after the observed error, quote error in thought ──────
+        result = await self.shell.run(
+            "python3 -c \""
+            "import csv, statistics; "
+            "rows = list(csv.DictReader(open('input.csv'))); "
+            "vals = [float(r['price']) for r in rows if r['price'].strip()]; "
+            "print(statistics.median(vals))\""
+        )
+        steps.append(RationaleStep(
+            thought=(
+                "The prior observation showed `ValueError: could not convert "
+                "string to float`. Blank `price` entries cause the cast to "
+                "fail — skip them before computing."
+            ),
+            action="Re-compute median skipping blank `price` values.",
+            observation=str(result)[:600],  # "47.5\n"
+        ))
+
+        # ── Step 5: write artifact using the derived value ───────────────────
+        result = await self.shell.run(
+            "mkdir -p out && echo 47.5 > out/result.txt && cat out/result.txt"
+        )
+        steps.append(RationaleStep(
+            thought=(
+                "The median observation returned `47.5`. The instruction says "
+                "write to `out/result.txt`; always create the directory first "
+                "in case it does not yet exist."
+            ),
+            action="Write `47.5` to `out/result.txt`.",
+            observation=str(result)[:600],  # "47.5\n"
+        ))
+
+        return Rationale(task_name=task.id, steps=steps)
+        ```
+
+        Key patterns demonstrated above:
+        - The instruction is read from ``task.inputs`` — never from host paths.
+        - Each thought quotes the **exact string** from the prior observation.
+        - Step 3 fails; step 4's thought quotes the error from step 3 and
+          does NOT cite the numeric answer as if step 3 had succeeded.
+        - Paths are grounded in the instruction observation, not memory.
+
+        The exact task may instead require a running service, compiled binary,
+        modified source tree, or final answer. Let the instruction and coverage
+        checklist define the target; never assume an ``output.*`` artifact.
+
+        """
+        ...

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/repository.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/repository.py
@@ -1,0 +1,436 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fetch an agent from a git repo and publish a candidate as a draft PR/MR.
+
+Fetching clones ``<git-url>[@<ref>]`` into a local checkout (retaining ``.git`` so
+it can serve as a push target). Publishing takes that checkout plus a directory of
+updated agent files, creates a branch off the source ref, commits the files, pushes,
+and opens a draft pull request (GitHub) or merge request (GitLab) via the ``gh`` /
+``glab`` CLIs. Branching from the exact source ref keeps the published change
+reproducible against the commit the agent came from.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from fnmatch import fnmatch
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+# Upper bound (seconds) for any single git/gh/glab call during publishing, so a
+# network stall or auth prompt can't hang the optimizer's awaited publish path.
+_COMMAND_TIMEOUT = 120
+
+# Matches the ``userinfo@`` of a URL (e.g. ``https://oauth2:<token>@host``). Git clone URLs
+# can embed credentials there, so we strip them before logging a URL.
+_CREDENTIAL_RE = re.compile(r"://[^/@]+@")
+
+_AGENT_PATH_ERROR = "agent path must be a normalized relative POSIX path"
+_AGENT_PATH_CHECKOUT_ERROR = "agent path must stay within the checkout without symlinks"
+
+
+def _redact_url(url: str) -> str:
+    """Return *url* with any embedded ``userinfo@`` credentials masked, safe for logging."""
+    return _CREDENTIAL_RE.sub("://***@", url)
+
+
+def _validated_agent_path(agent_path: str) -> str:
+    """Return a safe relative POSIX agent path or raise a controlled error."""
+    agent_path = agent_path.removesuffix("/").removeprefix("./")
+    if agent_path == ".":
+        return agent_path
+    components = agent_path.split("/")
+    if (
+        not agent_path
+        or agent_path.startswith(("/", ":"))
+        or "\\" in agent_path
+        or any(ord(char) < 32 or ord(char) == 127 for char in agent_path)
+        or any(component in {"", ".", ".."} for component in components)
+        or any(component.casefold() == ".git" for component in components)
+    ):
+        raise ValueError(_AGENT_PATH_ERROR)
+    return agent_path
+
+
+def pr_cli_for_repo_url(url: str) -> tuple[str, str] | None:
+    """Return the PR CLI and hostname for a supported git remote.
+
+    Substring match on the host family so both github.com and self-hosted
+    GitLab (e.g. gitlab.example.com) are recognized.
+    """
+    if "github" in url:
+        cli = "gh"
+    elif "gitlab" in url:
+        cli = "glab"
+    else:
+        return None
+    hostname = urlsplit(url).hostname if "://" in url else url.partition("@")[2].partition(":")[0]
+    return cli, hostname or ""
+
+
+def split_agent_spec(spec: str) -> tuple[str, str]:
+    """Split an agent spec ``<url@ref>#<agent_path>`` into ``(core_spec, agent_path)``.
+
+    The ``#<agent_path>`` fragment carries the agent's location within the repo (monorepo
+    support), so repo, rev, and sub-path all travel together on the one ``--agent`` value.
+    A spec with no fragment has agent_path ``"."`` (whole-repo agent).
+    """
+    core, separator, fragment = spec.partition("#")
+    agent_path = fragment if separator else "."
+    return core, _validated_agent_path(agent_path)
+
+
+# Glob patterns for files never copied into the published branch: generated/run-local
+# files, VCS/tool dirs, and build artifacts. Matched with fnmatch against each name.
+_EXCLUDE_GLOBS = (
+    "metadata.json",
+    "harbor_wrapper.py",
+    "dind_environment.py",
+    "architecture.md",
+    ".git",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    "*.pyc",
+    "*.pyo",
+)
+
+
+class AgentSource(BaseModel):
+    """Git provenance of the agent under test.
+
+    Set when ``--agent`` is given as ``<git-url>@<ref>[#<agent_path>]``. ``repo_url`` is the
+    clone URL (the PR/MR target remote), ``ref`` is the base branch/tag/commit the agent was
+    checked out from, and ``agent_path`` is the agent's location within the repo (``"."`` for
+    a whole-repo agent) — the subtree that archival/PR overlays and commits.
+    """
+
+    repo_url: str
+    ref: str
+    agent_path: str = "."
+
+
+class AgentCloneError(ValueError):
+    """A git source could not be materialized."""
+
+
+def split_git_ref(spec: str) -> tuple[str, str | None]:
+    """Split a ``<git-url>.git@<ref>`` spec into ``(url, ref)``.
+
+    Locates the first ``.git@`` marker in the repository path, excluding URL
+    authority/userinfo. A spec without a path marker has no ref.
+    """
+    marker = ".git@"
+    if "://" in spec:
+        try:
+            parsed = urlsplit(spec)
+        except (ValueError, UnicodeError):
+            return spec, None
+        idx = parsed.path.find(marker)
+        if idx == -1:
+            return spec, None
+        repo_path = parsed.path[: idx + len(".git")]
+        ref = parsed.path[idx + len(marker) :]
+        return parsed._replace(path=repo_path).geturl(), ref
+
+    user_end = spec.find("@")
+    path_start = spec.find(":", user_end + 1) if user_end >= 0 else -1
+    search_start = path_start + 1 if path_start >= 0 else 0
+    idx = spec.find(marker, search_start)
+    if idx == -1:
+        return spec, None
+    return spec[: idx + len(".git")], spec[idx + len(marker) :]
+
+
+def looks_like_git(spec: str) -> bool:
+    """Return True if *spec* looks like a git URL (vs a local path)."""
+    url, _ = split_git_ref(spec)
+    return "://" in url or url.startswith("git@") or url.endswith(".git")
+
+
+def clone_agent_repo(spec: str, dest: Path, *, clone_depth: int | None = None) -> AgentSource:
+    """Clone ``<git-url>[@<ref>][#<agent_path>]`` into *dest* (retaining ``.git``) and return provenance.
+
+    The clone keeps ``.git``/``origin`` so *dest* can serve as the PR/MR push target. The whole
+    repo is cloned; ``agent_path`` (the ``#`` fragment, ``"."`` when omitted) records the agent's
+    sub-path within it for downstream overlay/commit. When no ``@ref`` is given, the checked-out
+    default branch is resolved and recorded. When ``clone_depth`` is given a shallow clone is made
+    (it must be deep enough to branch from ``ref``). Raises on git failure (callers decide how to
+    handle).
+    """
+    core, agent_path = split_agent_spec(spec)
+    url, ref = split_git_ref(core)
+    dest = Path(dest)
+    if dest.exists():
+        shutil.rmtree(dest)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    safe_url = _redact_url(url)
+    logger.info(f"[AGENT] cloning {safe_url} -> {dest}")
+    clone_cmd = ["git", "clone", "--quiet"]
+    if clone_depth is not None:
+        clone_cmd += ["--depth", str(clone_depth)]
+    clone_cmd += [url, str(dest)]
+
+    def run_git(command: list[str], operation: str) -> subprocess.CompletedProcess[str]:
+        try:
+            return subprocess.run(  # noqa: S603, S607
+                command,
+                capture_output=True,
+                text=True,
+                check=True,
+                stdin=subprocess.DEVNULL,
+                timeout=_COMMAND_TIMEOUT,
+            )
+        except subprocess.CalledProcessError as exc:
+            details = _redact_url((exc.stderr or exc.stdout or "").strip())
+            suffix = f": {details}" if details else ""
+            raise AgentCloneError(f"{operation} failed for {safe_url} (exit status {exc.returncode}){suffix}") from None
+        except subprocess.TimeoutExpired:
+            raise AgentCloneError(f"{operation} timed out after {_COMMAND_TIMEOUT}s for {safe_url}") from None
+        except OSError as exc:
+            raise AgentCloneError(f"could not run 'git' during {operation} for {safe_url}: {exc}") from None
+
+    run_git(clone_cmd, "git clone")
+    if ref:
+        run_git(["git", "-C", str(dest), "checkout", "--quiet", ref], "git checkout")
+    else:
+        ref = run_git(
+            ["git", "-C", str(dest), "rev-parse", "--abbrev-ref", "HEAD"],
+            "git rev-parse",
+        ).stdout.strip()
+    # repo_url is provenance (it becomes the candidate's source_link), so keep it
+    # credential-free; the conventional ssh ``git`` user is not a secret.
+    repo_url = url if url.startswith("ssh://git@") or "://" not in url else _redact_url(url)
+    return AgentSource(repo_url=repo_url, ref=ref, agent_path=agent_path)
+
+
+class PRPublisherError(RuntimeError):
+    """Raised when publishing the winner PR/MR fails."""
+
+
+class PRPublisher:
+    """Open a draft PR/MR for the winning candidate against the agent's source repo.
+
+    Args:
+        agent_dir: The local git checkout of the agent under test (its ``origin``
+            remote is the PR/MR target). Must be a git work tree.
+    """
+
+    def __init__(self, *, agent_dir: Path) -> None:
+        self.agent_dir = Path(agent_dir).resolve()
+
+    def _run(self, cmd: list[str], *, cwd: Path | None = None) -> str:
+        """Run a command and return stdout; raise :class:`PRPublisherError` on failure.
+
+        Bounded by ``_COMMAND_TIMEOUT`` so a git/gh/glab call that blocks on the
+        network or an auth prompt can never hang the awaited publish path.
+        """
+        command = _redact_url(" ".join(cmd))
+        try:
+            result = subprocess.run(  # noqa: S603
+                cmd,
+                cwd=str(cwd or self.agent_dir),
+                capture_output=True,
+                text=True,
+                timeout=_COMMAND_TIMEOUT,
+                stdin=subprocess.DEVNULL,  # never block on an interactive auth prompt
+            )
+        except subprocess.TimeoutExpired:
+            raise PRPublisherError(f"command timed out after {_COMMAND_TIMEOUT}s: {command}") from None
+        except OSError as exc:  # e.g. git/gh/glab not installed -> FileNotFoundError
+            raise PRPublisherError(f"could not run {cmd[0]!r}: {exc}") from None
+        if result.returncode != 0:
+            stderr = _redact_url(result.stderr.strip())
+            raise PRPublisherError(f"command failed ({result.returncode}): {command}\n{stderr}")
+        return result.stdout.strip()
+
+    # -- helpers --------------------------------------------------------------
+
+    def _origin_url(self) -> str:
+        return self._run(["git", "remote", "get-url", "origin"])
+
+    def _is_remote_branch(self, ref: str) -> bool:
+        """Return True if *ref* is a branch on origin (vs a tag or bare commit)."""
+        return bool(self._run(["git", "ls-remote", "--heads", "origin", ref]))
+
+    def _default_branch(self) -> str:
+        """Resolve origin's default branch (e.g. ``main``) from its local symbolic HEAD.
+
+        Reads ``refs/remotes/origin/HEAD``, which the fresh clone in
+        ``clone_agent_repo`` sets, so no extra network round-trip is needed. Strips
+        only the ``origin/`` prefix so slashed branch names (e.g. ``release/2026.07``)
+        survive intact.
+        """
+        ref = self._run(["git", "rev-parse", "--abbrev-ref", "origin/HEAD"])  # e.g. "origin/main"
+        prefix = "origin/"
+        if not ref.startswith(prefix) or ref == "origin/HEAD":
+            raise PRPublisherError(f"could not resolve origin default branch (got {ref!r})")
+        return ref[len(prefix) :]
+
+    @staticmethod
+    def _overlay(winner_dir: Path, dest: Path) -> None:
+        """Copy the winner's agent files over *dest*, excluding files matching ``_EXCLUDE_GLOBS``.
+
+        Exclusions apply at the top level and recursively (via ``shutil.ignore_patterns``),
+        so nested ``__pycache__``/``*.pyc`` and the like never reach the published branch.
+        """
+        dest.mkdir(parents=True, exist_ok=True)
+        ignore = shutil.ignore_patterns(*_EXCLUDE_GLOBS)
+        for item in winner_dir.iterdir():
+            if any(fnmatch(item.name, pat) for pat in _EXCLUDE_GLOBS):
+                continue
+            target = dest / item.name
+            if item.is_dir():
+                shutil.copytree(item, target, dirs_exist_ok=True, ignore=ignore)
+            else:
+                shutil.copy2(item, target)
+
+    def _validated_subtree(self, agent_path: str) -> Path:
+        """Resolve an agent subtree without following a path component symlink."""
+        agent_path = _validated_agent_path(agent_path)
+        if agent_path == ".":
+            return self.agent_dir
+        subtree = self.agent_dir
+        try:
+            for component in agent_path.split("/"):
+                subtree /= component
+                if subtree.is_symlink():
+                    raise ValueError(_AGENT_PATH_CHECKOUT_ERROR)
+            if not subtree.resolve(strict=False).is_relative_to(self.agent_dir):
+                raise ValueError(_AGENT_PATH_CHECKOUT_ERROR)
+        except OSError:
+            raise ValueError(_AGENT_PATH_CHECKOUT_ERROR) from None
+        return subtree
+
+    def _snapshot_subtree(self, src_dir: Path, agent_path: str) -> None:
+        """Replace the ``agent_path`` subtree with *src_dir*'s files (deletions captured).
+
+        ``git rm`` the existing subtree first so files the candidate removed don't linger,
+        using literal pathspec semantics, then overlay the candidate's files. ``agent_path``
+        ``"."`` targets the whole repo.
+        """
+        self._validated_subtree(agent_path)
+        self._run(["git", "--literal-pathspecs", "rm", "-r", "-q", "-f", "--ignore-unmatch", "--", agent_path])
+        subtree = self._validated_subtree(agent_path)
+        stale_items = (
+            (item for item in subtree.iterdir() if item.name.casefold() != ".git") if agent_path == "." else (subtree,)
+        )
+        for item in stale_items:
+            if item.is_dir() and not item.is_symlink():
+                shutil.rmtree(item)
+            else:
+                item.unlink(missing_ok=True)
+        self._overlay(Path(src_dir), subtree)
+        self._run(["git", "--literal-pathspecs", "add", "-A", "--", agent_path])
+
+    # -- public API -----------------------------------------------------------
+
+    def push_branch(
+        self,
+        *,
+        src_dir: Path,
+        branch: str,
+        base_ref: str,
+        message: str,
+        agent_path: str = ".",
+    ) -> bool:
+        """Archive one candidate: push *src_dir* as *branch* cut from *base_ref*.
+
+        Snapshots the ``agent_path`` subtree (``git rm`` + overlay, capturing deletions).
+        Skip-if-exists and idempotent without force-pushing: returns ``False`` when *branch*
+        already exists on origin or the result is byte-identical to *base_ref* (empty diff),
+        ``True`` when a new branch was pushed. Used to archive every candidate to its own
+        branch during a run.
+        """
+        agent_path = _validated_agent_path(agent_path)
+        if self._is_remote_branch(branch):
+            logger.info(f"[PUSH] branch {branch} already exists on origin; skipping")
+            return False
+        self._run(["git", "fetch", "origin", base_ref])
+        self._run(["git", "checkout", "-B", branch, "FETCH_HEAD"])
+        self._snapshot_subtree(Path(src_dir), agent_path)
+        if not self._run(["git", "--literal-pathspecs", "status", "--porcelain", "--", agent_path]):
+            logger.info(f"[PUSH] {branch} identical to {base_ref}; skipping")
+            return False
+        self._run(["git", "--literal-pathspecs", "commit", "--only", "-m", message, "--", agent_path])
+        self._run(["git", "push", "-u", "origin", branch])
+        return True
+
+    def publish(
+        self,
+        *,
+        winner_dir: Path,
+        branch: str,
+        base_ref: str,
+        title: str,
+        body: str,
+        draft: bool = True,
+        agent_path: str = ".",
+        base_branch_override: str | None = None,
+        labels: list[str] | None = None,
+    ) -> str:
+        """Create a branch with the winner's code and open a draft PR/MR.
+
+        Args:
+            winner_dir: Directory holding the winning candidate's agent files.
+            branch: Name of the branch to create and push.
+            base_ref: Source ref the branch is created from. Used as the PR/MR base
+                when it is a branch; for a tag/commit source the base falls back to
+                the remote's default branch (a PR/MR base must be a branch).
+            title: PR/MR title.
+            body: PR/MR description.
+            draft: Open as a draft (default True).
+            agent_path: In-repo sub-path the winner's files overlay (``"."`` = whole repo).
+            base_branch_override: Explicit PR/MR base branch; overrides the ``base_ref``/default.
+            labels: Optional labels applied to the PR/MR.
+
+        Returns:
+            The created PR/MR URL.
+        """
+        agent_path = _validated_agent_path(agent_path)
+        origin = self._origin_url()
+        target = pr_cli_for_repo_url(origin)
+        if target is None:
+            raise PRPublisherError(f"unsupported remote host for PR creation: {_redact_url(origin)}")
+        cli, _ = target
+
+        # Branch from the exact source ref (branch, tag, or commit) via FETCH_HEAD so
+        # the change is reproducible against the commit the agent came from.
+        self._run(["git", "fetch", "origin", base_ref])
+        self._run(["git", "checkout", "-B", branch, "FETCH_HEAD"])
+        self._snapshot_subtree(Path(winner_dir), agent_path)
+        # Nothing to commit → no PR (winner identical to base).
+        status = self._run(["git", "--literal-pathspecs", "status", "--porcelain", "--", agent_path])
+        if not status:
+            logger.info("[TERMINATOR] winner is identical to base ref; skipping PR creation")
+            return ""
+        self._run(["git", "--literal-pathspecs", "commit", "--only", "-m", title, "--", agent_path])
+        self._run(["git", "push", "--force-with-lease", "-u", "origin", branch])
+
+        # A PR/MR base must be a branch: an explicit override wins; else target base_ref when it
+        # is a branch, else the remote's default branch (the source may be a tag/commit).
+        pr_base = base_branch_override or (base_ref if self._is_remote_branch(base_ref) else self._default_branch())
+        if cli == "gh":
+            cmd = ["gh", "pr", "create", "--base", pr_base, "--head", branch, "--title", title, "--body", body]
+            if draft:
+                cmd.append("--draft")
+            for label in labels or []:
+                cmd += ["--label", label]
+            return self._run(cmd)
+        # gitlab
+        cmd = ["glab", "mr", "create", "--source-branch", branch, "--target-branch", pr_base]
+        cmd += ["--title", title, "--description", body, "--yes"]
+        if draft:
+            cmd.append("--draft")
+        if labels:
+            cmd += ["--label", ",".join(labels)]
+        return self._run(cmd)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Terminator step — decides when the evolutionary optimization loop should stop.
+
+The loop consults :meth:`Terminator.run` once per round; it stops when the round
+budget is exhausted or the optimization has converged (a deterministic Pareto-front
+check, with a qualitative LLM check as a tie-breaker). Publishing the winner is the
+loop's job (``backend.publish_candidate``), not the Terminator's.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from nemo_experimentalist_plugin.skills import skills_dir
+from nooa import Agent, CodeActStrategy, TextSkill, hidden, strategy
+from nooa.agentdoc import doc
+from nooa.config import CodeActConfig
+from pydantic import BaseModel
+
+from .model_config import get_fast_model
+from .models import pareto_front
+
+if TYPE_CHECKING:
+    from .loop import EvolutionaryOptimizerConfig
+    from .models import EvolutionTree
+
+logger = logging.getLogger(__name__)
+
+
+class TerminationDecision(BaseModel):
+    """Structured result of a termination assessment.
+
+    Attributes:
+        stop: True when the optimization loop should stop.
+        reason: Human-readable explanation; empty string when ``stop`` is False.
+    """
+
+    stop: bool
+    reason: str = ""
+
+
+class Terminator(Agent, llm=get_fast_model()):
+    """Decides when the evolutionary optimization loop should stop."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.terminator_skill = TextSkill(path=skills_dir() / "terminator")
+
+    @hidden
+    async def run(
+        self,
+        *,
+        round_num: int,
+        evolution_tree: EvolutionTree,
+        prior_analysis: str | None,
+        config: EvolutionaryOptimizerConfig,
+    ) -> TerminationDecision:
+        """Canonical termination decision, consulted once per round at the top of the loop.
+
+        Stops when the round budget is exhausted; otherwise stops when the
+        optimization has converged. Composes :meth:`assess_round_budget` and
+        :meth:`assess_convergence` (budget first — it is cheap and deterministic,
+        so an exhausted budget avoids the qualitative LLM call).
+
+        Args:
+            round_num: Rounds completed so far.
+            evolution_tree: Live tree of scored candidates across rounds.
+            prior_analysis: Markdown analysis from the previous round, if any.
+            config: Active optimizer config (read-only).
+
+        Returns:
+            A :class:`TerminationDecision`.
+        """
+        budget = self.assess_round_budget(round_num=round_num, config=config)
+        if budget.stop:
+            return budget
+        return await self.assess_convergence(
+            evolution_tree=evolution_tree,
+            prior_analysis=prior_analysis,
+            config=config,
+        )
+
+    @hidden
+    async def assess_convergence(
+        self,
+        *,
+        evolution_tree: EvolutionTree,
+        prior_analysis: str | None,
+        config: EvolutionaryOptimizerConfig,
+    ) -> TerminationDecision:
+        """Decide whether to early-stop before running another round.
+
+        Mirrors the original top-of-loop gating: returns ``stop=False`` immediately
+        when there is no prior analysis to reason about or when the convergence
+        check is disabled. Otherwise consults :meth:`_has_converged`.
+
+        Args:
+            evolution_tree: Live tree of scored candidates across rounds.
+            prior_analysis: Markdown analysis from the previous round, if any.
+            config: Active optimizer config (read-only).
+
+        Returns:
+            A :class:`TerminationDecision`.
+        """
+        if prior_analysis is None or config.disable_convergence_check:
+            return TerminationDecision(stop=False)
+        converged = await self._has_converged(
+            evolution_tree=evolution_tree,
+            prior_analysis=prior_analysis,
+            min_rounds_before_stopping=config.min_rounds_before_stopping,
+        )
+        if converged:
+            return TerminationDecision(stop=True, reason="optimization converged (Pareto front stagnated)")
+        return TerminationDecision(stop=False)
+
+    @hidden
+    def assess_round_budget(
+        self,
+        *,
+        round_num: int,
+        config: EvolutionaryOptimizerConfig,
+    ) -> TerminationDecision:
+        """Decide whether the round budget is exhausted.
+
+        Args:
+            round_num: The number of rounds completed so far.
+            config: Active optimizer config (read-only).
+
+        Returns:
+            A :class:`TerminationDecision` that stops when
+            ``round_num >= config.max_rounds``.
+        """
+        if round_num >= config.max_rounds:
+            return TerminationDecision(stop=True, reason=f"reached max_rounds ({config.max_rounds})")
+        return TerminationDecision(stop=False)
+
+    @hidden
+    async def _has_converged(
+        self,
+        *,
+        evolution_tree: EvolutionTree,
+        prior_analysis: str,
+        min_rounds_before_stopping: int,
+    ) -> bool:
+        """Return True if the optimization has converged and should stop early."""
+        # Truthy check (not ``is not None``): ``EvolutionNode.val_reward`` returns ``{}`` for
+        # unscored nodes, so ``is not None`` would pull them in and skew the round cutoff /
+        # Pareto front. Match ``EvolutionTree.get_best()``.
+        scored = [n for n in evolution_tree.nodes.values() if n.val_reward]
+        rounds = sorted({n.round for n in scored})
+        if len(rounds) < min_rounds_before_stopping:
+            return False
+        cutoff_round = rounds[-min_rounds_before_stopping]
+        old = [n for n in scored if n.round <= cutoff_round]
+        if not old:
+            return False
+        old_front_ids = {n.label for n in pareto_front(old, lambda n: n.val_reward)}
+        full_front_ids = {n.label for n in pareto_front(scored, lambda n: n.val_reward)}
+        if full_front_ids.issubset(old_front_ids):
+            return True
+        return await self.qualitative_stop_check(prior_analysis)
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=5)))
+    async def qualitative_stop_check(self, analysis: str) -> bool:  # pyright: ignore[reportReturnType]
+        """Decide whether the optimization has qualitatively plateaued; return True to stop.
+
+        Judge the round ``analysis`` text against the terminator skill's stop
+        heuristics (prefilled below). Return True only with concrete textual
+        evidence of stagnation in ``analysis``; when in doubt, return False.
+        """
+        print(doc(self.terminator_skill))
+        ...

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
@@ -12,8 +12,11 @@ loop's job (``backend.publish_candidate``), not the Terminator's.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+# Imported from `resolve` rather than `.loop`, which merely re-exports it: `loop` imports
+# this module, so going through it would be circular.
+from nemo_experimentalist_plugin.resolve import EvolutionaryOptimizerConfig
 from nemo_experimentalist_plugin.skills import skills_dir
 from nooa import Agent, CodeActStrategy, TextSkill, hidden, strategy
 from nooa.agentdoc import doc
@@ -21,11 +24,7 @@ from nooa.config import CodeActConfig
 from pydantic import BaseModel
 
 from .model_config import get_fast_model
-from .models import pareto_front
-
-if TYPE_CHECKING:
-    from .loop import EvolutionaryOptimizerConfig
-    from .models import EvolutionTree
+from .models import EvolutionTree, pareto_front
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/tools.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/tools.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from collections.abc import Sequence
+from pathlib import Path
+
+from nemo_experimentalist_plugin.entities import Candidate
+from nooa.tools import ShellResult, ShellTools
+
+from .holdout_utils import (
+    BLOCKED_MESSAGE,
+    DEFAULT_BLOCKED_PATHS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GuardedShellTools(ShellTools):
+    """``ShellTools`` that refuses shell access to held-out dataset splits.
+
+    The optimizer's sub-agents run CodeAct with a raw shell rooted at the
+    workspace, so they could read the held-out validation ground truth straight off disk
+    (``cat dataset/validation/.../tests/test.sh``) and overfit the selection
+    signal. This intercepts the ``ShellTools.run`` chokepoint and refuses any command that
+    references a held-out split.
+
+    It is a tripwire, not a wall: a substring match can be bypassed by a
+    determined caller (globs, shell variables, ``find / -name test.sh``). It
+    defeats casual and accidental access and logs every attempt. Pair it with the
+    ``DatasetTool`` split guard, which covers the separate ``Path.read_text``
+    channel that never touches bash.
+
+    Args:
+        cwd: Working directory forwarded to ``ShellTools``.
+        blocked_paths: Token substrings whose presence in a command causes the
+            command to be rejected; defaults to ``DEFAULT_BLOCKED_PATHS``.
+        init_command: Optional command run once when the shell session starts.
+
+    """
+
+    def __init__(
+        self,
+        cwd: str | Path = ".",
+        *,
+        blocked_paths: Sequence[str] = DEFAULT_BLOCKED_PATHS,
+        init_command: str | None = None,
+    ) -> None:
+        """Initialize with a working directory and an optional set of blocked path tokens."""
+        super().__init__(cwd=str(cwd), init_command=init_command)
+        self._blocked_paths = tuple(blocked_paths)
+
+    def is_blocked(self, command: str) -> bool:
+        """Return True if the command references any held-out split path token.
+
+        Args:
+            command: shell command string to inspect.
+
+        Returns:
+            bool: True if any blocked path token appears in the command.
+
+        """
+        return any(token in command for token in self._blocked_paths)
+
+    async def run(
+        self,
+        command: str,
+        *,
+        stdin: str | None = None,
+        timeout: float = 30.0,
+    ) -> ShellResult:
+        """Execute a shell command, blocking access to held-out dataset splits.
+
+        Args:
+            command: Shell command string to execute.
+            stdin: Optional text piped to stdin.
+            timeout: Timeout in seconds; forwarded to ``ShellTools.run``.
+
+        Returns:
+            ShellResult: The result of the command, or a synthetic failure result
+            with ``returncode=1`` and ``stderr=BLOCKED_MESSAGE`` when the command
+            references a held-out split path.
+
+        """
+        if self.is_blocked(command):
+            logger.warning(f"GuardedShellTools blocked held-out access: {command}")
+            return ShellResult(stdout="", stderr=BLOCKED_MESSAGE, returncode=1)
+        return await super().run(command, stdin=stdin, timeout=timeout)
+
+
+class WorkspaceTool:
+    """Navigate the eval-and-optimize workspace: agents and analysis files.
+
+    Args:
+        workspace: Absolute path to the eval-and-optimize workspace root.
+
+    """
+
+    def __init__(self, workspace: Path) -> None:
+        """Initialize the workspace tool for the given workspace."""
+        self.workspace = Path(workspace).resolve()
+        self._eval_root = self.workspace / "eval-and-optimize"
+        self._agents_root = self._eval_root / "agents"
+        self._analysis_root = self._eval_root / "analysis"
+
+    # ── Navigation ────────────────────────────────────────────────────────────
+
+    def list_agents(self) -> list[str]:
+        """Return all agent IDs that have a ``metadata.json``, sorted naturally.
+
+        Returns:
+            list[str]: agent IDs in natural numeric order.
+
+        """
+        if not self._agents_root.exists():
+            return []
+        ids = [d.name for d in self._agents_root.iterdir() if d.is_dir() and (d / "metadata.json").exists()]
+        return sorted(
+            ids,
+            key=lambda s: int(s.split("-")[1]) if s.split("-")[1].isdigit() else 0,
+        )
+
+    def get_agent_path(self, agent_id: str) -> str:
+        """Return the absolute path to an agent's directory.
+
+        Args:
+            agent_id: the agent to locate.
+
+        Returns:
+            str: absolute path to the agent's directory under ``eval-and-optimize/agents/``.
+
+        """
+        return str(self._agents_root / agent_id)
+
+    # ── File listing ──────────────────────────────────────────────────────────
+
+    def list_agent_files(self, agent_id: str) -> list[str]:
+        """Return all files in an agent's directory (relative paths).
+
+        Args:
+            agent_id: the agent to inspect.
+
+        Returns:
+            list[str]: sorted relative paths of all files in the agent directory.
+
+        """
+        agent_dir = self._agents_root / agent_id
+        if not agent_dir.exists():
+            return []
+        return sorted(str(f.relative_to(agent_dir)) for f in agent_dir.rglob("*") if f.is_file())
+
+    # ── File reading ──────────────────────────────────────────────────────────
+
+    def read_agent_file(self, agent_id: str, relative_path: str, limit: int | None = 8000) -> str:
+        """Read any file inside an agent's directory by relative path.
+
+        Args:
+            agent_id:      e.g. "agent-2"
+            relative_path: e.g. "main.py", "metadata.json"
+            limit:         max characters (default 8000, None = no truncation)
+
+        Returns:
+            str: file contents, truncated to ``limit`` characters if needed, or empty
+            string if the file is not found.
+
+        """
+        return self._read_file(self._agents_root / agent_id / relative_path, limit=limit)
+
+    def read_analysis_file(self, path_or_round: "str | int", limit: int | None = 8000) -> str:
+        """Read a file from eval-and-optimize/analysis/.
+
+        Args:
+            path_or_round: round number (e.g. 1 → round-1.md) or filename.
+            limit:         max characters (default 8000, None = no truncation)
+
+        Returns:
+            str: file contents, truncated to ``limit`` characters if needed, or empty
+            string if the file is not found.
+
+        """
+        if isinstance(path_or_round, int):
+            path = self._analysis_root / f"round-{path_or_round}.md"
+        else:
+            path = self._analysis_root / path_or_round
+        return self._read_file(path, limit=limit)
+
+    def get_metadata(self, agent_id: str) -> Candidate:
+        """Read ``agents/{agent_id}/metadata.json`` as a :class:`Candidate`.
+
+        Args:
+            agent_id: the agent whose metadata to read.
+
+        Returns:
+            Candidate: parsed candidate, or a minimal candidate with default
+            values if the file is missing or unreadable.
+
+        """
+        from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import (
+            LocalExperimentalistBackend,
+        )
+
+        path = self._agents_root / agent_id / "metadata.json"
+        # Build a throw-away backend instance scoped to the workspace root so we
+        # can reuse its deserialization logic without duplicating it here.
+        _backend = LocalExperimentalistBackend.__new__(LocalExperimentalistBackend)
+        _backend._eo = self._eval_root  # type: ignore[attr-defined]
+        if not path.exists():
+            raise FileNotFoundError(f"Metadata file not found: {path}")
+        return _backend._load_candidate(path)
+
+    # ── Private helpers ───────────────────────────────────────────────────────
+
+    def _read_file(self, path: Path, limit: int | None = 4000) -> str:
+        if not path.exists():
+            return ""
+        try:
+            text = path.read_text().strip()
+            if limit is not None and len(text) > limit:
+                text = text[:limit] + f"... [truncated, {len(text)} chars total]"
+            return text
+        except (OSError, UnicodeDecodeError):
+            return ""

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
@@ -1,0 +1,352 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ast  # noqa: D100, F401
+import hashlib
+import logging
+import os  # noqa: F401
+import re  # noqa: F401
+from collections import Counter, defaultdict  # noqa: F401
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import unquote, urlparse
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import MetricResult, Task, TrialResult
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DependencyRuntime
+from nemo_insights_plugin.entities import Insight
+from nemo_platform import AsyncNeMoPlatform
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc, spec
+from nooa.agents import TokenBudgetSummarizer
+from nooa.config import CodeActConfig
+from nooa.config.summarizer_config import TokenBudgetConfig
+from nooa.skill_registry import SkillRegistry
+from nooa.tools import Match, TodoManager
+from pydantic import BaseModel, Field
+
+from . import cache
+from .model_config import get_fast_model, get_smart_model
+from .rationalizer import Rationale
+from .tools import GuardedShellTools, WorkspaceTool
+from .trace_explorer import SearchResult, SessionData, SessionSummary, TraceExplorer, TurnInfo
+from .util import load_framework_skills
+
+
+class TraceAnalyzerConfig(BaseModel):
+    """Configuration for TraceAnalyzer tuning parameters."""
+
+    max_summary_tokens: int = Field(
+        default=80_000,
+        description="Max tokens the token-budget summarizer may use.",
+    )
+
+
+logger = logging.getLogger(__name__)
+
+
+def _trace_cache_key(trace_uri: str) -> str:
+    parsed = urlparse(trace_uri)
+    if parsed.scheme == "file" and parsed.netloc in ("", "localhost"):
+        return cache.trace_hash(Path(unquote(parsed.path)).expanduser())
+    if parsed.scheme == "":
+        return cache.trace_hash(Path(trace_uri).expanduser())
+    digest = hashlib.sha256(trace_uri.encode()).hexdigest()
+    return f"trace-uri-{digest}"
+
+
+class TraceOverview(BaseModel):
+    """High-level structural overview of a trace execution."""
+
+    outcome: Literal["SUCCESS", "FAILURE"] | None
+    status: str
+    number_of_sessions: int
+    total_turns: int
+    errors_present: bool
+    metrics: dict[str, MetricResult]
+
+
+class DecisionPoint(BaseModel):
+    """A single span where the agent made an incorrect or suboptimal decision."""
+
+    span_index: int
+    observation: str  # what the agent did or concluded at this span
+    mistake: str  # what was wrong or missing about it
+
+
+class StepAnalysis(BaseModel):
+    """Trajectory summary and key decision points from trace analysis."""
+
+    trajectory_summary: str
+    decision_points: list[DecisionPoint]
+
+
+class Diagnostic(BaseModel):
+    """Root-cause diagnosis for a single agent trial."""
+
+    outcome: Literal["SUCCESS", "FAILURE"]
+    summary: str
+    failure_point: int | None
+    root_cause: str
+
+
+def _outcome_from_eval_passed(eval_passed: bool | None) -> Literal["SUCCESS", "FAILURE"] | None:
+    if eval_passed is None:
+        return None
+    return "SUCCESS" if eval_passed else "FAILURE"
+
+
+class TraceAnalyzer(Agent, llm=get_smart_model()):
+    """Perform deep trace analysis for a single task.
+
+    Spawned by AgentAnalyzer.run in parallel — one instance per task.
+    Never call this sequentially; always use asyncio.gather.
+
+    When using TraceExplorer return types, prefer attribute access. If you
+    encounter a type whose fields aren't in your system prompt, call
+    ``doc(TheType)`` before assuming attribute names — don't guess.
+
+    """
+
+    def __init__(
+        self,
+        experiment_dir: Path,
+        config: TraceAnalyzerConfig | None = None,
+        framework_skills_dirs: list[Path] | None = None,
+        **kwargs: Any,
+    ):
+        """Initialize the trace analyzer for the given experiment directory.
+
+        Args:
+            experiment_dir: Absolute path to the experiment root.
+            config: Tuning parameters; defaults to ``TraceAnalyzerConfig()`` if ``None``.
+            framework_skills_dirs: Optional list of directories containing framework skills to load.
+            **kwargs: Forwarded to ``Agent.__init__``.
+
+        """
+        super().__init__(**kwargs)
+        self._config = config or TraceAnalyzerConfig()
+        self._experiment_dir = experiment_dir
+        self.shell = GuardedShellTools(cwd=experiment_dir)
+        self.workspace = WorkspaceTool(workspace=experiment_dir)
+        self.todos = TodoManager()
+        self.context["file_match"] = doc(Match)
+        self.context["workspace_tool_documentation"] = doc(WorkspaceTool)
+        self.context["trace_documentation"] = doc(
+            TraceExplorer,
+            SessionSummary,
+            TurnInfo,
+            SessionData,
+            SearchResult,
+            inline_depth=2,
+        )
+        self.skills: SkillRegistry = SkillRegistry(self)
+        spec(self, "skills", hidden=True)
+        load_framework_skills(self.skills, framework_skills_dirs or [])
+        TokenBudgetSummarizer.install(
+            self,
+            llm=get_fast_model(),
+            config=TokenBudgetConfig(max_tokens=self._config.max_summary_tokens),
+        )
+
+    async def get_overview(self, trace: TraceExplorer, trial: TrialResult) -> TraceOverview:
+        """Return a high-level structural overview of the trace.
+
+        Args:
+            trace: The loaded trace to inspect.
+            trial: Trial result whose status, error, and metrics are attached
+                to the overview without assuming evaluator-specific semantics.
+
+        Returns:
+            TraceOverview: outcome, number of sessions, total turns, and whether
+            runtime errors are present.
+
+        """
+        overview_data = await trace.get_overview_data()  # type: ignore[misc] (nooa lacks py.typed marker, so pyright ignores its type annotations)
+
+        if not overview_data:
+            return TraceOverview(
+                outcome="FAILURE",
+                status=trial.status,
+                number_of_sessions=0,
+                total_turns=0,
+                errors_present=trial.error is not None,
+                metrics=trial.metrics,
+            )
+
+        stats = overview_data.stats
+        return TraceOverview(
+            outcome=_outcome_from_eval_passed(stats.eval_passed),
+            status=trial.status,
+            number_of_sessions=stats.session_count,
+            total_turns=stats.turn_count,
+            errors_present=stats.runtime_errors > 0 or trial.error is not None,
+            metrics=trial.metrics,
+        )
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=40, cell_timeout=3600.0)))
+    async def analyze_trajectory(
+        self,
+        trace: TraceExplorer,
+        trial: TrialResult,
+        task: Task,
+        overview: TraceOverview,
+        rationale: Rationale,
+        agent_path: Path,
+        runtime: DependencyRuntime | None,
+        insight: Insight | None = None,
+    ) -> StepAnalysis:
+        """Trace the agent's path and find where it went wrong.
+
+        Args:
+            trace: The loaded trace to inspect from the trial result.
+            task: The input task to analyze.
+            trial: The output trial result to analyze of the input task.
+            overview (TraceOverview): result from get_overview
+            rationale (Rationale): reference solution; may have empty steps
+            insight: Production insight. If present, use its title and
+                description as the analysis lens.
+            agent_path: Local path to the agent root.
+            runtime: Dependency runtime to use for analyzing the trace.
+
+        Returns:
+            StepAnalysis: result with trajectory_summary and decision_points.
+
+        Use overview for context on the trace structure.
+        If rationale has steps, use it as compass: where did the agent's reasoning diverge?
+        If insight is present, look specifically for the behavior described by
+        ``insight.title`` and ``insight.description``. If ``agent_path`` is present,
+        inspect agent code there when it helps explain the trace.
+
+        All TraceExplorer methods are async — always `await` them.
+
+        The framework enters ``task.start_deps()`` before this method. Inspect
+        ``self.context["dependencies"]`` to see the active dependency runtime,
+        including start, readiness, and stop command specs.
+
+        1. Use ``task.inputs``, ``task.resources``, and ``task.metric_specs`` for
+           task-side context. Do not assume Harbor paths or hidden verifier/oracle
+           resources exist.
+        2. Use ``trial.outputs``, ``trial.resources``, ``trial.metrics``,
+           ``trial.error``, and ``trial.metadata`` for run-side evidence.
+        3. Read ResourceRef descriptions and metadata first; load referenced files
+           only when needed.
+        4. Review what each trace method/tool call returned.
+        5. Search for errors, bad decisions, missed verifier signals, and missing side effects.
+        6. Sample turns at beginning, middle, and end for long sessions.
+        7. For every problematic span, ask WHY given what the agent knew at that point.
+
+        Return analysis text and 1-5 key decision point span indices.
+        """  # noqa: D413
+        ...
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=30, cell_timeout=3600.0)))
+    async def diagnose(
+        self,
+        trace: TraceExplorer,
+        analysis: StepAnalysis,
+        insight: Insight | None = None,
+    ) -> Diagnostic:
+        """Determine the primary root cause and produce a Diagnostic.
+
+        Args:
+            trace (TraceExplorer): the loaded trace to inspect from the trial result.
+            analysis (StepAnalysis): result from analyze_trajectory
+            insight: Optional production insight. If present, diagnose the root cause
+                of that insight's failure behavior.
+
+        Returns:
+            Diagnostic: result with outcome, summary, failure_point, and root_cause.
+
+        Ask for each candidate: 'If we fixed this one thing, would the agent pass?'
+        If yes → root cause. If not → dig deeper.
+
+        Required evidence:
+        - Direct quote or span from one of analysis.decision_points (each has span_index, observation, mistake)
+        - Count of turns with this pattern (use `await trace.search(...)` — all TraceExplorer methods are async)
+        - Why earlier turns didn't catch or correct it
+
+        Return a complete Diagnostic with outcome, summary, failure_point, and root_cause.
+        If insight is present and the trace does not match the insight's behavior,
+        set ``outcome="SUCCESS"`` with ``failure_point=None``.
+        """  # noqa: D413
+        ...
+
+    async def run(
+        self,
+        trial: TrialResult,
+        task: Task,
+        agent_path: Path,
+        rationale: Rationale | None = None,
+        insight: Insight | None = None,
+        client: AsyncNeMoPlatform | None = None,
+        workspace: str | None = None,
+    ) -> Diagnostic:
+        """Run the full trace analysis pipeline for one agent trial.
+
+        Args:
+            trial: The trial to analyze.
+            task: The task to analyze.
+            agent_path: Required local path to the agent root.
+            rationale: Optional reference solution produced by Rationalizer; used as
+                a compass for trajectory analysis. Pass ``None`` to skip comparison.
+            insight: Optional production insight to use as the failure lens.
+            client: Existing NeMo Platform client for Intake trace identifiers.
+            workspace: NMP workspace request context for Intake trace identifiers.
+
+        Returns:
+            Diagnostic: outcome, summary, failure point span index, and root cause.
+
+        """
+        if not trial.trace:
+            return Diagnostic(
+                outcome="FAILURE",
+                summary=f"Trial {trial.id} has no trace reference.",
+                failure_point=None,
+                root_cause=(
+                    "Trace data was not provided by the evaluator, so trajectory-level root cause analysis could not run."
+                ),
+            )
+
+        try:
+            trace = await TraceExplorer.from_ref(trial.trace, client, workspace)
+        except Exception as exc:
+            logger.warning("Skipping unloadable trace %s for trial %s: %s", trial.trace.uri, trial.id, exc)
+            return Diagnostic(
+                outcome="FAILURE",
+                summary=f"Trace could not be loaded: {type(exc).__name__}: {exc}",
+                failure_point=None,
+                root_cause=(
+                    "Trace data could not be loaded before analysis. Inspect the trial trace ResourceRef, evaluator "
+                    "trace artifact, Intake client/workspace configuration, and any trial error metadata."
+                ),
+            )
+
+        # The cache key intentionally omits the insight lens. Within the optimization
+        # loop the Eval Author (insight-conditioned) and the AgentAnalyzer (no insight)
+        # analyze disjoint trace sets in a single experiment_dir, so a given trace is
+        # only ever diagnosed through one lens and cannot collide here. If a future
+        # caller analyzes the same trace under different insights in one experiment_dir,
+        # fold the insight identity into this key to avoid returning a stale-lens Diagnostic.
+        key = _trace_cache_key(trial.trace.uri)
+
+        cached = cache.load(self._experiment_dir, key, Diagnostic)
+        if cached is not None:
+            return cached
+
+        rationale = rationale or Rationale(task_name=task.id, steps=[])
+
+        async with task.start_deps() as runtime:
+            overview = await self.get_overview(trace, trial)
+            analysis = await self.analyze_trajectory(
+                trace=trace,
+                trial=trial,
+                task=task,
+                overview=overview,
+                rationale=rationale,
+                insight=insight,
+                agent_path=agent_path,
+                runtime=runtime,
+            )
+            diagnostic = await self.diagnose(trace, analysis, insight)
+            cache.store(self._experiment_dir, key, diagnostic)
+        return diagnostic

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_explorer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_explorer.py
@@ -1,0 +1,2237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import re
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import ResourceRef
+from nemo_platform import AsyncNeMoPlatform
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ToolCall(BaseModel):
+    """A tool/function call made by the LLM."""
+
+    function_name: str
+    arguments: str = "{}"
+    tool_call_id: str = ""
+
+
+class LLMMessage(BaseModel):
+    """A single message in an LLM conversation."""
+
+    role: str
+    content: str = ""
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    tool_call_id: str = ""
+
+    def format_preview(self, max_length: int = 100) -> str:
+        """Format a short preview of the message content."""
+        if len(self.content) <= max_length:
+            return self.content.replace("\n", " ")
+        return self.content[:max_length].replace("\n", " ") + "..."
+
+
+class ToolDefinition(BaseModel):
+    """A tool definition available to the LLM."""
+
+    name: str
+    description: str = ""
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+class SpanStatus(BaseModel):
+    """OpenTelemetry span status."""
+
+    status_code: str = "OK"
+    description: str | None = None
+
+
+class Span(BaseModel):
+    """Base OpenTelemetry/OpenInference span.
+
+    Spans are raw trace units. Sessions and turns are derived from spans.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    span_id: str
+    kind: str
+    trace_id: str = ""
+    parent_span_id: str | None = None
+    name: str = ""
+    start_time: int = 0
+    end_time: int = 0
+    duration_ns: int = 0
+    status: SpanStatus = Field(default_factory=SpanStatus)
+    attributes: dict[str, Any] = Field(default_factory=dict)
+    events: list[dict[str, Any]] = Field(default_factory=list)
+
+    @property
+    def duration_ms(self) -> float:
+        """Duration in milliseconds."""
+        return self.duration_ns / 1_000_000
+
+
+class LLMSpan(Span):
+    """Represents an OpenInference LLM span.
+
+    https://arize-ai.github.io/openinference/spec/llm_spans.html
+    """
+
+    kind: Literal["LLM"] = "LLM"
+    system: str | None = None
+    provider: str | None = None
+    model_name: str | None = None
+    invocation_parameters: dict[str, Any] = Field(default_factory=dict)
+    input_value: str | None = None
+    input_mime_type: str | None = None
+    output_value: str | None = None
+    output_mime_type: str | None = None
+    input_messages: list[LLMMessage] = Field(default_factory=list)
+    output_messages: list[LLMMessage] = Field(default_factory=list)
+    tools: list[ToolDefinition] = Field(default_factory=list)
+    token_counts: dict[str, int] = Field(default_factory=dict)
+
+
+class ToolSpan(Span):
+    """Represents an OpenInference TOOL span."""
+
+    kind: Literal["TOOL"] = "TOOL"
+    tool_name: str | None = None
+    tool_call_id: str = ""
+    input_value: str | None = None
+    input_mime_type: str | None = None
+    output_value: str | None = None
+    output_mime_type: str | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+class AgentSpan(Span):
+    """Represents an OpenInference AGENT span.
+
+    TraceExplorer derives AgentSession objects from these spans.
+    """
+
+    kind: Literal["AGENT"] = "AGENT"
+    agent_name: str | None = None
+    method_name: str | None = None
+    input_value: str | None = None
+    output_value: str | None = None
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+class ChainSpan(Span):
+    """Represents an OpenInference CHAIN span."""
+
+    kind: Literal["CHAIN"] = "CHAIN"
+    input_value: str | None = None
+    output_value: str | None = None
+
+
+class EvaluatorSpan(Span):
+    """Represents an evaluation span."""
+
+    kind: Literal["EVALUATOR"] = "EVALUATOR"
+    evaluator_name: str | None = None
+    input_value: str | None = None
+    input_mime_type: str | None = None
+    output_value: str | None = None
+    output_mime_type: str | None = None
+    score: Any = None
+
+
+TraceSpan = LLMSpan | ToolSpan | AgentSpan | ChainSpan | EvaluatorSpan | Span
+
+
+class LLMTurn(BaseModel):
+    """Derived TraceExplorer view of one LLM generation turn."""
+
+    session_id: str
+    messages: list[LLMMessage]
+    response: str
+    model: str
+    token_counts: dict[str, int] | None = None
+    duration_ms: float | None = None
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    reasoning_content: str = ""
+    span_id: str = ""
+    provider: str = ""
+    invocation_parameters: dict[str, Any] = Field(default_factory=dict)
+    tools: list[ToolDefinition] = Field(default_factory=list)
+    start_time: int = 0
+    end_time: int = 0
+
+
+class ToolTurn(BaseModel):
+    """Derived TraceExplorer view of one tool call result."""
+
+    tool_name: str = ""
+    input: str
+    stdout: str = ""
+    error: str | None = None
+    output: Any = None
+    status: str = "OK"
+    duration_ms: float | None = None
+    execution_id: str = ""
+    generation_id: str = ""
+    error_type: str | None = None
+    span_id: str = ""
+    tool_call_id: str = ""
+    start_time: int = 0
+    end_time: int = 0
+
+
+class AgentSession(BaseModel):
+    """A single agent method/session invocation."""
+
+    session_id: str
+    agent_name: str
+    method_name: str
+    parent_session_id: str | None
+    depth: int = 0
+    turns: list[LLMTurn | ToolTurn] = Field(default_factory=list)
+    children: list[AgentSession] = Field(default_factory=list)
+    start_time: int = 0
+    end_time: int = 0
+    result: Any = None
+    status: str = "OK"
+    span_id: str = ""
+    method_signature: str = ""
+    docstring: str = ""
+    file_path: str = ""
+    args: list[Any] = Field(default_factory=list)
+    kwargs: dict[str, Any] = Field(default_factory=dict)
+    error_message: str | None = None
+    strategy: str | None = None
+    call_id: str = ""
+
+    @property
+    def duration_ms(self) -> float:
+        """Duration in milliseconds."""
+        return (self.end_time - self.start_time) / 1_000_000
+
+    @property
+    def full_name(self) -> str:
+        """Full method name like 'RouterTestWrapper.process'."""
+        return f"{self.agent_name}.{self.method_name}"
+
+    def get_error_turns(self) -> list[ToolTurn]:
+        """Get all turns that have errors."""
+        return [t for t in self.turns if isinstance(t, ToolTurn) and t.error]
+
+    def get_llm_turns(self) -> list[LLMTurn]:
+        """Get all LLM turns."""
+        return [t for t in self.turns if isinstance(t, LLMTurn)]
+
+    def get_tool_turns(self) -> list[ToolTurn]:
+        """Get all tool turns."""
+        return [t for t in self.turns if isinstance(t, ToolTurn)]
+
+    def get_execution_turns(self) -> list[ToolTurn]:
+        """Compatibility alias for code that still says execution turns."""
+        return self.get_tool_turns()
+
+
+class SessionSummary(BaseModel):
+    """Summary of one agent session."""
+
+    session_id: str
+    agent_name: str
+    method_name: str
+    status: str
+    turn_count: int
+    llm_turns: int
+    tool_turns: int
+    execution_turns: int = 0
+    duration_ms: float
+    parent_session_id: str | None = None
+    has_children: bool = False
+    result_preview: str | None = None
+
+
+class TurnInfo(BaseModel):
+    """Structured turn detail for programmatic use."""
+
+    session_id: str
+    turn_index: int
+    turn_type: Literal["llm", "tool"]
+    messages: list[LLMMessage] | None = None
+    response: str | None = None
+    model: str | None = None
+    token_counts: dict[str, int] | None = None
+    tool_calls: list[ToolCall] | None = None
+    provider: str | None = None
+    invocation_parameters: dict[str, Any] | None = None
+    tools: list[ToolDefinition] | None = None
+    code: str | None = None
+    tool_name: str | None = None
+    stdout: str | None = None
+    error: str | None = None
+    error_type: str | None = None
+    output: Any = None
+    status: str | None = None
+    duration_ms: float | None = None
+    span_id: str = ""
+    tool_call_id: str = ""
+    start_time: int = 0
+    end_time: int = 0
+
+
+class SessionData(BaseModel):
+    """Structured session data."""
+
+    session: SessionSummary
+    turns: list[TurnInfo]
+
+
+class SearchResult(BaseModel):
+    """Result of searching trace content."""
+
+    session_id: str
+    turn_index: int
+    turn_type: str
+    location: str
+    match_text: str
+    line_number: int | None = None
+
+
+class SearchMatches(BaseModel):
+    """Structured search results."""
+
+    pattern: str
+    match_count: int
+    matches: list[SearchResult]
+    by_location: dict[str, int]
+
+    def __bool__(self) -> bool:
+        """Return true when at least one match exists."""
+        return self.match_count > 0
+
+
+class TimelineEvent(BaseModel):
+    """One chronological event in a trace."""
+
+    time_ns: int
+    span_id: str
+    event_type: str
+    summary: str
+
+
+class TimelineData(BaseModel):
+    """Structured timeline output."""
+
+    total_events: int
+    max_events: int
+    events: list[TimelineEvent]
+
+
+class OverviewStats(BaseModel):
+    """Trace overview counters."""
+
+    duration_ms: float
+    session_count: int
+    turn_count: int
+    runtime_errors: int
+    eval_passed: bool | None = None
+
+
+class RootSessionInfo(BaseModel):
+    """Root/main session metadata."""
+
+    agent_name: str
+    method_name: str
+    session_id: str
+
+
+class EvalContextData(BaseModel):
+    """Evaluation metadata attached to a trace, if available.
+
+    This model also represents Intake evaluator result rows. When a trace has
+    multiple evaluator rows, the top-level context is an aggregate and `results`
+    contains one EvalContextData per row.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    test_id: str | None = None
+    passed: bool | None = None
+    input: Any = None
+    expected: Any = None
+    output: Any = None
+    error: str | None = None
+    evaluator_result_id: str = ""
+    span_id: str = ""
+    session_id: str = ""
+    workspace: str = ""
+    name: str = ""
+    value: float | None = None
+    string_value: str | None = None
+    data_type: str = ""
+    comment: str | None = None
+    created_by: str | None = None
+    created_at: datetime | None = None
+    ingested_at: datetime | None = None
+    results: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class OverviewData(BaseModel):
+    """Structured trace overview."""
+
+    trace_id: str
+    root: RootSessionInfo
+    stats: OverviewStats
+    sessions: list[SessionSummary]
+    call_graph: list[dict[str, Any]]
+    eval_result: EvalContextData | None = None
+    benchmark_context: str | None = None
+
+
+def _short_id(value: str | None) -> str:
+    return (value or "")[:6]
+
+
+def _kind(value: Any) -> str:
+    text = str(value or "").split(".")[-1].upper()
+    return text if text in {"AGENT", "CHAIN", "EVALUATOR", "LLM", "TOOL"} else "UNKNOWN"
+
+
+def _parse_jsonish(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text:
+        return value
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return value
+
+
+def _json_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, default=str)
+
+
+def _preview(value: Any, limit: int = 160) -> str:
+    text = _json_text(value).replace("\n", "\\n")
+    return text if len(text) <= limit else f"{text[: limit - 3]}..."
+
+
+def _attr(attrs: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = attrs.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _time_ns(value: Any) -> int:
+    if value in (None, ""):
+        return 0
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value)
+    if text.isdigit():
+        return int(text)
+    if text.endswith("Z"):
+        text = f"{text[:-1]}+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+def _otel_value(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    for key in ("stringValue", "intValue", "doubleValue", "boolValue", "bytesValue"):
+        if key in value:
+            return value[key]
+    if "arrayValue" in value:
+        return [_otel_value(item) for item in value["arrayValue"].get("values", [])]
+    if "kvlistValue" in value:
+        return {item.get("key", ""): _otel_value(item.get("value")) for item in value["kvlistValue"].get("values", [])}
+    return value
+
+
+def _otel_attrs_to_dict(attributes: Any) -> dict[str, Any]:
+    if isinstance(attributes, dict):
+        return dict(attributes)
+    result: dict[str, Any] = {}
+    for item in attributes or []:
+        if isinstance(item, dict) and "key" in item:
+            result[item["key"]] = _otel_value(item.get("value"))
+    return result
+
+
+def _status_from_raw(raw: Any, attrs: dict[str, Any]) -> SpanStatus:
+    error_message = _attr(attrs, "error.message", "exception.message")
+    if isinstance(raw, dict):
+        code = raw.get("status_code", raw.get("code"))
+        description = raw.get("description", raw.get("message", error_message))
+        if code in (2, "2", "ERROR", "error"):
+            return SpanStatus(status_code="ERROR", description=description)
+        return SpanStatus(status_code="OK", description=description)
+    if str(raw or "").lower() == "error" or error_message:
+        return SpanStatus(status_code="ERROR", description=error_message)
+    return SpanStatus(status_code="OK", description=None)
+
+
+def _tool_call_from_raw(raw: Any) -> ToolCall | None:
+    if not isinstance(raw, dict):
+        return None
+    function = raw.get("function")
+    if not isinstance(function, dict):
+        function = {}
+    name = function.get("name") or raw.get("name") or raw.get("tool_call.function.name")
+    if not name:
+        return None
+    arguments = function.get("arguments") or raw.get("arguments") or raw.get("tool_call.function.arguments") or "{}"
+    tool_call_id = raw.get("id") or raw.get("tool_call.id") or raw.get("tool_call_id") or ""
+    return ToolCall(
+        function_name=str(name),
+        arguments=_json_text(arguments),
+        tool_call_id=str(tool_call_id),
+    )
+
+
+def _messages_from_payload(value: Any) -> list[LLMMessage]:
+    parsed = _parse_jsonish(value)
+    if isinstance(parsed, dict):
+        messages = parsed.get("messages")
+    elif isinstance(parsed, list):
+        messages = parsed
+    else:
+        messages = None
+    if not isinstance(messages, list):
+        return []
+
+    result: list[LLMMessage] = []
+    for item in messages:
+        if not isinstance(item, dict):
+            continue
+        nested = item.get("message")
+        source = {**item, **nested} if isinstance(nested, dict) else item
+        raw_tool_calls = source.get("tool_calls") or []
+        tool_calls = [call for raw_call in raw_tool_calls if (call := _tool_call_from_raw(raw_call))]
+        result.append(
+            LLMMessage(
+                role=str(source.get("role") or "unknown"),
+                content=_json_text(source.get("content")),
+                tool_calls=tool_calls,
+                tool_call_id=str(source.get("tool_call_id") or source.get("tool_call.id") or ""),
+            )
+        )
+    return result
+
+
+def _messages_from_attrs(attrs: dict[str, Any], prefix: str) -> list[LLMMessage]:
+    message_pattern = re.compile(rf"^{re.escape(prefix)}\.(\d+)\.message\.(.+)$")
+    tool_pattern = re.compile(rf"^{re.escape(prefix)}\.(\d+)\.message\.tool_calls\.(\d+)\.tool_call\.(.+)$")
+    messages: dict[int, dict[str, Any]] = {}
+    tool_calls: dict[tuple[int, int], dict[str, Any]] = {}
+
+    for key, value in attrs.items():
+        if tool_match := tool_pattern.match(key):
+            msg_idx = int(tool_match.group(1))
+            call_idx = int(tool_match.group(2))
+            tool_calls.setdefault((msg_idx, call_idx), {})[tool_match.group(3)] = value
+            continue
+        if msg_match := message_pattern.match(key):
+            msg_idx = int(msg_match.group(1))
+            messages.setdefault(msg_idx, {})[msg_match.group(2)] = value
+
+    result: list[LLMMessage] = []
+    for msg_idx in sorted(messages):
+        data = messages[msg_idx]
+        calls: list[ToolCall] = []
+        for (owner_idx, _), call_data in sorted(tool_calls.items()):
+            if owner_idx != msg_idx:
+                continue
+            name = _attr(call_data, "function.name", "name")
+            if not name:
+                continue
+            calls.append(
+                ToolCall(
+                    function_name=str(name),
+                    arguments=_json_text(_attr(call_data, "function.arguments", "arguments") or "{}"),
+                    tool_call_id=str(_attr(call_data, "id", "tool_call_id") or ""),
+                )
+            )
+        content = _attr(data, "content", "message_content.text")
+        result.append(
+            LLMMessage(
+                role=str(data.get("role") or "unknown"),
+                content=_json_text(content),
+                tool_calls=calls,
+                tool_call_id=str(_attr(data, "tool_call_id", "tool_call.id") or ""),
+            )
+        )
+    return result
+
+
+def _tools_from_attrs(attrs: dict[str, Any]) -> list[ToolDefinition]:
+    tools: list[ToolDefinition] = []
+    pattern = re.compile(r"^llm\.tools\.(\d+)\.tool\.json_schema$")
+    for key, value in sorted(attrs.items()):
+        if not pattern.match(key):
+            continue
+        schema = _parse_jsonish(value)
+        if not isinstance(schema, dict):
+            continue
+        raw_func = schema.get("function")
+        function: dict[str, Any] = raw_func if isinstance(raw_func, dict) else schema
+        name = function.get("name")
+        if not name:
+            continue
+        raw_params = function.get("parameters")
+        tools.append(
+            ToolDefinition(
+                name=str(name),
+                description=str(function.get("description") or ""),
+                parameters=raw_params if isinstance(raw_params, dict) else {},
+            )
+        )
+    return tools
+
+
+def _token_counts(attrs: dict[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    prefix = "llm.token_count."
+    for key, value in attrs.items():
+        if key.startswith(prefix) and isinstance(value, (int, float, str)):
+            try:
+                counts[key.removeprefix(prefix)] = int(value)
+            except ValueError:
+                pass
+    return counts
+
+
+def _raw_attrs(raw: dict[str, Any]) -> dict[str, Any]:
+    attrs: dict[str, Any] = {}
+    if isinstance(raw.get("attributes"), list):
+        attrs.update(_otel_attrs_to_dict(raw["attributes"]))
+    elif isinstance(raw.get("attributes"), dict):
+        attrs.update(raw["attributes"])
+    parsed_raw = _parse_jsonish(raw.get("raw_attributes"))
+    if isinstance(parsed_raw, dict):
+        attrs.update(parsed_raw)
+    return attrs
+
+
+def _span_from_record(raw: dict[str, Any], resource_attrs: dict[str, Any] | None = None) -> TraceSpan:
+    attrs = _raw_attrs(raw)
+    if resource_attrs:
+        for key, value in resource_attrs.items():
+            attrs.setdefault(key, value)
+
+    span_id = str(raw.get("span_id") or raw.get("spanId") or raw.get("external_span_id") or "")
+    trace_id = str(raw.get("trace_id") or raw.get("traceId") or "")
+    parent_span_id = raw.get("parent_span_id") or raw.get("parentSpanId") or raw.get("external_parent_span_id")
+    parent_span_id = str(parent_span_id) if parent_span_id else None
+    start_time = _time_ns(raw.get("start_time") or raw.get("started_at") or raw.get("startTimeUnixNano"))
+    end_time = _time_ns(raw.get("end_time") or raw.get("ended_at") or raw.get("endTimeUnixNano"))
+    status = _status_from_raw(raw.get("status"), attrs)
+    kind = _kind(_attr(attrs, "openinference.span.kind") or raw.get("kind"))
+    if kind == "UNKNOWN":
+        kind = _kind(raw.get("openinference.span.kind"))
+
+    input_value = raw.get("input")
+    if input_value is None:
+        input_value = _attr(attrs, "input.value")
+    output_value = raw.get("output")
+    if output_value is None:
+        output_value = _attr(attrs, "output.value")
+
+    raw_events = raw.get("events")
+    base: dict[str, Any] = dict(
+        span_id=span_id,
+        trace_id=trace_id,
+        parent_span_id=parent_span_id,
+        name=str(raw.get("name") or ""),
+        start_time=start_time,
+        end_time=end_time,
+        duration_ns=end_time - start_time if start_time and end_time else int(raw.get("duration_ns") or 0),
+        status=status,
+        attributes=attrs,
+        events=raw_events if isinstance(raw_events, list) else [],
+    )
+
+    if kind == "LLM":
+        input_messages = _messages_from_payload(input_value) or _messages_from_attrs(attrs, "llm.input_messages")
+        output_messages = _messages_from_payload(output_value) or _messages_from_attrs(attrs, "llm.output_messages")
+        return LLMSpan(
+            **base,
+            provider=str(raw.get("provider") or _attr(attrs, "llm.provider") or ""),
+            model_name=str(raw.get("model") or _attr(attrs, "gen_ai.request.model", "llm.model_name") or ""),
+            invocation_parameters=_parse_jsonish(_attr(attrs, "llm.invocation_parameters")) or {},
+            input_value=_json_text(input_value) if input_value is not None else None,
+            input_mime_type=_attr(attrs, "input.mime_type"),
+            output_value=_json_text(output_value) if output_value is not None else None,
+            output_mime_type=_attr(attrs, "output.mime_type"),
+            input_messages=input_messages,
+            output_messages=output_messages,
+            tools=_tools_from_attrs(attrs),
+            token_counts=_token_counts(attrs),
+        )
+
+    if kind == "TOOL":
+        return ToolSpan(
+            **base,
+            tool_name=str(
+                raw.get("tool_name") or _attr(attrs, "tool.name", "tool_call.function.name") or raw.get("name") or ""
+            ),
+            tool_call_id=str(_attr(attrs, "tool_call.id", "tool.id", "tool_call_id") or ""),
+            input_value=_json_text(input_value) if input_value is not None else None,
+            input_mime_type=_attr(attrs, "input.mime_type"),
+            output_value=_json_text(output_value) if output_value is not None else None,
+            output_mime_type=_attr(attrs, "output.mime_type"),
+            error_type=_attr(attrs, "error.type", "exception.type"),
+            error_message=_attr(attrs, "error.message", "exception.message") or status.description,
+        )
+
+    if kind == "AGENT":
+        return AgentSpan(
+            **base,
+            agent_name=str(
+                _attr(attrs, "gen_ai.agent.name", "agent.name", "nemo.agent.name") or raw.get("agent_name") or "Agent"
+            ),
+            method_name=str(_attr(attrs, "agent.method", "method.name") or raw.get("name") or "run"),
+            input_value=_json_text(input_value) if input_value is not None else None,
+            output_value=_json_text(output_value) if output_value is not None else None,
+            error_type=_attr(attrs, "error.type", "exception.type"),
+            error_message=_attr(attrs, "error.message", "exception.message") or status.description,
+        )
+
+    if kind == "CHAIN":
+        return ChainSpan(
+            **base,
+            input_value=_json_text(input_value) if input_value is not None else None,
+            output_value=_json_text(output_value) if output_value is not None else None,
+        )
+
+    if kind == "EVALUATOR":
+        return EvaluatorSpan(
+            **base,
+            evaluator_name=str(raw.get("name") or _attr(attrs, "name", "evaluator.name") or ""),
+            input_value=_json_text(input_value) if input_value is not None else None,
+            input_mime_type=_attr(attrs, "input.mime_type"),
+            output_value=_json_text(output_value) if output_value is not None else None,
+            output_mime_type=_attr(attrs, "output.mime_type"),
+            score=_attr(attrs, "score", "evaluator.score") or raw.get("score"),
+        )
+
+    return Span(**base, kind=kind)
+
+
+def _looks_like_span_record(record: dict[str, Any]) -> bool:
+    if "evaluator_result_id" in record:
+        return False
+    return any(
+        key in record
+        for key in (
+            "span_id",
+            "spanId",
+            "external_span_id",
+            "trace_id",
+            "traceId",
+            "attributes",
+            "raw_attributes",
+        )
+    )
+
+
+def _iter_span_records(
+    document: Any,
+) -> list[tuple[dict[str, Any], dict[str, Any] | None]]:
+    if isinstance(document, list):
+        records: list[tuple[dict[str, Any], dict[str, Any] | None]] = []
+        for item in document:
+            records.extend(_iter_span_records(item))
+        return records
+
+    if not isinstance(document, dict):
+        return []
+
+    if "resourceSpans" in document:
+        records = []
+        for resource_spans in document.get("resourceSpans", []):
+            resource_attrs = _otel_attrs_to_dict(resource_spans.get("resource", {}).get("attributes", []))
+            for scope_spans in resource_spans.get("scopeSpans", []):
+                for span in scope_spans.get("spans", []):
+                    records.append((span, resource_attrs))
+        return records
+
+    if isinstance(document.get("data"), list):
+        return [(span, None) for span in document["data"] if isinstance(span, dict) and _looks_like_span_record(span)]
+
+    if "spans" in document and isinstance(document["spans"], list):
+        return [(span, None) for span in document["spans"] if isinstance(span, dict) and _looks_like_span_record(span)]
+
+    if _looks_like_span_record(document):
+        return [(document, None)]
+
+    return []
+
+
+def _eval_context_from_record(raw: dict[str, Any]) -> EvalContextData:
+    context = EvalContextData.model_validate(raw)
+    passed = _eval_context_passed(context)
+    if passed is not None and context.passed is None:
+        context = context.model_copy(update={"passed": passed})
+    if not context.test_id and context.session_id:
+        context = context.model_copy(update={"test_id": context.session_id})
+    return context
+
+
+def _iter_evaluator_result_records(document: Any) -> list[dict[str, Any]]:
+    if isinstance(document, list):
+        records: list[dict[str, Any]] = []
+        for item in document:
+            records.extend(_iter_evaluator_result_records(item))
+        return records
+
+    if not isinstance(document, dict):
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for key in ("evaluator_results", "evaluatorResults"):
+        value = document.get(key)
+        if isinstance(value, list):
+            rows.extend(item for item in value if isinstance(item, dict))
+
+    data = document.get("data")
+    if isinstance(data, list):
+        rows.extend(item for item in data if isinstance(item, dict) and "evaluator_result_id" in item)
+
+    if "evaluator_result_id" in document:
+        rows.append(document)
+
+    return rows
+
+
+def _load_trace_models(
+    path: str | Path,
+) -> tuple[list[TraceSpan], list[EvalContextData]]:
+    text = Path(path).read_text()
+    documents: list[Any] = []
+    try:
+        documents.append(json.loads(text))
+    except json.JSONDecodeError:
+        for line in text.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                documents.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    spans: list[TraceSpan] = []
+    eval_contexts: list[EvalContextData] = []
+    for document in documents:
+        for record, resource_attrs in _iter_span_records(document):
+            span = _span_from_record(record, resource_attrs)
+            if span.span_id:
+                spans.append(span)
+        eval_contexts.extend(_eval_context_from_record(record) for record in _iter_evaluator_result_records(document))
+    return spans, eval_contexts
+
+
+def _load_span_models(path: str | Path) -> list[TraceSpan]:
+    spans, _ = _load_trace_models(path)
+    return spans
+
+
+async def _fetch_intake_eval_contexts(
+    *,
+    client: AsyncNeMoPlatform,
+    workspace: str,
+    session_ids: set[str],
+    page_size: int,
+) -> list[EvalContextData]:
+    results: list[EvalContextData] = []
+    seen: set[str] = set()
+
+    for session_id in sorted(session_ids):
+        paginator = client.intake.evaluator_results.list(
+            workspace=workspace,
+            filter=cast(Any, {"session_id": session_id}),
+            page_size=max(1, page_size),
+            sort="created_at",
+        )
+        async for item in paginator:
+            row = item.model_dump(mode="json", exclude_none=True)
+            result = _eval_context_from_record(row)
+            dedupe_key = result.evaluator_result_id or json.dumps(row, sort_keys=True, default=str)
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            results.append(result)
+
+    return results
+
+
+def _eval_context_value(context: EvalContextData) -> Any:
+    if context.value is not None:
+        return context.value
+    if context.string_value is not None:
+        return context.string_value
+    return context.output
+
+
+def _eval_context_passed(context: EvalContextData) -> bool | None:
+    if context.passed is not None:
+        return context.passed
+    data_type = context.data_type.upper()
+    if data_type == "BOOLEAN" and context.value is not None:
+        return context.value == 1.0
+    if context.string_value is None:
+        return None
+    text = context.string_value.strip().lower()
+    if text in {"true", "pass", "passed", "success", "ok"}:
+        return True
+    if text in {"false", "fail", "failed", "failure", "error"}:
+        return False
+    return None
+
+
+def _eval_context_result_dict(context: EvalContextData) -> dict[str, Any]:
+    return {
+        "test_id": context.test_id,
+        "passed": context.passed,
+        "input": context.input,
+        "expected": context.expected,
+        "output": context.output,
+        "error": context.error,
+        "evaluator_result_id": context.evaluator_result_id,
+        "span_id": context.span_id,
+        "session_id": context.session_id,
+        "workspace": context.workspace,
+        "name": context.name,
+        "value": context.value,
+        "string_value": context.string_value,
+        "data_type": context.data_type,
+        "comment": context.comment,
+        "created_by": context.created_by,
+        "created_at": context.created_at,
+        "ingested_at": context.ingested_at,
+    }
+
+
+def _merge_eval_contexts(
+    eval_contexts: list[EvalContextData],
+) -> EvalContextData | None:
+    if not eval_contexts:
+        return None
+
+    normalized = []
+    for context in eval_contexts:
+        passed = _eval_context_passed(context)
+        if passed is not None and context.passed is None:
+            context = context.model_copy(update={"passed": passed})
+        if not context.test_id and context.session_id:
+            context = context.model_copy(update={"test_id": context.session_id})
+        normalized.append(context)
+
+    if len(normalized) == 1:
+        return normalized[0]
+
+    pass_values = [context.passed for context in normalized if context.passed is not None]
+    session_ids = sorted({context.session_id for context in normalized if context.session_id})
+    output: dict[str, Any] = {}
+    for index, context in enumerate(normalized):
+        key = context.name or context.evaluator_result_id or f"result_{index}"
+        value = _eval_context_value(context)
+        if key not in output:
+            output[key] = value
+            continue
+        existing = output[key]
+        if not isinstance(existing, list):
+            output[key] = [existing]
+        output[key].append(value)
+
+    return EvalContextData(
+        test_id=session_ids[0] if len(session_ids) == 1 else None,
+        passed=all(pass_values) if pass_values else None,
+        output=output or None,
+        results=[_eval_context_result_dict(context) for context in normalized],
+    )
+
+
+def _flatten_sessions(sessions: list[AgentSession]) -> list[AgentSession]:
+    result: list[AgentSession] = []
+    for session in sessions:
+        result.append(session)
+        result.extend(_flatten_sessions(session.children))
+    return result
+
+
+def _turn_from_llm_span(span: LLMSpan, session_id: str) -> LLMTurn:
+    tool_calls = [tc for message in span.output_messages for tc in message.tool_calls]
+    response_parts = [message.content for message in span.output_messages if message.content]
+    if not response_parts and span.output_value:
+        parsed = _parse_jsonish(span.output_value)
+        if not (isinstance(parsed, dict) and isinstance(parsed.get("messages"), list)):
+            response_parts = [span.output_value]
+    return LLMTurn(
+        session_id=_short_id(_attr(span.attributes, "generation.id") or session_id),
+        messages=span.input_messages,
+        response="\n".join(response_parts),
+        model=span.model_name or "",
+        token_counts=span.token_counts or None,
+        duration_ms=span.duration_ms,
+        tool_calls=tool_calls,
+        reasoning_content=str(_attr(span.attributes, "llm.reasoning_content") or ""),
+        span_id=span.span_id,
+        provider=span.provider or "",
+        invocation_parameters=span.invocation_parameters,
+        tools=span.tools,
+        start_time=span.start_time,
+        end_time=span.end_time,
+    )
+
+
+def _turn_from_tool_span(span: ToolSpan) -> ToolTurn:
+    parsed_input = _parse_jsonish(span.input_value)
+    parsed_output = _parse_jsonish(span.output_value)
+    stdout = ""
+    output: Any = parsed_output
+    error = span.error_message
+
+    if isinstance(parsed_output, dict):
+        stdout = str(parsed_output.get("stdout") or "")
+        error = error or parsed_output.get("error")
+        output = parsed_output.get("returned_value", parsed_output.get("result", parsed_output))
+    input_text = _json_text(parsed_input)
+    status = "ERROR" if error or span.status.status_code == "ERROR" else "OK"
+
+    return ToolTurn(
+        tool_name=span.tool_name or span.name,
+        input=input_text,
+        stdout=stdout,
+        error=error,
+        output=output,
+        status=status,
+        duration_ms=span.duration_ms,
+        execution_id=_short_id(_attr(span.attributes, "execution.id") or span.span_id),
+        generation_id=_short_id(_attr(span.attributes, "generation.id")),
+        error_type=span.error_type,
+        span_id=span.span_id,
+        tool_call_id=span.tool_call_id,
+        start_time=span.start_time,
+        end_time=span.end_time,
+    )
+
+
+def _session_from_agent_span(span: AgentSpan, parent_session_id: str | None) -> AgentSession:
+    args: list[Any] = []
+    kwargs: dict[str, Any] = {}
+    parsed_input = _parse_jsonish(span.input_value)
+    if isinstance(parsed_input, dict):
+        parsed_args = _parse_jsonish(parsed_input.get("args"))
+        parsed_kwargs = _parse_jsonish(parsed_input.get("kwargs"))
+        if isinstance(parsed_args, list):
+            args = parsed_args
+        elif parsed_args not in (None, ""):
+            args = [parsed_args]
+        if isinstance(parsed_kwargs, dict):
+            kwargs = parsed_kwargs
+
+    return AgentSession(
+        session_id=_short_id(span.span_id),
+        agent_name=span.agent_name or "Agent",
+        method_name=span.method_name or span.name or "run",
+        parent_session_id=parent_session_id,
+        start_time=span.start_time,
+        end_time=span.end_time,
+        result=_parse_jsonish(_attr(span.attributes, "agent.result") or span.output_value),
+        status="ERROR" if span.status.status_code == "ERROR" or span.error_message else "OK",
+        span_id=span.span_id,
+        method_signature=str(_attr(span.attributes, "agent.method_signature") or ""),
+        docstring=str(_attr(span.attributes, "agent.docstring") or ""),
+        file_path=str(_attr(span.attributes, "agent.file_path") or ""),
+        args=args,
+        kwargs=kwargs,
+        error_message=span.error_message,
+        strategy=_attr(span.attributes, "agent.strategy.name", "agent.strategy"),
+        call_id=str(_attr(span.attributes, "agent.call_id") or ""),
+    )
+
+
+def _session_from_chain_span(span: ChainSpan) -> AgentSession:
+    return AgentSession(
+        session_id=_short_id(span.span_id),
+        agent_name="Chain",
+        method_name=span.name or "root",
+        parent_session_id=None,
+        start_time=span.start_time,
+        end_time=span.end_time,
+        result=_parse_jsonish(span.output_value),
+        status="ERROR" if span.status.status_code == "ERROR" else "OK",
+        span_id=span.span_id,
+    )
+
+
+def _build_sessions(spans: list[TraceSpan]) -> list[AgentSession]:
+    span_by_id = {span.span_id: span for span in spans if span.span_id}
+    agent_spans = sorted(
+        [span for span in spans if isinstance(span, AgentSpan)],
+        key=lambda span: (span.start_time, span.span_id),
+    )
+
+    def nearest_agent_id(span: TraceSpan) -> str | None:
+        parent_id = span.parent_span_id
+        seen: set[str] = set()
+        while parent_id and parent_id not in seen:
+            seen.add(parent_id)
+            parent = span_by_id.get(parent_id)
+            if isinstance(parent, AgentSpan):
+                return parent.span_id
+            parent_id = parent.parent_span_id if parent else None
+        return None
+
+    if not agent_spans:
+        root_chain_spans = sorted(
+            [
+                span
+                for span in spans
+                if isinstance(span, ChainSpan) and (not span.parent_span_id or span.parent_span_id not in span_by_id)
+            ],
+            key=lambda span: (span.start_time, span.span_id),
+        )
+        if not root_chain_spans:
+            trace_id = next((span.trace_id for span in spans if span.trace_id), "trace")
+            session = AgentSession(
+                session_id=_short_id(trace_id) or "trace",
+                agent_name="Trace",
+                method_name="root",
+                parent_session_id=None,
+                start_time=min((span.start_time for span in spans if span.start_time), default=0),
+                end_time=max((span.end_time for span in spans if span.end_time), default=0),
+            )
+            session.turns = _turns_for_spans(spans, session.session_id)
+            return [session]
+
+        session_by_span_id = {span.span_id: _session_from_chain_span(span) for span in root_chain_spans}
+
+        def root_chain_id(span: TraceSpan) -> str | None:
+            parent_id = span.parent_span_id
+            root_id: str | None = None
+            seen: set[str] = set()
+            while parent_id and parent_id not in seen:
+                seen.add(parent_id)
+                parent = span_by_id.get(parent_id)
+                if isinstance(parent, ChainSpan):
+                    root_id = parent.span_id
+                parent_id = parent.parent_span_id if parent else None
+            if root_id in session_by_span_id:
+                return root_id
+            if len(session_by_span_id) == 1:
+                return next(iter(session_by_span_id))
+            return None
+
+        turn_buckets: dict[str, list[tuple[int, LLMTurn | ToolTurn]]] = {span_id: [] for span_id in session_by_span_id}
+        for span in spans:
+            if isinstance(span, (LLMSpan, ToolSpan)):
+                owner_id = root_chain_id(span)
+                if not owner_id:
+                    continue
+                turn = (
+                    _turn_from_llm_span(span, _short_id(owner_id))
+                    if isinstance(span, LLMSpan)
+                    else _turn_from_tool_span(span)
+                )
+                turn_buckets[owner_id].append((span.start_time, turn))
+
+        for span_id, bucket in turn_buckets.items():
+            session_by_span_id[span_id].turns = [turn for _, turn in sorted(bucket, key=lambda item: item[0])]
+
+        return [session_by_span_id[span.span_id] for span in root_chain_spans]
+
+    session_by_span_id: dict[str, AgentSession] = {}
+    for span in agent_spans:
+        parent_agent_id = nearest_agent_id(span)
+        parent_session_id = _short_id(parent_agent_id) if parent_agent_id else None
+        session_by_span_id[span.span_id] = _session_from_agent_span(span, parent_session_id)
+
+    roots: list[AgentSession] = []
+    for span in agent_spans:
+        session = session_by_span_id[span.span_id]
+        parent_agent_id = nearest_agent_id(span)
+        parent = session_by_span_id.get(parent_agent_id or "")
+        if parent is None:
+            roots.append(session)
+        else:
+            parent.children.append(session)
+
+    def set_depth(session: AgentSession, depth: int) -> None:
+        session.depth = depth
+        session.children.sort(key=lambda child: (child.start_time, child.session_id))
+        for child in session.children:
+            set_depth(child, depth + 1)
+
+    for root in sorted(roots, key=lambda item: (item.start_time, item.session_id)):
+        set_depth(root, 0)
+
+    turn_buckets: dict[str, list[tuple[int, LLMTurn | ToolTurn]]] = {span_id: [] for span_id in session_by_span_id}
+    for span in spans:
+        if isinstance(span, (LLMSpan, ToolSpan)):
+            owner_id = nearest_agent_id(span)
+            if not owner_id or owner_id not in turn_buckets:
+                continue
+            turn = (
+                _turn_from_llm_span(span, _short_id(owner_id))
+                if isinstance(span, LLMSpan)
+                else _turn_from_tool_span(span)
+            )
+            turn_buckets[owner_id].append((span.start_time, turn))
+
+    for span_id, bucket in turn_buckets.items():
+        session_by_span_id[span_id].turns = [turn for _, turn in sorted(bucket, key=lambda item: item[0])]
+
+    return sorted(roots, key=lambda item: (item.start_time, item.session_id))
+
+
+def _turns_for_spans(spans: list[TraceSpan], session_id: str) -> list[LLMTurn | ToolTurn]:
+    turns: list[tuple[int, LLMTurn | ToolTurn]] = []
+    for span in spans:
+        if isinstance(span, LLMSpan):
+            turns.append((span.start_time, _turn_from_llm_span(span, session_id)))
+        elif isinstance(span, ToolSpan):
+            turns.append((span.start_time, _turn_from_tool_span(span)))
+    return [turn for _, turn in sorted(turns, key=lambda item: item[0])]
+
+
+class TraceExplorer:
+    """Programmatic interface for exploring traces.
+
+    Load traces with `from_file(path)` for local JSON/JSONL, `from_intake(...)`
+    for Intake API data, or `from_spans(...)` when another adapter already
+    produced semantic spans.
+
+    Public query methods return either readable text or structured `*_data`
+    models. They operate on normalized sessions and turns, not on source-
+    specific raw span envelopes.
+
+    TraceExplorer accepts semantic OpenInference spans from any source. Source
+    adapters (`from_file`, `from_intake`, `from_spans`) produce `TraceSpan`
+    models; query methods operate only on sessions and turns derived from those
+    models.
+    """
+
+    def __init__(
+        self,
+        trace_id: str,
+        sessions: list[AgentSession],
+        eval_context: EvalContextData | None = None,
+        raw_spans: list[TraceSpan] | None = None,
+        eval_contexts: list[EvalContextData] | None = None,
+        benchmark_context: str | None = None,
+    ):
+        self.sessions = sessions
+        self.raw_spans = raw_spans or []
+        self.eval_context = eval_context or _merge_eval_contexts(eval_contexts or [])
+        self.trace_id = trace_id
+        self.benchmark_context = benchmark_context
+        self._all_sessions = _flatten_sessions(sessions)
+        self._session_by_id = {session.session_id: session for session in self._all_sessions}
+        self._span_by_id = {span.span_id: span for span in self.raw_spans if span.span_id}
+
+    @property
+    def eval_result(self) -> EvalContextData | None:
+        """Evaluation context, if provided."""
+        return self.eval_context
+
+    @property
+    def task_name(self) -> str | None:
+        """Task identifier recorded by trace or evaluator metadata."""
+        attribute_names = (
+            "nemo.test_case.id",
+            "test_case.id",
+            "task.name",
+            "task_name",
+            "task.id",
+            "task_id",
+        )
+        for span in self.raw_spans:
+            for attribute_name in attribute_names:
+                value = span.attributes.get(attribute_name)
+                if value is not None and str(value).strip():
+                    return str(value)
+
+        if self.eval_context is not None and self.eval_context.test_id:
+            return self.eval_context.test_id
+        return None
+
+    @property
+    def agent_count(self) -> int:
+        """Total number of agent sessions."""
+        return len(self._all_sessions)
+
+    @property
+    def max_agent_depth(self) -> int:
+        """Maximum session depth."""
+        return max((session.depth for session in self._all_sessions), default=0)
+
+    @classmethod
+    def from_spans(
+        cls,
+        spans: list[TraceSpan],
+        *,
+        eval_result: EvalContextData | None = None,
+        benchmark_context: str | None = None,
+        eval_contexts: list[EvalContextData] | None = None,
+        trace_id: str = "",
+    ) -> TraceExplorer:
+        """Build a TraceExplorer from already-normalized semantic spans."""
+        return cls(
+            sessions=_build_sessions(spans),
+            eval_context=eval_result,
+            raw_spans=spans,
+            eval_contexts=eval_contexts,
+            trace_id=trace_id,
+            benchmark_context=benchmark_context,
+        )
+
+    @classmethod
+    async def from_file(
+        cls,
+        trace_path: str | Path,
+        eval_result: EvalContextData | None = None,
+        benchmark_context: str | None = None,
+    ) -> TraceExplorer:
+        """Load a trace from JSON/JSONL without assuming one raw source envelope."""
+        path = Path(trace_path)
+        spans, eval_contexts = await asyncio.to_thread(_load_trace_models, path)
+        if not spans:
+            raise ValueError(f"No spans found in trace file: {path}")
+        return cls.from_spans(
+            spans,
+            eval_result=eval_result,
+            benchmark_context=benchmark_context,
+            eval_contexts=eval_contexts,
+            trace_id=str(path),
+        )
+
+    @classmethod
+    async def from_ref(
+        cls, ref: ResourceRef, client: AsyncNeMoPlatform | None = None, workspace: str | None = None
+    ) -> TraceExplorer:
+        """Load a trace from a resource reference."""
+        if ref.uri.startswith("file://"):
+            return await cls.from_file(ref.uri[len("file://") :])
+        elif ref.uri.startswith("intake://") and client is not None and workspace is not None:
+            # Trial/eval traces are stored as ``intake://traces/<id>`` (see the
+            # backend's persist path), while Eval Author traces attached to an Insight
+            # use the bare ``intake://<id>`` form. Strip both prefixes so either resolves to the
+            # raw trace id that Intake filters on.
+            trace_id = ref.uri.removeprefix("intake://").removeprefix("traces/")
+            return await cls.from_intake(client, trace_id, workspace=workspace)
+        else:
+            raise ValueError(f"Unsupported resource type: {ref.uri} or missing client/workspace")
+
+    @classmethod
+    async def from_intake(
+        cls,
+        client: AsyncNeMoPlatform,
+        trace_id: str,
+        *,
+        workspace: str,
+        page_size: int = 1000,
+        eval_result: EvalContextData | None = None,
+        benchmark_context: str | None = None,
+    ) -> TraceExplorer:
+        """Load a trace from Intake by adapting returned rows into semantic spans."""
+        spans: list[TraceSpan] = []
+        session_ids: set[str] = set()
+
+        paginator = client.intake.spans.list(
+            workspace=workspace,
+            filter=cast(Any, {"trace_id": trace_id}),
+            mode="detailed",
+            page_size=max(1, page_size),
+            sort="started_at",
+        )
+        async for item in paginator:
+            row = item.model_dump(mode="json", exclude_none=True)
+            if row.get("session_id"):
+                session_ids.add(str(row["session_id"]))
+            spans.append(_span_from_record(row))
+
+        eval_contexts = await _fetch_intake_eval_contexts(
+            client=client,
+            workspace=workspace,
+            session_ids=session_ids,
+            page_size=page_size,
+        )
+
+        if not spans:
+            raise ValueError(f"No spans found in Intake for trace: {trace_id}")
+        return cls.from_spans(
+            spans,
+            eval_result=eval_result,
+            benchmark_context=benchmark_context,
+            eval_contexts=eval_contexts,
+            trace_id=f"intake://{workspace}/{trace_id}",
+        )
+
+    async def help(self) -> str:
+        """Return API documentation."""
+        return inspect.cleandoc(self.__doc__ or "")
+
+    def _find_session(self, session_id: str) -> AgentSession | None:
+        if session_id in self._session_by_id:
+            return self._session_by_id[session_id]
+        for sid, session in self._session_by_id.items():
+            if sid.startswith(session_id) or session_id.startswith(sid):
+                return session
+        return None
+
+    def _summary(self, session: AgentSession) -> SessionSummary:
+        return SessionSummary(
+            session_id=session.session_id,
+            agent_name=session.agent_name,
+            method_name=session.method_name,
+            status=session.status,
+            turn_count=len(session.turns),
+            llm_turns=len(session.get_llm_turns()),
+            tool_turns=len(session.get_tool_turns()),
+            execution_turns=len(session.get_tool_turns()),
+            duration_ms=session.duration_ms,
+            parent_session_id=session.parent_session_id,
+            has_children=bool(session.children),
+            result_preview=_preview(session.result) if session.result is not None else None,
+        )
+
+    def _turn_info(self, session_id: str, turn_index: int, turn: LLMTurn | ToolTurn) -> TurnInfo:
+        if isinstance(turn, LLMTurn):
+            return TurnInfo(
+                session_id=session_id,
+                turn_index=turn_index,
+                turn_type="llm",
+                messages=turn.messages,
+                response=turn.response,
+                model=turn.model,
+                token_counts=turn.token_counts,
+                tool_calls=turn.tool_calls,
+                provider=turn.provider,
+                invocation_parameters=turn.invocation_parameters,
+                tools=turn.tools,
+                duration_ms=turn.duration_ms,
+                span_id=turn.span_id,
+                start_time=turn.start_time,
+                end_time=turn.end_time,
+            )
+        return TurnInfo(
+            session_id=session_id,
+            turn_index=turn_index,
+            turn_type="tool",
+            code=turn.input,
+            tool_name=turn.tool_name,
+            stdout=turn.stdout,
+            error=turn.error,
+            error_type=turn.error_type,
+            output=turn.output,
+            status=turn.status,
+            duration_ms=turn.duration_ms,
+            span_id=turn.span_id,
+            tool_call_id=turn.tool_call_id,
+            start_time=turn.start_time,
+            end_time=turn.end_time,
+        )
+
+    async def get_session_list(self) -> list[SessionSummary]:
+        """Return sessions root-first, including children."""
+        return [self._summary(session) for session in self._all_sessions]
+
+    async def get_span_id(self, session_id: str, turn_index: int) -> str | None:
+        """Return the span ID for a turn."""
+        session = self._find_session(session_id)
+        if not session or turn_index < 0 or turn_index >= len(session.turns):
+            return None
+        return session.turns[turn_index].span_id
+
+    async def get_overview_data(self) -> OverviewData | None:
+        """Return structured trace overview."""
+        if not self.sessions:
+            return None
+        total_turns = sum(len(session.turns) for session in self._all_sessions)
+        runtime_errors = sum(
+            1
+            for session in self._all_sessions
+            if session.status != "OK" or any(turn.error for turn in session.get_tool_turns())
+        )
+        root = self.sessions[0]
+        return OverviewData(
+            trace_id=self.trace_id,
+            root=RootSessionInfo(
+                agent_name=root.agent_name,
+                method_name=root.method_name,
+                session_id=root.session_id,
+            ),
+            stats=OverviewStats(
+                duration_ms=sum(session.duration_ms for session in self._all_sessions),
+                session_count=len(self._all_sessions),
+                turn_count=total_turns,
+                runtime_errors=runtime_errors,
+                eval_passed=self.eval_context.passed if self.eval_context else None,
+            ),
+            sessions=[self._summary(session) for session in self._all_sessions],
+            call_graph=[
+                {
+                    "session_id": session.session_id,
+                    "full_name": session.full_name,
+                    "depth": session.depth,
+                    "status": session.status,
+                    "turn_count": len(session.turns),
+                    "duration_ms": session.duration_ms,
+                    "parent_session_id": session.parent_session_id,
+                }
+                for session in self._all_sessions
+            ],
+            eval_result=self.eval_context,
+            benchmark_context=self.benchmark_context,
+        )
+
+    async def get_overview(self, *, concise: bool = True) -> str:
+        """Return readable high-level trace overview."""
+        del concise
+        data = await self.get_overview_data()
+        if data is None:
+            return "No sessions found in trace."
+        lines = [
+            f"# {data.root.agent_name}.{data.root.method_name}()",
+            "",
+            (
+                f"Duration: {data.stats.duration_ms:.1f}ms | Sessions: {data.stats.session_count} | "
+                f"Turns: {data.stats.turn_count} | Runtime Errors: {data.stats.runtime_errors}"
+            ),
+            "",
+            "## Call Graph",
+        ]
+        for session in self._all_sessions:
+            indent = "  " * session.depth
+            lines.append(
+                f"{indent}- [{session.session_id}] {session.full_name} "
+                f"{len(session.turns)}t {session.duration_ms:.1f}ms [{session.status}]"
+            )
+        return "\n".join(lines)
+
+    async def get_session_data(self, session_id: str) -> SessionData:
+        """Return structured session detail."""
+        session = self._find_session(session_id)
+        if not session:
+            raise ValueError(f"Session '{session_id}' not found.")
+        return SessionData(
+            session=self._summary(session),
+            turns=[self._turn_info(session.session_id, idx, turn) for idx, turn in enumerate(session.turns)],
+        )
+
+    async def get_session(self, session_id: str, *, concise: bool = False) -> str:
+        """Return readable session detail."""
+        session = self._find_session(session_id)
+        if not session:
+            return f"Session '{session_id}' not found. Use get_overview() to see available sessions."
+        lines = [
+            f"# {session.full_name} [{session.session_id}]",
+            f"Status: {session.status} | Turns: {len(session.turns)} | Duration: {session.duration_ms:.1f}ms",
+        ]
+        if session.result is not None:
+            lines.append(f"Result: {_preview(session.result, 500 if not concise else 160)}")
+        if session.error_message:
+            lines.append(f"Error: {session.error_message}")
+        lines.append("")
+        lines.append("## Turns")
+        for idx, turn in enumerate(session.turns):
+            if isinstance(turn, LLMTurn):
+                tool_names = ", ".join(call.function_name for call in turn.tool_calls)
+                suffix = f" -> {tool_names}" if tool_names else ""
+                lines.append(f"- {idx}: LLM {len(turn.messages)} messages{suffix}")
+            else:
+                lines.append(f"- {idx}: TOOL {turn.tool_name} [{turn.status}]")
+        return "\n".join(lines)
+
+    async def get_turn_data(self, session_id: str, turn_index: int) -> TurnInfo | None:
+        """Return structured turn data."""
+        session = self._find_session(session_id)
+        if not session or turn_index < 0 or turn_index >= len(session.turns):
+            return None
+        return self._turn_info(session.session_id, turn_index, session.turns[turn_index])
+
+    async def get_turn(self, session_id: str, turn_index: int) -> str:
+        """Return readable turn detail."""
+        info = await self.get_turn_data(session_id, turn_index)
+        if info is None:
+            session = self._find_session(session_id)
+            size = len(session.turns) if session else 0
+            return f"Turn index {turn_index} out of range (session has {size} turns)"
+        if info.turn_type == "llm":
+            lines = [f"# Turn {turn_index}: LLM", ""]
+            for idx, message in enumerate(info.messages or []):
+                lines.append(f"## Message {idx}: {message.role}")
+                lines.append(message.content)
+                for call in message.tool_calls:
+                    lines.append(f"TOOL CALL {call.function_name}: {call.arguments}")
+            if info.response:
+                lines.extend(["", "## Response", info.response])
+            if info.tool_calls:
+                lines.append("")
+                lines.append("## Tool Calls")
+                for call in info.tool_calls:
+                    lines.append(f"- {call.function_name}: {call.arguments}")
+            return "\n".join(lines)
+        lines = [f"# Turn {turn_index}: Tool", f"Tool input: {info.code or ''}"]
+        if info.stdout:
+            lines.extend(["", "## Stdout", info.stdout])
+        if info.output is not None:
+            lines.extend(["", "## Output", _json_text(info.output)])
+        if info.error:
+            lines.extend(["", "## Error", info.error])
+        return "\n".join(lines)
+
+    async def get_errors_data(self) -> dict[str, Any]:
+        """Return structured errors."""
+        errors: list[dict[str, Any]] = []
+        for session in self._all_sessions:
+            if session.status != "OK" or session.error_message:
+                errors.append(
+                    {
+                        "session_id": session.session_id,
+                        "turn_index": None,
+                        "error_message": session.error_message or session.status,
+                        "context": session.full_name,
+                    }
+                )
+            for idx, turn in enumerate(session.turns):
+                if isinstance(turn, ToolTurn) and turn.error:
+                    errors.append(
+                        {
+                            "session_id": session.session_id,
+                            "turn_index": idx,
+                            "error_type": turn.error_type,
+                            "error_message": turn.error,
+                            "context": turn.tool_name,
+                        }
+                    )
+        return {"count": len(errors), "errors": errors}
+
+    async def get_errors(self) -> str:
+        """Return readable errors."""
+        data = await self.get_errors_data()
+        if data["count"] == 0:
+            return "No errors found in trace."
+        lines = [f"Found {data['count']} error(s):", ""]
+        for error in data["errors"]:
+            turn = "" if error["turn_index"] is None else f" turn {error['turn_index']}"
+            lines.append(f"- [{error['session_id']}]{turn}: {error['error_message']}")
+        return "\n".join(lines)
+
+    async def get_eval_context(self, concise: bool = True) -> str:
+        """Return eval context if available."""
+        del concise
+        if not self.eval_context:
+            return "No evaluation result provided."
+        return json.dumps(self.eval_context.model_dump(), indent=2, default=str)
+
+    async def get_eval_context_data(self) -> dict[str, Any]:
+        """Return structured eval context."""
+        if not self.eval_context:
+            return {"error": "No evaluation result provided."}
+        return {
+            "eval_result": self.eval_context,
+            "benchmark_context": self.benchmark_context,
+        }
+
+    def _search_turn(self, pattern: str) -> list[SearchResult]:
+        if not pattern or len(pattern) > 256:
+            return []
+        regex = re.compile(re.escape(pattern), re.IGNORECASE)
+        results: list[SearchResult] = []
+        for session in self._all_sessions:
+            for idx, turn in enumerate(session.turns):
+                fields: list[tuple[str, str]] = []
+                if isinstance(turn, LLMTurn):
+                    fields.extend((f"message[{msg.role}]", msg.content) for msg in turn.messages)
+                    fields.append(("response", turn.response))
+                    fields.extend((f"tool_call[{call.function_name}]", call.arguments) for call in turn.tool_calls)
+                    turn_type = "llm"
+                else:
+                    fields.extend(
+                        [
+                            ("tool_input", turn.input),
+                            ("stdout", turn.stdout),
+                            ("output", _json_text(turn.output)),
+                            ("error", turn.error or ""),
+                        ]
+                    )
+                    turn_type = "tool"
+                for location, text in fields:
+                    for match in regex.finditer(text or ""):
+                        start = max(0, match.start() - 40)
+                        end = min(len(text), match.end() + 40)
+                        results.append(
+                            SearchResult(
+                                session_id=session.session_id,
+                                turn_index=idx,
+                                turn_type=turn_type,
+                                location=location,
+                                match_text=text[start:end],
+                            )
+                        )
+        return results
+
+    async def search_data(self, pattern: str) -> SearchMatches:
+        """Search trace content and return structured matches."""
+        matches = self._search_turn(pattern)
+        counts = Counter(match.location for match in matches)
+        return SearchMatches(
+            pattern=pattern,
+            match_count=len(matches),
+            matches=matches,
+            by_location=dict(counts),
+        )
+
+    async def search(self, pattern: str, *, concise: bool = True) -> str:
+        """Search trace content."""
+        del concise
+        data = await self.search_data(pattern)
+        if not data.matches:
+            return f"No matches found for pattern: {pattern}"
+        lines = [f"Found {data.match_count} match(es) for '{pattern}':", ""]
+        for match in data.matches[:20]:
+            lines.append(
+                f"- [{match.session_id} t{match.turn_index}] {match.location}: {_preview(match.match_text, 120)}"
+            )
+        if data.match_count > 20:
+            lines.append(f"... and {data.match_count - 20} more matches")
+        return "\n".join(lines)
+
+    async def get_turn_context(
+        self,
+        session_id: str,
+        turn_index: int,
+        max_length: int | None = None,
+        include_system: bool = False,
+    ) -> str:
+        """Return message context for an LLM turn."""
+        session = self._find_session(session_id)
+        if not session or turn_index < 0 or turn_index >= len(session.turns):
+            return ""
+        turn = session.turns[turn_index]
+        if not isinstance(turn, LLMTurn):
+            return ""
+        parts = [message.content for message in turn.messages if include_system or message.role.lower() != "system"]
+        text = "\n".join(parts)
+        return f"{text[:max_length]}... [truncated]" if max_length and len(text) > max_length else text
+
+    async def search_in_turn_context(
+        self,
+        session_id: str,
+        turn_index: int,
+        pattern: str,
+        max_matches: int = 10,
+        include_system: bool = False,
+    ) -> list[SearchResult]:
+        """Search inside one turn context."""
+        context = await self.get_turn_context(session_id, turn_index, include_system=include_system)
+        if not context or not pattern or len(pattern) > 256:
+            return []
+        regex = re.compile(re.escape(pattern), re.IGNORECASE)
+        matches: list[SearchResult] = []
+        for match in regex.finditer(context):
+            if len(matches) >= max_matches:
+                break
+            start = max(0, match.start() - 40)
+            end = min(len(context), match.end() + 40)
+            matches.append(
+                SearchResult(
+                    session_id=session_id,
+                    turn_index=turn_index,
+                    turn_type="llm",
+                    location="context",
+                    match_text=context[start:end],
+                )
+            )
+        return matches
+
+    async def get_method_counts(self) -> dict[str, int]:
+        """Return invocation count per method."""
+        return dict(Counter(session.full_name for session in self._all_sessions))
+
+    async def get_recursion_pattern(self) -> str:
+        """Return high-level method involvement description."""
+        counts = await self.get_method_counts()
+        if not counts:
+            return "no agent calls"
+        repeated = [name for name, count in counts.items() if count > 1]
+        if repeated:
+            return f"repeated method calls ({', '.join(repeated)})"
+        if len(counts) == 1:
+            return f"single method ({next(iter(counts))})"
+        return f"{len(counts)} methods involved"
+
+    async def get_timeline_data(self, max_events: int = 50) -> TimelineData:
+        """Return chronological span/session event timeline."""
+        events: list[TimelineEvent] = []
+        for session in self._all_sessions:
+            events.append(
+                TimelineEvent(
+                    time_ns=session.start_time,
+                    span_id=session.span_id,
+                    event_type="AGENT_START",
+                    summary=session.full_name,
+                )
+            )
+            for idx, turn in enumerate(session.turns):
+                if isinstance(turn, LLMTurn):
+                    events.append(
+                        TimelineEvent(
+                            time_ns=turn.start_time or session.start_time + idx,
+                            span_id=turn.span_id,
+                            event_type="LLM",
+                            summary=f"{len(turn.messages)} messages",
+                        )
+                    )
+                else:
+                    events.append(
+                        TimelineEvent(
+                            time_ns=turn.start_time or session.start_time + idx,
+                            span_id=turn.span_id,
+                            event_type="TOOL",
+                            summary=f"{turn.tool_name} [{turn.status}]",
+                        )
+                    )
+            events.append(
+                TimelineEvent(
+                    time_ns=session.end_time,
+                    span_id=session.span_id,
+                    event_type="AGENT_END",
+                    summary=session.status,
+                )
+            )
+        events.sort(key=lambda event: (event.time_ns, event.span_id))
+        return TimelineData(total_events=len(events), max_events=max_events, events=events[:max_events])
+
+    async def get_timeline(self, max_events: int = 50) -> str:
+        """Return readable chronological timeline."""
+        data = await self.get_timeline_data(max_events=max_events)
+        lines = ["# Timeline", ""]
+        for event in data.events:
+            lines.append(f"[{_short_id(event.span_id)}] {event.event_type}: {event.summary}")
+        if data.total_events > len(data.events):
+            lines.append(f"... ({data.total_events - len(data.events)} more events)")
+        return "\n".join(lines)
+
+    async def find_first_error_data(self) -> dict[str, Any]:
+        """Return first error by timeline order."""
+        errors = (await self.get_errors_data())["errors"]
+        if not errors:
+            return {"error": "No errors found in trace."}
+        return errors[0]
+
+    async def find_first_error(self) -> str:
+        """Return first error."""
+        error = await self.find_first_error_data()
+        if "error" in error and len(error) == 1:
+            return error["error"]
+        return json.dumps(error, indent=2, default=str)
+
+    def _session_span_ids(self, session: AgentSession) -> set[str]:
+        """Return the session span and all descendants by parent relationship."""
+        span_ids = {session.span_id} if session.span_id else set()
+        span_ids.update(turn.span_id for turn in session.turns if turn.span_id)
+        changed = True
+        while changed:
+            changed = False
+            for span in self.raw_spans:
+                if span.parent_span_id in span_ids and span.span_id not in span_ids:
+                    span_ids.add(span.span_id)
+                    changed = True
+        return span_ids
+
+    async def get_harness_telemetry_data(self, session_id: str | None = None) -> dict[str, Any]:
+        """Return any harness telemetry attributes exposed by spans.
+
+        This method intentionally treats harness telemetry as optional
+        key-value data. It does not require a specific span name or runtime
+        package.
+        """
+        title = "Harness Telemetry (all sessions)"
+        spans = self.raw_spans
+        if session_id:
+            session = self._find_session(session_id)
+            if not session:
+                return {"error": f"Session not found: {session_id}"}
+            title = f"Harness Telemetry for session {session.session_id}"
+            span_ids = self._session_span_ids(session)
+            spans = [span for span in self.raw_spans if span.span_id in span_ids]
+
+        merged: dict[str, Any] = {}
+        prefill_type = ""
+        for span in spans:
+            for key, value in span.attributes.items():
+                if not key.startswith("harness."):
+                    continue
+                if key == "harness.prefill_type":
+                    prefill_type = str(value)
+                    continue
+                if key not in merged:
+                    merged[key] = value
+                    continue
+                existing = merged[key]
+                if isinstance(existing, int) and isinstance(value, int):
+                    merged[key] = existing + value
+                elif isinstance(existing, list) and isinstance(value, list):
+                    merged[key] = existing + value
+                elif existing != value:
+                    values = existing if isinstance(existing, list) else [existing]
+                    values.append(value)
+                    merged[key] = values
+
+        return {"title": title, "metrics": merged, "prefill_type": prefill_type}
+
+    async def get_harness_telemetry(self, session_id: str | None = None) -> str:
+        """Return readable harness telemetry, if the trace includes it."""
+        data = await self.get_harness_telemetry_data(session_id)
+        if "error" in data:
+            return str(data["error"])
+        title = str(data.get("title") or "Harness Telemetry")
+        metrics = data.get("metrics", {})
+        lines = [title, "-" * len(title), ""]
+        if not metrics:
+            lines.append("(no harness telemetry found)")
+            return "\n".join(lines)
+        for key, value in sorted(metrics.items()):
+            lines.append(f"{key}: {_preview(value, 240)}")
+        if data.get("prefill_type"):
+            lines.append(f"harness.prefill_type: {data['prefill_type']}")
+        return "\n".join(lines)
+
+    async def find_span(self, span_id: str, *, json_output: bool = False) -> str:
+        """Find a span by ID or prefix and show where it appears."""
+        for session in self._all_sessions:
+            for idx, turn in enumerate(session.turns):
+                if turn.span_id and (turn.span_id == span_id or turn.span_id.startswith(span_id)):
+                    turn_data = await self.get_turn_data(session.session_id, idx)
+                    if json_output:
+                        payload = {
+                            "span_id": turn.span_id,
+                            "session_id": session.session_id,
+                            "agent": session.full_name,
+                            "turn_index": idx,
+                            "turn_count": len(session.turns),
+                            "turn": turn_data.model_dump(mode="json") if turn_data else None,
+                        }
+                        return json.dumps(payload, indent=2, default=str)
+                    header = (
+                        f"# Span {_short_id(turn.span_id)} -> session {session.session_id} "
+                        f"({session.full_name}), turn {idx} of {len(session.turns)}"
+                    )
+                    return f"{header}\n\n{await self.get_turn(session.session_id, idx)}"
+
+        raw = await self.get_raw_span_data(span_id)
+        if "error" in raw:
+            return f"Span {span_id} not found in any session or raw spans."
+        if json_output:
+            return json.dumps(raw, indent=2, default=str)
+        return f"# Span {_short_id(str(raw.get('span_id')))} (raw)\n\n{json.dumps(raw, indent=2, default=str)}"
+
+    async def compare(self, other: TraceExplorer) -> str:
+        """Compare this trace with another trace."""
+        return await TraceExplorer.diff(self, other)
+
+    async def compare_data(self, other: TraceExplorer) -> dict[str, Any]:
+        """Return structured comparison data for this trace and another trace."""
+        return await TraceExplorer.diff_data(self, other)
+
+    @staticmethod
+    def _turn_type(turn: LLMTurn | ToolTurn) -> str:
+        return "llm" if isinstance(turn, LLMTurn) else "tool"
+
+    @staticmethod
+    def _turn_brief(turn: LLMTurn | ToolTurn) -> dict[str, Any]:
+        if isinstance(turn, LLMTurn):
+            return {
+                "type": "llm",
+                "model": turn.model,
+                "message_count": len(turn.messages),
+                "tool_calls": [call.function_name for call in turn.tool_calls],
+                "span_id": turn.span_id,
+            }
+        return {
+            "type": "tool",
+            "tool_name": turn.tool_name,
+            "status": turn.status,
+            "has_error": bool(turn.error),
+            "span_id": turn.span_id,
+        }
+
+    @classmethod
+    def _find_prompt_diffs(cls, turn1: LLMTurn, turn2: LLMTurn) -> list[str]:
+        """Find prompt-level differences between two LLM turns."""
+
+        def extract_expr_paths(messages: list[LLMMessage]) -> dict[str, set[str]]:
+            paths: dict[str, set[str]] = {}
+            for message in messages:
+                for match in re.finditer(r"<(\w+)[^>]*\bexpr=\"([^\"]+)\"", message.content):
+                    paths.setdefault(match.group(1), set()).add(match.group(2))
+            return paths
+
+        diffs: list[str] = []
+        paths1 = extract_expr_paths(turn1.messages)
+        paths2 = extract_expr_paths(turn2.messages)
+        for tag in sorted(set(paths1) | set(paths2)):
+            left = paths1.get(tag, set())
+            right = paths2.get(tag, set())
+            if left and right:
+                if left != right:
+                    diffs.append(f"`<{tag}>` expr differs: {sorted(left)} vs {sorted(right)}")
+            elif left:
+                diffs.append(f"`<{tag}>` present in trace 1 only")
+            elif right:
+                diffs.append(f"`<{tag}>` present in trace 2 only")
+        if len(turn1.messages) != len(turn2.messages):
+            diffs.append(f"message count differs: {len(turn1.messages)} vs {len(turn2.messages)}")
+        return diffs
+
+    @classmethod
+    def _turn_differences(cls, turn1: LLMTurn | ToolTurn, turn2: LLMTurn | ToolTurn) -> list[str]:
+        diffs: list[str] = []
+        if cls._turn_type(turn1) != cls._turn_type(turn2):
+            return [f"turn type differs: {cls._turn_type(turn1)} vs {cls._turn_type(turn2)}"]
+        if isinstance(turn1, LLMTurn) and isinstance(turn2, LLMTurn):
+            if turn1.model != turn2.model:
+                diffs.append(f"model differs: {turn1.model!r} vs {turn2.model!r}")
+            calls1 = [call.function_name for call in turn1.tool_calls]
+            calls2 = [call.function_name for call in turn2.tool_calls]
+            if calls1 != calls2:
+                diffs.append(f"tool calls differ: {calls1} vs {calls2}")
+            diffs.extend(cls._find_prompt_diffs(turn1, turn2))
+            return diffs
+        if isinstance(turn1, ToolTurn) and isinstance(turn2, ToolTurn):
+            if turn1.tool_name != turn2.tool_name:
+                diffs.append(f"tool differs: {turn1.tool_name!r} vs {turn2.tool_name!r}")
+            if turn1.status != turn2.status:
+                diffs.append(f"status differs: {turn1.status} vs {turn2.status}")
+            if bool(turn1.error) != bool(turn2.error):
+                diffs.append("error presence differs")
+        return diffs
+
+    @classmethod
+    def _matched_sessions(
+        cls, trace1: TraceExplorer, trace2: TraceExplorer
+    ) -> list[tuple[AgentSession | None, AgentSession | None]]:
+        by_name1: dict[str, list[AgentSession]] = {}
+        by_name2: dict[str, list[AgentSession]] = {}
+        for session in trace1._all_sessions:
+            by_name1.setdefault(session.full_name, []).append(session)
+        for session in trace2._all_sessions:
+            by_name2.setdefault(session.full_name, []).append(session)
+
+        pairs: list[tuple[AgentSession | None, AgentSession | None]] = []
+        for name in sorted(set(by_name1) | set(by_name2)):
+            left = by_name1.get(name, [])
+            right = by_name2.get(name, [])
+            for index in range(max(len(left), len(right))):
+                pairs.append(
+                    (
+                        left[index] if index < len(left) else None,
+                        right[index] if index < len(right) else None,
+                    )
+                )
+        return pairs
+
+    @classmethod
+    def _collect_prompt_expr_diffs(
+        cls,
+        matched_pairs: list[tuple[AgentSession | None, AgentSession | None]],
+    ) -> list[dict[str, Any]]:
+        diffs: list[dict[str, Any]] = []
+        for session1, session2 in matched_pairs:
+            if not session1 or not session2:
+                continue
+            for idx, (turn1, turn2) in enumerate(zip(session1.turns, session2.turns, strict=False)):
+                if isinstance(turn1, LLMTurn) and isinstance(turn2, LLMTurn):
+                    for diff in cls._find_prompt_diffs(turn1, turn2):
+                        diffs.append(
+                            {
+                                "session": session1.full_name,
+                                "session_id_1": session1.session_id,
+                                "session_id_2": session2.session_id,
+                                "turn_index": idx,
+                                "diff": diff,
+                            }
+                        )
+        return diffs
+
+    @classmethod
+    async def diff_data(cls, trace1: TraceExplorer, trace2: TraceExplorer) -> dict[str, Any]:
+        """Return structured comparison data for two traces."""
+        pairs = cls._matched_sessions(trace1, trace2)
+        turn_differences: list[dict[str, Any]] = []
+        missing_sessions: list[dict[str, Any]] = []
+
+        for session1, session2 in pairs:
+            if session1 is None and session2 is not None:
+                missing_sessions.append({"trace": 1, "session": session2.full_name})
+                continue
+            if session2 is None and session1 is not None:
+                missing_sessions.append({"trace": 2, "session": session1.full_name})
+                continue
+            if session1 is None or session2 is None:
+                continue
+            if len(session1.turns) != len(session2.turns):
+                turn_differences.append(
+                    {
+                        "session": session1.full_name,
+                        "session_id_1": session1.session_id,
+                        "session_id_2": session2.session_id,
+                        "kind": "turn_count",
+                        "trace_1": len(session1.turns),
+                        "trace_2": len(session2.turns),
+                    }
+                )
+            for idx, (turn1, turn2) in enumerate(zip(session1.turns, session2.turns, strict=False)):
+                diffs = cls._turn_differences(turn1, turn2)
+                if diffs:
+                    turn_differences.append(
+                        {
+                            "session": session1.full_name,
+                            "session_id_1": session1.session_id,
+                            "session_id_2": session2.session_id,
+                            "turn_index": idx,
+                            "differences": diffs,
+                            "trace_1": cls._turn_brief(turn1),
+                            "trace_2": cls._turn_brief(turn2),
+                        }
+                    )
+
+        prompt_differences = cls._collect_prompt_expr_diffs(pairs)
+        summary = {
+            "file_1": Path(trace1.trace_id).name or trace1.trace_id or "(memory)",
+            "file_2": Path(trace2.trace_id).name or trace2.trace_id or "(memory)",
+            "sessions_1": len(trace1._all_sessions),
+            "sessions_2": len(trace2._all_sessions),
+            "total_turns_1": sum(len(session.turns) for session in trace1._all_sessions),
+            "total_turns_2": sum(len(session.turns) for session in trace2._all_sessions),
+            "status_1": "ERROR" if (await trace1.get_errors_data())["count"] else "OK",
+            "status_2": "ERROR" if (await trace2.get_errors_data())["count"] else "OK",
+            "eval_1": trace1.eval_context.passed if trace1.eval_context else None,
+            "eval_2": trace2.eval_context.passed if trace2.eval_context else None,
+        }
+        return {
+            "summary": summary,
+            "equivalent": not missing_sessions and not turn_differences,
+            "missing_sessions": missing_sessions,
+            "turn_differences": turn_differences,
+            "prompt_expression_differences": prompt_differences,
+            "call_graphs": {
+                "trace_1": [
+                    {
+                        **trace1._summary(session).model_dump(mode="json"),
+                        "full_name": session.full_name,
+                        "depth": session.depth,
+                    }
+                    for session in trace1._all_sessions
+                ],
+                "trace_2": [
+                    {
+                        **trace2._summary(session).model_dump(mode="json"),
+                        "full_name": session.full_name,
+                        "depth": session.depth,
+                    }
+                    for session in trace2._all_sessions
+                ],
+            },
+            "first_difference": (missing_sessions or turn_differences or [None])[0],
+        }
+
+    @classmethod
+    async def diff(cls, trace1: TraceExplorer, trace2: TraceExplorer) -> str:
+        """Return a readable diff report for two traces."""
+        data = await cls.diff_data(trace1, trace2)
+        summary = data["summary"]
+        lines = [
+            "# Trace Comparison",
+            "",
+            "## Summary",
+            "",
+            "| Metric | Trace 1 | Trace 2 |",
+            "|--------|---------|---------|",
+            f"| File | {summary['file_1']} | {summary['file_2']} |",
+            f"| Sessions | {summary['sessions_1']} | {summary['sessions_2']} |",
+            f"| Total Turns | {summary['total_turns_1']} | {summary['total_turns_2']} |",
+            f"| Status | {summary['status_1']} | {summary['status_2']} |",
+            f"| Eval | {summary['eval_1']} | {summary['eval_2']} |",
+            "",
+            "## Call Graphs",
+            "",
+            "### Trace 1",
+        ]
+        for item in data["call_graphs"]["trace_1"]:
+            lines.append(f"{'  ' * item['depth']}- {item['full_name']} ({item['turn_count']} turns, {item['status']})")
+        lines.extend(["", "### Trace 2"])
+        for item in data["call_graphs"]["trace_2"]:
+            lines.append(f"{'  ' * item['depth']}- {item['full_name']} ({item['turn_count']} turns, {item['status']})")
+
+        lines.extend(["", "## Differences"])
+        if data["equivalent"]:
+            lines.append("No structural differences found.")
+        for missing in data["missing_sessions"]:
+            lines.append(f"- Missing in trace {missing['trace']}: {missing['session']}")
+        for diff in data["turn_differences"][:20]:
+            if diff.get("kind") == "turn_count":
+                lines.append(f"- {diff['session']}: turn count {diff['trace_1']} vs {diff['trace_2']}")
+            else:
+                lines.append(f"- {diff['session']} turn {diff['turn_index']}: {'; '.join(diff['differences'])}")
+        if len(data["turn_differences"]) > 20:
+            lines.append(f"... and {len(data['turn_differences']) - 20} more turn differences")
+        return "\n".join(lines)
+
+    async def get_raw_span_data(self, span_id: str) -> dict[str, Any]:
+        """Return raw semantic span data."""
+        for sid, span in self._span_by_id.items():
+            if sid == span_id or sid.startswith(span_id):
+                return span.model_dump(mode="json")
+        return {"error": f"No span found matching '{span_id}'"}
+
+    async def get_raw_span(self, span_id: str) -> str:
+        """Return readable raw semantic span JSON."""
+        data = await self.get_raw_span_data(span_id)
+        if "error" in data:
+            return data["error"]
+        return json.dumps(data, indent=2, default=str)
+
+    async def get_raw_spans(self, session_id: str) -> str:
+        """Return raw spans associated with a session subtree."""
+        session = self._find_session(session_id)
+        if not session:
+            return f"Session not found: {session_id}"
+        span_ids = {session.span_id}
+        changed = True
+        while changed:
+            changed = False
+            for span in self.raw_spans:
+                if span.parent_span_id in span_ids and span.span_id not in span_ids:
+                    span_ids.add(span.span_id)
+                    changed = True
+        spans = [span.model_dump(mode="json") for span in self.raw_spans if span.span_id in span_ids]
+        return json.dumps(spans, indent=2, default=str)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_scorer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_scorer.py
@@ -115,9 +115,11 @@ class GroupLeafScorer(Agent):
         - "trace shows the agent covered the required domains"
 
         Also populate `span_ids` with the IDs of the spans that contain the key evidence you cited.
-        Span IDs MUST be retrieved from TraceExplorer (e.g. `await explorer.get_spans()`) and
-        copied verbatim from the returned objects — never abbreviated, guessed, or constructed from
-        the overview text.  Include only spans that directly support the score — not every span.
+        Span IDs MUST be retrieved from TraceExplorer — `await explorer.get_span_id(session_id, turn_index)`
+        for a single turn, or `await explorer.get_turn_data(session_id, turn_index)` when you also need
+        the turn's contents — and copied verbatim from the returned values, never abbreviated, guessed,
+        or constructed from the overview text.  Include only spans that directly support the score —
+        not every span.
 
         Returns:
             dict[str, GroupLeafScore]: scores indexed by agent ID; each entry includes a numeric

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_scorer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_scorer.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import Dataset, TrialResult
+from nemo_platform import AsyncNeMoPlatform
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.agentdoc import doc
+from nooa.config import CodeActConfig
+from pydantic import BaseModel, Field
+
+from .goal_tree import GoalNode
+from .model_config import get_mid_model
+from .trace_explorer import TraceExplorer  # noqa: F401
+
+logger = logging.getLogger(__name__)
+
+
+class GroupLeafScore(BaseModel):
+    """A numeric score and qualitative reason for a single agent on a goal-tree leaf."""
+
+    score: float = Field(ge=0.0, le=1.0)
+    reason: str
+    span_ids: list[str] = Field(
+        default_factory=list,
+        description="Span IDs from the trace that contain the key evidence cited in `reason`.",
+    )
+
+
+class GroupLeafScorer(Agent):
+    """Score a group of agent traces against a goal-tree leaf node."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        llm: Any | None = None,
+        client: AsyncNeMoPlatform | None = None,
+        nmp_workspace: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the scorer for the given workspace.
+
+        Args:
+            workspace: Path to the workspace directory.
+            llm: Language model instance; defaults to mid-tier model selection.
+            client: NeMo Platform client; required to load ``intake://`` traces.
+            nmp_workspace: NeMo Platform workspace name; required to load ``intake://`` traces.
+            **kwargs: Additional arguments passed to parent Agent class.
+
+        Raises:
+            ValueError: if workspace does not exist or is invalid.
+
+        """
+        super().__init__(llm=llm or get_mid_model(), **kwargs)
+        self.workspace = workspace
+        self._client = client
+        self._nmp_workspace = nmp_workspace
+        self.context["trace_explorer_documentation"] = doc(TraceExplorer)
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=15, cell_timeout=120.0)))
+    async def run(
+        self,
+        node: GoalNode,
+        trials: dict[str, TrialResult],
+        dataset: Dataset,
+    ) -> dict[str, GroupLeafScore]:  # pyright: ignore[reportReturnType]
+        """Compute the relative group advantage score for a group of traces coming from different agents for a given node.
+        All scores must be strictly ordered: score_a < score_b < ... < score_n (no ties).
+
+        Args:
+            node: The node to score. Contains the goal description and the expected output.
+            trials: Trials to score.  Each TrialResult carries a ``trace`` reference and a
+                ``metrics`` dict populated by the task evaluator (e.g. ``{"score": 0.82}``).
+                Metrics reflect overall task success — do NOT use them for scoring.
+            dataset: The dataset to score.
+
+        ## Loading traces
+
+        Load each trace with
+        `await TraceExplorer.from_ref(trial.trace, self._client, self._nmp_workspace)`.
+        If the trace is not available, skip the trial.
+
+        Use TraceExplorer to inspect the full span hierarchy: sessions, turns, LLM messages, tool
+        calls, code execution outputs, sub-agent spans, errors, and observations.
+        All TraceExplorer query methods are async — await them.
+        Descend into sub-agent spans; key evidence is often buried inside nested agents, not in the root span.
+
+        ## Scoring against the goal node
+
+        Score each agent *exclusively* on how well its trace satisfies `node.goal`.
+        Do NOT use `trial.metrics` to determine or adjust scores — `TrialResult.metrics`
+        are task-level outcome signals, not node-level evidence.  Never mention metric values
+        in reasoning as justification for a score.
+
+        Apply proportional partial credit:
+        - Agent performs all required steps correctly → 0.8–1.0
+        - Agent performs most steps correctly but fails or skips one key requirement → 0.5–0.7
+        - Agent attempts the right approach but with significant errors that undermine the goal → 0.2–0.4
+        - Agent does not address the goal or uses a fundamentally wrong approach → 0.0–0.2
+
+        ## Writing reasons and grounding span IDs
+
+        Each reason must cite specific evidence observed in the trace — exact function names, tool outputs,
+        quoted values, or code snippets that directly relate to `node.goal`.  Generic descriptions
+        ("the agent tried X") are not sufficient.  Good examples:
+        - "trace shows readUInt32BE at offset 24 → 0x400520, matching ELF e_entry"
+        - "grepped /app/morpheus for ImageMath imports, found zero matches in source files"
+        - "WritingAgent output lists five domains: daily life, workplace, marriage, parenting, emotional well-being"
+
+        Bad (insufficient):
+        - "the agent verified the package version"
+        - "trace shows the agent covered the required domains"
+
+        Also populate `span_ids` with the IDs of the spans that contain the key evidence you cited.
+        Span IDs MUST be retrieved from TraceExplorer (e.g. `await explorer.get_spans()`) and
+        copied verbatim from the returned objects — never abbreviated, guessed, or constructed from
+        the overview text.  Include only spans that directly support the score — not every span.
+
+        Returns:
+            dict[str, GroupLeafScore]: scores indexed by agent ID; each entry includes a numeric
+            score, a reason citing specific trace evidence, and the span IDs that ground the reason.
+        """
+        explorers: dict[str, TraceExplorer] = {}
+        for agent_id, trial in trials.items():
+            if not trial.trace:
+                continue
+            explorer = await TraceExplorer.from_ref(trial.trace, self._client, self._nmp_workspace)
+            explorers[agent_id] = explorer
+            print(f"Agent {agent_id} trace overview:")
+            print(await explorer.get_overview())
+            print(await explorer.get_errors())
+        ...

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/util.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/util.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from nooa import TextSkill
+from nooa.skill_registry import SkillRegistry
+
+
+def load_framework_skills(registry: SkillRegistry, dirs: list[Path]) -> None:
+    """Register TextSkills from user-provided framework skill directories."""
+    for skill_dir in dirs:
+        if not skill_dir.is_dir():
+            continue
+        if (skill_dir / "SKILL.md").exists() or (skill_dir / "skill.md").exists():
+            skill = TextSkill(path=skill_dir)
+            registry.register(f"ext.{skill.id}", skill)
+    registry.load(["cmd.*", "ext.*"])
+    registry.activate(["cmd.*", "ext.*"])

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/deps.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/deps.py
@@ -12,13 +12,13 @@ coordinates.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import EvaluatorType
 from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
 from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import (
     ExperimentalistBackend,
 )
+from nemo_experimentalist_plugin.resolve import EvolutionaryOptimizerConfig
 from pydantic import BaseModel, model_validator
 
 
@@ -56,7 +56,7 @@ class ExperimentalistDeps(BaseModel):
     evaluator_type: EvaluatorType = "harbor"
     agent_spec: str | None = None
     backend: ExperimentalistBackend | None = None
-    config: Any = None  # EvolutionaryOptimizerConfig | None, avoids circular import
+    config: EvolutionaryOptimizerConfig | None = None
 
     @model_validator(mode="after")
     def _require_insight_or_agent(self) -> ExperimentalistDeps:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/deps.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/deps.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run-time dependencies injected into every Experimentalist tool call.
+
+A single :class:`ExperimentalistDeps` instance carries the resolved run
+configuration through the Experimentalist loop. Keeping it in its own module
+avoids an import cycle between the agent definition and the components it
+coordinates.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import EvaluatorType
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import (
+    ExperimentalistBackend,
+)
+from pydantic import BaseModel, model_validator
+
+
+class ExperimentalistDeps(BaseModel):
+    """Per-run configuration injected into every Experimentalist tool.
+
+    At least one of ``insight`` or ``agent`` must be set:
+    - Mode 1 (``insight``): agent code defaults to the NMP insight entity's agent.
+      When ``agent`` is also set, it overrides the insight's agent.
+    - Mode 2 (``agent``): a local agent directory is used as the baseline.
+
+    Attributes:
+        workspace: NMP workspace the Experimentalist operates in.
+        insight: Entity id of the Insight being processed (Mode 1).
+        agent: Local path to the baseline agent directory (Mode 2), or an
+            override for the agent referenced by ``insight``.
+        dataset: Local directory path OR fileset ID for the evaluation dataset.
+            A :class:`~pathlib.Path` means a local directory; a plain string
+            means a fileset ID that the backend will resolve at evaluation time.
+            Defaults to None and must be set before ``run()``.
+        backend: Shared data-access backend used by every tool. The CLI
+            owns the backend's client lifecycle — tools must not close it.
+        config: Optional per-run override of the EvolutionaryOptimizerConfig.
+            When None the optimizer uses its own default config.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    workspace: str = "default"
+    insight: Path | str | None = None
+    agent: Path | str | None = None
+    train_dataset: DatasetRef
+    validation_dataset: DatasetRef
+    task_template: DatasetRef | None = None
+    evaluator_type: EvaluatorType = "harbor"
+    agent_spec: str | None = None
+    backend: ExperimentalistBackend | None = None
+    config: Any = None  # EvolutionaryOptimizerConfig | None, avoids circular import
+
+    @model_validator(mode="after")
+    def _require_insight_or_agent(self) -> ExperimentalistDeps:
+        has_insight = self.insight is not None
+        has_agent = self.agent is not None
+        if not has_insight and not has_agent:
+            raise ValueError("One of 'insight' (Mode 1) or 'agent' (Mode 2) must be set.")
+        if has_insight and self.task_template is None:
+            raise ValueError("'task_template' is required when 'insight' is set.")
+        return self

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experiment_mirror.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experiment_mirror.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""One-way, best-effort projection of the plugin's run/candidate entities onto the
+platform's native ``ExperimentGroup``/``Experiment``.
+
+This module is the *only* place that talks to ``client.experiment_groups`` /
+``client.experiments``; the optimization loop never imports it. Mapping is
+``ExperimentRun → ExperimentGroup`` (1:1) and ``Candidate → Experiment[]`` (one per
+evaluated split). It mirrors **structure only** (identity/lineage/status/description);
+eval results (reward/trials) are NOT copied into ``Experiment.metadata`` — those arrive
+via the Intake rollup path later (spec §4.3).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from typing import Any
+
+from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun
+from nemo_platform import AsyncNeMoPlatform, ConflictError, NotFoundError, omit
+
+logger = logging.getLogger(__name__)
+
+SPLITS: tuple[str, str] = ("train", "validation")
+_NAME_RE = re.compile(r"[^a-z0-9-]+")
+
+
+def _slug(value: str) -> str:
+    return _NAME_RE.sub("-", value.lower()).strip("-") or "run"
+
+
+def group_name(run_id: str) -> str:
+    """Deterministic, workspace-unique ExperimentGroup name from the run id."""
+    return f"opt-{_slug(run_id)}"[:63].rstrip("-")
+
+
+def experiment_name(gname: str, label: str, split: str) -> str:
+    """Deterministic, workspace-unique Experiment name (one per candidate × split).
+
+    ``label`` is sanitized with the same ``_slug`` as the group's run id. If the composed
+    name would exceed the platform's 63-char limit, a short deterministic hash suffix
+    preserves uniqueness — so distinct candidates/splits can never truncate onto the same
+    name and silently overwrite each other via the create→conflict→update upsert path.
+    """
+    name = f"{gname}-{_slug(label)}-{split}"
+    if len(name) <= 63:
+        return name
+    digest = hashlib.sha1(name.encode()).hexdigest()[:8]  # noqa: S324 - identity, not security
+    return f"{name[:54].rstrip('-')}-{digest}"
+
+
+def pseudo_source_link(gname: str, label: str) -> str:
+    """Fallback grouping-key URI, stable per candidate across its splits (OQ-4)."""
+    return f"opt://{gname}/candidate/{label}"
+
+
+def experiment_status(candidate: Candidate) -> str:
+    """Derive the producer status string from candidate lineage (spec §4.1)."""
+    if candidate.killed_round is not None:
+        return "killed"
+    if candidate.round == 0:
+        return "baseline"
+    return "survived"
+
+
+def group_metadata(run: ExperimentRun) -> dict[str, str]:
+    """The ExperimentRun fields with no first-class ExperimentGroup home (spec §4.1).
+
+    Platform ``metadata`` is ``dict[str, str]``: every value must be a string. Non-string
+    fields are serialized (``config_snapshot`` as JSON, ``rounds_completed`` via ``str``);
+    ``winner_candidate`` is omitted until a winner exists rather than sent as ``None``.
+    """
+    md = {
+        "agent": run.agent,
+        "config_snapshot": json.dumps(run.config_snapshot, sort_keys=True),
+        "status": run.status,
+        "rounds_completed": str(run.rounds_completed),
+    }
+    if run.winner_agent is not None:
+        md["winner_candidate"] = run.winner_agent
+    return md
+
+
+def experiment_metadata(candidate: Candidate, split: str) -> dict[str, str]:
+    """Identity/grouping metadata only. Eval results (reward/trials) are NOT copied this
+    PR — scores/traces arrive via the Intake rollup path later (spec §4.3).
+
+    Platform ``metadata`` is ``dict[str, str]``, so ``round`` is serialized via ``str``."""
+    return {"round": str(candidate.round), "candidate_id": candidate.label, "split": split}
+
+
+def _split_reward(candidate: Candidate, split: str) -> Any:
+    """The candidate's reward object for *split* — an explicit lookup over the two known
+    split fields (``train_reward``/``validation_reward``) rather than a dynamic attribute
+    read. Used only as a presence check: the reward value itself is never projected."""
+    return {"train": candidate.train_reward, "validation": candidate.validation_reward}[split]
+
+
+class ExperimentMirror:
+    """Best-effort, one-way projection to native Experiments. Callers wrap each method
+    so failures don't propagate (spec F)."""
+
+    def __init__(self, client: AsyncNeMoPlatform, workspace: str) -> None:
+        self._client = client
+        self._workspace = workspace
+        self._group_ids: dict[str, str] = {}  # run_id -> ExperimentGroup id
+        self._experiment_ids: dict[tuple[str, str], str] = {}  # (label, split) -> Experiment id
+
+    # -- ExperimentGroup ----------------------------------------------------
+
+    async def ensure_group(self, run: ExperimentRun) -> None:
+        gname = group_name(run.id)
+        try:
+            grp = await self._client.experiment_groups.create(
+                workspace=self._workspace,
+                name=gname,
+                insight_id=run.insight or omit,
+                summary=run.summary or "",
+                metadata=group_metadata(run),
+            )
+        except ConflictError:
+            grp = await self._client.experiment_groups.retrieve(gname, workspace=self._workspace)
+        self._group_ids[run.id] = grp.id
+
+    async def update_group(self, run: ExperimentRun) -> None:
+        gname = group_name(run.id)
+        # experiment_groups.update is a full-replace PUT: omitted fields reset to None
+        # server-side, so re-supply the whole body (we have the run).
+        await self._client.experiment_groups.update(
+            gname,
+            workspace=self._workspace,
+            body_name=gname,
+            summary=run.summary or "",
+            insight_id=run.insight or omit,
+            metadata=group_metadata(run),
+        )
+
+    async def _group_id_for(self, run_id: str) -> str:
+        gid = self._group_ids.get(run_id)
+        if gid is None:  # resume path: group exists, look it up by deterministic name
+            grp = await self._client.experiment_groups.retrieve(group_name(run_id), workspace=self._workspace)
+            gid = self._group_ids[run_id] = grp.id
+        return gid
+
+    # -- Experiment ---------------------------------------------------------
+
+    async def ensure_experiment(self, candidate: Candidate, split: str) -> str:
+        """Ensure the Experiment exists for candidate × split; return its deterministic
+        name (``opt-<run>-<label>-<split>``).
+
+        The name — not the server-assigned id (``experiment-…``) — is what tags the trace's
+        ``nemo.experiment.id``: it is human-readable, greppable, and stable across resumes,
+        and matches the Experiment's own ``name`` so the trace still joins back to it.
+        """
+        gname = group_name(candidate.run_id)
+        gid = await self._group_id_for(candidate.run_id)
+        await self._upsert_experiment(
+            candidate=candidate,
+            split=split,
+            gname=gname,
+            group_id=gid,
+            agent_source=None,
+        )
+        return experiment_name(gname, candidate.label, split)
+
+    async def project_candidate(
+        self, candidate: Candidate, *, agent_source: Any = None, source_link: str | None = None
+    ) -> None:
+        gname = group_name(candidate.run_id)
+        gid = await self._group_id_for(candidate.run_id)
+        for split in SPLITS:
+            if _split_reward(candidate, split) is None:
+                continue  # split not evaluated yet (presence check only — reward is NOT copied)
+            await self._upsert_experiment(
+                candidate=candidate,
+                split=split,
+                gname=gname,
+                group_id=gid,
+                agent_source=agent_source,
+                source_link=source_link,
+            )
+
+    async def _upsert_experiment(
+        self,
+        *,
+        candidate: Candidate,
+        split: str,
+        gname: str,
+        group_id: str,
+        agent_source: Any,
+        source_link: str | None = None,
+        status: str | None = None,
+    ) -> None:
+        name = experiment_name(gname, candidate.label, split)
+        link = source_link or self._source_link(gname, candidate, agent_source)
+        parent = await self._parent_experiment_id(candidate, gname)
+        parent_id = parent if parent is not None else omit
+        st = status or experiment_status(candidate)
+        md = experiment_metadata(candidate, split)  # identity only — no reward/trials (§4.3)
+        try:
+            exp = await self._client.evaluations.create(
+                name=name,
+                dataset_name=self._dataset_name(split),
+                dataset_version="v1",
+                workspace=self._workspace,
+                experiment_group_id=group_id,
+                source_link=link,
+                description=candidate.optimization,
+                parent_evaluation_id=parent_id,
+                root_cause="",  # OQ-RC: left empty for now
+                status=st,
+                metadata=md,
+            )
+        except ConflictError:
+            exp = await self._client.evaluations.update(
+                name,
+                workspace=self._workspace,
+                dataset_name=self._dataset_name(split),
+                dataset_version="v1",
+                body_name=name,
+                experiment_group_id=group_id,
+                source_link=link,
+                description=candidate.optimization,
+                parent_evaluation_id=parent_id,
+                root_cause="",  # OQ-RC: left empty for now
+                status=st,
+                metadata=md,
+            )
+        self._experiment_ids[(candidate.label, split)] = exp.id
+
+    def _dataset_name(self, split: str) -> str:
+        return split  # OQ-8: derive a real dataset name/version later
+
+    def _source_link(self, gname: str, candidate: Candidate, agent_source: Any) -> str:
+        if candidate.round == 0 and agent_source is not None:
+            return f"{agent_source.repo_url}@{agent_source.ref}"
+        return pseudo_source_link(gname, candidate.label)
+
+    async def _existing_source_link(self, gname: str, label: str, split: str) -> str | None:
+        """The source_link already stored for this candidate/split, or None.
+
+        ``finalize`` re-upserts the winner via a full-replace update without the run's
+        ``agent_source``; reusing the link written during the run keeps a round-0 seed's real
+        ``{repo}@{ref}`` from being clobbered with a pseudo link when no PR was opened."""
+        try:
+            exp = await self._client.evaluations.retrieve(
+                experiment_name(gname, label, split), workspace=self._workspace
+            )
+        except NotFoundError:
+            return None
+        return exp.source_link
+
+    async def _parent_experiment_id(self, candidate: Candidate, gname: str) -> str | None:
+        if not candidate.ancestor:
+            return None
+        cached = self._experiment_ids.get((candidate.ancestor, "train"))
+        if cached is not None:
+            return cached
+        try:  # resume / ancestor created earlier this run
+            exp = await self._client.evaluations.retrieve(
+                experiment_name(gname, candidate.ancestor, "train"), workspace=self._workspace
+            )
+        except NotFoundError:
+            logger.debug(
+                "Ancestor experiment %r not found for candidate %r; lineage link omitted",
+                experiment_name(gname, candidate.ancestor, "train"),
+                candidate.label,
+            )
+            return None
+        self._experiment_ids[(candidate.ancestor, "train")] = exp.id
+        return exp.id
+
+    # -- Finalize -----------------------------------------------------------
+
+    async def finalize(self, *, run_id: str, summary: str, winner: Candidate | None, pr_url: str | None = None) -> None:
+        gname = group_name(run_id)
+        gid = await self._group_id_for(run_id)
+        # experiment_groups.update is a full-replace PUT: omitted fields reset to None
+        # server-side. finalize has no `run`, so read-preserve-write the current
+        # insight_id/metadata before writing the summary (stays within the mirror; no
+        # data flows back into the loop).
+        grp = await self._client.experiment_groups.retrieve(gname, workspace=self._workspace)
+        await self._client.experiment_groups.update(
+            gname,
+            workspace=self._workspace,
+            body_name=gname,
+            summary=summary,
+            insight_id=grp.insight_id if grp.insight_id is not None else omit,
+            metadata=grp.metadata if grp.metadata is not None else omit,
+        )
+        if winner is None:
+            return
+        # The winner's Experiment is always status="winner"; whether a PR was opened is
+        # captured in source_link (=pr_url), so a separate "deployed" status would be
+        # redundant (and "deployed" overstates a draft PR). With no PR, preserve the
+        # source_link stored during the run so a round-0 winner's real {repo}@{ref} isn't
+        # clobbered by the full-replace update (agent_source isn't threaded into finalize).
+        for split in SPLITS:
+            if _split_reward(winner, split) is None:
+                continue
+            link = pr_url or await self._existing_source_link(gname, winner.label, split)
+            await self._upsert_experiment(
+                candidate=winner,
+                split=split,
+                gname=gname,
+                group_id=gid,
+                agent_source=None,
+                source_link=link,
+                status="winner",
+            )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
@@ -1,0 +1,900 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Data-access backend abstractions for the Experimentalist.
+
+One :class:`ExperimentalistBackend` is built per run and shared through
+:class:`ExperimentalistDeps`. The backend interface covers entity CRUD, dataset
+and agent-code materialization, Intake reads, agent metadata reads, and terminal
+result persistence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+import subprocess
+import uuid
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, Literal, cast
+from urllib.parse import urlparse
+
+import httpx
+from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import (
+    EvaluationResult,
+    ResourceRef,
+    TrialResult,
+)
+from nemo_experimentalist_plugin.experimentalist.components.repository import (
+    AgentSource,
+    PRPublisher,
+    _redact_url,
+    clone_agent_repo,
+    looks_like_git,
+    split_agent_spec,
+    split_git_ref,
+)
+from nemo_experimentalist_plugin.experimentalist.experiment_mirror import ExperimentMirror
+from nemo_experimentalist_plugin.experimentalist.otlp import jsonl_to_protobuf, read_trace_id, spans_to_protobuf
+from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
+from nemo_experimentalist_plugin.resolve import (
+    AgentSourceConfig as AgentSourceConfig,
+)
+from nemo_experimentalist_plugin.resolve import (
+    CandidateStorageConfig as CandidateStorageConfig,
+)
+from nemo_insights_plugin.entities import Insight
+from nemo_platform import AsyncNeMoPlatform
+
+logger = logging.getLogger(__name__)
+
+
+async def _upload_trace_otlp(
+    client: AsyncNeMoPlatform,
+    workspace: str,
+    ref: ResourceRef,
+    *,
+    experiment_id: str,
+    trial_id: str,
+    task_id: str,
+    extra_attrs: dict[str, str] | None = None,
+) -> None:
+    """Upload an experimentalist trace file to Intake as protobuf."""
+
+    path = Path(urlparse(ref.uri).path)
+    attrs: dict[str, str] = {
+        "nemo.experiment.id": experiment_id,
+        "nemo.test_case.id": task_id,
+        "nemo.trial.id": trial_id,
+        **(extra_attrs or {}),
+    }
+    url = f"/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
+    for payload in jsonl_to_protobuf(path, extra_resource_attrs=attrs):
+        await client.post(
+            url,
+            cast_to=object,
+            content=payload,
+            options={"headers": {"Content-Type": "application/x-protobuf"}},
+        )
+
+
+_BASELINE_AGENT_LABEL = "agent-0"
+
+_AGENT_COPY_EXCLUDE_NAMES = {
+    "__pycache__",
+    ".git",
+    ".claude",
+    ".uv",
+    ".venv",
+    "artifacts",
+    "dataset",
+    "eval-and-optimize",
+    "scratch",
+}
+
+
+def _ignore_agent_copy(directory: str, contents: list[str]) -> set[str]:
+    del directory
+    return {name for name in contents if name in _AGENT_COPY_EXCLUDE_NAMES}
+
+
+class ExperimentalistBackend(ABC):
+    """Pluggable data-access interface for the Experimentalist."""
+
+    def __init__(
+        self,
+        client: AsyncNeMoPlatform | None = None,
+        path: Path | None = None,
+        storage: CandidateStorageConfig | None = None,
+    ) -> None:
+        self.client = client
+        self.path = path
+        # Candidate-archival / winner-PR settings (the config slice), so the archive/publish
+        # verbs take only (workspace, candidate) and derive branch/title/body/options from here.
+        self.storage = storage or CandidateStorageConfig()
+
+    # -- Insight read --------------------------------------------------------
+
+    @abstractmethod
+    async def get_insight(self, *, workspace: str, insight_id: str) -> Insight:
+        """Fetch or load the Insight identified by *insight_id*."""
+        ...
+
+    # -- ExperimentRun CRUD --------------------------------------------------
+
+    @abstractmethod
+    async def create_run(self, *, workspace: str, run: ExperimentRun) -> ExperimentRun:
+        """Persist a new ExperimentRun and return it with its durable id."""
+        ...
+
+    @abstractmethod
+    async def update_run(self, *, workspace: str, run: ExperimentRun) -> ExperimentRun:
+        """Persist changes to an existing ExperimentRun."""
+        ...
+
+    # -- Candidate CRUD ------------------------------------------------------
+
+    @abstractmethod
+    async def create_candidate(self, *, workspace: str, candidate: Candidate) -> Candidate:
+        """Persist a new Candidate and return it with its durable id."""
+        ...
+
+    @abstractmethod
+    async def update_candidate(self, *, workspace: str, candidate: Candidate) -> Candidate:
+        """Persist changes to an existing Candidate."""
+        ...
+
+    @abstractmethod
+    async def get_candidate(self, *, workspace: str, candidate_id: str) -> Candidate:
+        """Fetch a single Candidate by its durable id."""
+        ...
+
+    @abstractmethod
+    async def list_candidates(self, *, workspace: str, run_id: str) -> list[Candidate]:
+        """Return all Candidates that belong to a given ExperimentRun."""
+        ...
+
+    # -- Result persistence --------------------------------------------------
+
+    @abstractmethod
+    async def persist_result(self, *, workspace: str, result: ExperimentalistResult) -> None:
+        """Persist the terminal result for an Experimentalist run.
+
+        The result identifies the run and carries the terminal summary,
+        completed round count, and optional winning Candidate.
+        """
+        ...
+
+    @abstractmethod
+    async def persist_evaluation(
+        self,
+        *,
+        workspace: str,
+        result: EvaluationResult,
+        candidate: Candidate,
+        split: str,
+    ) -> None:
+        """Persist traces and metrics for a completed evaluation.
+
+        Derives experiment_id internally from candidate × split, ensuring the
+        Experiment entity exists before stamping traces.
+        """
+        ...
+
+    @abstractmethod
+    async def get_experiment_id(self, *, workspace: str, candidate: Candidate, split: str) -> str:
+        """Best-effort native Experiment id for *candidate* × *split* in *workspace*.
+
+        Returns "" when there is no projection (offline) or it fails — the id only
+        tags Intake resource attributes, so a run must not break on it.
+        """
+        ...
+
+    # -- Agent code access ---------------------------------------------------
+
+    @abstractmethod
+    async def get_agent_code(
+        self, *, workspace: str, agent: str | Path, dest: Path, clone_depth: int | None = None
+    ) -> AgentSource | None:
+        """Materialize the agent's code files into *dest*.
+
+        Returns the git :class:`AgentSource` provenance when *agent* is a git
+        ``url@ref[#agent_path]`` (the clone retains ``.git`` so *dest* can serve as a PR/MR push
+        target); returns ``None`` for a local path or non-git source. *clone_depth* optionally
+        makes a shallow clone.
+        """
+        ...
+
+    async def _clone_git_agent(self, agent: str, dest: Path, *, clone_depth: int | None = None) -> AgentSource:
+        """Clone a git ``url@ref`` agent into *dest*, surfacing failures as ``ValueError``.
+
+        Shared by every backend: git-sourced agents fetch identically regardless of
+        backend. Safe :class:`AgentCloneError` details pass through; a legacy raw
+        ``CalledProcessError`` is replaced so both reach the CLI's clean error path.
+        """
+        try:
+            return await asyncio.to_thread(clone_agent_repo, agent, dest, clone_depth=clone_depth)
+        except subprocess.CalledProcessError:
+            remote, _ = split_git_ref(split_agent_spec(agent)[0])
+            raise ValueError(f"failed to fetch --agent {_redact_url(remote)!r}") from None
+
+    @abstractmethod
+    async def archive_candidate(self, *, workspace: str, candidate: Candidate) -> str | None:
+        """Persist a produced candidate's code to durable storage; return a locator for it, or None.
+
+        Records the returned locator as the candidate's ``source_link``. Returns ``None`` when this
+        backend cannot archive the candidate (e.g. no code source to store from) or there is nothing
+        new to persist. How and where the code is stored is backend-specific. Best-effort: callers
+        gate on :attr:`storage`.archive_candidates and never let a failure fail the run.
+        """
+        ...
+
+    @abstractmethod
+    async def publish_candidate(self, *, workspace: str, candidate: Candidate) -> str | None:
+        """Surface a candidate (the winner) as a reviewable change; return its URL, or None.
+
+        Records the returned URL as the candidate's ``source_link``. Returns ``None`` when this
+        backend cannot publish (e.g. no code source) or there is nothing to publish. How the change
+        is surfaced is backend-specific. Callers gate on :attr:`storage`.publish_winner.
+        """
+        ...
+
+    # -- Intake reads --------------------------------------------------------
+
+    @abstractmethod
+    async def list_traces(
+        self,
+        *,
+        workspace: str,
+        filter: dict[str, Any] | None,
+        sort: str,
+        mode: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        """Return up to *limit* traces matching the requested query."""
+        ...
+
+    @abstractmethod
+    async def get_trace(self, *, workspace: str, trace_id: str, mode: str) -> dict[str, Any]:
+        """Fetch a single trace by id."""
+        ...
+
+    @abstractmethod
+    async def list_scores(self, *, workspace: str, span_id: str) -> dict[str, Any]:
+        """Fetch evaluator results for a span."""
+        ...
+
+    # -- Agent reads ---------------------------------------------------------
+
+    @abstractmethod
+    async def get_agent(self, *, workspace: str, agent: str) -> Any:
+        """Return metadata for the registered agent."""
+        ...
+
+    @abstractmethod
+    async def get_agent_spec(self, *, workspace: str, spec: str, dest: Path) -> Path:
+        """Materialize the agent-spec URI *spec* into *dest*; return *dest*."""
+        ...
+
+
+class RemoteExperimentalistBackend(ExperimentalistBackend):
+    """Backend selected for platform-backed Experimentalist runs."""
+
+    def __init__(self, *, client: AsyncNeMoPlatform, path: Path, storage: CandidateStorageConfig | None = None) -> None:
+        super().__init__(client, path, storage)
+        # Reuse local-mode file persistence for the plugin entities (spec §3 decision 5).
+        # LocalExperimentalistBackend also performs the best-effort projection to native
+        # Experiments whenever it has a platform client — which this backend always passes —
+        # so delegation here covers both persistence and projection.
+        self.client = client
+        self._files = LocalExperimentalistBackend(client=client, path=path, storage=self.storage)
+
+    async def get_insight(self, *, workspace: str, insight_id: str) -> Insight:
+        raise NotImplementedError
+
+    async def create_run(self, *, workspace: str, run: ExperimentRun) -> ExperimentRun:
+        return await self._files.create_run(workspace=workspace, run=run)
+
+    async def update_run(self, *, workspace: str, run: ExperimentRun) -> ExperimentRun:
+        return await self._files.update_run(workspace=workspace, run=run)
+
+    async def create_candidate(self, *, workspace: str, candidate: Candidate) -> Candidate:
+        return await self._files.create_candidate(workspace=workspace, candidate=candidate)
+
+    async def update_candidate(self, *, workspace: str, candidate: Candidate) -> Candidate:
+        return await self._files.update_candidate(workspace=workspace, candidate=candidate)
+
+    async def get_candidate(self, *, workspace: str, candidate_id: str) -> Candidate:
+        return await self._files.get_candidate(workspace=workspace, candidate_id=candidate_id)
+
+    async def list_candidates(self, *, workspace: str, run_id: str) -> list[Candidate]:
+        return await self._files.list_candidates(workspace=workspace, run_id=run_id)
+
+    async def persist_result(self, *, workspace: str, result: ExperimentalistResult) -> None:
+        await self._files.persist_result(workspace=workspace, result=result)
+
+    async def persist_evaluation(
+        self, *, workspace: str, result: EvaluationResult, candidate: Candidate, split: str
+    ) -> None:
+        await self._files.persist_evaluation(workspace=workspace, result=result, candidate=candidate, split=split)
+
+    async def get_experiment_id(self, *, workspace: str, candidate: Candidate, split: str) -> str:
+        return await self._files.get_experiment_id(workspace=workspace, candidate=candidate, split=split)
+
+    async def get_agent_code(
+        self, *, workspace: str, agent: str | Path, dest: Path, clone_depth: int | None = None
+    ) -> AgentSource | None:
+        # Git-sourced agents fetch identically regardless of backend (git transport).
+        # A non-git "live" platform agent (fetched via the platform) is not supported yet.
+        # Delegate to the local file backend so its captured _agent_source powers archival.
+        if looks_like_git(str(agent)):
+            return await self._files.get_agent_code(
+                workspace=workspace, agent=agent, dest=dest, clone_depth=clone_depth
+            )
+        raise NotImplementedError
+
+    async def archive_candidate(self, *, workspace: str, candidate: Candidate) -> str | None:
+        return await self._files.archive_candidate(workspace=workspace, candidate=candidate)
+
+    async def publish_candidate(self, *, workspace: str, candidate: Candidate) -> str | None:
+        return await self._files.publish_candidate(workspace=workspace, candidate=candidate)
+
+    async def list_traces(
+        self,
+        *,
+        workspace: str,
+        filter: dict[str, Any] | None,
+        sort: str,
+        mode: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def get_trace(self, *, workspace: str, trace_id: str, mode: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def list_scores(self, *, workspace: str, span_id: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def get_agent(self, *, workspace: str, agent: str) -> Any:
+        raise NotImplementedError
+
+    async def get_agent_spec(self, *, workspace: str, spec: str, dest: Path) -> Path:
+        return await self._files.get_agent_spec(workspace=workspace, spec=spec, dest=dest)
+
+
+def _load_entity(cls: type, path: Path) -> Any:
+    """Deserialize *path* as JSON into *cls*, restoring the private ``_id`` field."""
+    data = json.loads(path.read_text())
+    entity_id = data.get("id", "")
+    obj = cls.model_validate(data)
+    if entity_id:
+        obj._id = entity_id  # PrivateAttr set the same way as the real entity client
+    return obj
+
+
+class LocalExperimentalistBackend(ExperimentalistBackend):
+    """Persist entities under the optimizer's working directory (offline mode).
+
+    Entity CRUD and result persistence land in local files under the same
+    ``eval-and-optimize/`` tree that AAD created::
+
+        {path}/
+          eval-and-optimize/
+            insight.json          ← loaded via get_insight(insight_id=path)
+            run.json              ← ExperimentRun state
+            agents/
+              agent-0/
+                metadata.json     ← Candidate fields
+              agent-1/
+                metadata.json
+              ...
+            analysis/
+              round-0.md
+              round-0-goal.json
+              ...
+            results/
+            OPTIMIZATION.md       ← final report (same as AAD)
+
+    Insight references may be local filesystem paths or Platform IDs. Dataset
+    and agent-code references must be local filesystem paths.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: AsyncNeMoPlatform | None = None,
+        path: Path,
+        storage: CandidateStorageConfig | None = None,
+    ) -> None:
+        super().__init__(client, path, storage)
+        self.path = path
+        self._eo = path / "eval-and-optimize"
+        for subdir in ("agents", "analysis", "results"):
+            (self._eo / subdir).mkdir(parents=True, exist_ok=True)
+        # Best-effort, one-way projection onto native platform Experiments. Active only when
+        # a platform client is present (offline/local-only runs leave it a no-op); mirrors are
+        # built lazily by ``_project_best_effort`` and cached per workspace so reusing this
+        # backend across workspaces never projects into the wrong one.
+        self._mirrors: dict[str, ExperimentMirror] = {}
+        # Run-level git provenance captured by get_agent_code: the fetched AgentSource (repo,
+        # ref, sub-path) and the local .git clone that is the push target. archive_candidate /
+        # publish_candidate derive everything from these, so their signatures stay (workspace, candidate).
+        self._agent_source: AgentSource | None = None
+        self._agent_checkout: Path | None = None
+        self._pr_url: str | None = None
+        # label -> archived branch source_link, so re-projection keeps the real git link
+        # (set by archive_candidate) instead of falling back to the pseudo placeholder.
+        self._candidate_source_links: dict[str, str] = {}
+
+    async def _project_best_effort(self, workspace: str, call: Callable[[ExperimentMirror], Awaitable[None]]) -> None:
+        """Run a mirror projection best-effort (spec §3 / F).
+
+        No-op when the backend has no platform client (pure-offline runs). Otherwise builds
+        the workspace's mirror lazily (cached per workspace), runs *call* against it, and
+        logs+swallows any failure so a projection problem can never fail the run or the
+        local-file persistence. One-way: nothing read back into the loop.
+        """
+        if self.client is None:
+            return
+        mirror = self._mirrors.get(workspace)
+        if mirror is None:
+            mirror = self._mirrors[workspace] = ExperimentMirror(self.client, workspace)
+        try:
+            await call(mirror)
+        except Exception as exc:  # noqa: BLE001 - projection must never fail the run
+            logger.warning("[MIRROR] projection failed (run continues): %s", exc)
+
+    # -- Insight read --------------------------------------------------------
+
+    async def get_insight(self, *, workspace: str, insight_id: str) -> Insight:
+        # A local insight file preserves offline behavior; otherwise treat
+        # ``insight_id`` as a platform insight id and fetch it from the Insights
+        # API. The dispatch is heuristic: an id that happens to match a path in
+        # the cwd is read as a file, so callers wanting the platform must use an id
+        # that isn't also a local path.
+        p = Path(insight_id)
+        if p.exists():
+            return _load_entity(Insight, p)
+        if self.client is None:
+            raise ValueError(
+                f"Insight {insight_id!r} is not an existing local file and no platform "
+                "client is available to fetch it from the platform."
+            )
+        try:
+            return await self.client.insights.insights.get(workspace=workspace, insight_id=insight_id)
+        except httpx.HTTPStatusError as exc:
+            # Surface as ValueError so the CLI's clean-error path reports it instead
+            # of dumping a raw traceback (mirrors the local-file FileNotFoundError).
+            if exc.response.status_code == 404:
+                raise ValueError(f"Insight not found on the platform: {insight_id!r}") from exc
+            raise ValueError(f"Failed to fetch insight {insight_id!r} from the platform: {exc}") from exc
+
+    # -- Agent code access ---------------------------------------------------
+
+    async def get_agent_code(
+        self, *, workspace: str, agent: str | Path, dest: Path, clone_depth: int | None = None
+    ) -> AgentSource | None:
+        # Git source: clone (keeps .git for the PR push target) and return provenance.
+        # Stash it so the mirror can use the real repo@ref as the baseline's source_link.
+        if looks_like_git(str(agent)):
+            self._agent_source = await self._clone_git_agent(str(agent), dest, clone_depth=clone_depth)
+            self._agent_checkout = dest  # the .git clone is the archive/PR push target
+            return self._agent_source
+        # Local path: copy the agent into dest, replacing it (mirror clone_agent_repo)
+        # so files removed from the local agent don't linger and get optimized/published
+        # as stale code.
+        src = Path(agent)
+        if not src.exists():
+            raise FileNotFoundError(f"Local agent path not found: {src}")
+        if dest.resolve() != src.resolve():
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(src, dest, ignore=_ignore_agent_copy)
+        return None
+
+    def _candidate_branch(self, candidate: Candidate) -> str:
+        """Deterministic archive branch for a candidate: ``<prefix>/<run-id>/<label>``."""
+        return f"{self.storage.candidate_branch_prefix}/{candidate.run_id}/{candidate.label}"
+
+    def _candidate_code_dir(self, candidate: Candidate) -> Path:
+        """Local directory holding *candidate*'s code (the per-candidate agent dir)."""
+        return self._eo / "agents" / candidate.label
+
+    async def archive_candidate(self, *, workspace: str, candidate: Candidate) -> str | None:
+        """Git implementation: push ``<prefix>/<run-id>/<label>`` (subtree at the agent's
+        ``agent_path``) cut from the source ref, and record ``{repo}@{branch}`` as the candidate's
+        Experiment source_link. No-op (None) for a non-git source, or a skipped/empty-diff branch."""
+        # Non-git source (local agent) or no checkout: nothing to push, so archival is a no-op.
+        src = self._agent_source
+        if src is None or self._agent_checkout is None:
+            return None
+        checkout, branch = self._agent_checkout, self._candidate_branch(candidate)
+        code_dir = self._candidate_code_dir(candidate)
+        message = (
+            f"Experimentalist candidate {candidate.label} (round {candidate.round}): {candidate.optimization}\n\n"
+            f"Candidate-Id: {candidate.id}"
+        )
+        pushed = await asyncio.to_thread(
+            lambda: PRPublisher(agent_dir=checkout).push_branch(
+                src_dir=code_dir, branch=branch, base_ref=src.ref, agent_path=src.agent_path, message=message
+            )
+        )
+        if not pushed:
+            return None
+        # Record the branch as the candidate's real source_link and re-project its Experiment
+        # so the mirror surfaces the git branch instead of the pseudo placeholder.
+        link = f"{src.repo_url}@{branch}"
+        self._candidate_source_links[candidate.label] = link
+        await self._project_best_effort(
+            workspace, lambda m: m.project_candidate(candidate, agent_source=src, source_link=link)
+        )
+        return link
+
+    async def publish_candidate(self, *, workspace: str, candidate: Candidate) -> str | None:
+        """Git implementation: open a draft PR/MR from the candidate's ``<prefix>/<run-id>/<label>``
+        branch (title/body derived from the candidate + run summary + archived-branch links, per the
+        ``storage`` PR options) and stash the URL for the winner's source_link. No-op (None) for a
+        non-git source or empty diff."""
+        # Non-git source or no checkout: cannot open a PR, so this is a no-op.
+        src = self._agent_source
+        if src is None or self._agent_checkout is None:
+            return None
+        checkout, branch = self._agent_checkout, self._candidate_branch(candidate)
+        title = (
+            self.storage.pr_title
+            or f"Experimentalist: candidate {candidate.label} ({candidate.optimization_type or 'improvement'})"
+        )
+        body = self.storage.pr_body or await self._compose_pr_body(workspace=workspace, candidate=candidate)
+        code_dir = self._candidate_code_dir(candidate)
+        url = await asyncio.to_thread(
+            lambda: PRPublisher(agent_dir=checkout).publish(
+                winner_dir=code_dir,
+                branch=branch,
+                base_ref=src.ref,
+                agent_path=src.agent_path,
+                title=title,
+                body=body,
+                draft=self.storage.pr_draft,
+                base_branch_override=self.storage.pr_base_branch,
+                labels=self.storage.pr_labels,
+            )
+        )
+        # Stash the PR URL so the mirror's finalize() records it on the winner's source_link.
+        self._pr_url = url or None
+        return url or None
+
+    async def _compose_pr_body(self, *, workspace: str, candidate: Candidate) -> str:
+        """Compose the winner PR body: run summary + links to every archived candidate branch."""
+        run_path = self._eo / "run.json"
+        run = _load_entity(ExperimentRun, run_path) if run_path.exists() else None
+        summary = (run.summary if run is not None else None) or "Experimentalist run complete."
+        if not self.storage.archive_candidates:
+            return summary  # only the winner's branch exists; nothing else to link
+        siblings = await self.list_candidates(workspace=workspace, run_id=candidate.run_id)
+        lines = ["", "## Candidate branches", ""]
+        for sib in siblings:
+            if sib.label == _BASELINE_AGENT_LABEL:
+                continue
+            marker = " (winner)" if sib.label == candidate.label else ""
+            reward = sib.validation_reward or sib.train_reward or {}
+            lines.append(f"- `{sib.label}`{marker}: `{self._candidate_branch(sib)}` — reward={reward}")
+        return summary + "\n" + "\n".join(lines) + "\n"
+
+    # -- Intake reads and agent reads (PR #3) --------------------------------
+
+    async def list_traces(
+        self,
+        *,
+        workspace: str,
+        filter: dict[str, Any] | None,
+        sort: str,
+        mode: str,
+        limit: int,
+    ) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def get_trace(self, *, workspace: str, trace_id: str, mode: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def list_scores(self, *, workspace: str, span_id: str) -> dict[str, Any]:
+        raise NotImplementedError
+
+    async def get_agent(self, *, workspace: str, agent: str) -> Any:
+        raise NotImplementedError
+
+    async def get_agent_spec(self, *, workspace: str, spec: str, dest: Path) -> Path:
+        src = Path(spec)
+        if not src.is_file():
+            raise FileNotFoundError(f"Agent spec not found: {src}")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dest)
+        return dest
+
+    # ------------------------------------------------------------------
+    # ExperimentRun CRUD  (eval-and-optimize/run.json)
+    # ------------------------------------------------------------------
+
+    async def create_run(self, *, workspace: str, run: ExperimentRun) -> ExperimentRun:
+        if not run.id:
+            run._id = str(uuid.uuid4())  # type: ignore[attr-defined]
+        (self._eo / "run.json").write_text(run.model_dump_json(indent=2))
+        await self._project_best_effort(workspace, lambda m: m.ensure_group(run))
+        return run
+
+    async def update_run(self, *, workspace: str, run: ExperimentRun) -> ExperimentRun:
+        (self._eo / "run.json").write_text(run.model_dump_json(indent=2))
+        await self._project_best_effort(workspace, lambda m: m.update_group(run))
+        return run
+
+    # ------------------------------------------------------------------
+    # Candidate CRUD  (eval-and-optimize/agents/{label}/metadata.json)
+    #
+    # The candidate ``label`` is the agent directory name (e.g. "agent-0").
+    # Locally we use it as the entity id so lookup is O(1); remotely the store
+    # assigns the id and auto-slugs ``name`` (identity is the id, as for every
+    # entity in this plugin).
+    # ------------------------------------------------------------------
+
+    def _candidate_path(self, label: str) -> Path:
+        if not label:
+            raise ValueError("Label is required")
+        return self._eo / "agents" / label / "metadata.json"
+
+    def _load_candidate(self, path: Path) -> Candidate:
+        """Deserialize a current-schema ``metadata.json`` file into a Candidate."""
+        data = json.loads(path.read_text())
+        candidate = Candidate.model_validate(data)
+        # Restore private _id if present in the serialized form.
+        entity_id = data.get("id", "")
+        if entity_id:
+            candidate._id = entity_id  # type: ignore[attr-defined]
+        return candidate
+
+    async def create_candidate(self, *, workspace: str, candidate: Candidate) -> Candidate:
+        if not candidate.id:
+            candidate._id = candidate.label or str(uuid.uuid4())  # type: ignore[attr-defined]
+        p = self._candidate_path(candidate.label)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(
+            json.dumps(
+                {**candidate.model_dump(exclude={"artifacts"}), "id": candidate.id},
+                indent=2,
+            )
+        )
+        await self._project_best_effort(
+            workspace,
+            lambda m: m.project_candidate(
+                candidate,
+                agent_source=self._agent_source,
+                source_link=self._candidate_source_links.get(candidate.label),
+            ),
+        )
+        return candidate
+
+    async def update_candidate(self, *, workspace: str, candidate: Candidate) -> Candidate:
+        p = self._candidate_path(candidate.label)
+        p.write_text(
+            json.dumps(
+                {**candidate.model_dump(exclude={"artifacts"}), "id": candidate.id},
+                indent=2,
+            )
+        )
+        await self._project_best_effort(
+            workspace,
+            lambda m: m.project_candidate(
+                candidate,
+                agent_source=self._agent_source,
+                source_link=self._candidate_source_links.get(candidate.label),
+            ),
+        )
+        return candidate
+
+    async def get_candidate(self, *, workspace: str, candidate_id: str) -> Candidate:
+        # In local mode the store id equals the candidate label (e.g. "agent-0"),
+        # which is also the agent directory name.
+        p = self._candidate_path(candidate_id)
+        return self._load_candidate(p)
+
+    async def list_candidates(self, *, workspace: str, run_id: str) -> list[Candidate]:
+        results: list[Candidate] = []
+        agents_dir = self._eo / "agents"
+        for meta in sorted(agents_dir.glob("*/metadata.json")):
+            c: Candidate = self._load_candidate(meta)
+            if c.run_id == run_id:
+                results.append(c)
+        return results
+
+    # ------------------------------------------------------------------
+    # Result persistence  (eval-and-optimize/OPTIMIZATION.md)
+    # ------------------------------------------------------------------
+
+    async def persist_evaluation(
+        self, *, workspace: str, result: EvaluationResult, candidate: Candidate, split: str
+    ) -> None:
+        """Persist traces and metrics for a completed evaluation.
+
+        Side effect: For trials with local file:// traces, uploads to Intake and rewrites
+        trial.trace.uri to intake://traces/{id}. Original URI preserved in metadata.
+
+        TODO(future): Uploading traces can be slow (large payloads, many trials). Consider
+        moving this to a background task so the optimization loop can continue without
+        blocking on Intake I/O. The loop would need to either: (a) await the background
+        task before _reward_trajectories (which reads intake:// URIs), or (b) fall back
+        to reading local file:// traces if upload is still in progress.
+        """
+        if self.client is None:
+            return  # pure-offline run: traces stay on local disk
+
+        # Derive experiment_id internally (ensures entity exists, returns deterministic name)
+        experiment_id = await self.get_experiment_id(workspace=workspace, candidate=candidate, split=split)
+        if not experiment_id:
+            return  # projection failed (shouldn't happen, but defensive)
+
+        agent_attrs = {
+            k: str(result.metadata[k])
+            for k in ("gen_ai.agent.name", "agent.version", "gen_ai.request.model")
+            if k in result.metadata
+        }
+        for trial in result.trials:
+            if trial.trace is None:
+                continue
+            try:
+                await self._persist_trial(
+                    trial, workspace=workspace, experiment_id=experiment_id, agent_attrs=agent_attrs
+                )
+            except Exception as exc:  # noqa: BLE001 - Intake persistence is best-effort
+                logger.warning(f"[INTAKE] persist_evaluation failed for trial {trial.id}: {exc}")
+
+    async def _persist_trial(
+        self, trial: TrialResult, *, workspace: str, experiment_id: str, agent_attrs: dict[str, str]
+    ) -> None:
+        assert trial.trace is not None
+        assert self.client is not None
+        uri = trial.trace.uri
+        if uri.startswith("intake://"):
+            trace_id = uri.removeprefix("intake://traces/")
+            trace = await self._retrieve_trace_with_retry(trace_id, workspace=workspace)
+            ctx = getattr(trace, "evaluation_context", None)
+            if ctx is None or getattr(ctx, "evaluation_id", None) != experiment_id:
+                rows: list[dict] = []
+                async for span in self.client.intake.spans.list(
+                    workspace=workspace,
+                    filter=cast(Any, {"trace_id": trace_id}),
+                    mode="detailed",
+                    page_size=1000,
+                ):
+                    rows.append(span.model_dump(mode="json", exclude_none=True))
+                attrs = {
+                    "nemo.experiment.id": experiment_id,
+                    "nemo.test_case.id": trial.task_id,
+                    "nemo.trial.id": trial.id,
+                    **agent_attrs,
+                }
+                url = f"/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
+                for payload in spans_to_protobuf(rows, attrs):
+                    await self.client.post(
+                        url,
+                        cast_to=object,
+                        content=payload,
+                        options={"headers": {"Content-Type": "application/x-protobuf"}},
+                    )
+                trace = await self._retrieve_trace_with_retry(trace_id, workspace=workspace)
+        else:
+            try:
+                trace_id = read_trace_id(trial.trace)
+            except (ValueError, json.JSONDecodeError, FileNotFoundError) as exc:
+                # Empty, invalid, or missing trace file (e.g., cancelled trial) — skip upload
+                logger.debug(f"[INTAKE] No valid trace found for trial {trial.id}: {exc}; skipping upload")
+                return
+            original_uri = uri
+            await _upload_trace_otlp(
+                self.client,
+                workspace,
+                trial.trace,
+                experiment_id=experiment_id,
+                trial_id=trial.id,
+                task_id=trial.task_id,
+                extra_attrs=agent_attrs,
+            )
+            trial.trace = ResourceRef(
+                uri=f"intake://traces/{trace_id}",
+                description=trial.trace.description,
+                metadata={**trial.trace.metadata, "local_uri": original_uri},
+            )
+            trace = await self._retrieve_trace_with_retry(trace_id, workspace=workspace)
+        for name, metric in trial.metrics.items():
+            await self.client.intake.evaluator_results.create(
+                workspace=workspace,
+                span_id=trace.root_span_id,
+                session_id=trace.session_id,
+                name=name,
+                value=float(metric.value),
+                data_type="NUMERIC",
+            )
+
+    async def _retrieve_trace_with_retry(
+        self, trace_id: str, *, workspace: str, retries: int = 5, initial_delay: float = 1.0
+    ) -> Any:
+        """Retrieve trace with exponential backoff.
+
+        Intake indexing after OTLP upload can take several seconds. Uses exponential
+        backoff: 1s, 2s, 4s, 8s, 16s (up to 31s total) by default.
+        """
+        from nemo_platform import NotFoundError
+
+        assert self.client is not None
+        last_exc: Exception = RuntimeError(f"trace {trace_id!r} not found after {retries} retries")
+        delay = initial_delay
+        for attempt in range(retries):
+            try:
+                return await self.client.intake.traces.retrieve(trace_id, workspace=workspace)
+            except NotFoundError as exc:
+                last_exc = exc
+                if attempt < retries - 1:  # Don't sleep after the last attempt
+                    await asyncio.sleep(delay)
+                    delay *= 2  # Exponential backoff
+        raise last_exc
+
+    async def get_experiment_id(self, *, workspace: str, candidate: Candidate, split: str) -> str:
+        if self.client is None:
+            return ""
+        mirror = self._mirrors.get(workspace)
+        if mirror is None:
+            mirror = self._mirrors[workspace] = ExperimentMirror(self.client, workspace)
+        try:
+            return await mirror.ensure_experiment(candidate, split=split)
+        except Exception as exc:  # noqa: BLE001 - projection is best-effort
+            logger.warning("[MIRROR] ensure_experiment failed: %s", exc)
+            return ""
+
+    async def persist_result(self, *, workspace: str, result: ExperimentalistResult) -> None:
+        (self._eo / "OPTIMIZATION.md").write_text(result.summary)
+        run_path = self._eo / "run.json"
+        if run_path.exists():
+            run: ExperimentRun = _load_entity(ExperimentRun, run_path)
+            run.status = "completed"
+            run.rounds_completed = result.rounds_completed
+            run.summary = result.summary  # so publish_candidate's _compose_pr_body reads the real summary
+            if result.winner is not None:
+                run.winner_agent = result.winner.id
+            run_path.write_text(run.model_dump_json(indent=2))
+        await self._project_best_effort(
+            workspace,
+            lambda m: m.finalize(
+                run_id=result.run_id, summary=result.summary, winner=result.winner, pr_url=self._pr_url
+            ),
+        )
+
+
+def make_experimentalist_backend(
+    *,
+    client: AsyncNeMoPlatform | None,
+    experiments_output: str,
+    mode: Literal["local", "remote"],
+    storage: CandidateStorageConfig | None = None,
+) -> ExperimentalistBackend:
+    """Select the experimentalist backend based on *mode*.
+
+    When *mode* is "local", entity state is written to that local directory using the
+    ``eval-and-optimize/`` tree layout. Otherwise, the platform-backed backend is selected.
+
+    Args:
+        client(AsyncNeMoPlatform | None): Optional platform API client for local
+            runs. Remote mode requires a client.
+        experiments_output(str): Optional local output directory.
+        mode(Literal["local", "remote"]): The backend mode.
+        storage(CandidateStorageConfig | None): Candidate-archival / winner-PR settings.
+    Returns:
+        ExperimentalistBackend: The experimentalist backend.
+    """
+    if mode == "local":
+        return LocalExperimentalistBackend(client=client, path=Path(experiments_output), storage=storage)
+    if client is None:
+        raise ValueError("remote Experimentalist backend requires a platform client")
+    return RemoteExperimentalistBackend(client=client, path=Path(experiments_output), storage=storage)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
@@ -295,7 +295,7 @@ class RemoteExperimentalistBackend(ExperimentalistBackend):
         self._files = LocalExperimentalistBackend(client=client, path=path, storage=self.storage)
 
     async def get_insight(self, *, workspace: str, insight_id: str) -> Insight:
-        raise NotImplementedError
+        return await self._files.get_insight(workspace=workspace, insight_id=insight_id)
 
     async def create_run(self, *, workspace: str, run: ExperimentRun) -> ExperimentRun:
         return await self._files.create_run(workspace=workspace, run=run)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/otlp.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/otlp.py
@@ -86,23 +86,27 @@ def _serialize_chunks(resource_spans: list[dict], max_bytes: int) -> list[bytes]
     Re-ingesting OTLP is idempotent per span_id, so splitting one trace's spans across
     several requests is safe: Intake merges them back into the same trace.
     """
+
+    def encode(entries: list[dict]) -> bytes:
+        req = ExportTraceServiceRequest()
+        ParseDict({"resourceSpans": entries}, req)
+        return req.SerializeToString()
+
     payloads: list[bytes] = []
     batch: list[dict] = []
+    # Each entry is encoded once and its size accumulated. Summing the individual
+    # encodings slightly over-estimates the batch (repeated-field framing is counted
+    # per entry), which only ever splits earlier than strictly necessary.
+    batch_bytes = 0
     for rs in resource_spans:
+        rs_bytes = len(encode([rs]))
+        if batch and batch_bytes + rs_bytes > max_bytes:
+            payloads.append(encode(batch))
+            batch, batch_bytes = [], 0
         batch.append(rs)
-        req = ExportTraceServiceRequest()
-        ParseDict({"resourceSpans": batch}, req)
-        payload = req.SerializeToString()
-        if len(payload) > max_bytes and len(batch) > 1:
-            batch.pop()
-            prev = ExportTraceServiceRequest()
-            ParseDict({"resourceSpans": batch}, prev)
-            payloads.append(prev.SerializeToString())
-            batch = [rs]
+        batch_bytes += rs_bytes
     if batch:
-        req = ExportTraceServiceRequest()
-        ParseDict({"resourceSpans": batch}, req)
-        payload = req.SerializeToString()
+        payload = encode(batch)
         if len(payload) > max_bytes:
             logger.warning(
                 f"Single span exceeds Intake limit ({len(payload)} > {max_bytes} bytes); upload will likely fail"

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/otlp.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/otlp.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""OTLP protobuf helpers for reading and uploading JSONL traces."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from pathlib import Path
+from urllib.parse import urlparse
+
+from google.protobuf.json_format import ParseDict
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import ResourceRef
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+logger = logging.getLogger(__name__)
+
+# Intake rejects OTLP bodies over 5 MiB; pack chunks under a 4 MiB budget to leave
+# headroom for protobuf framing so no single request trips the server limit.
+_MAX_OTLP_BYTES = 4 * 1024 * 1024
+
+
+def read_trace_id(ref: ResourceRef) -> str:
+    """Return the hex trace_id from the first span in a JSONL trace file.
+
+    Normalises to lowercase hex regardless of whether the JSONL stores the id as
+    hex (16/32 hex chars) or base64 (standard or URL-safe), so the result is always
+    safe to embed as a URL path component.
+
+    Args:
+        ref(ResourceRef): Resource reference to the JSONL trace file.
+
+    Returns:
+        str: The lowercase hex trace_id.
+    """
+    path = Path(urlparse(ref.uri).path)
+    for raw in path.read_text().splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        for rs in json.loads(raw).get("resourceSpans", []):
+            for ss in rs.get("scopeSpans", []):
+                for span in ss.get("spans", []):
+                    if tid := span.get("traceId"):
+                        if len(tid) in (16, 32) and all(c in "0123456789abcdefABCDEF" for c in tid):
+                            return tid.lower()
+                        # base64 (standard or URL-safe) → bytes → hex
+                        padded = tid.replace("-", "+").replace("_", "/")
+                        padded += "=" * (-len(padded) % 4)
+                        return base64.b64decode(padded).hex()
+    raise ValueError(f"No traceId found in {ref.uri}")
+
+
+def _to_unix_nano(value: object) -> str | None:
+    """Coerce an Intake timestamp (ISO string or epoch number) to unix-nanos string."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return str(int(value))
+    from datetime import datetime
+
+    try:
+        dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return str(int(dt.timestamp() * 1_000_000_000))
+
+
+def _attr_value(value: object) -> dict:
+    """Render a Python value as an OTLP AnyValue dict."""
+    if isinstance(value, bool):
+        return {"boolValue": value}
+    if isinstance(value, int):
+        return {"intValue": str(value)}
+    if isinstance(value, float):
+        return {"doubleValue": value}
+    if isinstance(value, str):
+        return {"stringValue": value}
+    return {"stringValue": json.dumps(value)}
+
+
+def _serialize_chunks(resource_spans: list[dict], max_bytes: int) -> list[bytes]:
+    """Pack resourceSpans into ExportTraceServiceRequest payloads under *max_bytes* each.
+
+    Re-ingesting OTLP is idempotent per span_id, so splitting one trace's spans across
+    several requests is safe: Intake merges them back into the same trace.
+    """
+    payloads: list[bytes] = []
+    batch: list[dict] = []
+    for rs in resource_spans:
+        batch.append(rs)
+        req = ExportTraceServiceRequest()
+        ParseDict({"resourceSpans": batch}, req)
+        payload = req.SerializeToString()
+        if len(payload) > max_bytes and len(batch) > 1:
+            batch.pop()
+            prev = ExportTraceServiceRequest()
+            ParseDict({"resourceSpans": batch}, prev)
+            payloads.append(prev.SerializeToString())
+            batch = [rs]
+    if batch:
+        req = ExportTraceServiceRequest()
+        ParseDict({"resourceSpans": batch}, req)
+        payload = req.SerializeToString()
+        if len(payload) > max_bytes:
+            logger.warning(
+                f"Single span exceeds Intake limit ({len(payload)} > {max_bytes} bytes); upload will likely fail"
+            )
+        payloads.append(payload)
+    return payloads
+
+
+def spans_to_protobuf(
+    span_rows: list[dict], extra_resource_attrs: dict[str, str], max_bytes: int = _MAX_OTLP_BYTES
+) -> list[bytes]:
+    """Rebuild OTLP ExportTraceServiceRequest payloads from Intake span records.
+
+    Args:
+        span_rows(list[dict]): List of span rows from Intake.
+        extra_resource_attrs(dict[str, str]): Extra resource attributes to add to the spans.
+        max_bytes(int): Maximum bytes per payload.
+
+    Returns:
+        list[bytes]: List of OTLP ExportTraceServiceRequest payloads.
+    """
+
+    def _hex_b64(val: object) -> str | None:
+        s = str(val) if val else ""
+        if s and len(s) in (16, 32) and all(c in "0123456789abcdefABCDEF" for c in s):
+            return base64.b64encode(bytes.fromhex(s)).decode()
+        return s or None
+
+    resource_attrs = [{"key": k, "value": {"stringValue": v}} for k, v in extra_resource_attrs.items()]
+    resource_spans: list[dict] = []
+    for row in span_rows:
+        raw_attrs = row.get("raw_attributes")
+        if isinstance(raw_attrs, str):
+            try:
+                raw_attrs = json.loads(raw_attrs)
+            except json.JSONDecodeError:
+                raw_attrs = {}
+        if not isinstance(raw_attrs, dict):
+            raw_attrs = {}
+
+        span: dict = {
+            "traceId": _hex_b64(row.get("trace_id") or row.get("traceId")),
+            "spanId": _hex_b64(row.get("span_id") or row.get("spanId")),
+            "attributes": [{"key": k, "value": _attr_value(v)} for k, v in raw_attrs.items()],
+        }
+        parent = _hex_b64(row.get("parent_span_id") or row.get("parentSpanId"))
+        if parent:
+            span["parentSpanId"] = parent
+        if name := row.get("name"):
+            span["name"] = str(name)
+        if start := _to_unix_nano(row.get("started_at") or row.get("startTimeUnixNano")):
+            span["startTimeUnixNano"] = start
+        if end := _to_unix_nano(row.get("ended_at") or row.get("endTimeUnixNano")):
+            span["endTimeUnixNano"] = end
+        resource_spans.append({"resource": {"attributes": resource_attrs}, "scopeSpans": [{"spans": [span]}]})
+
+    return _serialize_chunks(resource_spans, max_bytes)
+
+
+def jsonl_to_protobuf(
+    path: Path, extra_resource_attrs: dict[str, str], max_bytes: int = _MAX_OTLP_BYTES
+) -> list[bytes]:
+    """Merge JSONL spans into OTLP ExportTraceServiceRequest payloads under *max_bytes* each.
+
+    Args:
+        path(Path): Path to the JSONL file.
+        extra_resource_attrs(dict[str, str]): Extra resource attributes to add to the spans.
+        max_bytes(int): Maximum bytes per payload.
+
+    Returns:
+        list[bytes]: List of OTLP ExportTraceServiceRequest payloads.
+    """
+    resource_spans: list[dict] = []
+    for raw in path.read_text().splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        for rs in json.loads(raw).get("resourceSpans", []):
+            attrs = {a["key"]: a for a in rs.setdefault("resource", {}).setdefault("attributes", [])}
+            for key, value in extra_resource_attrs.items():
+                attrs[key] = {"key": key, "value": {"stringValue": value}}
+            resource = {
+                **rs.get("resource", {}),
+                "attributes": list(attrs.values()),
+            }
+            for ss in rs.get("scopeSpans", []):
+                scope = ss.get("scope", {})
+                for span in ss.get("spans", []):
+                    for field in ("traceId", "spanId", "parentSpanId"):
+                        val = span.get(field)
+                        if val and len(val) in (16, 32) and all(c in "0123456789abcdefABCDEF" for c in val):
+                            span[field] = base64.b64encode(bytes.fromhex(val)).decode()
+                    # One span per resourceSpan so _serialize_chunks has span-level granularity
+                    resource_spans.append({"resource": resource, "scopeSpans": [{"scope": scope, "spans": [span]}]})
+
+    return _serialize_chunks(resource_spans, max_bytes)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/result.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/result.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The Experimentalist's terminal result — a pure, storage-agnostic summary.
+
+:class:`ExperimentalistResult` is ephemeral: its data is unpacked into
+:class:`~nemo_experimentalist_plugin.entities.ExperimentRun` and
+:class:`~nemo_experimentalist_plugin.entities.Candidate` via
+``backend.persist_result()``. It is fully recoverable from entity store
+queries after a completed run.
+"""
+
+from nemo_experimentalist_plugin.entities import Candidate
+from pydantic import BaseModel, Field
+
+
+class ExperimentalistResult(BaseModel):
+    """Ephemeral output of one Experimentalist run.
+
+    Passed to ``backend.persist_result()`` which writes it into the entity
+    store (ExperimentRun status/summary + winner Candidate id). All fields
+    are recoverable from entity queries after persistence.
+    """
+
+    summary: str = Field(
+        min_length=1,
+        description=(
+            "Brief natural-language summary of the optimization run and its "
+            "outcome, for the developer reading the result."
+        ),
+    )
+    run_id: str = Field(
+        min_length=1,
+        description="ExperimentRun entity id updated by persist_result.",
+    )
+    rounds_completed: int = Field(
+        ge=0,
+        description="Number of full optimization rounds that ran.",
+    )
+    winner: Candidate | None = Field(
+        default=None,
+        description=(
+            "The best candidate from the run (highest validation reward). "
+            "None when no candidate outperformed the baseline."
+        ),
+    )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/run.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/run.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable optimizer Experimentalist run orchestration."""
+
+import importlib
+from pathlib import Path
+from typing import Literal, Protocol, cast
+
+from nemo_experimentalist_plugin.experimentalist.agent import build_experimentalist_agent
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizerConfig
+from nemo_experimentalist_plugin.experimentalist.deps import ExperimentalistDeps
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import (
+    make_experimentalist_backend,
+)
+from nemo_platform import AsyncNeMoPlatform
+
+
+class _LiteLLMModule(Protocol):
+    drop_params: bool
+
+
+async def run_experimentalist(
+    *,
+    agent: str | None = None,
+    agent_spec: str | None = None,
+    insight: Path | str | None,
+    train_dataset: DatasetRef,
+    validation_dataset: DatasetRef,
+    experiment_dir: Path,
+    workspace: str,
+    client: AsyncNeMoPlatform | None,
+    config: EvolutionaryOptimizerConfig,
+    task_template: DatasetRef | None = None,
+    mode: Literal["local", "remote"] = "local",
+    framework_skills_dirs: list[Path] | None = None,
+) -> str:
+    """Build and run the Experimentalist against an agent and dataset.
+
+    Args:
+        agent: Optional baseline agent for Mode 2, or an override for the agent
+            referenced by ``insight``. A local directory or a git ``url@ref``; a git
+            source is fetched by the backend and enables opening a draft PR/MR for
+            the winner against that ref.
+        agent_spec: Optional URI of a markdown file describing the agent under test.
+            Materialized by the backend and threaded to components that use it.
+        insight: Optional Mode 1 insight — a local Insight file path or a platform
+            insight id (fetched from the platform by the backend).
+        train_dataset: Evaluator dataset reference for training.
+        validation_dataset: Evaluator dataset reference for validation.
+        task_template: Evaluator-specific task template used for production traces.
+        experiment_dir: Working directory for optimization artifacts.
+        workspace: Platform workspace.
+        client: Optional caller-owned Platform client. Local-only Mode 2 runs
+            may pass ``None``; Platform Insight access, mirroring, and Intake
+            persistence require a client.
+        config: Evolutionary optimizer configuration.
+        mode: Backend mode. Local writes to ``experiment_dir``; remote uses the
+            platform-backed backend.
+
+    Returns:
+        Terminal optimization summary.
+    """
+    # Logging is configured at the entry-point boundary (the root ``nemo`` CLI
+    # callback runs ``configure_logging`` before dispatching this subcommand),
+    # so this library function leaves root logging untouched.
+    _enable_litellm_drop_params()
+
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    experiment_dir = experiment_dir.resolve()
+    # Leave ``agent`` unresolved: it may be a git ``url@ref`` (not a filesystem path).
+    # The backend's get_agent_code handles both local dirs and git sources.
+    # A local file path is resolved; a platform insight id (str) is forwarded verbatim.
+    insight = insight.resolve() if isinstance(insight, Path) else insight
+
+    backend = make_experimentalist_backend(
+        client=client,
+        experiments_output=str(experiment_dir),
+        mode=mode,
+        storage=config.storage,
+    )
+    deps = ExperimentalistDeps(
+        workspace=workspace,
+        agent=agent,
+        agent_spec=agent_spec,
+        insight=insight,
+        train_dataset=train_dataset,
+        validation_dataset=validation_dataset,
+        task_template=task_template,
+        backend=backend,
+        config=config,
+    )
+    experimentalist = build_experimentalist_agent(
+        working_dir=experiment_dir,
+        config=config,
+        framework_skills_dirs=framework_skills_dirs,
+    )
+    result = await experimentalist.run(deps)
+    return result.summary
+
+
+def _enable_litellm_drop_params() -> None:
+    """Let LiteLLM omit unsupported model parameters when it is installed."""
+    try:
+        litellm = cast(_LiteLLMModule, importlib.import_module("litellm"))
+    except ModuleNotFoundError:
+        return
+    litellm.drop_params = True

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/preflight.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/preflight.py
@@ -1,0 +1,556 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Preflight checks: four natural-signature suites, two presentations (auto-run + doctor).
+
+Read-only. Certain-failure conditions are ``severity="required"`` (the main
+flow hard-errors on them); environment probes that can false-negative are
+``severity="advisory"`` (warn and continue). Doctor prints everything.
+"""
+
+import importlib.util
+import os
+import subprocess
+import tomllib
+from collections.abc import Callable, Mapping
+from pathlib import Path
+
+import httpx
+from nemo_experimentalist_plugin.experimentalist.components.repository import (
+    _redact_url,
+    looks_like_git,
+    pr_cli_for_repo_url,
+    split_agent_spec,
+    split_git_ref,
+)
+from nemo_experimentalist_plugin.profile import AgentProfile
+from nemo_experimentalist_plugin.resolve import (
+    ResolveError,
+    classify_dataset_value,
+    parse_local_insights,
+    profile_storage_flags,
+    select_local_insight,
+)
+from nemo_insights_plugin.contracts.checks import CheckResult, make_check_result
+from nemo_insights_plugin.contracts.profile import resolve_profile_path
+from pydantic import BaseModel
+
+_SKELETON_HINT = (
+    "Create optimizer.yaml next to your agent:\n"
+    "  agent: <name>\n  task_template: ./path/to/task_template\n"
+    "  datasets:\n    train: ./path\n    validation: ./path"
+)
+
+
+def _default_run_cmd(argv: list[str]) -> tuple[int, str]:
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=15, check=False)
+    except FileNotFoundError as exc:
+        return 127, str(exc)
+    except subprocess.TimeoutExpired:
+        return 124, ""
+    return proc.returncode, (proc.stdout + proc.stderr).strip()
+
+
+def _default_http_ok(url: str) -> bool:
+    try:
+        return httpx.get(url, timeout=5, follow_redirects=True).status_code < 500
+    except Exception:
+        # Boolean reachability probe: any failure (including a malformed URL,
+        # which raises httpx.InvalidURL, not HTTPError) means "not reachable".
+        return False
+
+
+class Probes(BaseModel):
+    """Injectable environment probes; defaults hit the real system."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    run_cmd: Callable[[list[str]], tuple[int, str]] = _default_run_cmd
+    http_ok: Callable[[str], bool] = _default_http_ok
+    env: Mapping[str, str] = os.environ
+
+
+def check_profile(profile: AgentProfile | None, profile_error: str | None) -> list[CheckResult]:
+    """Profile presence/parse check. Doctor-only on purpose: the auto path
+    announces a present profile via the loader, and a missing one is fine
+    when flags fully specify the run."""
+    if profile_error is not None:
+        return [
+            CheckResult(
+                name="profile-parse",
+                group="profile",
+                status="fail",
+                severity="required",
+                message=profile_error,
+                hint=_SKELETON_HINT,
+            )
+        ]
+    if profile is None:
+        return [
+            CheckResult(
+                name="profile-found",
+                group="profile",
+                status="fail",
+                severity="required",
+                message="no optimizer.yaml found (searched cwd and parents)",
+                hint=_SKELETON_HINT,
+            )
+        ]
+    return [
+        CheckResult(
+            name="profile-found",
+            group="profile",
+            status="pass",
+            severity="required",
+            message=f"profile for agent {profile.agent!r} at {profile.profile_dir}",
+        )
+    ]
+
+
+def check_environment(
+    *,
+    profile: AgentProfile | None,
+    insight: str | None,
+    insight_id: str | None = None,
+    base_url: str,
+    enforce_insight_agent: bool = True,
+    probes: Probes | None = None,
+) -> list[CheckResult]:
+    """Environment checks for Experiment and Doctor.
+
+    Checks the experimentalist credentials and model endpoint, platform
+    reachability, an optional insight file, Docker, and Harbor.
+
+    ``enforce_insight_agent=False`` skips the local-insight agent match (an
+    explicit ``--agent`` overrides the insight's agent).
+    """
+    p = probes or Probes()
+    results: list[CheckResult] = []
+    profile_dir = profile.profile_dir if profile is not None else None
+    results += _check_env(
+        p, "credentials-experiment", ("EXPERIMENTALIST_API_BASE", "EXPERIMENTALIST_API_KEY"), profile_dir
+    )
+    base = p.env.get("EXPERIMENTALIST_API_BASE")
+    if base:
+        model_url = f"{base.rstrip('/')}/models"
+        ok = p.http_ok(model_url)
+        display_model_url = f"{_redact_url(base).rstrip('/')}/models"
+        results.append(
+            make_check_result(
+                "model-endpoint",
+                "credentials-experiment",
+                ok,
+                "advisory",
+                f"{display_model_url} reachable",
+                "model endpoint unreachable",
+                hint="check EXPERIMENTALIST_API_BASE and network",
+            )
+        )
+    ok = p.http_ok(f"{base_url.rstrip('/')}/health/ready")
+    display_base_url = _redact_url(base_url)
+    results.append(
+        make_check_result(
+            "platform-reachable",
+            "platform",
+            ok,
+            "advisory",
+            f"{display_base_url} reachable",
+            f"{display_base_url} unreachable",
+            hint="is the platform running? check --base-url/NMP_BASE_URL",
+        )
+    )
+    profile_agent = profile.agent if (profile is not None and enforce_insight_agent) else None
+    results += _check_insight_file(insight, insight_id, profile_agent)
+    code, _ = p.run_cmd(["docker", "info"])
+    results.append(
+        make_check_result(
+            "docker",
+            "runtime",
+            code == 0,
+            "required",
+            "docker daemon running",
+            "docker daemon not running",
+            hint="start Docker; Harbor evaluation requires it",
+        )
+    )
+    has_harbor = importlib.util.find_spec("harbor") is not None
+    results.append(
+        make_check_result(
+            "harbor-import",
+            "runtime",
+            has_harbor,
+            "required",
+            "harbor importable",
+            "harbor not importable",
+            hint="uv sync",
+        )
+    )
+    return results
+
+
+def check_artifacts(
+    profile: AgentProfile | None,
+    *,
+    task_template: str | None = None,
+    agent_source: str | None = None,
+    storage: dict | None = None,
+    require_template: bool = True,
+    probes: Probes | None = None,
+) -> list[CheckResult]:
+    """Task-template + agent-source (+ pr-cli-auth via *storage*) checks.
+
+    The optional effective-value kwargs replace the profile-derived values when
+    provided: the auto path passes its RESOLVED inputs so checks validate what
+    the run will actually use (flags/--config may have overridden the profile),
+    while doctor passes nothing because there the profile values are the
+    effective ones. A profileless auto path supplies all effective values
+    directly. ``require_template=False`` skips the task-template checks
+    (insight-less runs never read the template). No dataset checks here: the
+    experiment flow's resolved dataset URIs are proven-existing by construction,
+    so dataset validation lives only in check_datasets (doctor).
+    """
+    p = probes or Probes()
+    results: list[CheckResult] = []
+    base_dir = profile.profile_dir if profile is not None else Path.cwd()
+    effective_template = task_template or (profile.task_template if profile is not None else None)
+    if require_template and effective_template is not None:
+        results += _check_task_template(resolve_profile_path(effective_template, base_dir))
+    results += _check_agent_source(profile, p, agent_source=agent_source, storage=storage)
+    return results
+
+
+def check_datasets(profile: AgentProfile) -> list[CheckResult]:
+    """Classify and validate the profile's train/validation dataset refs
+    (path-exists / registry-ref pass). Doctor-only: the experiment flow
+    resolves its datasets, which proves they exist."""
+    results: list[CheckResult] = []
+    for label, value in (("train", profile.datasets.train), ("validation", profile.datasets.validation)):
+        try:
+            kind = classify_dataset_value(value, profile.profile_dir)
+        except ResolveError as exc:
+            results.append(
+                CheckResult(
+                    name=f"dataset-{label}", group="artifacts", status="fail", severity="required", message=str(exc)
+                )
+            )
+            continue
+        if kind == "path":
+            path = resolve_profile_path(value, profile.profile_dir)
+            results.append(
+                make_check_result(
+                    f"dataset-{label}",
+                    "artifacts",
+                    path.is_dir(),
+                    "required",
+                    f"{label} dataset at {path}",
+                    (
+                        f"{label} dataset path is not a directory: {path}"
+                        if path.exists()
+                        else f"{label} dataset path missing: {path}"
+                    ),
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name=f"dataset-{label}",
+                    group="artifacts",
+                    status="pass",
+                    severity="required",
+                    message=f"{label}: registry ref {value!r}, resolved at run time",
+                )
+            )
+    return results
+
+
+def _check_task_template(tt: Path) -> list[CheckResult]:
+    results = [
+        make_check_result(
+            "task-template-dir",
+            "artifacts",
+            tt.is_dir(),
+            "required",
+            f"task_template at {tt}",
+            f"task_template dir missing: {tt}",
+        )
+    ]
+    toml_path = tt / "task.toml"
+    if toml_path.is_file():
+        try:
+            data = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+            task = data.get("task")
+            name = task.get("name") if isinstance(task, Mapping) else None
+            ok = isinstance(name, str) and "/" in name
+            results.append(
+                make_check_result(
+                    "task-toml",
+                    "artifacts",
+                    ok,
+                    "required",
+                    "task.toml parses; name keeps org/name format",
+                    f"task.toml [task].name {name!r} must keep org/name format",
+                )
+            )
+        except (OSError, UnicodeError, tomllib.TOMLDecodeError) as exc:
+            results.append(
+                CheckResult(
+                    name="task-toml",
+                    group="artifacts",
+                    status="fail",
+                    severity="required",
+                    message=f"task.toml unreadable or does not parse: {exc}",
+                    hint="save task.toml as readable UTF-8 TOML, then retry",
+                )
+            )
+    elif tt.is_dir():
+        results.append(
+            CheckResult(
+                name="task-toml", group="artifacts", status="fail", severity="required", message=f"missing {toml_path}"
+            )
+        )
+    if tt.is_dir():
+        results.append(
+            make_check_result(
+                "instruction-md",
+                "artifacts",
+                (tt / "instruction.md").is_file(),
+                "advisory",
+                "instruction.md present",
+                "instruction.md missing (Eval Author fills it per trace)",
+            )
+        )
+    return results
+
+
+def _check_agent_source(
+    profile: AgentProfile | None,
+    p: Probes,
+    *,
+    agent_source: str | None = None,
+    storage: dict | None = None,
+) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    source = agent_source or (profile.agent_source if profile is not None else None)
+    repo: str | None = None
+    if source is not None and looks_like_git(source):
+        try:
+            core, _ = split_agent_spec(source)  # drop the #path fragment
+        except ValueError as exc:
+            return [
+                CheckResult(
+                    name="agent-source-path",
+                    group="agent-source",
+                    status="fail",
+                    severity="required",
+                    message=str(exc),
+                    hint="use a normalized relative POSIX path without traversal, pathspecs, or .git components",
+                )
+            ]
+        repo, _ = split_git_ref(core)  # drop the @ref pin (splits on ".git@", so ssh://git@host survives)
+    elif source is not None:
+        base_dir = profile.profile_dir if profile is not None else Path.cwd()
+        path = resolve_profile_path(source, base_dir)
+        results.append(
+            make_check_result(
+                "agent-source-dir",
+                "agent-source",
+                path.is_dir(),
+                "required",
+                f"agent source at {path}",
+                f"agent source dir missing: {path}",
+            )
+        )
+    # Effective storage flags from the auto path (resolved config, which may come
+    # from --config); doctor falls back to reading the profile's inline dict or
+    # path-form experiment_config without importing the loop chain.
+    if storage is not None:
+        flags = storage
+    elif profile is not None:
+        flags = profile_storage_flags(profile)
+    else:
+        flags = {}
+    persistence_requested = bool(flags.get("publish_winner") or flags.get("archive_candidates"))
+    git_available = True
+    if repo is not None or persistence_requested:
+        git_code, _ = p.run_cmd(["git", "--version"])
+        git_available = git_code == 0
+        results.append(
+            make_check_result(
+                "git-installed",
+                "agent-source",
+                git_available,
+                "required",
+                "git is available",
+                "'git' is not available but the effective agent source or storage behavior requires it",
+                hint="install git, or disable candidate persistence and use a local agent source",
+            )
+        )
+    if repo is not None and git_available:
+        code, _ = p.run_cmd(["git", "ls-remote", repo])
+        safe_repo = _redact_url(repo)
+        failure_message = (
+            f"git ls-remote timed out for {safe_repo}"
+            if code == 124
+            else f"git ls-remote failed for {safe_repo} (exit status {code})"
+        )
+        results.append(
+            make_check_result(
+                "agent-source-git",
+                "agent-source",
+                code == 0,
+                "advisory",
+                f"git source reachable: {safe_repo}",
+                failure_message,
+                hint="could not reach the git remote; the run will fail at clone time if this persists",
+            )
+        )
+    if persistence_requested and repo is None:
+        results.append(
+            CheckResult(
+                name="remote-persistence",
+                group="agent-source",
+                status="warn",
+                severity="advisory",
+                message="remote candidate persistence requires agent_source to be a git URL",
+                hint="set agent_source to an HTTPS, SSH, or SCP-style git URL, or disable remote persistence",
+            )
+        )
+    elif flags.get("publish_winner") and repo is not None:
+        target = pr_cli_for_repo_url(repo)
+        if target is None:
+            results.append(
+                CheckResult(
+                    name="pr-cli-auth",
+                    group="agent-source",
+                    status="warn",
+                    severity="advisory",
+                    message="automatic PR/MR creation is unsupported for this repository host",
+                    hint="use a GitHub or GitLab source, or disable publish_winner and use archive_candidates",
+                )
+            )
+        else:
+            cli, hostname = target
+            authenticated = p.run_cmd([cli, "auth", "status", "--hostname", hostname])[0] == 0
+            results.append(
+                make_check_result(
+                    "pr-cli-auth",
+                    "agent-source",
+                    authenticated,
+                    "advisory",
+                    f"{cli} authenticated for {hostname}",
+                    f"{cli} is not authenticated for {hostname} PR/MR publishing",
+                    hint=f"run `{cli} auth login --hostname {hostname}`, or publish_winner cannot open the winner PR/MR",
+                )
+            )
+    return results
+
+
+# Where each credential comes from — surfaced in the missing-var hint so the
+# fix is actionable without hunting through the README.
+_ENV_SOURCES = {
+    "EXPERIMENTALIST_API_BASE": (
+        "OpenAI-compatible LLM endpoint for the experimentalist (defaults to https://inference-api.nvidia.com/v1)"
+    ),
+    "EXPERIMENTALIST_API_KEY": "API key for EXPERIMENTALIST_API_BASE (on the gateway, INFERENCE_API_KEY fills this)",
+}
+
+_ENV_EXAMPLE_POINTER = "see examples/tau2-nemo-oo-agent/.env.example"
+
+
+def _check_env(p: Probes, group: str, names: tuple[str, ...], profile_dir: Path | None) -> list[CheckResult]:
+    env_location = str(profile_dir / ".env") if profile_dir else ".env next to your optimizer.yaml"
+    return [
+        make_check_result(
+            name,
+            group,
+            bool(p.env.get(name, "").strip()),
+            "required",
+            f"{name} set",
+            f"{name} not set",
+            hint=(
+                f"{_ENV_SOURCES.get(name, 'required credential')}. "
+                f"Save it in {env_location} (auto-loaded; {_ENV_EXAMPLE_POINTER}) or export {name}=..."
+            ),
+        )
+        for name in names
+    ]
+
+
+def _check_insight_file(
+    insight: str | None,
+    selector: str | None,
+    profile_agent: str | None,
+) -> list[CheckResult]:
+    if insight is None:
+        if selector is not None:
+            return [
+                CheckResult(
+                    name="insight-file",
+                    group="platform",
+                    status="fail",
+                    severity="required",
+                    message="--insight-id requires a resolved local multi-insight file",
+                )
+            ]
+        return []
+    path = Path(insight)
+    if not path.is_file():
+        if selector is not None:
+            return [
+                CheckResult(
+                    name="insight-file",
+                    group="platform",
+                    status="fail",
+                    severity="required",
+                    message=f"--insight-id requires a local multi-insight file; {insight!r} is a platform id or non-file ref",
+                )
+            ]
+        return [
+            CheckResult(
+                name="insight-ref",
+                group="platform",
+                status="pass",
+                severity="required",
+                message=f"insight {insight!r}: platform id, verified at run time",
+            )
+        ]
+    try:
+        items = parse_local_insights(insight)
+        if items is None:
+            return []
+        selected = select_local_insight(items, selector, insight)
+    except ResolveError as exc:
+        return [
+            CheckResult(
+                name="insight-file",
+                group="platform",
+                status="fail",
+                severity="required",
+                message=str(exc),
+            )
+        ]
+    results = [
+        CheckResult(
+            name="insight-file",
+            group="platform",
+            status="pass",
+            severity="required",
+            message=f"insight file parses: {path} ({len(items)} insight{'s' if len(items) != 1 else ''})",
+        )
+    ]
+    if profile_agent:
+        selected_agent = selected.get("agent")
+        if isinstance(selected_agent, str) and selected_agent:
+            results.append(
+                make_check_result(
+                    "insight-agent",
+                    "platform",
+                    selected_agent == profile_agent,
+                    "required",
+                    f"insight agent matches profile: {profile_agent!r}",
+                    f"insight is about agent {selected_agent!r} but the profile is for {profile_agent!r}",
+                    hint="pass --agent to override, or use the matching profile (--profile)",
+                )
+            )
+    return results

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/profile.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/profile.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimentalist-owned models for the shared ``optimizer.yaml`` profile.
+
+The profile is the shared per-agent contract: the Platform-owned
+``nemo insights analyze`` producer writes
+``<profile-dir>/.nemo-optimizer/insights.yaml``, and
+``nemo experimentalist run`` reads it by default. NeMo Experimentalist validates
+the full experiment schema; NeMo Insights consumes only its analysis subset.
+"""
+
+from pathlib import Path
+
+from nemo_insights_plugin.contracts.profile import load_profile_model
+from pydantic import BaseModel, ConfigDict
+
+
+class DatasetsSpec(BaseModel):
+    """Train/validation dataset references: local paths or harbor registry refs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    train: str
+    validation: str
+    registry_url: str | None = None
+
+
+class AgentProfile(BaseModel):
+    """Parsed ``optimizer.yaml``; ``profile_dir`` anchors its relative paths."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent: str
+    task_template: str
+    datasets: DatasetsSpec
+    agent_source: str = "."
+    agent_spec: str | None = None
+    experiment_config: dict | str | None = None
+    framework_skills: list[str] = []
+    workspace: str = "default"
+    profile_dir: Path
+
+
+def load_profile(path: Path) -> AgentProfile:
+    """Load and validate *path* as the Experimentalist's strict profile model."""
+    return load_profile_model(path, AgentProfile)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/resolve.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/resolve.py
@@ -1,0 +1,657 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Input resolution for one-command experiments.
+
+Joins profile values with CLI overrides, normalizes insight references
+(including the NeMo Insights producer's ``{"insights": [...]}`` local output),
+and resolves dataset values (local paths or harbor registry refs). This module is the
+Studio-parity seam: the CLI is a thin caller, and a future remote trigger
+calls the same functions server-side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import shutil
+import uuid
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from nemo_experimentalist_plugin.eval_author.models import EvalAuthorConfig
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.components.repository import looks_like_git
+from nemo_experimentalist_plugin.profile import AgentProfile
+from nemo_insights_plugin.contracts.insights import InsightsFileError, load_insights_document
+from nemo_insights_plugin.contracts.profile import ProfileError, resolve_agent_spec_path, resolve_profile_path
+from pydantic import BaseModel, Field, ValidationError, model_validator
+
+
+class ResolveError(ValueError):
+    """Experiment inputs could not be resolved from profile + overrides."""
+
+
+class AgentSourceConfig(BaseModel):
+    """Import-safe git/source modifiers for an experiment."""
+
+    clone_depth: int | None = None
+    source_path: str | None = None
+    entrypoint: str | None = None
+
+
+class CandidateStorageConfig(BaseModel):
+    """Import-safe candidate persistence settings."""
+
+    archive_candidates: bool = False
+    candidate_branch_prefix: str = "optimizer"
+    publish_winner: bool = False
+    pr_draft: bool = True
+    pr_base_branch: str | None = None
+    pr_title: str | None = None
+    pr_body: str | None = None
+    pr_labels: list[str] = Field(default_factory=list)
+
+
+class GoalTreeConfig(BaseModel):
+    """Import-safe goal-tree settings used by the optimizer loop."""
+
+    max_depth: int = Field(default=3, gt=0)
+    max_initial_depth: int = Field(default=2, gt=0)
+    min_initial_nodes: int = Field(default=3, gt=0)
+    max_initial_nodes: int = Field(default=4, gt=0)
+
+    @model_validator(mode="after")
+    def validate_constraints(self) -> GoalTreeConfig:
+        if self.max_initial_depth > self.max_depth:
+            raise ValueError(f"max_initial_depth ({self.max_initial_depth}) cannot exceed max_depth ({self.max_depth})")
+        if self.min_initial_nodes > self.max_initial_nodes:
+            raise ValueError(
+                f"min_initial_nodes ({self.min_initial_nodes}) cannot exceed "
+                f"max_initial_nodes ({self.max_initial_nodes})"
+            )
+        return self
+
+    def validate_tree(self, tree: Any) -> Any:
+        """Validate a runtime GoalTree without importing the agent module."""
+
+        def visit(node: Any, depth: int) -> None:
+            if depth > self.max_depth:
+                raise ValueError(f"goal tree exceeds max depth {self.max_depth} at node {node.id!r}")
+            if node.added_at_generation is None and depth > self.max_initial_depth:
+                raise ValueError(
+                    f"initial goal tree nodes exceed max depth {self.max_initial_depth} at node {node.id!r}"
+                )
+            for child in node.children:
+                visit(child, depth + 1)
+
+        visit(tree.root, 1)
+        initial_nodes = [node for node in tree._iter_nodes() if node.added_at_generation is None]
+        if not (self.min_initial_nodes <= len(initial_nodes) <= self.max_initial_nodes):
+            raise ValueError(
+                f"initial goal tree must have {self.min_initial_nodes}-"
+                f"{self.max_initial_nodes} nodes, got {len(initial_nodes)}"
+            )
+        return tree
+
+
+class CoderConfig(BaseModel):
+    """Import-safe Coder tuning settings."""
+
+    max_summary_tokens: int = 80_000
+    max_fix_attempts: int = 2
+    timeout_model_list_secs: float = 10.0
+    model_catalog_path: Path | None = None
+
+
+class RationalizerConfig(BaseModel):
+    """Import-safe Rationalizer tuning settings."""
+
+    max_summary_tokens: int = 80_000
+
+
+class TraceAnalyzerConfig(BaseModel):
+    """Import-safe trace-analysis tuning settings."""
+
+    max_summary_tokens: int = 80_000
+
+
+class AnalyzerConfig(BaseModel):
+    """Import-safe AgentAnalyzer tuning settings."""
+
+    max_summary_tokens: int = 80_000
+    max_trials: int = 5
+    max_divergent_pairs: int = 3
+    rationalizer: RationalizerConfig = Field(default_factory=RationalizerConfig)
+    trace_analyzer: TraceAnalyzerConfig = Field(default_factory=TraceAnalyzerConfig)
+
+
+class ProposerConfig(BaseModel):
+    """Import-safe Proposer tuning settings."""
+
+    max_summary_tokens: int = 80_000
+
+
+class EvolutionaryOptimizerConfig(BaseModel):
+    """Complete import-safe schema for one optimizer run."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_curator_config(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "curator" in data:
+            raise ValueError("'curator' was renamed to 'eval_author'; update the optimizer configuration")
+        return data
+
+    max_rounds: int = 15
+    min_rounds_before_stopping: int = 3
+    max_survivors: int = 3
+    max_candidates: int = 3
+    max_trajectory_tasks: int = 8
+    max_train_batch_tasks: int | None = None
+    train_batch_seed: int = 0
+    max_summary_tokens: int = 80_000
+    model_catalog_path: Path | None = None
+    disable_trajectory_scoring: bool = False
+    disable_convergence_check: bool = False
+    source: AgentSourceConfig = Field(default_factory=AgentSourceConfig)
+    storage: CandidateStorageConfig = Field(default_factory=CandidateStorageConfig)
+    goal_config: GoalTreeConfig = Field(default_factory=GoalTreeConfig)
+    coder: CoderConfig = Field(default_factory=CoderConfig)
+    analyzer: AnalyzerConfig = Field(default_factory=AnalyzerConfig)
+    proposer: ProposerConfig = Field(default_factory=ProposerConfig)
+    evaluator: dict[str, Any] = Field(default_factory=dict)
+    eval_author: EvalAuthorConfig = Field(default_factory=EvalAuthorConfig)
+
+
+class EffectiveInsight(BaseModel):
+    """The insight reference selected by flags and the shared profile default."""
+
+    ref: str | None
+    selector: str | None
+    is_profile_default: bool = False
+
+
+def resolve_effective_insight(
+    *,
+    profile: AgentProfile | None,
+    insight: str | None,
+    insight_id: str | None,
+    disabled: bool = False,
+) -> EffectiveInsight:
+    """Resolve explicit/disabled/profile-default insight selection without I/O writes."""
+    if disabled:
+        if insight is not None or insight_id is not None:
+            raise ResolveError("--no-insight cannot be combined with --insight or --insight-id")
+        return EffectiveInsight(ref=None, selector=None)
+    ref = insight
+    is_default = False
+    if ref is None and profile is not None:
+        default_path = profile.profile_dir / ".nemo-optimizer" / "insights.yaml"
+        if default_path.is_file():
+            ref = str(default_path)
+            is_default = True
+    if insight_id is not None and ref is None:
+        raise ResolveError(
+            "--insight-id cannot be used without an insight; pass an explicit or shared local multi-insight file"
+        )
+    return EffectiveInsight(ref=ref, selector=insight_id, is_profile_default=is_default)
+
+
+def _validate_json_insight(insight: dict[str, Any], source: str) -> dict[str, Any]:
+    try:
+        json.dumps(insight)
+    except (TypeError, ValueError) as exc:
+        raise ResolveError(f"{source} must be JSON-serializable: {exc}") from exc
+    return insight
+
+
+def parse_local_insights(ref: str) -> list[dict[str, Any]] | None:
+    """Parse and validate a local insight file, or return ``None`` for a platform id."""
+    path = Path(ref)
+    if not path.is_file():
+        return None
+    try:
+        payload = load_insights_document(path)
+    except InsightsFileError as exc:
+        raise ResolveError(str(exc)) from None
+    if "insights" not in payload:
+        return [_validate_json_insight(dict(payload), f"Insight in {path}")]
+    raw_insights = payload["insights"]
+    if not raw_insights:
+        raise ResolveError(f"{ref} contains no insights")
+    return [
+        _validate_json_insight(dict(insight), f"Insight entry {index} in {path}")
+        for index, insight in enumerate(raw_insights)
+    ]
+
+
+def select_local_insight(
+    insights: list[dict[str, Any]],
+    selector: str | None,
+    ref: str,
+) -> dict[str, Any]:
+    """Select one insight by zero-based decimal index or exact id/title."""
+    if selector is None:
+        if len(insights) != 1:
+            raise ResolveError(f"{ref} contains {len(insights)} insights; pass --insight-id. " + _candidates(insights))
+        return insights[0]
+    matches = [insight for insight in insights if selector in (insight.get("id"), insight.get("title"))]
+    if len(matches) > 1:
+        raise ResolveError(
+            f"Insight selector {selector!r} is ambiguous in {ref} ({len(matches)} matches); "
+            + _candidates(insights)
+            + ". Use a zero-based index to disambiguate."
+        )
+    if matches:
+        return matches[0]
+    if selector.isdecimal():
+        index = int(selector)
+        if index >= len(insights):
+            raise ResolveError(
+                f"Insight index {index} is out of range for {ref} ({len(insights)} insights); " + _candidates(insights)
+            )
+        return insights[index]
+    raise ResolveError(f"No insight matching {selector!r} in {ref}; " + _candidates(insights))
+
+
+def normalize_insight_ref(ref: str, selector: str | None, scratch_dir: Path) -> str:
+    """Return an insight reference the local backend can consume.
+
+    Platform ids pass through. Every local file — a single-insight document or
+    the NeMo Insights producer's ``{"insights": [...]}`` output (narrowed by ``selector``
+    as a zero-based index or exact ``id``/``title``; unambiguous when the list
+    has exactly one) — is rewritten as a single-insight JSON file under
+    *scratch_dir*: the local backend reads insight files with ``json.loads``,
+    so a YAML-authored file must not reach it raw.
+    """
+    insights = parse_local_insights(ref)
+    if insights is None:
+        if selector is not None:
+            raise ResolveError(f"--insight-id requires a local multi-insight file; {ref!r} is not a local file")
+        return ref
+    selected = select_local_insight(insights, selector, ref)
+    scratch_dir.mkdir(parents=True, exist_ok=True)
+    out = scratch_dir / "insight.json"
+    out.write_text(json.dumps(selected, indent=2), encoding="utf-8")
+    return str(out)
+
+
+def _candidates(insights: list[dict[str, Any]]) -> str:
+    listing = ", ".join(f"{i.get('id', '?')} ({i.get('title', 'untitled')})" for i in insights)
+    return f"Available: {listing}"
+
+
+DEFAULT_DATASET_CACHE = Path.home() / ".cache" / "nemo-experimentalist" / "datasets"
+CACHE_LAYOUT_VERSION = "v2"
+
+DownloadFn = Callable[[str, Path, str | None], Awaitable[None]]
+
+
+async def _harbor_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+    """Download a registry dataset via harbor into *output_dir*."""
+    if "/" in name.partition("@")[0]:
+        from harbor.registry.client.package import PackageDatasetClient  # noqa: PLC0415 - heavy import, CLI hot path
+
+        client = PackageDatasetClient()
+    else:
+        from harbor.registry.client.factory import RegistryClientFactory  # noqa: PLC0415 - heavy import, CLI hot path
+
+        client = RegistryClientFactory.create(registry_url=registry_url)
+    await client.download_dataset(name, output_dir=output_dir, export=True)
+
+
+DatasetKind = Literal["path", "ref"]
+
+
+def classify_dataset_value(value: str, base_dir: Path, *, registry_url: str | None = None) -> DatasetKind:
+    """Classify a dataset value as a local path or a harbor registry ref.
+
+    Explicit paths (prefixed ``./ ../ / ~``) are always local. When a registry
+    URL is configured, every other value is a registry ref, including
+    namespaced refs containing ``/``. Without a registry URL, preserve the
+    historical heuristic: values containing a path separator or naming an
+    existing entry under *base_dir* are local paths.
+    """
+    if value.startswith(("./", "../", "/", "~")):
+        return "path"
+    if registry_url is not None:
+        return "ref"
+    if "/" in value:
+        return "path"
+    try:
+        if (base_dir / value).exists():
+            return "path"
+    except OSError:  # not representable as a local path (e.g. name too long)
+        pass
+    return "ref"
+
+
+def _cache_digest(value: str) -> str:
+    """Return a bounded lowercase digest of the exact UTF-8 input bytes."""
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _dataset_cache_target(value: str, registry_url: str | None, cache: Path) -> Path:
+    """Cache layout ``v2/<registry>/name-<digest>/<bare|version-<digest>>``."""
+    name, separator, version = value.partition("@")
+    registry_slug = hashlib.sha256(registry_url.encode()).hexdigest()[:12] if registry_url else "default"
+    name_key = f"name-{_cache_digest(name)}"
+    version_key = f"version-{_cache_digest(version)}" if separator else "bare"
+    return cache / CACHE_LAYOUT_VERSION / registry_slug / name_key / version_key
+
+
+async def resolve_dataset(
+    value: str,
+    profile_dir: Path,
+    *,
+    registry_url: str | None = None,
+    cache_dir: Path | None = None,
+    download: DownloadFn | None = None,
+) -> str:
+    """Resolve a dataset value to a local directory path (str).
+
+    Local paths resolve against *profile_dir* and must exist. Registry refs
+    (``name[@version]``) download to the cache directory on first use.
+    """
+    if classify_dataset_value(value, profile_dir, registry_url=registry_url) == "path":
+        try:
+            path = resolve_profile_path(value, profile_dir)
+        except (ProfileError, RuntimeError) as exc:  # expanduser: ~user or unset HOME
+            raise ResolveError(f"Dataset path {value!r} could not be resolved: {exc}") from None
+        if not path.exists():
+            raise ResolveError(f"Dataset path {value!r} does not exist (resolved to {path})")
+        if not path.is_dir():
+            raise ResolveError(f"Dataset path {value!r} is not a directory (resolved to {path})")
+        return str(path)
+    cache = cache_dir or DEFAULT_DATASET_CACHE
+    target = _dataset_cache_target(value, registry_url, cache)
+    if target.exists() and not target.is_dir():
+        raise ResolveError(f"Dataset cache target for {value!r} is not a directory: {target}")
+    if not target.exists():
+        downloader = download or _harbor_download
+        target.parent.mkdir(parents=True, exist_ok=True)
+        partial = target.with_name(f"{target.name}.{uuid.uuid4().hex}.partial")
+        try:
+            try:
+                await downloader(value, partial, registry_url)
+            except ResolveError:
+                raise
+            except Exception as exc:
+                raise ResolveError(f"Failed to download dataset {value!r}: {exc}") from exc
+            if not partial.is_dir():
+                raise ResolveError(f"Downloaded dataset {value!r} is not a directory: {partial}")
+            try:
+                partial.rename(target)  # atomic: cache path appears only on complete download
+            except OSError as exc:
+                if not target.is_dir():
+                    raise ResolveError(f"Failed to publish downloaded dataset {value!r}: {exc}") from exc
+        finally:
+            if partial.is_symlink() or (partial.exists() and not partial.is_dir()):
+                partial.unlink(missing_ok=True)
+            elif partial.is_dir():
+                shutil.rmtree(partial, ignore_errors=True)
+    if not target.is_dir():
+        raise ResolveError(f"Dataset cache target for {value!r} is not a directory: {target}")
+    return str(target)
+
+
+_PROFILE_SKELETON = """\
+agent: <agent-name>            # must match the insight's agent
+task_template: ./path/to/task_template
+datasets:
+  train: ./path/to/train       # local path or harbor registry ref
+  validation: ./path/to/val
+"""
+
+
+class EffectiveExperimentPlan(BaseModel):
+    """Pure effective values shared by Experiment and Doctor before downloads."""
+
+    agent: str | None
+    agent_spec: str | None
+    insight: str | None
+    insight_id: str | None
+    train_dataset: str
+    validation_dataset: str
+    task_template: str | None
+    train_anchor: Path
+    validation_anchor: Path
+    task_template_anchor: Path
+    registry_url: str | None
+    workspace: str
+    config: EvolutionaryOptimizerConfig
+    framework_skills_dirs: list[Path]
+
+
+class ResolvedExperimentInputs(BaseModel):
+    """Everything ``run_experimentalist`` needs after materialization."""
+
+    agent: str | None
+    agent_spec: str | None
+    insight: str | None
+    train_dataset: DatasetRef
+    validation_dataset: DatasetRef
+    task_template: DatasetRef | None
+    workspace: str
+    config: EvolutionaryOptimizerConfig
+    framework_skills_dirs: list[Path]
+
+
+def _read_agent_spec_path(spec: Path) -> str:
+    try:
+        spec.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise ResolveError(f"Could not read agent_spec {spec}: {exc}") from None
+    return str(spec)
+
+
+def build_effective_experiment_plan(
+    *,
+    profile: AgentProfile | None,
+    agent: str | None = None,
+    agent_spec: str | None = None,
+    insight: str | None = None,
+    insight_id: str | None = None,
+    no_insight: bool = False,
+    train_dataset: str | None = None,
+    validation_dataset: str | None = None,
+    task_template: str | None = None,
+    workspace: str | None = None,
+    config_payload: Any | None = None,
+    framework_skills: list[Path] | None = None,
+) -> EffectiveExperimentPlan:
+    """Build and validate the import-safe effective Experiment plan."""
+    effective_insight = resolve_effective_insight(
+        profile=profile,
+        insight=insight,
+        insight_id=insight_id,
+        disabled=no_insight,
+    )
+    missing: list[str] = []
+    profile_dir = profile.profile_dir if profile else Path.cwd()
+    cwd = Path.cwd()
+    train = train_dataset or (profile.datasets.train if profile else None)
+    validation = validation_dataset or (profile.datasets.validation if profile else None)
+    template = task_template or (profile.task_template if profile else None)
+    train_anchor = cwd if train_dataset else profile_dir
+    validation_anchor = cwd if validation_dataset else profile_dir
+    template_anchor = cwd if task_template else profile_dir
+
+    resolved_agent = agent
+    if resolved_agent is not None and not looks_like_git(resolved_agent):
+        resolved_agent = str(resolve_profile_path(resolved_agent, cwd))
+    if resolved_agent is None and profile is not None:
+        source = profile.agent_source
+        resolved_agent = source if looks_like_git(source) else str(resolve_profile_path(source, profile_dir))
+
+    if train is None:
+        missing.append("--train-dataset")
+    if validation is None:
+        missing.append("--validation-dataset")
+    if effective_insight.ref is not None and template is None:
+        missing.append("--task-template")
+    if effective_insight.ref is None and resolved_agent is None:
+        missing.append("--agent")
+    if missing:
+        raise ResolveError(
+            "Missing required inputs: " + ", ".join(missing) + ". Provide flags or add an "
+            f"optimizer.yaml to the agent directory:\n{_PROFILE_SKELETON}"
+        )
+    assert train is not None and validation is not None
+
+    if agent_spec is not None:
+        spec = resolve_profile_path(agent_spec, cwd)
+        if not spec.is_file():
+            raise ResolveError(f"Explicit agent_spec {agent_spec!r} does not exist (resolved to {spec})")
+        resolved_spec = _read_agent_spec_path(spec)
+    elif profile is not None:
+        resolved_spec = pick_agent_spec(profile)
+    else:
+        resolved_spec = None
+    skills = (
+        list(framework_skills)
+        if framework_skills
+        else [resolve_profile_path(skill, profile_dir) for skill in (profile.framework_skills if profile else [])]
+    )
+    return EffectiveExperimentPlan(
+        agent=resolved_agent,
+        agent_spec=resolved_spec,
+        insight=effective_insight.ref,
+        insight_id=effective_insight.selector,
+        train_dataset=train,
+        validation_dataset=validation,
+        task_template=str(resolve_profile_path(template, template_anchor)) if template is not None else None,
+        train_anchor=train_anchor,
+        validation_anchor=validation_anchor,
+        task_template_anchor=template_anchor,
+        registry_url=profile.datasets.registry_url if profile else None,
+        workspace=workspace or (profile.workspace if profile else "default"),
+        config=_resolve_config(config_payload, profile),
+        framework_skills_dirs=skills,
+    )
+
+
+async def resolve_experiment_inputs(
+    *,
+    profile: AgentProfile | None,
+    scratch_dir: Path,
+    agent: str | None = None,
+    agent_spec: str | None = None,
+    insight: str | None = None,
+    insight_id: str | None = None,
+    no_insight: bool = False,
+    train_dataset: str | None = None,
+    validation_dataset: str | None = None,
+    task_template: str | None = None,
+    workspace: str | None = None,
+    config_payload: Any | None = None,
+    framework_skills: list[Path] | None = None,
+    download: DownloadFn | None = None,
+    cache_dir: Path | None = None,
+    plan: EffectiveExperimentPlan | None = None,
+) -> ResolvedExperimentInputs:
+    """Join CLI overrides with profile values (flag > profile > default)."""
+    if plan is None:
+        plan = build_effective_experiment_plan(
+            profile=profile,
+            agent=agent,
+            agent_spec=agent_spec,
+            insight=insight,
+            insight_id=insight_id,
+            no_insight=no_insight,
+            train_dataset=train_dataset,
+            validation_dataset=validation_dataset,
+            task_template=task_template,
+            workspace=workspace,
+            config_payload=config_payload,
+            framework_skills=framework_skills,
+        )
+    resolved_insight = (
+        normalize_insight_ref(plan.insight, plan.insight_id, scratch_dir) if plan.insight is not None else None
+    )
+
+    if plan.train_dataset == plan.validation_dataset and plan.train_anchor == plan.validation_anchor:
+        # Same ref for both: resolve once — two concurrent downloads would race
+        # on the same cache .partial directory.
+        train_uri = validation_uri = await resolve_dataset(
+            plan.train_dataset,
+            plan.train_anchor,
+            registry_url=plan.registry_url,
+            cache_dir=cache_dir,
+            download=download,
+        )
+    else:
+        train_uri, validation_uri = await asyncio.gather(
+            resolve_dataset(
+                plan.train_dataset,
+                plan.train_anchor,
+                registry_url=plan.registry_url,
+                cache_dir=cache_dir,
+                download=download,
+            ),
+            resolve_dataset(
+                plan.validation_dataset,
+                plan.validation_anchor,
+                registry_url=plan.registry_url,
+                cache_dir=cache_dir,
+                download=download,
+            ),
+        )
+    template_uri = (
+        str(resolve_profile_path(plan.task_template, plan.task_template_anchor))
+        if plan.task_template is not None
+        else None
+    )
+    return ResolvedExperimentInputs(
+        agent=plan.agent,
+        agent_spec=plan.agent_spec,
+        insight=resolved_insight,
+        train_dataset=DatasetRef(uri=train_uri, metadata={"id": "train"}),
+        validation_dataset=DatasetRef(uri=validation_uri, metadata={"id": "validation"}),
+        task_template=DatasetRef(uri=template_uri, metadata={"id": "task-template"}) if template_uri else None,
+        workspace=plan.workspace,
+        config=plan.config,
+        framework_skills_dirs=plan.framework_skills_dirs,
+    )
+
+
+def profile_storage_flags(profile: AgentProfile) -> dict:
+    """Return validated, explicitly configured storage flags for Doctor."""
+    return _resolve_config(None, profile).storage.model_dump(exclude_defaults=True)
+
+
+def pick_agent_spec(profile: AgentProfile) -> str | None:
+    """Resolve and read-check the configured or conventional agent spec."""
+    try:
+        spec = resolve_agent_spec_path(profile.profile_dir, profile.agent_spec)
+    except ProfileError as exc:
+        raise ResolveError(str(exc)) from None
+    return _read_agent_spec_path(spec) if spec is not None else None
+
+
+def _resolve_config(config_payload: Any | None, profile: AgentProfile | None) -> EvolutionaryOptimizerConfig:
+    """Validate flag > profile-inline > profile-path > default config."""
+
+    def validate(payload: Any, source: str) -> EvolutionaryOptimizerConfig:
+        if not isinstance(payload, dict):
+            raise ResolveError(f"Experiment config from {source} must be a YAML mapping, got {type(payload).__name__}")
+        try:
+            return EvolutionaryOptimizerConfig.model_validate(payload)
+        except ValidationError as exc:
+            raise ResolveError(f"Invalid experiment config from {source}: {exc}") from None
+
+    if config_payload is not None:
+        return validate(config_payload, "--config")
+    if profile is None or profile.experiment_config is None:
+        return EvolutionaryOptimizerConfig()
+    if isinstance(profile.experiment_config, dict):
+        return validate(profile.experiment_config, "profile experiment_config")
+    config_path = resolve_profile_path(profile.experiment_config, profile.profile_dir)
+    try:
+        payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise ResolveError(f"Could not read experiment_config {config_path}: {exc}") from None
+    return validate(payload, str(config_path))

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/skills.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/skills.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Skills directory exposure — registered under ``nemo.skills``.
+
+Returns the path to the ``skills/`` directory inside this package so the
+platform can discover and load skill markdown files shipped with the plugin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def skills_dir() -> Path:
+    """Return the directory containing this plugin's skills."""
+    return Path(__file__).parent / "skills"

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/skills/README.md
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/skills/README.md
@@ -1,0 +1,10 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# NeMo Experimentalist plugin skills
+
+Skills this plugin ships to coding agents, discovered via the `nemo.skills`
+entry point and installed with `nemo skills install`. Currently:
+
+- `terminator/` — internal guidance for the Experimentalist's qualitative stop
+  check.

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/skills/terminator/SKILL.md
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/skills/terminator/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: terminator
+description: |
+  Guidance for the Terminator's qualitative stop check: judge whether the
+  optimization has plateaued in ways the numeric scores don't capture, from the
+  latest round's analysis text, and return stop / continue.
+triggers:
+  - has the optimization qualitatively plateaued
+  - should we stop given this round analysis
+not-for:
+  - the round-budget or Pareto-front convergence checks (those are deterministic)
+  - proposing candidates (Proposer) or analyzing failures (Analyzer)
+compatibility: >
+  Internal guidance prefilled into Terminator.qualitative_stop_check
+  (`components/terminator.py`); consumed by the agent at runtime, not user-invocable.
+maturity: alpha
+license: Apache-2.0
+user-invocable: false
+---
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Terminator — qualitative stop check
+
+You are deciding whether the optimization has **qualitatively plateaued** — in ways
+the numeric scores don't capture — from the latest round's `analysis` text. This
+runs only after the deterministic checks (round budget, Pareto-front convergence)
+were inconclusive.
+
+Return **True (stop)** only when you can cite specific evidence in `analysis`, such as:
+
+- the analyzer flagging the same root cause across multiple rounds,
+- survivors converging to architecturally identical mutations,
+- diagnostics getting shorter / less specific (a sign of diminishing returns),
+- every new mutation reshuffling the same component.
+
+Return **False (continue)** when:
+
+- there is no specific textual evidence of qualitative stagnation,
+- the `analysis` is short, missing, or describes ongoing improvement,
+- you would have to assume any value not present in `analysis`.
+
+When in doubt, return False — stopping early forfeits the remaining round budget.

--- a/plugins/nemo-experimentalist/tests/conftest.py
+++ b/plugins/nemo-experimentalist/tests/conftest.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Top-level conftest: runs before any test module is imported.
+
+Coder and Proposer call get_smart_model() at class-definition time (class keyword
+argument). That call requires EXPERIMENTALIST_API_BASE and EXPERIMENTALIST_API_KEY to be set.
+We must satisfy that requirement before pytest imports any test module, so we do it
+here at module level using setdefault — real CI values are not overwritten.
+"""
+
+import os
+
+import litellm
+import pytest
+
+os.environ.setdefault("EXPERIMENTALIST_API_BASE", "http://placeholder-for-import")
+os.environ.setdefault("EXPERIMENTALIST_API_KEY", "placeholder-for-import")
+
+# Some NVIDIA inference endpoint models reject the tool_choice parameter.
+# Drop unsupported params silently so the CodeAct strategy can call tools.
+litellm.drop_params = True
+
+
+@pytest.fixture(autouse=True)
+def _restore_environ():
+    """Undo environment changes that monkeypatch cannot.
+
+    The CLI loads a profile's .env straight into os.environ. When the variable was
+    previously unset, monkeypatch has nothing recorded to restore, so the value
+    survives the test and leaks into whatever else the xdist worker runs next.
+    """
+    snapshot = os.environ.copy()
+    yield
+    os.environ.clear()
+    os.environ.update(snapshot)

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components import loop as loop_module
+from nemo_experimentalist_plugin.experimentalist.components.dataset_staging import (
+    stage_eval_author_inputs,
+    stage_task_template,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizer
+from nemo_experimentalist_plugin.resolve import EvolutionaryOptimizerConfig
+from nemo_platform import AsyncNeMoPlatform
+
+
+def _write_tree(root: Path, content: str) -> None:
+    tests = root / "task-1" / "tests"
+    tests.mkdir(parents=True)
+    (tests / "test.sh").write_text(content, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_stage_eval_author_inputs_isolates_all_mutable_sources(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    train = source / "train"
+    validation = source / "validation"
+    template = source / "task-template"
+    _write_tree(train, "train source")
+    _write_tree(validation, "validation source")
+    _write_tree(template, "template source")
+
+    experiment = tmp_path / "experiment"
+    staged = await stage_eval_author_inputs(
+        experiment,
+        train_dataset=DatasetRef(uri=str(train), metadata={"id": "train"}),
+        validation_dataset=DatasetRef(uri=str(validation), metadata={"id": "validation"}),
+        task_template=DatasetRef(uri=template.as_uri(), metadata={"id": "template"}),
+        client=cast(AsyncNeMoPlatform, object()),
+        workspace="default",
+    )
+
+    staged_train = Path(staged.train_dataset.uri)
+    staged_validation = Path(staged.validation_dataset.uri)
+    staged_template = Path(staged.task_template.uri)
+    (staged_train / "task-1" / "tests" / "test.sh").write_text("curated train", encoding="utf-8")
+    (staged_validation / "task-1" / "tests" / "test.sh").write_text("curated validation", encoding="utf-8")
+    generated = staged_template.parent / "generated-task"
+    generated.mkdir()
+
+    assert (train / "task-1" / "tests" / "test.sh").read_text(encoding="utf-8") == "train source"
+    assert (validation / "task-1" / "tests" / "test.sh").read_text(encoding="utf-8") == "validation source"
+    assert not (template.parent / "generated-task").exists()
+    assert staged_train == experiment / "dataset" / "train"
+    assert staged_validation == experiment / "dataset" / "validation"
+    assert staged_template == experiment / "dataset" / "task-template"
+    assert staged.train_dataset.metadata == {"id": "train"}
+    assert staged.validation_dataset.metadata == {"id": "validation"}
+    assert staged.task_template.metadata == {"id": "template"}
+
+
+@pytest.mark.asyncio
+async def test_stage_eval_author_inputs_keeps_train_and_validation_isolated_when_source_is_shared(
+    tmp_path: Path,
+) -> None:
+    shared = tmp_path / "shared"
+    template = tmp_path / "template"
+    _write_tree(shared, "shared source")
+    _write_tree(template, "template source")
+    shared_ref = DatasetRef(uri=str(shared))
+
+    staged = await stage_eval_author_inputs(
+        tmp_path / "experiment",
+        train_dataset=shared_ref,
+        validation_dataset=shared_ref,
+        task_template=DatasetRef(uri=str(template)),
+        client=cast(AsyncNeMoPlatform, object()),
+        workspace="default",
+    )
+    staged_train_test = Path(staged.train_dataset.uri) / "task-1" / "tests" / "test.sh"
+    staged_validation_test = Path(staged.validation_dataset.uri) / "task-1" / "tests" / "test.sh"
+    staged_train_test.write_text("train only", encoding="utf-8")
+
+    assert staged_validation_test.read_text(encoding="utf-8") == "shared source"
+    assert (shared / "task-1" / "tests" / "test.sh").read_text(encoding="utf-8") == "shared source"
+
+
+@pytest.mark.asyncio
+async def test_stage_eval_author_inputs_reuses_dataset_destinations_but_refreshes_template(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    template = tmp_path / "template"
+    experiment = tmp_path / "experiment"
+    _write_tree(source, "source")
+    _write_tree(template, "template")
+    staged = await stage_eval_author_inputs(
+        experiment,
+        train_dataset=DatasetRef(uri=str(source)),
+        validation_dataset=DatasetRef(uri=str(source)),
+        task_template=DatasetRef(uri=str(template)),
+        client=cast(AsyncNeMoPlatform, object()),
+        workspace="default",
+    )
+    (Path(staged.train_dataset.uri) / "task-1" / "tests" / "test.sh").write_text("curated", encoding="utf-8")
+    (template / "task-1" / "tests" / "test.sh").write_text("updated template", encoding="utf-8")
+
+    restaged = await stage_eval_author_inputs(
+        experiment,
+        train_dataset=DatasetRef(uri=str(source)),
+        validation_dataset=DatasetRef(uri=str(source)),
+        task_template=DatasetRef(uri=str(template)),
+        client=cast(AsyncNeMoPlatform, object()),
+        workspace="default",
+    )
+
+    staged_test = Path(restaged.train_dataset.uri) / "task-1" / "tests" / "test.sh"
+    assert staged_test.read_text(encoding="utf-8") == "curated"
+    staged_template_test = Path(restaged.task_template.uri) / "task-1" / "tests" / "test.sh"
+    assert staged_template_test.read_text(encoding="utf-8") == "updated template"
+
+
+@pytest.mark.asyncio
+async def test_stage_task_template_hydrates_and_refreshes_fileset_reference(tmp_path: Path) -> None:
+    calls: list[dict[str, str]] = []
+    content = "first fileset template"
+
+    class FakeFiles:
+        async def download(self, *, remote_path: str, local_path: str, workspace: str) -> None:
+            assert Path(local_path).parent.is_dir()
+            calls.append({"remote_path": remote_path, "local_path": local_path, "workspace": workspace})
+            _write_tree(Path(local_path), content)
+
+    client = cast(AsyncNeMoPlatform, SimpleNamespace(files=FakeFiles()))
+    ref = DatasetRef(uri="fileset://workspace-a/task-template", metadata={"id": "template-fileset"})
+
+    first = await stage_task_template(tmp_path / "experiment", ref, client=client, workspace="workspace-a")
+    content = "second fileset template"
+    second = await stage_task_template(tmp_path / "experiment", ref, client=client, workspace="workspace-a")
+
+    expected_path = tmp_path / "experiment" / "dataset" / "task-template"
+    assert first.uri == str(expected_path)
+    assert second.uri == str(expected_path)
+    assert second.metadata == {"id": "template-fileset"}
+    assert (expected_path / "task-1" / "tests" / "test.sh").read_text(encoding="utf-8") == content
+    assert calls == [
+        {
+            "remote_path": ref.uri,
+            "local_path": str(expected_path),
+            "workspace": "workspace-a",
+        },
+        {
+            "remote_path": ref.uri,
+            "local_path": str(expected_path),
+            "workspace": "workspace-a",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_insight_run_stages_inputs_before_eval_author(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "source"
+    train = source / "train"
+    validation = source / "validation"
+    template = source / "task-template"
+    _write_tree(train, "train source")
+    _write_tree(validation, "validation source")
+    _write_tree(template, "template source")
+    experiment = tmp_path / "experiment"
+    captured: dict[str, Path] = {}
+
+    class RecordingDatasetFactory:
+        def build_dataset(self, evaluator_type: str, ref: DatasetRef) -> SimpleNamespace:
+            return SimpleNamespace(ref=ref)
+
+        def build_task_template(self, evaluator_type: str, ref: DatasetRef) -> SimpleNamespace:
+            return SimpleNamespace(uri=ref.uri)
+
+    class MutatingEvalAuthor:
+        def __init__(self, **kwargs: object) -> None:
+            pass
+
+        async def run(
+            self,
+            *,
+            task_template: SimpleNamespace,
+            train_dataset: SimpleNamespace,
+            validation_dataset: SimpleNamespace,
+            **kwargs: object,
+        ) -> None:
+            captured["train"] = Path(train_dataset.ref.uri)
+            captured["validation"] = Path(validation_dataset.ref.uri)
+            captured["template"] = Path(task_template.uri)
+            (captured["train"] / "task-1" / "tests" / "test.sh").write_text("curated", encoding="utf-8")
+            (captured["template"].parent / "generated-task").mkdir()
+            raise RuntimeError("stop after eval_author")
+
+    monkeypatch.setattr(
+        loop_module,
+        "EvaluatorFactory",
+        lambda: SimpleNamespace(build_evaluator=lambda *args, **kwargs: object()),
+    )
+    monkeypatch.setattr(loop_module, "DatasetFactory", RecordingDatasetFactory)
+    monkeypatch.setattr(loop_module, "EvalAuthor", MutatingEvalAuthor)
+    monkeypatch.setattr(
+        EvolutionaryOptimizer,
+        "_init_structure",
+        lambda self: (experiment / "agents", experiment / "analysis", experiment / "results"),
+    )
+
+    backend = SimpleNamespace(
+        client=object(),
+        get_insight=AsyncMock(return_value=SimpleNamespace(agent=str(tmp_path / "agent"))),
+        get_agent_code=AsyncMock(),
+    )
+    config = EvolutionaryOptimizerConfig()
+    optimizer = object.__new__(EvolutionaryOptimizer)
+    optimizer.working_dir = experiment
+    optimizer.config = config
+    optimizer.shell = SimpleNamespace(close=AsyncMock())
+    deps = SimpleNamespace(
+        backend=backend,
+        workspace="default",
+        config=config,
+        evaluator_type="harbor",
+        train_dataset=DatasetRef(uri=str(train)),
+        validation_dataset=DatasetRef(uri=str(validation)),
+        task_template=DatasetRef(uri=str(template)),
+        insight="insight-1",
+        agent=tmp_path / "agent",
+        agent_spec=None,
+    )
+
+    with pytest.raises(RuntimeError, match="stop after eval_author"):
+        await optimizer.run(deps)
+
+    optimizer.shell.close.assert_awaited_once()
+    assert captured == {
+        "train": experiment / "dataset" / "train",
+        "validation": experiment / "dataset" / "validation",
+        "template": experiment / "dataset" / "task-template",
+    }
+    assert (train / "task-1" / "tests" / "test.sh").read_text(encoding="utf-8") == "train source"
+    assert not (template.parent / "generated-task").exists()

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_base.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_base.py
@@ -1,0 +1,241 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import statistics
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import (
+    Dataset,
+    Evaluator,
+    EvaluatorConfig,
+    MetricResult,
+    TrialResult,
+)
+
+_HAPPY_PATH_TRIAL_RESULTS = [
+    TrialResult(
+        id="trial1",
+        task_id="task1",
+        status="completed",
+        metrics={
+            "accuracy": MetricResult(name="accuracy", value=0.95),
+            "loss": MetricResult(name="loss", value=0.05),
+        },
+    ),
+    TrialResult(
+        id="trial2",
+        task_id="task1",
+        status="completed",
+        metrics={
+            "accuracy": MetricResult(name="accuracy", value=0.90),
+            "loss": MetricResult(name="loss", value=0.10),
+        },
+    ),
+    TrialResult(
+        id="trial3",
+        task_id="task1",
+        status="completed",
+        metrics={
+            "accuracy": MetricResult(name="accuracy", value=0.85),
+            "loss": MetricResult(name="loss", value=0.15),
+        },
+    ),
+]
+
+_FAILED_TRIAL_RESULTS = [
+    TrialResult(
+        id="trial1",
+        task_id="task1",
+        status="completed",
+        metrics={
+            "loss": MetricResult(name="loss", value=0.05),
+            "accuracy": MetricResult(name="accuracy", value=0.95),
+        },
+    ),
+    TrialResult(
+        id="trial1",
+        task_id="task1",
+        status="failed",
+        metrics={},
+    ),
+]
+_MISSING_METRIC_TRIAL_RESULTS = [
+    TrialResult(
+        id="trial1",
+        task_id="task1",
+        status="completed",
+        metrics={
+            "loss": MetricResult(name="loss", value=0.05),
+            "accuracy": MetricResult(name="accuracy", value=0.95),
+        },
+    ),
+    TrialResult(
+        id="trial2",
+        task_id="task1",
+        status="completed",
+        metrics={
+            "accuracy": MetricResult(name="accuracy", value=0.90),
+        },
+    ),
+]
+
+
+class ConcreteEvaluator(Evaluator):
+    async def _run(self, agent: Path, dataset: Dataset, options: EvaluatorConfig) -> Sequence[TrialResult]:
+        return [
+            TrialResult(
+                id="trial",
+                task_id="task",
+                status="completed",
+                metrics={"reward": MetricResult(name="reward", value=1.0)},
+            )
+        ]
+
+
+class CustomAggregatorEvaluator(Evaluator):
+    async def _run(self, agent: Path, dataset: Dataset, options: EvaluatorConfig) -> Sequence[TrialResult]:
+        return []
+
+    async def aggregate_results(self, results: Sequence[TrialResult]) -> dict[str, float | int]:
+        metric_names = results[0].metrics.keys() if results else []
+        aggregated_metrics = {}
+        for metric_name in metric_names:
+            values = [result.metrics[metric_name].value for result in results]
+            aggregated_metrics[metric_name] = statistics.median(values)
+        return aggregated_metrics
+
+
+def test_cannot_instantiate_abstract_evaluator():
+    with pytest.raises(TypeError):
+        Evaluator(options=EvaluatorConfig())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "trial_results,expected_aggregated_metrics,expected_error",
+    [
+        (
+            _HAPPY_PATH_TRIAL_RESULTS,
+            {
+                "accuracy": (0.95 + 0.90 + 0.85) / 3,
+                "loss": (0.05 + 0.10 + 0.15) / 3,
+            },
+            None,
+        ),
+        (
+            _FAILED_TRIAL_RESULTS,
+            {
+                "loss": 0.05,
+                "accuracy": 0.95,
+            },
+            None,
+        ),
+        (
+            _MISSING_METRIC_TRIAL_RESULTS,
+            None,
+            ValueError,
+        ),
+    ],
+)
+async def test_default_aggregation(trial_results, expected_aggregated_metrics, expected_error):
+    evaluator = ConcreteEvaluator(options=EvaluatorConfig())
+    if expected_error:
+        with pytest.raises(expected_error):
+            await evaluator.aggregate_results(trial_results)
+    else:
+        aggregated_metrics = await evaluator.aggregate_results(trial_results)
+        assert aggregated_metrics == expected_aggregated_metrics
+
+
+@pytest.mark.asyncio
+async def test_custom_aggregator():
+    trial_results = _HAPPY_PATH_TRIAL_RESULTS
+    evaluator = CustomAggregatorEvaluator(options=EvaluatorConfig())
+    aggregated_metrics = await evaluator.aggregate_results(trial_results)
+    assert aggregated_metrics == {
+        "accuracy": 0.90,
+        "loss": 0.10,
+    }
+
+
+@pytest.mark.asyncio
+async def test_aggregate_results_empty():
+    evaluator = ConcreteEvaluator(options=EvaluatorConfig())
+    result = await evaluator.aggregate_results([])
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_results_all_failed():
+    evaluator = ConcreteEvaluator(options=EvaluatorConfig())
+    failed_trials = [
+        TrialResult(id="t1", task_id="task1", status="failed", metrics={}),
+        TrialResult(id="t2", task_id="task1", status="failed", metrics={}),
+    ]
+    result = await evaluator.aggregate_results(failed_trials)
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_run_returns_result_when_all_trials_failed():
+    class AllFailedEvaluator(ConcreteEvaluator):
+        async def _run(self, agent: Path, dataset: Dataset, options: EvaluatorConfig) -> Sequence[TrialResult]:
+            return [
+                TrialResult(id="t1", task_id="task1", status="failed", metrics={}),
+                TrialResult(id="t2", task_id="task2", status="failed", metrics={}),
+            ]
+
+    evaluator = AllFailedEvaluator(options=EvaluatorConfig())
+    result = await evaluator.run(agent=Path("/tmp/agent"), dataset=Dataset(id="ds"))
+    assert result.aggregate_metrics == {}
+    assert len(result.trials) == 2
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_explicit_zero_metric():
+    class ZeroRewardEvaluator(ConcreteEvaluator):
+        async def _run(self, agent: Path, dataset: Dataset, options: EvaluatorConfig) -> Sequence[TrialResult]:
+            return [
+                TrialResult(
+                    id="t1",
+                    task_id="task1",
+                    status="completed",
+                    metrics={"reward": MetricResult(name="reward", value=0.0)},
+                )
+            ]
+
+    evaluator = ZeroRewardEvaluator(options=EvaluatorConfig())
+    result = await evaluator.run(agent=Path("/tmp/agent"), dataset=Dataset(id="ds"))
+    assert result.aggregate_metrics == {"reward": 0.0}
+
+
+@pytest.mark.asyncio
+async def test_run_with_none_options_uses_default():
+    class ConcreteDataset(Dataset):
+        @classmethod
+        def from_ref(cls, ref):
+            return cls(id="test")
+
+    evaluator = ConcreteEvaluator(options=EvaluatorConfig())
+    dataset = ConcreteDataset(id="ds")
+    result = await evaluator.run(agent=Path("/tmp/agent"), dataset=dataset, options=None)
+    assert result.id == "agent-ds"
+
+
+@pytest.mark.asyncio
+async def test_run_with_dict_options_merges():
+    class ConcreteDataset(Dataset):
+        @classmethod
+        def from_ref(cls, ref):
+            return cls(id="test")
+
+    evaluator = ConcreteEvaluator(options=EvaluatorConfig(force_rerun=False))
+    dataset = ConcreteDataset(id="ds")
+    result = await evaluator.run(
+        agent=Path("/tmp/agent"),
+        dataset=dataset,
+        options={"force_rerun": True},
+    )
+    assert result.id == "agent-ds"

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_factory.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_factory.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from typing import Sequence
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.base import (
+    Dataset,
+    Evaluator,
+    EvaluatorConfig,
+    TrialResult,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.factory import DatasetFactory, EvaluatorFactory
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import (
+    HarborEvaluator,
+    HarborEvaluatorConfig,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import Task
+
+_UNSUPPORTED_TYPE = "unsupported"
+_SUPPORTED_TYPE = "concrete"
+_NONEXISTENT_URI = "/tmp/nonexistent.jsonl"
+
+
+class ConcreteEvaluator(Evaluator):
+    async def _run(self, agent: Path, dataset: Dataset, options: EvaluatorConfig) -> Sequence[TrialResult]:
+        return []
+
+
+class ConcreteDataset(Dataset):
+    """Takes a jsonl file with every line being a task."""
+
+    @classmethod
+    def from_ref(cls, ref: DatasetRef) -> "ConcreteDataset":
+        tasks = cls._from_jsonl(ref.uri)
+        return cls(id=ref.uri, source=ref, tasks=tasks)
+
+    @staticmethod
+    def _from_jsonl(uri: str) -> list[Task]:
+        with open(uri, "r") as f:
+            return [
+                Task(
+                    id=f"task_{line_number}",
+                    uri=f"{uri}#L{line_number}",
+                    description=f"task {line_number}",
+                    inputs=json.loads(line),
+                )
+                for line_number, line in enumerate(f, start=1)
+                if line.strip()
+            ]
+
+
+@pytest.mark.parametrize(
+    "evaluator_type, dataset_ref, expected_error",
+    [
+        (_UNSUPPORTED_TYPE, DatasetRef(uri=_NONEXISTENT_URI, description="test"), ValueError),
+    ],
+)
+def test_build_dataset_raises_on_invalid_type(evaluator_type, dataset_ref, expected_error):
+    with pytest.raises(expected_error):
+        DatasetFactory(
+            supported_evaluator_types={_SUPPORTED_TYPE: (ConcreteDataset, ConcreteEvaluator, EvaluatorConfig)}
+        ).build_dataset(evaluator_type, dataset_ref)
+
+
+def test_build_dataset_on_supported_type(tmp_path):
+    jsonl = tmp_path / "tasks.jsonl"
+    rows = [
+        {"question": "What is 2+2?", "answer": "4"},
+        {"question": "Capital of France?", "answer": "Paris"},
+    ]
+    jsonl.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    dataset = DatasetFactory(
+        supported_evaluator_types={_SUPPORTED_TYPE: (ConcreteDataset, ConcreteEvaluator, EvaluatorConfig)}
+    ).build_dataset(_SUPPORTED_TYPE, DatasetRef(uri=str(jsonl), description="test"))
+    assert len(dataset.list_tasks()) == 2
+
+
+def test_concrete_dataset_raises_on_nonexistent_file():
+    ref = DatasetRef(uri=_NONEXISTENT_URI, description="test")
+    with pytest.raises(FileNotFoundError):
+        ConcreteDataset.from_ref(ref)
+
+
+def test_concrete_dataset_empty_file(tmp_path):
+    jsonl = tmp_path / "empty.jsonl"
+    jsonl.write_text("")
+    dataset = ConcreteDataset.from_ref(DatasetRef(uri=str(jsonl), description="empty"))
+    assert dataset.list_tasks() == []
+
+
+def test_concrete_dataset_loads_tasks(tmp_path):
+    jsonl = tmp_path / "tasks.jsonl"
+    rows = [
+        {"question": "What is 2+2?", "answer": "4"},
+        {"question": "Capital of France?", "answer": "Paris"},
+    ]
+    jsonl.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+    dataset = ConcreteDataset.from_ref(DatasetRef(uri=str(jsonl), description="test"))
+    tasks = dataset.list_tasks()
+
+    assert len(tasks) == 2
+    assert tasks[0].id == "task_1"
+    assert tasks[0].uri == f"{jsonl}#L1"
+    assert tasks[0].inputs == rows[0]
+    assert tasks[1].id == "task_2"
+    assert tasks[1].inputs == rows[1]
+
+
+def test_build_dataset_falsy_evaluator_type():
+    with pytest.raises(ValueError, match="Evaluator type and dataset reference are required"):
+        DatasetFactory().build_dataset("", DatasetRef(uri="/tmp/x"))
+
+
+def test_build_dataset_falsy_dataset_ref():
+    with pytest.raises(ValueError, match="Evaluator type and dataset reference are required"):
+        DatasetFactory().build_dataset("harbor", None)
+
+
+def test_build_task_template_zero_tasks(tmp_path):
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    (empty_dir / "not-a-task").mkdir()
+    with pytest.raises(ValueError, match="contains no Harbor task directories"):
+        DatasetFactory().build_task_template("harbor", DatasetRef(uri=str(empty_dir)))
+
+
+def test_build_task_template_multiple_tasks(tmp_path):
+    dataset_dir = tmp_path / "ds"
+    (dataset_dir / "task-a").mkdir(parents=True)
+    (dataset_dir / "task-a" / "task.toml").write_text("")
+    (dataset_dir / "task-b").mkdir()
+    (dataset_dir / "task-b" / "task.toml").write_text("")
+    with pytest.raises(ValueError, match="exactly one harbor task"):
+        DatasetFactory().build_task_template("harbor", DatasetRef(uri=str(dataset_dir)))
+
+
+def test_build_task_template_single_task(tmp_path):
+    task_dir = tmp_path / "task-only"
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text("")
+    task = DatasetFactory().build_task_template("harbor", DatasetRef(uri=str(task_dir)))
+    assert task.id == "task-only"
+
+
+def test_evaluator_factory_build_evaluator_with_config():
+    factory = EvaluatorFactory()
+    evaluator = factory.build_evaluator("harbor", HarborEvaluatorConfig())
+    assert isinstance(evaluator, HarborEvaluator)
+
+
+def test_evaluator_factory_build_evaluator_with_dict():
+    factory = EvaluatorFactory()
+    evaluator = factory.build_evaluator("harbor", {"import_path": "x:Y"})
+    assert isinstance(evaluator, HarborEvaluator)
+
+
+def test_evaluator_factory_build_evaluator_unsupported():
+    factory = EvaluatorFactory()
+    with pytest.raises(ValueError, match="Unsupported evaluator type"):
+        factory.build_evaluator("unsupported", {})
+
+
+def test_evaluator_factory_build_evaluator_wrong_config_type():
+    factory = EvaluatorFactory()
+    with pytest.raises(TypeError, match="Harbor evaluator config must be an EvaluatorConfig or dict"):
+        factory.build_evaluator("harbor", 42)

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor.py
@@ -1,0 +1,1889 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import (
+    _TRACE_ARTIFACT_DESTINATION,
+    _TRACE_ARTIFACT_SOURCE,
+    HarborDataset,
+    HarborDependencyContext,
+    HarborDependencyRuntime,
+    HarborEvaluator,
+    HarborEvaluatorConfig,
+    HarborVerifierValidationError,
+    _chmod_path_chain,
+    _cleanup_scoped_imports,
+    _ensure_package,
+    _python_syntax_failure,
+    _safe_identifier,
+    _scoped_import_path,
+    _shell_syntax_failure,
+    _trial_error,
+    _trial_metric_spec,
+    _trial_metrics,
+    _trial_resources,
+    _with_trace_artifact,
+)
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import (
+    CommandSpec,
+    Dataset,
+    DatasetRef,
+    DependencyContext,
+    DependencyRuntime,
+    MetricResult,
+    MetricSpec,
+    ResourceRef,
+    Task,
+    TrialResult,
+    local_path_from_uri,
+    run_dependency_command,
+    subset_dataset_id,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_json(path: Path, data: dict) -> None:
+    _write(path, json.dumps(data))
+
+
+def _write_task_config(task_dir: Path, verifier_dir: str = "test") -> None:
+    _write(
+        task_dir / "task.toml",
+        f"""
+schema_version = "1.3"
+artifacts = ["/tmp/output.txt"]
+
+[task]
+name = "harbor/{task_dir.name}"
+description = "Synthetic Harbor task."
+
+[metadata]
+difficulty = "easy"
+
+[agent]
+timeout_sec = 10.0
+
+[environment]
+build_timeout_sec = 42.0
+cpus = 1
+memory_mb = 2048
+
+[verifier]
+directory = "{verifier_dir}"
+timeout_sec = 5.0
+""".lstrip(),
+    )
+
+
+def _recording_job(job_dir: Path):
+    class RecordingJob:
+        create_calls = 0
+        run_calls = 0
+
+        def __init__(self, config) -> None:
+            self.config = config
+            self.job_dir = job_dir
+
+        @classmethod
+        async def create(cls, config):
+            cls.create_calls += 1
+            job_dir.mkdir(parents=True, exist_ok=True)
+            return cls(config)
+
+        async def run(self):
+            type(self).run_calls += 1
+            return SimpleNamespace(id="job-id", stats=None)
+
+    return RecordingJob
+
+
+class _BlockingProcess:
+    def __init__(self) -> None:
+        self.returncode = None
+        self.communicate_calls = 0
+        self.killed = False
+        self.started = asyncio.Event()
+
+    async def communicate(self, _input=None):
+        self.communicate_calls += 1
+        if self.communicate_calls == 1:
+            self.started.set()
+            await asyncio.Event().wait()
+        self.returncode = -9
+        return b"", b""
+
+    def kill(self) -> None:
+        self.killed = True
+
+
+def test_harbor_dataset_from_path_maps_task_output(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "harbor-dataset"
+    task_dir = dataset_dir / "task-a"
+    _write_task_config(task_dir)
+    _write(task_dir / "instruction.md", "Solve the task.\n")
+    _write(task_dir / "README.md", "README text.\n")
+    _write(task_dir / "environment" / "docker-compose.yaml", "services: {}\n")
+    _write(task_dir / "environment" / "nested" / "ignored.txt", "nested\n")
+    _write(task_dir / "test" / "test.sh", "echo 1 > /logs/verifier/reward.json\n")
+    _write(task_dir / "solution" / "solution.sh", "touch /tmp/output.txt\n")
+
+    dataset = HarborDataset.from_path(dataset_dir)
+
+    environment_description = (
+        "Harbor task environment directory. Contains the container definition and supporting files Harbor uses "
+        "to create the task environment, such as Dockerfile, docker-compose.yaml, singularity-compose.yaml, "
+        "and dependency files."
+    )
+    verifier_description = (
+        "Harbor verifier tests directory. Harbor copies this directory into the task environment at /tests "
+        "after the agent phase, discovers test.{sh,ps1,cmd,bat}, and expects rewards under /logs/verifier "
+        "as reward.txt or reward.json."
+    )
+    oracle_description = (
+        "Harbor oracle solution directory. Harbor's OracleAgent copies this directory into the task environment "
+        "at /solution and discovers solve.{sh,ps1,cmd,bat} as the reference solution script."
+    )
+    readme_ref = ResourceRef(uri=(task_dir / "README.md").resolve().as_uri(), description="Task README.")
+    expected_config = {
+        "schema_version": "1.3",
+        "artifacts": ["/tmp/output.txt"],
+        "task": {
+            "name": "harbor/task-a",
+            "description": "Synthetic Harbor task.",
+        },
+        "metadata": {"difficulty": "easy"},
+        "agent": {"timeout_sec": 10.0},
+        "environment": {
+            "build_timeout_sec": 42.0,
+            "cpus": 1,
+            "memory_mb": 2048,
+        },
+        "verifier": {
+            "directory": "test",
+            "timeout_sec": 5.0,
+        },
+    }
+    expected_task = Task(
+        uri=task_dir.resolve().as_uri(),
+        description="Harbor task root directory.",
+        id="task-a",
+        inputs={
+            "instruction": "Solve the task.\n",
+            "config": expected_config,
+            "readme": readme_ref,
+        },
+        resources={
+            "instruction": ResourceRef(
+                uri=(task_dir / "instruction.md").resolve().as_uri(),
+                description="Task instruction shown to the benchmark agent.",
+            ),
+            "readme": readme_ref,
+            "task_dir": ResourceRef(uri=task_dir.resolve().as_uri(), description="Harbor task root directory."),
+            "task_config": ResourceRef(
+                uri=(task_dir / "task.toml").resolve().as_uri(),
+                description="Harbor task configuration file.",
+            ),
+            "environment_dir": ResourceRef(
+                uri=(task_dir / "environment").resolve().as_uri(),
+                description=environment_description,
+            ),
+            "verifier_dir": ResourceRef(uri=(task_dir / "test").resolve().as_uri(), description=verifier_description),
+            "oracle_dir": ResourceRef(uri=(task_dir / "solution").resolve().as_uri(), description=oracle_description),
+        },
+        metric_specs={
+            "reward": MetricSpec(
+                name="reward",
+                description="Harbor verifier reward emitted for harbor/task-a.",
+                ref=ResourceRef(uri=(task_dir / "test").resolve().as_uri(), description=verifier_description),
+            )
+        },
+        dependencies=HarborDependencyRuntime(
+            task_path=ResourceRef(
+                uri=task_dir.resolve().as_uri(),
+                description="Harbor task directory to start via Harbor EnvironmentFactory.",
+            ),
+            build_timeout_sec=42,
+        ),
+    )
+
+    assert dataset.id == "harbor-dataset"
+    assert dataset.source == ResourceRef(
+        uri=dataset_dir.resolve().as_uri(),
+        description="Harbor dataset root directory.",
+    )
+    assert dataset.tasks == [expected_task]
+    assert dataset.metadata == {}
+
+
+def test_harbor_dataset_from_plain_path_ref_and_sparse_task_output(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset-root"
+    ignored_dir = dataset_dir / "not-a-task"
+    ignored_dir.mkdir(parents=True)
+    task_dir = dataset_dir / "task-b"
+    _write(task_dir / "task.toml", "")
+    _write(task_dir / "readme.md", "lowercase readme\n")
+
+    dataset = HarborDataset.from_ref(DatasetRef(uri=str(dataset_dir), metadata={}))
+
+    readme_ref = ResourceRef(uri=(task_dir / "readme.md").resolve().as_uri(), description="Task README.")
+    expected_task = Task(
+        uri=task_dir.resolve().as_uri(),
+        description="Harbor task root directory.",
+        id="task-b",
+        inputs={"readme": readme_ref},
+        resources={
+            "readme": readme_ref,
+            "task_dir": ResourceRef(uri=task_dir.resolve().as_uri(), description="Harbor task root directory."),
+            "task_config": ResourceRef(
+                uri=(task_dir / "task.toml").resolve().as_uri(),
+                description="Harbor task configuration file.",
+            ),
+        },
+        metric_specs={
+            "reward": MetricSpec(
+                name="reward",
+                description="Harbor verifier reward emitted for this task.",
+            )
+        },
+        dependencies=HarborDependencyRuntime(
+            task_path=ResourceRef(
+                uri=task_dir.resolve().as_uri(),
+                description="Harbor task directory to start via Harbor EnvironmentFactory.",
+            ),
+        ),
+    )
+
+    assert dataset.id == "dataset-root"
+    assert dataset.source == ResourceRef(
+        uri=dataset_dir.resolve().as_uri(),
+        description="Harbor dataset root directory.",
+    )
+    assert dataset.tasks == [expected_task]
+    assert dataset.metadata == {}
+
+
+def test_harbor_dataset_from_ref_selects_task_ids(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset-root"
+    for task_id in ("task-c", "task-a", "task-b"):
+        _write(dataset_dir / task_id / "task.toml", "")
+
+    dataset = HarborDataset.from_ref(
+        DatasetRef(
+            uri=str(dataset_dir),
+            metadata={"id": "canonical-suite", "task_ids": ["task-b", "task-a"]},
+        )
+    )
+
+    assert [task.id for task in dataset.list_tasks()] == ["task-a", "task-b"]
+    assert dataset.id == subset_dataset_id("canonical-suite", ["task-a", "task-b"])
+    assert dataset.source == ResourceRef(
+        uri=dataset_dir.resolve().as_uri(),
+        description="Harbor dataset root directory.",
+    )
+
+
+def test_harbor_dataset_from_ref_rejects_missing_task_ids(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / "dataset-root"
+    _write(dataset_dir / "task-a" / "task.toml", "")
+
+    with pytest.raises(ValueError, match=r"Task id\(s\) not found.*task-missing"):
+        HarborDataset.from_ref(
+            DatasetRef(
+                uri=str(dataset_dir),
+                metadata={"task_ids": ["task-a", "task-missing"]},
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "task_ids",
+    ["task-a", [], ["task-a", 7], [""], ["task-a", "task-a"]],
+    ids=["not-list", "empty", "non-string", "empty-string", "duplicate"],
+)
+def test_harbor_dataset_from_ref_validates_task_ids(tmp_path: Path, task_ids: object) -> None:
+    dataset_dir = tmp_path / "dataset-root"
+    _write(dataset_dir / "task-a" / "task.toml", "")
+
+    with pytest.raises(ValueError, match="task_ids"):
+        HarborDataset.from_ref(
+            DatasetRef(
+                uri=str(dataset_dir),
+                metadata={"task_ids": task_ids},  # type: ignore[dict-item]
+            )
+        )
+
+
+def test_harbor_dataset_maps_step_edge_cases(tmp_path: Path) -> None:
+    task_dir = tmp_path / "step-edge-task"
+    _write(
+        task_dir / "task.toml",
+        """
+[task]
+name = "plain-task-name"
+
+[[steps]]
+
+[[steps]]
+name = ""
+
+[[steps]]
+name = "missing-instruction"
+""".lstrip(),
+    )
+
+    dataset = HarborDataset.from_path(task_dir)
+
+    expected_task = Task(
+        uri=task_dir.resolve().as_uri(),
+        description="Harbor task root directory.",
+        id="step-edge-task",
+        inputs={
+            "steps": [
+                {
+                    "name": "missing-instruction",
+                    "instruction": None,
+                    "config": {"name": "missing-instruction"},
+                }
+            ],
+            "instruction": "",
+            "config": {
+                "task": {"name": "plain-task-name"},
+                "steps": [{}, {"name": ""}, {"name": "missing-instruction"}],
+            },
+        },
+        resources={
+            "task_dir": ResourceRef(uri=task_dir.resolve().as_uri(), description="Harbor task root directory."),
+            "task_config": ResourceRef(
+                uri=(task_dir / "task.toml").resolve().as_uri(),
+                description="Harbor task configuration file.",
+            ),
+        },
+        metric_specs={
+            "reward": MetricSpec(
+                name="reward",
+                description="Harbor verifier reward emitted for plain-task-name.",
+            )
+        },
+        dependencies=HarborDependencyRuntime(
+            task_path=ResourceRef(
+                uri=task_dir.resolve().as_uri(),
+                description="Harbor task directory to start via Harbor EnvironmentFactory.",
+            ),
+        ),
+    )
+
+    assert dataset.tasks == [expected_task]
+
+
+def test_harbor_dataset_from_ref_and_multistep_output(tmp_path: Path) -> None:
+    task_dir = tmp_path / "multi-step-task"
+    _write(
+        task_dir / "task.toml",
+        """
+version = "1.0"
+
+[[steps]]
+name = "create-file"
+
+[steps.agent]
+timeout_sec = 10.0
+
+[[steps]]
+name = "append-content"
+
+[steps.verifier]
+timeout_sec = 5.0
+""".lstrip(),
+    )
+    _write(task_dir / "steps" / "create-file" / "instruction.md", "Create a file.\n")
+    _write(task_dir / "steps" / "append-content" / "instruction.md", "Append content.\n")
+    _write(task_dir / "tests" / "test.sh", "echo 1 > /logs/verifier/reward.json\n")
+
+    dataset = HarborDataset.from_ref(
+        DatasetRef(
+            uri=task_dir.resolve().as_uri(),
+            metadata={"id": "custom-id"},
+        )
+    )
+
+    verifier_description = (
+        "Harbor verifier tests directory. Harbor copies this directory into the task environment at /tests "
+        "after the agent phase, discovers test.{sh,ps1,cmd,bat}, and expects rewards under /logs/verifier "
+        "as reward.txt or reward.json."
+    )
+    steps_description = (
+        "Harbor multi-step task directory. Contains one subdirectory per [[steps]] entry; each step can provide "
+        "instruction.md plus step-specific tests/ and solution/ directories that Harbor uses like the top-level "
+        "verifier and oracle directories."
+    )
+    expected_config = {
+        "version": "1.0",
+        "steps": [
+            {"name": "create-file", "agent": {"timeout_sec": 10.0}},
+            {"name": "append-content", "verifier": {"timeout_sec": 5.0}},
+        ],
+    }
+    expected_task = Task(
+        uri=task_dir.resolve().as_uri(),
+        description="Harbor task root directory.",
+        id="multi-step-task",
+        inputs={
+            "steps": [
+                {
+                    "name": "create-file",
+                    "instruction": "Create a file.",
+                    "config": {"name": "create-file", "agent": {"timeout_sec": 10.0}},
+                },
+                {
+                    "name": "append-content",
+                    "instruction": "Append content.",
+                    "config": {"name": "append-content", "verifier": {"timeout_sec": 5.0}},
+                },
+            ],
+            "instruction": (
+                "## Step 1: create-file\n\nCreate a file.\n\n---\n\n## Step 2: append-content\n\nAppend content."
+            ),
+            "config": expected_config,
+        },
+        resources={
+            "step_1_instruction": ResourceRef(
+                uri=(task_dir / "steps" / "create-file" / "instruction.md").resolve().as_uri(),
+                description="Instruction for Harbor task step create-file.",
+            ),
+            "step_2_instruction": ResourceRef(
+                uri=(task_dir / "steps" / "append-content" / "instruction.md").resolve().as_uri(),
+                description="Instruction for Harbor task step append-content.",
+            ),
+            "task_dir": ResourceRef(uri=task_dir.resolve().as_uri(), description="Harbor task root directory."),
+            "task_config": ResourceRef(
+                uri=(task_dir / "task.toml").resolve().as_uri(),
+                description="Harbor task configuration file.",
+            ),
+            "verifier_dir": ResourceRef(uri=(task_dir / "tests").resolve().as_uri(), description=verifier_description),
+            "steps_dir": ResourceRef(uri=(task_dir / "steps").resolve().as_uri(), description=steps_description),
+        },
+        metric_specs={
+            "reward": MetricSpec(
+                name="reward",
+                description="Harbor verifier reward emitted for this task.",
+                ref=ResourceRef(uri=(task_dir / "tests").resolve().as_uri(), description=verifier_description),
+            )
+        },
+        dependencies=HarborDependencyRuntime(
+            task_path=ResourceRef(
+                uri=task_dir.resolve().as_uri(),
+                description="Harbor task directory to start via Harbor EnvironmentFactory.",
+            ),
+        ),
+    )
+
+    assert dataset.id == "custom-id"
+    assert dataset.source == ResourceRef(
+        uri=task_dir.resolve().as_uri(),
+        description="Harbor dataset root directory.",
+    )
+    assert dataset.tasks == [expected_task]
+    assert dataset.metadata == {}
+
+    subset = dataset.subset(["multi-step-task"])
+    assert subset.id == subset_dataset_id("custom-id", ["multi-step-task"])
+    assert subset.tasks == [expected_task]
+
+
+def test_harbor_dataset_rejects_invalid_refs_and_paths(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="Harbor dataset path not found"):
+        HarborDataset.from_path(tmp_path / "missing")
+
+    file_path = tmp_path / "not-a-directory"
+    file_path.write_text("not a dataset", encoding="utf-8")
+    with pytest.raises(ValueError, match="not a directory"):
+        HarborDataset.from_path(file_path)
+
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    with pytest.raises(ValueError, match="contains no Harbor task directories"):
+        HarborDataset.from_path(empty_dir)
+
+    with pytest.raises(ValueError, match="metadata field 'id' must be a string"):
+        HarborDataset.from_ref(DatasetRef(uri=str(tmp_path), metadata={"id": 1}))
+
+    with pytest.raises(ValueError, match="Harbor dataset reference file URI must be local"):
+        HarborDataset.from_ref(DatasetRef(uri="file://remote-host/tmp/dataset"))
+
+    with pytest.raises(ValueError, match="URI scheme 's3'"):
+        HarborDataset.from_ref(DatasetRef(uri="s3://bucket/dataset"))
+
+
+def test_harbor_dataset_rejects_missing_task_ids(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task-a"
+    _write(task_dir / "task.toml", "")
+    dataset = HarborDataset.from_path(task_dir)
+
+    with pytest.raises(ValueError, match="Task id not found"):
+        dataset.get_task("missing")
+
+    with pytest.raises(ValueError, match="Task id\\(s\\) not found"):
+        dataset.subset(["missing"])
+
+
+@pytest.mark.asyncio
+async def test_harbor_trial_metric_spec_uses_task_verifier_dir(tmp_path: Path) -> None:
+    task_dir = tmp_path / "dataset" / "task-a"
+    _write(task_dir / "task.toml", "")
+    _write(task_dir / "tests" / "test.sh", "echo reward")
+
+    trial_dir = tmp_path / "job" / "task-a__0"
+    _write_json(
+        trial_dir / "result.json",
+        {
+            "task_name": "terminal-bench/task-a",
+            "trial_name": "task-a__0",
+            "task_id": {"path": str(task_dir.resolve())},
+            "verifier_result": {"rewards": {"reward": 0.5}},
+            "exception_info": None,
+        },
+    )
+    _write(trial_dir / "verifier" / "reward.txt", "0.5")
+
+    trials = await HarborEvaluator()._trials_from_dir(
+        tmp_path / "job",
+        [Task(id="task-a", metric_specs={"reward": MetricSpec(name="reward", description="reward")})],
+    )
+
+    verifier_description = (
+        "Harbor verifier tests directory. Harbor copies this directory into the task environment at /tests "
+        "after the agent phase, discovers test.{sh,ps1,cmd,bat}, and expects rewards under /logs/verifier "
+        "as reward.txt or reward.json."
+    )
+    metric_spec = MetricSpec(
+        name="reward",
+        description="Harbor verifier reward emitted for terminal-bench/task-a.",
+        ref=ResourceRef(uri=(task_dir / "tests").resolve().as_uri(), description=verifier_description),
+    )
+    assert trials == [
+        TrialResult(
+            id="task-a__0",
+            task_id="task-a",
+            attempt=0,
+            status="completed",
+            resources={
+                "trial_dir": ResourceRef(
+                    uri=trial_dir.resolve().as_uri(),
+                    description=(
+                        "Harbor trial output directory for one task attempt. Contains config.json, result.json, "
+                        "trial.log, agent logs, verifier logs, and collected artifacts."
+                    ),
+                ),
+                "result": ResourceRef(
+                    uri=(trial_dir / "result.json").resolve().as_uri(),
+                    description=(
+                        "Harbor trial result JSON. Contains task and trial identifiers, agent info, verifier rewards, "
+                        "exception info, phase timings, and token or cost usage."
+                    ),
+                ),
+                "log:verifier/reward.txt": ResourceRef(
+                    uri=(trial_dir / "verifier" / "reward.txt").resolve().as_uri(),
+                    description=(
+                        "Verifier scalar reward file written under /logs/verifier. Harbor parses this file as the "
+                        "reward metric."
+                    ),
+                ),
+            },
+            metrics={
+                "reward": MetricResult(
+                    name="reward",
+                    value=0.5,
+                    spec=metric_spec,
+                )
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_harbor_evaluator_runs_job_and_maps_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    evaluator = HarborEvaluator()
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    dataset_dir = tmp_path / "dataset"
+    task_a = dataset_dir / "task-a"
+    task_b = dataset_dir / "task-b"
+    _write(task_a / "task.toml", "")
+    _write(task_a / "test" / "test.sh", "echo 1")
+    _write(task_b / "task.toml", "")
+    harbor_dataset = HarborDataset.from_path(dataset_dir)
+
+    job_dir = tmp_path / "jobs" / "agent-0-validation"
+    trial_a = job_dir / "task-a__0"
+    _write_json(
+        trial_a / "result.json",
+        {
+            "task_name": "harbor/task-a",
+            "trial_name": "task-a__0",
+            "trial_uri": trial_a.resolve().as_uri(),
+            "task_id": {"path": str(task_a.resolve())},
+            "verifier_result": {"rewards": {"reward": 1.0}},
+            "exception_info": None,
+        },
+    )
+    _write(trial_a / "config.json", "{}")
+    _write(trial_a / "trial.log", "ok")
+    _write(trial_a / "agent" / "setup" / "stdout.txt", "setup")
+    _write(trial_a / "agent" / "command-0" / "stdout.txt", "command")
+    _write(trial_a / "verifier" / "reward.txt", "1.0")
+    _write(trial_a / "verifier" / "test-stdout.txt", "stdout")
+    _write(trial_a / "verifier" / "test-stderr.txt", "stderr")
+    trace_path = trial_a / "artifacts" / "traces" / "trace.jsonl"
+    _write(trace_path, "{}")
+    _write(trial_a / "artifacts" / "logs" / "artifacts" / "output.txt", "published")
+    _write(trial_a / "artifacts" / "manifest.json", "[]")
+
+    trial_b = job_dir / "task-b__1"
+    _write_json(
+        trial_b / "result.json",
+        {
+            "task_name": "harbor/task-b",
+            "trial_name": "task-b__1",
+            "trial_uri": trial_b.resolve().as_uri(),
+            "verifier_result": None,
+            "exception_info": {
+                "exception_type": "ValueError",
+                "exception_message": "bad task",
+                "exception_traceback": "traceback",
+            },
+        },
+    )
+
+    trial_c = job_dir / "task-c__abc"
+    _write_json(
+        trial_c / "result.json",
+        {
+            "trial_name": "task-c__abc",
+            "trial_uri": trial_c.resolve().as_uri(),
+            "verifier_result": None,
+            "exception_info": None,
+        },
+    )
+    _write_json(trial_c / "verifier" / "reward.json", {"reward": 0.25})
+
+    trial_d = job_dir / "task-d__2"
+    _write_json(
+        trial_d / "result.json",
+        {
+            "task_name": "harbor/task-d",
+            "trial_name": "task-d__2",
+            "trial_uri": trial_d.resolve().as_uri(),
+            "verifier_result": None,
+            "exception_info": None,
+        },
+    )
+    _write(trial_d / "verifier" / "reward.txt", "0.75")
+
+    (job_dir / "not-a-trial").mkdir(parents=True)
+
+    class FakeStats:
+        def model_dump(self, mode: str) -> dict:
+            return {
+                "evals": {
+                    "agent__dataset": {
+                        "metrics": [{"mean": 0.5}],
+                        "reward_stats": {},
+                        "exception_stats": {},
+                    }
+                }
+            }
+
+    class FakeJob:
+        created_config = None
+
+        def __init__(self, config) -> None:
+            self.config = config
+            self.job_dir = job_dir
+
+        @classmethod
+        async def create(cls, config):
+            cls.created_config = config
+            return cls(config)
+
+        async def run(self):
+            return SimpleNamespace(id="job-id", stats=FakeStats())
+
+    monkeypatch.setattr("nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.Job", FakeJob)
+
+    result = await evaluator.run(
+        agent=tmp_path / "agent",
+        dataset=harbor_dataset,
+        options=HarborEvaluatorConfig(import_path="harbor_wrapper:WrappedAgent", jobs_dir=tmp_path / "jobs"),
+    )
+
+    assert result.id == "agent-dataset"
+    assert result.aggregate_metrics["reward"] == pytest.approx(2 / 3)
+    assert str((tmp_path / "agent").resolve()) not in sys.path
+    assert "harbor_wrapper" not in sys.modules
+    assert FakeJob.created_config.agents[0].import_path.startswith("_nemo_experimentalist_eval_agents.")
+    assert FakeJob.created_config.agents[0].import_path.endswith(".harbor_wrapper:WrappedAgent")
+    assert FakeJob.created_config.datasets[0].path == dataset_dir.resolve()
+    assert FakeJob.created_config.datasets[0].task_names == ["task-a", "task-b"]
+
+    first_trial = result.trials[0]
+    assert first_trial.id == "task-a__0"
+    assert first_trial.task_id == "task-a"
+    assert first_trial.attempt == 0
+    assert first_trial.status == "completed"
+    assert first_trial.metrics["reward"].value == 1.0
+    assert first_trial.metrics["reward"].spec is not None
+    assert first_trial.metrics["reward"].spec.ref is not None
+    assert first_trial.metrics["reward"].spec.ref.uri == (task_a / "test").resolve().as_uri()
+    assert first_trial.trace is not None
+    assert first_trial.trace.uri == trace_path.resolve().as_uri()
+    assert set(first_trial.resources) >= {
+        "artifact:logs/artifacts/output.txt",
+        "artifact:manifest.json",
+        "config",
+        "log:agent/command-0/stdout.txt",
+        "log:agent/setup/stdout.txt",
+        "log:trial.log",
+        "log:verifier/reward.txt",
+        "log:verifier/test-stderr.txt",
+        "log:verifier/test-stdout.txt",
+        "result",
+        "trace:traces/trace.jsonl",
+        "trial_dir",
+    }
+    expected_resource_descriptions = {
+        "trial_dir": (
+            "Harbor trial output directory for one task attempt. Contains config.json, result.json, trial.log, agent "
+            "logs, verifier logs, and collected artifacts."
+        ),
+        "config": (
+            "Harbor trial configuration snapshot. Records the task, agent, environment, verifier, artifact collection, "
+            "and job id used for this attempt."
+        ),
+        "result": (
+            "Harbor trial result JSON. Contains task and trial identifiers, agent info, verifier rewards, exception "
+            "info, phase timings, and token or cost usage."
+        ),
+        "trace:traces/trace.jsonl": "Agent execution trace JSONL for traces/trace.jsonl.",
+        "log:agent/command-0/stdout.txt": "Agent command stdout captured while Harbor runs the benchmark agent.",
+        "log:agent/setup/stdout.txt": (
+            "Agent setup stdout captured while Harbor uploads the agent and installs dependencies."
+        ),
+        "log:trial.log": (
+            "Harbor trial orchestration log covering environment setup, agent execution, verifier execution, artifact "
+            "collection, and cleanup."
+        ),
+        "log:verifier/reward.txt": (
+            "Verifier scalar reward file written under /logs/verifier. Harbor parses this file as the reward metric."
+        ),
+        "log:verifier/test-stderr.txt": (
+            "Verifier stderr captured while Harbor runs the task tests from the /tests directory."
+        ),
+        "log:verifier/test-stdout.txt": (
+            "Verifier stdout captured while Harbor runs the task tests from the /tests directory."
+        ),
+        "artifact:manifest.json": (
+            "Harbor artifact manifest. Lists collected artifact files and the environment paths they were copied from."
+        ),
+        "artifact:logs/artifacts/output.txt": "Collected Harbor artifact logs/artifacts/output.txt.",
+    }
+    assert {key: first_trial.resources[key].description for key in expected_resource_descriptions} == (
+        expected_resource_descriptions
+    )
+
+    second_trial = result.trials[1]
+    assert second_trial.id == "task-b__1"
+    assert second_trial.status == "failed"
+    assert second_trial.error == {
+        "type": "ValueError",
+        "message": "bad task",
+        "traceback": "traceback",
+    }
+
+    third_trial = result.trials[2]
+    assert third_trial.id == "task-c__abc"
+    assert third_trial.task_id == "task-c"
+    assert third_trial.attempt is None
+    assert third_trial.metrics["reward"].value == 0.25
+    assert third_trial.metrics["reward"].spec is not None
+    assert third_trial.metrics["reward"].spec.ref is not None
+    assert third_trial.metrics["reward"].spec.ref.uri == (trial_c / "verifier").resolve().as_uri()
+    assert (
+        third_trial.resources["log:verifier/reward.json"].uri
+        == (trial_c / "verifier" / "reward.json").resolve().as_uri()
+    )
+
+    fourth_trial = result.trials[3]
+    assert fourth_trial.id == "task-d__2"
+    assert fourth_trial.metrics["reward"].value == 0.75
+
+
+@pytest.mark.asyncio
+async def test_harbor_evaluator_rejects_invalid_python_verifiers_before_job_create(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    dataset_dir = tmp_path / "dataset"
+    invalid_source = "def check():\n    try:\n        pass\n"
+    for task_id in ("task-a", "task-b"):
+        task_dir = dataset_dir / task_id
+        _write(task_dir / "task.toml", "")
+        _write(task_dir / "tests" / "check_tool_hallucination.py", invalid_source)
+
+    dataset = HarborDataset.from_path(dataset_dir)
+    fake_job = _recording_job(tmp_path / "jobs" / "preflight")
+    monkeypatch.setattr("nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.Job", fake_job)
+    compile_calls = 0
+    original_compile = compile
+
+    def counting_compile(source, filename, mode):
+        nonlocal compile_calls
+        compile_calls += 1
+        return original_compile(source, filename, mode)
+
+    monkeypatch.setattr("builtins.compile", counting_compile)
+
+    with pytest.raises(HarborVerifierValidationError) as exc_info:
+        await HarborEvaluator()._run(agent_dir, dataset, HarborEvaluatorConfig())
+
+    message = str(exc_info.value)
+    assert "task 'task-a'" in message
+    assert "task 'task-b'" in message
+    assert message.count("check_tool_hallucination.py:3:13") == 2
+    assert "SyntaxError: expected 'except' or 'finally' block" in message
+    assert compile_calls == 1
+    assert fake_job.create_calls == 0
+    assert fake_job.run_calls == 0
+
+
+def test_python_syntax_failure_reports_recursion_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def raise_recursion_error(_source, _filename, _mode):
+        raise RecursionError("maximum recursion depth exceeded during compilation")
+
+    monkeypatch.setattr("builtins.compile", raise_recursion_error)
+
+    failure = _python_syntax_failure("deeply nested source", tmp_path / "check.py")
+
+    assert failure is not None
+    assert failure.error == "RecursionError: maximum recursion depth exceeded during compilation"
+    assert failure.line is None
+    assert failure.column is None
+
+
+@pytest.mark.asyncio
+async def test_shell_syntax_failure_kills_process_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    process = _BlockingProcess()
+    process_args = []
+    process_options = {}
+
+    async def create_process(*_args, **_kwargs):
+        process_args.extend(_args)
+        process_options.update(_kwargs)
+        return process
+
+    monkeypatch.setenv("NVIDIA_API_KEY", "secret")
+    monkeypatch.setattr("asyncio.create_subprocess_exec", create_process)
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor._SHELL_SYNTAX_TIMEOUT_SEC",
+        0.01,
+    )
+
+    with pytest.raises(TimeoutError):
+        await _shell_syntax_failure("echo valid\n")
+
+    assert process.killed
+    assert process.communicate_calls == 2
+    assert "-n" in process_args
+    assert process_options["env"] == {"LC_ALL": "C", "PATH": os.defpath, "SHELLOPTS": "noexec"}
+    assert "NVIDIA_API_KEY" not in process_options["env"]
+
+
+@pytest.mark.asyncio
+async def test_shell_noexec_environment_prevents_execution_without_n_flag() -> None:
+    bash_path = shutil.which("bash", path=os.defpath)
+    assert bash_path is not None
+    process = await asyncio.create_subprocess_exec(
+        bash_path,
+        "--noprofile",
+        "--norc",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env={"LC_ALL": "C", "PATH": os.defpath, "SHELLOPTS": "noexec"},
+    )
+
+    stdout, _ = await process.communicate(b"printf 'EXECUTED\\n'\n")
+
+    assert process.returncode == 0
+    assert stdout == b""
+
+
+@pytest.mark.asyncio
+async def test_shell_syntax_failure_kills_process_on_cancellation(monkeypatch: pytest.MonkeyPatch) -> None:
+    process = _BlockingProcess()
+
+    async def create_process(*_args, **_kwargs):
+        return process
+
+    monkeypatch.setattr("asyncio.create_subprocess_exec", create_process)
+
+    validation = asyncio.create_task(_shell_syntax_failure("echo valid\n"))
+    await process.started.wait()
+    validation.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await validation
+
+    assert process.killed
+    assert process.communicate_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_harbor_evaluator_accepts_valid_python_verifier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    task_dir = tmp_path / "task-a"
+    _write(task_dir / "task.toml", "")
+    _write(task_dir / "tests" / "check.py", "def check():\n    return True\n")
+    dataset = HarborDataset.from_path(task_dir)
+    fake_job = _recording_job(tmp_path / "jobs" / "valid-python")
+    monkeypatch.setattr("nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.Job", fake_job)
+
+    trials = await HarborEvaluator()._run(agent_dir, dataset, HarborEvaluatorConfig())
+
+    assert trials == []
+    assert fake_job.create_calls == 1
+    assert fake_job.run_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_harbor_evaluator_rejects_invalid_configured_test_sh_before_job_create(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    task_dir = tmp_path / "task-a"
+    _write_task_config(task_dir, verifier_dir="test")
+    _write(task_dir / "tests" / "test.sh", "echo ignored\n")
+    _write(task_dir / "test" / "test.sh", "if true; then\n  echo broken\n")
+    dataset = HarborDataset.from_path(task_dir)
+    fake_job = _recording_job(tmp_path / "jobs" / "invalid-shell")
+    monkeypatch.setattr("nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.Job", fake_job)
+
+    with pytest.raises(HarborVerifierValidationError) as exc_info:
+        await HarborEvaluator()._run(agent_dir, dataset, HarborEvaluatorConfig())
+
+    message = str(exc_info.value)
+    assert "task 'task-a'" in message
+    assert str((task_dir / "test" / "test.sh").resolve()) in message
+    assert "syntax error" in message
+    assert fake_job.create_calls == 0
+    assert fake_job.run_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_harbor_evaluator_accepts_valid_legacy_test_sh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    task_dir = tmp_path / "task-a"
+    _write(task_dir / "task.toml", "")
+    _write(task_dir / "test" / "test.sh", "if true; then\n  echo valid\nfi\n")
+    dataset = HarborDataset.from_path(task_dir)
+    fake_job = _recording_job(tmp_path / "jobs" / "valid-shell")
+    monkeypatch.setattr("nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.Job", fake_job)
+
+    trials = await HarborEvaluator()._run(agent_dir, dataset, HarborEvaluatorConfig())
+
+    assert trials == []
+    assert fake_job.create_calls == 1
+    assert fake_job.run_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_harbor_evaluator_rejects_invalid_inputs(tmp_path: Path) -> None:
+    evaluator = HarborEvaluator()
+    task_dir = tmp_path / "task-a"
+    _write(task_dir / "task.toml", "")
+    harbor_dataset = HarborDataset.from_path(task_dir)
+
+    with pytest.raises(ValueError, match="Dataset must be a Harbor dataset"):
+        await evaluator.run(agent=tmp_path, dataset=Dataset(id="base"), options={"import_path": "agent:Agent"})
+
+    with pytest.raises(ValueError, match="Harbor dataset source is required"):
+        await evaluator.run(agent=tmp_path, dataset=HarborDataset(id="manual"), options={"import_path": "agent:Agent"})
+
+    with pytest.raises(FileNotFoundError, match="Harbor agent path not found"):
+        await evaluator.run(
+            agent=tmp_path / "nonexistent",
+            dataset=harbor_dataset,
+            options=HarborEvaluatorConfig(),
+        )
+
+
+# ── harbor.py additional coverage ────────────────────────────────────────────
+
+
+def test_harbor_dependency_runtime_context():
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""))
+    ctx = runtime.context()
+    assert isinstance(ctx, HarborDependencyContext)
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_enter_exit(monkeypatch):
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""))
+
+    async def fake_start(self):
+        pass
+
+    async def fake_stop(self):
+        pass
+
+    monkeypatch.setattr(HarborDependencyContext, "_start_harbor_runtime", fake_start)
+    monkeypatch.setattr(HarborDependencyContext, "_stop_started_runtime", fake_stop)
+
+    ctx = HarborDependencyContext(runtime)
+    entered = await ctx.__aenter__()
+    assert entered is runtime
+    result = await ctx.__aexit__(None, None, None)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_enter_failure_calls_stop(monkeypatch):
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""))
+    stop_called = []
+
+    async def fake_start(self):
+        raise RuntimeError("start failed")
+
+    async def fake_stop(self):
+        stop_called.append(True)
+
+    monkeypatch.setattr(HarborDependencyContext, "_start_harbor_runtime", fake_start)
+    monkeypatch.setattr(HarborDependencyContext, "_stop_started_runtime", fake_stop)
+
+    ctx = HarborDependencyContext(runtime)
+    with pytest.raises(RuntimeError, match="start failed"):
+        await ctx.__aenter__()
+    assert stop_called
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_aexit_suppresses_stop_error_when_exc_active(monkeypatch):
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""))
+
+    async def fake_start(self):
+        pass
+
+    async def fake_stop(self):
+        raise RuntimeError("stop failed")
+
+    monkeypatch.setattr(HarborDependencyContext, "_start_harbor_runtime", fake_start)
+    monkeypatch.setattr(HarborDependencyContext, "_stop_started_runtime", fake_stop)
+
+    ctx = HarborDependencyContext(runtime)
+    await ctx.__aenter__()
+    result = await ctx.__aexit__(ValueError, ValueError("original"), None)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_stop_started_runtime_no_environment(monkeypatch):
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""))
+    ctx = HarborDependencyContext(runtime)
+    await ctx._stop_started_runtime()
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_stop_started_runtime_with_environment(monkeypatch):
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""), delete=True)
+    ctx = HarborDependencyContext(runtime)
+
+    class FakeEnv:
+        async def stop(self, delete):
+            pass
+
+    ctx._environment = FakeEnv()
+    await ctx._stop_started_runtime()
+    assert ctx._environment is None
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_start_runtime(tmp_path, monkeypatch):
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    runtime = HarborDependencyRuntime(
+        task_path=ResourceRef(uri=task_dir.resolve().as_uri(), description=""),
+        build_timeout_sec=None,
+        run_healthcheck=False,
+    )
+
+    class FakeEnv:
+        context_id = None
+
+        class capabilities:
+            mounted = False
+
+        async def start(self, force_build):
+            pass
+
+        async def stop(self, delete):
+            pass
+
+    class FakeEnvPaths:
+        verifier_dir = Path("/verifier")
+        agent_dir = Path("/agent")
+        artifacts_dir = Path("/artifacts")
+
+    class FakeTrialPaths:
+        def __init__(self, path):
+            self.trial_dir = path
+            self.verifier_dir = path / "verifier"
+            self.agent_dir = path / "agent"
+            self.artifacts_dir = path / "artifacts"
+
+        def mkdir(self):
+            pass
+
+        def host_artifact_path(self, service, path):
+            result = self.trial_dir / "artifacts" / "main"
+            result.mkdir(parents=True, exist_ok=True)
+            return result
+
+    class FakeHarborTask:
+        short_name = "test-task"
+        paths = SimpleNamespace(environment_dir=tmp_path, tests_dir=tmp_path / "tests")
+        config = SimpleNamespace(environment=SimpleNamespace(os="linux", healthcheck=None, build_timeout_sec=None))
+
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.HarborTaskModel",
+        lambda p: FakeHarborTask(),
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.TrialPaths",
+        FakeTrialPaths,
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.EnvironmentPaths",
+        SimpleNamespace(for_os=staticmethod(lambda os: FakeEnvPaths())),
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.EnvironmentFactory",
+        SimpleNamespace(create_environment=staticmethod(lambda *a, **kw: FakeEnv())),
+    )
+
+    ctx = HarborDependencyContext(runtime)
+    await ctx._start_harbor_runtime()
+    assert ctx._environment is not None
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_start_runtime_mounted(tmp_path, monkeypatch):
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    runtime = HarborDependencyRuntime(
+        task_path=ResourceRef(uri=task_dir.resolve().as_uri(), description=""),
+        build_timeout_sec=None,
+        run_healthcheck=False,
+    )
+
+    class FakeEnv:
+        context_id = None
+
+        class capabilities:
+            mounted = True
+
+        async def start(self, force_build):
+            pass
+
+        async def stop(self, delete):
+            pass
+
+    class FakeEnvPaths:
+        verifier_dir = Path("/verifier")
+        agent_dir = Path("/agent")
+        artifacts_dir = Path("/artifacts")
+
+    class FakeTrialPaths:
+        def __init__(self, path):
+            self.trial_dir = path
+            self.verifier_dir = path / "verifier"
+            self.agent_dir = path / "agent"
+            self.artifacts_dir = path / "artifacts"
+
+        def mkdir(self):
+            pass
+
+        def chmod_dir(self):
+            pass
+
+        def host_artifact_path(self, service, path):
+            result = self.trial_dir / "artifacts" / "main"
+            result.mkdir(parents=True, exist_ok=True)
+            return result
+
+    class FakeHarborTask:
+        short_name = "test-task"
+        paths = SimpleNamespace(environment_dir=tmp_path, tests_dir=tmp_path / "tests")
+        config = SimpleNamespace(environment=SimpleNamespace(os="linux", healthcheck=None, build_timeout_sec=None))
+
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.HarborTaskModel",
+        lambda p: FakeHarborTask(),
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.TrialPaths",
+        FakeTrialPaths,
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.EnvironmentPaths",
+        SimpleNamespace(for_os=staticmethod(lambda os: FakeEnvPaths())),
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.EnvironmentFactory",
+        SimpleNamespace(create_environment=staticmethod(lambda *a, **kw: FakeEnv())),
+    )
+
+    ctx = HarborDependencyContext(runtime)
+    await ctx._start_harbor_runtime()
+    assert ctx._environment is not None
+
+
+def test_chmod_path_chain(tmp_path):
+    deep = tmp_path / "a" / "b" / "c"
+    deep.mkdir(parents=True)
+    _chmod_path_chain(deep, tmp_path / "a")
+
+
+def test_safe_identifier_empty():
+    assert _safe_identifier("") == "path"
+
+
+def test_safe_identifier_starts_with_digit():
+    assert _safe_identifier("123abc") == "_123abc"
+
+
+def test_safe_identifier_normal():
+    assert _safe_identifier("hello world") == "hello_world"
+
+
+def test_scoped_import_path_empty_module(tmp_path):
+    with pytest.raises(ValueError, match="import_path module is required"):
+        _scoped_import_path(tmp_path, ":SomeClass")
+
+
+def test_cleanup_scoped_imports_removes_parent_attr():
+    _ensure_package("_test_root_xyz.sub")
+    assert "_test_root_xyz" in sys.modules
+    _cleanup_scoped_imports("_test_root_xyz.sub")
+    assert "_test_root_xyz" not in sys.modules
+
+
+def test_trial_metric_spec_uses_trial_verifier_dir(tmp_path):
+    trial_dir = tmp_path / "trial"
+    verifier_dir = trial_dir / "verifier"
+    verifier_dir.mkdir(parents=True)
+    spec = _trial_metric_spec(trial_dir, {})
+    assert spec.ref is not None
+    assert spec.ref.uri == verifier_dir.resolve().as_uri()
+
+
+def test_trial_metric_spec_task_dir_verifier(tmp_path):
+    task_dir = tmp_path / "task"
+    verifier_dir = task_dir / "tests"
+    verifier_dir.mkdir(parents=True)
+    trial_dir = tmp_path / "trial"
+    trial_dir.mkdir()
+    trial_data = {"task_id": {"path": str(task_dir)}}
+    spec = _trial_metric_spec(trial_dir, trial_data)
+    assert spec.ref is not None
+    assert spec.ref.uri == verifier_dir.resolve().as_uri()
+
+
+def test_with_trace_artifact_already_has_source():
+    from harbor.models.job.config import ArtifactConfig
+
+    existing = ArtifactConfig(source=_TRACE_ARTIFACT_SOURCE, destination="traces")
+    result = _with_trace_artifact([existing], _TRACE_ARTIFACT_SOURCE)
+    assert result == [existing]
+
+
+def test_with_trace_artifact_already_has_destination():
+    from harbor.models.job.config import ArtifactConfig
+
+    existing = ArtifactConfig(source="/other", destination=_TRACE_ARTIFACT_DESTINATION)
+    result = _with_trace_artifact([existing], _TRACE_ARTIFACT_SOURCE)
+    assert result == [existing]
+
+
+def test_with_trace_artifact_adds_when_missing():
+    from harbor.models.job.config import ArtifactConfig
+
+    other = ArtifactConfig(source="/other", destination="other")
+    result = _with_trace_artifact([other], _TRACE_ARTIFACT_SOURCE)
+    assert len(result) == 2
+    assert result[0].source == _TRACE_ARTIFACT_SOURCE
+
+
+def test_trial_error_non_dict():
+    result = _trial_error("some string error")
+    assert result == {"exception_info": "some string error"}
+
+
+def test_trial_metrics_skips_non_numeric(tmp_path):
+    spec = MetricSpec(name="reward", description="")
+    result = _trial_metrics(
+        tmp_path,
+        {"verifier_result": {"rewards": {"reward": "not-a-number", "score": 1.0}}},
+        spec,
+    )
+    assert "reward" not in result
+    assert result["score"].value == 1.0
+
+
+def test_trial_resources_fallback_artifact(tmp_path):
+    unknown_file = tmp_path / "some_unknown_file.txt"
+    unknown_file.write_text("data")
+    resources, _trace = _trial_resources(tmp_path)
+    assert "artifact:some_unknown_file.txt" in resources
+
+
+def test_harbor_dataset_get_task_found(tmp_path):
+    task_dir = tmp_path / "task-a"
+    _write(task_dir / "task.toml", "")
+    dataset = HarborDataset.from_path(task_dir)
+    task = dataset.get_task("task-a")
+    assert task.id == "task-a"
+
+
+@pytest.mark.asyncio
+async def test_harbor_evaluator_force_rerun(tmp_path, monkeypatch):
+    evaluator = HarborEvaluator()
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    task_dir = tmp_path / "task-a"
+    _write(task_dir / "task.toml", "")
+    harbor_dataset = HarborDataset.from_path(task_dir)
+
+    jobs_dir = tmp_path / "jobs"
+    job_name = f"agent-{harbor_dataset.id}"
+    job_dir = jobs_dir / job_name
+    job_dir.mkdir(parents=True)
+    (job_dir / "existing_file.txt").write_text("old result")
+
+    rmtree_calls = []
+
+    def fake_rmtree(path, **kwargs):
+        rmtree_calls.append(path)
+
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.shutil.rmtree", fake_rmtree
+    )
+
+    class FakeJob:
+        created_config = None
+
+        def __init__(self, config):
+            self.config = config
+            self.job_dir = job_dir
+
+        @classmethod
+        async def create(cls, config):
+            cls.created_config = config
+            return cls(config)
+
+        async def run(self):
+            return SimpleNamespace(id="job-id", stats=None)
+
+    monkeypatch.setattr("nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.Job", FakeJob)
+
+    trials = await evaluator._run(
+        agent=agent_dir,
+        dataset=harbor_dataset,
+        options=HarborEvaluatorConfig(
+            import_path="harbor_wrapper:WrappedAgent",
+            jobs_dir=jobs_dir,
+            force_rerun=True,
+        ),
+    )
+    assert trials == []
+    assert len(rmtree_calls) == 1
+    assert rmtree_calls[0] == job_dir
+
+
+@pytest.mark.asyncio
+async def test_harbor_trials_from_dir_trial_id_fallback(tmp_path):
+    job_dir = tmp_path / "job"
+    trial_dir = job_dir / "task-x__0"
+    _write_json(
+        trial_dir / "result.json",
+        {
+            "verifier_result": {"rewards": {"reward": 0.5}},
+            "exception_info": None,
+        },
+    )
+
+    evaluator = HarborEvaluator()
+    trials = await evaluator._trials_from_dir(job_dir, [Task(id="task-x", metric_specs={})])
+    assert trials[0].id == trial_dir.name
+
+
+# ── models.py additional coverage ────────────────────────────────────────────
+
+
+def test_dependency_runtime_context():
+    runtime = DependencyRuntime()
+    ctx = runtime.context()
+    assert isinstance(ctx, DependencyContext)
+
+
+def test_local_path_from_uri_decodes_file_uri(tmp_path: Path):
+    path = tmp_path / "directory with spaces"
+
+    assert local_path_from_uri(path.as_uri()) == path
+
+
+def test_local_path_from_uri_rejects_non_file_scheme():
+    with pytest.raises(ValueError, match="URI scheme 's3'"):
+        local_path_from_uri("s3://bucket/path")
+
+
+def test_local_path_from_uri_rejects_remote_file_uri():
+    with pytest.raises(ValueError, match="file URI must be local"):
+        local_path_from_uri("file://remote-host/path")
+
+
+@pytest.mark.asyncio
+async def test_run_dependency_command_success(tmp_path):
+    spec = CommandSpec(argv=["echo", "hello"], cwd=ResourceRef(uri=tmp_path.resolve().as_uri(), description=""))
+    await run_dependency_command(spec, "test")
+
+
+@pytest.mark.asyncio
+async def test_run_dependency_command_failure():
+    spec = CommandSpec(argv=["false"])
+    with pytest.raises(RuntimeError, match="failed with exit code"):
+        await run_dependency_command(spec, "test")
+
+
+@pytest.mark.asyncio
+async def test_run_dependency_command_timeout():
+    spec = CommandSpec(argv=["sleep", "10"], timeout_sec=0)
+    with pytest.raises(TimeoutError):
+        await run_dependency_command(spec, "test")
+
+
+@pytest.mark.asyncio
+async def test_run_dependency_command_empty_argv():
+    spec = CommandSpec(argv=[])
+    with pytest.raises(ValueError, match="empty argv"):
+        await run_dependency_command(spec, "test")
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_with_none_runtime():
+    ctx = DependencyContext(None)
+    assert ctx._runtime is None
+    entered = await ctx.__aenter__()
+    assert entered is None
+    result = await ctx.__aexit__(None, None, None)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_with_real_runtime(tmp_path):
+    spec_start = CommandSpec(argv=["echo", "start"], cwd=ResourceRef(uri=tmp_path.resolve().as_uri(), description=""))
+    spec_stop = CommandSpec(argv=["echo", "stop"], cwd=ResourceRef(uri=tmp_path.resolve().as_uri(), description=""))
+    runtime = DependencyRuntime(start=spec_start, stop=spec_stop)
+    ctx = DependencyContext(runtime)
+    entered = await ctx.__aenter__()
+    assert entered is runtime
+    result = await ctx.__aexit__(None, None, None)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_cleanup_on_start_failure(tmp_path):
+    spec_start = CommandSpec(argv=["false"])
+    spec_stop = CommandSpec(argv=["echo", "stop"])
+    runtime = DependencyRuntime(start=spec_start, stop=spec_stop)
+    ctx = DependencyContext(runtime)
+    with pytest.raises(RuntimeError):
+        await ctx.__aenter__()
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_aexit_stop_raises_no_original_exc(tmp_path):
+    spec_start = CommandSpec(argv=["echo", "start"])
+    spec_stop = CommandSpec(argv=["false"])
+    runtime = DependencyRuntime(start=spec_start, stop=spec_stop)
+    ctx = DependencyContext(runtime)
+    await ctx.__aenter__()
+    with pytest.raises(RuntimeError):
+        await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_aexit_stop_raises_with_original_exc(tmp_path):
+    spec_start = CommandSpec(argv=["echo", "start"])
+    spec_stop = CommandSpec(argv=["false"])
+    runtime = DependencyRuntime(start=spec_start, stop=spec_stop)
+    ctx = DependencyContext(runtime)
+    await ctx.__aenter__()
+    result = await ctx.__aexit__(ValueError, ValueError("orig"), None)
+    assert result is False
+
+
+def test_task_start_deps_with_no_dependencies():
+    task = Task(id="t1")
+    ctx = task.start_deps()
+    assert isinstance(ctx, DependencyContext)
+
+
+def test_task_start_deps_with_dependencies():
+    runtime = DependencyRuntime(start=CommandSpec(argv=["true"]))
+    task = Task(id="t1", dependencies=runtime)
+    ctx = task.start_deps()
+    assert isinstance(ctx, DependencyContext)
+
+
+def test_dataset_subset_missing_raises():
+    class ConcreteDataset(Dataset):
+        @classmethod
+        def from_ref(cls, ref):
+            return cls(id="test")
+
+    ds = ConcreteDataset(id="ds", tasks=[Task(id="t1")])
+    with pytest.raises(ValueError, match="not found in dataset"):
+        ds.subset(["t1", "missing"])
+
+
+def test_dataset_from_ref_not_implemented():
+    from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+
+    class ConcreteDataset(Dataset):
+        pass
+
+    with pytest.raises(NotImplementedError):
+        ConcreteDataset.from_ref(DatasetRef(uri="/tmp"))
+
+
+def test_dataset_subset_success():
+    class ConcreteDataset(Dataset):
+        @classmethod
+        def from_ref(cls, ref):
+            return cls(id="test")
+
+    ds = ConcreteDataset(id="ds", tasks=[Task(id="t1"), Task(id="t2")])
+    sub = ds.subset(["t1"])
+    assert len(sub.list_tasks()) == 1
+    assert sub.tasks[0].id == "t1"
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_start_none_raises_on_no_start():
+    runtime = DependencyRuntime(start=None)
+    ctx = DependencyContext(runtime)
+    with pytest.raises(ValueError, match="requires start"):
+        await ctx.__aenter__()
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_with_readiness(tmp_path):
+    spec_start = CommandSpec(argv=["echo", "start"])
+    spec_readiness = CommandSpec(argv=["echo", "ready"])
+    spec_stop = CommandSpec(argv=["echo", "stop"])
+    runtime = DependencyRuntime(start=spec_start, readiness=spec_readiness, stop=spec_stop)
+    ctx = DependencyContext(runtime)
+    entered = await ctx.__aenter__()
+    assert entered is runtime
+    await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_dependency_context_start_failure_stop_also_fails():
+    spec_start = CommandSpec(argv=["false"])
+    spec_stop = CommandSpec(argv=["false"])
+    runtime = DependencyRuntime(start=spec_start, stop=spec_stop)
+    ctx = DependencyContext(runtime)
+    with pytest.raises(RuntimeError):
+        await ctx.__aenter__()
+
+
+# ── harbor.py additional coverage (round 2) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_aenter_readiness_real(monkeypatch):
+    runtime = HarborDependencyRuntime(
+        task_path=ResourceRef(uri="file:///tmp/task", description=""),
+        readiness=CommandSpec(argv=["echo", "ready"]),
+    )
+
+    async def fake_start(self):
+        pass
+
+    async def fake_stop(self):
+        pass
+
+    monkeypatch.setattr(HarborDependencyContext, "_start_harbor_runtime", fake_start)
+    monkeypatch.setattr(HarborDependencyContext, "_stop_started_runtime", fake_stop)
+
+    ctx = HarborDependencyContext(runtime)
+    entered = await ctx.__aenter__()
+    assert entered is runtime
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_aenter_start_fails_stop_also_fails(monkeypatch):
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""))
+
+    async def fake_start(self):
+        raise RuntimeError("start failed")
+
+    async def fake_stop(self):
+        raise RuntimeError("stop also failed")
+
+    monkeypatch.setattr(HarborDependencyContext, "_start_harbor_runtime", fake_start)
+    monkeypatch.setattr(HarborDependencyContext, "_stop_started_runtime", fake_stop)
+
+    ctx = HarborDependencyContext(runtime)
+    with pytest.raises(RuntimeError, match="start failed"):
+        await ctx.__aenter__()
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_aexit_stop_raises_no_exc(monkeypatch):
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""))
+
+    async def fake_start(self):
+        pass
+
+    async def fake_stop(self):
+        raise RuntimeError("stop failed")
+
+    monkeypatch.setattr(HarborDependencyContext, "_start_harbor_runtime", fake_start)
+    monkeypatch.setattr(HarborDependencyContext, "_stop_started_runtime", fake_stop)
+
+    ctx = HarborDependencyContext(runtime)
+    await ctx.__aenter__()
+    with pytest.raises(RuntimeError, match="stop failed"):
+        await ctx.__aexit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_stop_runtime_env_raises(monkeypatch):
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""), delete=True)
+    ctx = HarborDependencyContext(runtime)
+
+    class FakeEnv:
+        async def stop(self, delete):
+            raise RuntimeError("env stop failed")
+
+    ctx._environment = FakeEnv()
+    with pytest.raises(RuntimeError, match="env stop failed"):
+        await ctx._stop_started_runtime()
+    assert ctx._environment is None
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_stop_runtime_with_stop_command(tmp_path):
+    runtime = HarborDependencyRuntime(
+        task_path=ResourceRef(uri="file:///tmp/task", description=""),
+        stop=CommandSpec(argv=["echo", "stop"]),
+    )
+    ctx = HarborDependencyContext(runtime)
+    await ctx._stop_started_runtime()
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_stop_runtime_env_and_stop_command_both_fail():
+    runtime = HarborDependencyRuntime(
+        task_path=ResourceRef(uri="file:///tmp/task", description=""),
+        delete=True,
+        stop=CommandSpec(argv=["false"]),
+    )
+    ctx = HarborDependencyContext(runtime)
+
+    class FakeEnv:
+        async def stop(self, delete):
+            raise RuntimeError("env stop failed")
+
+    ctx._environment = FakeEnv()
+    with pytest.raises(RuntimeError, match="env stop failed"):
+        await ctx._stop_started_runtime()
+    assert ctx._environment is None
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_stop_runtime_stop_command_fails_no_env_error():
+    runtime = HarborDependencyRuntime(
+        task_path=ResourceRef(uri="file:///tmp/task", description=""),
+        stop=CommandSpec(argv=["false"]),
+    )
+    ctx = HarborDependencyContext(runtime)
+    with pytest.raises(RuntimeError):
+        await ctx._stop_started_runtime()
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_stop_runtime_with_temp_dir(tmp_path, monkeypatch):
+    import tempfile
+
+    runtime = HarborDependencyRuntime(task_path=ResourceRef(uri="file:///tmp/task", description=""))
+    ctx = HarborDependencyContext(runtime)
+    temp = tempfile.TemporaryDirectory()
+    ctx._temp_dir = temp
+    await ctx._stop_started_runtime()
+    assert ctx._temp_dir is None
+
+
+@pytest.mark.asyncio
+async def test_harbor_dependency_context_start_runtime_with_healthcheck(tmp_path, monkeypatch):
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    runtime = HarborDependencyRuntime(
+        task_path=ResourceRef(uri=task_dir.resolve().as_uri(), description=""),
+        build_timeout_sec=None,
+        run_healthcheck=True,
+    )
+
+    healthcheck_called = []
+
+    class FakeEnv:
+        context_id = None
+
+        class capabilities:
+            mounted = False
+
+        async def start(self, force_build):
+            pass
+
+        async def run_healthcheck(self):
+            healthcheck_called.append(True)
+
+        async def stop(self, delete):
+            pass
+
+    class FakeEnvPaths:
+        verifier_dir = Path("/verifier")
+        agent_dir = Path("/agent")
+        artifacts_dir = Path("/artifacts")
+
+    class FakeTrialPaths:
+        def __init__(self, path):
+            self.trial_dir = path
+            self.verifier_dir = path / "verifier"
+            self.agent_dir = path / "agent"
+            self.artifacts_dir = path / "artifacts"
+
+        def mkdir(self):
+            pass
+
+        def host_artifact_path(self, service, path):
+            result = self.trial_dir / "artifacts" / "main"
+            result.mkdir(parents=True, exist_ok=True)
+            return result
+
+    class FakeHarborTask:
+        short_name = "test-task"
+        paths = SimpleNamespace(environment_dir=tmp_path, tests_dir=tmp_path / "tests")
+        config = SimpleNamespace(
+            environment=SimpleNamespace(
+                os="linux",
+                healthcheck=SimpleNamespace(test=["CMD", "echo", "ok"]),
+                build_timeout_sec=None,
+            )
+        )
+
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.HarborTaskModel",
+        lambda p: FakeHarborTask(),
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.TrialPaths",
+        FakeTrialPaths,
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.EnvironmentPaths",
+        SimpleNamespace(for_os=staticmethod(lambda os: FakeEnvPaths())),
+    )
+    monkeypatch.setattr(
+        "nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor.EnvironmentFactory",
+        SimpleNamespace(create_environment=staticmethod(lambda *a, **kw: FakeEnv())),
+    )
+
+    ctx = HarborDependencyContext(runtime)
+    await ctx._start_harbor_runtime()
+    assert healthcheck_called
+
+
+def test_cleanup_scoped_imports_with_sibling_prevents_parent_removal():
+    _ensure_package("_test_multi_abc.child1")
+    _ensure_package("_test_multi_abc.child2")
+    assert "_test_multi_abc" in sys.modules
+    _cleanup_scoped_imports("_test_multi_abc.child1")
+    assert "_test_multi_abc" in sys.modules
+    _cleanup_scoped_imports("_test_multi_abc.child2")
+    assert "_test_multi_abc" not in sys.modules
+
+
+def test_trial_task_path_from_config_dict():
+    from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import _trial_task_path
+
+    trial_data = {"config": {"task": {"path": "/tmp/task-x"}}}
+    result = _trial_task_path(trial_data)
+    assert result is not None
+    assert result.name == "task-x"
+
+
+def test_resolve_trial_task_id_invalid_uri_in_task(tmp_path):
+    from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import _resolve_trial_task_id
+
+    task_map = {"task-x": Task(id="task-x", uri="s3://bad-uri/task-x")}
+    trial_data = {"task_id": {"path": str(tmp_path / "task-x")}}
+    result = _resolve_trial_task_id("task-x__0", trial_data, task_map)
+    assert result == "task-x"
+
+
+def test_resolve_trial_task_id_fallback_to_trial_base():
+    from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import _resolve_trial_task_id
+
+    task_map = {"task-x": Task(id="task-x")}
+    trial_data = {"task_name": "unknown/nonexistent"}
+    result = _resolve_trial_task_id("task-x__0", trial_data, task_map)
+    assert result == "task-x"
+
+
+def test_with_trace_artifact_string_match():
+    result = _with_trace_artifact([_TRACE_ARTIFACT_SOURCE], _TRACE_ARTIFACT_SOURCE)
+    assert result == [_TRACE_ARTIFACT_SOURCE]
+
+
+def test_with_trace_artifact_string_destination_match():
+    result = _with_trace_artifact([_TRACE_ARTIFACT_DESTINATION], _TRACE_ARTIFACT_SOURCE)
+    assert result == [_TRACE_ARTIFACT_DESTINATION]

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_loop_failure.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_loop_failure.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from nemo_experimentalist_plugin.entities import ExperimentRun
+from nemo_experimentalist_plugin.experimentalist.components import loop as loop_module
+from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizer
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
+from nemo_experimentalist_plugin.resolve import EvolutionaryOptimizerConfig
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_method", ["create", "evaluate"])
+async def test_baseline_failure_marks_run_failed(monkeypatch, tmp_path, failure_method):
+    candidate = SimpleNamespace(label="agent-0")
+    evolution_tree = SimpleNamespace(survivors=lambda round_num: [candidate])
+    backend = LocalExperimentalistBackend(path=tmp_path)
+    run_entity = await backend.create_run(
+        workspace="default",
+        run=ExperimentRun(
+            workspace="default",
+            agent="agent",
+            config_snapshot={},
+            status="running",
+            rounds_completed=0,
+        ),
+    )
+    monkeypatch.setattr(backend, "get_agent_code", AsyncMock())
+    config = EvolutionaryOptimizerConfig()
+
+    monkeypatch.setattr(
+        loop_module,
+        "EvaluatorFactory",
+        lambda: SimpleNamespace(build_evaluator=lambda *args, **kwargs: object()),
+    )
+    monkeypatch.setattr(
+        loop_module,
+        "DatasetFactory",
+        lambda: SimpleNamespace(build_dataset=lambda *args, **kwargs: object()),
+    )
+    monkeypatch.setattr(loop_module.EvolutionTree, "from_dir", lambda path: evolution_tree)
+    monkeypatch.setattr(EvolutionaryOptimizer, "_init_structure", lambda self: (tmp_path, tmp_path, tmp_path))
+    monkeypatch.setattr(EvolutionaryOptimizer, "_detect_last_round", lambda self: None)
+    monkeypatch.setattr(
+        EvolutionaryOptimizer,
+        "_create_experiment_run",
+        AsyncMock(return_value=run_entity),
+    )
+    baseline_failure = ValueError("baseline failed")
+    create_baseline = (
+        AsyncMock(side_effect=baseline_failure) if failure_method == "create" else AsyncMock(return_value=candidate)
+    )
+    monkeypatch.setattr(EvolutionaryOptimizer, "_create_baseline_agent", create_baseline)
+    monkeypatch.setattr(EvolutionaryOptimizer, "_update_candidate", AsyncMock())
+    evaluate_validation = (
+        AsyncMock(side_effect=baseline_failure)
+        if failure_method == "evaluate"
+        else AsyncMock(return_value={"agent-0": object()})
+    )
+    monkeypatch.setattr(EvolutionaryOptimizer, "_evaluate_validation_candidates", evaluate_validation)
+
+    optimizer = object.__new__(EvolutionaryOptimizer)
+    optimizer.working_dir = tmp_path
+    optimizer.config = config
+    optimizer.shell = SimpleNamespace(close=AsyncMock())
+    deps = SimpleNamespace(
+        backend=backend,
+        workspace="default",
+        config=config,
+        evaluator_type="harbor",
+        train_dataset=object(),
+        validation_dataset=object(),
+        insight=None,
+        agent=tmp_path / "agent",
+        agent_spec=None,
+        task_template=None,
+    )
+
+    with pytest.raises(ValueError, match="baseline failed"):
+        await optimizer.run(deps)
+
+    optimizer.shell.close.assert_awaited_once()
+    assert run_entity.status == "failed"
+    saved = json.loads((tmp_path / "eval-and-optimize" / "run.json").read_text(encoding="utf-8"))
+    assert saved["status"] == "failed"

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_model_config.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_model_config.py
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_experimentalist_plugin.experimentalist.components.model_config import get_mid_model, log_model_config
+
+
+def test_mid_model_default_uses_openai_provider_for_gateway(monkeypatch) -> None:
+    monkeypatch.setenv("EXPERIMENTALIST_API_BASE", "https://example.test/v1")
+    monkeypatch.setenv("EXPERIMENTALIST_API_KEY", "test-key")
+    monkeypatch.delenv("EXPERIMENTALIST_MID_MODEL_NAME", raising=False)
+    get_mid_model.cache_clear()
+
+    try:
+        client = get_mid_model()
+    finally:
+        get_mid_model.cache_clear()
+
+    assert client.model == "openai/gcp/google/gemini-3.5-flash"
+    assert "mid model:   openai/gcp/google/gemini-3.5-flash" in log_model_config()

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_repository.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_repository.py
@@ -1,0 +1,730 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for git-source resolution and PR/MR publishing.
+
+No network or real git: the git-ref parsing helpers are pure, and PRPublisher's
+single command boundary (``_run``) is stubbed.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components import repository as repo
+from nemo_experimentalist_plugin.experimentalist.components.repository import (
+    AgentCloneError,
+    AgentSource,
+    PRPublisher,
+    PRPublisherError,
+    clone_agent_repo,
+    looks_like_git,
+    split_agent_spec,
+    split_git_ref,
+)
+
+# ---------------------------------------------------------------------------
+# git-ref parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec", "url", "ref"),
+    [
+        (
+            "ssh://git@gitlab.example.com:12051/org/agents-under-test.git@main",
+            "ssh://git@gitlab.example.com:12051/org/agents-under-test.git",
+            "main",
+        ),
+        # No ref: the git@ user in the ssh URL must NOT be treated as a ref.
+        (
+            "ssh://git@gitlab.example.com:12051/org/agents-under-test.git",
+            "ssh://git@gitlab.example.com:12051/org/agents-under-test.git",
+            None,
+        ),
+        ("git@github.com:org/repo.git", "git@github.com:org/repo.git", None),
+        ("git@github.com:org/repo.git@feature/x", "git@github.com:org/repo.git", "feature/x"),
+        ("https://github.com/org/repo.git@v1.2", "https://github.com/org/repo.git", "v1.2"),
+        (
+            "https://token.git@github.com/org/repo.git",
+            "https://token.git@github.com/org/repo.git",
+            None,
+        ),
+        (
+            "https://token.git@github.com/org/repo.git@main",
+            "https://token.git@github.com/org/repo.git",
+            "main",
+        ),
+        ("token.git@github.com:org/repo.git", "token.git@github.com:org/repo.git", None),
+        ("token.git@github.com:org/repo.git@main", "token.git@github.com:org/repo.git", "main"),
+        (
+            "https://token.git@github.com/org/repo.git@feature/x.git@debug?access_token=secret",
+            "https://token.git@github.com/org/repo.git?access_token=secret",
+            "feature/x.git@debug",
+        ),
+        ("../repo.git@feature/x", "../repo.git", "feature/x"),
+    ],
+)
+def test_split_git_ref(spec: str, url: str, ref: str | None) -> None:
+    assert split_git_ref(spec) == (url, ref)
+
+
+def test_looks_like_git() -> None:
+    assert looks_like_git("ssh://git@host:1/grp/repo.git@main")
+    assert looks_like_git("git@github.com:org/repo.git")
+    assert looks_like_git("https://github.com/org/repo.git")
+    assert not looks_like_git("examples/terminal-bench-agent")
+    assert not looks_like_git("/abs/local/dir")
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/org/repo.git", ("gh", "github.com")),
+        ("ssh://git@github.com/org/repo.git", ("gh", "github.com")),
+        ("git@github.com:org/repo.git", ("gh", "github.com")),
+        ("https://gitlab.com/org/repo.git", ("glab", "gitlab.com")),
+        (
+            "ssh://git@gitlab-master.example.com:12051/org/repo.git",
+            ("glab", "gitlab-master.example.com"),
+        ),
+        ("git@gitlab-master.example.com:org/repo.git", ("glab", "gitlab-master.example.com")),
+        # Self-hosted GitLab under any hostname is recognized by the host family.
+        ("https://gitlab.example.com/org/repo.git", ("glab", "gitlab.example.com")),
+        (
+            "https://oauth2:secret@gitlab-master.example.com/org/repo.git",  # trufflehog:ignore
+            ("glab", "gitlab-master.example.com"),
+        ),
+        ("https://bitbucket.org/org/repo.git", None),
+        ("not a repository URL", None),
+    ],
+)
+def test_pr_cli_for_repo_url(url: str, expected: tuple[str, str] | None) -> None:
+    assert repo.pr_cli_for_repo_url(url) == expected
+
+
+def test_redact_url_masks_userinfo() -> None:
+    assert (
+        repo._redact_url("https://oauth2:secret-token@gitlab.example.com/g/r.git")  # trufflehog:ignore
+        == "https://***@gitlab.example.com/g/r.git"
+    )
+    assert repo._redact_url("https://github.com/org/repo.git") == "https://github.com/org/repo.git"
+
+
+# ---------------------------------------------------------------------------
+# PRPublisher (stubbed command boundary)
+# ---------------------------------------------------------------------------
+
+
+class _StubPublisher(PRPublisher):
+    """PRPublisher that records commands and returns canned outputs instead of shelling out."""
+
+    def __init__(
+        self,
+        *,
+        agent_dir: Path,
+        origin: str,
+        status: str,
+        branches: tuple[str, ...] = ("main",),
+        default_branch: str = "main",
+    ) -> None:
+        super().__init__(agent_dir=agent_dir)
+        self.calls: list[list[str]] = []
+        self._origin = origin
+        self._status = status
+        self._branches = branches  # refs that ls-remote --heads reports as branches
+        self._default_head = default_branch  # origin/HEAD target
+
+    def _run(self, cmd: list[str], *, cwd: Path | None = None) -> str:
+        self.calls.append(cmd)
+        if cmd[:3] == ["git", "remote", "get-url"]:
+            return self._origin
+        if cmd[:2] == ["git", "ls-remote"] and "--heads" in cmd:
+            ref = cmd[-1]
+            return f"deadbeef\trefs/heads/{ref}" if ref in self._branches else ""
+        if cmd[:2] == ["git", "rev-parse"] and cmd[-1] == "origin/HEAD":
+            return f"origin/{self._default_head}"
+        if cmd[:3] == ["git", "--literal-pathspecs", "status"]:
+            return self._status
+        if cmd[:1] == ["glab"]:
+            return "https://gitlab.example.com/org/agents-under-test/-/merge_requests/1"
+        if cmd[:1] == ["gh"]:
+            return "https://github.com/org/repo/pull/1"
+        return ""
+
+
+def _winner(tmp_path: Path) -> Path:
+    w = tmp_path / "winner"
+    w.mkdir()
+    (w / "main.py").write_text("print('improved')\n")
+    (w / "metadata.json").write_text("{}")  # must be skipped
+    return w
+
+
+def _git(checkout: Path, *args: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "-C", str(checkout), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.splitlines()
+
+
+def test_publish_gitlab_opens_draft_mr(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    pub = _StubPublisher(
+        agent_dir=agent_dir,
+        origin="ssh://git@gitlab.example.com:12051/org/agents-under-test.git",
+        status=" M main.py",
+    )
+    url = pub.publish(
+        winner_dir=_winner(tmp_path),
+        branch="optimizer/run-1-agent-2",
+        base_ref="main",
+        title="Experimentalist: candidate agent-2",
+        body="summary",
+    )
+    assert url.endswith("/merge_requests/1")
+    glab = next(c for c in pub.calls if c[0] == "glab")
+    assert "mr" in glab and "create" in glab and "--draft" in glab
+    assert "--source-branch" in glab and "optimizer/run-1-agent-2" in glab
+    assert "--target-branch" in glab and "main" in glab
+    assert ["git", "fetch", "origin", "main"] in pub.calls
+    assert ["git", "push", "--force-with-lease", "-u", "origin", "optimizer/run-1-agent-2"] in pub.calls
+    assert ["git", "ls-remote", "--heads", "origin", "main"] in pub.calls
+    # Generated file was not committed (overlay skipped it).
+    assert not (agent_dir / "metadata.json").exists()
+    assert (agent_dir / "main.py").read_text() == "print('improved')\n"
+
+
+def test_publish_github_opens_draft_pr(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    pub = _StubPublisher(
+        agent_dir=agent_dir,
+        origin="https://github.com/org/repo.git",
+        status=" M main.py",
+    )
+    url = pub.publish(
+        winner_dir=_winner(tmp_path),
+        branch="optimizer/x",
+        base_ref="main",
+        title="t",
+        body="b",
+    )
+    assert url.endswith("/pull/1")
+    gh = next(c for c in pub.calls if c[0] == "gh")
+    assert gh[:3] == ["gh", "pr", "create"] and "--draft" in gh
+
+
+def test_publish_skips_build_artifacts(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    # Winner dir with top-level and NESTED build artifacts that must not be committed.
+    winner = tmp_path / "winner"
+    (winner / "pkg" / "__pycache__").mkdir(parents=True)
+    (winner / "main.py").write_text("print('improved')\n")
+    (winner / "stray.pyc").write_bytes(b"\x00")
+    (winner / "__pycache__").mkdir()
+    (winner / "__pycache__" / "main.cpython-313.pyc").write_bytes(b"\x00")
+    (winner / "pkg" / "mod.py").write_text("x = 1\n")
+    (winner / "pkg" / "__pycache__" / "mod.cpython-313.pyc").write_bytes(b"\x00")
+
+    pub = _StubPublisher(
+        agent_dir=agent_dir,
+        origin="https://github.com/org/repo.git",
+        status=" M main.py",
+    )
+    pub.publish(winner_dir=winner, branch="b", base_ref="main", title="t", body="b")
+
+    # Real source copied; build artifacts (top-level + nested) excluded.
+    assert (agent_dir / "main.py").exists()
+    assert (agent_dir / "pkg" / "mod.py").exists()
+    assert not (agent_dir / "__pycache__").exists()
+    assert not (agent_dir / "stray.pyc").exists()
+    assert not (agent_dir / "pkg" / "__pycache__").exists()
+
+
+def test_publish_tag_source_targets_default_branch(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    # base_ref is a tag (not a branch on origin); the MR base must fall back to the
+    # remote's default branch (main), while the winner branch is still cut from the tag.
+    pub = _StubPublisher(
+        agent_dir=agent_dir,
+        origin="ssh://git@gitlab.example.com:12051/org/agents-under-test.git",
+        status=" M main.py",
+        branches=("main",),
+    )
+    pub.publish(
+        winner_dir=_winner(tmp_path),
+        branch="optimizer/run-1-agent-2",
+        base_ref="v1.2",  # a tag
+        title="t",
+        body="b",
+    )
+    glab = next(c for c in pub.calls if c[0] == "glab")
+    assert glab[glab.index("--target-branch") + 1] == "main"
+    assert glab[glab.index("--source-branch") + 1] == "optimizer/run-1-agent-2"
+    # The winner branch is cut from the exact source ref via FETCH_HEAD.
+    assert ["git", "checkout", "-B", "optimizer/run-1-agent-2", "FETCH_HEAD"] in pub.calls
+
+
+def test_publish_default_branch_keeps_slashes(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    # A slashed default branch (origin/release/2026.07) must survive the origin/ strip,
+    # not be truncated to "2026.07".
+    pub = _StubPublisher(
+        agent_dir=agent_dir,
+        origin="https://github.com/org/repo.git",
+        status=" M main.py",
+        branches=("main",),
+        default_branch="release/2026.07",
+    )
+    pub.publish(winner_dir=_winner(tmp_path), branch="b", base_ref="v1.2", title="t", body="b")
+    gh = next(c for c in pub.calls if c[0] == "gh")
+    assert gh[gh.index("--base") + 1] == "release/2026.07"
+
+
+def test_publish_no_diff_skips_pr(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    pub = _StubPublisher(
+        agent_dir=agent_dir,
+        origin="https://github.com/org/repo.git",
+        status="",  # winner identical to base → nothing to commit
+    )
+    url = pub.publish(winner_dir=_winner(tmp_path), branch="b", base_ref="main", title="t", body="b")
+    assert url == ""
+    assert not any(c[0] in ("gh", "glab") for c in pub.calls)
+    assert not any(c[:2] == ["git", "commit"] for c in pub.calls)
+
+
+def test_run_failure_includes_command_and_redacted_stderr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(command: list[str], **_kwargs) -> repo.subprocess.CompletedProcess[str]:
+        return repo.subprocess.CompletedProcess(command, 1, stdout="", stderr="fatal: boom\n")
+
+    monkeypatch.setattr(repo.subprocess, "run", fake_run)
+    publisher = PRPublisher(agent_dir=tmp_path)
+
+    with pytest.raises(PRPublisherError) as exc_info:
+        publisher._run(["git", "fetch", "https://oauth2:token-secret@github.com/org/repo.git"])  # trufflehog:ignore
+
+    message = str(exc_info.value)
+    assert "command failed (1): git fetch https://***@github.com/org/repo.git" in message
+    assert "fatal: boom" in message
+    assert "token-secret" not in message
+
+
+def test_run_timeout_includes_command(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(command: list[str], **_kwargs) -> repo.subprocess.CompletedProcess[str]:
+        raise repo.subprocess.TimeoutExpired(command, repo._COMMAND_TIMEOUT)
+
+    monkeypatch.setattr(repo.subprocess, "run", fake_run)
+    publisher = PRPublisher(agent_dir=tmp_path)
+
+    with pytest.raises(PRPublisherError, match="command timed out after 120s: git ls-remote"):
+        publisher._run(["git", "ls-remote", "--heads", "origin", "main"])
+
+
+@pytest.mark.parametrize(
+    ("origin", "display"),
+    [
+        ("https://bitbucket.org/x/y.git", "https://bitbucket.org/x/y.git"),
+        ("https://oauth2:secret-token@bitbucket.org/x/y.git", "https://***@bitbucket.org/x/y.git"),  # trufflehog:ignore
+    ],
+)
+def test_publish_unsupported_host_uses_sanitized_remote(tmp_path: Path, origin: str, display: str) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    pub = _StubPublisher(agent_dir=agent_dir, origin=origin, status=" M f")
+
+    with pytest.raises(PRPublisherError) as exc_info:
+        pub.publish(winner_dir=_winner(tmp_path), branch="b", base_ref="main", title="t", body="b")
+
+    assert str(exc_info.value) == f"unsupported remote host for PR creation: {display}"
+    assert "secret-token" not in str(exc_info.value)
+
+
+def test_agent_source_model() -> None:
+    s = AgentSource(repo_url="ssh://git@h/g/r.git", ref="main")
+    assert s.repo_url.endswith("r.git") and s.ref == "main"
+    assert s.agent_path == "."  # whole-repo agent by default
+
+
+# ---------------------------------------------------------------------------
+# candidate-storage helpers: spec fragment and agent-path validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("spec", "core", "agent_path"),
+    [
+        ("ssh://git@h/g/r.git@main", "ssh://git@h/g/r.git@main", "."),
+        ("ssh://git@h/g/r.git@main#pkg/agent", "ssh://git@h/g/r.git@main", "pkg/agent"),
+        ("https://h/g/r.git#sub", "https://h/g/r.git", "sub"),
+        # Benign fragment forms are normalized rather than rejected.
+        ("https://h/g/r.git#pkg/agent/", "https://h/g/r.git", "pkg/agent"),
+        ("https://h/g/r.git#./pkg/agent", "https://h/g/r.git", "pkg/agent"),
+        ("https://h/g/r.git#./", "https://h/g/r.git", "."),
+    ],
+)
+def test_split_agent_spec(spec: str, core: str, agent_path: str) -> None:
+    assert split_agent_spec(spec) == (core, agent_path)
+
+
+@pytest.mark.parametrize(
+    "agent_path",
+    [
+        ":(top,glob)**",
+        ".git",
+        ".GIT/hooks",
+        "pkg/.GiT/hooks",
+        "..",
+        "../outside",
+        "pkg/../outside",
+        "/absolute",
+        "pkg\\agent",
+        "pkg//agent",
+        "pkg/./agent",
+        "",
+        "pkg/\x00agent",
+    ],
+)
+def test_split_agent_spec_rejects_unsafe_agent_path_without_echo(agent_path: str) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        split_agent_spec(f"https://github.com/org/repo.git#{agent_path}")
+
+    assert str(exc_info.value) == "agent path must be a normalized relative POSIX path"
+    if agent_path:
+        assert agent_path not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("agent_path", [":(top,glob)**", "pkg/.GiT/hooks"])
+@pytest.mark.parametrize("boundary", ["snapshot", "push", "publish"])
+def test_publisher_rejects_unsafe_agent_path_before_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    boundary: str,
+    agent_path: str,
+) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    publisher = _StubPublisher(
+        agent_dir=agent_dir,
+        origin="https://github.com/org/repo.git",
+        status=" M main.py",
+    )
+    winner = _winner(tmp_path)
+    overlay_calls: list[Path] = []
+    monkeypatch.setattr(publisher, "_overlay", lambda _src, dest: overlay_calls.append(dest))
+
+    with pytest.raises(ValueError, match="normalized relative POSIX path"):
+        if boundary == "snapshot":
+            publisher._snapshot_subtree(winner, agent_path)
+        elif boundary == "push":
+            publisher.push_branch(
+                src_dir=winner,
+                branch="optimizer/test",
+                base_ref="main",
+                message="message",
+                agent_path=agent_path,
+            )
+        else:
+            publisher.publish(
+                winner_dir=winner,
+                branch="optimizer/test",
+                base_ref="main",
+                title="title",
+                body="body",
+                agent_path=agent_path,
+            )
+
+    assert publisher.calls == []
+    assert overlay_calls == []
+
+
+def test_clone_agent_repo_parses_fragment_and_depth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run(cmd, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+        calls.append((cmd, kwargs))
+
+        class _R:
+            stdout = "main\n"
+
+        return _R()
+
+    monkeypatch.setattr(repo.subprocess, "run", fake_run)
+    src = clone_agent_repo("ssh://git@h/g/r.git@main#pkg/agent", tmp_path / "dest", clone_depth=2)
+    assert src == AgentSource(repo_url="ssh://git@h/g/r.git", ref="main", agent_path="pkg/agent")
+    clone, clone_kwargs = next(call for call in calls if call[0][:2] == ["git", "clone"])
+    assert "--depth" in clone and clone[clone.index("--depth") + 1] == "2"
+    # the #fragment is stripped from the clone URL (only repo+ref reach git clone)
+    assert "ssh://git@h/g/r.git" in clone and "pkg/agent" not in " ".join(clone)
+    assert clone_kwargs["capture_output"] is True
+    assert clone_kwargs["text"] is True
+    assert clone_kwargs["stdin"] is repo.subprocess.DEVNULL
+
+
+def test_clone_failure_includes_git_stderr_with_redacted_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_git = fake_bin / "git"
+    fake_git.write_text(
+        f"#!{sys.executable}\nimport os\nos.write(2, b'fatal: repository not found')\nraise SystemExit(128)\n",
+        encoding="utf-8",
+    )
+    fake_git.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{fake_bin}{os.pathsep}{os.environ.get('PATH', '')}")
+    source = "https://token-user:secret-token@gitlab.com/org/repo.git"  # trufflehog:ignore
+
+    with pytest.raises(AgentCloneError) as exc_info:
+        clone_agent_repo(source, tmp_path / "dest")
+
+    message = str(exc_info.value)
+    assert "git clone failed" in message
+    assert "exit status 128" in message
+    assert "https://***@gitlab.com/org/repo.git" in message
+    assert "fatal: repository not found" in message
+    assert "secret-token" not in message
+
+
+def test_clone_timeout_redacts_credentials(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    remote = "ssh://deploy-token@github.com/org/repo.git"
+
+    def _timeout(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise repo.subprocess.TimeoutExpired(["git", "clone", remote], repo._COMMAND_TIMEOUT)
+
+    monkeypatch.setattr(repo.subprocess, "run", _timeout)
+
+    with pytest.raises(AgentCloneError) as exc_info:
+        clone_agent_repo(remote, tmp_path / "dest")
+
+    message = str(exc_info.value)
+    assert "git clone timed out after 120s for ssh://***@github.com/org/repo.git" in message
+    assert "deploy-token" not in message
+
+
+def test_clone_agent_repo_redacts_credentials_in_repo_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        repo.subprocess,
+        "run",
+        lambda *_args, **_kwargs: repo.subprocess.CompletedProcess(args=[], returncode=0, stdout="main\n"),
+    )
+
+    source = clone_agent_repo("https://gitlab.com/org/repo.git", tmp_path / "dest")
+    assert source.repo_url == "https://gitlab.com/org/repo.git"
+
+    source = clone_agent_repo("https://oauth2:token@gitlab.com/org/repo.git", tmp_path / "dest")  # trufflehog:ignore
+    assert source.repo_url == "https://***@gitlab.com/org/repo.git"
+
+
+# ---------------------------------------------------------------------------
+# PRPublisher.push_branch — per-candidate archival (skip-if-exists, subtree)
+# ---------------------------------------------------------------------------
+
+
+def test_push_branch_archives_candidate(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    (agent_dir / "pkg" / "agent").mkdir(parents=True)
+    pub = _StubPublisher(agent_dir=agent_dir, origin="ssh://git@h/g/r.git", status=" M main.py")
+    pushed = pub.push_branch(
+        src_dir=_winner(tmp_path),
+        branch="optimizer/run-1/agent-2",
+        base_ref="main",
+        message="archive agent-2",
+        agent_path="pkg/agent",
+    )
+    assert pushed is True
+    push = next(c for c in pub.calls if c[:2] == ["git", "push"])
+    assert "optimizer/run-1/agent-2" in push and "--force-with-lease" not in push  # no force for archival
+    assert ["git", "ls-remote", "--heads", "origin", "optimizer/run-1/agent-2"] in pub.calls
+    assert ["git", "fetch", "origin", "main"] in pub.calls
+    assert [
+        "git",
+        "--literal-pathspecs",
+        "rm",
+        "-r",
+        "-q",
+        "-f",
+        "--ignore-unmatch",
+        "--",
+        "pkg/agent",
+    ] in pub.calls
+    assert (agent_dir / "pkg" / "agent" / "main.py").read_text() == "print('improved')\n"
+    assert not (agent_dir / "pkg" / "agent" / "metadata.json").exists()  # generated file excluded
+
+
+def test_snapshot_subtree_recreates_removed_nested_destination_with_real_git(tmp_path: Path) -> None:
+    checkout = tmp_path / "repo"
+    checkout.mkdir()
+    _git(checkout, "init", "-q")
+
+    old_file = checkout / "pkg" / "agent" / "old.py"
+    old_file.parent.mkdir(parents=True)
+    old_file.write_text("old\n", encoding="utf-8")
+    _git(checkout, "add", "pkg/agent/old.py")
+    stale = checkout / "pkg" / "agent" / "local-secret.txt"
+    stale.write_text("must not survive\n", encoding="utf-8")
+    (checkout / "pkg" / "agent" / "metadata.json").write_text("must not survive\n", encoding="utf-8")
+
+    PRPublisher(agent_dir=checkout)._snapshot_subtree(_winner(tmp_path), "pkg/agent")
+
+    assert not old_file.exists()
+    assert not stale.exists()
+    assert not (checkout / "pkg" / "agent" / "metadata.json").exists()
+    assert (checkout / "pkg" / "agent" / "main.py").read_text(encoding="utf-8") == "print('improved')\n"
+    assert _git(checkout, "ls-files") == ["pkg/agent/main.py"]
+
+
+def test_snapshot_subtree_rejects_symlink_ancestor_before_commands_or_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "repo"
+    checkout.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "sentinel"
+    sentinel.write_text("unchanged\n", encoding="utf-8")
+    (checkout / "pkg").symlink_to(outside, target_is_directory=True)
+    publisher = PRPublisher(agent_dir=checkout)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(publisher, "_run", lambda command, **_kwargs: commands.append(command))
+
+    with pytest.raises(ValueError) as exc_info:
+        publisher._snapshot_subtree(_winner(tmp_path), "pkg/agent")
+
+    assert str(exc_info.value) == "agent path must stay within the checkout without symlinks"
+    assert commands == []
+    assert sentinel.read_text(encoding="utf-8") == "unchanged\n"
+    assert not (outside / "agent" / "main.py").exists()
+
+
+def test_snapshot_subtree_rechecks_path_after_removal_before_overlay(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "repo"
+    target = checkout / "pkg" / "agent"
+    target.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    publisher = PRPublisher(agent_dir=checkout)
+
+    def replace_ancestor_after_remove(command: list[str], **_kwargs: object) -> str:
+        if "rm" in command:
+            shutil.rmtree(checkout / "pkg")
+            (checkout / "pkg").symlink_to(outside, target_is_directory=True)
+        return ""
+
+    monkeypatch.setattr(publisher, "_run", replace_ancestor_after_remove)
+
+    with pytest.raises(ValueError, match="stay within the checkout without symlinks"):
+        publisher._snapshot_subtree(_winner(tmp_path), "pkg/agent")
+
+    assert not (outside / "agent" / "main.py").exists()
+
+
+def test_push_branch_scopes_snapshot_status_and_commit_to_agent_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for role in ("AUTHOR", "COMMITTER"):
+        monkeypatch.setenv(f"GIT_{role}_NAME", "Test")
+        monkeypatch.setenv(f"GIT_{role}_EMAIL", "test@example.com")
+    checkout = tmp_path / "repo"
+    checkout.mkdir()
+    _git(checkout, "init", "-q")
+    (checkout / "pkg" / "agent").mkdir(parents=True)
+    (checkout / "pkg" / "agent" / "old.py").write_text("old\n", encoding="utf-8")
+    unrelated = checkout / "unrelated.txt"
+    unrelated.write_text("base\n", encoding="utf-8")
+    _git(checkout, "add", ".")
+    _git(checkout, "commit", "-qm", "base")
+    unrelated.write_text("staged unrelated\n", encoding="utf-8")
+    _git(checkout, "add", "unrelated.txt")
+    (checkout / "untracked.txt").write_text("untracked\n", encoding="utf-8")
+    pushes: list[str] = []
+
+    class _LocalPublisher(PRPublisher):
+        def _run(self, cmd: list[str], *, cwd: Path | None = None) -> str:
+            if cmd[:4] == ["git", "remote", "get-url", "origin"]:
+                return "https://github.com/org/repo.git"
+            if cmd[:2] == ["git", "ls-remote"]:
+                return ""
+            if cmd[:2] in (["git", "fetch"], ["git", "checkout"], ["git", "push"]):
+                if cmd[:2] == ["git", "push"]:
+                    pushes.append(cmd[-1])
+                return ""
+            return super()._run(cmd, cwd=cwd)
+
+    publisher = _LocalPublisher(agent_dir=checkout)
+    pushed = publisher.push_branch(
+        src_dir=_winner(tmp_path),
+        branch="optimizer/test",
+        base_ref="main",
+        message="candidate",
+        agent_path="pkg/agent",
+    )
+
+    assert pushed is True
+    assert _git(checkout, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD") == [
+        "pkg/agent/main.py",
+        "pkg/agent/old.py",
+    ]
+    assert _git(checkout, "diff", "--cached", "--name-only") == ["unrelated.txt"]
+    assert _git(checkout, "status", "--porcelain") == ["M  unrelated.txt", "?? untracked.txt"]
+    assert pushes == ["optimizer/test"]
+
+    skipped = publisher.push_branch(
+        src_dir=tmp_path / "winner",
+        branch="optimizer/identical",
+        base_ref="main",
+        message="identical",
+        agent_path="pkg/agent",
+    )
+    assert skipped is False
+    assert pushes == ["optimizer/test"]
+
+
+def test_push_branch_skips_when_branch_exists(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    # ls-remote reports the target branch already on origin -> skip (no push), returns False.
+    pub = _StubPublisher(
+        agent_dir=agent_dir, origin="ssh://git@h/g/r.git", status=" M f", branches=("main", "optimizer/run-1/agent-2")
+    )
+    assert (
+        pub.push_branch(src_dir=_winner(tmp_path), branch="optimizer/run-1/agent-2", base_ref="main", message="m")
+        is False
+    )
+    assert not any(c[:2] == ["git", "push"] for c in pub.calls)
+
+
+def test_push_branch_skips_empty_diff(tmp_path: Path) -> None:
+    agent_dir = tmp_path / "clone"
+    agent_dir.mkdir()
+    # git status returns empty (candidate identical to base) -> no commit/push, returns False.
+    pub = _StubPublisher(agent_dir=agent_dir, origin="ssh://git@h/g/r.git", status="")
+    assert (
+        pub.push_branch(src_dir=_winner(tmp_path), branch="optimizer/run-1/agent-3", base_ref="main", message="m")
+        is False
+    )
+    assert not any(c[:2] == ["git", "push"] for c in pub.calls)

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_terminal_bench_langchain_agent.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_terminal_bench_langchain_agent.py
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import importlib.util
+import io
+import json
+import tomllib
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_DIR = REPO_ROOT / "examples" / "terminal-bench-agent"
+
+
+def _load_wrapper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("terminal_bench_harbor_wrapper", AGENT_DIR / "harbor_wrapper.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RecordingEnvironment:
+    def __init__(self, *, platform: str = "Linux\nx86_64\n") -> None:
+        self.default_user = "root"
+        self.platform = platform
+        self.commands: list[dict[str, object]] = []
+        self.uploads: dict[str, bytes] = {}
+
+    async def exec(
+        self,
+        command: str,
+        user: str | int | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout_sec: int | None = None,
+    ) -> SimpleNamespace:
+        self.commands.append(
+            {
+                "command": command,
+                "user": user,
+                "env": env,
+                "cwd": cwd,
+                "timeout_sec": timeout_sec,
+            }
+        )
+        stdout = self.platform if command == "uname -s && uname -m" else ""
+        return SimpleNamespace(return_code=0, stdout=stdout, stderr="")
+
+    async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        self.uploads[target_path] = Path(source_path).read_bytes()
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [("amd64", "x86_64"), ("x86_64", "x86_64"), ("arm64", "aarch64"), ("aarch64", "aarch64")],
+)
+def test_static_uv_architecture_aliases(raw: str, expected: str) -> None:
+    wrapper = _load_wrapper()
+
+    assert wrapper._normalize_architecture(raw) == expected
+
+
+def test_static_uv_architecture_rejects_unsupported_target() -> None:
+    wrapper = _load_wrapper()
+
+    with pytest.raises(RuntimeError, match="Unsupported.*riscv64"):
+        wrapper._normalize_architecture("riscv64")
+
+
+def test_uv_download_rejects_checksum_mismatch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    wrapper = _load_wrapper()
+    payload = b"not-the-pinned-uv-archive"
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(payload))
+    destination = tmp_path / "uv.tar.gz"
+
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        wrapper._download_archive("https://example.invalid/uv.tar.gz", destination, "0" * 64)
+
+    assert not destination.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_uv_download_accepts_pinned_checksum(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    wrapper = _load_wrapper()
+    payload = b"pinned-uv-archive"
+    monkeypatch.setattr(wrapper.urllib.request, "urlopen", lambda *_args, **_kwargs: io.BytesIO(payload))
+    destination = tmp_path / "uv.tar.gz"
+
+    wrapper._download_archive(
+        "https://example.invalid/uv.tar.gz",
+        destination,
+        hashlib.sha256(payload).hexdigest(),
+    )
+
+    assert destination.read_bytes() == payload
+
+
+@pytest.mark.asyncio
+async def test_installed_agent_stages_locked_uv_managed_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    wrapper = _load_wrapper()
+    uv_binary = tmp_path / "uv"
+    uv_binary.write_bytes(b"static uv")
+    monkeypatch.setattr(wrapper, "_cached_uv_binary", lambda architecture: uv_binary)
+    logs_dir = tmp_path / "logs"
+    agent = wrapper.WrappedAgent(logs_dir=logs_dir, model_name="gateway/model")
+    environment = RecordingEnvironment()
+
+    await agent.install(environment)
+
+    assert environment.uploads[wrapper.REMOTE_UV] == b"static uv"
+    assert set(environment.uploads) == {
+        wrapper.REMOTE_UV,
+        *(f"{wrapper.REMOTE_PROJECT}/{name}" for name in wrapper.PROJECT_FILES),
+    }
+    commands = "\n".join(str(call["command"]) for call in environment.commands)
+    assert f"{wrapper.REMOTE_UV} python install 3.12" in commands
+    assert f"{wrapper.REMOTE_UV} sync --project {wrapper.REMOTE_PROJECT} --frozen --no-dev" in commands
+    assert "curl" not in commands
+    assert "apt" not in commands
+    assert "docker" not in commands
+    sync_call = next(call for call in environment.commands if " sync " in str(call["command"]))
+    assert sync_call["env"]["UV_PYTHON_PREFERENCE"] == "only-managed"  # type: ignore[index]
+
+
+@pytest.mark.asyncio
+async def test_installed_agent_runs_module_in_app_and_populates_usage(tmp_path: Path) -> None:
+    wrapper = _load_wrapper()
+    logs_dir = tmp_path / "logs"
+    logs_dir.mkdir()
+    (logs_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "answer": "done",
+                "usage": {
+                    "input_tokens": 11,
+                    "output_tokens": 7,
+                    "cache_read_tokens": 3,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    agent = wrapper.WrappedAgent(
+        logs_dir=logs_dir,
+        model_name="aws/anthropic/claude-haiku-4-5-v1",
+        extra_env={"INFERENCE_API_KEY": "test-key"},
+    )
+    environment = RecordingEnvironment()
+    context = wrapper.AgentContext()
+
+    await agent.run("solve it", environment, context)
+
+    run_call = environment.commands[-1]
+    command = str(run_call["command"])
+    assert f"{wrapper.REMOTE_VENV}/bin/python -m main" in command
+    assert run_call["cwd"] == "/app"
+    assert run_call["env"]["INFERENCE_API_KEY"] == "test-key"  # type: ignore[index]
+    assert "docker" not in command
+    assert "sidecar" not in command
+    assert context.n_input_tokens == 11
+    assert context.n_output_tokens == 7
+    assert context.n_cache_tokens == 3
+    assert context.metadata is not None and context.metadata["answer"] == "done"
+
+
+def test_agent_project_is_locked_and_has_no_nemo_oo_dependency() -> None:
+    project = tomllib.loads((AGENT_DIR / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = project["project"]["dependencies"]
+
+    assert (AGENT_DIR / "uv.lock").is_file()
+    assert any(dependency.startswith("langchain") for dependency in dependencies)
+    assert all("nemo-oo" not in dependency for dependency in dependencies)

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_terminator.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_terminator.py
@@ -1,0 +1,262 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the Terminator step.
+
+These guard the behavior-preserving extraction of the termination logic
+(``_has_converged`` + ``qualitative_stop_check`` + ``max_rounds``) out of the
+loop and into :mod:`terminator`. Every Terminator is constructed with an injected
+``FakeLLMClient`` so the tests need no ``EXPERIMENTALIST_API_*`` env vars and make no
+network calls.
+"""
+
+import json
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizerConfig
+from nemo_experimentalist_plugin.experimentalist.components.terminator import (
+    TerminationDecision,
+    Terminator,
+)
+from nooa.unifiedllm import FakeLLMClient, LLMResponse, ToolCall
+
+
+@dataclass
+class _FakeNode:
+    """Stand-in for EvolutionNode exposing only what _has_converged reads."""
+
+    label: str
+    round: int
+    val_reward: dict[str, float] = field(default_factory=dict)
+
+
+def _tree(*nodes: _FakeNode) -> SimpleNamespace:
+    """Build a stand-in EvolutionTree: an object with a ``.nodes`` dict."""
+    return SimpleNamespace(nodes={n.label: n for n in nodes})
+
+
+def _exec_response(code: str) -> LLMResponse:
+    """A scripted LLM turn that drives CodeAct's ``execute_python`` tool with ``code``."""
+    return LLMResponse(
+        raw_response=None,
+        content="",
+        finish_reason="tool_calls",
+        assistant_message={"role": "assistant", "content": ""},
+        tool_calls=[ToolCall(id="call_exec", name="execute_python", arguments=json.dumps({"code": code}))],
+    )
+
+
+def _terminator(*, stop_verdict: bool | None = None) -> Terminator:
+    """Build a Terminator with an injected fake LLM.
+
+    When ``stop_verdict`` is None the fake makes no scripted response (used by tests
+    that never reach the qualitative check). Otherwise the qualitative_stop_check
+    strategy resolves to that boolean via a scripted ``return_result``.
+    """
+    if stop_verdict is None:
+        return Terminator(llm=FakeLLMClient())
+    fake = FakeLLMClient(scripted_responses=[_exec_response(f"return_result(result={stop_verdict})")])
+    return Terminator(llm=fake)
+
+
+# ---------------------------------------------------------------------------
+# assess_round_budget
+# ---------------------------------------------------------------------------
+
+
+def test_assess_round_budget_stops_at_max_rounds() -> None:
+    term = _terminator()
+    config = EvolutionaryOptimizerConfig(max_rounds=3)
+
+    assert term.assess_round_budget(round_num=2, config=config) == TerminationDecision(stop=False)
+
+    at_limit = term.assess_round_budget(round_num=3, config=config)
+    assert at_limit.stop is True
+    assert "max_rounds" in at_limit.reason
+
+    assert term.assess_round_budget(round_num=4, config=config).stop is True
+
+
+# ---------------------------------------------------------------------------
+# run() — unified entry point (budget first, then convergence)
+# ---------------------------------------------------------------------------
+
+
+async def test_run_stops_on_budget() -> None:
+    term = _terminator()
+    config = EvolutionaryOptimizerConfig(max_rounds=2)
+    decision = await term.run(
+        round_num=2,
+        evolution_tree=_tree(),
+        prior_analysis=None,
+        config=config,
+    )
+    assert decision.stop is True
+    assert "max_rounds" in decision.reason
+
+
+async def test_run_stops_on_convergence_when_budget_not_hit() -> None:
+    term = _terminator()
+    # Budget not exhausted (round 2 < max_rounds 15), but the front has stagnated.
+    tree = _tree(
+        _FakeNode("a0", 0, {"score": 0.9}),
+        _FakeNode("a1", 1, {"score": 0.5}),
+        _FakeNode("a2", 2, {"score": 0.6}),
+    )
+    decision = await term.run(
+        round_num=2,
+        evolution_tree=tree,
+        prior_analysis="prior analysis",
+        config=EvolutionaryOptimizerConfig(max_rounds=15, min_rounds_before_stopping=2),
+    )
+    assert decision.stop is True
+    assert "converged" in decision.reason
+
+
+async def test_run_continues_when_neither_triggers() -> None:
+    term = _terminator()
+    decision = await term.run(
+        round_num=0,
+        evolution_tree=_tree(),
+        prior_analysis=None,  # round 0: no convergence check
+        config=EvolutionaryOptimizerConfig(max_rounds=15),
+    )
+    assert decision == TerminationDecision(stop=False)
+
+
+# ---------------------------------------------------------------------------
+# assess_convergence gating (no LLM, no deterministic work)
+# ---------------------------------------------------------------------------
+
+
+async def test_assess_convergence_no_prior_analysis_does_not_stop() -> None:
+    term = _terminator()
+    config = EvolutionaryOptimizerConfig()
+    decision = await term.assess_convergence(
+        evolution_tree=_tree(),
+        prior_analysis=None,
+        config=config,
+    )
+    assert decision == TerminationDecision(stop=False)
+
+
+async def test_assess_convergence_disabled_does_not_stop() -> None:
+    term = _terminator()
+    config = EvolutionaryOptimizerConfig(disable_convergence_check=True)
+    # A tree that WOULD converge — proves the disable flag short-circuits first.
+    tree = _tree(
+        _FakeNode("a0", 0, {"score": 0.9}),
+        _FakeNode("a1", 1, {"score": 0.5}),
+        _FakeNode("a2", 2, {"score": 0.6}),
+    )
+    decision = await term.assess_convergence(
+        evolution_tree=tree,
+        prior_analysis="some analysis",
+        config=config,
+    )
+    assert decision == TerminationDecision(stop=False)
+
+
+# ---------------------------------------------------------------------------
+# _has_converged deterministic paths
+# ---------------------------------------------------------------------------
+
+
+async def test_has_converged_false_when_too_few_rounds() -> None:
+    term = _terminator()
+    tree = _tree(
+        _FakeNode("a0", 0, {"score": 0.5}),
+        _FakeNode("a1", 1, {"score": 0.6}),
+    )
+    # Only 2 distinct scored rounds < min_rounds_before_stopping=3 -> False, no LLM.
+    assert (
+        await term._has_converged(
+            evolution_tree=tree,
+            prior_analysis="ignored",
+            min_rounds_before_stopping=3,
+        )
+        is False
+    )
+
+
+async def test_has_converged_ignores_unscored_nodes() -> None:
+    term = _terminator()
+    # Two scored rounds + an unscored ({}) node. The unscored node must NOT count toward the
+    # round set (val_reward is {} for unscored, so a truthy filter excludes it); with only two
+    # scored rounds < min_rounds_before_stopping=3 the check returns False.
+    tree = _tree(
+        _FakeNode("a0", 0, {"score": 0.5}),
+        _FakeNode("a1", 1, {"score": 0.6}),
+        _FakeNode("a2", 2, {}),  # unscored — must be ignored
+    )
+    assert (
+        await term._has_converged(
+            evolution_tree=tree,
+            prior_analysis="ignored",
+            min_rounds_before_stopping=3,
+        )
+        is False
+    )
+
+
+async def test_has_converged_true_when_front_stagnates() -> None:
+    term = _terminator()
+    # Best candidate is the round-0 baseline; later rounds never beat it, so the
+    # full Pareto front (a0) is a subset of the old front (a0) -> converged.
+    tree = _tree(
+        _FakeNode("a0", 0, {"score": 0.9}),
+        _FakeNode("a1", 1, {"score": 0.5}),
+        _FakeNode("a2", 2, {"score": 0.6}),
+    )
+    assert (
+        await term._has_converged(
+            evolution_tree=tree,
+            prior_analysis="ignored",
+            min_rounds_before_stopping=2,
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Qualitative fallback (deterministic check inconclusive -> LLM decides)
+# ---------------------------------------------------------------------------
+
+
+async def test_qualitative_fallback_true() -> None:
+    term = _terminator(stop_verdict=True)
+    # Newest round (a2=0.7) is the unique front, NOT in the old front -> not a
+    # deterministic stop, so the qualitative check is consulted.
+    tree = _tree(
+        _FakeNode("a0", 0, {"score": 0.5}),
+        _FakeNode("a1", 1, {"score": 0.6}),
+        _FakeNode("a2", 2, {"score": 0.7}),
+    )
+    assert (
+        await term._has_converged(
+            evolution_tree=tree,
+            prior_analysis="plateaued: same root cause every round",
+            min_rounds_before_stopping=2,
+        )
+        is True
+    )
+
+
+async def test_qualitative_fallback_false_propagates_through_assess_convergence() -> None:
+    term = _terminator(stop_verdict=False)
+    tree = _tree(
+        _FakeNode("a0", 0, {"score": 0.5}),
+        _FakeNode("a1", 1, {"score": 0.6}),
+        _FakeNode("a2", 2, {"score": 0.7}),
+    )
+    decision = await term.assess_convergence(
+        evolution_tree=tree,
+        prior_analysis="still improving",
+        config=EvolutionaryOptimizerConfig(min_rounds_before_stopping=2),
+    )
+    assert decision == TerminationDecision(stop=False)
+
+
+# Winner publishing moved off the Terminator: the loop gates on config.storage.publish_winner and
+# calls backend.publish_candidate directly. Its behavior is covered in test_experimentalist_backend.

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_tools.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_tools.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from nemo_experimentalist_plugin.experimentalist.components.coder import Coder
+from nemo_experimentalist_plugin.experimentalist.components.holdout_utils import BLOCKED_MESSAGE
+from nemo_experimentalist_plugin.experimentalist.components.tools import GuardedShellTools
+from nooa.agentdoc import pformat
+from nooa.tools import ShellResult
+
+
+async def test_guarded_shell_tools_runs_allowed_commands(tmp_path):
+    shell = GuardedShellTools(cwd=tmp_path)
+    try:
+        result = await shell.run("python -", stdin="print('allowed')")
+    finally:
+        await shell.close()
+
+    assert result.stdout.strip() == "allowed"
+    assert result.returncode == 0
+    assert result.success
+
+
+async def test_guarded_shell_tools_returns_failure_for_blocked_paths(tmp_path):
+    shell = GuardedShellTools(cwd=tmp_path)
+    try:
+        result = await shell.run("cat dataset/validation/secret")
+    finally:
+        await shell.close()
+
+    assert isinstance(result, ShellResult)
+    assert result.stdout == ""
+    assert result.stderr == BLOCKED_MESSAGE
+    assert result.returncode == 1
+    assert not result.success
+
+
+def test_coder_hides_skill_registry_that_can_replace_guarded_shell(tmp_path):
+    nooa_skill = Path(__file__).resolve().parents[2] / "framework-skills" / "nooa"
+    coder = Coder(workspace=tmp_path, framework_skills_dirs=[nooa_skill])
+
+    rendered = pformat(coder)
+
+    assert "skills=SkillRegistry" not in rendered
+    assert "shell=ShellTools" in rendered
+    assert "nooa=Nooa" in rendered

--- a/plugins/nemo-experimentalist/tests/test_cli_profile.py
+++ b/plugins/nemo-experimentalist/tests/test_cli_profile.py
@@ -1,0 +1,1207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI profile-driven behavior for experiment."""
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from nemo_experimentalist_plugin import cli
+from nemo_experimentalist_plugin.preflight import Probes
+from nemo_insights_plugin.contracts.profile import DEFAULT_BASE_URL
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def quiet_probes(env: dict | None = None) -> Probes:
+    return Probes(
+        run_cmd=lambda argv: (0, "ok"),
+        http_ok=lambda url: True,
+        env=env
+        or {
+            "EXPERIMENTALIST_API_BASE": "http://llm",
+            "EXPERIMENTALIST_API_KEY": "k",
+            "INFERENCE_API_KEY": "k",
+        },
+    )
+
+
+def write_task_toml(profile_tree: Path) -> None:
+    (profile_tree / "evals" / "task_template" / "task.toml").write_text('[task]\nname = "org/x__t"\n', encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _quiet_preflight(monkeypatch):
+    """Deterministic probes for every test; tests override with their own
+    monkeypatch.setattr when they exercise specific probe behavior."""
+    monkeypatch.setattr(cli, "_PREFLIGHT_PROBES", quiet_probes())
+
+
+@dataclass
+class FakePlatformClient:
+    base_url: str
+    closed: bool = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def _fake_platform_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli, "make_client", FakePlatformClient)
+
+
+@pytest.fixture()
+def app():
+    return cli.ExperimentalistCLI().get_cli()
+
+
+@pytest.fixture()
+def profile_tree(tmp_path: Path) -> Path:
+    for sub in ("evals/task_template", "evals/train", "evals/val"):
+        (tmp_path / sub).mkdir(parents=True)
+    (tmp_path / "optimizer.yaml").write_text(
+        "agent: flight-planner\n"
+        "task_template: ./evals/task_template\n"
+        "datasets:\n  train: ./evals/train\n  validation: ./evals/val\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+class RunRecorder:
+    def __init__(self) -> None:
+        self.kwargs: dict | None = None
+
+    async def __call__(self, **kwargs) -> str:
+        self.kwargs = kwargs
+        return "ok"
+
+
+def test_experiment_insight_only_with_profile(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(cli, "_PREFLIGHT_PROBES", quiet_probes())
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", "ins-1", "-o", str(profile_tree / "out")])
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs["insight"] == "ins-1"
+    assert recorder.kwargs["train_dataset"].uri == str((profile_tree / "evals" / "train").resolve())
+    assert recorder.kwargs["agent"] == str(profile_tree.resolve())
+
+
+def test_experiment_explicit_profile_flag(app, profile_tree: Path, monkeypatch, tmp_path: Path) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(cli, "_PREFLIGHT_PROBES", quiet_probes())
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--insight",
+            "ins-1",
+            "--profile",
+            str(profile_tree / "optimizer.yaml"),
+            "-o",
+            str(elsewhere / "o"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs["workspace"] == "default"
+
+
+def test_experiment_no_profile_missing_flags_errors_with_skeleton(app, tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["run", "--insight", "ins-1", "-o", str(tmp_path / "o")])
+    assert result.exit_code == 1
+    assert "optimizer.yaml" in result.output
+    assert "--train-dataset" in result.output
+
+
+def test_experiment_all_flags_no_profile_still_works(app, tmp_path: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(cli, "_PREFLIGHT_PROBES", quiet_probes())
+    for sub in ("agent", "t", "v"):
+        (tmp_path / sub).mkdir()
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--agent",
+            str(tmp_path / "agent"),
+            "--train-dataset",
+            str(tmp_path / "t"),
+            "--validation-dataset",
+            str(tmp_path / "v"),
+            "-o",
+            str(tmp_path / "o"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs["insight"] is None
+
+
+def test_profileless_experiment_blocks_missing_effective_agent_path(app, tmp_path: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    for sub in ("train", "validation"):
+        (tmp_path / sub).mkdir()
+    missing_agent = tmp_path / "missing-agent"
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--agent",
+            str(missing_agent),
+            "--train-dataset",
+            str(tmp_path / "train"),
+            "--validation-dataset",
+            str(tmp_path / "validation"),
+            "-o",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert recorder.kwargs is None
+    assert f"agent source dir missing: {missing_agent}" in result.output
+
+
+def test_profileless_experiment_blocks_missing_effective_task_template(app, tmp_path: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    for sub in ("agent", "train", "validation"):
+        (tmp_path / sub).mkdir()
+    missing_template = tmp_path / "missing-template"
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--agent",
+            str(tmp_path / "agent"),
+            "--insight",
+            "ins-1",
+            "--train-dataset",
+            str(tmp_path / "train"),
+            "--validation-dataset",
+            str(tmp_path / "validation"),
+            "--task-template",
+            str(missing_template),
+            "-o",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert recorder.kwargs is None
+    assert f"task_template dir missing: {missing_template}" in result.output
+
+
+def test_profileless_implicit_experiment_dirs_retry_collisions_and_stay_unique(
+    app, tmp_path: Path, monkeypatch
+) -> None:
+    fixed_now = cli.datetime(2026, 7, 14, 12, 34, 56, tzinfo=cli.UTC)
+
+    class FrozenDateTime:
+        @staticmethod
+        def now(*, tz):
+            assert tz is cli.UTC
+            return fixed_now
+
+    collision_hex = "a" * 32
+    first_hex = "b" * 32
+    second_hex = "c" * 32
+    generated_uuids = iter(
+        [
+            cli.uuid.UUID(hex=collision_hex),
+            cli.uuid.UUID(hex=collision_hex),
+            cli.uuid.UUID(hex=first_hex),
+            cli.uuid.UUID(hex=first_hex),
+            cli.uuid.UUID(hex=second_hex),
+        ]
+    )
+    output_root = tmp_path / "tmp"
+    colliding_dir = output_root / f"20260714-123456-{collision_hex}"
+    colliding_dir.mkdir(parents=True)
+
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "datetime", FrozenDateTime)
+    monkeypatch.setattr(cli.uuid, "uuid4", lambda: next(generated_uuids))
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    for sub in ("agent", "t", "v"):
+        (tmp_path / sub).mkdir()
+    monkeypatch.chdir(tmp_path)
+    args = [
+        "run",
+        "--agent",
+        str(tmp_path / "agent"),
+        "--train-dataset",
+        str(tmp_path / "t"),
+        "--validation-dataset",
+        str(tmp_path / "v"),
+    ]
+
+    first_result = runner.invoke(app, args)
+    first_dir = Path(recorder.kwargs["experiment_dir"])
+    second_result = runner.invoke(app, args)
+    second_dir = Path(recorder.kwargs["experiment_dir"])
+
+    expected_first = Path("tmp") / f"20260714-123456-{first_hex}"
+    expected_second = Path("tmp") / f"20260714-123456-{second_hex}"
+    assert first_result.exit_code == 0, first_result.output
+    assert second_result.exit_code == 0, second_result.output
+    assert first_dir == expected_first
+    assert second_dir == expected_second
+    assert first_dir != second_dir
+    assert (tmp_path / first_dir).is_dir()
+    assert (tmp_path / second_dir).is_dir()
+    assert f"Experiment dir: {expected_first}" in first_result.output
+    assert f"Experiment dir: {expected_second}" in second_result.output
+
+
+def test_experiment_insight_id_selects_from_analyst_file(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(cli, "_PREFLIGHT_PROBES", quiet_probes())
+    insights = profile_tree / "insights.yaml"
+    items = [
+        {"id": "i-a", "title": "A", "description": "d", "agent": "flight-planner", "status": "open", "trace_refs": []},
+        {"id": "i-b", "title": "B", "description": "d", "agent": "flight-planner", "status": "open", "trace_refs": []},
+    ]
+    insights.write_text(json.dumps({"insights": items}), encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(
+        app,
+        ["run", "--insight", str(insights), "--insight-id", "i-b", "-o", str(profile_tree / "o")],
+    )
+    assert result.exit_code == 0, result.output
+    selected = json.loads(Path(recorder.kwargs["insight"]).read_text(encoding="utf-8"))
+    assert selected["id"] == "i-b"
+
+
+def test_doctor_healthy_exits_zero(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    monkeypatch.setattr(cli, "_PREFLIGHT_PROBES", quiet_probes())
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0, result.output
+    assert "✓" in result.output
+
+
+def test_doctor_no_profile_exits_one_with_skeleton(app, tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(cli, "_PREFLIGHT_PROBES", quiet_probes())
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 1
+    assert "optimizer.yaml" in result.output
+
+
+def test_doctor_invalid_utf8_profile_is_structured_without_traceback(
+    app,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "optimizer.yaml").write_bytes(b"agent: \xff\n")
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Profile\n  ✗ Could not parse profile" in result.output
+    assert "readable UTF-8 YAML" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_doctor_invalid_utf8_task_toml_is_structured_without_traceback(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (profile_tree / "evals" / "task_template" / "task.toml").write_bytes(b"[task]\nname = \xff\n")
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor", "--insight", "ins-1"])
+
+    assert result.exit_code == 1
+    assert "Artifacts\n" in result.output
+    assert "✗ task.toml unreadable or does not parse" in result.output
+    assert "readable UTF-8 TOML" in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    ["pkg//agent", ":(top,glob)**", "../outside"],
+    ids=["malformed", "pathspec", "traversal"],
+)
+def test_doctor_invalid_git_agent_path_is_structured_without_traceback(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fragment: str,
+) -> None:
+    profile = profile_tree / "optimizer.yaml"
+    profile.write_text(
+        profile.read_text(encoding="utf-8") + f'agent_source: "https://host/g/repo.git#{fragment}"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "✗ agent path must be a normalized relative POSIX path" in result.output
+    assert fragment not in result.output
+    assert "Traceback" not in result.output
+
+
+def test_doctor_redacts_model_and_platform_display_urls(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    model_base = "https://model-user:model-secret@models.example:8443/v1"  # trufflehog:ignore
+    platform_base = "https://platform-user:platform-secret@platform.example:9443/api"  # trufflehog:ignore
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        quiet_probes(env={"EXPERIMENTALIST_API_BASE": model_base, "EXPERIMENTALIST_API_KEY": "k"}),
+    )
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor", "--base-url", platform_base])
+
+    assert result.exit_code == 0, result.output
+    assert "https://***@models.example:8443/v1/models reachable" in result.output
+    assert "https://***@platform.example:9443/api reachable" in result.output
+    assert not any(
+        secret in result.output for secret in ("model-user", "model-secret", "platform-user", "platform-secret")
+    )
+
+
+def test_experiment_hard_fails_on_required_check(app, profile_tree: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        Probes(
+            run_cmd=lambda argv: (1, "docker down"),
+            http_ok=lambda url: True,
+            env={"EXPERIMENTALIST_API_BASE": "b", "EXPERIMENTALIST_API_KEY": "k"},
+        ),
+    )
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", "ins-1", "-o", str(profile_tree / "o")])
+    assert result.exit_code == 1
+    assert recorder.kwargs is None  # run never started
+    assert "✗" in result.output
+
+
+def test_experiment_advisory_warns_but_runs(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        Probes(
+            run_cmd=lambda argv: (0, "ok"),
+            http_ok=lambda url: False,  # platform unreachable → advisory
+            env={"EXPERIMENTALIST_API_BASE": "b", "EXPERIMENTALIST_API_KEY": "k"},
+        ),
+    )
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", "ins-1", "-o", str(profile_tree / "o")])
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs is not None  # run proceeded
+
+
+def test_experiment_effective_storage_requires_git_before_runner(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+
+    def missing_git(argv: list[str]) -> tuple[int, str]:
+        if argv == ["git", "--version"]:
+            return 127, "git not found"
+        return 0, "ok"
+
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        Probes(
+            run_cmd=missing_git,
+            http_ok=lambda url: True,
+            env={"EXPERIMENTALIST_API_BASE": "b", "EXPERIMENTALIST_API_KEY": "k"},
+        ),
+    )
+    config = profile_tree / "experiment.yaml"
+    config.write_text("storage:\n  archive_candidates: true\n", encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(
+        app,
+        ["run", "--no-insight", "--config", str(config), "-o", str(profile_tree / "o")],
+    )
+
+    assert result.exit_code == 1
+    assert "'git' is not available" in result.output
+    assert recorder.kwargs is None
+
+
+def test_discovered_profile_is_announced(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", "ins-1", "-o", str(profile_tree / "out")])
+    assert result.exit_code == 0, result.output
+    assert "Using profile:" in result.output
+    assert "flight-planner" in result.output
+
+
+def test_explicit_profile_is_not_announced(app, profile_tree: Path, monkeypatch, tmp_path: Path) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    elsewhere = tmp_path / "elsewhere2"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--insight",
+            "ins-1",
+            "--profile",
+            str(profile_tree / "optimizer.yaml"),
+            "-o",
+            str(elsewhere / "o"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Using profile:" not in result.output
+
+
+def test_missing_creds_reported_before_any_resolution(app, profile_tree: Path, monkeypatch) -> None:
+    # Phase-1 ordering: the grouped credentials report must surface even though
+    # resolution (whose loop import would raise a bare ValueError) never runs.
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        Probes(run_cmd=lambda argv: (0, "ok"), http_ok=lambda url: True, env={}),
+    )
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", "ins-1", "-o", str(profile_tree / "o")])
+    assert result.exit_code == 1
+    assert recorder.kwargs is None
+    assert "EXPERIMENTALIST_API_BASE" in result.output
+    assert "export EXPERIMENTALIST_API_BASE" in result.output  # the hint, not a bare ValueError
+
+
+def test_insightless_run_skips_template_checks(app, profile_tree: Path, monkeypatch) -> None:
+    # profile_tree's template dir has no task.toml — a Mode 2 (no insight) run
+    # never reads the template, so preflight must not fail on it.
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "-o", str(profile_tree / "o")])
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs is not None
+    assert recorder.kwargs["insight"] is None
+
+
+def test_empty_config_flag_is_an_error_not_silent_fallback(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    empty = profile_tree / "empty.yaml"
+    empty.write_text("# comments only\n", encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", "ins-1", "--config", str(empty), "-o", str(profile_tree / "o")])
+    assert result.exit_code == 1
+    assert "is empty" in result.output
+    assert recorder.kwargs is None
+
+
+def test_doctor_multi_insight_file_requires_selector(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    insights = profile_tree / "insights.yaml"
+    items = [
+        {"id": "i-a", "title": "A", "agent": "flight-planner"},
+        {"id": "i-b", "title": "B", "agent": "flight-planner"},
+    ]
+    insights.write_text(json.dumps({"insights": items}), encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["doctor", "--insight", str(insights)])
+    assert result.exit_code == 1
+    assert "--insight-id" in result.output
+
+
+def test_doctor_multi_insight_agent_mismatch_fails(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    insights = profile_tree / "insights.yaml"
+    items = [{"id": "i-a", "title": "A", "agent": "someone-else"}]
+    insights.write_text(json.dumps({"insights": items}), encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["doctor", "--insight", str(insights)])
+    assert result.exit_code == 1
+    assert "someone-else" in result.output
+
+
+def test_profile_dir_env_file_is_loaded_for_experiment(app, profile_tree: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.delenv("NEMO_OPT_TEST_DOTENV", raising=False)
+    (profile_tree / ".env").write_text("NEMO_OPT_TEST_DOTENV=from-env-file\n", encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+
+    try:
+        result = runner.invoke(app, ["run", "-o", str(profile_tree / "out")])
+        assert result.exit_code == 0, result.output
+        assert "Loaded .env" in result.output
+        assert os.environ["NEMO_OPT_TEST_DOTENV"] == "from-env-file"
+    finally:
+        os.environ.pop("NEMO_OPT_TEST_DOTENV", None)
+
+
+def test_experiment_loads_nmp_base_url_from_profile_env(app, profile_tree: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    (profile_tree / ".env").write_text(
+        "NMP_BASE_URL=https://platform.example\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(
+        app,
+        ["run", "--no-insight", "-o", str(profile_tree / "out")],
+    )
+
+    assert result.exit_code == 0, result.output
+    client = recorder.kwargs["client"]
+    assert client.base_url == "https://platform.example"
+    assert client.closed
+
+
+def test_doctor_loads_nmp_base_url_from_profile_env(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    urls: list[str] = []
+
+    def record_http(url: str) -> bool:
+        urls.append(url)
+        return True
+
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        Probes(
+            run_cmd=lambda argv: (0, "ok"),
+            http_ok=record_http,
+            env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"},
+        ),
+    )
+    monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    (profile_tree / ".env").write_text(
+        "NMP_BASE_URL=https://platform.example\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 0, result.output
+    assert "https://platform.example/health/ready" in urls
+
+
+def test_default_experiment_dir_is_profile_scoped_and_announced(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", "ins-1"])
+    assert result.exit_code == 0, result.output
+    assert "Experiment dir:" in result.output
+    experiment_dir = Path(recorder.kwargs["experiment_dir"])
+    assert experiment_dir.is_relative_to(profile_tree / ".nemo-optimizer" / "experiments")
+
+
+def test_default_experiment_dir_retries_collision_and_reserves(app, profile_tree: Path, monkeypatch) -> None:
+    fixed_now = cli.datetime(2026, 7, 14, 12, 34, 56, tzinfo=cli.UTC)
+
+    class FrozenDateTime:
+        @staticmethod
+        def now(*, tz):
+            assert tz is cli.UTC
+            return fixed_now
+
+    collision_hex = "a" * 32
+    unique_hex = "b" * 32
+    generated_uuids = iter(
+        [
+            cli.uuid.UUID(hex=collision_hex),
+            cli.uuid.UUID(hex=collision_hex),
+            cli.uuid.UUID(hex=unique_hex),
+        ]
+    )
+    experiments_root = profile_tree / ".nemo-optimizer" / "experiments"
+    colliding_dir = experiments_root / f"20260714-123456-{collision_hex}"
+    colliding_dir.mkdir(parents=True)
+
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "datetime", FrozenDateTime)
+    monkeypatch.setattr(cli.uuid, "uuid4", lambda: next(generated_uuids))
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["run", "--insight", "ins-1"])
+
+    expected = experiments_root / f"20260714-123456-{unique_hex}"
+    assert result.exit_code == 0, result.output
+    assert Path(recorder.kwargs["experiment_dir"]) == expected
+    assert expected.is_dir()
+    assert colliding_dir.is_dir()
+
+
+def test_default_experiment_dir_is_not_reserved_before_required_preflight(app, profile_tree: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        Probes(
+            run_cmd=lambda argv: (1, "docker down"),
+            http_ok=lambda url: True,
+            env={"EXPERIMENTALIST_API_BASE": "b", "EXPERIMENTALIST_API_KEY": "k"},
+        ),
+    )
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["run", "--insight", "ins-1"])
+
+    assert result.exit_code == 1
+    assert recorder.kwargs is None
+    assert not (profile_tree / ".nemo-optimizer" / "experiments").exists()
+
+
+def test_explicit_experiment_dir_still_wins(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", "ins-1", "-o", str(profile_tree / "custom")])
+    assert result.exit_code == 0, result.output
+    assert "Experiment dir:" not in result.output
+    assert Path(recorder.kwargs["experiment_dir"]) == profile_tree / "custom"
+
+
+def test_credential_defaults_inference_key_powers_gateway_experiment() -> None:
+    env = {"INFERENCE_API_KEY": "sk-gateway"}
+    applied = cli._apply_credential_defaults(env)
+    assert env["EXPERIMENTALIST_API_BASE"] == "https://inference-api.nvidia.com/v1"
+    assert env["EXPERIMENTALIST_API_KEY"] == "sk-gateway"
+    assert len(applied) == 2
+
+
+def test_credential_defaults_never_fill_analyst_key() -> None:
+    env = {"EXPERIMENTALIST_API_KEY": "sk-gateway"}
+    cli._apply_credential_defaults(env)
+    assert "INFERENCE_API_KEY" not in env
+
+
+def test_credential_defaults_custom_base_never_inherits_gateway_key() -> None:
+    custom = {"EXPERIMENTALIST_API_BASE": "https://api.openai.com/v1", "INFERENCE_API_KEY": "sk-gateway"}
+    cli._apply_credential_defaults(custom)
+    assert "EXPERIMENTALIST_API_KEY" not in custom
+
+
+def test_credential_defaults_reject_gateway_lookalike_hosts() -> None:
+    for base in (
+        "https://inference-api.nvidia.com.attacker.example/v1",
+        "https://evil-inference-api.nvidia.com/v1",
+        "http://inference-api.nvidia.com/v1",
+    ):
+        env = {"EXPERIMENTALIST_API_BASE": base, "INFERENCE_API_KEY": "sk-secret"}
+        cli._apply_credential_defaults(env)
+        assert "EXPERIMENTALIST_API_KEY" not in env
+
+
+def test_credential_defaults_never_override() -> None:
+    env = {
+        "INFERENCE_API_KEY": "sk-a",
+        "EXPERIMENTALIST_API_BASE": "https://inference-api.nvidia.com/v1",
+        "EXPERIMENTALIST_API_KEY": "sk-b",
+    }
+    assert cli._apply_credential_defaults(env) == []
+    assert env["EXPERIMENTALIST_API_KEY"] == "sk-b"
+
+
+def test_experiment_defaults_to_shared_insights_file(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    shared = profile_tree / ".nemo-optimizer" / "insights.yaml"
+    shared.parent.mkdir(parents=True)
+    shared.write_text(
+        json.dumps({"insights": [{"id": "i-1", "title": "T", "agent": "flight-planner", "trace_refs": []}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "-o", str(profile_tree / "o")])
+    assert result.exit_code == 0, result.output
+    assert "Insight file:" in result.output
+    selected = json.loads(Path(recorder.kwargs["insight"]).read_text(encoding="utf-8"))
+    assert selected["id"] == "i-1"
+
+
+def test_experiment_selected_insight_uses_shared_default_without_stale_warning(
+    app, profile_tree: Path, monkeypatch
+) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    shared = profile_tree / ".nemo-optimizer" / "insights.yaml"
+    shared.parent.mkdir(parents=True)
+    shared.write_text(
+        json.dumps(
+            {
+                "insights": [
+                    {"id": "i-a", "title": "A", "agent": "flight-planner"},
+                    {"id": "i-b", "title": "B", "agent": "flight-planner"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(
+        app,
+        ["run", "--insight-id", "1", "-o", str(profile_tree / "o")],
+    )
+    assert result.exit_code == 0, result.output
+    selected = json.loads(Path(recorder.kwargs["insight"]).read_text(encoding="utf-8"))
+    assert selected["id"] == "i-b"
+    assert "will require --insight-id" not in result.output
+
+
+def test_experiment_insight_id_requires_resolved_insight(app, profile_tree: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(
+        app,
+        ["run", "--insight-id", "0", "-o", str(profile_tree / "o")],
+    )
+    assert result.exit_code == 1
+    assert "--insight-id" in result.output
+    assert "local multi-insight" in result.output
+    assert recorder.kwargs is None
+
+
+def test_experiment_insight_id_rejects_platform_id(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--insight",
+            "ins-platform",
+            "--insight-id",
+            "0",
+            "-o",
+            str(profile_tree / "o"),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "local multi-insight" in result.output
+    assert recorder.kwargs is None
+
+
+def test_experiment_insight_id_matching_single_local_insight_passes(app, profile_tree: Path, monkeypatch) -> None:
+    write_task_toml(profile_tree)
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    single = profile_tree / "insights.yaml"
+    single.write_text(
+        json.dumps({"insights": [{"id": "i-1", "title": "T", "agent": "flight-planner"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--insight",
+            str(single),
+            "--insight-id",
+            "i-1",
+            "-o",
+            str(profile_tree / "o"),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    selected = json.loads(Path(recorder.kwargs["insight"]).read_text(encoding="utf-8"))
+    assert selected["id"] == "i-1"
+
+
+def test_experiment_no_insight_skips_existing_shared_default(app, profile_tree: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    shared = profile_tree / ".nemo-optimizer" / "insights.yaml"
+    shared.parent.mkdir(parents=True)
+    shared.write_text(
+        json.dumps({"insights": [{"id": "i-1", "title": "T", "agent": "flight-planner"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(
+        app,
+        ["run", "--no-insight", "-o", str(profile_tree / "o")],
+    )
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs["insight"] is None
+    assert "Insight disabled" in result.output
+    assert "Insight file:" not in result.output
+
+
+@pytest.mark.parametrize(
+    "insight_args",
+    [
+        ["--no-insight", "--insight", "ins-1"],
+        ["--no-insight", "--insight-id", "0"],
+    ],
+)
+def test_experiment_insight_conflict_is_clean(
+    app,
+    profile_tree: Path,
+    monkeypatch,
+    insight_args: list[str],
+) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(
+        app,
+        ["run", *insight_args, "-o", str(profile_tree / "o")],
+    )
+    assert result.exit_code == 1
+    assert "--no-insight cannot be combined" in result.output
+    assert recorder.kwargs is None
+
+
+def test_experiment_insight_id_help_documents_zero_based_index(app) -> None:
+    result = runner.invoke(app, ["run", "--help"])
+    assert result.exit_code == 0, result.output
+    help_text = " ".join(result.output.replace("│", " ").split())
+    assert "exact id/title first" in help_text
+    assert "zero-based index" in help_text
+    assert "local multi-insight" in help_text
+
+
+def test_experiment_mismatched_insight_blocked_before_resolution(app, profile_tree: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    bad = profile_tree / "insight.json"
+    bad.write_text(json.dumps({"id": "i-x", "title": "T", "agent": "someone-else"}), encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+    result = runner.invoke(app, ["run", "--insight", str(bad), "-o", str(profile_tree / "o")])
+    assert result.exit_code == 1
+    assert "someone-else" in result.output
+    assert recorder.kwargs is None  # blocked in phase-1 preflight, before resolution
+
+
+def test_profileless_mode2_without_agent_stops_before_runner(app, tmp_path: Path, monkeypatch) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    for sub in ("train", "validation"):
+        (tmp_path / sub).mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--train-dataset",
+            str(tmp_path / "train"),
+            "--validation-dataset",
+            str(tmp_path / "validation"),
+            "-o",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--agent" in result.output
+    assert recorder.kwargs is None
+
+
+def test_doctor_validates_implicit_shared_insight_and_selector(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_task_toml(profile_tree)
+    shared = profile_tree / ".nemo-optimizer" / "insights.yaml"
+    shared.parent.mkdir(parents=True)
+    shared.write_text(
+        json.dumps(
+            {
+                "insights": [
+                    {"id": "i-a", "title": "A", "agent": "flight-planner"},
+                    {"id": "i-b", "title": "B", "agent": "flight-planner"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+
+    unselected = runner.invoke(app, ["doctor"])
+    selected = runner.invoke(app, ["doctor", "--insight-id", "i-b"])
+
+    assert unselected.exit_code == 1
+    assert "pass --insight-id" in unselected.output
+    assert selected.exit_code == 0, selected.output
+    assert "2 insights" in selected.output
+
+
+def test_doctor_validates_implicit_shared_insight_agent(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_task_toml(profile_tree)
+    shared = profile_tree / ".nemo-optimizer" / "insights.yaml"
+    shared.parent.mkdir(parents=True)
+    shared.write_text(
+        json.dumps({"insights": [{"id": "i-x", "title": "Other", "agent": "someone-else"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "someone-else" in result.output
+
+
+def test_doctor_validates_effective_agent_spec_readability(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_task_toml(profile_tree)
+    spec = profile_tree / "AGENT-SPEC.md"
+    spec.write_bytes(b"\xff")
+    with (profile_tree / "optimizer.yaml").open("a", encoding="utf-8") as profile_file:
+        profile_file.write("agent_spec: ./AGENT-SPEC.md\n")
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Could not read agent_spec" in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("config_body", "expected"),
+    [
+        (None, "Could not read experiment_config"),
+        ("storage: [\n", "Could not read experiment_config"),
+        ("max_rounds: banana\n", "Invalid experiment config"),
+    ],
+    ids=["missing", "malformed-yaml", "invalid-value"],
+)
+def test_doctor_validates_full_effective_experiment_config(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    config_body: str | None,
+    expected: str,
+) -> None:
+    write_task_toml(profile_tree)
+    with (profile_tree / "optimizer.yaml").open("a", encoding="utf-8") as profile_file:
+        profile_file.write("experiment_config: ./experiment.yaml\n")
+    if config_body is not None:
+        (profile_tree / "experiment.yaml").write_text(config_body, encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert expected in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize("command", ["run", "doctor"])
+def test_env_file_encoding_failure_is_clean_and_actionable(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    write_task_toml(profile_tree)
+    (profile_tree / ".env").write_bytes(b"NMP_BASE_URL=\xff")
+    monkeypatch.chdir(profile_tree)
+    args = [command]
+    if command == "run":
+        args += ["--no-insight", "-o", str(profile_tree / "out")]
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 1
+    assert "Could not read environment file" in result.output
+    assert "UTF-8" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_doctor_env_file_permission_failure_is_required_and_actionable(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_task_toml(profile_tree)
+    env_file = profile_tree / ".env"
+    env_file.write_text("NMP_BASE_URL=https://profile.example\n", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def deny_env_file(path: Path, *args: object, **kwargs: object) -> str:
+        if path == env_file:
+            raise PermissionError("permission denied by test")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", deny_env_file)
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Could not read environment file" in result.output
+    assert "permission denied" in result.output
+    assert "check that the file is readable UTF-8" in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("explicit", "shell", "profile_env", "expected"),
+    [
+        ("https://explicit.example", "https://shell.example", "https://profile.example", "https://explicit.example"),
+        (None, "https://shell.example", "https://profile.example", "https://shell.example"),
+        (None, None, "https://profile.example", "https://profile.example"),
+        (None, None, None, DEFAULT_BASE_URL),
+    ],
+    ids=["explicit", "shell", "profile-env", "default-ignores-nemo"],
+)
+def test_experiment_nmp_base_url_precedence_and_ignores_nemo_base_url(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    explicit: str | None,
+    shell: str | None,
+    profile_env: str | None,
+    expected: str,
+) -> None:
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setenv("NEMO_BASE_URL", "https://legacy-must-be-ignored.example")
+    if shell is None:
+        monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    else:
+        monkeypatch.setenv("NMP_BASE_URL", shell)
+    if profile_env is not None:
+        (profile_tree / ".env").write_text(f"NMP_BASE_URL={profile_env}\n", encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+    args = ["run", "--no-insight", "-o", str(profile_tree / "out")]
+    if explicit is not None:
+        args += ["--base-url", explicit]
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0, result.output
+    client = recorder.kwargs["client"]
+    assert client.base_url == expected
+    assert client.closed
+
+
+@pytest.mark.parametrize(
+    ("explicit", "shell", "profile_env", "expected"),
+    [
+        ("https://explicit.example", "https://shell.example", "https://profile.example", "https://explicit.example"),
+        (None, "https://shell.example", "https://profile.example", "https://shell.example"),
+        (None, None, "https://profile.example", "https://profile.example"),
+        (None, None, None, DEFAULT_BASE_URL),
+    ],
+    ids=["explicit", "shell", "profile-env", "default-ignores-nemo"],
+)
+def test_doctor_nmp_base_url_precedence_and_ignores_nemo_base_url(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    explicit: str | None,
+    shell: str | None,
+    profile_env: str | None,
+    expected: str,
+) -> None:
+    write_task_toml(profile_tree)
+    urls: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        Probes(
+            run_cmd=lambda argv: (0, "ok"),
+            http_ok=lambda url: not urls.append(url),
+            env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"},
+        ),
+    )
+    monkeypatch.setenv("NEMO_BASE_URL", "https://legacy-must-be-ignored.example")
+    if shell is None:
+        monkeypatch.delenv("NMP_BASE_URL", raising=False)
+    else:
+        monkeypatch.setenv("NMP_BASE_URL", shell)
+    if profile_env is not None:
+        (profile_tree / ".env").write_text(f"NMP_BASE_URL={profile_env}\n", encoding="utf-8")
+    monkeypatch.chdir(profile_tree)
+    args = ["doctor"]
+    if explicit is not None:
+        args += ["--base-url", explicit]
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 0, result.output
+    assert urls == ["http://llm/models", f"{expected}/health/ready"]
+
+
+def test_experiment_help_names_insights_writer(app) -> None:
+    result = runner.invoke(app, ["run", "--help"])
+
+    assert result.exit_code == 0, result.output
+    help_text = " ".join(result.output.replace("│", " ").split())
+    assert "nemo insights analyze" in help_text
+    assert "writes by default" in help_text

--- a/plugins/nemo-experimentalist/tests/test_contract_dependency.py
+++ b/plugins/nemo-experimentalist/tests/test_contract_dependency.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import tomllib
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+WORKSPACE_ROOT = PLUGIN_ROOT.parents[1]
+
+
+def test_platform_stack_dependencies_resolve_through_the_workspace() -> None:
+    """The plugin tracks the monorepo it lives in, never a pinned copy of it."""
+    project = tomllib.loads((PLUGIN_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    workspace = tomllib.loads((WORKSPACE_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    sources = workspace["tool"]["uv"]["sources"]
+
+    for package_name in ("nemo-platform", "nemo-platform-plugin", "nemo-insights-plugin"):
+        assert project["project"]["dependencies"].count(package_name) == 1
+        assert sources[package_name] == {"workspace": True}
+
+    assert "uv" not in project["tool"]
+    assert str(PLUGIN_ROOT.relative_to(WORKSPACE_ROOT)) in workspace["tool"]["uv"]["workspace"]["members"]
+
+
+def test_runtime_dependencies_match_retained_imports() -> None:
+    project = tomllib.loads((PLUGIN_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = set(project["project"]["dependencies"])
+
+    assert "pydantic>=2" in dependencies
+    assert "opentelemetry-proto>=1.42.1" in dependencies
+    assert "protobuf>=6.0.0" in dependencies
+    assert "nemo-insights-plugin" in dependencies
+    assert all("opentelemetry-sdk" not in dependency for dependency in dependencies)
+    assert all("opentelemetry-exporter-otlp" not in dependency for dependency in dependencies)
+    assert all("pydantic-ai" not in dependency for dependency in dependencies)
+    assert all("tzdata" not in dependency for dependency in dependencies)
+
+
+def test_shared_contract_modules_are_importable(tmp_path: Path) -> None:
+    from nemo_insights_plugin.contracts.checks import CheckResult, format_report
+    from nemo_insights_plugin.contracts.insights import InsightsFileError, load_insights_document
+    from nemo_insights_plugin.contracts.profile import DEFAULT_BASE_URL, discover_profile, resolve_base_url
+
+    result = CheckResult(
+        name="profile",
+        group="profile",
+        status="pass",
+        severity="required",
+        message="ready",
+    )
+    insight = tmp_path / "insight.yaml"
+    insight.write_text("id: one\n", encoding="utf-8")
+
+    assert format_report([result]) == "Profile\n  ✓ ready"
+    assert issubclass(InsightsFileError, ValueError)
+    assert load_insights_document(insight) == {"id": "one"}
+    assert discover_profile(tmp_path) is None
+    assert resolve_base_url(None, {}) == DEFAULT_BASE_URL

--- a/plugins/nemo-experimentalist/tests/test_deps.py
+++ b/plugins/nemo-experimentalist/tests/test_deps.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ExperimentalistDeps validation: insight and/or agent may be set (or combined)."""
+
+from pathlib import Path
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.deps import ExperimentalistDeps
+
+
+def _datasets(tmp_path: Path) -> dict:
+    # DatasetRef is a lazy URI handle resolved at evaluation time, so the paths
+    # need not exist here.
+    return {
+        "train_dataset": DatasetRef(uri=str(tmp_path / "train")),
+        "validation_dataset": DatasetRef(uri=str(tmp_path / "val")),
+    }
+
+
+def _task_template(tmp_path: Path) -> DatasetRef:
+    return DatasetRef(uri=str(tmp_path / "template"))
+
+
+def test_agent_only_ok(tmp_path: Path) -> None:
+    ExperimentalistDeps(agent="ssh://git@h/g/r.git@main", **_datasets(tmp_path))
+
+
+def test_insight_only_ok(tmp_path: Path) -> None:
+    ExperimentalistDeps(insight="ins-1", task_template=_task_template(tmp_path), **_datasets(tmp_path))
+
+
+def test_insight_and_agent_combined_ok(tmp_path: Path) -> None:
+    # The Mode-1 PR workflow: an insight guides optimization while a git agent
+    # supplies the code + PR target. Both set together is now valid.
+    deps = ExperimentalistDeps(
+        insight="ins-1",
+        agent="ssh://git@h/g/r.git@main",
+        task_template=_task_template(tmp_path),
+        **_datasets(tmp_path),
+    )
+    assert deps.insight == "ins-1"
+    assert deps.agent == "ssh://git@h/g/r.git@main"
+
+
+def test_insight_without_task_template_raises(tmp_path: Path) -> None:
+    # Mode 1 needs a task template to fill from production traces.
+    with pytest.raises(ValueError, match="task_template"):
+        ExperimentalistDeps(insight="ins-1", **_datasets(tmp_path))
+
+
+def test_neither_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="must be set"):
+        ExperimentalistDeps(**_datasets(tmp_path))

--- a/plugins/nemo-experimentalist/tests/test_eval_author_agent.py
+++ b/plugins/nemo-experimentalist/tests/test_eval_author_agent.py
@@ -1,0 +1,677 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic contract tests for the canonical top-level Eval Author agent."""
+
+import asyncio
+import inspect
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from nemo_experimentalist_plugin.eval_author import agent as eval_author_module
+from nemo_experimentalist_plugin.eval_author.agent import EvalAuthor, EvalAuthorDatasetValidationError
+from nemo_experimentalist_plugin.eval_author.models import EvalAuthorConfig, EvalAuthorResult
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import (
+    Dataset,
+    DatasetRef,
+    DatasetValidationError,
+    Task,
+    TrialResult,
+)
+from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizerConfig
+from nemo_experimentalist_plugin.experimentalist.components.trace_analyzer import (
+    Diagnostic,
+    TraceAnalyzerConfig,
+)
+from nemo_insights_plugin.entities import Insight
+from nemo_platform import AsyncNeMoPlatform
+
+
+@dataclass
+class _FillTaskTemplateCall:
+    trace_ref: str
+    task_template: Task
+    client: Any
+    workspace: str
+    result: Task
+
+
+@dataclass
+class _AnalyzerInitCall:
+    experiment_dir: Path
+    config: TraceAnalyzerConfig
+
+
+@dataclass
+class _AnalyzerRunCall:
+    trial: TrialResult
+    task: Task
+    agent_path: Path
+    insight: Insight
+    client: Any
+    workspace: str
+
+
+@dataclass
+class _PipelineCalls:
+    fill_task_template: list[_FillTaskTemplateCall]
+    analyzer_init: list[_AnalyzerInitCall]
+    analyzer_run: list[_AnalyzerRunCall]
+    fileset_publications: list[tuple[AsyncNeMoPlatform, str]]
+    discovered_datasets: list[Dataset]
+    augment_args: list[tuple[Insight, list[tuple[str, Diagnostic]], Dataset, Dataset, str, str | None]]
+    suite_discards: int
+
+
+@dataclass
+class _ClosingShell:
+    close_calls: int = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+
+def _insight(trace_refs: list[str], *, insight_id: str = "insight-1") -> Insight:
+    insight = Insight(
+        workspace="workspace-a",
+        title="Tool selection failures",
+        description="The agent selects the wrong tool.",
+        agent="research-agent",
+        trace_refs=trace_refs,
+    )
+    insight._id = insight_id
+    return insight
+
+
+def _eval_author(
+    tmp_path: Path,
+    *,
+    max_traces: int = 10,
+    max_summary_tokens: int = 80_000,
+    max_validation_repair_attempts: int = 5,
+) -> EvalAuthor:
+    eval_author = object.__new__(EvalAuthor)
+    eval_author.experiment_dir = tmp_path
+    eval_author._config = EvalAuthorConfig(
+        max_traces=max_traces,
+        max_summary_tokens=max_summary_tokens,
+        max_validation_repair_attempts=max_validation_repair_attempts,
+    )
+    eval_author.context = {}
+    eval_author.shell = cast(Any, _ClosingShell())
+    return eval_author
+
+
+def _diagnostic(summary: str) -> Diagnostic:
+    return Diagnostic(outcome="FAILURE", summary=summary, failure_point=1, root_cause="wrong tool")
+
+
+def _prompt(method: Any) -> str:
+    prompt = inspect.getdoc(method)
+    assert prompt is not None
+    return " ".join(prompt.split())
+
+
+def test_eval_author_prompts_retain_dataset_inspection_and_suite_wide_guidance() -> None:
+    discover_prompt = _prompt(EvalAuthor.discover_runner)
+    augment_prompt = _prompt(EvalAuthor.augment_dataset)
+
+    assert "read it first" in discover_prompt
+    assert "inspect the actual files" in discover_prompt
+    assert "authoritative reference for what artifacts exist at evaluation runtime" in augment_prompt
+    assert "how tasks are structured, and how to add metrics" in augment_prompt
+    assert "Add the metric to every task in ``train_dataset`` and ``validation_dataset``" in augment_prompt
+    assert "call ``await train_dataset.validate()``" in augment_prompt
+    assert "``await validation_dataset.validate()``" in augment_prompt
+    assert "fix all reported failures and revalidate both datasets" in augment_prompt
+
+
+def test_eval_author_prompts_retain_root_cause_and_normalized_scoring_guidance() -> None:
+    prompt = _prompt(EvalAuthor.augment_dataset)
+
+    assert "Focus the metric on the root cause, not the surface symptom" in prompt
+    assert "Every metric value must be a float in ``[0.0, 1.0]``" in prompt
+    assert "Error rate → ``max(0.0, 1.0 - errors / total_calls)``" in prompt
+    assert "Presence of a behavior → ``1.0`` if present, ``0.0`` if absent" in prompt
+    assert "Partial credit → fraction of required steps completed correctly" in prompt
+
+
+def test_eval_author_prompts_retain_template_path_and_harbor_name_guidance() -> None:
+    prompt = _prompt(EvalAuthor.fill_task_template)
+
+    assert "``task_template.uri`` (file:// URI)" in prompt
+    assert "edit this directory in place and do not copy or rename it" in prompt
+    assert "Leave unfillable placeholders as-is" in prompt
+    assert "keep ``[task] name`` in ``org/name``" in prompt
+    assert "deterministically finalize the name and provenance" in prompt
+
+
+def _install_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    outcomes: Sequence[Diagnostic | BaseException],
+    eval_author: EvalAuthor,
+) -> _PipelineCalls:
+    calls = _PipelineCalls(
+        fill_task_template=[],
+        analyzer_init=[],
+        analyzer_run=[],
+        fileset_publications=[],
+        discovered_datasets=[],
+        augment_args=[],
+        suite_discards=0,
+    )
+    next_analyzer = 0
+
+    class FakeInsightSuite:
+        def __init__(self, *, task_template: Task, **_: Any) -> None:
+            self.task_template = task_template
+            self.staged: list[Any] = []
+
+        def stage(self, trace_refs: list[str]) -> list[Any]:
+            self.staged = [
+                type(
+                    "StagedTask",
+                    (),
+                    {"trace_ref": trace_ref, "task": self.task_template, "result": None},
+                )()
+                for trace_ref in trace_refs
+            ]
+            return self.staged
+
+        def validate(self, staged: Any) -> None:
+            staged.result = calls.fill_task_template[-1].result
+
+        def promote_local(self, trace_refs: list[str], staged_tasks: list[Any]) -> Dataset:
+            assert trace_refs == [staged.trace_ref for staged in staged_tasks]
+            return Dataset(id="insight-suite", tasks=[staged.result for staged in staged_tasks])
+
+        def discard(self) -> None:
+            calls.suite_discards += 1
+
+        def record_analysis(self, statuses: dict[str, tuple[str, str | None]]) -> None:
+            pass
+
+        async def publish_fileset(self, client: AsyncNeMoPlatform, workspace: str) -> DatasetRef:
+            calls.fileset_publications.append((client, workspace))
+            return DatasetRef(
+                uri=f"fileset://{workspace}/insight-suite",
+                metadata={"id": "insight-suite", "fileset_id": "fileset-1"},
+            )
+
+    class FillTaskTemplate:
+        async def __call__(
+            self,
+            trace_ref: str,
+            task_template: Task,
+            client: Any,
+            workspace: str,
+        ) -> Task:
+            result = Task(id=f"task-{trace_ref}", uri=f"file:///tasks/{trace_ref}")
+            calls.fill_task_template.append(
+                _FillTaskTemplateCall(
+                    trace_ref=trace_ref,
+                    task_template=task_template,
+                    client=client,
+                    workspace=workspace,
+                    result=result,
+                )
+            )
+            return result
+
+    class FakeTraceAnalyzer:
+        def __init__(self, *, experiment_dir: Path, config: TraceAnalyzerConfig) -> None:
+            nonlocal next_analyzer
+            self._index = next_analyzer
+            next_analyzer += 1
+            calls.analyzer_init.append(_AnalyzerInitCall(experiment_dir=experiment_dir, config=config))
+
+        async def run(
+            self,
+            *,
+            trial: TrialResult,
+            task: Task,
+            agent_path: Path,
+            insight: Insight,
+            client: Any,
+            workspace: str,
+        ) -> Diagnostic:
+            calls.analyzer_run.append(
+                _AnalyzerRunCall(
+                    trial=trial,
+                    task=task,
+                    agent_path=agent_path,
+                    insight=insight,
+                    client=client,
+                    workspace=workspace,
+                )
+            )
+            outcome = outcomes[self._index]
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+    class DiscoverRunner:
+        async def __call__(self, dataset: Dataset) -> str:
+            calls.discovered_datasets.append(dataset)
+            return "runner conventions"
+
+    class AugmentDataset:
+        async def __call__(
+            self,
+            insight: Insight,
+            diagnostics: list[tuple[str, Diagnostic]],
+            train_dataset: Dataset,
+            validation_dataset: Dataset,
+            runner_conventions: str,
+            validation_feedback: str | None = None,
+        ) -> EvalAuthorResult:
+            calls.augment_args.append(
+                (
+                    insight,
+                    diagnostics,
+                    train_dataset,
+                    validation_dataset,
+                    runner_conventions,
+                    validation_feedback,
+                )
+            )
+            return EvalAuthorResult(
+                train_dataset=train_dataset,
+                validation_dataset=validation_dataset,
+                summary="augmented",
+            )
+
+    eval_author.fill_task_template = FillTaskTemplate()  # type: ignore[method-assign,assignment]
+    eval_author.discover_runner = DiscoverRunner()  # type: ignore[method-assign,assignment]
+    eval_author.augment_dataset = AugmentDataset()  # type: ignore[method-assign,assignment]
+    monkeypatch.setattr(eval_author_module, "TraceAnalyzer", FakeTraceAnalyzer)
+    monkeypatch.setattr(eval_author_module, "InsightSuite", FakeInsightSuite)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_run_without_traces_returns_input_datasets_unchanged(tmp_path: Path) -> None:
+    eval_author = _eval_author(tmp_path)
+    train_dataset = Dataset(id="train")
+    validation_dataset = Dataset(id="validation")
+
+    result = await eval_author.run(
+        _insight([]),
+        Path("agent"),
+        Task(id="template"),
+        train_dataset,
+        validation_dataset,
+        client=cast(Any, object()),
+    )
+
+    assert result.train_dataset is train_dataset
+    assert result.validation_dataset is validation_dataset
+    assert result.summary == "No trace refs on insight — nothing to analyze."
+    assert cast(_ClosingShell, eval_author.shell).close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_run_requires_persisted_insight_id(tmp_path: Path) -> None:
+    insight = Insight(
+        workspace="workspace-a",
+        title="Tool selection failures",
+        description="The agent selects the wrong tool.",
+        agent="research-agent",
+        trace_refs=["trace-1"],
+    )
+
+    with pytest.raises(ValueError, match="persisted Insight with a durable id"):
+        await _eval_author(tmp_path).run(
+            insight,
+            Path("agent"),
+            Task(id="template"),
+            Dataset(id="train"),
+            Dataset(id="validation"),
+            client=cast(Any, object()),
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_enforces_max_traces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    diagnostics = [_diagnostic("one"), _diagnostic("two")]
+    eval_author = _eval_author(tmp_path, max_traces=2)
+    calls = _install_pipeline(monkeypatch, diagnostics, eval_author)
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: None)
+
+    await eval_author.run(
+        _insight(["trace-1", "trace-2", "trace-3"]),
+        Path("agent"),
+        Task(id="template"),
+        Dataset(id="train"),
+        Dataset(id="validation"),
+        client=cast(Any, object()),
+    )
+
+    assert [call.trace_ref for call in calls.fill_task_template] == ["trace-1", "trace-2"]
+    assert [call.trial.metadata["trace_ref"] for call in calls.analyzer_run] == ["trace-1", "trace-2"]
+
+
+@pytest.mark.asyncio
+async def test_run_discards_staged_suite_when_filling_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eval_author = _eval_author(tmp_path)
+    calls = _install_pipeline(monkeypatch, [], eval_author)
+
+    class FailedFillTaskTemplate:
+        async def __call__(self, *_: Any) -> Task:
+            raise RuntimeError("fill failed")
+
+    eval_author.fill_task_template = FailedFillTaskTemplate()  # type: ignore[method-assign,assignment]
+
+    with pytest.raises(RuntimeError, match="fill failed"):
+        await eval_author.run(
+            _insight(["trace-1"]),
+            Path("agent"),
+            Task(id="template"),
+            Dataset(id="train"),
+            Dataset(id="validation"),
+            client=cast(Any, object()),
+        )
+
+    assert calls.suite_discards == 1
+    assert cast(_ClosingShell, eval_author.shell).close_calls == 1
+
+
+def test_trace_trial_uses_intake_uri_and_insight_metadata(tmp_path: Path) -> None:
+    insight = _insight(["trace-7"])
+
+    trial = _eval_author(tmp_path)._trace_trial(insight, Task(id="task-7"), "trace-7", 3, insight.id)
+
+    assert trial.id == "insight-trace-3"
+    assert trial.task_id == "task-7"
+    assert trial.status == "completed"
+    assert trial.trace is not None
+    assert trial.trace.uri == "intake://trace-7"
+    assert trial.trace.description == "Production trace attached to the insight."
+    assert trial.metadata == {
+        "source": "insight",
+        "trace_ref": "trace-7",
+        "insight_id": insight.id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_caches_each_successful_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _diagnostic("first")
+    second = _diagnostic("second")
+    eval_author = _eval_author(tmp_path)
+    _install_pipeline(monkeypatch, [first, second], eval_author)
+    stored: list[tuple[Path, str, Diagnostic]] = []
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: stored.append(args))
+
+    await eval_author.run(
+        _insight(["trace-a", "trace-b"]),
+        Path("agent"),
+        Task(id="template"),
+        Dataset(id="train"),
+        Dataset(id="validation"),
+        client=cast(Any, object()),
+    )
+
+    assert stored == [
+        (tmp_path, eval_author_module.cache.task_hash("eval_author:trace-a"), first),
+        (tmp_path, eval_author_module.cache.task_hash("eval_author:trace-b"), second),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_skips_failed_trace_analysis_and_keeps_successes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    successful = _diagnostic("successful")
+    eval_author = _eval_author(tmp_path)
+    calls = _install_pipeline(monkeypatch, [RuntimeError("analysis failed"), successful], eval_author)
+    stored: list[Diagnostic] = []
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda workspace, key, value: stored.append(value))
+    insight = _insight(["trace-bad", "trace-good"])
+
+    result = await eval_author.run(
+        insight,
+        Path("agent"),
+        Task(id="template"),
+        Dataset(id="train"),
+        Dataset(id="validation"),
+        client=cast(Any, object()),
+    )
+
+    assert result.summary == "augmented"
+    assert stored == [successful]
+    assert calls.augment_args[0][1] == [("trace-good", successful)]
+    assert len(calls.fileset_publications) == 1
+    assert "Trace analysis failed for trace-bad: analysis failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_propagates_trace_analysis_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eval_author = _eval_author(tmp_path)
+    calls = _install_pipeline(monkeypatch, [asyncio.CancelledError()], eval_author)
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await eval_author.run(
+            _insight(["trace-cancelled"]),
+            Path("agent"),
+            Task(id="template"),
+            Dataset(id="train"),
+            Dataset(id="validation"),
+            client=cast(Any, object()),
+        )
+
+    assert calls.augment_args == []
+
+
+@pytest.mark.asyncio
+async def test_run_documents_dataset_discovers_runner_and_forwards_augmentation_arguments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    diagnostic = _diagnostic("diagnostic")
+    eval_author = _eval_author(tmp_path, max_summary_tokens=12_345)
+    calls = _install_pipeline(monkeypatch, [diagnostic], eval_author)
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: None)
+    documentation = object()
+    doc_calls: list[tuple[type[Dataset], int]] = []
+
+    def fake_doc(dataset_type: type[Dataset], *, inline_depth: int) -> object:
+        doc_calls.append((dataset_type, inline_depth))
+        return documentation
+
+    monkeypatch.setattr(eval_author_module, "doc", fake_doc)
+    insight = _insight(["trace-1"])
+    task_template = Task(id="template")
+    train_dataset = Dataset(id="train")
+    validation_dataset = Dataset(id="validation")
+    client = cast(Any, object())
+
+    result = await eval_author.run(
+        insight,
+        Path("relative-agent"),
+        task_template,
+        train_dataset,
+        validation_dataset,
+        client=client,
+    )
+
+    assert result.summary == "augmented"
+    assert result.insight_suite == DatasetRef(
+        uri="fileset://workspace-a/insight-suite",
+        metadata={"id": "insight-suite", "fileset_id": "fileset-1"},
+    )
+    assert calls.fileset_publications == [(client, "workspace-a")]
+    assert len(calls.fill_task_template) == 1
+    fill_call = calls.fill_task_template[0]
+    assert fill_call.trace_ref == "trace-1"
+    assert fill_call.task_template is task_template
+    assert fill_call.client is client
+    assert fill_call.workspace == "workspace-a"
+    assert fill_call.result == Task(id="task-trace-1", uri="file:///tasks/trace-1")
+
+    assert len(calls.analyzer_init) == 1
+    assert calls.analyzer_init[0].experiment_dir == tmp_path
+    assert type(calls.analyzer_init[0].config) is TraceAnalyzerConfig
+    assert calls.analyzer_init[0].config.max_summary_tokens == 12_345
+
+    assert len(calls.analyzer_run) == 1
+    analyzer_call = calls.analyzer_run[0]
+    assert analyzer_call.trial == eval_author._trace_trial(
+        insight,
+        fill_call.result,
+        "trace-1",
+        1,
+        insight.id,
+    )
+    assert analyzer_call.task is fill_call.result
+    assert analyzer_call.agent_path == tmp_path / "relative-agent"
+    assert analyzer_call.insight is insight
+    assert analyzer_call.client is client
+    assert analyzer_call.workspace == "workspace-a"
+
+    assert doc_calls == [(Dataset, 1)]
+    assert eval_author.context["dataset_documentation"] is documentation
+    assert calls.discovered_datasets == [train_dataset]
+    assert len(calls.augment_args) == 1
+    (
+        augmented_insight,
+        diagnostics,
+        augmented_train,
+        augmented_validation,
+        runner_conventions,
+        validation_feedback,
+    ) = calls.augment_args[0]
+    assert augmented_insight is insight
+    assert diagnostics == [("trace-1", diagnostic)]
+    assert augmented_train is train_dataset
+    assert augmented_validation is validation_dataset
+    assert runner_conventions == "runner conventions"
+    assert validation_feedback is None
+
+
+class _RepairableDataset(Dataset):
+    def __init__(self, id: str, error: str | None) -> None:
+        super().__init__(id=id)
+        self.error = error
+        self.validate_calls = 0
+
+    async def validate(self) -> None:
+        self.validate_calls += 1
+        if self.error is not None:
+            raise DatasetValidationError(self.error)
+
+
+@pytest.mark.asyncio
+async def test_run_feeds_validation_failures_back_for_one_repair_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eval_author = _eval_author(tmp_path)
+    _install_pipeline(monkeypatch, [_diagnostic("diagnostic")], eval_author)
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: None)
+    train_dataset = _RepairableDataset("train", "task 'train-a': check.py:2:1: invalid syntax")
+    validation_dataset = _RepairableDataset("validation", "task 'validation-a': test.sh:4: syntax error")
+    feedback: list[str | None] = []
+
+    class RepairDataset:
+        async def __call__(
+            self,
+            insight: Insight,
+            diagnostics: list[tuple[str, Diagnostic]],
+            train: Dataset,
+            validation: Dataset,
+            runner_conventions: str,
+            validation_feedback: str | None = None,
+        ) -> EvalAuthorResult:
+            feedback.append(validation_feedback)
+            if validation_feedback is not None:
+                train_dataset.error = None
+                validation_dataset.error = None
+            return EvalAuthorResult(train_dataset=train, validation_dataset=validation, summary="augmented")
+
+    eval_author.augment_dataset = RepairDataset()  # type: ignore[method-assign,assignment]
+
+    result = await eval_author.run(
+        _insight(["trace-1"]),
+        Path("agent"),
+        Task(id="template"),
+        train_dataset,
+        validation_dataset,
+        client=cast(Any, object()),
+    )
+
+    assert result.train_dataset is train_dataset
+    assert result.validation_dataset is validation_dataset
+    assert feedback[0] is None
+    assert feedback[1] is not None
+    assert "train dataset" in feedback[1]
+    assert "task 'train-a': check.py:2:1: invalid syntax" in feedback[1]
+    assert "validation dataset" in feedback[1]
+    assert "task 'validation-a': test.sh:4: syntax error" in feedback[1]
+    assert train_dataset.validate_calls == 2
+    assert validation_dataset.validate_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_run_raises_after_validation_repair_budget_is_exhausted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eval_author = _eval_author(tmp_path, max_validation_repair_attempts=1)
+    calls = _install_pipeline(monkeypatch, [_diagnostic("diagnostic")], eval_author)
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: None)
+    train_dataset = _RepairableDataset("train", "task 'train-a': check.py:2:1: invalid syntax")
+
+    with pytest.raises(EvalAuthorDatasetValidationError) as exc_info:
+        await eval_author.run(
+            _insight(["trace-1"]),
+            Path("agent"),
+            Task(id="template"),
+            train_dataset,
+            Dataset(id="validation"),
+            client=cast(Any, object()),
+        )
+
+    assert "task 'train-a': check.py:2:1: invalid syntax" in str(exc_info.value)
+    assert len(calls.augment_args) == 2
+    assert calls.augment_args[0][-1] is None
+    assert calls.augment_args[1][-1] is not None
+    assert train_dataset.validate_calls == 2
+
+
+def test_evolutionary_optimizer_uses_top_level_eval_author_config() -> None:
+    config = EvolutionaryOptimizerConfig().eval_author
+
+    assert type(config) is EvalAuthorConfig
+    assert config.max_validation_repair_attempts == 5
+    assert EvalAuthorConfig(max_validation_repair_attempts=10).max_validation_repair_attempts == 10
+    with pytest.raises(ValueError, match="less than or equal to 10"):
+        EvalAuthorConfig(max_validation_repair_attempts=11)
+
+
+def test_evolutionary_optimizer_tolerates_unknown_eval_author_config() -> None:
+    config = EvolutionaryOptimizerConfig.model_validate({"eval_author": {"bogus": 1}})
+    assert type(config.eval_author) is EvalAuthorConfig
+
+
+def test_evolutionary_optimizer_rejects_legacy_curator_config() -> None:
+    with pytest.raises(ValueError, match="'curator' was renamed to 'eval_author'"):
+        EvolutionaryOptimizerConfig.model_validate({"curator": {"max_traces": 1}})

--- a/plugins/nemo-experimentalist/tests/test_eval_author_materialization.py
+++ b/plugins/nemo-experimentalist/tests/test_eval_author_materialization.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contract tests for persisted Eval Author insight suites."""
+
+from __future__ import annotations
+
+import json
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from nemo_experimentalist_plugin.eval_author import materialization as materialization_module
+from nemo_experimentalist_plugin.eval_author.materialization import InsightSuite
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import Task
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import HarborDataset
+from nemo_platform import AsyncNeMoPlatform
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeFileset:
+    id: str
+    name: str
+    workspace: str
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeRemoteFile:
+    path: str
+    size: int
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeFileList:
+    data: list[_FakeRemoteFile]
+
+
+class _FakeFilesets:
+    def __init__(self, files: _FakeFiles) -> None:
+        self._files = files
+        self.created: list[str] = []
+        self.deleted: list[str] = []
+
+    async def create(self, *, workspace: str, name: str, **_: Any) -> _FakeFileset:
+        fileset = _FakeFileset(id=f"fileset-id-{len(self.created) + 1}", name=name, workspace=workspace)
+        self.created.append(name)
+        self._files.contents[name] = {}
+        return fileset
+
+    async def delete(self, name: str, *, workspace: str) -> _FakeFileset:
+        self.deleted.append(name)
+        self._files.contents.pop(name)
+        return _FakeFileset(id="deleted", name=name, workspace=workspace)
+
+
+class _FakeFiles:
+    def __init__(self) -> None:
+        self.contents: dict[str, dict[str, int]] = {}
+        self.fail_upload = False
+        self.omit_from_listing: str | None = None
+        self.filesets = _FakeFilesets(self)
+
+    async def upload(self, *, local_path: str, fileset: str, **_: Any) -> _FakeFileset:
+        if self.fail_upload:
+            raise RuntimeError("upload failed")
+        root = Path(local_path)
+        self.contents[fileset] = {
+            path.relative_to(root).as_posix(): path.stat().st_size for path in root.rglob("*") if path.is_file()
+        }
+        return _FakeFileset(id="uploaded", name=fileset, workspace="workspace-a")
+
+    async def list(self, *, fileset: str, **_: Any) -> _FakeFileList:
+        return _FakeFileList(
+            data=[
+                _FakeRemoteFile(path=path, size=size)
+                for path, size in self.contents[fileset].items()
+                if path != self.omit_from_listing
+            ]
+        )
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.files = _FakeFiles()
+
+
+def _write_template(root: Path) -> Task:
+    root.mkdir(parents=True)
+    (root / "task.toml").write_text(
+        """
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version = "1.1"
+
+[task]
+name = "example/template__placeholder"
+
+[metadata]
+difficulty = "easy"
+
+[environment]
+build_timeout_sec = 60.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (root / "instruction.md").write_text("{{ instruction }}\n", encoding="utf-8")
+    environment = root / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text("FROM ubuntu:24.04\n", encoding="utf-8")
+    tests = root / "tests"
+    tests.mkdir()
+    (tests / "test.sh").write_text("#!/bin/sh\nmkdir -p /logs/verifier\necho 1 > /logs/verifier/reward.txt\n")
+    return Task(id="task-template", uri=root.as_uri())
+
+
+def test_insight_suite_publishes_discoverable_tasks_with_provenance(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    refs = ["intake/traces/unsafe ref", "intake/traces/unsafe ref"]
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight/unsafe id", task_template=template)
+
+    staged = suite.stage(refs)
+    for index, task in enumerate(staged, start=1):
+        (task.path / "instruction.md").write_text(f"Reproduce production scenario {index}.\n", encoding="utf-8")
+        suite.validate(task)
+    dataset = suite.promote_local(refs, staged)
+
+    assert suite.suite_dir == next((tmp_path / "eval-and-optimize" / "eval_author").iterdir()) / "insight-suite"
+    assert [task.id for task in dataset.list_tasks()] == [task.slug for task in staged]
+    assert len(HarborDataset.from_path(suite.suite_dir).list_tasks()) == 2
+    names: list[str] = []
+    for trace_ref, task in zip(refs, dataset.list_tasks(), strict=True):
+        task_dir = Path(task.uri.removeprefix("file://"))
+        config = tomllib.loads((task_dir / "task.toml").read_text(encoding="utf-8"))
+        task_toml = (task_dir / "task.toml").read_text(encoding="utf-8")
+        names.append(config["task"]["name"])
+        assert "# SPDX-License-Identifier: Apache-2.0" in task_toml
+        assert config["metadata"]["nemo_experimentalist"] == {
+            "source_trace_ref": trace_ref,
+            "insight_id": "insight/unsafe id",
+        }
+        assert (task_dir / "instruction.md").read_text(encoding="utf-8").strip()
+        assert (task_dir / "environment").is_dir()
+        assert (task_dir / "tests").is_dir()
+    assert len(set(names)) == 2
+    assert all(name.startswith("example/template__") for name in names)
+
+    manifest = json.loads((suite.suite_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["insight_id"] == "insight/unsafe id"
+    assert manifest["trace_refs"] == refs
+    assert manifest["task_template"] == {"uri": template.uri}
+    assert [task["source_trace_ref"] for task in manifest["tasks"]] == refs
+
+
+@pytest.mark.asyncio
+async def test_insight_suite_uploads_complete_suite_to_fresh_filesets(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight/unsafe id", task_template=template)
+    staged = suite.stage(["trace-1"])
+    (staged[0].path / "instruction.md").write_text("Generated instruction.\n", encoding="utf-8")
+    suite.validate(staged[0])
+    suite.promote_local(["trace-1"], staged)
+    client = _FakeClient()
+
+    first_ref = await suite.publish_fileset(cast(AsyncNeMoPlatform, client), "workspace-a")
+    second_ref = await suite.publish_fileset(cast(AsyncNeMoPlatform, client), "workspace-a")
+
+    assert first_ref.uri.startswith("fileset://workspace-a/nemo-experimentalist-insight-insight-unsafe-id-")
+    assert second_ref.uri.startswith("fileset://workspace-a/nemo-experimentalist-insight-insight-unsafe-id-")
+    assert first_ref.uri != second_ref.uri
+    assert first_ref.metadata["insight_id"] == "insight/unsafe id"
+    assert first_ref.metadata["fileset_id"] == "fileset-id-1"
+    assert first_ref.metadata["workspace"] == "workspace-a"
+    first_name = cast(str, first_ref.metadata["fileset_name"])
+    assert "manifest.json" in client.files.contents[first_name]
+    assert any(path.endswith("/task.toml") for path in client.files.contents[first_name])
+    assert client.files.filesets.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_failed_fileset_upload_removes_only_incomplete_artifact(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    staged = suite.stage(["trace-1"])
+    (staged[0].path / "instruction.md").write_text("Generated instruction.\n", encoding="utf-8")
+    suite.validate(staged[0])
+    suite.promote_local(["trace-1"], staged)
+    client = _FakeClient()
+    published_ref = await suite.publish_fileset(cast(AsyncNeMoPlatform, client), "workspace-a")
+    published_name = cast(str, published_ref.metadata["fileset_name"])
+    published_contents = dict(client.files.contents[published_name])
+    client.files.fail_upload = True
+
+    with pytest.raises(RuntimeError, match="upload failed"):
+        await suite.publish_fileset(cast(AsyncNeMoPlatform, client), "workspace-a")
+
+    failed_name = client.files.filesets.created[-1]
+    assert client.files.filesets.deleted == [failed_name]
+    assert failed_name not in client.files.contents
+    assert client.files.contents[published_name] == published_contents
+
+
+@pytest.mark.asyncio
+async def test_fileset_inventory_mismatch_fails_and_removes_incomplete_artifact(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    staged = suite.stage(["trace-1"])
+    (staged[0].path / "instruction.md").write_text("Generated instruction.\n", encoding="utf-8")
+    suite.validate(staged[0])
+    suite.promote_local(["trace-1"], staged)
+    client = _FakeClient()
+    client.files.omit_from_listing = "manifest.json"
+
+    with pytest.raises(RuntimeError, match="does not match the validated local suite"):
+        await suite.publish_fileset(cast(AsyncNeMoPlatform, client), "workspace-a")
+
+    failed_name = client.files.filesets.created[-1]
+    assert client.files.filesets.deleted == [failed_name]
+    assert failed_name not in client.files.contents
+
+
+def test_insight_suite_second_publication_replaces_first_at_stable_path(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    refs = ["trace-1"]
+    first_suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    first_staged = first_suite.stage(refs)
+    (first_staged[0].path / "instruction.md").write_text("First generated instruction.\n", encoding="utf-8")
+    first_suite.validate(first_staged[0])
+    first_suite.promote_local(refs, first_staged)
+    published_path = first_suite.suite_dir
+
+    second_suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    second_staged = second_suite.stage(refs)
+    (second_staged[0].path / "instruction.md").write_text("Second generated instruction.\n", encoding="utf-8")
+    second_suite.validate(second_staged[0])
+    second_suite.promote_local(refs, second_staged)
+
+    assert second_suite.suite_dir == published_path
+    task = list(HarborDataset.from_path(published_path).list_tasks())[0]
+    task_dir = Path(task.uri.removeprefix("file://"))
+    assert (task_dir / "instruction.md").read_text(encoding="utf-8") == "Second generated instruction.\n"
+
+
+def test_failed_rebuild_preserves_previous_published_suite(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    refs = ["trace-1"]
+    first_suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    first_staged = first_suite.stage(refs)
+    (first_staged[0].path / "instruction.md").write_text("Valid published instruction.\n", encoding="utf-8")
+    first_suite.validate(first_staged[0])
+    first_suite.promote_local(refs, first_staged)
+
+    failed_suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    failed_staged = failed_suite.stage(refs)
+    (failed_staged[0].path / "instruction.md").write_text("\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="instruction is missing or empty"):
+        failed_suite.validate(failed_staged[0])
+
+    task = list(HarborDataset.from_path(first_suite.suite_dir).list_tasks())[0]
+    task_dir = Path(task.uri.removeprefix("file://"))
+    assert (task_dir / "instruction.md").read_text(encoding="utf-8") == "Valid published instruction.\n"
+
+
+def test_post_promotion_validation_failure_restores_previous_suite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    template = _write_template(tmp_path / "template")
+    refs = ["trace-1"]
+    first_suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    first_staged = first_suite.stage(refs)
+    (first_staged[0].path / "instruction.md").write_text("Previously published.\n", encoding="utf-8")
+    first_suite.validate(first_staged[0])
+    first_suite.promote_local(refs, first_staged)
+
+    failed_suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    failed_staged = failed_suite.stage(refs)
+    (failed_staged[0].path / "instruction.md").write_text("Broken promotion.\n", encoding="utf-8")
+    failed_suite.validate(failed_staged[0])
+
+    def fail_post_promotion_validation(_: Path) -> None:
+        raise RuntimeError("post-promotion validation failed")
+
+    monkeypatch.setattr(materialization_module, "HarborTask", fail_post_promotion_validation)
+
+    with pytest.raises(RuntimeError, match="post-promotion validation failed"):
+        failed_suite.promote_local(refs, failed_staged)
+
+    task = list(HarborDataset.from_path(first_suite.suite_dir).list_tasks())[0]
+    task_dir = Path(task.uri.removeprefix("file://"))
+    assert (task_dir / "instruction.md").read_text(encoding="utf-8") == "Previously published.\n"
+    assert list(first_suite.root.glob(".insight-suite-backup-*")) == []
+
+
+def test_insight_suite_rejects_empty_instruction_before_publication(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    staged = suite.stage(["trace-1"])
+    (staged[0].path / "instruction.md").write_text("\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="instruction is missing or empty"):
+        suite.validate(staged[0])
+
+    assert not suite.suite_dir.exists()
+
+
+def test_discard_removes_candidate_and_allows_restaging(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    staged = suite.stage(["trace-1"])
+    candidate_root = staged[0].path.parent.parent
+
+    suite.discard()
+
+    assert not candidate_root.exists()
+    restaged = suite.stage(["trace-2"])
+    assert len(restaged) == 1
+    suite.discard()
+    assert not restaged[0].path.exists()
+
+
+def test_insight_suite_records_analysis_without_removing_failed_tasks(tmp_path: Path) -> None:
+    template = _write_template(tmp_path / "template")
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+    staged = suite.stage(["trace-good", "trace-bad"])
+    for task in staged:
+        (task.path / "instruction.md").write_text(f"Run {task.trace_ref}.\n", encoding="utf-8")
+        suite.validate(task)
+    suite.promote_local([task.trace_ref for task in staged], staged)
+
+    suite.record_analysis(
+        {
+            staged[0].slug: ("completed", None),
+            staged[1].slug: ("failed", "analysis failed"),
+        }
+    )
+
+    manifest = json.loads((suite.suite_dir / "manifest.json").read_text(encoding="utf-8"))
+    assert [task["analysis"] for task in manifest["tasks"]] == [
+        {"status": "completed"},
+        {"error": "analysis failed", "status": "failed"},
+    ]
+    assert len(HarborDataset.from_path(suite.suite_dir).list_tasks()) == 2

--- a/plugins/nemo-experimentalist/tests/test_eval_author_run.py
+++ b/plugins/nemo-experimentalist/tests/test_eval_author_run.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+from nemo_experimentalist_plugin.eval_author import run as eval_author_run
+from nemo_experimentalist_plugin.eval_author.models import EvalAuthorConfig, EvalAuthorResult
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import Dataset, DatasetRef, Task
+from nemo_insights_plugin.entities import Insight
+
+
+@dataclass
+class ClosingClient:
+    closed: bool = False
+    files: Any = None
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@dataclass
+class BackendFactoryCall:
+    client: ClosingClient
+    experiments_output: str
+    mode: Literal["local", "remote"]
+
+
+@dataclass
+class AgentCodeCall:
+    workspace: str
+    agent: str | Path
+    dest: Path
+
+
+@dataclass
+class EvalAuthorFactoryCall:
+    experiment_dir: Path
+    config: EvalAuthorConfig
+
+
+@dataclass
+class EvalAuthorCall:
+    insight: Insight
+    agent_path: Path
+    task_template: Task
+    train_dataset: Dataset
+    validation_dataset: Dataset
+    client: ClosingClient
+
+
+class FakeBackend:
+    def __init__(self, insight: Insight) -> None:
+        self.insight = insight
+        self.insight_calls: list[dict[str, str]] = []
+        self.agent_code_calls: list[AgentCodeCall] = []
+
+    async def get_insight(self, *, workspace: str, insight_id: str) -> Insight:
+        self.insight_calls.append({"workspace": workspace, "insight_id": insight_id})
+        return self.insight
+
+    async def get_agent_code(self, *, workspace: str, agent: str | Path, dest: Path) -> None:
+        self.agent_code_calls.append(AgentCodeCall(workspace=workspace, agent=agent, dest=dest))
+
+
+class FakeDatasetFactory:
+    def __init__(self) -> None:
+        self.train = Dataset(id="train")
+        self.validation = Dataset(id="validation")
+        self.template = Task(id="template-task", uri="file:///template")
+        self.dataset_refs: list[tuple[str, DatasetRef]] = []
+        self.template_refs: list[tuple[str, DatasetRef]] = []
+
+    def build_dataset(self, evaluator_type: str, dataset_ref: DatasetRef) -> Dataset:
+        self.dataset_refs.append((evaluator_type, dataset_ref))
+        if dataset_ref.metadata.get("id") == "validation":
+            return self.validation
+        return self.train
+
+    def build_task_template(self, evaluator_type: str, template_ref: DatasetRef) -> Task:
+        self.template_refs.append((evaluator_type, template_ref))
+        return self.template
+
+
+class FakeEvalAuthor:
+    def __init__(self) -> None:
+        self.call: EvalAuthorCall | None = None
+
+    async def run(
+        self,
+        insight: Insight,
+        agent_path: Path,
+        task_template: Task,
+        train_dataset: Dataset,
+        validation_dataset: Dataset,
+        *,
+        client: ClosingClient,
+    ) -> EvalAuthorResult:
+        self.call = EvalAuthorCall(
+            insight=insight,
+            agent_path=agent_path,
+            task_template=task_template,
+            train_dataset=train_dataset,
+            validation_dataset=validation_dataset,
+            client=client,
+        )
+        return EvalAuthorResult(
+            train_dataset=train_dataset,
+            validation_dataset=validation_dataset,
+            summary="Eval Author complete",
+        )
+
+
+@pytest.mark.asyncio
+async def test_run_eval_author_builds_and_runs_complete_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = ClosingClient()
+    insight = Insight(
+        workspace="workspace-a",
+        title="failure",
+        description="description",
+        agent=str(tmp_path / "agent-src"),
+        trace_refs=["trace-1"],
+    )
+    backend = FakeBackend(insight)
+    dataset_factory = FakeDatasetFactory()
+    eval_author = FakeEvalAuthor()
+    backend_calls: list[BackendFactoryCall] = []
+    eval_author_calls: list[EvalAuthorFactoryCall] = []
+    litellm_calls: list[bool] = []
+
+    def make_backend(
+        *,
+        client: ClosingClient,
+        experiments_output: str,
+        mode: Literal["local", "remote"],
+    ) -> FakeBackend:
+        backend_calls.append(BackendFactoryCall(client=client, experiments_output=experiments_output, mode=mode))
+        return backend
+
+    def build_eval_author_agent(*, experiment_dir: Path, config: EvalAuthorConfig) -> FakeEvalAuthor:
+        eval_author_calls.append(EvalAuthorFactoryCall(experiment_dir=experiment_dir, config=config))
+        return eval_author
+
+    monkeypatch.setattr(eval_author_run, "make_client", lambda base_url: client)
+    monkeypatch.setattr(eval_author_run, "make_experimentalist_backend", make_backend)
+    monkeypatch.setattr(eval_author_run, "DatasetFactory", lambda: dataset_factory)
+    monkeypatch.setattr(eval_author_run, "build_eval_author_agent", build_eval_author_agent)
+    monkeypatch.setattr(eval_author_run, "_enable_litellm_drop_params", lambda: litellm_calls.append(True))
+
+    config = EvalAuthorConfig(max_traces=2)
+    train_ref = DatasetRef(uri=str(tmp_path / "train"), metadata={"id": "train"})
+    validation_ref = DatasetRef(uri=str(tmp_path / "validation"), metadata={"id": "validation"})
+    template_path = tmp_path / "template"
+    template_path.mkdir()
+    template_ref = DatasetRef(uri=str(template_path), metadata={"id": "task-template"})
+
+    result = await eval_author_run.run_eval_author(
+        insight="insight-remote-123",
+        train_dataset=train_ref,
+        validation_dataset=validation_ref,
+        task_template=template_ref,
+        experiment_dir=tmp_path / "eval_author",
+        workspace="workspace-a",
+        base_url="http://platform.test",
+        config=config,
+        mode="local",
+    )
+
+    experiment_dir = (tmp_path / "eval_author").resolve()
+    assert result.summary == "Eval Author complete"
+    assert result.train_dataset is dataset_factory.train
+    assert result.validation_dataset is dataset_factory.validation
+    assert litellm_calls == [True]
+    assert backend_calls == [
+        BackendFactoryCall(client=client, experiments_output=str(experiment_dir), mode="local"),
+    ]
+    assert backend.insight_calls == [{"workspace": "workspace-a", "insight_id": "insight-remote-123"}]
+    assert backend.agent_code_calls == [
+        AgentCodeCall(
+            workspace="workspace-a",
+            agent=insight.agent,
+            dest=experiment_dir / "eval_author" / "source-agent",
+        )
+    ]
+    assert dataset_factory.dataset_refs == [("harbor", train_ref), ("harbor", validation_ref)]
+    assert dataset_factory.template_refs == [
+        (
+            "harbor",
+            template_ref.model_copy(update={"uri": str(experiment_dir / "dataset" / "task-template")}),
+        )
+    ]
+    assert eval_author_calls == [EvalAuthorFactoryCall(experiment_dir=experiment_dir, config=config)]
+    assert eval_author.call == EvalAuthorCall(
+        insight=insight,
+        agent_path=experiment_dir / "eval_author" / "source-agent",
+        task_template=dataset_factory.template,
+        train_dataset=dataset_factory.train,
+        validation_dataset=dataset_factory.validation,
+        client=client,
+    )
+    assert client.closed
+
+
+@pytest.mark.asyncio
+async def test_run_eval_author_hydrates_fileset_task_template(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    download_calls: list[dict[str, str]] = []
+
+    class FakeFiles:
+        async def download(self, *, remote_path: str, local_path: str, workspace: str) -> None:
+            download_calls.append({"remote_path": remote_path, "local_path": local_path, "workspace": workspace})
+            destination = Path(local_path)
+            destination.mkdir(parents=True)
+            (destination / "task.toml").write_text("template", encoding="utf-8")
+
+    client = ClosingClient(files=FakeFiles())
+    insight = Insight(workspace="workspace-a", title="failure", description="description", agent="insight-agent")
+    backend = FakeBackend(insight)
+    dataset_factory = FakeDatasetFactory()
+    eval_author = FakeEvalAuthor()
+
+    monkeypatch.setattr(eval_author_run, "make_client", lambda base_url: client)
+    monkeypatch.setattr(eval_author_run, "make_experimentalist_backend", lambda **_: backend)
+    monkeypatch.setattr(eval_author_run, "DatasetFactory", lambda: dataset_factory)
+    monkeypatch.setattr(eval_author_run, "build_eval_author_agent", lambda **_: eval_author)
+    monkeypatch.setattr(eval_author_run, "_enable_litellm_drop_params", lambda: None)
+
+    template_ref = DatasetRef(uri="fileset://workspace-a/task-template", metadata={"id": "task-template"})
+    experiment_dir = (tmp_path / "eval_author").resolve()
+    await eval_author_run.run_eval_author(
+        insight="insight-remote-123",
+        train_dataset=DatasetRef(uri="train", metadata={"id": "train"}),
+        validation_dataset=DatasetRef(uri="validation", metadata={"id": "validation"}),
+        task_template=template_ref,
+        experiment_dir=experiment_dir,
+        workspace="workspace-a",
+        base_url="http://platform.test",
+        config=EvalAuthorConfig(),
+    )
+
+    staged_path = experiment_dir / "dataset" / "task-template"
+    assert download_calls == [
+        {
+            "remote_path": template_ref.uri,
+            "local_path": str(staged_path),
+            "workspace": "workspace-a",
+        }
+    ]
+    assert dataset_factory.template_refs == [("harbor", template_ref.model_copy(update={"uri": str(staged_path)}))]
+    assert client.closed
+
+
+@pytest.mark.asyncio
+async def test_run_eval_author_uses_agent_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = ClosingClient()
+    insight = Insight(workspace="workspace-a", title="failure", description="description", agent="insight-agent")
+    backend = FakeBackend(insight)
+    dataset_factory = FakeDatasetFactory()
+    eval_author = FakeEvalAuthor()
+
+    monkeypatch.setattr(eval_author_run, "make_client", lambda base_url: client)
+    monkeypatch.setattr(eval_author_run, "make_experimentalist_backend", lambda **_: backend)
+    monkeypatch.setattr(eval_author_run, "DatasetFactory", lambda: dataset_factory)
+    monkeypatch.setattr(eval_author_run, "build_eval_author_agent", lambda **_: eval_author)
+    monkeypatch.setattr(eval_author_run, "_enable_litellm_drop_params", lambda: None)
+
+    override = tmp_path / "override-agent"
+    template = tmp_path / "template"
+    template.mkdir()
+    await eval_author_run.run_eval_author(
+        insight="insight-remote-123",
+        agent=override,
+        train_dataset=DatasetRef(uri="train", metadata={"id": "train"}),
+        validation_dataset=DatasetRef(uri="validation", metadata={"id": "validation"}),
+        task_template=DatasetRef(uri=str(template)),
+        experiment_dir=tmp_path / "eval_author",
+        workspace="workspace-a",
+        base_url="http://platform.test",
+        config=EvalAuthorConfig(),
+    )
+
+    assert backend.agent_code_calls[0].agent == override
+    assert client.closed
+
+
+@pytest.mark.asyncio
+async def test_run_eval_author_closes_client_when_backend_creation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = ClosingClient()
+
+    def fail_backend_creation(**_: object) -> object:
+        raise RuntimeError("backend creation failed")
+
+    monkeypatch.setattr(eval_author_run, "make_client", lambda base_url: client)
+    monkeypatch.setattr(eval_author_run, "make_experimentalist_backend", fail_backend_creation)
+
+    with pytest.raises(RuntimeError, match="backend creation failed"):
+        await eval_author_run.run_eval_author(
+            insight="insight-remote-123",
+            train_dataset=DatasetRef(uri="train"),
+            validation_dataset=DatasetRef(uri="validation"),
+            task_template=DatasetRef(uri="template"),
+            experiment_dir=tmp_path / "eval_author",
+            workspace="workspace-a",
+            base_url="http://platform.test",
+            config=EvalAuthorConfig(),
+        )
+
+    assert client.closed

--- a/plugins/nemo-experimentalist/tests/test_experiment_cli.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_cli.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+import pytest
+from click.testing import Result
+from nemo_experimentalist_plugin import cli
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizerConfig
+from nemo_experimentalist_plugin.preflight import Probes
+from nemo_platform import AsyncNeMoPlatform
+from typer.testing import CliRunner
+
+
+@pytest.fixture(autouse=True)
+def quiet_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auto-preflight runs inside the experiment flow; make it pass deterministically.
+
+    These tests pin the CLI→runner contract, not preflight behavior (that lives
+    in test_cli_profile.py / test_preflight.py), so probes never hit the system.
+    """
+    monkeypatch.setattr(
+        cli,
+        "_PREFLIGHT_PROBES",
+        Probes(
+            run_cmd=lambda argv: (0, "ok"),
+            http_ok=lambda url: True,
+            env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"},
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def hermetic_cwd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Run from an isolated directory: profile discovery walks up from cwd, so
+    an optimizer.yaml in any ancestor of the checkout must never leak in."""
+    monkeypatch.chdir(tmp_path)
+
+
+@dataclass
+class FakePlatformClient:
+    closed: bool = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def platform_client(monkeypatch: pytest.MonkeyPatch) -> FakePlatformClient:
+    client = FakePlatformClient()
+    monkeypatch.setattr(cli, "make_client", lambda _base_url: cast(AsyncNeMoPlatform, client))
+    return client
+
+
+@dataclass
+class CapturedExperimentRun:
+    agent: str | Path
+    train_dataset: DatasetRef
+    validation_dataset: DatasetRef
+    task_template: DatasetRef | None
+    experiment_dir: Path
+    workspace: str
+    client: AsyncNeMoPlatform | None
+    config: EvolutionaryOptimizerConfig
+    mode: Literal["local", "remote"]
+    insight: Path | str | None
+    agent_spec: str | None
+    framework_skills_dirs: list[Path] | None
+
+
+@dataclass
+class ExperimentCliPaths:
+    agent: Path
+    train: Path
+    validation: Path
+    template: Path
+    experiment: Path
+
+    def args(self) -> list[str]:
+        return [
+            "--agent",
+            str(self.agent),
+            "--train-dataset",
+            str(self.train),
+            "--validation-dataset",
+            str(self.validation),
+            "--task-template",
+            str(self.template),
+            "--experiment-dir",
+            str(self.experiment),
+        ]
+
+
+class ExperimentRunRecorder:
+    def __init__(self, result: str = "experiment-summary") -> None:
+        self.captured: CapturedExperimentRun | None = None
+        self.result = result
+
+    async def __call__(
+        self,
+        *,
+        agent: str | Path,
+        train_dataset: DatasetRef,
+        validation_dataset: DatasetRef,
+        experiment_dir: Path,
+        workspace: str,
+        client: AsyncNeMoPlatform | None,
+        config: EvolutionaryOptimizerConfig,
+        task_template: DatasetRef | None = None,
+        insight: Path | str | None = None,
+        agent_spec: str | None = None,
+        framework_skills_dirs: list[Path] | None = None,
+        mode: Literal["local", "remote"],
+    ) -> str:
+        self.captured = CapturedExperimentRun(
+            agent=agent,
+            train_dataset=train_dataset,
+            validation_dataset=validation_dataset,
+            task_template=task_template,
+            experiment_dir=experiment_dir,
+            workspace=workspace,
+            client=client,
+            config=config,
+            mode=mode,
+            insight=insight,
+            agent_spec=agent_spec,
+            framework_skills_dirs=framework_skills_dirs,
+        )
+        return self.result
+
+
+def _make_dir(path: Path) -> Path:
+    path.mkdir()
+    return path
+
+
+def _make_paths(tmp_path: Path) -> ExperimentCliPaths:
+    template = _make_dir(tmp_path / "template")
+    (template / "task.toml").write_text('[task]\nname = "org/test-template"\n', encoding="utf-8")
+    (template / "instruction.md").write_text("Test task instructions.\n", encoding="utf-8")
+    return ExperimentCliPaths(
+        agent=_make_dir(tmp_path / "agent"),
+        train=_make_dir(tmp_path / "train"),
+        validation=_make_dir(tmp_path / "validation"),
+        template=template,
+        experiment=tmp_path / "experiment",
+    )
+
+
+def _run_experiment(args: list[str]) -> Result:
+    app = cli.ExperimentalistCLI().get_cli()
+    return CliRunner().invoke(app, ["run", *args])
+
+
+async def _fail_if_runner_starts(**_: object) -> str:
+    raise AssertionError("invalid CLI input must not start the experimentalist runner")
+
+
+def test_cli_help_exposes_only_run_and_doctor() -> None:
+    app = cli.ExperimentalistCLI().get_cli()
+    result = CliRunner().invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "run" in result.output
+    assert "doctor" in result.output
+    assert "analyze" not in result.output
+    assert "analysis" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("config_body", "expected_config", "expected_output"),
+    [
+        pytest.param(
+            "max_rounds: 2\nevaluator:\n  max_attempts: 3\n",
+            EvolutionaryOptimizerConfig.model_validate({"max_rounds": 2, "evaluator": {"max_attempts": 3}}),
+            "configured-summary",
+            id="with-config",
+        ),
+        pytest.param(
+            None,
+            EvolutionaryOptimizerConfig(),
+            "default-config-summary",
+            id="without-config",
+        ),
+    ],
+)
+def test_experiment_cli_passes_dataset_driven_contract_to_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    platform_client: FakePlatformClient,
+    config_body: str | None,
+    expected_config: EvolutionaryOptimizerConfig,
+    expected_output: str,
+) -> None:
+    paths = _make_paths(tmp_path)
+    insight_file = tmp_path / "insight.json"
+    insight_file.write_text("{}", encoding="utf-8")
+    runner = ExperimentRunRecorder(result=expected_output)
+    monkeypatch.setattr(cli, "run_experimentalist", runner)
+    args = [
+        *paths.args(),
+        "--workspace",
+        "workspace-a",
+        "--base-url",
+        "http://platform.test",
+        "--insight",
+        str(insight_file),
+    ]
+
+    if config_body is not None:
+        # NOT named optimizer.yaml: that would collide with profile discovery
+        # from the hermetic cwd — a run config is not a profile.
+        config_path = tmp_path / "run-config.yaml"
+        config_path.write_text(config_body, encoding="utf-8")
+        args.extend(["--config", str(config_path)])
+
+    result = _run_experiment(args)
+
+    assert result.exit_code == 0
+    assert result.output.strip() == expected_output
+    assert runner.captured is not None
+    # The CLI passes --agent through verbatim (a str); resolution / git-cloning
+    # happens inside the loop via backend.get_agent_code().
+    assert runner.captured.agent == str(paths.agent)
+    # A local --insight file is normalized to scratch JSON (the local backend
+    # reads insight files with json.loads, so YAML-authored files must not
+    # reach it raw); platform ids still pass through verbatim.
+    assert runner.captured.insight == str(paths.experiment / "resolved" / "insight.json")
+    assert Path(runner.captured.insight).read_text(encoding="utf-8").strip() == "{}"
+    # Datasets and the task template are forwarded as DatasetRef URI handles,
+    # tagged with a stable id the evaluator adapter uses when building datasets.
+    assert runner.captured.train_dataset == DatasetRef(uri=str(paths.train), metadata={"id": "train"})
+    assert runner.captured.validation_dataset == DatasetRef(uri=str(paths.validation), metadata={"id": "validation"})
+    assert runner.captured.task_template == DatasetRef(uri=str(paths.template), metadata={"id": "task-template"})
+    assert runner.captured.experiment_dir == paths.experiment
+    assert runner.captured.workspace == "workspace-a"
+    assert runner.captured.client is platform_client
+    assert platform_client.closed
+    assert runner.captured.mode == "local"
+    assert runner.captured.config == expected_config
+
+
+@pytest.mark.parametrize(
+    ("extra_args", "config_body", "expected_exit_code", "expected_errors"),
+    [
+        pytest.param(
+            ("--mode", "remote"),
+            None,
+            1,
+            ("Remote mode is not implemented yet",),
+            id="unsupported-remote-mode",
+        ),
+        pytest.param(
+            (),
+            "max_rounds: [",
+            1,
+            ("while parsing a flow node",),
+            id="malformed-yaml",
+        ),
+        pytest.param(
+            (),
+            "max_rounds: not-an-int\n",
+            1,
+            ("max_rounds", "Input should be a valid integer"),
+            id="invalid-schema",
+        ),
+    ],
+)
+def test_experiment_cli_reports_expected_errors_without_starting_runner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    extra_args: tuple[str, ...],
+    config_body: str | None,
+    expected_exit_code: int,
+    expected_errors: tuple[str, ...],
+) -> None:
+    paths = _make_paths(tmp_path)
+    args = [*paths.args(), *extra_args]
+
+    if config_body is not None:
+        config_path = tmp_path / "bad.yaml"
+        config_path.write_text(config_body, encoding="utf-8")
+        args.extend(["--config", str(config_path)])
+
+    monkeypatch.setattr(cli, "run_experimentalist", _fail_if_runner_starts)
+
+    result = _run_experiment(args)
+
+    assert result.exit_code == expected_exit_code
+    for expected_error in expected_errors:
+        assert expected_error in result.output
+
+
+def test_experiment_cli_exits_nonzero_when_evaluation_has_no_scores(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    platform_client: FakePlatformClient,
+) -> None:
+    async def fail_no_scores(**_: object) -> str:
+        raise ValueError("Evaluation agent-validation produced no scoreable metrics from 3 trial(s)")
+
+    paths = _make_paths(tmp_path)
+    monkeypatch.setattr(cli, "run_experimentalist", fail_no_scores)
+
+    result = _run_experiment(paths.args())
+
+    assert result.exit_code == 1
+    assert "produced no scoreable metrics from 3 trial(s)" in result.output
+    assert platform_client.closed
+
+
+def test_experiment_cli_forwards_insight_platform_id_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    paths = _make_paths(tmp_path)
+    runner = ExperimentRunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", runner)
+    # A non-file value (a platform insight id) is accepted by --insight and forwarded
+    # verbatim; the backend routes it to the platform at get_insight time.
+    args = [*paths.args(), "--insight", "insight-remote-123"]
+
+    result = _run_experiment(args)
+
+    assert result.exit_code == 0
+    assert runner.captured is not None
+    assert runner.captured.insight == "insight-remote-123"

--- a/plugins/nemo-experimentalist/tests/test_experiment_mirror.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_mirror.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun
+from nemo_experimentalist_plugin.experimentalist.experiment_mirror import ExperimentMirror, group_metadata
+from nemo_platform import ConflictError, NotFoundError, omit  # VERIFY-2
+
+pytestmark = pytest.mark.asyncio
+
+_CONFLICT = ConflictError(
+    "conflict", response=httpx.Response(409, request=httpx.Request("POST", "http://x/y")), body=None
+)
+_NOTFOUND = NotFoundError(
+    "not found", response=httpx.Response(404, request=httpx.Request("GET", "http://x/y")), body=None
+)
+
+
+def _client(groups: object, experiments: object) -> object:
+    return SimpleNamespace(experiment_groups=groups, evaluations=experiments)
+
+
+class _StatefulGroups:
+    """Models experiment_groups as a full-replace PUT store: create/update set the
+    stored body to exactly the fields passed, treating ``omit`` (or an absent kwarg)
+    as "field became None". This is what catches accidental field-wiping on update."""
+
+    _TRACKED = ("insight_id", "summary", "metadata")
+
+    def __init__(self) -> None:
+        self.name: str | None = None
+        self.body: dict[str, object | None] = {}
+
+    def _apply(self, **kwargs: object) -> None:
+        for field in self._TRACKED:
+            value = kwargs.get(field, omit)
+            self.body[field] = None if value is omit else value
+
+    async def create(self, *, name: str, **kwargs: object) -> object:
+        self.name = name
+        self._apply(**kwargs)
+        return SimpleNamespace(id="grp-1", name=name, **self.body)
+
+    async def retrieve(self, name: str, **kwargs: object) -> object:
+        return SimpleNamespace(id="grp-1", name=self.name, **self.body)
+
+    async def update(self, path_name: str, **kwargs: object) -> object:
+        self._apply(**kwargs)
+        return SimpleNamespace(id="grp-1", name=self.name, **self.body)
+
+
+def _run(**kw) -> ExperimentRun:
+    base = dict(
+        workspace="default",
+        agent="a",
+        insight="ins-1",
+        config_snapshot={},
+        status="running",
+        rounds_completed=0,
+        winner_agent=None,
+    )
+    base.update(kw)
+    run = ExperimentRun(**base)
+    run._id = "run-1"  # store id (private attr, as the entity client sets it)
+    return run
+
+
+def _cand(**kw) -> Candidate:
+    base = dict(run_id="run-1", label="agent-0", round=0, optimization="baseline")
+    base.update(kw)
+    return Candidate(**base)
+
+
+async def test_ensure_group_creates_with_insight_and_metadata():
+    groups = AsyncMock()
+    groups.create.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    mirror = ExperimentMirror(_client(groups, AsyncMock()), workspace="default")
+    await mirror.ensure_group(_run())
+    kwargs = groups.create.await_args.kwargs
+    assert kwargs["name"] == "opt-run-1" and kwargs["insight_id"] == "ins-1"
+    assert kwargs["metadata"]["agent"] == "a"
+
+
+async def test_ensure_group_conflict_retrieves():
+    groups = AsyncMock()
+    groups.create.side_effect = _CONFLICT
+    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    mirror = ExperimentMirror(_client(groups, AsyncMock()), workspace="default")
+    await mirror.ensure_group(_run())
+    groups.retrieve.assert_awaited_once()
+
+
+async def test_project_candidate_upserts_experiment_per_evaluated_split():
+    experiments = AsyncMock()
+    experiments.create.return_value = SimpleNamespace(id="exp-train")
+    mirror = ExperimentMirror(_client(AsyncMock(), experiments), workspace="default")
+    cand = _cand(round=0, train_reward={"reward": 1.0}, train_reward_details=[])
+    await mirror.project_candidate(cand)
+    kwargs = experiments.create.await_args.kwargs
+    assert kwargs["name"] == "opt-run-1-agent-0-train"
+    assert kwargs["status"] == "baseline"
+    # metadata is identity-only — reward/trials are NOT copied (§4.3)
+    assert kwargs["metadata"] == {"round": "0", "candidate_id": "agent-0", "split": "train"}
+    assert "aggregate_metrics" not in kwargs["metadata"] and "trials" not in kwargs["metadata"]
+    # validation not evaluated → not created
+    assert experiments.create.await_count == 1
+
+
+async def test_project_candidate_skips_when_no_reward():
+    experiments = AsyncMock()
+    mirror = ExperimentMirror(_client(AsyncMock(), experiments), workspace="default")
+    await mirror.project_candidate(_cand())  # no reward set
+    experiments.create.assert_not_awaited()
+
+
+async def test_project_candidate_conflict_updates_experiment():
+    groups = AsyncMock()
+    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    experiments = AsyncMock()
+    experiments.create.side_effect = _CONFLICT
+    experiments.update.return_value = SimpleNamespace(id="exp-train")
+    mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
+    cand = _cand(round=0, train_reward={"reward": 1.0}, train_reward_details=[])
+    await mirror.project_candidate(cand)
+    experiments.update.assert_awaited_once()
+    # update is a full-replace: dataset_version must be re-supplied (symmetric with create)
+    kwargs = experiments.update.await_args.kwargs
+    assert kwargs["dataset_version"] == "v1"
+    assert kwargs["metadata"] == {"round": "0", "candidate_id": "agent-0", "split": "train"}
+
+
+async def test_parent_experiment_id_cache_hit():
+    groups = AsyncMock()
+    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    experiments = AsyncMock()
+    experiments.create.side_effect = [
+        SimpleNamespace(id="exp-ancestor-train"),  # ancestor train experiment
+        SimpleNamespace(id="exp-child-train"),  # child train experiment
+    ]
+    mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
+    ancestor = _cand(label="agent-0", round=0, train_reward={"reward": 1.0}, train_reward_details=[])
+    await mirror.project_candidate(ancestor)
+    child = _cand(label="agent-1", ancestor="agent-0", round=1, train_reward={"reward": 1.0}, train_reward_details=[])
+    await mirror.project_candidate(child)
+    child_kwargs = experiments.create.await_args.kwargs  # last call == child
+    assert child_kwargs["parent_evaluation_id"] == "exp-ancestor-train"
+    experiments.retrieve.assert_not_awaited()  # resolved from cache, no lookup
+
+
+async def test_parent_experiment_id_fallback_retrieve():
+    groups = AsyncMock()
+    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    experiments = AsyncMock()
+    experiments.retrieve.return_value = SimpleNamespace(id="exp-ancestor-train")
+    experiments.create.return_value = SimpleNamespace(id="exp-child-train")
+    mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
+    child = _cand(label="agent-1", ancestor="agent-0", round=1, train_reward={"reward": 1.0}, train_reward_details=[])
+    await mirror.project_candidate(child)
+    experiments.retrieve.assert_awaited()
+    kwargs = experiments.create.await_args.kwargs
+    assert kwargs["parent_evaluation_id"] == "exp-ancestor-train"
+
+
+async def test_parent_experiment_id_not_found_omits():
+    groups = AsyncMock()
+    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1")
+    experiments = AsyncMock()
+    experiments.retrieve.side_effect = _NOTFOUND
+    experiments.create.return_value = SimpleNamespace(id="exp-child-train")
+    mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
+    child = _cand(label="agent-1", ancestor="agent-0", round=1, train_reward={"reward": 1.0}, train_reward_details=[])
+    await mirror.project_candidate(child)
+    kwargs = experiments.create.await_args.kwargs
+    assert kwargs["parent_evaluation_id"] is omit
+
+
+async def test_finalize_round0_winner_preserves_existing_source_link():
+    # A round-0 winner with no PR must keep the source_link written during the run (e.g. a
+    # real {repo}@{ref}), not have it clobbered with a pseudo link by the full-replace update.
+    groups = AsyncMock()
+    groups.retrieve.return_value = SimpleNamespace(id="grp-1", name="opt-run-1", insight_id=None, metadata=None)
+    experiments = AsyncMock()
+    experiments.retrieve.return_value = SimpleNamespace(id="exp-w", source_link="https://git/repo.git@main")
+    experiments.create.return_value = SimpleNamespace(id="exp-w")
+    mirror = ExperimentMirror(_client(groups, experiments), workspace="default")
+    winner = _cand(label="agent-0", round=0, train_reward={"reward": 1.0}, train_reward_details=[])
+    await mirror.finalize(run_id="run-1", summary="done", winner=winner, pr_url=None)
+    kwargs = experiments.create.await_args.kwargs
+    assert kwargs["source_link"] == "https://git/repo.git@main"  # preserved, not pseudo
+    assert kwargs["status"] == "winner"
+
+
+async def test_group_update_and_finalize_do_not_wipe_insight_or_metadata():
+    # experiment_groups.update is a full-replace PUT; ensure_group → update_group →
+    # finalize must all preserve insight_id + metadata rather than reset them to None.
+    groups = _StatefulGroups()
+    mirror = ExperimentMirror(_client(groups, AsyncMock()), workspace="default")
+    run = _run(insight="ins-1")
+    await mirror.ensure_group(run)
+    await mirror.update_group(run)
+    await mirror.finalize(run_id="run-1", summary="done", winner=None)
+    assert groups.body["insight_id"] == "ins-1"
+    assert groups.body["metadata"] == group_metadata(run)
+    assert groups.body["metadata"] is not None
+    assert groups.body["summary"] == "done"

--- a/plugins/nemo-experimentalist/tests/test_experiment_mirror_mapping.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_mirror_mapping.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun
+from nemo_experimentalist_plugin.experimentalist import experiment_mirror as m
+
+
+def _cand(**kw):
+    base = dict(run_id="run-1", label="agent-0", round=0, optimization="baseline")
+    base.update(kw)
+    return Candidate(**base)
+
+
+def test_group_name_is_sanitized_and_bounded():
+    assert m.group_name("Run_1/ABC") == "opt-run-1-abc"
+    assert len(m.group_name("x" * 200)) <= 63
+
+
+def test_experiment_name_deterministic():
+    assert m.experiment_name("opt-run-1", "agent-0", "train") == "opt-run-1-agent-0-train"
+
+
+def test_status_derivation():
+    assert m.experiment_status(_cand(round=0)) == "baseline"
+    assert m.experiment_status(_cand(round=2, killed_round=3)) == "killed"
+    assert m.experiment_status(_cand(round=2)) == "survived"
+
+
+def test_group_metadata_carries_run_fields():
+    run = ExperimentRun(
+        workspace="default",
+        agent="a",
+        insight=None,
+        config_snapshot={"k": 1},
+        status="running",
+        rounds_completed=2,
+        winner_agent="agent-3",
+    )
+    md = m.group_metadata(run)
+    # Platform metadata is dict[str, str]: config_snapshot is JSON-serialized and the
+    # round counter is stringified, so the create/update body passes server validation.
+    assert md == {
+        "agent": "a",
+        "config_snapshot": '{"k": 1}',
+        "status": "running",
+        "rounds_completed": "2",
+        "winner_candidate": "agent-3",
+    }
+
+
+def test_group_metadata_omits_winner_until_present():
+    run = ExperimentRun(
+        workspace="default",
+        agent="a",
+        insight=None,
+        config_snapshot={"k": 1},
+        status="running",
+        rounds_completed=0,
+        winner_agent=None,
+    )
+    md = m.group_metadata(run)
+    # None is not a valid metadata value; omit the key rather than send null (would 422).
+    assert "winner_candidate" not in md
+    assert all(isinstance(v, str) for v in md.values())
+
+
+def test_experiment_metadata_is_identity_only():
+    md = m.experiment_metadata(_cand(round=1), "train")
+    # round stringified for dict[str, str] metadata; no reward/trials copied
+    assert md == {"round": "1", "candidate_id": "agent-0", "split": "train"}
+
+
+def test_pseudo_source_link_is_a_url():
+    assert m.pseudo_source_link("opt-run-1", "agent-0") == "opt://opt-run-1/candidate/agent-0"

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for AgentAnalyzer client/workspace plumbing.
+
+The Experimentalist round-N analysis path used to silently skip every
+``intake://`` trial trace because ``AgentAnalyzer`` never received (and never
+forwarded) a platform ``client`` or the Intake ``workspace`` name. These tests
+pin the plumbing: ``AgentAnalyzer.run`` must accept ``client`` / ``nmp_workspace``
+and thread them into ``TraceAnalyzer.run``.
+
+``AgentAnalyzer`` is built via ``object.__new__`` to skip its LLM-heavy
+``__init__``, and the LLM-driven strategy methods (``select_trials``,
+``classify_failures``, ``compare_with_peers``) are replaced by callable
+*objects* — the agent framework's method guard rejects attaching plain
+functions/methods to public attributes, but allows non-function callables.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar, cast
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components import analyzer as analyzer_module
+from nemo_experimentalist_plugin.experimentalist.components.analyzer import (
+    AgentAnalyzer,
+    AnalyzerConfig,
+    FailureClassification,
+    PeerComparison,
+)
+from nemo_experimentalist_plugin.experimentalist.components.rationalizer import Rationale
+from nemo_experimentalist_plugin.experimentalist.components.trace_analyzer import Diagnostic
+
+
+@dataclass
+class _FakeMetric:
+    value: float
+
+
+@dataclass
+class _FakeTrial:
+    id: str
+    task_id: str
+    trace: object
+    metrics: dict[str, _FakeMetric]
+
+
+@dataclass
+class _FakeTask:
+    id: str
+
+
+@dataclass
+class _FakeDataset:
+    tasks: list[_FakeTask]
+
+    def list_tasks(self) -> list[_FakeTask]:
+        return self.tasks
+
+
+@dataclass
+class _FakeEvaluation:
+    id: str = "eval-1"
+    aggregate_metrics: dict[str, float] = field(default_factory=lambda: {"reward": 1.0})
+
+
+class _RecordingTraceAnalyzer:
+    """Stand-in for TraceAnalyzer that records the run() call context.
+
+    ``calls`` is a class attribute so subclasses can point it at a per-test list.
+    """
+
+    calls: ClassVar[list[dict[str, Any]]] = []
+
+    def __init__(self, *, experiment_dir: Path, config: Any, framework_skills_dirs: list[Path] | None = None) -> None:
+        self.experiment_dir = experiment_dir
+        self.config = config
+        self.framework_skills_dirs = framework_skills_dirs or []
+
+    async def run(
+        self,
+        *,
+        trial: Any,
+        task: Any,
+        agent_path: Any,
+        rationale: Any = None,
+        insight: Any = None,
+        client: Any = None,
+        workspace: Any = None,
+    ) -> Diagnostic:
+        type(self).calls.append({"client": client, "workspace": workspace})
+        return Diagnostic(outcome="SUCCESS", summary="stub", failure_point=None, root_cause="stub")
+
+
+class _FakeRationalizer:
+    def __init__(self, *, workspace: Path, config: Any, framework_skills_dirs: list[Path] | None = None) -> None:
+        self.workspace = workspace
+        self.config = config
+        self.framework_skills_dirs = framework_skills_dirs or []
+
+    async def run(self, task: Any, agent_spec: Any = None) -> Rationale:
+        return Rationale(task_name=task.id, steps=[])
+
+
+# Callable *objects* (not functions) so the framework method guard permits
+# assigning them to the analyzer's public strategy attributes.
+class _SelectTrials:
+    def __init__(self, trials: list[Any]) -> None:
+        self._trials = trials
+
+    async def __call__(self, agent_id: str, dataset: Any, evaluation: Any) -> list[Any]:
+        return self._trials
+
+
+class _ClassifyFailures:
+    async def __call__(self, agent_id: str, diagnoses: Any, trials: Any) -> FailureClassification:
+        return FailureClassification(systematic=[], mechanical=[])
+
+
+class _CompareWithPeers:
+    async def __call__(
+        self, agent_id: str, evaluation: Any, diagnoses: Any, peer_evaluations: Any = None
+    ) -> PeerComparison:
+        return PeerComparison(divergent_trials=[], complementary_patterns=[])
+
+
+def _make_analyzer(tmp_path: Path, trials: list[Any]) -> AgentAnalyzer:
+    """Build an AgentAnalyzer without the LLM-heavy __init__ and stub its strategies."""
+    analyzer = object.__new__(AgentAnalyzer)
+    analyzer._workspace_path = tmp_path
+    analyzer._config = AnalyzerConfig()
+    analyzer._framework_skills_dirs = []
+    analyzer.select_trials = _SelectTrials(trials)  # type: ignore[method-assign,assignment]
+    analyzer.classify_failures = _ClassifyFailures()  # type: ignore[method-assign,assignment]
+    analyzer.compare_with_peers = _CompareWithPeers()  # type: ignore[method-assign,assignment]
+    return analyzer
+
+
+def _install_fakes(monkeypatch: pytest.MonkeyPatch, calls: list[dict[str, Any]]) -> None:
+    class _TA(_RecordingTraceAnalyzer):
+        pass
+
+    _TA.calls = calls
+    monkeypatch.setattr(analyzer_module, "TraceAnalyzer", _TA)
+    monkeypatch.setattr(analyzer_module, "Rationalizer", _FakeRationalizer)
+
+
+def _fixtures() -> tuple[_FakeTrial, _FakeDataset, _FakeEvaluation]:
+    trial = _FakeTrial(id="trial-1", task_id="task-1", trace=object(), metrics={"reward": _FakeMetric(0.0)})
+    dataset = _FakeDataset(tasks=[_FakeTask(id="task-1")])
+    return trial, dataset, _FakeEvaluation()
+
+
+@pytest.mark.asyncio
+async def test_run_threads_client_and_workspace_into_trace_analyzer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """AgentAnalyzer.run forwards client and nmp_workspace to TraceAnalyzer.run."""
+    calls: list[dict[str, Any]] = []
+    _install_fakes(monkeypatch, calls)
+    trial, dataset, evaluation = _fixtures()
+    analyzer = _make_analyzer(tmp_path, [trial])
+
+    sentinel_client = object()
+    result = await analyzer.run(
+        agent="agent-a",
+        dataset=cast(Any, dataset),
+        evaluation=cast(Any, evaluation),
+        round=0,
+        client=cast(Any, sentinel_client),
+        nmp_workspace="tau2-airline-ws",
+    )
+
+    assert result.agent_id == "agent-a"
+    assert len(calls) == 1
+    assert calls[0]["client"] is sentinel_client
+    assert calls[0]["workspace"] == "tau2-airline-ws"
+
+
+@pytest.mark.asyncio
+async def test_run_defaults_client_and_workspace_to_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitting client/nmp_workspace still runs and forwards None (backward compat)."""
+    calls: list[dict[str, Any]] = []
+    _install_fakes(monkeypatch, calls)
+    trial, dataset, evaluation = _fixtures()
+    analyzer = _make_analyzer(tmp_path, [trial])
+
+    await analyzer.run(agent="agent-a", dataset=cast(Any, dataset), evaluation=cast(Any, evaluation), round=0)
+
+    assert len(calls) == 1
+    assert calls[0]["client"] is None
+    assert calls[0]["workspace"] is None
+
+
+@pytest.mark.asyncio
+async def test_intake_availability_is_part_of_cache_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A trace-skipped (no client) result must not be replayed once a client is available."""
+    calls: list[dict[str, Any]] = []
+    _install_fakes(monkeypatch, calls)
+    trial, dataset, evaluation = _fixtures()
+
+    # Same workspace/tmp_path across both runs, so the on-disk cache persists.
+    analyzer_no_client = _make_analyzer(tmp_path, [trial])
+    await analyzer_no_client.run(agent="agent-a", dataset=cast(Any, dataset), evaluation=cast(Any, evaluation), round=0)
+
+    analyzer_with_client = _make_analyzer(tmp_path, [trial])
+    await analyzer_with_client.run(
+        agent="agent-a",
+        dataset=cast(Any, dataset),
+        evaluation=cast(Any, evaluation),
+        round=0,
+        client=cast(Any, object()),
+        nmp_workspace="ws-1",
+    )
+
+    # The second (intake-available) run must recompute rather than reuse the
+    # trace-skipped cache entry from the first run.
+    assert len(calls) == 2
+    assert calls[0]["client"] is None
+    assert calls[1]["client"] is not None

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_backend.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend fetch/archive/publish tests.
+
+Covers insight resolution, the git vs local dispatch in ``get_agent_code``, and the
+``archive_candidate`` / ``publish_candidate`` verbs (which derive branch/base_ref/agent_path
+from the captured ``AgentSource`` and delegate to ``PRPublisher``) — with the git/subprocess
+boundary mocked.
+"""
+
+import asyncio
+import json
+import traceback
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from nemo_experimentalist_plugin.entities import Candidate
+from nemo_experimentalist_plugin.experimentalist import experimentalist_backend as beim
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import EvaluationResult
+from nemo_experimentalist_plugin.experimentalist.components.repository import AgentCloneError, AgentSource
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import (
+    CandidateStorageConfig,
+    LocalExperimentalistBackend,
+    RemoteExperimentalistBackend,
+)
+from nemo_insights_plugin.entities import Insight
+
+
+def _local_backend(tmp_path: Path) -> LocalExperimentalistBackend:
+    return LocalExperimentalistBackend(path=tmp_path / "backend")
+
+
+# ---------------------------------------------------------------------------
+# get_insight — local file (offline) vs platform id fetch
+# ---------------------------------------------------------------------------
+
+
+class _StubInsightResource:
+    def __init__(self, insight: Insight | None, error: Exception | None = None) -> None:
+        self._insight = insight
+        self._error = error
+        self.calls: list[dict[str, str]] = []
+
+    async def get(self, *, workspace: str, insight_id: str) -> Insight:
+        self.calls.append({"workspace": workspace, "insight_id": insight_id})
+        if self._error is not None:
+            raise self._error
+        assert self._insight is not None
+        return self._insight
+
+
+class _StubInsights:
+    def __init__(self, insight: Insight) -> None:
+        self.insights = _StubInsightResource(insight)
+
+
+class _StubClient:
+    def __init__(self, insight: Insight) -> None:
+        self.insights = _StubInsights(insight)
+
+
+class _ErrorStubClient:
+    def __init__(self, error: Exception) -> None:
+        self.insights = type("_StubInsights", (), {"insights": _StubInsightResource(None, error=error)})()
+
+
+async def test_get_insight_reads_local_file(tmp_path: Path) -> None:
+    insight_file = tmp_path / "insight.json"
+    insight_file.write_text(
+        json.dumps({"id": "insight-local", "workspace": "w", "title": "t", "description": "d", "agent": "a"})
+    )
+    backend = LocalExperimentalistBackend(path=tmp_path / "backend")
+
+    insight = await backend.get_insight(workspace="w", insight_id=str(insight_file))
+
+    assert insight.id == "insight-local"
+
+
+async def test_get_insight_fetches_platform_id_via_client(tmp_path: Path) -> None:
+    platform_insight = Insight(workspace="ws", title="platform", description="d", agent="a")
+    client = _StubClient(platform_insight)
+    backend = LocalExperimentalistBackend(client=client, path=tmp_path / "backend")  # type: ignore[arg-type]
+
+    insight = await backend.get_insight(workspace="ws", insight_id="insight-remote-123")
+
+    assert insight is platform_insight
+    assert client.insights.insights.calls == [{"workspace": "ws", "insight_id": "insight-remote-123"}]
+
+
+async def test_get_insight_platform_id_without_client_raises(tmp_path: Path) -> None:
+    backend = LocalExperimentalistBackend(path=tmp_path / "backend")
+    with pytest.raises(ValueError, match="no platform client is available"):
+        await backend.get_insight(workspace="w", insight_id="insight-remote-123")
+
+
+async def test_get_insight_platform_404_raises_value_error(tmp_path: Path) -> None:
+    request = httpx.Request("GET", "http://platform.test/insights/missing")
+    response = httpx.Response(404, request=request)
+    error = httpx.HTTPStatusError("not found", request=request, response=response)
+    backend = LocalExperimentalistBackend(client=_ErrorStubClient(error), path=tmp_path / "backend")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Insight not found on the platform"):
+        await backend.get_insight(workspace="w", insight_id="missing")
+
+
+# ---------------------------------------------------------------------------
+# get_agent_code — local path (unchanged behavior, returns None)
+# ---------------------------------------------------------------------------
+
+
+async def test_get_agent_code_local_copies_returns_none(tmp_path: Path) -> None:
+    src = tmp_path / "agent"
+    src.mkdir()
+    (src / "main.py").write_text("print('x')\n")
+    dest = tmp_path / "dest"
+    source = await _local_backend(tmp_path).get_agent_code(workspace="w", agent=src, dest=dest)
+    assert source is None
+    assert (dest / "main.py").read_text() == "print('x')\n"
+
+
+# ---------------------------------------------------------------------------
+# get_agent_code — git source (dispatches to clone_agent_repo, returns AgentSource)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend_factory", ["local", "remote"])
+def test_get_agent_code_git_dispatches_to_clone(backend_factory, tmp_path, monkeypatch):  # noqa: ANN001
+    calls: list[tuple[str, Path]] = []
+
+    def fake_clone(spec: str, dest: Path, *, clone_depth: int | None = None) -> AgentSource:
+        calls.append((spec, Path(dest)))
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        return AgentSource(repo_url="ssh://git@h/g/r.git", ref="main")
+
+    monkeypatch.setattr(beim, "clone_agent_repo", fake_clone)
+
+    backend = (
+        _local_backend(tmp_path)
+        if backend_factory == "local"
+        else RemoteExperimentalistBackend(client=None, path=tmp_path / "backend")  # type: ignore[arg-type]
+    )
+    spec = "ssh://git@h/g/r.git@main"
+    dest = tmp_path / "agent-src"
+
+    source = asyncio.run(backend.get_agent_code(workspace="w", agent=spec, dest=dest))
+    assert source == AgentSource(repo_url="ssh://git@h/g/r.git", ref="main")
+    assert calls == [(spec, dest)]
+
+
+async def test_get_agent_code_git_preserves_owned_clone_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    message = "git clone failed for https://***@gitlab.com/org/repo.git (exit status 128)"
+    failure = AgentCloneError(message)
+
+    def fail_clone(spec: str, *_args, **_kwargs) -> AgentSource:  # noqa: ANN002, ANN003
+        raise failure
+
+    monkeypatch.setattr(beim, "clone_agent_repo", fail_clone)
+
+    with pytest.raises(AgentCloneError) as exc_info:
+        await _local_backend(tmp_path).get_agent_code(
+            workspace="w",
+            agent="https://gitlab.com/org/repo.git",
+            dest=tmp_path / "dest",
+        )
+
+    assert exc_info.value is failure
+    assert str(exc_info.value) == message
+    assert exc_info.value.__cause__ is None
+
+
+async def test_get_agent_code_git_suppresses_legacy_called_process_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    failure = beim.subprocess.CalledProcessError(
+        128,
+        ["git", "clone", "command-secret"],
+        output="stdout-secret",
+        stderr="stderr-secret",
+    )
+
+    def fail_clone(spec: str, *_args, **_kwargs) -> AgentSource:  # noqa: ANN002, ANN003
+        raise failure
+
+    monkeypatch.setattr(beim, "clone_agent_repo", fail_clone)
+    secrets = ("token-user", "secret-token")
+    source = f"https://{secrets[0]}:{secrets[1]}@gitlab.com/org/repo.git@main"
+
+    with pytest.raises(ValueError) as exc_info:
+        await _local_backend(tmp_path).get_agent_code(workspace="w", agent=source, dest=tmp_path / "dest")
+
+    formatted = "".join(traceback.format_exception(exc_info.value))
+    assert str(exc_info.value) == "failed to fetch --agent 'https://***@gitlab.com/org/repo.git'"
+    assert not any(secret in formatted for secret in (*secrets, "command-secret", "stdout-secret", "stderr-secret"))
+    assert exc_info.value.__cause__ is None
+
+
+async def test_get_agent_code_remote_nongit_raises(tmp_path: Path) -> None:
+    backend = RemoteExperimentalistBackend(client=None, path=tmp_path / "backend")  # type: ignore[arg-type]
+    with pytest.raises(NotImplementedError):
+        await backend.get_agent_code(workspace="w", agent="some-live-agent-name", dest=tmp_path / "d")
+
+
+# ---------------------------------------------------------------------------
+# get_agent_spec — local path copies to dest and returns dest
+# ---------------------------------------------------------------------------
+
+
+async def test_get_agent_spec_local_copies_to_dest_and_returns_dest(tmp_path: Path) -> None:
+    spec_file = tmp_path / "AGENT-SPEC.md"
+    spec_file.write_text("# My Agent\nDoes things.\n")
+    dest = tmp_path / "workspace" / "AGENT-SPEC.md"
+
+    result = await _local_backend(tmp_path).get_agent_spec(workspace="w", spec=str(spec_file), dest=dest)
+
+    assert result == dest
+    assert dest.read_text() == "# My Agent\nDoes things.\n"
+
+
+async def test_get_agent_spec_local_missing_raises(tmp_path: Path) -> None:
+    dest = tmp_path / "workspace" / "AGENT-SPEC.md"
+    with pytest.raises(FileNotFoundError, match="Agent spec not found"):
+        await _local_backend(tmp_path).get_agent_spec(workspace="w", spec=str(tmp_path / "nonexistent.md"), dest=dest)
+
+
+async def test_get_agent_spec_directory_raises(tmp_path: Path) -> None:
+    dest = tmp_path / "workspace" / "AGENT-SPEC.md"
+    with pytest.raises(FileNotFoundError, match="Agent spec not found"):
+        await _local_backend(tmp_path).get_agent_spec(workspace="w", spec=str(tmp_path), dest=dest)
+
+
+async def test_get_agent_spec_remote_delegates_to_files(tmp_path: Path) -> None:
+    spec_file = tmp_path / "AGENT-SPEC.md"
+    spec_file.write_text("# Remote Agent\n")
+    dest = tmp_path / "workspace" / "AGENT-SPEC.md"
+    backend = RemoteExperimentalistBackend(client=None, path=tmp_path / "backend")  # type: ignore[arg-type]
+
+    result = await backend.get_agent_spec(workspace="w", spec=str(spec_file), dest=dest)
+
+    assert result == dest
+    assert dest.read_text() == "# Remote Agent\n"
+
+
+# ---------------------------------------------------------------------------
+# archive_candidate / publish_candidate — clean (workspace, candidate) verbs.
+# The backend derives branch/base_ref/agent_path/title/body from the captured git
+# provenance + storage config; the git/subprocess boundary (PRPublisher) is stubbed.
+# ---------------------------------------------------------------------------
+
+
+def _cand(label: str = "agent-2", run_id: str = "run-1") -> Candidate:
+    return Candidate(name=label, label=label, run_id=run_id, round=1, optimization="edit")
+
+
+def _git_backend(tmp_path: Path, storage: CandidateStorageConfig | None = None) -> LocalExperimentalistBackend:
+    backend = LocalExperimentalistBackend(path=tmp_path / "backend", storage=storage)
+    backend._agent_source = AgentSource(repo_url="ssh://git@h/g/r.git", ref="main", agent_path="pkg/agent")
+    backend._agent_checkout = tmp_path / "clone"
+    return backend
+
+
+async def test_archive_candidate_git_pushes_and_records_source_link(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _StubPublisher:
+        def __init__(self, *, agent_dir: Path) -> None:
+            captured["agent_dir"] = agent_dir
+
+        def push_branch(self, *, src_dir, branch, base_ref, message, agent_path="."):  # noqa: ANN001, ANN202
+            captured.update(branch=branch, base_ref=base_ref, agent_path=agent_path)
+            return True
+
+    monkeypatch.setattr(beim, "PRPublisher", _StubPublisher)
+    backend = _git_backend(tmp_path, CandidateStorageConfig(candidate_branch_prefix="optimizer"))
+
+    # Clean verb: only (workspace, candidate); branch/base_ref/agent_path are derived internally.
+    link = await backend.archive_candidate(workspace="w", candidate=_cand())
+    assert captured == {
+        "agent_dir": tmp_path / "clone",
+        "branch": "optimizer/run-1/agent-2",
+        "base_ref": "main",
+        "agent_path": "pkg/agent",
+    }
+    assert link == "ssh://git@h/g/r.git@optimizer/run-1/agent-2"
+    # The link is recorded so re-projection surfaces the real branch, not the pseudo placeholder.
+    assert backend._candidate_source_links["agent-2"] == link
+
+
+async def test_publish_candidate_git_delegates_and_stashes_pr_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _StubPublisher:
+        def __init__(self, *, agent_dir: Path) -> None:
+            captured["agent_dir"] = agent_dir
+
+        def publish(
+            self, *, winner_dir, branch, base_ref, title, body, draft, agent_path, base_branch_override, labels
+        ):  # noqa: ANN001, ANN202
+            captured.update(branch=branch, base_ref=base_ref, agent_path=agent_path, draft=draft, labels=labels)
+            return "https://gitlab.example.com/g/r/-/merge_requests/7"
+
+    monkeypatch.setattr(beim, "PRPublisher", _StubPublisher)
+    storage = CandidateStorageConfig(candidate_branch_prefix="optimizer", pr_draft=False, pr_labels=["opt"])
+    backend = _git_backend(tmp_path, storage)
+
+    url = await backend.publish_candidate(workspace="w", candidate=_cand(label="agent-1"))
+    assert url == "https://gitlab.example.com/g/r/-/merge_requests/7"
+    assert captured["branch"] == "optimizer/run-1/agent-1" and captured["base_ref"] == "main"
+    assert captured["agent_path"] == "pkg/agent" and captured["draft"] is False and captured["labels"] == ["opt"]
+    # PR URL stashed so the mirror's finalize() records it on the winner's Experiment source_link.
+    assert backend._pr_url == url
+
+
+async def test_archive_and_publish_noop_for_non_git_source(tmp_path: Path) -> None:
+    # No captured git source (local agent) -> both verbs no-op returning None.
+    backend = _local_backend(tmp_path)
+    assert await backend.archive_candidate(workspace="w", candidate=_cand()) is None
+    assert await backend.publish_candidate(workspace="w", candidate=_cand()) is None
+
+
+async def test_persist_result_writes_run_summary(tmp_path: Path) -> None:
+    # persist_result must write result.summary into run.json, else publish_candidate's
+    # _compose_pr_body falls back to "Experimentalist run complete." instead of the real summary.
+    from nemo_experimentalist_plugin.entities import ExperimentRun
+    from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
+
+    backend = _local_backend(tmp_path)
+    run = ExperimentRun(workspace="w", agent="a")
+    run._id = "run-1"  # type: ignore[attr-defined]
+    (backend._eo / "run.json").write_text(run.model_dump_json(indent=2))
+
+    result = ExperimentalistResult(summary="the real run summary", run_id="run-1", rounds_completed=2, winner=None)
+    await backend.persist_result(workspace="w", result=result)
+
+    saved = json.loads((backend._eo / "run.json").read_text())
+    assert saved["summary"] == "the real run summary"
+
+
+# ---------------------------------------------------------------------------
+# persist_evaluation
+# ---------------------------------------------------------------------------
+
+
+async def test_remote_forwards_to_local(tmp_path: Path) -> None:
+    """Remote delegates persist_evaluation verbatim to its local file backend."""
+    backend = RemoteExperimentalistBackend(client=None, path=tmp_path / "backend")  # type: ignore[arg-type]
+    delegate = AsyncMock()
+    backend._files.persist_evaluation = delegate
+    result = EvaluationResult(id="r1")
+    candidate = _cand()
+
+    await backend.persist_evaluation(workspace="w", result=result, candidate=candidate, split="train")
+
+    delegate.assert_called_once_with(workspace="w", result=result, candidate=candidate, split="train")

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_benchmark.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_benchmark.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import (
+    EvaluationResult,
+    MetricResult,
+    ResourceRef,
+    TrialResult,
+)
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+BENCHMARK_ROOT = PLUGIN_ROOT / "benchmarks"
+
+
+def _load_runner() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("canonical_benchmark_runner", BENCHMARK_ROOT / "run.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_shipped_suite_covers_canonical_count_and_fast_subset() -> None:
+    runner = _load_runner()
+    suite = runner.load_suite(BENCHMARK_ROOT / "suites" / "terminal-bench-2.1.yaml")
+    canonical_ids = set(suite.partitions.quality.all_ids())
+
+    runner.validate_canonical_suite(
+        suite,
+        canonical_task_ids=canonical_ids,
+        resolved_ref=suite.dataset.resolved_ref,
+    )
+
+    assert len(suite.partitions.quality.train) == 38
+    assert len(suite.partitions.quality.validation) == 25
+    assert len(suite.partitions.quality.test) == 26
+    assert len(suite.partitions.fast.train) == 35
+    assert len(suite.partitions.fast.validation) == 12
+    assert len(suite.partitions.fast.test) == 12
+    assert "install-windows-3.11" in canonical_ids
+    assert "install-windows-3-11" not in canonical_ids
+
+
+@pytest.mark.parametrize("name", ["smoke.yaml", "quality.yaml"])
+def test_shipped_benchmark_configs_use_current_contracts(name: str) -> None:
+    runner = _load_runner()
+
+    config = runner.load_benchmark_config(BENCHMARK_ROOT / "configs" / name)
+
+    assert config.optimizer.evaluator["n_attempts"] >= 1
+    assert config.optimizer.eval_author.max_validation_repair_attempts >= 0
+
+
+def test_suite_validation_rejects_changed_dataset_revision() -> None:
+    runner = _load_runner()
+    suite = runner.load_suite(BENCHMARK_ROOT / "suites" / "terminal-bench-2.1.yaml")
+
+    with pytest.raises(ValueError, match="resolved to"):
+        runner.validate_canonical_suite(
+            suite,
+            canonical_task_ids=set(suite.partitions.quality.all_ids()),
+            resolved_ref="sha256:changed",
+        )
+
+
+def test_evaluation_summary_counts_errors_and_missing_trials_as_zero(tmp_path: Path) -> None:
+    runner = _load_runner()
+    result_path = tmp_path / "result.json"
+    result_path.write_text(
+        json.dumps(
+            {
+                "agent_result": {
+                    "n_input_tokens": 10,
+                    "n_cache_tokens": 2,
+                    "n_output_tokens": 4,
+                    "cost_usd": 0.25,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = EvaluationResult(
+        id="heldout",
+        trials=[
+            TrialResult(
+                id="task-a__0",
+                task_id="task-a",
+                attempt=0,
+                status="completed",
+                metrics={"reward": MetricResult(name="reward", value=1.0)},
+                resources={"result": ResourceRef(uri=result_path.as_uri())},
+            ),
+            TrialResult(
+                id="task-b__0",
+                task_id="task-b",
+                attempt=0,
+                status="failed",
+                metrics={},
+                error={"type": "RuntimeError", "message": "failed"},
+            ),
+        ],
+    )
+
+    summary = runner.summarize_evaluation(result, task_count=3, attempts=1)
+
+    assert summary["expected_trials"] == 3
+    assert summary["observed_trials"] == 2
+    assert summary["missing_trials"] == 1
+    assert summary["mean_reward_over_expected"] == pytest.approx(1 / 3)
+    assert summary["harness_error_count"] == 2
+    assert summary["tokens"] == {"input_tokens": 10, "cache_tokens": 2, "output_tokens": 4}
+    assert summary["cost_usd"] == 0.25
+
+
+def test_optimizer_job_summary_reports_full_trial_and_usage_totals(tmp_path: Path) -> None:
+    runner = _load_runner()
+    for name, trials, errors, tokens in (
+        ("agent-0-train", 4, 1, 100),
+        ("agent-1-validation", 2, 0, 50),
+    ):
+        job_dir = tmp_path / name
+        job_dir.mkdir()
+        (job_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "n_total_trials": trials,
+                    "stats": {
+                        "n_completed_trials": trials,
+                        "n_errored_trials": errors,
+                        "n_input_tokens": tokens,
+                        "n_cache_tokens": tokens // 2,
+                        "n_output_tokens": tokens // 4,
+                        "cost_usd": 0.1,
+                        "evals": {"agent__dataset": {"metrics": [{"mean": 0.5}]}},
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    summary = runner.summarize_experimentalist_jobs(tmp_path)
+
+    assert summary["jobs"] == 2
+    assert summary["trials"] == 6
+    assert summary["errored_trials"] == 1
+    assert summary["input_tokens"] == 150
+    assert summary["cost_usd"] == pytest.approx(0.2)
+    assert len(summary["job_results"]) == 2

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_run.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_run.py
@@ -1,0 +1,259 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, cast
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist import run as experimentalist_run
+from nemo_experimentalist_plugin.experimentalist.components import loop as loop_module
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import DatasetRef
+from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizerConfig
+from nemo_experimentalist_plugin.experimentalist.deps import ExperimentalistDeps
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
+from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
+from nemo_platform import AsyncNeMoPlatform
+
+
+@dataclass
+class ClosingClient:
+    closed: bool = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@dataclass
+class ExperimentRunPaths:
+    agent: Path
+    train: Path
+    validation: Path
+    experiment: Path
+
+
+@dataclass
+class BackendFactoryCall:
+    client: ClosingClient | None
+    experiments_output: str
+    mode: Literal["local", "remote"]
+
+
+@dataclass
+class AgentFactoryCall:
+    working_dir: Path
+    config: EvolutionaryOptimizerConfig
+
+
+@dataclass
+class FakeExperimentalist:
+    deps: ExperimentalistDeps | None = None
+
+    async def run(self, deps: ExperimentalistDeps) -> ExperimentalistResult:
+        self.deps = deps
+        return ExperimentalistResult(summary="optimization complete", run_id="run-1", rounds_completed=1)
+
+
+def test_persistence_warning_includes_exception_message(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.WARNING, logger=loop_module.__name__)
+
+    loop_module._warn_persistence_failure("archive", "agent-2", RuntimeError("push rejected by remote"))
+
+    assert "archive" in caplog.text
+    assert "agent-2" in caplog.text
+    assert "push rejected by remote" in caplog.text
+
+
+def _make_run_paths(tmp_path: Path) -> ExperimentRunPaths:
+    agent = tmp_path / "agent"
+    train = tmp_path / "train"
+    validation = tmp_path / "validation"
+    for path in (agent, train, validation):
+        path.mkdir()
+    return ExperimentRunPaths(
+        agent=agent,
+        train=train,
+        validation=validation,
+        experiment=tmp_path / "experiment",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_experimentalist_builds_and_runs_complete_local_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    paths = _make_run_paths(tmp_path)
+    client = ClosingClient()
+    backend = LocalExperimentalistBackend(path=tmp_path / "backend")
+    optimizer_config = EvolutionaryOptimizerConfig(max_rounds=2)
+    experimentalist = FakeExperimentalist()
+    backend_calls: list[BackendFactoryCall] = []
+    agent_calls: list[AgentFactoryCall] = []
+    litellm_calls: list[bool] = []
+
+    def make_backend(
+        *,
+        client: ClosingClient | None,
+        experiments_output: str,
+        mode: Literal["local", "remote"],
+        storage: object = None,
+    ) -> LocalExperimentalistBackend:
+        backend_calls.append(
+            BackendFactoryCall(
+                client=client,
+                experiments_output=experiments_output,
+                mode=mode,
+            )
+        )
+        return backend
+
+    def build_agent(
+        *, working_dir: Path, config: EvolutionaryOptimizerConfig, framework_skills_dirs: list[Path] | None
+    ) -> FakeExperimentalist:
+        assert framework_skills_dirs is None
+        agent_calls.append(AgentFactoryCall(working_dir=working_dir, config=config))
+        return experimentalist
+
+    monkeypatch.setattr(experimentalist_run, "make_experimentalist_backend", make_backend)
+    monkeypatch.setattr(experimentalist_run, "build_experimentalist_agent", build_agent)
+    monkeypatch.setattr(experimentalist_run, "_enable_litellm_drop_params", lambda: litellm_calls.append(True))
+
+    train_dataset = DatasetRef(uri=str(paths.train))
+    validation_dataset = DatasetRef(uri=str(paths.validation))
+
+    summary = await experimentalist_run.run_experimentalist(
+        agent=paths.agent,
+        insight=None,
+        train_dataset=train_dataset,
+        validation_dataset=validation_dataset,
+        experiment_dir=paths.experiment,
+        workspace="workspace-a",
+        client=cast(AsyncNeMoPlatform, client),
+        config=optimizer_config,
+        mode="local",
+    )
+
+    assert summary == "optimization complete"
+    assert paths.experiment.is_dir()
+    assert backend_calls == [
+        BackendFactoryCall(
+            client=client,
+            experiments_output=str(paths.experiment.resolve()),
+            mode="local",
+        )
+    ]
+    assert agent_calls == [AgentFactoryCall(working_dir=paths.experiment.resolve(), config=optimizer_config)]
+    assert litellm_calls == [True]
+    assert not client.closed
+    assert experimentalist.deps is not None
+    assert experimentalist.deps.workspace == "workspace-a"
+    # ``agent`` is forwarded verbatim (it may be a git url@ref); the loop resolves it.
+    assert experimentalist.deps.agent == paths.agent
+    assert experimentalist.deps.insight is None
+    assert experimentalist.deps.train_dataset == train_dataset
+    assert experimentalist.deps.validation_dataset == validation_dataset
+    assert experimentalist.deps.backend is backend
+    assert experimentalist.deps.config is optimizer_config
+    assert experimentalist.deps.agent_spec is None
+
+
+@pytest.mark.asyncio
+async def test_run_experimentalist_forwards_platform_insight_id_verbatim(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    paths = _make_run_paths(tmp_path)
+    client = ClosingClient()
+    backend = LocalExperimentalistBackend(path=tmp_path / "backend")
+    experimentalist = FakeExperimentalist()
+
+    monkeypatch.setattr(
+        experimentalist_run,
+        "make_experimentalist_backend",
+        lambda **_: backend,
+    )
+    monkeypatch.setattr(
+        experimentalist_run,
+        "build_experimentalist_agent",
+        lambda **_: experimentalist,
+    )
+    monkeypatch.setattr(experimentalist_run, "_enable_litellm_drop_params", lambda: None)
+
+    await experimentalist_run.run_experimentalist(
+        insight="insight-remote-123",
+        train_dataset=DatasetRef(uri=str(paths.train)),
+        validation_dataset=DatasetRef(uri=str(paths.validation)),
+        task_template=DatasetRef(uri=str(paths.train)),
+        experiment_dir=paths.experiment,
+        workspace="workspace-a",
+        client=cast(AsyncNeMoPlatform, client),
+        config=EvolutionaryOptimizerConfig(),
+        mode="remote",
+    )
+
+    assert experimentalist.deps is not None
+    # A str id is not resolved to a Path — it flows through untouched to the backend.
+    assert experimentalist.deps.insight == "insight-remote-123"
+
+
+@pytest.mark.asyncio
+async def test_run_experimentalist_forwards_agent_spec_uri_to_deps(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    paths = _make_run_paths(tmp_path)
+    backend = LocalExperimentalistBackend(path=tmp_path / "backend")
+    experimentalist = FakeExperimentalist()
+
+    monkeypatch.setattr(experimentalist_run, "make_experimentalist_backend", lambda **_: backend)
+    monkeypatch.setattr(experimentalist_run, "build_experimentalist_agent", lambda **_: experimentalist)
+    monkeypatch.setattr(experimentalist_run, "_enable_litellm_drop_params", lambda: None)
+
+    spec_uri = "/path/to/AGENT-SPEC.md"
+    await experimentalist_run.run_experimentalist(
+        agent=paths.agent,
+        agent_spec=spec_uri,
+        insight=None,
+        train_dataset=DatasetRef(uri=str(paths.train)),
+        validation_dataset=DatasetRef(uri=str(paths.validation)),
+        experiment_dir=paths.experiment,
+        workspace="default",
+        client=None,
+        config=EvolutionaryOptimizerConfig(),
+    )
+
+    assert experimentalist.deps is not None
+    assert experimentalist.deps.agent_spec == spec_uri
+
+
+@pytest.mark.asyncio
+async def test_run_experimentalist_does_not_close_caller_client_when_backend_creation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    paths = _make_run_paths(tmp_path)
+    client = ClosingClient()
+
+    def fail_backend_creation(**_: object) -> object:
+        raise RuntimeError("backend creation failed")
+
+    monkeypatch.setattr(experimentalist_run, "make_experimentalist_backend", fail_backend_creation)
+
+    with pytest.raises(RuntimeError, match="backend creation failed"):
+        await experimentalist_run.run_experimentalist(
+            agent=paths.agent,
+            insight=None,
+            train_dataset=DatasetRef(uri=str(paths.train)),
+            validation_dataset=DatasetRef(uri=str(paths.validation)),
+            experiment_dir=paths.experiment,
+            workspace="default",
+            client=cast(AsyncNeMoPlatform, client),
+            config=EvolutionaryOptimizerConfig(),
+            mode="remote",
+        )
+
+    assert not client.closed

--- a/plugins/nemo-experimentalist/tests/test_local_backend_projection.py
+++ b/plugins/nemo-experimentalist/tests/test_local_backend_projection.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""LocalExperimentalistBackend's best-effort projection onto native platform Experiments.
+
+The projection is active only when the backend has a platform client (the real-world
+local-mode-with-a-live-platform run); without a client it is a no-op. A projection failure
+must never fail the run or the local-file persistence (spec §3 / F).
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
+from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
+
+pytestmark = pytest.mark.asyncio
+
+
+def _run() -> ExperimentRun:
+    return ExperimentRun(workspace="default", agent="a", config_snapshot={}, status="running", rounds_completed=0)
+
+
+async def test_no_projection_without_client(tmp_path: Path) -> None:
+    # No platform client → projection is a no-op; local files still written, no mirror built.
+    be = LocalExperimentalistBackend(client=None, path=tmp_path)
+    out = await be.create_run(workspace="default", run=_run())
+    assert out.id
+    assert (tmp_path / "eval-and-optimize" / "run.json").exists()
+    assert be._mirrors == {}  # never constructed a mirror
+
+
+async def test_create_run_projects_when_client_present(tmp_path: Path) -> None:
+    # A platform client is present → create_run best-effort projects (ensure_group).
+    be = LocalExperimentalistBackend(client=SimpleNamespace(), path=tmp_path)
+    be._mirrors["default"] = AsyncMock()  # injected so no real SDK call is made
+    await be.create_run(workspace="default", run=_run())
+    be._mirrors["default"].ensure_group.assert_awaited_once()
+    assert (tmp_path / "eval-and-optimize" / "run.json").exists()
+
+
+async def test_create_candidate_projects_when_client_present(tmp_path: Path) -> None:
+    be = LocalExperimentalistBackend(client=SimpleNamespace(), path=tmp_path)
+    be._mirrors["default"] = AsyncMock()
+    await be.create_candidate(
+        workspace="default",
+        candidate=Candidate(run_id="run-1", label="agent-0", round=0, optimization="baseline"),
+    )
+    be._mirrors["default"].project_candidate.assert_awaited_once()
+
+
+async def test_persist_result_projects_finalize(tmp_path: Path) -> None:
+    be = LocalExperimentalistBackend(client=SimpleNamespace(), path=tmp_path)
+    be._mirrors["default"] = AsyncMock()
+    await be.persist_result(
+        workspace="default",
+        result=ExperimentalistResult(summary="done", run_id="run-1", rounds_completed=1, winner=None),
+    )
+    be._mirrors["default"].finalize.assert_awaited_once()
+
+
+async def test_projection_failure_is_swallowed(tmp_path: Path) -> None:
+    # A projection failure must never fail the run or the local-file write.
+    class _BoomMirror:
+        async def ensure_group(self, _run: ExperimentRun) -> None:
+            raise RuntimeError("platform down")
+
+    be = LocalExperimentalistBackend(client=SimpleNamespace(), path=tmp_path)
+    be._mirrors["default"] = _BoomMirror()
+    out = await be.create_run(workspace="default", run=_run())  # must NOT raise
+    assert out.id
+    assert (tmp_path / "eval-and-optimize" / "run.json").exists()

--- a/plugins/nemo-experimentalist/tests/test_otlp.py
+++ b/plugins/nemo-experimentalist/tests/test_otlp.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Behavioral tests for the OTLP JSONL <-> protobuf helpers.
+
+Everything is asserted through observable output — the trace id string or a
+parsed ``ExportTraceServiceRequest`` — never through private helpers, so these
+pin the module's contract rather than its implementation.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components.evaluator import ResourceRef
+from nemo_experimentalist_plugin.experimentalist.otlp import (
+    jsonl_to_protobuf,
+    read_trace_id,
+    spans_to_protobuf,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+TRACE_HEX = "769b36252e9284e8a0329643dafcbe68"  # 32 hex chars = 16 bytes
+SPAN_HEX = "97f23312b666e0bc"  # 16 hex chars = 8 bytes
+PARENT_HEX = "aaaaaaaaaaaaaaaa"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _ref(path: Path) -> ResourceRef:
+    return ResourceRef(uri=f"file://{path}", description="", metadata={})
+
+
+def _write(path: Path, *lines: dict) -> Path:
+    path.write_text("\n".join(json.dumps(line) for line in lines))
+    return path
+
+
+def _merge(payloads: list[bytes]) -> ExportTraceServiceRequest:
+    """Concatenate chunked payloads back into one request (proto repeated-field merge)."""
+    req = ExportTraceServiceRequest()
+    req.ParseFromString(b"".join(payloads))
+    return req
+
+
+def _all_spans(req: ExportTraceServiceRequest) -> list:
+    return [sp for rs in req.resource_spans for ss in rs.scope_spans for sp in ss.spans]
+
+
+def _resource_attrs(rs) -> dict:
+    return {a.key: a.value for a in rs.resource.attributes}
+
+
+def _span_row(**overrides) -> dict:
+    row = {"trace_id": TRACE_HEX, "span_id": SPAN_HEX}
+    row.update(overrides)
+    return row
+
+
+# ---------------------------------------------------------------------------
+# read_trace_id
+# ---------------------------------------------------------------------------
+
+
+def test_read_trace_id_returns_first_span_hex(tmp_path):
+    p = _write(tmp_path / "t.jsonl", {"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": TRACE_HEX}]}]}]})
+    assert read_trace_id(_ref(p)) == TRACE_HEX
+
+
+def test_read_trace_id_skips_blank_lines_and_takes_first(tmp_path):
+    first_hex = "a" * 32
+    second_hex = "b" * 32
+    first = {"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": first_hex}]}]}]}
+    second = {"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": second_hex}]}]}]}
+    p = tmp_path / "t.jsonl"
+    p.write_text(f"\n\n{json.dumps(first)}\n\n{json.dumps(second)}\n")
+    assert read_trace_id(_ref(p)) == first_hex
+
+
+def test_read_trace_id_scans_across_nested_lists(tmp_path):
+    line = {
+        "resourceSpans": [
+            {"scopeSpans": [{"spans": [{"spanId": "no-trace-here"}]}]},
+            {"scopeSpans": [{"spans": [{}, {"traceId": TRACE_HEX}]}]},
+        ]
+    }
+    p = _write(tmp_path / "t.jsonl", line)
+    assert read_trace_id(_ref(p)) == TRACE_HEX
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        {"resourceSpans": [{"scopeSpans": [{"spans": [{"spanId": "1234567890"}]}]}]},  # no traceId
+        {"resourceSpans": []},  # no spans at all
+    ],
+)
+def test_read_trace_id_raises_when_absent(tmp_path, line):
+    p = _write(tmp_path / "t.jsonl", line)
+    with pytest.raises(ValueError, match="No traceId"):
+        read_trace_id(_ref(p))
+
+
+def test_read_trace_id_raises_on_empty_file(tmp_path):
+    p = tmp_path / "empty.jsonl"
+    p.write_text("")
+    with pytest.raises(ValueError, match="No traceId"):
+        read_trace_id(_ref(p))
+
+
+# ---------------------------------------------------------------------------
+# jsonl_to_protobuf
+# ---------------------------------------------------------------------------
+
+
+def test_jsonl_hex_ids_become_bytes(tmp_path):
+    p = _write(
+        tmp_path / "t.jsonl",
+        {"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": TRACE_HEX, "spanId": SPAN_HEX}]}]}]},
+    )
+    (sp,) = _all_spans(_merge(jsonl_to_protobuf(p, {})))
+    assert sp.trace_id.hex() == TRACE_HEX
+    assert sp.span_id.hex() == SPAN_HEX
+
+
+def test_jsonl_parent_span_hex_becomes_bytes(tmp_path):
+    p = _write(
+        tmp_path / "t.jsonl",
+        {"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": TRACE_HEX, "parentSpanId": PARENT_HEX}]}]}]},
+    )
+    (sp,) = _all_spans(_merge(jsonl_to_protobuf(p, {})))
+    assert sp.parent_span_id.hex() == PARENT_HEX
+
+
+def test_jsonl_injects_extra_resource_attrs(tmp_path):
+    p = _write(tmp_path / "t.jsonl", {"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": TRACE_HEX}]}]}]})
+    req = _merge(jsonl_to_protobuf(p, {"nemo.experiment.id": "exp-1", "nemo.trial.id": "t1"}))
+    attrs = _resource_attrs(req.resource_spans[0])
+    assert attrs["nemo.experiment.id"].string_value == "exp-1"
+    assert attrs["nemo.trial.id"].string_value == "t1"
+
+
+def test_jsonl_preserves_existing_resource_attrs(tmp_path):
+    line = {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": [{"key": "hostname", "value": {"stringValue": "h1"}}]},
+                "scopeSpans": [{"spans": [{"traceId": TRACE_HEX}]}],
+            }
+        ]
+    }
+    p = _write(tmp_path / "t.jsonl", line)
+    attrs = _resource_attrs(_merge(jsonl_to_protobuf(p, {"nemo.experiment.id": "exp-1"})).resource_spans[0])
+    assert attrs["hostname"].string_value == "h1"  # original kept
+    assert attrs["nemo.experiment.id"].string_value == "exp-1"  # new added
+
+
+def test_jsonl_extra_attr_overrides_duplicate_key(tmp_path):
+    line = {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": [{"key": "nemo.experiment.id", "value": {"stringValue": "old"}}]},
+                "scopeSpans": [{"spans": [{"traceId": TRACE_HEX}]}],
+            }
+        ]
+    }
+    p = _write(tmp_path / "t.jsonl", line)
+    rs = _merge(jsonl_to_protobuf(p, {"nemo.experiment.id": "new"})).resource_spans[0]
+    keys = [a.key for a in rs.resource.attributes]
+    assert keys.count("nemo.experiment.id") == 1  # not duplicated
+    assert _resource_attrs(rs)["nemo.experiment.id"].string_value == "new"  # overridden
+
+
+def test_jsonl_chunks_split_and_merge_back(tmp_path):
+    lines = [
+        {"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": TRACE_HEX, "spanId": format(i, "016x")}]}]}]}
+        for i in range(5)
+    ]
+    p = _write(tmp_path / "t.jsonl", *lines)
+    payloads = jsonl_to_protobuf(p, {}, max_bytes=1)  # force one resourceSpans per payload
+    assert len(payloads) == 5
+    assert len(_all_spans(_merge(payloads))) == 5  # nothing lost on split
+
+
+def test_jsonl_empty_file_yields_no_payloads(tmp_path):
+    p = tmp_path / "empty.jsonl"
+    p.write_text("")
+    assert jsonl_to_protobuf(p, {"nemo.experiment.id": "exp-1"}) == []
+
+
+# ---------------------------------------------------------------------------
+# spans_to_protobuf
+# ---------------------------------------------------------------------------
+
+
+def test_spans_builds_valid_protobuf_with_ids_and_name():
+    (sp,) = _all_spans(_merge(spans_to_protobuf([_span_row(name="root")], {})))
+    assert sp.trace_id.hex() == TRACE_HEX
+    assert sp.span_id.hex() == SPAN_HEX
+    assert sp.name == "root"
+
+
+def test_spans_injects_resource_attrs():
+    req = _merge(spans_to_protobuf([_span_row()], {"nemo.experiment.id": "exp-42", "nemo.test_case.id": "task1"}))
+    attrs = _resource_attrs(req.resource_spans[0])
+    assert attrs["nemo.experiment.id"].string_value == "exp-42"
+    assert attrs["nemo.test_case.id"].string_value == "task1"
+
+
+def test_spans_preserves_raw_attributes_from_json_string():
+    row = _span_row(raw_attributes=json.dumps({"gen_ai.system": "openai", "llm.token_count.total": 42}))
+    (sp,) = _all_spans(_merge(spans_to_protobuf([row], {})))
+    span_attrs = {a.key: a.value for a in sp.attributes}
+    assert span_attrs["gen_ai.system"].string_value == "openai"
+    assert span_attrs["llm.token_count.total"].int_value == 42
+
+
+def test_spans_accepts_raw_attributes_as_dict():
+    (sp,) = _all_spans(_merge(spans_to_protobuf([_span_row(raw_attributes={"k": "v"})], {})))
+    assert {a.key: a.value.string_value for a in sp.attributes}["k"] == "v"
+
+
+def test_spans_renders_each_attr_value_type():
+    row = _span_row(raw_attributes={"b": True, "i": 7, "f": 1.5, "s": "x", "obj": {"n": 1}})
+    (sp,) = _all_spans(_merge(spans_to_protobuf([row], {})))
+    d = {a.key: a.value for a in sp.attributes}
+    assert d["b"].bool_value is True
+    assert d["i"].int_value == 7
+    assert d["f"].double_value == 1.5
+    assert d["s"].string_value == "x"
+    assert json.loads(d["obj"].string_value) == {"n": 1}  # non-scalar -> JSON string
+
+
+def test_spans_invalid_raw_attributes_string_ignored():
+    (sp,) = _all_spans(_merge(spans_to_protobuf([_span_row(raw_attributes="{not json")], {})))
+    assert list(sp.attributes) == []
+
+
+def test_spans_iso_timestamp_converted_to_unix_nano():
+    row = _span_row(started_at="2026-01-01T00:00:00+00:00", ended_at="2026-01-01T00:00:01+00:00")
+    (sp,) = _all_spans(_merge(spans_to_protobuf([row], {})))
+    base = int(datetime(2026, 1, 1, tzinfo=timezone.utc).timestamp() * 1_000_000_000)
+    assert sp.start_time_unix_nano == base
+    assert sp.end_time_unix_nano == base + 1_000_000_000
+
+
+def test_spans_z_suffix_timestamp_equivalent_to_offset():
+    z = _all_spans(_merge(spans_to_protobuf([_span_row(started_at="2026-01-01T00:00:00Z")], {})))[0]
+    offset = _all_spans(_merge(spans_to_protobuf([_span_row(started_at="2026-01-01T00:00:00+00:00")], {})))[0]
+    assert z.start_time_unix_nano == offset.start_time_unix_nano
+
+
+def test_spans_epoch_number_timestamp_passthrough():
+    (sp,) = _all_spans(_merge(spans_to_protobuf([_span_row(started_at=1767225600000000000)], {})))
+    assert sp.start_time_unix_nano == 1767225600000000000
+
+
+def test_spans_unparseable_timestamp_is_omitted():
+    (sp,) = _all_spans(_merge(spans_to_protobuf([_span_row(started_at="not-a-date")], {})))
+    assert sp.start_time_unix_nano == 0  # field left unset
+
+
+def test_spans_parent_span_id_hex_becomes_bytes():
+    (sp,) = _all_spans(_merge(spans_to_protobuf([_span_row(parent_span_id=PARENT_HEX)], {})))
+    assert sp.parent_span_id.hex() == PARENT_HEX
+
+
+def test_spans_accepts_camelcase_intake_keys():
+    row = {"traceId": TRACE_HEX, "spanId": SPAN_HEX, "parentSpanId": PARENT_HEX, "startTimeUnixNano": 123}
+    (sp,) = _all_spans(_merge(spans_to_protobuf([row], {})))
+    assert sp.trace_id.hex() == TRACE_HEX
+    assert sp.parent_span_id.hex() == PARENT_HEX
+    assert sp.start_time_unix_nano == 123
+
+
+def test_spans_each_row_becomes_splittable_resource_spans():
+    rows = [_span_row(span_id=format(i, "016x")) for i in range(4)]
+    payloads = spans_to_protobuf(rows, {}, max_bytes=1)
+    assert len(payloads) == 4  # one resourceSpans per span -> one payload each under tiny budget
+    assert len(_all_spans(_merge(payloads))) == 4
+
+
+def test_spans_empty_rows_yield_no_payloads():
+    assert spans_to_protobuf([], {"nemo.experiment.id": "exp-1"}) == []

--- a/plugins/nemo-experimentalist/tests/test_preflight.py
+++ b/plugins/nemo-experimentalist/tests/test_preflight.py
@@ -1,0 +1,705 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+from pathlib import Path
+
+import nemo_experimentalist_plugin.preflight as preflight
+import pytest
+from nemo_experimentalist_plugin.preflight import (
+    Probes,
+    _default_http_ok,
+    _default_run_cmd,
+    check_artifacts,
+    check_datasets,
+    check_environment,
+    check_profile,
+)
+from nemo_experimentalist_plugin.profile import load_profile
+from nemo_insights_plugin.contracts.checks import CheckResult, required_failures
+
+
+def make_probes(*, cmd_ok: bool = True, http: bool = True, env: dict | None = None) -> Probes:
+    return Probes(
+        run_cmd=lambda argv: (0, "ok") if cmd_ok else (1, "boom"),
+        http_ok=lambda url: http,
+        env=env or {},
+    )
+
+
+def full_profile(tmp_path: Path, *, agent_source: str | None = None):
+    tt = tmp_path / "evals" / "task_template"
+    tt.mkdir(parents=True)
+    (tt / "task.toml").write_text('[task]\nname = "org/agent__template"\n', encoding="utf-8")
+    (tt / "instruction.md").write_text("do the thing", encoding="utf-8")
+    for sub in ("evals/train", "evals/val"):
+        (tmp_path / sub).mkdir(parents=True)
+    body = (
+        "agent: a\ntask_template: ./evals/task_template\ndatasets:\n  train: ./evals/train\n  validation: ./evals/val\n"
+    )
+    if agent_source is not None:
+        body += f'agent_source: "{agent_source}"\n'
+    (tmp_path / "optimizer.yaml").write_text(body, encoding="utf-8")
+    return load_profile(tmp_path / "optimizer.yaml")
+
+
+def test_preflight_results_use_shared_check_result() -> None:
+    result = check_profile(None, None)[0]
+
+    assert type(result) is CheckResult
+
+
+def test_healthy_experiment_setup_all_pass(tmp_path: Path) -> None:
+    probes = make_probes(env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"})
+    profile = full_profile(tmp_path)
+    results = (
+        check_profile(profile, None)
+        + check_environment(profile=profile, insight=None, base_url="http://localhost:8080", probes=probes)
+        + check_artifacts(profile, probes=probes)
+        + check_datasets(profile)
+    )
+    assert results and all(r.status == "pass" for r in results)
+    assert required_failures(results) == []
+
+
+def test_missing_profile_is_required_failure() -> None:
+    results = check_profile(None, None)
+    fails = required_failures(results)
+    assert any(r.group == "profile" for r in fails)
+    assert any("optimizer.yaml" in (r.hint or "") for r in fails)
+
+
+def test_bad_task_toml_fails_artifacts(tmp_path: Path) -> None:
+    profile = full_profile(tmp_path)
+    (tmp_path / "evals" / "task_template" / "task.toml").write_text('[task]\nname = "bare-name"\n', encoding="utf-8")
+    results = check_artifacts(profile, probes=make_probes())
+    assert any(r.status == "fail" and "org/name" in r.message for r in results)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        'task = "not-a-table"\n',
+        "task = []\n",
+        "[task]\nname = 42\n",
+    ],
+    ids=["scalar-task", "list-task", "non-string-name"],
+)
+def test_task_toml_schema_invalid_is_required_failure(tmp_path: Path, content: str) -> None:
+    profile = full_profile(tmp_path)
+    (tmp_path / "evals" / "task_template" / "task.toml").write_text(content, encoding="utf-8")
+
+    results = check_artifacts(profile, probes=make_probes())
+
+    task_toml = next(r for r in results if r.name == "task-toml")
+    assert task_toml.status == "fail"
+    assert task_toml.severity == "required"
+    assert "org/name" in task_toml.message
+
+
+def test_docker_down_is_required_failure(tmp_path: Path) -> None:
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=None,
+        base_url="http://x",
+        probes=make_probes(cmd_ok=False),
+    )
+    assert any(r.severity == "required" and r.status == "fail" and "docker" in r.name for r in results)
+
+
+def test_unreachable_platform_is_advisory(tmp_path: Path) -> None:
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=None,
+        base_url="http://x",
+        probes=make_probes(http=False, env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"}),
+    )
+    assert any(r.name == "platform-reachable" and r.status == "warn" for r in results)
+    assert all(r.severity == "advisory" for r in results if r.status != "pass")
+
+
+def test_environment_display_urls_are_sanitized_without_changing_probes(tmp_path: Path) -> None:
+    model_base = "https://model-user:model-secret@models.example:8443/v1"  # trufflehog:ignore
+    model_probe = f"{model_base}/models"
+    platform_base = "https://platform-user:platform-secret@platform.example:9443/api"  # trufflehog:ignore
+    probed_urls: list[str] = []
+
+    def http_ok(url: str) -> bool:
+        probed_urls.append(url)
+        return url == model_probe
+
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=None,
+        base_url=platform_base,
+        probes=Probes(
+            run_cmd=lambda argv: (0, "ok"),
+            http_ok=http_ok,
+            env={"EXPERIMENTALIST_API_BASE": model_base, "EXPERIMENTALIST_API_KEY": "k"},
+        ),
+    )
+
+    model = next(result for result in results if result.name == "model-endpoint")
+    platform = next(result for result in results if result.name == "platform-reachable")
+    assert probed_urls == [model_probe, f"{platform_base}/health/ready"]
+    assert model.message == "https://***@models.example:8443/v1/models reachable"
+    assert platform.message == "https://***@platform.example:9443/api unreachable"
+    assert not any(
+        secret in f"{model.message}\n{platform.message}"
+        for secret in ("model-user", "model-secret", "platform-user", "platform-secret")
+    )
+
+
+def test_missing_experiment_credentials_are_required(tmp_path: Path) -> None:
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=None,
+        base_url="http://x",
+        probes=make_probes(env={"EXPERIMENTALIST_API_BASE": "   "}),  # whitespace-only = unset
+    )
+    assert any(r.name == "EXPERIMENTALIST_API_BASE" and r.status == "fail" for r in results)
+    assert any(r.name == "EXPERIMENTALIST_API_KEY" and r.status == "fail" for r in results)
+    assert not any(r.name == "INFERENCE_API_KEY" for r in results)
+
+
+def test_git_source_probe_failure_is_advisory(tmp_path: Path) -> None:
+    def remote_unreachable(argv: list[str]) -> tuple[int, str]:
+        return (0, "git version 2") if argv == ["git", "--version"] else (1, "remote unavailable")
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source="https://host/g/repo.git@main"),
+        probes=Probes(run_cmd=remote_unreachable, http_ok=lambda url: True, env={}),
+    )
+    git = next(r for r in results if r.name == "agent-source-git")
+    assert git.severity == "advisory"
+    assert git.status == "warn"
+    assert "clone" in (git.hint or "")
+    assert required_failures(results) == []
+
+
+@pytest.mark.parametrize(
+    ("agent_source", "storage"),
+    [
+        ("https://host/g/repo.git@main", {}),
+        (".", {"archive_candidates": True}),
+        (".", {"publish_winner": True}),
+    ],
+    ids=["git-source", "archive", "publish"],
+)
+def test_missing_git_is_required_for_effective_source_or_storage(
+    tmp_path: Path,
+    agent_source: str,
+    storage: dict[str, bool],
+) -> None:
+    def missing_git(argv: list[str]) -> tuple[int, str]:
+        if argv == ["git", "--version"]:
+            return 127, "git not found"
+        return 0, "ok"
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source=agent_source),
+        probes=Probes(run_cmd=missing_git, http_ok=lambda url: True, env={}),
+        storage=storage,
+    )
+
+    git = next(result for result in results if result.name == "git-installed")
+    assert git.status == "fail"
+    assert git.severity == "required"
+    assert "install git" in (git.hint or "")
+
+
+def test_local_agent_source_dir_stays_required(tmp_path: Path) -> None:
+    results = check_artifacts(full_profile(tmp_path, agent_source="./no/such/dir"), probes=make_probes())
+    src = next(r for r in results if r.name == "agent-source-dir")
+    assert src.severity == "required"
+    assert src.status == "fail"
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_repo"),
+    [
+        ("https://host/g/repo.git@main#agents/x", "https://host/g/repo.git"),
+        ("ssh://git@host/g/repo.git@v1", "ssh://git@host/g/repo.git"),
+        ("https://token@host/g/repo.git", "https://token@host/g/repo.git"),
+        ("git@host:g/repo.git", "git@host:g/repo.git"),
+    ],
+)
+def test_git_repo_url_extraction(tmp_path: Path, source: str, expected_repo: str) -> None:
+    calls: list[list[str]] = []
+
+    def record(argv: list[str]) -> tuple[int, str]:
+        calls.append(list(argv))
+        return 0, "ok"
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source=source),
+        probes=Probes(run_cmd=record, http_ok=lambda url: True, env={}),
+    )
+    assert calls == [["git", "--version"], ["git", "ls-remote", expected_repo]]
+    assert all(r.status == "pass" for r in results)
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    ["pkg//agent", ":(top,glob)**", "../outside", "pkg/.GiT/hooks"],
+    ids=["malformed", "pathspec", "traversal", "git-component"],
+)
+def test_invalid_git_agent_path_is_required_failure_without_probes_or_echo(
+    tmp_path: Path,
+    fragment: str,
+) -> None:
+    calls: list[list[str]] = []
+
+    def record(argv: list[str]) -> tuple[int, str]:
+        calls.append(argv)
+        return 0, "ok"
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source=f"https://host/g/repo.git#{fragment}"),
+        probes=Probes(run_cmd=record, http_ok=lambda _url: True, env={}),
+    )
+
+    failure = next(result for result in results if result.name == "agent-source-path")
+    assert failure.status == "fail"
+    assert failure.severity == "required"
+    assert failure.message == "agent path must be a normalized relative POSIX path"
+    assert fragment not in failure.message
+    assert calls == []
+
+
+def test_default_http_ok_never_raises_on_malformed_url() -> None:
+    # "\x00" makes httpx raise InvalidURL (not an HTTPError) before any network I/O.
+    assert _default_http_ok("http://\x00/models") is False
+
+
+def test_default_run_cmd_timeout_suppresses_command_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    command = [
+        "git",
+        "ls-remote",
+        "https://token-user:command-secret@github.com/org/repo.git?query-secret#fragment-secret",  # trufflehog:ignore
+    ]
+
+    def timeout(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise preflight.subprocess.TimeoutExpired(
+            command + ["timeout-command-secret"],
+            15,
+            output="stdout-secret",
+            stderr="stderr-secret",
+        )
+
+    monkeypatch.setattr(preflight.subprocess, "run", timeout)
+
+    code, output = _default_run_cmd(command)
+
+    assert (code, output) == (124, "")
+
+
+def test_default_run_cmd_preserves_missing_executable_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise FileNotFoundError("git missing")
+
+    monkeypatch.setattr(preflight.subprocess, "run", missing)
+
+    assert _default_run_cmd(["git", "--version"]) == (127, "git missing")
+
+
+def test_git_source_probe_timeout_uses_controlled_message(tmp_path: Path) -> None:
+    source = "https://token-user:remote-secret@github.com/org/repo.git"  # trufflehog:ignore
+
+    def run_cmd(argv: list[str]) -> tuple[int, str]:
+        if argv == ["git", "--version"]:
+            return 0, "git version"
+        return 124, "child-output-secret"
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source=source),
+        probes=Probes(run_cmd=run_cmd, http_ok=lambda url: True, env={}),
+    )
+
+    failure = next(result for result in results if result.name == "agent-source-git")
+    assert failure.message == "git ls-remote timed out for https://***@github.com/org/repo.git"
+
+
+def test_unreadable_task_toml_is_required_failure(tmp_path: Path) -> None:
+    if os.geteuid() == 0:
+        pytest.skip("permission bits are ignored when running as root")
+    profile = full_profile(tmp_path)
+    toml_path = tmp_path / "evals" / "task_template" / "task.toml"
+    toml_path.chmod(0o000)
+    try:
+        results = check_artifacts(profile, probes=make_probes())
+    finally:
+        toml_path.chmod(0o644)
+    toml = next(r for r in results if r.name == "task-toml")
+    assert toml.status == "fail"
+    assert toml.severity == "required"
+    assert "Permission denied" in toml.message
+
+
+def test_invalid_utf8_task_toml_is_required_failure(tmp_path: Path) -> None:
+    profile = full_profile(tmp_path)
+    toml_path = tmp_path / "evals" / "task_template" / "task.toml"
+    toml_path.write_bytes(b"[task]\nname = \xff\n")
+
+    results = check_artifacts(profile, probes=make_probes())
+
+    toml = next(result for result in results if result.name == "task-toml")
+    assert toml.status == "fail"
+    assert toml.severity == "required"
+    assert "task.toml unreadable or does not parse" in toml.message
+    assert "readable UTF-8 TOML" in (toml.hint or "")
+
+
+def test_unreadable_insight_file_is_required_failure(tmp_path: Path) -> None:
+    if os.geteuid() == 0:
+        pytest.skip("permission bits are ignored when running as root")
+    insight = tmp_path / "insight.yaml"
+    insight.write_text("k: v\n", encoding="utf-8")
+    insight.chmod(0o000)
+    try:
+        results = check_environment(
+            profile=full_profile(tmp_path),
+            insight=str(insight),
+            base_url="http://x",
+            probes=make_probes(env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"}),
+        )
+    finally:
+        insight.chmod(0o644)
+    r = next(r for r in results if r.name == "insight-file")
+    assert r.status == "fail"
+    assert r.severity == "required"
+    assert "Permission denied" in r.message
+
+
+def test_non_json_insight_content_is_required_failure(tmp_path: Path) -> None:
+    insight = tmp_path / "insights.yaml"
+    insight.write_text(
+        "insights:\n"
+        "  - {id: good, title: Good, agent: a}\n"
+        "  - {id: dated, title: Dated, agent: a, observed_at: 2026-07-14}\n",
+        encoding="utf-8",
+    )
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=str(insight),
+        insight_id="0",
+        base_url="http://x",
+        probes=make_probes(env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"}),
+    )
+    failure = next(r for r in required_failures(results) if r.name == "insight-file")
+    assert "JSON-serializable" in failure.message
+
+
+def test_pr_cli_auth_uses_effective_storage_over_profile(tmp_path: Path) -> None:
+    # Effective (resolved) storage from the auto path wins: publish enabled via
+    # --config fires the advisory even though the profile has no experiment_config.
+    profile = full_profile(tmp_path, agent_source="https://github.com/org/repo.git")
+    results = check_artifacts(profile, probes=make_probes(cmd_ok=False), storage={"publish_winner": True})
+    auth = next(r for r in results if r.name == "pr-cli-auth")
+    assert auth.status == "warn"
+    # And the inverse: effective storage disabling publish suppresses the check
+    # even when the profile would have enabled it (storage={} beats profile flags).
+    quiet = check_artifacts(profile, probes=make_probes(cmd_ok=False), storage={"publish_winner": False})
+    assert not any(r.name == "pr-cli-auth" for r in quiet)
+
+
+def test_pr_cli_auth_reads_path_form_experiment_config(tmp_path: Path) -> None:
+    # Doctor path (no effective storage): a str-path experiment_config that
+    # enables publishing must still trigger the advisory.
+    profile = full_profile(tmp_path)
+    (tmp_path / "exp.yaml").write_text("storage:\n  publish_winner: true\n", encoding="utf-8")
+    body = (
+        "agent: a\ntask_template: ./evals/task_template\n"
+        "datasets:\n  train: ./evals/train\n  validation: ./evals/val\n"
+        'agent_source: "https://github.com/org/repo.git"\n'
+        "experiment_config: ./exp.yaml\n"
+    )
+    (tmp_path / "optimizer.yaml").write_text(body, encoding="utf-8")
+    profile = load_profile(tmp_path / "optimizer.yaml")
+    results = check_artifacts(profile, probes=make_probes(cmd_ok=False))
+    auth = next(r for r in results if r.name == "pr-cli-auth")
+    assert auth.status == "warn"
+
+
+@pytest.mark.parametrize(
+    ("source", "required_cli", "source_host", "authenticated"),
+    [
+        ("https://github.com/org/repo.git", "gh", "github.com", False),
+        (
+            "git@gitlab.example.com:org/repo.git",
+            "glab",
+            "gitlab.example.com",
+            False,
+        ),
+        ("git@github.com:org/repo.git", "gh", "github.com", True),
+        (
+            "ssh://git@gitlab.example.com:12051/org/repo.git",
+            "glab",
+            "gitlab.example.com",
+            True,
+        ),
+    ],
+)
+def test_forge_auth_checks_matching_cli_and_host(
+    tmp_path: Path,
+    source: str,
+    required_cli: str,
+    source_host: str,
+    authenticated: bool,
+) -> None:
+    calls: list[list[str]] = []
+    auth_command = [required_cli, "auth", "status", "--hostname", source_host]
+    hostless_auth_command = [required_cli, "auth", "status"]
+    wrong_cli = "glab" if required_cli == "gh" else "gh"
+
+    def run_cmd(argv: list[str]) -> tuple[int, str]:
+        calls.append(argv)
+        if (
+            argv[:2] == ["git", "ls-remote"]
+            or argv[0] == wrong_cli
+            or argv == hostless_auth_command
+            or (authenticated and argv == auth_command)
+        ):
+            return 0, "ok"
+        return 1, "not authenticated"
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source=source),
+        probes=Probes(run_cmd=run_cmd, http_ok=lambda url: True, env={}),
+        storage={"publish_winner": True},
+    )
+
+    auth = next(r for r in results if r.name == "pr-cli-auth")
+    assert auth.status == ("pass" if authenticated else "warn")
+    assert auth_command in calls
+    assert hostless_auth_command not in calls
+    assert not any(call[0] == wrong_cli for call in calls)
+
+
+def test_forge_auth_unknown_host_is_actionable_advisory(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def run_cmd(argv: list[str]) -> tuple[int, str]:
+        calls.append(argv)
+        return 0, "ok"
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source="https://bitbucket.org/org/repo.git"),
+        probes=Probes(run_cmd=run_cmd, http_ok=lambda url: True, env={}),
+        storage={"publish_winner": True},
+    )
+
+    auth = next(r for r in results if r.name == "pr-cli-auth")
+    assert auth.status == "warn"
+    assert "unsupported" in auth.message
+    assert "GitHub or GitLab" in (auth.hint or "")
+    assert not any(call[0] in {"gh", "glab"} for call in calls)
+
+
+@pytest.mark.parametrize(
+    "storage",
+    [
+        {"publish_winner": True},
+        {"archive_candidates": True},
+    ],
+    ids=["publish-winner", "archive-candidates"],
+)
+def test_local_persistence_requires_git_source(tmp_path: Path, storage: dict[str, bool]) -> None:
+    calls: list[list[str]] = []
+
+    def run_cmd(argv: list[str]) -> tuple[int, str]:
+        calls.append(argv)
+        return 0, "ok"
+
+    results = check_artifacts(
+        full_profile(tmp_path),
+        probes=Probes(run_cmd=run_cmd, http_ok=lambda url: True, env={}),
+        storage=storage,
+    )
+
+    persistence = next(r for r in results if r.name == "remote-persistence")
+    assert persistence.status == "warn"
+    assert persistence.severity == "advisory"
+    assert "git URL" in persistence.message
+    assert "agent_source" in (persistence.hint or "")
+    assert calls == [["git", "--version"]]
+
+
+def test_archive_candidates_alone_does_not_check_forge_auth(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def run_cmd(argv: list[str]) -> tuple[int, str]:
+        calls.append(argv)
+        return 0, "ok"
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source="https://github.com/org/repo.git"),
+        probes=Probes(run_cmd=run_cmd, http_ok=lambda url: True, env={}),
+        storage={"archive_candidates": True},
+    )
+
+    assert not any(r.name == "pr-cli-auth" for r in results)
+    assert not any(call[0] in {"gh", "glab"} for call in calls)
+
+
+def test_preflight_git_failure_suppresses_child_output_and_sanitizes_remote(tmp_path: Path) -> None:
+    secret_output = (
+        "fatal: https://output-token:output-secret@github.com/org/repo.git"  # trufflehog:ignore
+        "?output-query-secret#output-fragment-secret"
+    )
+    source = "ssh://deploy-token@github.com/org/repo.git"
+
+    def run_cmd(argv: list[str]) -> tuple[int, str]:
+        if argv == ["git", "--version"]:
+            return 0, "git version"
+        return 23, secret_output
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source=source),
+        probes=Probes(
+            run_cmd=run_cmd,
+            http_ok=lambda url: True,
+            env={},
+        ),
+    )
+
+    failure = next(result for result in results if result.name == "agent-source-git")
+    assert failure.message == "git ls-remote failed for ssh://***@github.com/org/repo.git (exit status 23)"
+
+
+def test_require_template_false_skips_template_checks(tmp_path: Path) -> None:
+    # Insight-less runs never read the template: a missing template dir must
+    # not fail the artifacts group when require_template=False.
+    profile = full_profile(tmp_path)
+    (tmp_path / "optimizer.yaml").write_text(
+        "agent: a\ntask_template: ./no/such/dir\ndatasets:\n  train: ./evals/train\n  validation: ./evals/val\n",
+        encoding="utf-8",
+    )
+    profile = load_profile(tmp_path / "optimizer.yaml")
+    skipped = check_artifacts(profile, probes=make_probes(), require_template=False)
+    assert not any(r.name.startswith("task-t") for r in skipped)
+    assert required_failures(skipped) == []
+    checked = check_artifacts(profile, probes=make_probes())
+    assert any(r.name == "task-template-dir" and r.status == "fail" for r in checked)
+
+
+def test_local_multi_insight_requires_selector(tmp_path: Path) -> None:
+    insights = tmp_path / "insights.yaml"
+    insights.write_text(
+        "insights:\n  - {id: i-a, title: A, agent: a}\n  - {id: i-b, title: B, agent: other}\n",
+        encoding="utf-8",
+    )
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=str(insights),
+        base_url="http://x",
+        probes=make_probes(env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"}),
+    )
+    failure = next(r for r in results if r.name == "insight-file")
+    assert failure.status == "fail" and failure.severity == "required"
+    assert "--insight-id" in failure.message
+    assert not any(r.name == "insight-agent" for r in results)
+
+
+def test_single_insight_file_with_matching_selector_passes(tmp_path: Path) -> None:
+    insights = tmp_path / "insights.yaml"
+    insights.write_text("insights:\n  - {id: i-a, title: A, agent: a}\n", encoding="utf-8")
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=str(insights),
+        insight_id="i-a",
+        base_url="http://x",
+        probes=make_probes(env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"}),
+    )
+    parse = next(r for r in results if r.name == "insight-file")
+    assert parse.status == "pass"
+    assert required_failures(results) == []
+
+
+def test_selected_insight_checks_only_selected_agent_without_selector_warning(tmp_path: Path) -> None:
+    insights = tmp_path / "insights.yaml"
+    insights.write_text(
+        "insights:\n  - {id: i-a, title: A, agent: a}\n  - {id: i-b, title: B, agent: other}\n",
+        encoding="utf-8",
+    )
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=str(insights),
+        insight_id="i-a",
+        base_url="http://x",
+        probes=make_probes(env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"}),
+    )
+    agent = next(r for r in results if r.name == "insight-agent")
+    assert agent.status == "pass"
+    assert not any(r.name == "insight-selector" for r in results)
+    assert required_failures(results) == []
+
+
+def test_ambiguous_selected_insight_is_required_failure(tmp_path: Path) -> None:
+    insights = tmp_path / "insights.yaml"
+    insights.write_text(
+        "insights:\n  - {id: i-a, title: same, agent: a}\n  - {id: i-b, title: same, agent: a}\n",
+        encoding="utf-8",
+    )
+    results = check_environment(
+        profile=full_profile(tmp_path),
+        insight=str(insights),
+        insight_id="same",
+        base_url="http://x",
+        probes=make_probes(env={"EXPERIMENTALIST_API_BASE": "http://llm", "EXPERIMENTALIST_API_KEY": "k"}),
+    )
+    failure = next(r for r in required_failures(results) if r.name == "insight-file")
+    assert "ambiguous" in failure.message
+
+
+def test_bare_dataset_name_matching_local_directory_is_local_path(tmp_path: Path) -> None:
+    profile = full_profile(tmp_path)
+    (tmp_path / "mydata").mkdir()
+    (tmp_path / "optimizer.yaml").write_text(
+        "agent: a\ntask_template: ./evals/task_template\ndatasets:\n  train: mydata\n  validation: ./evals/val\n",
+        encoding="utf-8",
+    )
+    profile = load_profile(tmp_path / "optimizer.yaml")
+    results = check_datasets(profile)
+    train = next(r for r in results if r.name == "dataset-train")
+    assert train.status == "pass" and str(tmp_path / "mydata") in train.message
+
+
+def test_doctor_rejects_local_dataset_file(tmp_path: Path) -> None:
+    full_profile(tmp_path)
+    dataset_file = tmp_path / "train.jsonl"
+    dataset_file.write_text("{}\n", encoding="utf-8")
+    (tmp_path / "optimizer.yaml").write_text(
+        "agent: a\ntask_template: ./evals/task_template\n"
+        "datasets:\n  train: ./train.jsonl\n  validation: ./evals/val\n",
+        encoding="utf-8",
+    )
+
+    results = check_datasets(load_profile(tmp_path / "optimizer.yaml"))
+
+    train = next(result for result in results if result.name == "dataset-train")
+    assert train.status == "fail"
+    assert "not a directory" in train.message
+
+
+def test_check_artifacts_has_no_dataset_results(tmp_path: Path) -> None:
+    # Pins the review deletion: the experiment flow's resolved dataset URIs are
+    # proven-existing by construction, so check_artifacts never validates
+    # datasets — that lives only in check_datasets (doctor).
+    results = check_artifacts(full_profile(tmp_path), probes=make_probes())
+    assert not any(r.name.startswith("dataset-") for r in results)
+
+
+def test_missing_env_hint_names_source_and_env_file(tmp_path: Path) -> None:
+    profile = full_profile(tmp_path)
+    results = check_environment(
+        profile=profile,
+        insight=None,
+        base_url="http://x",
+        probes=make_probes(env={}),
+    )
+    base = next(r for r in results if r.name == "EXPERIMENTALIST_API_BASE")
+    assert "inference-api.nvidia.com" in (base.hint or "")  # names the real endpoint
+    assert str(tmp_path / ".env") in (base.hint or "")  # says exactly where to save it
+    assert ".env.example" in (base.hint or "")
+    assert "export EXPERIMENTALIST_API_BASE" in (base.hint or "")

--- a/plugins/nemo-experimentalist/tests/test_profile.py
+++ b/plugins/nemo-experimentalist/tests/test_profile.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from nemo_experimentalist_plugin import profile as profile_module
+from nemo_experimentalist_plugin.profile import AgentProfile, load_profile
+from nemo_insights_plugin.contracts.profile import PROFILE_FILENAME, ProfileError
+
+MINIMAL = """\
+agent: flight-planner
+task_template: ./evals/task_template
+datasets:
+  train: ./evals/train
+  validation: ./evals/val
+"""
+
+SHARED_PROFILE_FIXTURE = """\
+agent: flight-planner
+task_template: ./evals/task_template
+datasets:
+  train: ./evals/train
+  validation: ./evals/validation
+experiment_config:
+  optimization:
+    rounds: 2
+framework_skills: [./skills]
+workspace: flight-workspace
+agent_spec: ./AGENT-SPEC.md
+"""
+
+
+def write_profile(tmp_path: Path, text: str = MINIMAL) -> Path:
+    p = tmp_path / PROFILE_FILENAME
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_load_profile_delegates_to_shared_model_loader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = write_profile(tmp_path)
+    expected = AgentProfile(
+        agent="delegated",
+        task_template="template",
+        datasets={"train": "train", "validation": "validation"},
+        profile_dir=tmp_path,
+    )
+    loader = Mock(return_value=expected)
+    monkeypatch.setattr(profile_module, "load_profile_model", loader)
+
+    assert load_profile(path) is expected
+    loader.assert_called_once_with(path, AgentProfile)
+
+
+def test_load_minimal_profile_defaults(tmp_path: Path) -> None:
+    profile = load_profile(write_profile(tmp_path))
+    assert profile.agent == "flight-planner"
+    assert profile.agent_source == "."
+    assert profile.agent_spec is None
+    assert profile.experiment_config is None
+    assert profile.framework_skills == []
+    assert profile.workspace == "default"
+    assert profile.profile_dir == tmp_path.resolve()
+
+
+def test_missing_required_field_names_it(tmp_path: Path) -> None:
+    with pytest.raises(ProfileError, match="task_template"):
+        load_profile(write_profile(tmp_path, "agent: a\ndatasets:\n  train: t\n  validation: v\n"))
+
+
+def test_unknown_key_raises_shared_profile_error(tmp_path: Path) -> None:
+    with pytest.raises(ProfileError, match="task_templte") as exc_info:
+        load_profile(write_profile(tmp_path, MINIMAL + "task_templte: typo\n"))
+
+    assert type(exc_info.value) is ProfileError
+
+
+def test_profile_dir_is_reserved_for_loader_injection(tmp_path: Path) -> None:
+    with pytest.raises(ProfileError, match="'profile_dir' is reserved"):
+        load_profile(write_profile(tmp_path, MINIMAL + "profile_dir: elsewhere\n"))
+
+
+def test_experiment_config_inline_and_path(tmp_path: Path) -> None:
+    inline = load_profile(
+        write_profile(tmp_path, MINIMAL + "experiment_config:\n  storage:\n    publish_winner: true\n")
+    )
+    assert inline.experiment_config == {"storage": {"publish_winner": True}}
+    as_path = load_profile(write_profile(tmp_path, MINIMAL + "experiment_config: ./experiment.yaml\n"))
+    assert as_path.experiment_config == "./experiment.yaml"
+
+
+def test_full_profile_matches_shared_contract_shape(tmp_path: Path) -> None:
+    profile = load_profile(write_profile(tmp_path, SHARED_PROFILE_FIXTURE))
+
+    assert profile.agent == "flight-planner"
+    assert profile.workspace == "flight-workspace"
+    assert profile.agent_spec == "./AGENT-SPEC.md"
+
+
+def test_profile_directory_anchors_shared_insights_path(tmp_path: Path) -> None:
+    path = tmp_path / "optimizer.yaml"
+    path.write_text(MINIMAL, encoding="utf-8")
+    profile = load_profile(path)
+
+    assert profile.profile_dir / ".nemo-optimizer" / "insights.yaml" == (
+        tmp_path.resolve() / ".nemo-optimizer" / "insights.yaml"
+    )

--- a/plugins/nemo-experimentalist/tests/test_remote_backend.py
+++ b/plugins/nemo-experimentalist/tests/test_remote_backend.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import json
+from pathlib import Path
+
+import pytest
+from nemo_experimentalist_plugin.entities import Candidate, ExperimentRun
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import RemoteExperimentalistBackend
+
+pytestmark = pytest.mark.asyncio
+
+
+def _backend(tmp_path: Path) -> RemoteExperimentalistBackend:
+    # client=None: no platform client, so the composed LocalExperimentalistBackend persists
+    # to files only (its projection is a no-op without a client). This exercises remote-mode
+    # delegation; the projection itself is covered in tests/test_local_backend_projection.py.
+    return RemoteExperimentalistBackend(client=None, path=tmp_path)  # type: ignore[arg-type]
+
+
+async def test_create_run_writes_run_json(tmp_path: Path) -> None:
+    be = _backend(tmp_path)
+    run = ExperimentRun(workspace="default", agent="a", config_snapshot={}, status="running", rounds_completed=0)
+    out = await be.create_run(workspace="default", run=run)
+    assert out.id  # local backend assigns an id
+    assert (tmp_path / "eval-and-optimize" / "run.json").exists()
+
+
+async def test_create_candidate_writes_metadata_json(tmp_path: Path) -> None:
+    be = _backend(tmp_path)
+    c = Candidate(run_id="run-1", label="agent-0", round=0, optimization="baseline")
+    out = await be.create_candidate(workspace="default", candidate=c)
+    assert out.label == "agent-0"
+    meta = tmp_path / "eval-and-optimize" / "agents" / "agent-0" / "metadata.json"
+    assert meta.exists()
+    assert json.loads(meta.read_text())["label"] == "agent-0"

--- a/plugins/nemo-experimentalist/tests/test_resolve.py
+++ b/plugins/nemo-experimentalist/tests/test_resolve.py
@@ -1,0 +1,904 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import yaml
+from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizerConfig
+from nemo_experimentalist_plugin.profile import load_profile
+from nemo_experimentalist_plugin.resolve import (
+    ResolveError,
+    _dataset_cache_target,
+    _harbor_download,
+    classify_dataset_value,
+    normalize_insight_ref,
+    parse_local_insights,
+    pick_agent_spec,
+    profile_storage_flags,
+    resolve_dataset,
+    resolve_experiment_inputs,
+)
+from nemo_insights_plugin.contracts.insights import InsightsFileError
+from nemo_insights_plugin.contracts.profile import ProfileError
+
+
+def insight_dict(title: str = "NOTAM staleness", *, insight_id: str = "ins-1") -> dict:
+    return {
+        "id": insight_id,
+        "title": title,
+        "description": "agent files plans through stale-NOTAM airspace",
+        "agent": "flight-planner",
+        "status": "open",
+        "trace_refs": ["t1", "t2", "t3"],
+    }
+
+
+def expected_cache_target(
+    cache: Path, name: str, version: str | None = None, *, registry_slug: str = "default"
+) -> Path:
+    name_digest = hashlib.sha256(name.encode("utf-8")).hexdigest()
+    version_key = "bare" if version is None else f"version-{hashlib.sha256(version.encode('utf-8')).hexdigest()}"
+    return cache / "v2" / registry_slug / f"name-{name_digest}" / version_key
+
+
+def test_platform_id_passes_through(tmp_path: Path) -> None:
+    assert normalize_insight_ref("ins-8f3a", None, tmp_path) == "ins-8f3a"
+
+
+def test_platform_id_rejects_selector(tmp_path: Path) -> None:
+    with pytest.raises(ResolveError, match="local multi-insight"):
+        normalize_insight_ref("ins-8f3a", "0", tmp_path)
+
+
+def test_parse_local_insights_delegates_to_shared_loader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    insight_file = tmp_path / "insight.yaml"
+    insight_file.write_text("ignored: by-shared-loader\n", encoding="utf-8")
+    loader = Mock(return_value={"id": "from-shared-loader"})
+    monkeypatch.setattr("nemo_experimentalist_plugin.resolve.load_insights_document", loader)
+
+    assert parse_local_insights(str(insight_file)) == [{"id": "from-shared-loader"}]
+    loader.assert_called_once_with(insight_file)
+
+
+def test_shared_insights_error_is_translated_without_exception_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    insight_file = tmp_path / "insight.yaml"
+    insight_file.touch()
+    loader = Mock(side_effect=InsightsFileError(f"insights file {insight_file} failed shared validation"))
+    monkeypatch.setattr("nemo_experimentalist_plugin.resolve.load_insights_document", loader)
+
+    with pytest.raises(ResolveError) as exc_info:
+        parse_local_insights(str(insight_file))
+
+    assert str(exc_info.value) == f"insights file {insight_file} failed shared validation"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True
+
+
+def test_single_object_file_is_normalized_to_scratch_json(tmp_path: Path) -> None:
+    f = tmp_path / "insight.json"
+    f.write_text(json.dumps(insight_dict()), encoding="utf-8")
+    out = normalize_insight_ref(str(f), None, tmp_path / "scratch")
+    assert out != str(f)
+    assert json.loads(Path(out).read_text(encoding="utf-8")) == insight_dict()
+
+
+def test_yaml_authored_single_insight_becomes_json(tmp_path: Path) -> None:
+    # The local backend reads insight files with json.loads; a YAML-authored
+    # file must be rewritten, not passed through raw.
+    f = tmp_path / "insight.yaml"
+    f.write_text(yaml.safe_dump(insight_dict()), encoding="utf-8")
+    out = normalize_insight_ref(str(f), None, tmp_path / "scratch")
+    assert json.loads(Path(out).read_text(encoding="utf-8"))["agent"] == "flight-planner"
+
+
+def test_non_json_insight_entry_is_rejected_before_selection(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(
+        "insights:\n  - {id: good, title: Good}\n  - id: dated\n    title: Dated\n    observed_at: 2026-07-14\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ResolveError, match="entry 1.*JSON-serializable"):
+        normalize_insight_ref(str(f), "0", tmp_path / "scratch")
+
+
+def test_analyst_list_with_one_insight_normalizes(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(yaml.safe_dump({"insights": [insight_dict()]}), encoding="utf-8")
+    out = normalize_insight_ref(str(f), None, tmp_path / "scratch")
+    data = json.loads(Path(out).read_text(encoding="utf-8"))
+    assert data["title"] == "NOTAM staleness"
+
+
+def test_analyst_list_multi_requires_selector(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(
+        yaml.safe_dump({"insights": [insight_dict("A", insight_id="i-a"), insight_dict("B", insight_id="i-b")]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ResolveError) as exc:
+        normalize_insight_ref(str(f), None, tmp_path)
+    assert "i-a" in str(exc.value) and "i-b" in str(exc.value)  # error lists candidates
+    out = normalize_insight_ref(str(f), "i-b", tmp_path / "scratch")
+    assert json.loads(Path(out).read_text(encoding="utf-8"))["title"] == "B"
+
+
+def test_selector_not_found_is_error(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(yaml.safe_dump({"insights": [insight_dict()]}), encoding="utf-8")
+    with pytest.raises(ResolveError, match="no-such"):
+        normalize_insight_ref(str(f), "no-such", tmp_path)
+
+
+def test_duplicate_title_selector_is_ambiguous(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(
+        yaml.safe_dump(
+            {
+                "insights": [
+                    insight_dict("same", insight_id="a"),
+                    insight_dict("same", insight_id="b"),
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ResolveError, match="ambiguous.*zero-based index"):
+        normalize_insight_ref(str(f), "same", tmp_path / "scratch")
+
+
+def test_numeric_selector_uses_zero_based_index(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(
+        yaml.safe_dump(
+            {
+                "insights": [
+                    insight_dict("first", insight_id="a"),
+                    insight_dict("second", insight_id="b"),
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    selected = normalize_insight_ref(str(f), "1", tmp_path / "scratch")
+    assert json.loads(Path(selected).read_text(encoding="utf-8"))["id"] == "b"
+
+
+def test_numeric_selector_prefers_exact_id_over_index(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(
+        yaml.safe_dump(
+            {
+                "insights": [
+                    insight_dict("numeric id", insight_id="1"),
+                    insight_dict("index one", insight_id="other"),
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    selected = normalize_insight_ref(str(f), "1", tmp_path / "scratch")
+    assert json.loads(Path(selected).read_text(encoding="utf-8"))["title"] == "numeric id"
+
+
+def test_duplicate_numeric_id_is_ambiguous_before_index_fallback(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(
+        yaml.safe_dump(
+            {
+                "insights": [
+                    insight_dict("first", insight_id="1"),
+                    insight_dict("second", insight_id="1"),
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ResolveError, match="ambiguous"):
+        normalize_insight_ref(str(f), "1", tmp_path / "scratch")
+
+
+def test_numeric_selector_checks_bounds(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(yaml.safe_dump({"insights": [insight_dict()]}), encoding="utf-8")
+    with pytest.raises(ResolveError, match="index 1.*out of range"):
+        normalize_insight_ref(str(f), "1", tmp_path / "scratch")
+
+
+def test_empty_list_is_error(tmp_path: Path) -> None:
+    f = tmp_path / "insights.yaml"
+    f.write_text(yaml.safe_dump({"insights": []}), encoding="utf-8")
+    with pytest.raises(ResolveError, match="no insights"):
+        normalize_insight_ref(str(f), None, tmp_path)
+
+
+async def test_harbor_download_exports_flat_task_layout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    calls: list[tuple[str, Path, bool]] = []
+    registries: list[str | None] = []
+
+    class FakeClient:
+        async def download_dataset(self, name: str, *, output_dir: Path, export: bool) -> None:
+            calls.append((name, output_dir, export))
+
+    class FakeFactory:
+        @staticmethod
+        def create(*, registry_url: str | None) -> FakeClient:
+            registries.append(registry_url)
+            return FakeClient()
+
+    monkeypatch.setattr("harbor.registry.client.factory.RegistryClientFactory", FakeFactory)
+
+    await _harbor_download("dataset@1", tmp_path, "https://registry.example/index.json")
+
+    assert calls == [("dataset@1", tmp_path, True)]
+    assert registries == ["https://registry.example/index.json"]
+
+
+async def test_harbor_download_uses_package_client_for_namespaced_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    calls: list[tuple[str, Path, bool]] = []
+
+    class FakePackageClient:
+        async def download_dataset(self, name: str, *, output_dir: Path, export: bool) -> None:
+            calls.append((name, output_dir, export))
+
+    monkeypatch.setattr(
+        "harbor.registry.client.package.PackageDatasetClient",
+        FakePackageClient,
+    )
+
+    await _harbor_download(
+        "terminal-bench/terminal-bench-2-1@6",
+        tmp_path,
+        "https://registry.example/index.json",
+    )
+
+    assert calls == [("terminal-bench/terminal-bench-2-1@6", tmp_path, True)]
+
+
+def test_registry_cache_keys_are_injective_and_path_safe(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    refs = [
+        "dataset",
+        "dataset@",
+        "dataset@unversioned",
+        "dataset@.",
+        "dataset@..",
+        "dataset@release/candidate",
+        r"dataset@release\candidate",
+        "dataset@release%2Fcandidate",
+        "dataset@50% ready",
+        "dataset@日本語@beta",
+    ]
+
+    targets = [_dataset_cache_target(ref, None, cache) for ref in refs]
+    dataset_root = expected_cache_target(cache, "dataset").parent
+
+    assert len(set(targets)) == len(refs)
+    assert targets[0] == expected_cache_target(cache, "dataset")
+    assert targets[1] == expected_cache_target(cache, "dataset", "")
+    assert targets[2] == expected_cache_target(cache, "dataset", "unversioned")
+    assert targets[3] == expected_cache_target(cache, "dataset", ".")
+    assert targets[4] == expected_cache_target(cache, "dataset", "..")
+    assert all(target.parent == dataset_root for target in targets)
+    assert all(target.name not in {"", ".", ".."} for target in targets)
+
+
+async def test_case_variant_registry_refs_materialize_distinct_lowercase_targets(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    refs = ["Dataset@release", "dataset@release", "dataset@Release"]
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        output_dir.mkdir(parents=True)
+        (output_dir / "ref").write_text(name, encoding="utf-8")
+
+    targets = [Path(await resolve_dataset(ref, tmp_path, cache_dir=cache, download=fake_download)) for ref in refs]
+
+    assert len(set(targets)) == len(refs)
+    assert [(target / "ref").read_text(encoding="utf-8") for target in targets] == refs
+    for target in targets:
+        name_component, version_component = target.relative_to(cache).parts[-2:]
+        assert name_component == name_component.lower()
+        assert version_component == version_component.lower()
+
+
+async def test_very_long_registry_version_uses_bounded_target_and_staging_components(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    staging_dirs: list[Path] = []
+    ref = f"dataset@{'Version-' * 100}"
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        staging_dirs.append(output_dir)
+        output_dir.mkdir(parents=True)
+        (output_dir / "ref").write_text(name, encoding="utf-8")
+
+    target = Path(await resolve_dataset(ref, tmp_path, cache_dir=cache, download=fake_download))
+
+    assert (target / "ref").read_text(encoding="utf-8") == ref
+    assert max(len(component.encode()) for component in target.relative_to(cache).parts) < 128
+    assert len(staging_dirs) == 1
+    assert len(staging_dirs[0].name.encode()) < 128
+
+
+def test_path_form_resolves_against_profile_dir(tmp_path: Path) -> None:
+    (tmp_path / "evals" / "train").mkdir(parents=True)
+    out = asyncio.run(resolve_dataset("./evals/train", tmp_path))
+    assert out == str((tmp_path / "evals" / "train").resolve())
+
+
+def test_path_form_missing_is_error(tmp_path: Path) -> None:
+    with pytest.raises(ResolveError, match="does not exist"):
+        asyncio.run(resolve_dataset("./evals/train", tmp_path))
+
+
+def test_path_form_file_is_rejected_as_not_a_dataset_directory(tmp_path: Path) -> None:
+    dataset_file = tmp_path / "train.jsonl"
+    dataset_file.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(ResolveError, match="not a directory"):
+        asyncio.run(resolve_dataset(str(dataset_file), tmp_path))
+
+
+def test_registry_ref_uses_cache_when_present(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    target = expected_cache_target(cache, "tau2-bench-live-test", "1.0")
+    target.mkdir(parents=True)
+    called = False
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        nonlocal called
+        called = True
+
+    out = asyncio.run(resolve_dataset("tau2-bench-live-test@1.0", tmp_path, cache_dir=cache, download=fake_download))
+    assert out == str(target)
+    assert called is False
+
+
+def test_registry_ref_rejects_cached_file(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    target = expected_cache_target(cache, "tau2-bench-live-test", "1.0")
+    target.parent.mkdir(parents=True)
+    target.write_text("not a dataset directory", encoding="utf-8")
+
+    with pytest.raises(ResolveError, match="cache target.*not a directory"):
+        asyncio.run(resolve_dataset("tau2-bench-live-test@1.0", tmp_path, cache_dir=cache))
+
+
+def test_registry_ref_downloads_when_absent(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    registry = "https://reg.example/registry.json"
+    seen: dict = {}
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        seen.update(name=name, output_dir=output_dir, registry_url=registry_url)
+        output_dir.mkdir(parents=True)
+
+    out = asyncio.run(
+        resolve_dataset(
+            "tau2-bench-live-test@1.0",
+            tmp_path,
+            registry_url=registry,
+            cache_dir=cache,
+            download=fake_download,
+        )
+    )
+    assert seen["name"] == "tau2-bench-live-test@1.0"
+    assert seen["registry_url"] == registry
+    slug = hashlib.sha256(registry.encode()).hexdigest()[:12]
+    assert out == str(expected_cache_target(cache, "tau2-bench-live-test", "1.0", registry_slug=slug))
+
+
+async def test_versioned_cache_ignores_old_unversioned_layout(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    old_target = cache / "default" / "dataset" / "1"
+    old_target.mkdir(parents=True)
+    (old_target / "payload").write_text("old-layout", encoding="utf-8")
+    calls = 0
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        nonlocal calls
+        calls += 1
+        output_dir.mkdir(parents=True)
+        (output_dir / "payload").write_text("new-layout", encoding="utf-8")
+
+    out = await resolve_dataset("dataset@1", tmp_path, cache_dir=cache, download=fake_download)
+
+    assert out == str(expected_cache_target(cache, "dataset", "1"))
+    assert (Path(out) / "payload").read_text(encoding="utf-8") == "new-layout"
+    assert (old_target / "payload").read_text(encoding="utf-8") == "old-layout"
+    assert calls == 1
+
+
+async def test_concurrent_identical_refs_publish_one_complete_winner(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    staging_dirs: list[Path] = []
+    slow_started = asyncio.Event()
+    release_slow = asyncio.Event()
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        staging_dirs.append(output_dir)
+        output_dir.mkdir(parents=True)
+        (output_dir / "payload").write_text(f"complete-{len(staging_dirs)}", encoding="utf-8")
+        if len(staging_dirs) == 1:
+            slow_started.set()
+            await asyncio.wait_for(release_slow.wait(), timeout=1)
+
+    slow_task = asyncio.create_task(resolve_dataset("dataset@1", tmp_path, cache_dir=cache, download=fake_download))
+    await asyncio.wait_for(slow_started.wait(), timeout=1)
+
+    winner = await resolve_dataset("dataset@1", tmp_path, cache_dir=cache, download=fake_download)
+
+    assert not slow_task.done()
+    assert staging_dirs[0].is_dir()
+    assert (staging_dirs[0] / "payload").read_text(encoding="utf-8") == "complete-1"
+    assert (Path(winner) / "payload").read_text(encoding="utf-8") == "complete-2"
+
+    release_slow.set()
+    loser = await slow_task
+
+    expected = expected_cache_target(cache, "dataset", "1")
+    assert winner == loser == str(expected)
+    assert (expected / "payload").read_text(encoding="utf-8") == "complete-2"
+    assert len(set(staging_dirs)) == 2
+    assert all(not staging.exists() for staging in staging_dirs)
+
+
+async def test_concurrent_unversioned_and_literal_latest_refs_use_distinct_targets(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    staging_dirs: list[Path] = []
+    both_started = asyncio.Event()
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        staging_dirs.append(output_dir)
+        output_dir.mkdir(parents=True)
+        (output_dir / "payload").write_text(name, encoding="utf-8")
+        if len(staging_dirs) == 2:
+            both_started.set()
+        await asyncio.wait_for(both_started.wait(), timeout=1)
+
+    unversioned, latest = await asyncio.gather(
+        resolve_dataset("dataset", tmp_path, cache_dir=cache, download=fake_download),
+        resolve_dataset("dataset@latest", tmp_path, cache_dir=cache, download=fake_download),
+    )
+
+    assert unversioned == str(expected_cache_target(cache, "dataset"))
+    assert latest == str(expected_cache_target(cache, "dataset", "latest"))
+    assert (Path(unversioned) / "payload").read_text(encoding="utf-8") == "dataset"
+    assert (Path(latest) / "payload").read_text(encoding="utf-8") == "dataset@latest"
+    assert len(set(staging_dirs)) == 2
+    assert all(not staging.exists() for staging in staging_dirs)
+
+
+def test_cache_keys_never_collide(tmp_path: Path) -> None:
+    # foo@1.0 and a distinct dataset literally named foo-1.0 must not share a
+    # cache directory (the old value.replace("@","-") key collided them).
+    cache = tmp_path / "cache"
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        output_dir.mkdir(parents=True)
+        (output_dir / "which").write_text(name, encoding="utf-8")
+
+    first = asyncio.run(resolve_dataset("foo@1.0", tmp_path, cache_dir=cache, download=fake_download))
+    second = asyncio.run(resolve_dataset("foo-1.0", tmp_path, cache_dir=cache, download=fake_download))
+    assert first != second
+    assert (Path(second) / "which").read_text(encoding="utf-8") == "foo-1.0"
+
+
+def test_unprefixed_relative_path_is_path_not_registry_ref(tmp_path: Path) -> None:
+    # 'data/train' contains a separator: a missing dir is a clean path error,
+    # never a registry download of the literal name.
+    with pytest.raises(ResolveError, match="does not exist"):
+        asyncio.run(resolve_dataset("data/train", tmp_path))
+
+
+async def test_registry_url_makes_namespaced_value_a_registry_ref(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    registry = "https://registry.example/index.json"
+    calls: list[tuple[str, str | None]] = []
+
+    async def fake_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        calls.append((name, registry_url))
+        output_dir.mkdir(parents=True)
+
+    out = await resolve_dataset(
+        "terminal-bench/terminal-bench-2-1@6",
+        tmp_path,
+        registry_url=registry,
+        cache_dir=cache,
+        download=fake_download,
+    )
+
+    assert Path(out).is_dir()
+    assert calls == [("terminal-bench/terminal-bench-2-1@6", registry)]
+
+
+def test_registry_url_overrides_implicit_local_match(tmp_path: Path) -> None:
+    (tmp_path / "terminal-bench").mkdir()
+
+    assert (
+        classify_dataset_value(
+            "terminal-bench",
+            tmp_path,
+            registry_url="https://registry.example/index.json",
+        )
+        == "ref"
+    )
+
+
+def test_registry_url_does_not_override_explicit_path(tmp_path: Path) -> None:
+    (tmp_path / "data").mkdir()
+
+    out = asyncio.run(
+        resolve_dataset(
+            "./data",
+            tmp_path,
+            registry_url="https://registry.example/index.json",
+        )
+    )
+
+    assert out == str((tmp_path / "data").resolve())
+
+
+def test_bare_name_matching_local_dir_is_path(tmp_path: Path) -> None:
+    (tmp_path / "mydata").mkdir()
+    assert classify_dataset_value("mydata", tmp_path) == "path"
+
+
+def test_bare_name_without_local_match_is_ref(tmp_path: Path) -> None:
+    assert classify_dataset_value("mydata", tmp_path) == "ref"
+    assert classify_dataset_value("./mydata", tmp_path) == "path"
+
+
+def test_dataset_path_unknown_user_expansion_is_clean_error(tmp_path: Path) -> None:
+    with pytest.raises(ResolveError, match="could not be resolved"):
+        asyncio.run(resolve_dataset("~no-such-user-xyz/data", tmp_path))
+
+
+def test_download_failure_surfaces(tmp_path: Path) -> None:
+    async def failing_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        raise RuntimeError("registry unreachable")
+
+    with pytest.raises(ResolveError, match="registry unreachable"):
+        asyncio.run(resolve_dataset("some-ds", tmp_path, cache_dir=tmp_path / "c", download=failing_download))
+
+
+def test_partial_download_does_not_poison_cache(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    staging_dirs: list[Path] = []
+
+    async def partial_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        staging_dirs.append(output_dir)
+        output_dir.mkdir(parents=True)
+        (output_dir / "shard-0.jsonl").write_text("truncated", encoding="utf-8")
+        raise RuntimeError("connection reset mid-download")
+
+    with pytest.raises(ResolveError, match="connection reset"):
+        asyncio.run(resolve_dataset("some-ds@1.0", tmp_path, cache_dir=cache, download=partial_download))
+    target = expected_cache_target(cache, "some-ds", "1.0")
+    assert not target.exists()  # no truncated dataset masquerading as a cache hit
+    assert not staging_dirs[0].exists()
+
+    async def working_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        staging_dirs.append(output_dir)
+        output_dir.mkdir(parents=True)
+        (output_dir / "shard-0.jsonl").write_text("complete", encoding="utf-8")
+
+    out = asyncio.run(resolve_dataset("some-ds@1.0", tmp_path, cache_dir=cache, download=working_download))
+    assert out == str(target)
+    assert (Path(out) / "shard-0.jsonl").read_text(encoding="utf-8") == "complete"
+    assert len(set(staging_dirs)) == 2
+    assert all(not staging.exists() for staging in staging_dirs)
+
+
+async def test_cancelled_download_cleans_unique_staging_directory(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    staging_dirs: list[Path] = []
+    download_started = asyncio.Event()
+    wait_forever = asyncio.Event()
+
+    async def cancelled_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        staging_dirs.append(output_dir)
+        output_dir.mkdir(parents=True)
+        (output_dir / "payload").write_text("partial", encoding="utf-8")
+        download_started.set()
+        await wait_forever.wait()
+
+    task = asyncio.create_task(resolve_dataset("some-ds@1.0", tmp_path, cache_dir=cache, download=cancelled_download))
+    await asyncio.wait_for(download_started.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert not staging_dirs[0].exists()
+
+    async def working_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        staging_dirs.append(output_dir)
+        output_dir.mkdir(parents=True)
+        (output_dir / "payload").write_text("complete", encoding="utf-8")
+
+    out = await resolve_dataset("some-ds@1.0", tmp_path, cache_dir=cache, download=working_download)
+
+    assert (Path(out) / "payload").read_text(encoding="utf-8") == "complete"
+    assert len(set(staging_dirs)) == 2
+    assert all(not staging.exists() for staging in staging_dirs)
+
+
+def test_stale_fixed_partial_file_does_not_interfere(tmp_path: Path) -> None:
+    cache = tmp_path / "cache"
+    target = expected_cache_target(cache, "some-ds", "1.0")
+    target.parent.mkdir(parents=True)
+    target.with_name(target.name + ".partial").write_text("stray file, not a dir", encoding="utf-8")
+
+    async def working_download(name: str, output_dir: Path, registry_url: str | None) -> None:
+        output_dir.mkdir(parents=True)
+
+    out = asyncio.run(resolve_dataset("some-ds@1.0", tmp_path, cache_dir=cache, download=working_download))
+    assert out == str(target)
+    assert Path(out).is_dir()
+
+
+def make_profile_tree(tmp_path: Path) -> Path:
+    for sub in ("evals/task_template", "evals/train", "evals/val"):
+        (tmp_path / sub).mkdir(parents=True)
+    (tmp_path / "AGENT-SPEC.md").write_text("# spec", encoding="utf-8")
+    (tmp_path / "optimizer.yaml").write_text(
+        "agent: flight-planner\n"
+        "task_template: ./evals/task_template\n"
+        "datasets:\n  train: ./evals/train\n  validation: ./evals/val\n"
+        "experiment_config:\n  storage:\n    publish_winner: true\n",
+        encoding="utf-8",
+    )
+    return tmp_path / "optimizer.yaml"
+
+
+def test_pick_agent_spec_delegates_profile_owned_selection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile_path = make_profile_tree(tmp_path)
+    with profile_path.open("a", encoding="utf-8") as profile_file:
+        profile_file.write("agent_spec: ./configured.md\n")
+    selected = tmp_path / "selected-by-shared-resolver.md"
+    selected.write_text("# selected", encoding="utf-8")
+    profile = load_profile(profile_path)
+    resolver = Mock(return_value=selected)
+    monkeypatch.setattr("nemo_experimentalist_plugin.resolve.resolve_agent_spec_path", resolver)
+
+    assert pick_agent_spec(profile) == str(selected)
+    resolver.assert_called_once_with(profile.profile_dir, "./configured.md")
+
+
+def test_shared_profile_error_is_translated_without_exception_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+    resolver = Mock(side_effect=ProfileError("shared profile selection failed"))
+    monkeypatch.setattr("nemo_experimentalist_plugin.resolve.resolve_agent_spec_path", resolver)
+
+    with pytest.raises(ResolveError) as exc_info:
+        pick_agent_spec(profile)
+
+    assert str(exc_info.value) == "shared profile selection failed"
+    assert exc_info.value.__cause__ is None
+    assert exc_info.value.__suppress_context__ is True
+
+
+def test_full_resolution_from_profile(tmp_path: Path) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+    inputs = asyncio.run(resolve_experiment_inputs(profile=profile, scratch_dir=tmp_path / "scratch", insight="ins-1"))
+    assert inputs.agent == str(tmp_path.resolve())  # agent_source "." → profile dir
+    assert inputs.agent_spec == str((tmp_path / "AGENT-SPEC.md").resolve())  # auto-pick
+    assert inputs.train_dataset.uri == str((tmp_path / "evals" / "train").resolve())
+    assert inputs.train_dataset.metadata == {"id": "train"}
+    assert inputs.task_template.uri == str((tmp_path / "evals" / "task_template").resolve())
+    assert inputs.workspace == "default"
+    assert inputs.config.storage.publish_winner is True
+    assert inputs.insight == "ins-1"
+
+
+def test_direct_resolution_rejects_insight_id_without_insight(tmp_path: Path) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+    with pytest.raises(ResolveError, match="--insight-id.*without.*insight"):
+        asyncio.run(
+            resolve_experiment_inputs(
+                profile=profile,
+                scratch_dir=tmp_path / "scratch",
+                insight=None,
+                insight_id="0",
+            )
+        )
+
+
+def test_flags_override_profile(tmp_path: Path) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+    (tmp_path / "other-train").mkdir()
+    inputs = asyncio.run(
+        resolve_experiment_inputs(
+            profile=profile,
+            scratch_dir=tmp_path / "s",
+            insight="ins-1",
+            agent="git@host:g/r.git@main",
+            workspace="ws2",
+            train_dataset=str(tmp_path / "other-train"),
+        )
+    )
+    assert inputs.agent == "git@host:g/r.git@main"
+    assert inputs.workspace == "ws2"
+    assert inputs.train_dataset.uri == str(tmp_path / "other-train")
+
+
+def test_no_profile_missing_inputs_lists_them(tmp_path: Path) -> None:
+    with pytest.raises(ResolveError) as exc:
+        asyncio.run(resolve_experiment_inputs(profile=None, scratch_dir=tmp_path, insight="ins-1"))
+    msg = str(exc.value)
+    assert "train-dataset" in msg and "validation-dataset" in msg and "task-template" in msg
+    assert "optimizer.yaml" in msg  # error shows the profile skeleton
+
+
+def test_no_profile_all_flags_works(tmp_path: Path) -> None:
+    for sub in ("t", "v", "tt"):
+        (tmp_path / sub).mkdir()
+    inputs = asyncio.run(
+        resolve_experiment_inputs(
+            profile=None,
+            scratch_dir=tmp_path / "s",
+            insight="ins-1",
+            agent=str(tmp_path),
+            train_dataset=str(tmp_path / "t"),
+            validation_dataset=str(tmp_path / "v"),
+            task_template=str(tmp_path / "tt"),
+        )
+    )
+    assert inputs.workspace == "default"
+    assert inputs.config.model_dump() == EvolutionaryOptimizerConfig().model_dump()
+
+
+def test_profileless_mode2_requires_effective_agent_source(tmp_path: Path) -> None:
+    for sub in ("train", "validation"):
+        (tmp_path / sub).mkdir()
+
+    with pytest.raises(ResolveError, match="--agent"):
+        asyncio.run(
+            resolve_experiment_inputs(
+                profile=None,
+                scratch_dir=tmp_path / "scratch",
+                train_dataset=str(tmp_path / "train"),
+                validation_dataset=str(tmp_path / "validation"),
+            )
+        )
+
+
+def test_config_flag_beats_profile_inline(tmp_path: Path) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+    inputs = asyncio.run(
+        resolve_experiment_inputs(
+            profile=profile,
+            scratch_dir=tmp_path / "s",
+            insight="ins-1",
+            config_payload={"storage": {"publish_winner": False}},
+        )
+    )
+    assert inputs.config.storage.publish_winner is False
+
+
+def test_config_unknown_top_level_key_is_tolerated(tmp_path: Path) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+    inputs = asyncio.run(
+        resolve_experiment_inputs(
+            profile=profile,
+            scratch_dir=tmp_path / "s",
+            insight="ins-1",
+            config_payload={"stroage": {"publish_winner": True}, "max_rounds": 2},
+        )
+    )
+    assert inputs.config.max_rounds == 2
+    assert inputs.config.storage.publish_winner is False
+
+
+@pytest.mark.parametrize(
+    "config_payload",
+    [
+        {"storage": {"publish_winer": True}},
+        {"source": {"clone_dept": 1}},
+        {"coder": {"max_fix_atempts": 1}},
+        {"analyzer": {"rationalizer": {"max_summary_token": 100}}},
+        {"goal_config": {"max_dept": 2}},
+    ],
+    ids=["storage", "source", "coder", "deep-analyzer", "goal-config"],
+)
+def test_config_unknown_typed_nested_key_is_tolerated(tmp_path: Path, config_payload: dict) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+
+    inputs = asyncio.run(
+        resolve_experiment_inputs(
+            profile=profile,
+            scratch_dir=tmp_path / "s",
+            insight="ins-1",
+            config_payload=config_payload,
+        )
+    )
+
+    assert inputs.config == EvolutionaryOptimizerConfig()
+
+
+def test_evaluator_payload_remains_intentionally_open(tmp_path: Path) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+
+    inputs = asyncio.run(
+        resolve_experiment_inputs(
+            profile=profile,
+            scratch_dir=tmp_path / "s",
+            insight="ins-1",
+            config_payload={"evaluator": {"plugin_specific_option": {"nested": True}}},
+        )
+    )
+
+    assert inputs.config.evaluator == {"plugin_specific_option": {"nested": True}}
+
+
+def test_config_invalid_value_is_wrapped_with_source(tmp_path: Path) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))
+    with pytest.raises(ResolveError, match="Invalid experiment config from --config"):
+        asyncio.run(
+            resolve_experiment_inputs(
+                profile=profile,
+                scratch_dir=tmp_path / "s",
+                insight="ins-1",
+                config_payload={"storage": "not-a-mapping"},
+            )
+        )
+
+
+def test_empty_experiment_config_file_names_the_file(tmp_path: Path) -> None:
+    make_profile_tree(tmp_path)
+    (tmp_path / "exp.yaml").write_text("# only comments\n", encoding="utf-8")
+    (tmp_path / "optimizer.yaml").write_text(
+        "agent: flight-planner\n"
+        "task_template: ./evals/task_template\n"
+        "datasets:\n  train: ./evals/train\n  validation: ./evals/val\n"
+        "experiment_config: ./exp.yaml\n",
+        encoding="utf-8",
+    )
+    profile = load_profile(tmp_path / "optimizer.yaml")
+    with pytest.raises(ResolveError, match="must be a YAML mapping"):
+        asyncio.run(resolve_experiment_inputs(profile=profile, scratch_dir=tmp_path / "s", insight="ins-1"))
+
+
+def test_profile_agent_spec_must_be_readable_utf8(tmp_path: Path) -> None:
+    profile_path = make_profile_tree(tmp_path)
+    spec = tmp_path / "AGENT-SPEC.md"
+    spec.write_bytes(b"\xff")
+    profile = load_profile(profile_path)
+
+    with pytest.raises(ResolveError, match="Could not read agent_spec"):
+        asyncio.run(resolve_experiment_inputs(profile=profile, scratch_dir=tmp_path / "s"))
+
+
+def test_profile_storage_flags_reads_inline_and_path_forms(tmp_path: Path) -> None:
+    profile = load_profile(make_profile_tree(tmp_path))  # inline dict with publish_winner: true
+    assert profile_storage_flags(profile) == {"publish_winner": True}
+
+    (tmp_path / "exp.yaml").write_text("storage:\n  archive_candidates: true\n", encoding="utf-8")
+    (tmp_path / "optimizer.yaml").write_text(
+        "agent: flight-planner\n"
+        "task_template: ./evals/task_template\n"
+        "datasets:\n  train: ./evals/train\n  validation: ./evals/val\n"
+        "experiment_config: ./exp.yaml\n",
+        encoding="utf-8",
+    )
+    path_profile = load_profile(tmp_path / "optimizer.yaml")
+    assert profile_storage_flags(path_profile) == {"archive_candidates": True}

--- a/plugins/nemo-experimentalist/tests/test_skills_entry_point.py
+++ b/plugins/nemo-experimentalist/tests/test_skills_entry_point.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the nemo.skills entry-point exposure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_skills_dir_contains_terminator() -> None:
+    from nemo_experimentalist_plugin.skills import skills_dir
+
+    terminator = skills_dir() / "terminator"
+    assert terminator.is_dir(), (
+        f"Expected 'terminator' subdir under {skills_dir()!r} — got {list(skills_dir().iterdir())}"
+    )
+
+
+def test_entry_point_loads_skills_dir() -> None:
+    """The nemo.skills entry-point must resolve to our skills_dir function."""
+    from importlib.metadata import entry_points
+
+    eps = [ep for ep in entry_points(group="nemo.skills") if ep.name == "experimentalist"]
+    assert len(eps) == 1, f"Expected exactly one 'experimentalist' entry-point, got {eps}"
+    loaded = eps[0].load()
+    assert callable(loaded), f"Entry-point did not resolve to a callable: {loaded!r}"
+    result = loaded()
+    assert isinstance(result, Path), f"skills_dir() returned {result!r} (not Path)"
+    assert result.is_dir(), f"skills_dir() returned {result!r} which is not a directory"

--- a/plugins/nemo-experimentalist/tests/test_trace_explorer_from_ref.py
+++ b/plugins/nemo-experimentalist/tests/test_trace_explorer_from_ref.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for TraceExplorer.from_ref intake:// URI parsing.
+
+Trial/eval traces are persisted as ``intake://traces/<id>`` while Eval Author traces
+attached to an Insight use the bare ``intake://<id>`` form. ``from_ref`` must resolve both to the
+raw ``<id>`` that Intake filters on — otherwise trial traces query ClickHouse
+with a ``traces/<id>`` id that never matches and are silently skipped, even once
+the platform client/workspace are correctly plumbed in.
+"""
+
+from typing import Any, cast
+
+import pytest
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.models import ResourceRef
+from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import TraceExplorer
+
+
+@pytest.fixture
+def capture_from_intake(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace TraceExplorer.from_intake with a recorder; return the call log."""
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_from_intake(cls: Any, client: Any, trace_id: str, *, workspace: str, **kwargs: Any) -> str:
+        calls.append({"client": client, "trace_id": trace_id, "workspace": workspace})
+        return "sentinel-trace-explorer"
+
+    monkeypatch.setattr(TraceExplorer, "from_intake", classmethod(_fake_from_intake))
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_from_ref_strips_traces_prefix_for_trial_traces(
+    capture_from_intake: list[dict[str, Any]],
+) -> None:
+    """``intake://traces/<id>`` (trial-trace format) resolves to the bare <id>."""
+    client = cast(Any, object())
+    ref = ResourceRef(uri="intake://traces/abc123")
+
+    result = await TraceExplorer.from_ref(ref, client, "ws-1")
+
+    assert result == "sentinel-trace-explorer"
+    assert capture_from_intake == [{"client": client, "trace_id": "abc123", "workspace": "ws-1"}]
+
+
+@pytest.mark.asyncio
+async def test_from_ref_handles_bare_intake_uri_for_eval_author_traces(
+    capture_from_intake: list[dict[str, Any]],
+) -> None:
+    """``intake://<id>`` (Eval Author Insight format) still resolves to <id>."""
+    client = cast(Any, object())
+    ref = ResourceRef(uri="intake://abc123")
+
+    await TraceExplorer.from_ref(ref, client, "ws-1")
+
+    assert capture_from_intake == [{"client": client, "trace_id": "abc123", "workspace": "ws-1"}]
+
+
+@pytest.mark.asyncio
+async def test_from_ref_requires_client_and_workspace(
+    capture_from_intake: list[dict[str, Any]],
+) -> None:
+    """Without client/workspace, intake refs raise rather than being silently skipped."""
+    ref = ResourceRef(uri="intake://traces/abc123")
+
+    with pytest.raises(ValueError, match="missing client/workspace"):
+        await TraceExplorer.from_ref(ref, None, None)
+
+    assert capture_from_intake == []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,10 @@ version = "0.0.0"
 [dependency-groups]
 # Optional Insights analyst plugin.
 insights = ["nemo-insights-plugin"]
+# Optional Experimentalist agent-optimization plugin. Its agent framework (nooa) and
+# evaluator (harbor) are both 3.12-only, so the whole plugin is gated rather than
+# installed half-resolved on 3.11.
+experimentalist = ["nemo-experimentalist-plugin ; python_full_version >= '3.12'"]
 dev = [
   "pre-commit>=3.8.0",
   "pydantic-settings>=2.6.1",
@@ -364,6 +368,9 @@ nmp-testing = { workspace = true }
 nmp-build-tools = { workspace = true }
 nemo-platform-plugin = { workspace = true }
 nemo-insights-plugin = { workspace = true }
+nemo-experimentalist-plugin = { workspace = true }
+# Not published to PyPI yet; pinned to an immutable public tag.
+nooa = { git = "https://github.com/NVIDIA-NeMo/labs-OO-Agents.git", tag = "v0.0.6" }
 
 nemo-evaluator-plugin = { workspace = true }
 nemo-guardrails-plugin = { workspace = true }
@@ -430,6 +437,7 @@ members = [
   "plugins/nemo-agents",
   "plugins/nemo-deployments",
   "plugins/nemo-insights",
+  "plugins/nemo-experimentalist",
   "plugins/nemo-agents/examples/calculator-agent",
   "plugins/nemo-agents/examples/email-phishing-analyzer",
   "plugins/nemo-customizer",
@@ -552,6 +560,8 @@ extra-paths = [
   "plugins/nemo-evaluator/src",
   # The optional Insights analyst is not part of the default environment.
   "plugins/nemo-insights/src",
+  # Same for the optional Experimentalist; its tests also import the benchmark runner.
+  "plugins/nemo-experimentalist/src",
   # Agentic-use tests place both tests/agentic-use and tests/agentic-use/shared
   # on sys.path in tests/conftest.py.
   "tests/agentic-use",
@@ -611,6 +621,10 @@ exclude = [
   # root `ty` until that cleanup lands in a focused follow-up.
   "plugins/nemo-switchyard/",
 
+  # Standalone Terminal-Bench agent-under-test: resolved from its own lockfile inside
+  # the benchmark's task containers, so its imports are absent from the workspace env.
+  "plugins/nemo-experimentalist/examples/",
+
   "docs/",
 
   "./sdk/",
@@ -618,3 +632,12 @@ exclude = [
   "tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk",
   "tools/nemo-platform-sdk-tools/tests/sdk",
 ]
+
+# nooa agents declare their LLM-generated methods as annotated signatures with an
+# ellipsis body; the framework fills them in at runtime. ty reads that as a missing
+# return, so the rule is off for the Experimentalist's agent classes only.
+[[tool.ty.overrides]]
+include = ["plugins/nemo-experimentalist/src/**"]
+
+[tool.ty.overrides.rules]
+empty-body = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -641,3 +641,12 @@ include = ["plugins/nemo-experimentalist/src/**"]
 
 [tool.ty.overrides.rules]
 empty-body = "ignore"
+
+# The Experimentalist's agent framework (nooa) and evaluator (harbor) are both
+# 3.12-only, so uv skips them when the lint job resolves on 3.11 and every import
+# of them goes unresolved. Everything else about the plugin still gets checked.
+[[tool.ty.overrides]]
+include = ["plugins/nemo-experimentalist/**"]
+
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"

--- a/tests/discovery_exclusions.py
+++ b/tests/discovery_exclusions.py
@@ -14,3 +14,8 @@ if find_spec("nemo_insights_plugin") is None:
     TEST_DISCOVERY_EXCLUSIONS[Path("plugins/nemo-insights/tests")] = (
         "The optional insights dependency group is not installed in the root test environment."
     )
+
+if find_spec("nemo_experimentalist_plugin") is None:
+    TEST_DISCOVERY_EXCLUSIONS[Path("plugins/nemo-experimentalist/tests")] = (
+        "The optional experimentalist dependency group is 3.12-only, so it is absent from a 3.11 test environment."
+    )

--- a/tools/lint/lint-python-types.sh
+++ b/tools/lint/lint-python-types.sh
@@ -24,4 +24,4 @@ for rule in "${ci_ignored_rules[@]}"; do
   ignore_args+=(--ignore "$rule")
 done
 
-uv run --frozen --group insights ty check --exit-zero-on-warning "${ignore_args[@]}"
+uv run --frozen --group insights --group experimentalist ty check --exit-zero-on-warning "${ignore_args[@]}"

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/license/overrides.yaml
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/license/overrides.yaml
@@ -270,6 +270,10 @@ overrides:
   crc32c: LGPL-2.1-or-later # https://pypi.org/project/crc32c/
   detect-installer: 0BSD # https://pypi.org/project/detect-installer/
 
+  # Experimentalist plugin. Only nooa needs an entry: it is a git dependency rather than
+  # a PyPI release, so osv has no metadata to read and reports UNKNOWN.
+  nooa: Apache-2.0 # https://github.com/NVIDIA-NeMo/labs-OO-Agents
+
   databricks-sdk: Apache-2.0  # https://github.com/databricks/databricks-sdk-py/blob/main/LICENSE
   mlflow-skinny: Apache-2.0  # https://github.com/mlflow/mlflow/blob/master/LICENSE.txt
   sqlparse: BSD-3-Clause  # https://github.com/andialbrecht/sqlparse/blob/master/LICENSE

--- a/uv.lock
+++ b/uv.lock
@@ -35,6 +35,7 @@ members = [
     "nemo-deployments-plugin",
     "nemo-evaluator-plugin",
     "nemo-evaluator-sdk",
+    "nemo-experimentalist-plugin",
     "nemo-guardrails-plugin",
     "nemo-insights-plugin",
     "nemo-nb",
@@ -4153,6 +4154,39 @@ dev = [
 ]
 
 [[package]]
+name = "nemo-experimentalist-plugin"
+version = "0.1.0"
+source = { editable = "plugins/nemo-experimentalist" }
+dependencies = [
+    { name = "harbor", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-insights-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-platform", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nooa", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-proto", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "protobuf", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "tomlkit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "harbor", marker = "python_full_version >= '3.12'", specifier = ">=0.16" },
+    { name = "httpx" },
+    { name = "nemo-insights-plugin", editable = "plugins/nemo-insights" },
+    { name = "nemo-platform", editable = "packages/nemo_platform" },
+    { name = "nemo-platform-plugin", editable = "packages/nemo_platform_plugin" },
+    { name = "nooa", marker = "python_full_version >= '3.12'", git = "https://github.com/NVIDIA-NeMo/labs-OO-Agents.git?tag=v0.0.6" },
+    { name = "opentelemetry-proto", specifier = ">=1.42.1" },
+    { name = "protobuf", specifier = ">=6.0.0" },
+    { name = "pydantic", specifier = ">=2" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "tomlkit", specifier = ">=0.13.3" },
+]
+
+[[package]]
 name = "nemo-fabric"
 version = "0.1.0a20260724"
 source = { registry = "https://pypi.org/simple" }
@@ -6115,6 +6149,9 @@ enabled-plugins = [
     { name = "nemo-switchyard", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-unsloth-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
+experimentalist = [
+    { name = "nemo-experimentalist-plugin", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
 functional-services = [
     { name = "nemo-agents-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-anonymizer-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -6319,6 +6356,7 @@ enabled-plugins = [
     { name = "nemo-switchyard", editable = "plugins/nemo-switchyard" },
     { name = "nemo-unsloth-plugin", editable = "plugins/nemo-unsloth" },
 ]
+experimentalist = [{ name = "nemo-experimentalist-plugin", marker = "python_full_version >= '3.12'", editable = "plugins/nemo-experimentalist" }]
 functional-services = [
     { name = "nemo-agents-plugin", editable = "plugins/nemo-agents" },
     { name = "nemo-anonymizer-plugin", editable = "plugins/nemo-anonymizer" },
@@ -7487,6 +7525,17 @@ wheels = [
 ]
 
 [[package]]
+name = "nooa"
+version = "0.0.6"
+source = { git = "https://github.com/NVIDIA-NeMo/labs-OO-Agents.git?tag=v0.0.6#be0aad9db6cbce9b6a62ff08e3680284af091d6f" }
+dependencies = [
+    { name = "httpx", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "litellm", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "openinference-instrumentation-litellm", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+
+[[package]]
 name = "nox"
 version = "2026.2.9"
 source = { registry = "https://pypi.org/simple" }
@@ -7979,6 +8028,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/b1/028a05846136805b29b7a3afb58a940c2d213fa2c3d0a7d7003c7fbaa115/openevals-0.2.0.tar.gz", hash = "sha256:7e95fa64625be53eaa8c657d7f69b842a52bda10bdf3bb91781c7d09a385b069", size = 140711, upload-time = "2026-04-07T19:45:22.749Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/8b/00f402b7f3475e235c339a9bc82d2eaf46cc08b53ecd85d4a117850170d3/openevals-0.2.0-py3-none-any.whl", hash = "sha256:2bce5964be9d162e3d38c2dfd026739156e1ac521536ade6b8e2f0a89b632f2c", size = 106958, upload-time = "2026-04-07T19:45:21.575Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation"
+version = "0.1.53"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-semantic-conventions", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-api", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-sdk", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "wrapt", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b6/c0e7e047ae4962f2755a3bc9141fdd6272c75c74e47dfc6aa71978a9b78f/openinference_instrumentation-0.1.53.tar.gz", hash = "sha256:3c0c145cf6e13cfa630b29d0e3ca806f3821470ffca7922f1590e3970fadd4da", size = 33712, upload-time = "2026-06-02T16:37:21.771Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bb/01262d9945c476e15aa21bb9ca05b18604e525d73d9761cadb677f485198/openinference_instrumentation-0.1.53-py3-none-any.whl", hash = "sha256:f43695080eded47b1e03ff1b19cb5c23ea4409459cfe16c5b5748d5656832eb1", size = 40958, upload-time = "2026-06-02T16:37:20.69Z" },
+]
+
+[[package]]
+name = "openinference-instrumentation-litellm"
+version = "0.1.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "openinference-semantic-conventions", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-api", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-instrumentation", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-sdk", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "setuptools", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "wrapt", marker = "(python_full_version >= '3.12' and platform_machine == 'arm64' and sys_platform == 'darwin') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/60/53c020d999db1e0a8cd389a308f8b4dea9e19e4dc2b03915f5daf33032c7/openinference_instrumentation_litellm-0.1.34.tar.gz", hash = "sha256:658e64d1ab72b5e98a72715f196c20a1e4a32ab6e85c83959b359c2532da4be7", size = 90562, upload-time = "2026-05-18T18:51:31.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/d0/efe9332070487d132d604bb7c6d0d57a5c2039760f200210efb57e7c940a/openinference_instrumentation_litellm-0.1.34-py3-none-any.whl", hash = "sha256:c73b5813467cc0faf010280e5196f677ac4f844f9c72ea7847b6dd29980261be", size = 17177, upload-time = "2026-05-18T18:51:29.987Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves the Experimentalist agent-optimization plugin over from the standalone `nemo-optimizer` repo. Purely additive — `nemo-optimizer` is untouched, and removing the migrated files there is a follow-up once this copy is proven.

## What moved

- the plugin source and its 537 unit tests
- the Terminal-Bench benchmark harness (`benchmarks/`)
- the LangChain agent-under-test example the harness runs against
- the `langchain-framework` and `nooa` framework skills the harness depends on

This adds `nemo experimentalist run|doctor` as a top-level CLI group.

## Two things worth a closer look

**The plugin silently raised the monorepo's Python floor.** A uv workspace resolves to the highest `requires-python` among its members, so declaring the plugin at `>=3.12` rewrote the root lock's floor from 3.11 to 3.12 and dropped every `python_full_version < '3.12'` conditional package. CI type-checks against 3.11, so this would have broken in a way that looked unrelated to the plugin.

The plugin is now declared at `>=3.11`, its two genuinely 3.12-only dependencies (`nooa`, `harbor`) carry markers, and the whole plugin is gated behind `python_full_version >= '3.12'` in the `experimentalist` dependency group so it can't install half-resolved. The lock diff is purely additive: 82 lines, 4 new packages, zero version changes, no `requires-python` change.

In a future change, we will either bump the python version or adjust `nooa` to allow Python 3.11.

`nooa` is a git dependency rather than a PyPI release, so osv cannot read its license metadata and it needs an entry in the license overrides.

## Validation

- `nemo experimentalist doctor` reaches the live inference endpoint, finds Docker, confirms harbor imports
- `benchmarks/run.py --validate-only` resolves all paths and validates 89 Terminal-Bench tasks (this is what proves the `REPO_ROOT` → `PLUGIN_ROOT` rewrites are right)
- 537 plugin tests pass; `ruff check` clean on everything added
- `make test-unit` adds zero failures versus the baseline
- 12 of 13 lint checks green

## Open source review

No secrets or keys, no internal-only hostnames (`inference-api.nvidia.com` is already referenced across the public SDK skills), no vendored Terminal-Bench task content — tasks download to a cache at runtime. The `langchain-framework` skill carries a provenance note stating it summarizes LangChain's MIT-licensed public docs, with original structure and comparisons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the NeMo Experimentalist plugin with `nemo experimentalist run` and `nemo experimentalist doctor` workflows for optimizer execution and environment validation.
  * Introduced Eval Author to stage, validate, and publish evaluator insight suites from traces and datasets.
  * Added Terminal-Bench integration with canonical benchmark suites/configs and an example runnable agent.
* **Documentation**
  * Expanded end-to-end guides for Experimentalist, Eval Author, benchmarks, and LangChain/LangGraph/Deep Agents skills.
* **Breaking Changes**
  * Updated migration guidance for the Optimizer→Experimentalist and Curator→Eval Author renames.
* **Tests**
  * Added extensive CLI, staging/materialization, evaluation/trace, benchmarking, publishing, and resilience test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->