### PR TITLE
docs: clarify Python versions for release vs Experimentalist/NOOA

### DIFF
--- a/docs/support-matrix.mdx
+++ b/docs/support-matrix.mdx
@@ -12,7 +12,7 @@ self-managed Kubernetes deployments installed with the NeMo Platform Helm chart.
 | Area | Supported | Notes |
 |------|-----------|-------|
 | Deployment mode | `nemo setup` local install; Helm chart on Kubernetes | `nemo setup` starts local services, registers a model provider, and configures the CLI and SDK. The Helm chart is the supported path for self-managed Kubernetes clusters. |
-| Python | 3.11, 3.12, 3.13, 3.14 (`>=3.11,<3.15`) | Use an isolated virtual environment. On Python 3.14, prefix `pip install "nemo-platform[all]"` with `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` while the transitive `litellm` Rust extension catches up to Python 3.14. Python 3.11 is the lowest supported Python version and Python 3.14 is the highest supported Python version for the OSS local install path. |
+| Python | 3.11, 3.12, 3.13, 3.14 (`>=3.11,<3.15`) | Use an isolated virtual environment. On Python 3.14, prefix `pip install "nemo-platform[all]"` with `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` while the transitive `litellm` Rust extension catches up to Python 3.14. Python 3.11 is the lowest supported Python version and Python 3.14 is the highest supported Python version for the OSS local install path. Published release wheels (`nemo-platform`, `nemo-platform-plugin`) and their CI matrix target this range. Self-managed container images built from this repo use Python 3.13 in `nmp-python-base`; that runtime version is independent of the wheel `requires-python` floor. |
 | Linux | Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, RHEL 9, Rocky Linux 9, Debian 12 | Supported for CLI, SDK, local services, and NVIDIA GPU workloads. |
 | macOS | [macOS Tahoe 26](https://support.apple.com/en-us/122868) and macOS Sequoia 15 | Supported for CLI, SDK, local services, and cloud/provider workflows. Local NVIDIA GPU workloads are not supported on macOS. |
 | Architecture | x86_64 Linux; Apple Silicon and Intel macOS | NVIDIA GPU workloads require x86_64 Linux. |
@@ -43,6 +43,17 @@ self-managed Kubernetes deployments installed with the NeMo Platform Helm chart.
 |---------|----------------|---------|-----|
 | CLI, SDK, and hosted-provider setup | 8 GB RAM minimum | 16 GB free disk space | Not required |
 | Local GPU workloads | 16 GB RAM minimum; 32 GB recommended | Additional tens to hundreds of GB for model artifacts and job outputs | 40 GB VRAM minimum; 80 GB recommended |
+
+## Optional components (stricter Python)
+
+These features are **not** bundled in published `nemo-platform` wheels or default Helm/local service images. They install only from a source checkout (or a future dedicated extra/wheel) and impose a **higher** Python floor than the core platform.
+
+| Component | Python | Notes |
+|-----------|--------|-------|
+| NeMo Experimentalist (agent optimization) | 3.12 or 3.13 (`>=3.12,<3.14`) | Depends on [NOOA](https://github.com/NVIDIA-NeMo/labs-OO-Agents) (`requires-python >=3.12,<3.14`) and Harbor. In the monorepo: Python 3.12+, then `uv sync --group insights --group experimentalist`. Not in the `enabled-plugins` set used for release containers. |
+| Harbor agent-eval runner | ≥ 3.12 | `harbor` is optional (`nemo-evaluator-sdk[harbor]`). See [Harbor runner](/documentation/evaluate-models/agent-eval/harbor-runner). |
+
+Core Platform on Python 3.11 remains fully supported without these components. On Python 3.14, Experimentalist is unavailable because NOOA caps below 3.14.
 
 ## Model Providers
 

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -10,10 +10,12 @@ or Git-backed agent against Harbor-compatible train and validation datasets.
 
 ## Install and develop
 
-From the root of this checkout:
+**Python:** 3.12 or 3.13 only. NOOA and Harbor both require `>=3.12`; NOOA caps at `<3.14`. The workspace root still supports 3.11 for the rest of NeMo Platform — Experimentalist is gated behind the `experimentalist` dependency group and is not installed by a default `uv sync`.
+
+From the root of this checkout (Python 3.12+):
 
 ```bash
-uv sync
+uv sync --group insights --group experimentalist
 export NEMO="$PWD/.venv/bin/nemo"
 ```
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the intentional split between NeMo Platform’s release Python range (3.11–3.14 wheels, 3.13 container base) and optional 3.12+ components (Experimentalist/NOOA, Harbor).

## Context

NOOA (`labs-OO-Agents`) declares `requires-python >=3.12,<3.14`. The monorepo already gates `nooa`, `harbor`, and the `experimentalist` dependency group with `python_full_version >= '3.12'` without raising the workspace floor. Published release wheels do not include Experimentalist.

## Changes

- `docs/support-matrix.mdx`: note wheel vs container Python, add optional-components table
- `plugins/nemo-experimentalist/README.md`: correct install instructions (`--group insights --group experimentalist`, 3.12–3.13)

No change to `requires-python` on `nemo-platform` — bumping the platform floor to 3.12 is not required for release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4838a70-f702-45e0-b058-e11eea09a738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4838a70-f702-45e0-b058-e11eea09a738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

