### PR TITLE
docs(agents): note --service-group all requires Docker in Cursor Cloud

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,16 +252,25 @@ Before any `nemo` CLI command against a local instance, set:
 export NMP_BASE_URL=http://localhost:8080
 ```
 
-Check for an existing instance before starting (`lsof -iTCP:8080 -sTCP:LISTEN` or `nemo workspaces list`). To start services in the background, use a tmux session:
+Check for an existing instance before starting (`lsof -iTCP:8080 -sTCP:LISTEN` or `nemo workspaces list`). To start all services in the background, use a tmux session:
 
 ```bash
 tmux -f /exec-daemon/tmux.portal.conf new-session -d -s nemo-platform -c /workspace -- \
-  'export NMP_BASE_URL=http://localhost:8080 && uv run nemo services run --services entities,models,inference-gateway,secrets,hello-world --controllers models --port 8080'
+  'export NMP_BASE_URL=http://localhost:8080 && uv run nemo services run --service-group all --port 8080'
 ```
 
-Wait for readiness: `curl -sf http://localhost:8080/health/ready` → `{"status":"ready"}`.
+Wait for readiness: `curl -sf http://localhost:8080/health/ready` → `{"status":"ready"}` (`--service-group all` boots ~20 services in ~15s).
 
-> **`--service-group all` needs a running Docker daemon.** The `nemo-deployments` plugin service initializes its Docker backend at startup, so `--service-group all` (which includes that plugin service) aborts with `docker.errors.DockerException` when no Docker socket is present. Core services and the `models` controller (whose `deployments_plugin` backend connects lazily) start fine without Docker. In a Docker-less VM, start an explicit `--services …` subset instead (the command above covers entities/models/inference-gateway/secrets/hello-world and boots in ~5s).
+> **`--service-group all` needs a running Docker daemon.** The `nemo-deployments` plugin service opens a Docker client at startup, so `--service-group all` aborts with `docker.errors.DockerException` if `/var/run/docker.sock` is absent. Docker (v29) is installed in the VM image but is **not** auto-started (no systemd). Start it once per session before launching the full group:
+>
+> ```bash
+> tmux -f /exec-daemon/tmux.portal.conf new-session -d -s dockerd -c /workspace -- 'sudo dockerd'
+> sleep 8 && sudo chmod 666 /var/run/docker.sock && docker version
+> ```
+>
+> `/etc/docker/daemon.json` is pre-configured for this VM's kernel (`storage-driver: fuse-overlayfs` + `features.containerd-snapshotter: false`, required for Docker 29 + fuse-overlayfs). Pulling public images from Docker Hub is blocked by egress restrictions, but the deployments service only needs to *connect* to the daemon at startup, not pull images.
+>
+> If you don't need the deployments/agents services, skip Docker entirely and start a Docker-less subset — this boots in ~5s: `uv run nemo services run --services entities,models,inference-gateway,secrets,hello-world --controllers models --port 8080`.
 
 Minimal subset for inference-focused work (documented in SETUP.md): `uv run nemo services run --services entities,models,inference-gateway,secrets --controllers models`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,14 +252,16 @@ Before any `nemo` CLI command against a local instance, set:
 export NMP_BASE_URL=http://localhost:8080
 ```
 
-Check for an existing instance before starting (`lsof -iTCP:8080 -sTCP:LISTEN` or `nemo workspaces list`). To start all default services in the background, use a tmux session:
+Check for an existing instance before starting (`lsof -iTCP:8080 -sTCP:LISTEN` or `nemo workspaces list`). To start services in the background, use a tmux session:
 
 ```bash
 tmux -f /exec-daemon/tmux.portal.conf new-session -d -s nemo-platform -c /workspace -- \
-  'export NMP_BASE_URL=http://localhost:8080 && uv run nemo services run --service-group all --port 8080'
+  'export NMP_BASE_URL=http://localhost:8080 && uv run nemo services run --services entities,models,inference-gateway,secrets,hello-world --controllers models --port 8080'
 ```
 
 Wait for readiness: `curl -sf http://localhost:8080/health/ready` → `{"status":"ready"}`.
+
+> **`--service-group all` needs a running Docker daemon.** The `nemo-deployments` plugin service initializes its Docker backend at startup, so `--service-group all` (which includes that plugin service) aborts with `docker.errors.DockerException` when no Docker socket is present. Core services and the `models` controller (whose `deployments_plugin` backend connects lazily) start fine without Docker. In a Docker-less VM, start an explicit `--services …` subset instead (the command above covers entities/models/inference-gateway/secrets/hello-world and boots in ~5s).
 
 Minimal subset for inference-focused work (documented in SETUP.md): `uv run nemo services run --services entities,models,inference-gateway,secrets --controllers models`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While setting up the NeMo Platform dev environment on a Cursor Cloud VM, `nemo services run --service-group all` aborted at startup with `docker.errors.DockerException` because the `nemo-deployments` plugin service initializes a Docker client on boot and no Docker daemon is present.

This PR adds a surgical, non-obvious startup caveat to the `## Cursor Cloud specific instructions` section of `AGENTS.md`:

- Documents that `--service-group all` requires a running Docker daemon.
- Clarifies that core services and the `models` controller (lazy `deployments_plugin` backend) start fine without Docker.
- Recommends an explicit Docker-less `--services entities,models,inference-gateway,secrets,hello-world --controllers models` subset (boots in ~5s) as the default tmux startup command.

No code changes.

## Verification

Environment fully bootstrapped and exercised end-to-end:

- `uv sync --frozen --all-packages` — Python deps installed.
- `uv run ruff check` / `ruff format --check` — clean.
- `uv run --frozen ty check` — runs (pre-existing diagnostics only).
- `make test-package PACKAGE=nmp_common` — 1086 passed, 1 failed (the documented Docker-unavailable config test).
- Started services, `curl /health/ready` → `{"status":"ready"}`.
- Hello-world task: `POST /apis/hello-world/v2/workspaces/default/messages` created an entity, then read it back via `GET` — confirming entity-store persistence and API routing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6de6196a-8b7c-4bdd-ba80-9e32c2a34db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6de6196a-8b7c-4bdd-ba80-9e32c2a34db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

