### PR TITLE
Set up Docker Engine in the cloud VM environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -267,7 +267,7 @@ Minimal subset for inference-focused work (documented in SETUP.md): `uv run nemo
 
 Standard commands from repo root (see sections above): `uv run ruff check`, `uv run --frozen ty check`, `make test-unit`, `make test-package PACKAGE=<name>`.
 
-- **Docker:** Not required for core platform smoke tests. One `nmp_common` config test expects Docker and sets runtime to `none` when Docker is unavailable.
+- **Docker:** Available in the cloud VM (Docker Engine `docker-ce` 29.x with the compose plugin). The daemon uses the `fuse-overlayfs` storage driver (`containerd-snapshotter` disabled) because the VM kernel lacks full overlay2/nftables support; iptables is pinned to legacy. There is no systemd (PID 1 is `tini`), so do NOT use `systemctl` — the daemon is started on VM boot via `sudo /etc/init.d/docker start` (part of the environment start command). If the socket is missing, run that command to (re)start it, then verify with `docker info` (works as `ubuntu` without sudo since `ubuntu` is in the `docker` group). Note: registry pulls (e.g. Docker Hub) may be blocked by network egress restrictions; local `FROM scratch` builds work. One `nmp_common` config test expects Docker and sets runtime to `none` when Docker is unavailable.
 - **Inference providers:** `nemo setup`, `nemo chat`, and agent invoke require an API key (`NVIDIA_API_KEY`, `OPENAI_API_KEY`, etc.). Core APIs (workspaces, secrets, hello-world, entities) work without provider credentials.
 
 ### Quick smoke verification


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up Docker Engine in the Cursor Cloud VM image and documents it, per the requested configuration. Docker now runs on the fuse-overlayfs storage driver, starts on VM boot via the environment start command (no systemd), and is usable by the `ubuntu` user without sudo.

The only code change in this PR is an AGENTS.md note; the rest of the setup lives in the VM environment snapshot + update script.

## What was configured

- **Docker Engine** `docker-ce` 29.6.2 + compose plugin v5.3.1 (already present in image; validated).
- **`/etc/docker/daemon.json`** with `storage-driver: fuse-overlayfs` and `features.containerd-snapshotter: false` (required for Docker 29 on this kernel).
- **iptables/ip6tables** pinned to legacy via `update-alternatives`.
- **`ubuntu` added to the `docker` group** so `docker` works without sudo.
- **Boot start**: because PID 1 is `tini` (no systemd), the daemon is started on every VM boot via `sudo /etc/init.d/docker start` in the environment update/start command (guarded so it is idempotent within a session). The script also refreshes Python deps with `uv sync --frozen --all-packages`.

## Verification

`docker info` as `ubuntu` (no sudo) reports the fuse-overlayfs driver, and an end-to-end `FROM scratch` image builds and runs a container:

```
--- docker info (as ubuntu, no sudo) ---
 Server Version: 29.6.2
 Storage Driver: fuse-overlayfs
 Cgroup Version: 2
 Kernel Version: 6.12.94+
 Operating System: Ubuntu 24.04.4 LTS

--- end-to-end: build FROM scratch + run container ---
Hello from a container on fuse-overlayfs!
```

Note: registry pulls (e.g. Docker Hub) are blocked by network egress restrictions in this environment, so the hello-world image was built locally `FROM scratch` instead of pulled.

[Docker verification log](https://cursor.com/agents/bc-eb6fef10-9038-445e-87ce-fdad605e8a3a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocker_verification.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb6fef10-9038-445e-87ce-fdad605e8a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb6fef10-9038-445e-87ce-fdad605e8a3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

