### PR TITLE
docs: clarify Python tiers for core platform vs NOOA experimentalist

### DIFF
--- a/docs/support-matrix.mdx
+++ b/docs/support-matrix.mdx
@@ -19,6 +19,26 @@ self-managed Kubernetes deployments installed with the NeMo Platform Helm chart.
 | Windows and WSL | Not supported for the OSS local install path | Use a supported Linux or macOS host for the local install path. |
 | Kubernetes clusters | minikube, kind, EKS, AKS, GKE, OKE, OpenShift, and on-prem Kubernetes | See [Install NeMo Platform with Helm](/documentation/self-managed-deployment/helm) for prerequisites and cluster-specific notes. |
 
+## Python tiers (core vs optional plugins)
+
+NeMo Platform declares `requires-python = ">=3.11,<3.15"` on the published
+`nemo-platform` and SDK wheels. That is the supported range for the default CLI,
+local services, and `nemo-platform[all]`.
+
+Some optional plugins and monorepo dependency groups impose a **narrower** range.
+You do not need to match the strictest plugin unless you install that plugin.
+
+| Component | Python range | Notes |
+|-----------|--------------|-------|
+| Core Platform (`nemo-platform`, SDK, default services) | 3.11–3.14 | Documented OSS local-install support. |
+| NeMo Experimentalist (`nooa`, Harbor eval loop) | 3.12–3.13 (`>=3.12,<3.14`) | [NOOA](https://github.com/NVIDIA-NeMo/labs-OO-Agents) (labs OO Agents) caps below 3.14. In this repository, install with `uv sync --group experimentalist` on Python 3.12 or 3.13 only. Not part of the default `nemo-platform[all]` wheel bundle today. |
+| GPU training plugins (RL, Automodel, Unsloth, and related services) | 3.11–3.13 (`>=3.11,<3.14`) | Same upper cap in workspace members; monorepo `uv.lock` resolves through 3.13. |
+| Release container images (`nmp-python-base`, API, CPU tasks) | 3.13 | Built from `python:3.13.x-slim` in `docker/base/Dockerfile.nmp-python-base`. Independent of the pip-install floor on 3.11. |
+
+Experimentalist on Python 3.11 is intentionally unsupported: the root
+`experimentalist` dependency group is omitted on 3.11 so Harbor and NOOA are
+not half-installed.
+
 ## Local Runtime
 
 | Area | Supported | Notes |

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -10,10 +10,14 @@ or Git-backed agent against Harbor-compatible train and validation datasets.
 
 ## Install and develop
 
+Use **Python 3.12 or 3.13** (`>=3.12,<3.14`). NOOA and Harbor do not support
+Python 3.11 or 3.14. The workspace keeps a 3.11 floor for the rest of NeMo
+Platform; enable Experimentalist only via the `experimentalist` dependency group.
+
 From the root of this checkout:
 
 ```bash
-uv sync
+uv sync --group experimentalist
 export NEMO="$PWD/.venv/bin/nemo"
 ```
 

--- a/plugins/nemo-experimentalist/pyproject.toml
+++ b/plugins/nemo-experimentalist/pyproject.toml
@@ -2,18 +2,17 @@
 name = "nemo-experimentalist-plugin"
 version = "0.1.0"
 description = "NeMo Experimentalist plugin for NeMo Platform."
-# The plugin itself needs 3.12 (so do nooa and harbor), but a workspace member cannot
-# raise its floor above the workspace's without dragging every other package up with it.
-# The floor is declared here and enforced by the markers below plus the `experimentalist`
-# dependency group in the workspace root.
+# nooa and harbor need Python >=3.12,<3.14. The workspace floor stays >=3.11 so the
+# rest of the monorepo can resolve on 3.11; this plugin's runtime deps are gated by
+# markers below and the root `experimentalist` dependency group.
 requires-python = ">=3.11,<3.14"
 dependencies = [
     "pydantic>=2",
     "httpx",
-    "harbor>=0.16 ; python_full_version >= '3.12'",
+    "harbor>=0.16 ; python_full_version >= '3.12' and python_full_version < '3.14'",
     "opentelemetry-proto>=1.42.1",
     "protobuf>=6.0.0",
-    "nooa ; python_full_version >= '3.12'",
+    "nooa ; python_full_version >= '3.12' and python_full_version < '3.14'",
     "pyyaml>=6.0.3",
     "nemo-insights-plugin",
     "nemo-platform",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,9 +70,11 @@ version = "0.0.0"
 # Optional Insights analyst plugin.
 insights = ["nemo-insights-plugin"]
 # Optional Experimentalist agent-optimization plugin. Its agent framework (nooa) and
-# evaluator (harbor) are both 3.12-only, so the whole plugin is gated rather than
-# installed half-resolved on 3.11.
-experimentalist = ["nemo-experimentalist-plugin ; python_full_version >= '3.12'"]
+# evaluator (harbor) require Python >=3.12,<3.14, so the whole plugin is gated rather
+# than installed half-resolved on 3.11 or on 3.14+ where nooa does not publish wheels.
+experimentalist = [
+  "nemo-experimentalist-plugin ; python_full_version >= '3.12' and python_full_version < '3.14'",
+]
 dev = [
   "pre-commit>=3.8.0",
   "pydantic-settings>=2.6.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves confusion about "Figure out Python versions for release" by documenting the **tiered** Python support model already implemented in the repo.

**Key finding:** [labs OO Agents (`nooa`)](https://github.com/NVIDIA-NeMo/labs-OO-Agents) declares `requires-python = ">=3.12,<3.14"` (Python **3.12 or 3.13**), not Python **>3.13**. The published NeMo Platform wheel still supports **3.11–3.14** for the default install path.

## Changes

- Add a **Python tiers** section to `docs/support-matrix.mdx` (core vs Experimentalist/nooa vs GPU training plugins vs release container images on 3.13).
- Document Experimentalist install prerequisites in `plugins/nemo-experimentalist/README.md`.
- Tighten `experimentalist` dependency-group and plugin dependency markers to `>=3.12,<3.14` so the group is omitted on 3.14 as well as 3.11.

## Release guidance (no floor bump)

| Surface | Python |
|---------|--------|
| `pip install nemo-platform[all]` | 3.11–3.14 |
| Monorepo + `--group experimentalist` | 3.12–3.13 only |
| `nmp-python-base` container images | 3.13 |

No change to the platform-wide `requires-python` floor (still 3.11); optional plugins stay opt-in via dependency groups/markers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c96491c6-c781-44ab-b7de-2a614bd60bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c96491c6-c781-44ab-b7de-2a614bd60bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

