### PR TITLE
fix(jobs): jobs-launcher authorization without token exchange

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/constants.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/constants.py
@@ -1,6 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared client constants."""
+"""Shared client constants and env checks."""
+
+import os
 
 WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR = "NMP_WORKLOAD_IDENTITY_TOKEN_FILE"
+
+
+def is_workload_identity_token_file_set() -> bool:
+    return bool(os.environ.get(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR))

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk_provider.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk_provider.py
@@ -39,6 +39,7 @@ from importlib.metadata import entry_points
 from typing import Any, Protocol, TypeVar, runtime_checkable
 
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.constants import is_workload_identity_token_file_set
 
 _SDKT = TypeVar("_SDKT", NeMoPlatform, AsyncNeMoPlatform)
 
@@ -157,6 +158,10 @@ def _on_behalf_of_headers(principal: dict[str, Any]) -> dict[str, str]:
     return headers
 
 
+def _workload_identity_headers(*, internal: bool) -> dict[str, str]:
+    return {_INTERNAL_REQUEST_HEADER: "true"} if internal else {}
+
+
 class DefaultSDKProvider:
     """Env-var-based provider that ships with the plugin package.
 
@@ -166,6 +171,12 @@ class DefaultSDKProvider:
     """
 
     def get_task_sdk(self, service_name: str) -> NeMoPlatform:
+        if is_workload_identity_token_file_set():
+            return NeMoPlatform(
+                base_url=self._base_url(),
+                default_headers=_workload_identity_headers(internal=True),
+            )
+
         headers: dict[str, str] = {
             "X-NMP-Principal-Id": f"service:{service_name}",
             _INTERNAL_REQUEST_HEADER: "true",
@@ -189,6 +200,12 @@ class DefaultSDKProvider:
     def get_async_task_sdk(self, service_name: str) -> AsyncNeMoPlatform:
         # Async mirror of get_task_sdk: identical headers (service principal,
         # internal marker, and full on-behalf-of id/email/groups), async client.
+        if is_workload_identity_token_file_set():
+            return AsyncNeMoPlatform(
+                base_url=self._base_url(),
+                default_headers=_workload_identity_headers(internal=True),
+            )
+
         headers: dict[str, str] = {
             "X-NMP-Principal-Id": f"service:{service_name}",
             _INTERNAL_REQUEST_HEADER: "true",
@@ -217,6 +234,10 @@ class DefaultSDKProvider:
         internal: bool = False,
         on_behalf_of: str | None = None,
     ) -> _SDKT:
+        if as_service is None and on_behalf_of is None and is_workload_identity_token_file_set():
+            headers = _workload_identity_headers(internal=internal)
+            return cls(base_url=self._base_url(), default_headers=headers or None)
+
         headers = self._build_headers(as_service=as_service, internal=internal, on_behalf_of=on_behalf_of)
         return cls(base_url=self._base_url(), default_headers=headers or None)
 

--- a/packages/nemo_platform_plugin/tests/test_sdk_provider.py
+++ b/packages/nemo_platform_plugin/tests/test_sdk_provider.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
 from nemo_platform_plugin.sdk_provider import (
     DefaultSDKProvider,
     SDKProvider,
@@ -127,6 +128,25 @@ class TestDefaultSDKProvider:
         sdk = provider.get_task_sdk("test")
         assert sdk.base_url == "http://localhost:8080"
 
+    def test_get_task_sdk_uses_workload_identity_when_token_file_configured(self, monkeypatch, tmp_path):
+        subject_token_file = tmp_path / "workload-token"
+        subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
+        monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")
+        monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
+        monkeypatch.setenv(
+            "NMP_PRINCIPAL",
+            json.dumps({"id": "creator@ex.com", "email": "creator@ex.com", "groups": ["team"]}),
+        )
+
+        provider = DefaultSDKProvider()
+        sdk = provider.get_task_sdk("evaluator")
+        try:
+            assert sdk.default_headers["X-NMP-Internal"] == "true"
+            assert "X-NMP-Principal-Id" not in sdk.default_headers
+            assert "X-NMP-Principal-On-Behalf-Of" not in sdk.default_headers
+        finally:
+            sdk.close()
+
     def test_get_platform_sdk_as_service(self, monkeypatch):
         monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")
         monkeypatch.delenv("NMP_PRINCIPAL", raising=False)
@@ -196,6 +216,25 @@ class TestAsyncTaskSdk:
 
         provider = DefaultSDKProvider()
         assert _xnmp(provider.get_async_task_sdk("evaluator")) == _xnmp(provider.get_task_sdk("evaluator"))
+
+    @pytest.mark.asyncio
+    async def test_async_task_sdk_uses_workload_identity_when_token_file_configured(self, monkeypatch, tmp_path):
+        subject_token_file = tmp_path / "workload-token"
+        subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
+        monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")
+        monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
+        monkeypatch.setenv(
+            "NMP_PRINCIPAL",
+            json.dumps({"id": "creator@ex.com", "email": "creator@ex.com", "groups": ["team"]}),
+        )
+
+        sdk = DefaultSDKProvider().get_async_task_sdk("evaluator")
+        try:
+            assert sdk.default_headers["X-NMP-Internal"] == "true"
+            assert "X-NMP-Principal-Id" not in sdk.default_headers
+            assert "X-NMP-Principal-On-Behalf-Of" not in sdk.default_headers
+        finally:
+            await sdk.close()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nmp_common/src/nmp/common/platform_endpoint.py
+++ b/packages/nmp_common/src/nmp/common/platform_endpoint.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 import httpx
 from httpx._types import TimeoutTypes
+from nemo_platform import DefaultAsyncHttpxClient, DefaultHttpxClient
 from nmp.common.config import PlatformConfig
 
 UDS_BASE_URL = "http://nemo-platform.local"
@@ -46,6 +47,20 @@ class PlatformEndpoint:
         if timeout is None:
             return httpx.AsyncClient(follow_redirects=True)
         return httpx.AsyncClient(follow_redirects=True, timeout=timeout)
+
+    def sync_sdk_http_client(self, *, timeout: TimeoutTypes | None = None) -> httpx.Client:
+        if self.transport == "uds":
+            return self.sync_http_client(timeout=timeout)
+        if timeout is None:
+            return DefaultHttpxClient()
+        return DefaultHttpxClient(timeout=timeout)
+
+    def async_sdk_http_client(self, *, timeout: TimeoutTypes | None = None) -> httpx.AsyncClient:
+        if self.transport == "uds":
+            return self.async_http_client(timeout=timeout)
+        if timeout is None:
+            return DefaultAsyncHttpxClient()
+        return DefaultAsyncHttpxClient(timeout=timeout)
 
 
 def resolve_platform_endpoint(platform_config: PlatformConfig | None = None) -> PlatformEndpoint:

--- a/packages/nmp_common/src/nmp/common/sdk_factory.py
+++ b/packages/nmp_common/src/nmp/common/sdk_factory.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Optional, TypeVar, cast
 
 import httpx
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.client.constants import is_workload_identity_token_file_set
 from nmp.common.auth import Principal, get_principal_auth_headers, principal_from_env
 from nmp.common.config import Configuration, PlatformConfig
 from nmp.common.http_clients import shared_async_http_client, shared_sync_http_client
@@ -156,6 +157,26 @@ def _async_http_client_for_endpoint(
     return shared_async_http_client()
 
 
+def _should_bootstrap_workload_identity(
+    *,
+    as_service: str | None,
+    on_behalf_of: str | Principal | None,
+    http_client: httpx.Client | httpx.AsyncClient | None,
+    endpoint: PlatformEndpoint,
+) -> bool:
+    return (
+        as_service is None
+        and on_behalf_of is None
+        and http_client is None
+        and endpoint.transport != "uds"
+        and is_workload_identity_token_file_set()
+    )
+
+
+def _workload_identity_extra_headers(*, internal: bool) -> dict[str, str]:
+    return MARK_INTERNAL_REQUEST_HEADERS.copy() if internal else {}
+
+
 def _get_default_headers(
     as_service: str | None = None, internal: bool = False, on_behalf_of: str | Principal | None = None
 ) -> dict[str, str]:
@@ -241,8 +262,21 @@ def get_platform_sdk(
     Returns:
         Configured NeMoPlatform SDK instance.
     """
-    headers = _get_default_headers(as_service, internal, on_behalf_of)
     endpoint = resolve_platform_endpoint()
+    if _should_bootstrap_workload_identity(
+        as_service=as_service,
+        on_behalf_of=on_behalf_of,
+        http_client=http_client,
+        endpoint=endpoint,
+    ):
+        headers = _workload_identity_extra_headers(internal=internal)
+        sdk = NeMoPlatform(
+            base_url=base_url or endpoint.connect_base_url,
+            default_headers=headers if headers else None,
+        )
+        return attach_platform_request_router(sdk)
+
+    headers = _get_default_headers(as_service, internal, on_behalf_of)
     sdk = NeMoPlatform(
         base_url=base_url or endpoint.connect_base_url,
         http_client=_sync_http_client_for_endpoint(endpoint, http_client),
@@ -265,6 +299,12 @@ def get_task_sdk(as_service: str, http_client: httpx.Client | None = None) -> Ne
     Returns:
         Configured NeMoPlatform SDK with internal + on-behalf-of headers.
     """
+    if http_client is None and is_workload_identity_token_file_set():
+        return get_platform_sdk(internal=True)
+
+    if http_client is None:
+        http_client = resolve_platform_endpoint().sync_sdk_http_client()
+
     principal = principal_from_env()
     if principal is None:
         logger.warning(
@@ -293,6 +333,12 @@ def get_async_task_sdk(as_service: str, http_client: Optional[httpx.AsyncClient]
     Returns:
         Configured AsyncNeMoPlatform SDK with internal + on-behalf-of headers.
     """
+    if http_client is None and is_workload_identity_token_file_set():
+        return get_async_platform_sdk(internal=True)
+
+    if http_client is None:
+        http_client = resolve_platform_endpoint().async_sdk_http_client()
+
     principal = principal_from_env()
     if principal is None:
         logger.warning(
@@ -331,8 +377,28 @@ def get_async_platform_sdk(
     Returns:
         Configured AsyncNeMoPlatform SDK instance.
     """
-    headers = _get_default_headers(as_service, internal, on_behalf_of)
     endpoint = resolve_platform_endpoint()
+    if _should_bootstrap_workload_identity(
+        as_service=as_service,
+        on_behalf_of=on_behalf_of,
+        http_client=http_client,
+        endpoint=endpoint,
+    ):
+        headers = _workload_identity_extra_headers(internal=internal)
+        if _test_http_client is None:
+            sdk = AsyncNeMoPlatform(
+                base_url=base_url or endpoint.connect_base_url,
+                default_headers=headers if headers else None,
+            )
+        else:
+            sdk = AsyncNeMoPlatform(
+                base_url=base_url or endpoint.connect_base_url,
+                http_client=_async_http_client_for_endpoint(endpoint, http_client),
+                default_headers=headers if headers else None,
+            )
+        return attach_platform_request_router(sdk)
+
+    headers = _get_default_headers(as_service, internal, on_behalf_of)
 
     # Use explicitly provided http_client (from DependencyProvider) or fall back to
     # module-level _test_http_client for backward compatibility with direct callers.

--- a/packages/nmp_common/tests/auth/test_middleware.py
+++ b/packages/nmp_common/tests/auth/test_middleware.py
@@ -84,6 +84,14 @@ def create_test_app(auth_config: AuthConfig) -> FastAPI:
     async def hf_download_endpoint(workspace: str, name: str, revision: str, path: str):
         return {"workspace": workspace, "name": name, "path": path}
 
+    @app.post("/apis/files/v2/workspaces/{workspace}/filesets/{name}/otlp/v1/logs")
+    async def files_otlp_logs_upload(workspace: str, name: str):
+        return {"workspace": workspace, "name": name}
+
+    @app.post("/apis/files/v2/workspaces/{workspace}/filesets/{name}/otlp/v1/logs/query")
+    async def files_otlp_logs_query(workspace: str, name: str):
+        return {"workspace": workspace, "name": name}
+
     Configuration.set_override(auth_config)
     app.add_middleware(AuthorizationMiddleware, service_name="test-service")
 
@@ -426,12 +434,8 @@ class TestServicePrincipalAuth:
             mock_authorize.assert_called_once()
 
 
-class TestHfEndpointAuth:
-    """Tests for HuggingFace-compatible endpoint authentication.
-
-    HF endpoints accept service principal tokens via Bearer header (HF_TOKEN),
-    allowing huggingface-hub clients to authenticate with HF_TOKEN=service:<name>.
-    """
+class TestCompatibilityAuth:
+    """Tests for compatibility auth paths used by non-standard clients."""
 
     @pytest.mark.parametrize(
         "token,expected_status",
@@ -474,6 +478,57 @@ class TestHfEndpointAuth:
         assert response.status_code == 200
         auth_client = mock_authorize.call_args.args[0]
         assert auth_client.principal.id == "service:models"
+
+    def test_files_otlp_logs_upload_accepts_service_principal_header(self, auth_config_enabled):
+        """Job log uploads accept the launcher fallback service principal header."""
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch.object(AuthClient, "authorize_request", autospec=True) as mock_authorize:
+            mock_authorize.return_value = MagicMock(allowed=True)
+
+            response = client.post(
+                "/apis/files/v2/workspaces/my-workspace/filesets/job-fileset-1/otlp/v1/logs",
+                headers={"X-NMP-Principal-Id": "service:jobs"},
+            )
+
+        assert response.status_code == 200
+        auth_client = mock_authorize.call_args.args[0]
+        assert auth_client.principal.id == "service:jobs"
+
+    def test_files_otlp_logs_upload_does_not_accept_service_bearer_token(self, auth_config_enabled):
+        """Job log uploads use X-NMP service headers, not raw service bearer tokens."""
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch("nmp.common.auth.jwt.JWTValidator.validate_token") as mock_validate:
+            mock_validate.return_value = None
+            with patch("nmp.common.auth.client.AuthClient.authorize_request") as mock_authorize:
+                response = client.post(
+                    "/apis/files/v2/workspaces/my-workspace/filesets/job-fileset-1/otlp/v1/logs",
+                    headers={"Authorization": "Bearer service:jobs"},
+                )
+
+        assert response.status_code == 401
+        mock_validate.assert_called_once()
+        mock_authorize.assert_not_called()
+
+    def test_regular_endpoint_does_not_accept_service_bearer_token(self, auth_config_enabled):
+        """Raw service bearer tokens are not accepted on arbitrary routes."""
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch("nmp.common.auth.jwt.JWTValidator.validate_token") as mock_validate:
+            mock_validate.return_value = None
+            with patch("nmp.common.auth.client.AuthClient.authorize_request") as mock_authorize:
+                response = client.get(
+                    "/test",
+                    headers={"Authorization": "Bearer service:jobs"},
+                )
+
+        assert response.status_code == 401
+        mock_validate.assert_called_once()
+        mock_authorize.assert_not_called()
 
 
 class TestInternalServiceOnlyRoutes:

--- a/packages/nmp_common/tests/sdk_factory/test_sdk.py
+++ b/packages/nmp_common/tests/sdk_factory/test_sdk.py
@@ -7,10 +7,14 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+from nemo_platform.auth.helpers import NMPOIDCConfig
+from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
 from nmp.common.config import Configuration, PlatformConfig
+from nmp.common.http_clients import shared_async_http_client, shared_sync_http_client
 from nmp.common.sdk_factory import (
     PlatformRequestRouter,
     get_async_platform_sdk,
+    get_async_task_sdk,
     get_entity_parts,
     get_platform_sdk,
     get_request_scoped_sdk,
@@ -18,6 +22,17 @@ from nmp.common.sdk_factory import (
     get_task_sdk,
     resolve_platform_request_url,
 )
+
+
+def _workload_oidc_config() -> NMPOIDCConfig:
+    return NMPOIDCConfig(
+        auth_enabled=True,
+        workload_token_exchange_enabled=True,
+        workload_client_id="workload-client",
+        workload_token_endpoint="https://idp.example.test/oauth2/token",
+        workload_audience="nemo-platform",
+        workload_scope="openid email groups",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -157,6 +172,38 @@ def test_get_platform_sdk_internal_flag():
     assert sdk.default_headers["X-NMP-Internal"] == "true"
 
 
+def test_get_platform_sdk_uses_workload_identity_when_token_file_configured(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Workload-token task environments should let the generated SDK inject Bearer auth."""
+    subject_token_file = tmp_path / "workload-token"
+    subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("{}\n", encoding="utf-8")
+    exchange_requests: list[dict] = []
+
+    def token_exchange_grant(**kwargs):
+        exchange_requests.append(kwargs)
+        return {"access_token": "exchanged-access-token", "expires_in": 300}
+
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(config_file))
+    monkeypatch.setenv("NMP_BASE_URL", "http://nmp.example.test")
+    monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
+    monkeypatch.setenv("NMP_PRINCIPAL", json.dumps({"id": "creator@example.com", "email": "creator@example.com"}))
+    monkeypatch.delenv("NMP_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr("nemo_platform.client.factory.discover_nmp_config", lambda _base_url: _workload_oidc_config())
+    monkeypatch.setattr("nemo_platform.auth.workload_exchange.token_exchange_grant", token_exchange_grant)
+
+    sdk = get_platform_sdk()
+    try:
+        request = sdk._client.build_request("GET", "http://nmp.example.test/apis/entities/v2/workspaces/default")
+        sdk._client._event_hooks["request"][0](request)
+    finally:
+        sdk.close()
+
+    assert request.headers["Authorization"] == "Bearer exchanged-access-token"
+    assert "X-NMP-Principal-Id" not in request.headers
+    assert exchange_requests[0]["subject_token"] == "subject-token-from-file"
+
+
 def test_get_async_platform_sdk():
     """Test get_async_platform_sdk basic functionality (config path: SDK base_url matches platform config)."""
     sdk = get_async_platform_sdk()
@@ -175,6 +222,29 @@ def test_get_async_platform_sdk_uses_uds_endpoint_from_base_url():
         sdk = get_async_platform_sdk()
 
     assert str(sdk.base_url).rstrip("/") == "http://nemo-platform.local"
+
+
+@pytest.mark.asyncio
+async def test_get_async_platform_sdk_workload_identity_reuses_test_http_client(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+):
+    import nmp.common.sdk_factory as sdk_factory_module
+
+    subject_token_file = tmp_path / "workload-token"
+    subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
+    monkeypatch.setenv("NMP_BASE_URL", "http://nmp.example.test")
+    monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
+
+    transport = httpx.MockTransport(lambda _request: httpx.Response(200, json={}))
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as http_client:
+        sdk_factory_module._test_http_client = http_client
+        try:
+            sdk = get_async_platform_sdk()
+
+            assert sdk._client is http_client
+            assert str(sdk.base_url).rstrip("/") == "http://nmp.example.test"
+        finally:
+            sdk_factory_module._test_http_client = None
 
 
 def test_get_async_platform_sdk_with_service_principal():
@@ -246,6 +316,93 @@ def test_get_task_sdk_without_principal(monkeypatch: pytest.MonkeyPatch):
     assert sdk.default_headers["X-NMP-Principal-Id"] == "service:customizer"
     assert sdk.default_headers["X-NMP-Internal"] == "true"
     assert "X-NMP-Principal-On-Behalf-Of" not in sdk.default_headers
+
+
+def test_get_task_sdk_does_not_inherit_shared_client_authorization(monkeypatch: pytest.MonkeyPatch):
+    """Service-principal task SDK auth must come from SDK headers, not stale shared-client auth."""
+    monkeypatch.setenv(
+        "NMP_PRINCIPAL",
+        json.dumps({"id": "creator@example.com", "email": "creator@example.com"}),
+    )
+    client = shared_sync_http_client()
+    old_headers = dict(client.headers)
+    client.headers["Authorization"] = "Bearer service:jobs"
+    sdk = None
+
+    try:
+        sdk = get_task_sdk(as_service="jobs")
+        assert sdk._client is not client
+        assert sdk.default_headers["X-NMP-Principal-Id"] == "service:jobs"
+        assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "creator@example.com"
+        assert "Authorization" not in sdk.default_headers
+        assert "Authorization" not in sdk._client.headers
+    finally:
+        if sdk is not None:
+            sdk.close()
+        client.headers.clear()
+        client.headers.update(old_headers)
+        client.headers.pop("Authorization", None)
+
+
+@pytest.mark.asyncio
+async def test_get_async_task_sdk_does_not_inherit_shared_client_authorization(monkeypatch: pytest.MonkeyPatch):
+    """Async task SDK auth must also avoid stale shared-client auth."""
+    monkeypatch.setenv(
+        "NMP_PRINCIPAL",
+        json.dumps({"id": "creator@example.com", "email": "creator@example.com"}),
+    )
+    client = shared_async_http_client()
+    old_headers = dict(client.headers)
+    client.headers["Authorization"] = "Bearer service:jobs"
+    sdk = None
+
+    try:
+        sdk = get_async_task_sdk(as_service="jobs")
+        assert sdk._client is not client
+        assert sdk.default_headers["X-NMP-Principal-Id"] == "service:jobs"
+        assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "creator@example.com"
+        assert "Authorization" not in sdk.default_headers
+        assert "Authorization" not in sdk._client.headers
+    finally:
+        if sdk is not None:
+            await sdk.close()
+        client.headers.clear()
+        client.headers.update(old_headers)
+        client.headers.pop("Authorization", None)
+
+
+def test_get_task_sdk_uses_workload_identity_when_token_file_configured(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Task SDKs should centralize the workload-token-vs-service-header choice."""
+    subject_token_file = tmp_path / "workload-token"
+    subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("{}\n", encoding="utf-8")
+    exchange_requests: list[dict] = []
+
+    def token_exchange_grant(**kwargs):
+        exchange_requests.append(kwargs)
+        return {"access_token": "task-access-token", "expires_in": 300}
+
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(config_file))
+    monkeypatch.setenv("NMP_BASE_URL", "http://nmp.example.test")
+    monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
+    monkeypatch.setenv("NMP_PRINCIPAL", json.dumps({"id": "creator@example.com", "email": "creator@example.com"}))
+    monkeypatch.delenv("NMP_ACCESS_TOKEN", raising=False)
+    monkeypatch.setattr("nemo_platform.client.factory.discover_nmp_config", lambda _base_url: _workload_oidc_config())
+    monkeypatch.setattr("nemo_platform.auth.workload_exchange.token_exchange_grant", token_exchange_grant)
+
+    sdk = get_task_sdk(as_service="customizer")
+    try:
+        request = sdk._client.build_request("GET", "http://nmp.example.test/apis/entities/v2/workspaces/default")
+        sdk._client._event_hooks["request"][0](request)
+    finally:
+        sdk.close()
+
+    assert sdk.default_headers["X-NMP-Internal"] == "true"
+    assert request.headers["Authorization"] == "Bearer task-access-token"
+    assert "X-NMP-Principal-Id" not in request.headers
+    assert "X-NMP-Principal-On-Behalf-Of" not in request.headers
+    assert exchange_requests[0]["subject_token"] == "subject-token-from-file"
 
 
 def test_get_task_sdk_uses_explicit_sync_http_client(monkeypatch: pytest.MonkeyPatch):

--- a/packages/nmp_common/tests/test_platform_endpoint.py
+++ b/packages/nmp_common/tests/test_platform_endpoint.py
@@ -98,12 +98,46 @@ def test_sync_http_client_passes_explicit_timeout() -> None:
     client.assert_called_once_with(follow_redirects=True, timeout=2.0)
 
 
+def test_sync_sdk_http_client_uses_sdk_default_for_tcp() -> None:
+    endpoint = parse_platform_endpoint("http://127.0.0.1:8080")
+
+    with patch("nmp.common.platform_endpoint.DefaultHttpxClient") as client:
+        endpoint.sync_sdk_http_client()
+
+    client.assert_called_once_with()
+
+
+def test_sync_sdk_http_client_passes_explicit_timeout() -> None:
+    endpoint = parse_platform_endpoint("http://127.0.0.1:8080")
+
+    with patch("nmp.common.platform_endpoint.DefaultHttpxClient") as client:
+        endpoint.sync_sdk_http_client(timeout=2.0)
+
+    client.assert_called_once_with(timeout=2.0)
+
+
 def test_uds_sync_http_client_keeps_transport_and_omits_unset_timeout() -> None:
     endpoint = parse_platform_endpoint("unix:///tmp/nemo-platform.sock")
 
     with patch("nmp.common.platform_endpoint.httpx.Client") as client:
         endpoint.sync_http_client()
 
+    kwargs = client.call_args.kwargs
+    assert kwargs["follow_redirects"] is True
+    assert "transport" in kwargs
+    assert "timeout" not in kwargs
+
+
+def test_uds_sync_sdk_http_client_keeps_transport_and_omits_unset_timeout() -> None:
+    endpoint = parse_platform_endpoint("unix:///tmp/nemo-platform.sock")
+
+    with (
+        patch("nmp.common.platform_endpoint.DefaultHttpxClient") as sdk_client,
+        patch("nmp.common.platform_endpoint.httpx.Client") as client,
+    ):
+        endpoint.sync_sdk_http_client()
+
+    sdk_client.assert_not_called()
     kwargs = client.call_args.kwargs
     assert kwargs["follow_redirects"] is True
     assert "transport" in kwargs
@@ -128,12 +162,46 @@ def test_async_http_client_passes_explicit_timeout() -> None:
     client.assert_called_once_with(follow_redirects=True, timeout=2.0)
 
 
+def test_async_sdk_http_client_uses_sdk_default_for_tcp() -> None:
+    endpoint = parse_platform_endpoint("http://127.0.0.1:8080")
+
+    with patch("nmp.common.platform_endpoint.DefaultAsyncHttpxClient") as client:
+        endpoint.async_sdk_http_client()
+
+    client.assert_called_once_with()
+
+
+def test_async_sdk_http_client_passes_explicit_timeout() -> None:
+    endpoint = parse_platform_endpoint("http://127.0.0.1:8080")
+
+    with patch("nmp.common.platform_endpoint.DefaultAsyncHttpxClient") as client:
+        endpoint.async_sdk_http_client(timeout=2.0)
+
+    client.assert_called_once_with(timeout=2.0)
+
+
 def test_uds_async_http_client_keeps_transport_and_omits_unset_timeout() -> None:
     endpoint = parse_platform_endpoint("unix:///tmp/nemo-platform.sock")
 
     with patch("nmp.common.platform_endpoint.httpx.AsyncClient") as client:
         endpoint.async_http_client()
 
+    kwargs = client.call_args.kwargs
+    assert kwargs["follow_redirects"] is True
+    assert "transport" in kwargs
+    assert "timeout" not in kwargs
+
+
+def test_uds_async_sdk_http_client_keeps_transport_and_omits_unset_timeout() -> None:
+    endpoint = parse_platform_endpoint("unix:///tmp/nemo-platform.sock")
+
+    with (
+        patch("nmp.common.platform_endpoint.DefaultAsyncHttpxClient") as sdk_client,
+        patch("nmp.common.platform_endpoint.httpx.AsyncClient") as client,
+    ):
+        endpoint.async_sdk_http_client()
+
+    sdk_client.assert_not_called()
     kwargs = client.call_args.kwargs
     assert kwargs["follow_redirects"] is True
     assert "transport" in kwargs

--- a/services/core/jobs/jobs-launcher/cmd/otel.go
+++ b/services/core/jobs/jobs-launcher/cmd/otel.go
@@ -125,7 +125,7 @@ func newLauncherOTLPLogExporter(ctx context.Context, endpointURL string) (log.Ex
 	if err != nil {
 		return nil, err
 	}
-	if _, err := authConfig.source.AuthorizationHeader(ctx); err != nil {
+	if _, err := authConfig.source.Headers(ctx); err != nil {
 		return nil, fmt.Errorf("configure %s for OTLP logs: %w", authConfig.description, err)
 	}
 	logOTLPLogAuthMechanism(authConfig.mechanism, authConfig.reason)
@@ -134,7 +134,7 @@ func newLauncherOTLPLogExporter(ctx context.Context, endpointURL string) (log.Ex
 	if httpClient == nil {
 		httpClient = &http.Client{Timeout: otlpHTTPLogExportTimeout}
 	}
-	httpClient.Transport = &authHeaderTransport{
+	httpClient.Transport = &authHeadersTransport{
 		source:          authConfig.source,
 		authDescription: authConfig.description,
 		base:            httpClient.Transport,
@@ -144,7 +144,7 @@ func newLauncherOTLPLogExporter(ctx context.Context, endpointURL string) (log.Ex
 		otlploghttp.WithEndpointURL(endpointURL),
 		// Platform job log upload is intentionally independent from OTEL_* header
 		// env vars. User workloads may use OTEL_EXPORTER_OTLP_LOGS_HEADERS for
-		// third-party telemetry; application logs construct Authorization in Go.
+		// third-party telemetry; application logs construct platform auth headers in Go.
 		// Passing explicit empty headers prevents the upstream exporter from
 		// applying OTEL_EXPORTER_OTLP_LOGS_HEADERS here.
 		otlploghttp.WithHeaders(map[string]string{}),
@@ -155,7 +155,7 @@ func newLauncherOTLPLogExporter(ctx context.Context, endpointURL string) (log.Ex
 }
 
 type launcherOTLPLogAuthConfig struct {
-	source      authHeaderSource
+	source      requestHeaderSource
 	description string
 	mechanism   string
 	reason      string
@@ -179,36 +179,38 @@ func newLauncherOTLPLogAuthConfig(ctx context.Context) (launcherOTLPLogAuthConfi
 	// Service identity default: when workload identity is not enabled, identify the
 	// launcher as service:jobs without touching user OTEL_* headers.
 	return launcherOTLPLogAuthConfig{
-		source:      serviceIdentityBearerTokenSource{},
-		description: "service identity bearer auth",
-		mechanism:   "service_identity_bearer_token",
+		source:      serviceIdentityPrincipalHeaderSource{},
+		description: "service identity principal headers",
+		mechanism:   "service_identity_principal_headers",
 		reason:      "workload_token_file_not_configured",
 	}, nil
 }
 
-type authHeaderSource interface {
-	AuthorizationHeader(context.Context) (string, error)
+type requestHeaderSource interface {
+	Headers(context.Context) (map[string]string, error)
 }
 
-type authHeaderTransport struct {
-	source          authHeaderSource
+type authHeadersTransport struct {
+	source          requestHeaderSource
 	authDescription string
 	base            http.RoundTripper
 }
 
-func (t *authHeaderTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	authHeader, err := t.source.AuthorizationHeader(req.Context())
+func (t *authHeadersTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	headers, err := t.source.Headers(req.Context())
 	if err != nil {
 		return nil, fmt.Errorf("refresh %s for OTLP logs: %w", t.authDescription, err)
 	}
 
 	clonedReq := req.Clone(req.Context())
 	clonedReq.Header = req.Header.Clone()
-	clonedReq.Header.Set("Authorization", authHeader)
+	for key, value := range headers {
+		clonedReq.Header.Set(key, value)
+	}
 	return t.baseTransport().RoundTrip(clonedReq)
 }
 
-func (t *authHeaderTransport) baseTransport() http.RoundTripper {
+func (t *authHeadersTransport) baseTransport() http.RoundTripper {
 	if t.base != nil {
 		return t.base
 	}
@@ -223,10 +225,10 @@ func logOTLPLogAuthMechanism(mechanism string, reason string) {
 	)
 }
 
-type serviceIdentityBearerTokenSource struct{}
+type serviceIdentityPrincipalHeaderSource struct{}
 
-func (serviceIdentityBearerTokenSource) AuthorizationHeader(context.Context) (string, error) {
-	return "Bearer " + serviceJobsPrincipal, nil
+func (serviceIdentityPrincipalHeaderSource) Headers(context.Context) (map[string]string, error) {
+	return map[string]string{"X-NMP-Principal-Id": serviceJobsPrincipal}, nil
 }
 
 func otlpHTTPLogExporter(ctx context.Context, opts ...otlploghttp.Option) (log.Exporter, error) {

--- a/services/core/jobs/jobs-launcher/cmd/workload_auth.go
+++ b/services/core/jobs/jobs-launcher/cmd/workload_auth.go
@@ -142,6 +142,10 @@ func (s *workloadAuthTokenSource) authHeaders(ctx context.Context) (map[string]s
 	return map[string]string{"Authorization": authHeader}, nil
 }
 
+func (s *workloadAuthTokenSource) Headers(ctx context.Context) (map[string]string, error) {
+	return s.authHeaders(ctx)
+}
+
 func (s *workloadAuthTokenSource) AuthorizationHeader(ctx context.Context) (string, error) {
 	accessToken, err := s.accessToken(ctx)
 	if err != nil {

--- a/services/core/jobs/jobs-launcher/cmd/workload_auth_test.go
+++ b/services/core/jobs/jobs-launcher/cmd/workload_auth_test.go
@@ -310,10 +310,10 @@ func TestNewLogExporterDoesNotLogAuthMechanismWhenWorkloadTokenExchangeFails(t *
 	}
 
 	assertLogNotContains(t, logOutput.String(), "auth_mechanism=workload_identity_token_exchange")
-	assertLogNotContains(t, logOutput.String(), "auth_mechanism=service_identity_bearer_token")
+	assertLogNotContains(t, logOutput.String(), "auth_mechanism=service_identity_principal_headers")
 }
 
-func TestNewLogExporterUsesServiceIdentityBearerHeadersWithoutWorkloadTokenFile(t *testing.T) {
+func TestNewLogExporterUsesServiceIdentityPrincipalHeadersWithoutWorkloadTokenFile(t *testing.T) {
 	var logOutput bytes.Buffer
 	captureSlogOutput(t, &logOutput)
 	var mu sync.Mutex
@@ -357,19 +357,19 @@ func TestNewLogExporterUsesServiceIdentityBearerHeadersWithoutWorkloadTokenFile(
 	if exportHeaders == nil {
 		t.Fatal("expected log export request")
 	}
-	if got := exportHeaders.Get("Authorization"); got != "Bearer service:jobs" {
-		t.Fatalf("expected service identity bearer Authorization header without workload token file, got %q", got)
+	if got := exportHeaders.Get("Authorization"); got != "" {
+		t.Fatalf("expected no Authorization header without workload token file, got %q", got)
 	}
 	if got := exportHeaders.Get("X-Third-Party"); got != "" {
 		t.Fatalf("expected user OTEL headers to stay off platform log exports, got X-Third-Party=%q", got)
 	}
-	if got := exportHeaders.Get("X-NMP-Principal-Id"); got != "" {
-		t.Fatalf("expected launcher OTLP principal headers to stay off platform log exports, got X-NMP-Principal-Id=%q", got)
+	if got := exportHeaders.Get("X-NMP-Principal-Id"); got != serviceJobsPrincipal {
+		t.Fatalf("expected service identity principal header without workload token file, got X-NMP-Principal-Id=%q", got)
 	}
 	if got := os.Getenv(otelExporterOTLPLogsHeadersEnv); got != "Authorization=Bearer%20third-party,X-Third-Party=external" {
 		t.Fatalf("expected OTEL headers env to remain untouched, got %q", got)
 	}
-	assertLogContains(t, logOutput.String(), "auth_mechanism=service_identity_bearer_token")
+	assertLogContains(t, logOutput.String(), "auth_mechanism=service_identity_principal_headers")
 	assertLogContains(t, logOutput.String(), "reason=workload_token_file_not_configured")
 }
 

--- a/services/hello-world/src/nmp/hello_world/tasks/workload_workspace_get/run.py
+++ b/services/hello-world/src/nmp/hello_world/tasks/workload_workspace_get/run.py
@@ -5,6 +5,7 @@
 
 from nemo_platform import NeMoPlatform
 from nmp.common.jobs.config import get_task_config
+from nmp.common.sdk_factory import get_task_sdk
 from pydantic import BaseModel
 
 
@@ -18,8 +19,7 @@ def run(*, sdk: NeMoPlatform | None = None) -> int:
     """Read the configured workspace using the public SDK workload identity path."""
     try:
         config = get_task_config(WorkloadWorkspaceGetConfig)
-        if sdk is None:
-            sdk = NeMoPlatform()
+        sdk = sdk or get_task_sdk(as_service="jobs")
         workspace = sdk.workspaces.retrieve(config.workspace)
         print(f"Successfully retrieved workspace: {workspace.name}")
         return 0

--- a/services/hello-world/tests/integration/tasks/test_workload_workspace_get_task.py
+++ b/services/hello-world/tests/integration/tasks/test_workload_workspace_get_task.py
@@ -1,16 +1,37 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from types import SimpleNamespace
 from typing import cast
 
 import httpx
+import pytest
 import respx
 from nemo_platform import NeMoPlatform
-from nemo_platform.auth.helpers import NMPOIDCConfig
 from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
+from nmp.common.config import Configuration, PlatformConfig
 from nmp.common.jobs.constants import TASK_CONFIG_ENVVAR
 from nmp.hello_world.tasks.workload_workspace_get.run import run as task_run
+
+
+@pytest.fixture(autouse=True)
+def clear_config_cache():
+    Configuration.clear_cache()
+    try:
+        yield
+    finally:
+        Configuration.clear_cache()
+
+
+@pytest.fixture
+def platform_base_url():
+    base_url = "http://nmp.example.test"
+    Configuration.set_override(PlatformConfig(base_url=base_url))
+    try:
+        yield base_url
+    finally:
+        Configuration.clear_override(PlatformConfig)
 
 
 class _StubWorkspaces:
@@ -27,68 +48,22 @@ class _StubSDK:
         self.workspaces = _StubWorkspaces()
 
 
-@respx.mock
-def test_workload_workspace_get_reads_workspace_via_public_sdk(monkeypatch, tmp_path):
-    subject_token_file = tmp_path / "workload-token"
-    subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
-    config_file = tmp_path / "config.yaml"
-    config_file.write_text("{}\n", encoding="utf-8")
-    discovery_requests: list[str] = []
-    exchange_requests: list[dict] = []
+def test_workload_workspace_get_uses_task_sdk_factory(monkeypatch):
+    sdk = _StubSDK()
+    sdk_factory_calls: list[str] = []
 
-    def discover_nmp_config(base_url: str) -> NMPOIDCConfig:
-        discovery_requests.append(base_url)
-        return NMPOIDCConfig(
-            auth_enabled=True,
-            workload_token_exchange_enabled=True,
-            workload_client_id="workload-client",
-            workload_token_endpoint="https://idp.example.test/oauth2/token",
-            workload_audience="nemo-platform",
-            workload_scope="openid email groups",
-        )
-
-    def token_exchange_grant(**kwargs):
-        exchange_requests.append(kwargs)
-        return {"access_token": "exchanged-access-token", "expires_in": 300}
+    def get_task_sdk(*, as_service: str) -> NeMoPlatform:
+        sdk_factory_calls.append(as_service)
+        return cast(NeMoPlatform, sdk)
 
     monkeypatch.setenv(TASK_CONFIG_ENVVAR, '{"workspace":"workload-read-target"}')
-    monkeypatch.setenv("NMP_CONFIG_FILE", str(config_file))
-    monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
-    monkeypatch.delenv("NMP_ACCESS_TOKEN", raising=False)
-    monkeypatch.setattr("nemo_platform.client.factory.discover_nmp_config", discover_nmp_config)
-    monkeypatch.setattr("nemo_platform.auth.workload_exchange.token_exchange_grant", token_exchange_grant)
+    monkeypatch.setattr("nmp.hello_world.tasks.workload_workspace_get.run.get_task_sdk", get_task_sdk)
 
-    workspace_route = respx.get("http://nmp.example.test/apis/entities/v2/workspaces/workload-read-target").mock(
-        return_value=httpx.Response(
-            200,
-            json={
-                "id": "workspace-id",
-                "name": "workload-read-target",
-                "created_at": "2026-01-01T00:00:00Z",
-                "updated_at": "2026-01-01T00:00:00Z",
-            },
-        )
-    )
-
-    sdk = NeMoPlatform(base_url="http://nmp.example.test")
-    try:
-        exit_code = task_run(sdk=sdk)
-    finally:
-        sdk.close()
+    exit_code = task_run()
 
     assert exit_code == 0
-    assert workspace_route.called
-    assert workspace_route.calls[0].request.headers["Authorization"] == "Bearer exchanged-access-token"
-    assert [url.rstrip("/") for url in discovery_requests] == ["http://nmp.example.test"]
-    assert exchange_requests == [
-        {
-            "token_endpoint": "https://idp.example.test/oauth2/token",
-            "client_id": "workload-client",
-            "subject_token": "subject-token-from-file",
-            "audience": "nemo-platform",
-            "scope": "openid email groups",
-        }
-    ]
+    assert sdk_factory_calls == ["jobs"]
+    assert sdk.workspaces.requested == ["workload-read-target"]
 
 
 def test_workload_workspace_get_uses_injected_sdk_without_workload_token(monkeypatch):
@@ -102,3 +77,53 @@ def test_workload_workspace_get_uses_injected_sdk_without_workload_token(monkeyp
 
     assert exit_code == 0
     assert sdk.workspaces.requested == ["workload-read-target"]
+
+
+@respx.mock
+def test_workload_workspace_get_uses_task_sdk_without_workload_token(monkeypatch, tmp_path, platform_base_url):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setenv(TASK_CONFIG_ENVVAR, '{"workspace":"workload-read-target"}')
+    monkeypatch.setenv("NMP_CONFIG_FILE", str(config_file))
+    monkeypatch.setenv("NMP_BASE_URL", platform_base_url)
+    monkeypatch.setenv(
+        "NMP_PRINCIPAL",
+        json.dumps(
+            {
+                "id": "creator@example.com",
+                "email": "creator@example.com",
+                "groups": ["engineering"],
+            }
+        ),
+    )
+    monkeypatch.delenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, raising=False)
+    monkeypatch.delenv("NMP_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("NEMO_WORKLOAD_TOKEN", raising=False)
+    monkeypatch.delenv("NEMO_WORKLOAD_TOKEN_FILE", raising=False)
+
+    def workspace_response(request: httpx.Request) -> httpx.Response:
+        if request.headers.get("X-NMP-Principal-Id") != "service:jobs":
+            return httpx.Response(401, json={"detail": "Unauthorized"})
+        if request.headers.get("X-NMP-Principal-On-Behalf-Of") != "creator@example.com":
+            return httpx.Response(403, json={"detail": "Forbidden"})
+        if request.headers.get("Authorization") == "Bearer service:jobs":
+            return httpx.Response(401, json={"detail": "Unauthorized"})
+        return httpx.Response(
+            200,
+            json={
+                "id": "workspace-id",
+                "name": "workload-read-target",
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            },
+        )
+
+    workspace_route = respx.get(f"{platform_base_url}/apis/entities/v2/workspaces/workload-read-target").mock(
+        side_effect=workspace_response
+    )
+
+    exit_code = task_run()
+
+    assert exit_code == 0
+    assert workspace_route.called


### PR DESCRIPTION
# Fix Kubernetes job log upload auth without service bearer spoofing

## Summary

This fixes Kubernetes job log upload and task-side SDK auth when platform auth is enabled but workload token exchange is disabled.

In that configuration, jobs do not receive `NMP_WORKLOAD_IDENTITY_TOKEN_FILE`, so they cannot exchange a workload identity token for a real access token. The previous fallback sent:

```text
Authorization: Bearer service:jobs
```

That is not valid auth for the Files OTLP log upload endpoint, so job logs failed with `401 Unauthorized`:

```text
failed to send logs to http://nemo-platform-api:8080/apis/files/v2/workspaces/<workspace>/filesets/<fileset>/otlp/v1/logs: 401 Unauthorized
```

## Problem

The failing Kubernetes setup has:

- `auth.enabled=true`
- workload token exchange disabled
- no workload token file mounted into the job
- job runtime URLs pointed directly at `http://nemo-platform-api:8080`
- job log upload endpoint set to `/apis/files/v2/workspaces/{workspace}/filesets/{fileset}/otlp/v1/logs`

The jobs launcher correctly detected that no workload token file was configured, but it fell back to a raw service bearer token. That raw bearer shortcut is only supported by the legacy HF-compatible Files path. It is intentionally not supported across normal API endpoints because an external caller that can reach the API directly could spoof a service principal with `Authorization: Bearer service:<name>`.

The same configuration also exposed a task-side SDK issue: individual tasks should not need to know whether workload token exchange is enabled. Task code should call a single SDK helper and let the SDK/factory layer choose the right auth mechanism.

## Root Cause

The no-workload-token path conflated two different auth mechanisms:

- Real bearer auth: `Authorization: Bearer <access-token>` from OIDC or workload token exchange.
- Internal service identity: `X-NMP-Principal-Id: service:<name>` inside the trusted service boundary.

When workload exchange is disabled, `Bearer service:jobs` is not a real access token. The Files OTLP endpoint goes through normal middleware auth, so it returned 401.

## Solution

Use internal service-principal headers for the no-workload-token fallback, and keep real bearer auth only for real tokens.

Changes included:

- Jobs launcher log upload:
  - If `NMP_WORKLOAD_IDENTITY_TOKEN_FILE` is present, exchange the workload token and send `Authorization: Bearer <access-token>`.
  - If no workload token file is present, send `X-NMP-Principal-Id: service:jobs`.
  - Rename the fallback log mechanism from service bearer token auth to service principal header auth.

- Workload auth source:
  - Expose a `Headers(ctx)` method so token-backed auth and header-backed auth share one exporter path.

- Task SDK behavior:
  - Centralize the workload-token-vs-service-header decision in `nmp.common.sdk_factory`.
  - `get_task_sdk(as_service=...)` now chooses workload identity when `NMP_WORKLOAD_IDENTITY_TOKEN_FILE` is set.
  - If no workload token file is set, `get_task_sdk(as_service=...)` uses `X-NMP-Principal-Id: service:<name>` plus on-behalf-of headers from `NMP_PRINCIPAL`.
  - Plain task code no longer has to branch on workload token env vars.

- Plugin SDK provider:
  - Mirror the same task SDK behavior in `nemo_platform_plugin.sdk_provider.DefaultSDKProvider` so plugin task authors also use one helper.

- Hello-world workload task:
  - The task now simply calls `get_task_sdk(as_service="jobs")`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workload-identity token-file support for platform and task SDK requests, including internal-marker-only headers and streamlined sync/async SDK creation.
  - Added platform endpoint helpers to retrieve SDK-specific HTTP clients for TCP vs UDS endpoints.
- **Bug Fixes**
  - Updated OTLP job log authentication to emit per-request header sets; service identity now uses `X-NMP-Principal-Id` when workload identity isn’t enabled.
- **Tests**
  - Expanded workload-identity and OTLP auth middleware coverage across SDK factories, plugins, jobs launcher, and hello-world integration.
- **Documentation**
  - Refreshed OTLP exporter option comments to reflect the new header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->