### PR TITLE
fix(nemo-deployments): observe one-shot Docker status at create time

### DIFF
--- a/e2e/configs/local-docker-agents.yaml
+++ b/e2e/configs/local-docker-agents.yaml
@@ -49,8 +49,8 @@ deployments:
         # local Docker daemon (pulled by the test's CI job), so disable the
         # per-run pull and use the image as-is.
         pull_images: false
-        port_range_start: 9000
-        port_range_end: 9100
+        port_range_start: 49152
+        port_range_end: 49251
 
 models:
   controller:

--- a/packages/nmp_platform/config/local.yaml
+++ b/packages/nmp_platform/config/local.yaml
@@ -128,8 +128,8 @@ deployments:
       backend: docker
       config:
         pull_images: false
-        port_range_start: 9000
-        port_range_end: 9100
+        port_range_start: 49152
+        port_range_end: 49251
   default_executor: local-docker
 
 models:

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
@@ -78,8 +78,8 @@ deployments:
       backend: docker
       config:
         pull_images: false
-        port_range_start: 9000
-        port_range_end: 9100
+        port_range_start: 49152
+        port_range_end: 49251
   default_executor: local-docker
 
 inference_gateway: {}

--- a/plugins/nemo-deployments/README.md
+++ b/plugins/nemo-deployments/README.md
@@ -30,8 +30,8 @@ Host port allocation for published container ports is configured per named docke
 executor (not on `DeploymentConfig.backend_config.docker`). Set the inclusive
 `port_range_start` / `port_range_end` bounds on the executor `config` block in
 platform YAML. The allocator scans every host port from `port_range_start`
-through `port_range_end`, including both endpoints (for example, 9000–9100
-allows 101 ports):
+through `port_range_end`, including both endpoints (for example, 49152–49251
+allows 100 ports):
 
 ```yaml
 deployments:
@@ -39,8 +39,8 @@ deployments:
     - name: local-docker
       backend: docker
       config:
-        port_range_start: 9000
-        port_range_end: 9100  # inclusive
+        port_range_start: 49152
+        port_range_end: 49251  # inclusive
   default_executor: local-docker
 ```
 

--- a/plugins/nemo-deployments/README.md
+++ b/plugins/nemo-deployments/README.md
@@ -44,6 +44,12 @@ deployments:
   default_executor: local-docker
 ```
 
+A port is considered taken when any container on the daemon publishes it — not just
+platform-managed ones — or when the host socket is already bound. Docker's own
+reservations are not observable until a publish is attempted, so a port claimed
+concurrently is retried against a different port rather than failing the deployment.
+Pick a range nothing else on the host publishes on.
+
 Entity-level `backend_config.docker` accepts only deployment-specific overrides such
 as `network`.
 

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
@@ -432,7 +432,7 @@ class DockerDeploymentBackend(DeploymentBackend):
         def _run_and_wait() -> int:
             container = self._client.containers.run(**run_kwargs)
             result = container.wait(timeout=self._executor_config.docker_timeout)
-            exit_code = int(result.get("StatusCode", 1)) if isinstance(result, dict) else int(result)
+            exit_code = self._exit_code_from_wait_result(result)
             try:
                 container.remove(force=True)
             except Exception:
@@ -550,6 +550,11 @@ class DockerDeploymentBackend(DeploymentBackend):
 
         return BackendStatusUpdate(status="STARTING", status_message=f"Container state: {state}")
 
+    @staticmethod
+    def _exit_code_from_wait_result(result: dict[str, Any] | int) -> int:
+        """Normalize a docker `container.wait()` result to an exit code."""
+        return int(result.get("StatusCode", 1)) if isinstance(result, dict) else int(result)
+
     def _status_from_exited_container(
         self,
         *,
@@ -615,8 +620,7 @@ class DockerDeploymentBackend(DeploymentBackend):
             observe_timeout = self._executor_config.oneshot_observe_timeout_seconds
 
             def _wait_for_exit() -> int:
-                result = container.wait(timeout=observe_timeout)
-                return int(result.get("StatusCode", 1)) if isinstance(result, dict) else int(result)
+                return self._exit_code_from_wait_result(container.wait(timeout=observe_timeout))
 
             try:
                 exit_code = await asyncio.to_thread(_wait_for_exit)

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
@@ -612,9 +612,10 @@ class DockerDeploymentBackend(DeploymentBackend):
         labels = container.labels or {}
 
         if restart_policy == "Never":
+            observe_timeout = self._executor_config.oneshot_observe_timeout_seconds
 
             def _wait_for_exit() -> int:
-                result = container.wait(timeout=self._executor_config.docker_timeout)
+                result = container.wait(timeout=observe_timeout)
                 return int(result.get("StatusCode", 1)) if isinstance(result, dict) else int(result)
 
             try:
@@ -629,7 +630,7 @@ class DockerDeploymentBackend(DeploymentBackend):
                     status="STARTING",
                     status_message=(
                         f"Container {container.name} still running or status unavailable "
-                        f"after wait ({self._executor_config.docker_timeout}s)"
+                        f"after observe wait ({observe_timeout}s)"
                     ),
                     endpoints=endpoints,
                 )

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
@@ -276,7 +276,7 @@ class DockerDeploymentBackend(DeploymentBackend):
             network=docker_cfg.network,
         )
         try:
-            await asyncio.to_thread(self._client.containers.run, **server_run_kwargs)
+            server_container = await asyncio.to_thread(self._client.containers.run, **server_run_kwargs)
         except Exception as exc:
             if gpu_ids and gpu_pool is not None:
                 gpu_pool.release_gpu(dep_key)
@@ -318,6 +318,15 @@ class DockerDeploymentBackend(DeploymentBackend):
                 )
 
         endpoints = self._build_endpoints(container_spec, host_ports)
+        if config.restart_policy in _ONE_SHOT_RESTART_POLICIES:
+            return await self._observe_one_shot_primary_after_create(
+                workspace=workspace,
+                name=name,
+                config=config,
+                container=server_container,
+                dep_key=dep_key,
+                endpoints=endpoints,
+            )
         return BackendStatusUpdate(
             status="STARTING",
             status_message=f"Container {c_name} created",
@@ -526,40 +535,13 @@ class DockerDeploymentBackend(DeploymentBackend):
 
         if state in ("exited", "dead"):
             exit_code = int(container.attrs.get("State", {}).get("ExitCode", 1))
-            if exit_code == 0 and restart_policy in ("Never", "OnFailure"):
-                if self._gpu_pool is not None:
-                    self._gpu_pool.release_gpu(dep_key)
-                return BackendStatusUpdate(
-                    status="SUCCEEDED",
-                    status_message="Container exited successfully (code 0)",
-                    exit_code=exit_code,
-                    endpoints=endpoints,
-                )
-            if restart_policy == "Always":
-                return BackendStatusUpdate(
-                    status="STARTING",
-                    status_message=f"Container exited (code {exit_code}); restart policy will recreate it",
-                    exit_code=exit_code,
-                    endpoints=endpoints,
-                )
-            if restart_policy == "OnFailure":
-                restart_count = int(container.attrs.get("RestartCount", 0))
-                backoff_limit = int(labels.get(BACKOFF_LIMIT_LABEL, "6"))
-                if restart_count < backoff_limit:
-                    return BackendStatusUpdate(
-                        status="STARTING",
-                        status_message=f"Container exited (code {exit_code}); retry {restart_count}/{backoff_limit}",
-                        exit_code=exit_code,
-                        endpoints=endpoints,
-                    )
-            if self._gpu_pool is not None:
-                self._gpu_pool.release_gpu(dep_key)
-            status = map_exited_status(exit_code, restart_policy)
-            message = f"Container exited with code {exit_code}"
-            return BackendStatusUpdate(
-                status=status,
-                status_message=message,
+            restart_count = int(container.attrs.get("RestartCount", 0))
+            return self._status_from_exited_container(
                 exit_code=exit_code,
+                restart_policy=restart_policy,
+                labels=labels,
+                dep_key=dep_key,
+                restart_count=restart_count,
                 endpoints=endpoints,
             )
 
@@ -567,6 +549,137 @@ class DockerDeploymentBackend(DeploymentBackend):
             return BackendStatusUpdate(status="DELETING", status_message=f"Container removing (ID: {container_id})")
 
         return BackendStatusUpdate(status="STARTING", status_message=f"Container state: {state}")
+
+    def _status_from_exited_container(
+        self,
+        *,
+        exit_code: int,
+        restart_policy: RestartPolicy,
+        labels: dict[str, str],
+        dep_key: str,
+        restart_count: int = 0,
+        endpoints: list[Endpoint] | None = None,
+    ) -> BackendStatusUpdate:
+        """Map a stopped container's exit code to a deployment status update."""
+        resolved_endpoints = endpoints or []
+        if exit_code == 0 and restart_policy in ("Never", "OnFailure"):
+            if self._gpu_pool is not None:
+                self._gpu_pool.release_gpu(dep_key)
+            return BackendStatusUpdate(
+                status="SUCCEEDED",
+                status_message="Container exited successfully (code 0)",
+                exit_code=exit_code,
+                endpoints=resolved_endpoints,
+            )
+        if restart_policy == "Always":
+            return BackendStatusUpdate(
+                status="STARTING",
+                status_message=f"Container exited (code {exit_code}); restart policy will recreate it",
+                exit_code=exit_code,
+                endpoints=resolved_endpoints,
+            )
+        if restart_policy == "OnFailure":
+            backoff_limit = int(labels.get(BACKOFF_LIMIT_LABEL, "6"))
+            if restart_count < backoff_limit:
+                return BackendStatusUpdate(
+                    status="STARTING",
+                    status_message=(f"Container exited (code {exit_code}); retry {restart_count}/{backoff_limit}"),
+                    exit_code=exit_code,
+                    endpoints=resolved_endpoints,
+                )
+        if self._gpu_pool is not None:
+            self._gpu_pool.release_gpu(dep_key)
+        status = map_exited_status(exit_code, restart_policy)
+        return BackendStatusUpdate(
+            status=status,
+            status_message=f"Container exited with code {exit_code}",
+            exit_code=exit_code,
+            endpoints=resolved_endpoints,
+        )
+
+    async def _observe_one_shot_primary_after_create(
+        self,
+        *,
+        workspace: str,
+        name: str,
+        config: DeploymentConfig,
+        container: DockerContainer,
+        dep_key: str,
+        endpoints: list[Endpoint],
+    ) -> BackendStatusUpdate:
+        """Observe a one-shot primary container immediately after create."""
+        restart_policy = config.restart_policy
+        labels = container.labels or {}
+
+        if restart_policy == "Never":
+
+            def _wait_for_exit() -> int:
+                result = container.wait(timeout=self._executor_config.docker_timeout)
+                return int(result.get("StatusCode", 1)) if isinstance(result, dict) else int(result)
+
+            try:
+                exit_code = await asyncio.to_thread(_wait_for_exit)
+            except (
+                ReadTimeout,
+                Urllib3ReadTimeoutError,
+                RequestsConnectionError,
+                self._docker_errors.APIError,
+            ):
+                return BackendStatusUpdate(
+                    status="STARTING",
+                    status_message=(
+                        f"Container {container.name} still running or status unavailable "
+                        f"after wait ({self._executor_config.docker_timeout}s)"
+                    ),
+                    endpoints=endpoints,
+                )
+            except Exception as exc:
+                logger.exception("Failed waiting for one-shot container %s to exit", container.name)
+                await self.delete_deployment(workspace, name)
+                return BackendStatusUpdate(
+                    status="FAILED",
+                    status_message=f"Failed waiting for container to exit: {exc}",
+                )
+            return self._status_from_exited_container(
+                exit_code=exit_code,
+                restart_policy=restart_policy,
+                labels=labels,
+                dep_key=dep_key,
+                endpoints=endpoints,
+            )
+
+        try:
+            await asyncio.to_thread(container.reload)
+        except (
+            self._docker_errors.APIError,
+            ReadTimeout,
+            Urllib3ReadTimeoutError,
+            RequestsConnectionError,
+        ) as exc:
+            return BackendStatusUpdate(
+                status="STARTING",
+                status_message=f"Container created but status check failed: {exc}",
+                endpoints=endpoints,
+            )
+        if container.status in _EXITED_CONTAINER_STATES:
+            attrs = container.attrs or {}
+            exit_code = int(attrs.get("State", {}).get("ExitCode", 1))
+            restart_count = int(attrs.get("RestartCount", 0))
+            return self._status_from_exited_container(
+                exit_code=exit_code,
+                restart_policy=restart_policy,
+                labels=labels,
+                dep_key=dep_key,
+                restart_count=restart_count,
+                endpoints=endpoints,
+            )
+
+        container_name_label = container.name or "primary"
+        return BackendStatusUpdate(
+            status="STARTING",
+            status_message=f"Container {container_name_label} created",
+            endpoints=endpoints,
+        )
 
     async def _sidecars_healthy(self, workspace: str, name: str, config: DeploymentConfig | None) -> tuple[bool, str]:
         """Return (all_healthy, reason) for a deployment's expected sidecar containers.

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
@@ -75,6 +75,11 @@ logger = logging.getLogger(__name__)
 
 _ONE_SHOT_RESTART_POLICIES = frozenset({"Never", "OnFailure"})
 _EXITED_CONTAINER_STATES = frozenset({"exited", "dead"})
+# Docker rejects a publish with this message when its own allocator already holds
+# the port. Its reservations are invisible to a host-socket probe, so a container
+# created concurrently can claim a port between allocation and run.
+_PORT_CONFLICT_MARKER = "port is already allocated"
+_PORT_CONFLICT_ATTEMPTS = 3
 NGC_IMAGE_REGISTRY = os.getenv("NGC_IMAGE_REGISTRY", "nvcr.io")
 NGC_IMAGE_REGISTRY_USER_NAME = os.getenv("NGC_IMAGE_REGISTRY_USER_NAME", "$oauthtoken")
 
@@ -198,21 +203,11 @@ class DockerDeploymentBackend(DeploymentBackend):
             except GPUAllocationError as exc:
                 return BackendStatusUpdate(status="FAILED", status_message=str(exc))
 
-        host_ports: dict[int, int] = {}
-        for port_spec in container_spec.ports:
-            host_port = await find_available_port(
-                self._client,
-                self._executor_config.port_range_start,
-                self._executor_config.port_range_end,
-                exclude_ports=set(host_ports.values()),
-            )
-            if host_port is None:
-                if gpu_ids and gpu_pool is not None:
-                    gpu_pool.release_gpu(dep_key)
-                return BackendStatusUpdate(
-                    status="FAILED", status_message="No host ports available in configured range"
-                )
-            host_ports[port_spec.container_port] = host_port
+        host_ports = await self._allocate_host_ports(container_spec)
+        if host_ports is None:
+            if gpu_ids and gpu_pool is not None:
+                gpu_pool.release_gpu(dep_key)
+            return BackendStatusUpdate(status="FAILED", status_message="No host ports available in configured range")
 
         # Pull all images in the group (init + primary + sidecars) up front.
         if self._executor_config.pull_images:
@@ -265,23 +260,20 @@ class DockerDeploymentBackend(DeploymentBackend):
                 return init_status
 
         # 2) Primary (server) container: publishes ports, owns GPUs.
-        server_run_kwargs = self._build_run_kwargs(
+        server_container, host_ports, run_error = await self._run_server_container(
             workspace=workspace,
             config=config,
-            container=container_spec,
+            container_spec=container_spec,
             name=c_name,
             labels={**base_labels, CONTAINER_ROLE_LABEL: CONTAINER_ROLE_SERVER},
             host_ports=host_ports,
             gpu_ids=gpu_ids,
             network=docker_cfg.network,
         )
-        try:
-            server_container = await asyncio.to_thread(self._client.containers.run, **server_run_kwargs)
-        except Exception as exc:
+        if server_container is None:
             if gpu_ids and gpu_pool is not None:
                 gpu_pool.release_gpu(dep_key)
-            logger.exception("Failed to start container %s", c_name)
-            return BackendStatusUpdate(status="FAILED", status_message=f"Failed to start container: {exc}")
+            return BackendStatusUpdate(status="FAILED", status_message=run_error)
 
         # 3) Sidecars share the primary's network namespace + volumes; no ports/GPU.
         #
@@ -332,6 +324,96 @@ class DockerDeploymentBackend(DeploymentBackend):
             status_message=f"Container {c_name} created",
             endpoints=endpoints,
         )
+
+    async def _allocate_host_ports(
+        self,
+        container_spec: Container,
+        *,
+        exclude_ports: set[int] | None = None,
+    ) -> dict[int, int] | None:
+        """Map each published container port to a free host port.
+
+        Returns None when the configured range holds no more free ports.
+        """
+        excluded = set(exclude_ports or ())
+        host_ports: dict[int, int] = {}
+        for port_spec in container_spec.ports:
+            host_port = await find_available_port(
+                self._client,
+                self._executor_config.port_range_start,
+                self._executor_config.port_range_end,
+                exclude_ports=excluded | set(host_ports.values()),
+            )
+            if host_port is None:
+                return None
+            host_ports[port_spec.container_port] = host_port
+        return host_ports
+
+    async def _remove_container_by_name(self, name: str) -> None:
+        """Best-effort removal of a container this call just created."""
+        try:
+            container = await asyncio.to_thread(self._client.containers.get, name)
+            await asyncio.to_thread(container.remove, force=True)
+        except self._docker_errors.NotFound:
+            pass
+        except Exception:
+            logger.warning("Failed to remove container %s", name, exc_info=True)
+
+    async def _run_server_container(
+        self,
+        *,
+        workspace: str,
+        config: DeploymentConfig,
+        container_spec: Container,
+        name: str,
+        labels: dict[str, str],
+        host_ports: dict[int, int],
+        gpu_ids: list[int],
+        network: str | None,
+    ) -> tuple[DockerContainer | None, dict[int, int], str]:
+        """Start the primary container, reallocating host ports on Docker port conflicts.
+
+        Returns the started container (None on failure), the host ports it actually
+        published, and an error message when it could not be started.
+        """
+        rejected_ports: set[int] = set()
+        attempt = 0
+        while True:
+            attempt += 1
+            run_kwargs = self._build_run_kwargs(
+                workspace=workspace,
+                config=config,
+                container=container_spec,
+                name=name,
+                labels=labels,
+                host_ports=host_ports,
+                gpu_ids=gpu_ids,
+                network=network,
+            )
+            try:
+                container = await asyncio.to_thread(self._client.containers.run, **run_kwargs)
+                return container, host_ports, ""
+            except Exception as exc:
+                last_attempt = attempt == _PORT_CONFLICT_ATTEMPTS
+                if not host_ports or last_attempt or _PORT_CONFLICT_MARKER not in str(exc):
+                    logger.exception("Failed to start container %s", name)
+                    return None, host_ports, f"Failed to start container: {exc}"
+
+                rejected_ports |= set(host_ports.values())
+                logger.warning(
+                    "Host port conflict starting %s (attempt %d/%d); reallocating outside %s",
+                    name,
+                    attempt,
+                    _PORT_CONFLICT_ATTEMPTS,
+                    sorted(rejected_ports),
+                )
+                # containers.run() creates then starts, so a failed start leaves the
+                # created container holding the name and blocking the retry.
+                await self._remove_container_by_name(name)
+                reallocated = await self._allocate_host_ports(container_spec, exclude_ports=rejected_ports)
+                if reallocated is None:
+                    return None, host_ports, "No host ports available in configured range"
+                host_ports = reallocated
 
     def _build_run_kwargs(
         self,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/config.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/config.py
@@ -37,13 +37,13 @@ class DockerExecutorConfig(BaseModel):
         ),
     )
     port_range_start: int = Field(
-        default=9000,
+        default=49152,
         ge=1,
         le=65535,
         description="First host port to consider when publishing container ports for this executor.",
     )
     port_range_end: int = Field(
-        default=9100,
+        default=49251,
         ge=1,
         le=65535,
         description="Last host port (inclusive) to consider when publishing container ports for this executor.",

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/config.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/config.py
@@ -18,6 +18,15 @@ class DockerExecutorConfig(BaseModel):
         ge=1,
         description="Docker client timeout in seconds for pull/create/status operations (default: 10 minutes).",
     )
+    oneshot_observe_timeout_seconds: int = Field(
+        default=5,
+        ge=1,
+        description=(
+            "Max seconds to wait for a Never one-shot container to exit during create. "
+            "Should stay near the deployments controller reconcile interval (default 5s). "
+            "Longer jobs return STARTING and finish via read_status polling."
+        ),
+    )
     pull_images: bool = Field(default=True, description="Pull container images before run when missing locally.")
     resource_scope: str = Field(
         default=DEFAULT_RESOURCE_SCOPE,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/ports.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/ports.py
@@ -11,8 +11,6 @@ import os
 import socket
 from typing import TYPE_CHECKING
 
-from nemo_deployments_plugin.backends.labels import managed_by_filter
-
 import docker
 
 if TYPE_CHECKING:
@@ -30,9 +28,11 @@ def is_port_free(port: int) -> bool:
     if is_remote_docker_host():
         return True
     try:
+        # Bind the wildcard address Docker publishes on, without SO_REUSEADDR:
+        # probing 127.0.0.1 misses 0.0.0.0 publishers, and SO_REUSEADDR lets the
+        # bind succeed against an already-bound wildcard socket.
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            sock.bind(("127.0.0.1", port))
+            sock.bind(("0.0.0.0", port))
             return True
     except OSError:
         return False
@@ -62,11 +62,10 @@ async def find_available_port(
     exclude_ports: set[int] | None = None,
 ) -> int | None:
     try:
-        containers = await asyncio.to_thread(
-            client.containers.list,
-            all=True,
-            filters=managed_by_filter(),
-        )
+        # Every container on the daemon competes for host ports, not just the ones
+        # this platform manages. ``resource_scope`` scopes ownership and cleanup;
+        # port safety has to consider foreign containers too.
+        containers = await asyncio.to_thread(client.containers.list, all=True)
     except Exception:
         logger.exception("Failed to list containers for port allocation")
         return None

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/ports.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/ports.py
@@ -28,11 +28,11 @@ def is_port_free(port: int) -> bool:
     if is_remote_docker_host():
         return True
     try:
-        # Bind the wildcard address Docker publishes on, without SO_REUSEADDR:
-        # probing 127.0.0.1 misses 0.0.0.0 publishers, and SO_REUSEADDR lets the
-        # bind succeed against an already-bound wildcard socket.
+        # Do not set SO_REUSEADDR: it can make this bind succeed while a Docker
+        # wildcard publisher already holds the port. Binding loopback is enough
+        # to detect that conflict without exposing a socket on external interfaces.
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-            sock.bind(("0.0.0.0", port))
+            sock.bind(("127.0.0.1", port))
             return True
     except OSError:
         return False

--- a/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
@@ -34,16 +34,28 @@ pytestmark = [
 
 ALPINE_IMAGE = "alpine:3.20"
 
+# The 9000-9100 product default overlaps ClickHouse's native port (9000), which
+# other integration suites publish on the same daemon. Keep these tests in a range
+# nothing else in CI claims, and below the Linux ephemeral range (32768+).
+TEST_PORT_RANGE_START = 21000
+TEST_PORT_RANGE_END = 21100
+
 
 def _build_docker_backend(**config_overrides: Any) -> DockerDeploymentBackend:
     mock_entities = AsyncMock()
     mock_sdk = MagicMock()
+    executor_config: dict[str, Any] = {
+        "pull_images": True,
+        "port_range_start": TEST_PORT_RANGE_START,
+        "port_range_end": TEST_PORT_RANGE_END,
+        **config_overrides,
+    }
     with (
         patch("nemo_deployments_plugin.backends.docker.backend.AsyncEntitiesResource"),
         patch("nemo_deployments_plugin.backends.docker.backend.NemoEntitiesClient", return_value=mock_entities),
         patch("nemo_deployments_plugin.backends.docker.backend.get_shared_gpu_pool", return_value=None),
     ):
-        backend = DockerDeploymentBackend(mock_sdk, {"pull_images": True, **config_overrides})
+        backend = DockerDeploymentBackend(mock_sdk, executor_config)
     backend._entities = mock_entities
     return backend
 

--- a/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -31,8 +32,10 @@ pytestmark = [
 ]
 
 
-@pytest.fixture
-def docker_backend() -> DockerDeploymentBackend:
+ALPINE_IMAGE = "alpine:3.20"
+
+
+def _build_docker_backend(**config_overrides: Any) -> DockerDeploymentBackend:
     mock_entities = AsyncMock()
     mock_sdk = MagicMock()
     with (
@@ -40,9 +43,14 @@ def docker_backend() -> DockerDeploymentBackend:
         patch("nemo_deployments_plugin.backends.docker.backend.NemoEntitiesClient", return_value=mock_entities),
         patch("nemo_deployments_plugin.backends.docker.backend.get_shared_gpu_pool", return_value=None),
     ):
-        backend = DockerDeploymentBackend(mock_sdk, {"pull_images": True})
+        backend = DockerDeploymentBackend(mock_sdk, {"pull_images": True, **config_overrides})
     backend._entities = mock_entities
     return backend
+
+
+@pytest.fixture
+def docker_backend() -> DockerDeploymentBackend:
+    return _build_docker_backend()
 
 
 def _never_config() -> DeploymentConfig:
@@ -50,7 +58,7 @@ def _never_config() -> DeploymentConfig:
         name="echo-cfg",
         workspace="itest",
         restart_policy="Never",  # ty: ignore[unknown-argument]
-        containers=[Container(name="main", image="alpine:3.20", command=["echo"], args=["hello"])],
+        containers=[Container(name="main", image=ALPINE_IMAGE, command=["echo"], args=["hello"])],
     )
 
 
@@ -62,7 +70,7 @@ def _never_sleep_config(*, sleep_seconds: int) -> DeploymentConfig:
         containers=[
             Container(
                 name="main",
-                image="alpine:3.20",
+                image=ALPINE_IMAGE,
                 command=["sleep"],
                 args=[str(sleep_seconds)],
             )
@@ -74,22 +82,7 @@ def _docker_backend_with_observe_timeout(
     *,
     oneshot_observe_timeout_seconds: int,
 ) -> DockerDeploymentBackend:
-    mock_entities = AsyncMock()
-    mock_sdk = MagicMock()
-    with (
-        patch("nemo_deployments_plugin.backends.docker.backend.AsyncEntitiesResource"),
-        patch("nemo_deployments_plugin.backends.docker.backend.NemoEntitiesClient", return_value=mock_entities),
-        patch("nemo_deployments_plugin.backends.docker.backend.get_shared_gpu_pool", return_value=None),
-    ):
-        backend = DockerDeploymentBackend(
-            mock_sdk,
-            {
-                "pull_images": True,
-                "oneshot_observe_timeout_seconds": oneshot_observe_timeout_seconds,
-            },
-        )
-    backend._entities = mock_entities
-    return backend
+    return _build_docker_backend(oneshot_observe_timeout_seconds=oneshot_observe_timeout_seconds)
 
 
 def _always_http_config() -> DeploymentConfig:
@@ -165,6 +158,10 @@ async def test_never_deployment_outlives_observe_wait_then_succeeds() -> None:
     client = docker.from_env()
 
     try:
+        # Warm the image cache so the timed window below measures the observe wait
+        # rather than an uncached image pull.
+        await asyncio.to_thread(client.images.pull, ALPINE_IMAGE)
+
         started = time.monotonic()
         created = await docker_backend.create_deployment(
             workspace="itest",
@@ -177,7 +174,7 @@ async def test_never_deployment_outlives_observe_wait_then_succeeds() -> None:
 
         assert created.status == "STARTING"
         assert "after observe wait" in (created.status_message or "")
-        assert create_elapsed < 3.0
+        assert create_elapsed < observe_timeout_seconds + 2.0
 
         deadline = time.monotonic() + 15.0
         status = created

--- a/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -50,6 +52,44 @@ def _never_config() -> DeploymentConfig:
         restart_policy="Never",  # ty: ignore[unknown-argument]
         containers=[Container(name="main", image="alpine:3.20", command=["echo"], args=["hello"])],
     )
+
+
+def _never_sleep_config(*, sleep_seconds: int) -> DeploymentConfig:
+    return DeploymentConfig(
+        name="sleep-cfg",
+        workspace="itest",
+        restart_policy="Never",  # ty: ignore[unknown-argument]
+        containers=[
+            Container(
+                name="main",
+                image="alpine:3.20",
+                command=["sleep"],
+                args=[str(sleep_seconds)],
+            )
+        ],
+    )
+
+
+def _docker_backend_with_observe_timeout(
+    *,
+    oneshot_observe_timeout_seconds: int,
+) -> DockerDeploymentBackend:
+    mock_entities = AsyncMock()
+    mock_sdk = MagicMock()
+    with (
+        patch("nemo_deployments_plugin.backends.docker.backend.AsyncEntitiesResource"),
+        patch("nemo_deployments_plugin.backends.docker.backend.NemoEntitiesClient", return_value=mock_entities),
+        patch("nemo_deployments_plugin.backends.docker.backend.get_shared_gpu_pool", return_value=None),
+    ):
+        backend = DockerDeploymentBackend(
+            mock_sdk,
+            {
+                "pull_images": True,
+                "oneshot_observe_timeout_seconds": oneshot_observe_timeout_seconds,
+            },
+        )
+    backend._entities = mock_entities
+    return backend
 
 
 def _always_http_config() -> DeploymentConfig:
@@ -108,6 +148,49 @@ async def test_never_deployment_succeeds(docker_backend: DockerDeploymentBackend
         assert status.exit_code == 0
     finally:
         await docker_backend.delete_deployment("itest", "echo-job")
+        force_remove_container(client, c_name)
+
+
+@pytest.mark.asyncio
+async def test_never_deployment_outlives_observe_wait_then_succeeds() -> None:
+    """Long Never jobs return STARTING on create and finish via read_status polling."""
+    job_sleep_seconds = 5
+    observe_timeout_seconds = 1
+    docker_backend = _docker_backend_with_observe_timeout(
+        oneshot_observe_timeout_seconds=observe_timeout_seconds,
+    )
+    config = _never_sleep_config(sleep_seconds=job_sleep_seconds)
+    docker_backend._entities.get.return_value = config  # ty: ignore[unresolved-attribute]
+    c_name = container_name("itest", "sleep-job")
+    client = docker.from_env()
+
+    try:
+        started = time.monotonic()
+        created = await docker_backend.create_deployment(
+            workspace="itest",
+            name="sleep-job",
+            config_name="sleep-cfg",
+            labels={"managed-by": MANAGED_BY_LABEL},
+            backend_config={},
+        )
+        create_elapsed = time.monotonic() - started
+
+        assert created.status == "STARTING"
+        assert "after observe wait" in (created.status_message or "")
+        assert create_elapsed < 3.0
+
+        deadline = time.monotonic() + 15.0
+        status = created
+        while time.monotonic() < deadline:
+            status = await docker_backend.read_status(workspace="itest", name="sleep-job")
+            if status.status in {"SUCCEEDED", "FAILED"}:
+                break
+            await asyncio.sleep(0.5)
+
+        assert status.status == "SUCCEEDED"
+        assert status.exit_code == 0
+    finally:
+        await docker_backend.delete_deployment("itest", "sleep-job")
         force_remove_container(client, c_name)
 
 

--- a/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
@@ -34,9 +34,8 @@ pytestmark = [
 
 ALPINE_IMAGE = "alpine:3.20"
 
-# The 9000-9100 product default overlaps ClickHouse's native port (9000), which
-# other integration suites publish on the same daemon. Keep these tests in a range
-# nothing else in CI claims, and below the Linux ephemeral range (32768+).
+# Keep these tests in a dedicated range that nothing else in CI claims, separate
+# from both service ports and the product's dynamic/private default range.
 TEST_PORT_RANGE_START = 21000
 TEST_PORT_RANGE_END = 21100
 

--- a/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -89,7 +88,7 @@ async def test_volume_lifecycle(docker_backend: DockerDeploymentBackend) -> None
 @pytest.mark.asyncio
 async def test_never_deployment_succeeds(docker_backend: DockerDeploymentBackend) -> None:
     config = _never_config()
-    docker_backend._entities.get.return_value = config  # type: ignore[attr-defined]
+    docker_backend._entities.get.return_value = config  # ty: ignore[unresolved-attribute]
     c_name = container_name("itest", "echo-job")
     client = docker.from_env()
 
@@ -101,14 +100,10 @@ async def test_never_deployment_succeeds(docker_backend: DockerDeploymentBackend
             labels={"managed-by": MANAGED_BY_LABEL},
             backend_config={},
         )
-        assert created.status == "STARTING"
+        assert created.status == "SUCCEEDED"
+        assert created.exit_code == 0
 
-        for _ in range(30):
-            status = await docker_backend.read_status(workspace="itest", name="echo-job")
-            if status.status in ("SUCCEEDED", "FAILED"):
-                break
-            await asyncio.sleep(0.5)
-
+        status = await docker_backend.read_status(workspace="itest", name="echo-job")
         assert status.status == "SUCCEEDED"
         assert status.exit_code == 0
     finally:
@@ -126,7 +121,7 @@ async def test_lost_detection_for_always(docker_backend: DockerDeploymentBackend
             return deployment
         return config
 
-    docker_backend._entities.get.side_effect = get_side_effect  # type: ignore[attr-defined]
+    docker_backend._entities.get.side_effect = get_side_effect  # ty: ignore[unresolved-attribute]
     c_name = container_name("itest", "lost-srv")
     client = docker.from_env()
 

--- a/plugins/nemo-deployments/tests/unit/backends/docker/docker_helpers.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/docker_helpers.py
@@ -27,6 +27,22 @@ def sample_config(*, restart_policy: RestartPolicy = "Always") -> DeploymentConf
     )
 
 
+def published_port_config(*, restart_policy: RestartPolicy = "Always") -> DeploymentConfig:
+    """Single-container config that publishes a host port."""
+    return DeploymentConfig(
+        name="cfg1",
+        workspace="default",
+        containers=[
+            Container(
+                name="main",
+                image="alpine:latest",
+                ports=[ContainerPort(name="http", containerPort=8000)],
+            )
+        ],
+        restart_policy=restart_policy,  # ty: ignore[unknown-argument]
+    )
+
+
 def lora_config(*, restart_policy: RestartPolicy = "Always") -> DeploymentConfig:
     """A LoRA-shaped multi-container config: init + server + adapters sidecar.
 

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
@@ -120,11 +120,12 @@ async def test_create_deployment_reallocates_port_after_docker_conflict(
     free_host_ports: None,
 ) -> None:
     """Docker's port reservations are invisible to the probe, so a publish can still lose a race."""
+    first_port = docker_backend._executor_config.port_range_start
     leftover = MagicMock()
     mock_entities.get.return_value = published_port_config()
     mock_docker_client.containers.get.side_effect = [NotFound("missing"), leftover]
     mock_docker_client.containers.run.side_effect = [
-        _port_conflict_error(9000),
+        _port_conflict_error(first_port),
         MagicMock(id="abc123"),
     ]
 
@@ -137,7 +138,7 @@ async def test_create_deployment_reallocates_port_after_docker_conflict(
     )
 
     assert update.status == "STARTING"
-    assert _published_host_ports(mock_docker_client.containers.run) == [9000, 9001]
+    assert _published_host_ports(mock_docker_client.containers.run) == [first_port, first_port + 1]
     # run() creates then starts, so the container that failed to start still holds the name.
     leftover.remove.assert_called_once_with(force=True)
 
@@ -149,10 +150,11 @@ async def test_create_deployment_fails_after_repeated_port_conflicts(
     mock_docker_client: MagicMock,
     free_host_ports: None,
 ) -> None:
+    first_port = docker_backend._executor_config.port_range_start
     mock_entities.get.return_value = published_port_config()
     mock_docker_client.containers.get.side_effect = NotFound("missing")
     mock_docker_client.containers.run.side_effect = [
-        _port_conflict_error(9000 + offset) for offset in range(_PORT_CONFLICT_ATTEMPTS)
+        _port_conflict_error(first_port + offset) for offset in range(_PORT_CONFLICT_ATTEMPTS)
     ]
 
     update = await docker_backend.create_deployment(
@@ -166,7 +168,7 @@ async def test_create_deployment_fails_after_repeated_port_conflicts(
     assert update.status == "FAILED"
     assert _PORT_CONFLICT_MARKER in (update.status_message or "")
     published = _published_host_ports(mock_docker_client.containers.run)
-    assert published == [9000 + offset for offset in range(_PORT_CONFLICT_ATTEMPTS)]
+    assert published == [first_port + offset for offset in range(_PORT_CONFLICT_ATTEMPTS)]
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
@@ -761,7 +761,44 @@ async def test_create_never_job_returns_succeeded_when_container_exits_immediate
 
     assert update.status == "SUCCEEDED"
     assert update.exit_code == 0
-    mock_docker_client.containers.run.return_value.wait.assert_called_once()
+    mock_docker_client.containers.run.return_value.wait.assert_called_once_with(timeout=5)
+
+
+@pytest.mark.asyncio
+async def test_create_never_job_uses_configured_oneshot_observe_timeout(
+    mock_sdk: MagicMock,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    with (
+        patch("nemo_deployments_plugin.backends.docker.backend.AsyncEntitiesResource"),
+        patch("nemo_deployments_plugin.backends.docker.backend.NemoEntitiesClient", return_value=mock_entities),
+        patch("nemo_deployments_plugin.backends.docker.backend.get_shared_gpu_pool", return_value=None),
+        patch("docker.from_env", return_value=mock_docker_client),
+    ):
+        backend = DockerDeploymentBackend(
+            mock_sdk,
+            {"docker_timeout": 600, "oneshot_observe_timeout_seconds": 7, "pull_images": False},
+        )
+        backend._client = mock_docker_client
+
+    mock_entities.get.return_value = sample_config(restart_policy="Never")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    mock_docker_client.containers.run.return_value = _one_shot_server_container(
+        restart_policy="Never",
+        exit_code=0,
+    )
+
+    update = await backend.create_deployment(
+        workspace="default",
+        name="job",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "SUCCEEDED"
+    mock_docker_client.containers.run.return_value.wait.assert_called_once_with(timeout=7)
 
 
 @pytest.mark.asyncio
@@ -887,7 +924,8 @@ async def test_create_never_job_returns_starting_when_wait_times_out(
     )
 
     assert update.status == "STARTING"
-    assert "after wait" in update.status_message
+    assert "after observe wait (5s)" in update.status_message
+    server.wait.assert_called_once_with(timeout=5)
 
 
 @pytest.mark.asyncio
@@ -911,7 +949,8 @@ async def test_create_never_job_returns_starting_when_wait_connection_error(
     )
 
     assert update.status == "STARTING"
-    assert "after wait" in update.status_message
+    assert "after observe wait (5s)" in update.status_message
+    server.wait.assert_called_once_with(timeout=5)
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
@@ -8,10 +8,20 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from backends.docker.docker_helpers import container_attrs, lora_config, sample_config
+from backends.docker.docker_helpers import (
+    container_attrs,
+    lora_config,
+    published_port_config,
+    sample_config,
+)
 from docker.errors import APIError, NotFound
 from nemo_deployments_plugin.backends.base import BackendStatusUpdate
-from nemo_deployments_plugin.backends.docker.backend import DockerDeploymentBackend
+from nemo_deployments_plugin.backends.docker import ports as ports_mod
+from nemo_deployments_plugin.backends.docker.backend import (
+    _PORT_CONFLICT_ATTEMPTS,
+    _PORT_CONFLICT_MARKER,
+    DockerDeploymentBackend,
+)
 from nemo_deployments_plugin.backends.labels import (
     BACKOFF_LIMIT_LABEL,
     CONFIG_NAME_LABEL,
@@ -83,6 +93,103 @@ async def test_create_deployment_maps_command_to_entrypoint(
     _, run_kwargs = mock_docker_client.containers.run.call_args
     assert run_kwargs["entrypoint"] == ["echo"]
     assert run_kwargs["command"] == ["hello"]
+
+
+def _port_conflict_error(port: int) -> APIError:
+    return APIError(
+        f"driver failed programming external connectivity: Bind for 0.0.0.0:{port} failed: {_PORT_CONFLICT_MARKER}"
+    )
+
+
+@pytest.fixture
+def free_host_ports(monkeypatch: pytest.MonkeyPatch, mock_docker_client: MagicMock) -> None:
+    """Make host port allocation deterministic: nothing published, every probe free."""
+    mock_docker_client.containers.list.return_value = []
+    monkeypatch.setattr(ports_mod, "is_port_free", lambda port: True)
+
+
+def _published_host_ports(run_mock: MagicMock) -> list[int]:
+    return [kwargs["ports"]["8000/tcp"] for _, kwargs in run_mock.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_reallocates_port_after_docker_conflict(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+    free_host_ports: None,
+) -> None:
+    """Docker's port reservations are invisible to the probe, so a publish can still lose a race."""
+    leftover = MagicMock()
+    mock_entities.get.return_value = published_port_config()
+    mock_docker_client.containers.get.side_effect = [NotFound("missing"), leftover]
+    mock_docker_client.containers.run.side_effect = [
+        _port_conflict_error(9000),
+        MagicMock(id="abc123"),
+    ]
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="srv",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "STARTING"
+    assert _published_host_ports(mock_docker_client.containers.run) == [9000, 9001]
+    # run() creates then starts, so the container that failed to start still holds the name.
+    leftover.remove.assert_called_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_fails_after_repeated_port_conflicts(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+    free_host_ports: None,
+) -> None:
+    mock_entities.get.return_value = published_port_config()
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    mock_docker_client.containers.run.side_effect = [
+        _port_conflict_error(9000 + offset) for offset in range(_PORT_CONFLICT_ATTEMPTS)
+    ]
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="srv",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "FAILED"
+    assert _PORT_CONFLICT_MARKER in (update.status_message or "")
+    published = _published_host_ports(mock_docker_client.containers.run)
+    assert published == [9000 + offset for offset in range(_PORT_CONFLICT_ATTEMPTS)]
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_does_not_retry_unrelated_start_failure(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+    free_host_ports: None,
+) -> None:
+    mock_entities.get.return_value = published_port_config()
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    mock_docker_client.containers.run.side_effect = APIError("no such image")
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="srv",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "FAILED"
+    mock_docker_client.containers.run.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_backend_mocked.py
@@ -10,8 +10,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from backends.docker.docker_helpers import container_attrs, lora_config, sample_config
 from docker.errors import APIError, NotFound
+from nemo_deployments_plugin.backends.base import BackendStatusUpdate
 from nemo_deployments_plugin.backends.docker.backend import DockerDeploymentBackend
 from nemo_deployments_plugin.backends.labels import (
+    BACKOFF_LIMIT_LABEL,
     CONFIG_NAME_LABEL,
     CONTAINER_ROLE_LABEL,
     DEFAULT_RESOURCE_SCOPE,
@@ -27,6 +29,8 @@ from nemo_deployments_plugin.backends.labels import (
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
 from nemo_deployments_plugin.entities import Deployment
 from nemo_deployments_plugin.types import RestartPolicy
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ReadTimeout
 
 
 @pytest.mark.asyncio
@@ -709,6 +713,257 @@ async def test_list_managed_deployment_names(
     names = await docker_backend.list_managed_deployment_names()
 
     assert names == ["default/srv"]
+
+
+def _one_shot_server_container(
+    *,
+    restart_policy: str,
+    status: str = "exited",
+    exit_code: int = 0,
+    restart_count: int = 0,
+    backoff_limit: str = "6",
+) -> MagicMock:
+    container = MagicMock()
+    container.name = container_name("default", "job")
+    container.wait.return_value = {"StatusCode": exit_code}
+    container.labels = {
+        RESTART_POLICY_LABEL: restart_policy,
+        BACKOFF_LIMIT_LABEL: backoff_limit,
+    }
+    container.status = status
+    container.attrs = {
+        **container_attrs(exit_code=exit_code),
+        "RestartCount": restart_count,
+    }
+    return container
+
+
+@pytest.mark.asyncio
+async def test_create_never_job_returns_succeeded_when_container_exits_immediately(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Never")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    mock_docker_client.containers.run.return_value = _one_shot_server_container(
+        restart_policy="Never",
+        exit_code=0,
+    )
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="job",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "SUCCEEDED"
+    assert update.exit_code == 0
+    mock_docker_client.containers.run.return_value.wait.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_never_job_returns_failed_on_non_zero_exit(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Never")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    mock_docker_client.containers.run.return_value = _one_shot_server_container(
+        restart_policy="Never",
+        exit_code=42,
+    )
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="job",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "FAILED"
+    assert update.exit_code == 42
+
+
+@pytest.mark.asyncio
+async def test_create_on_failure_returns_succeeded_when_already_exited_zero(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="OnFailure")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    server = _one_shot_server_container(restart_policy="OnFailure", exit_code=0)
+    mock_docker_client.containers.run.return_value = server
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="job",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "SUCCEEDED"
+    assert update.exit_code == 0
+    server.wait.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_on_failure_returns_starting_when_failed_under_backoff(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="OnFailure")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    server = _one_shot_server_container(
+        restart_policy="OnFailure",
+        exit_code=1,
+        restart_count=2,
+        backoff_limit="6",
+    )
+    mock_docker_client.containers.run.return_value = server
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="job",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "STARTING"
+    assert update.exit_code == 1
+    assert "retry 2/6" in update.status_message
+
+
+@pytest.mark.asyncio
+async def test_create_on_failure_returns_starting_when_still_running(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="OnFailure")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    server = _one_shot_server_container(restart_policy="OnFailure", status="running", exit_code=0)
+    mock_docker_client.containers.run.return_value = server
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="job",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "STARTING"
+    assert "created" in update.status_message.lower()
+    server.wait.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_never_job_returns_starting_when_wait_times_out(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Never")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    server = _one_shot_server_container(restart_policy="Never", exit_code=0)
+    server.wait.side_effect = ReadTimeout("timed out")
+    mock_docker_client.containers.run.return_value = server
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="job",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "STARTING"
+    assert "after wait" in update.status_message
+
+
+@pytest.mark.asyncio
+async def test_create_never_job_returns_starting_when_wait_connection_error(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Never")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    server = _one_shot_server_container(restart_policy="Never", exit_code=0)
+    server.wait.side_effect = RequestsConnectionError("connection reset")
+    mock_docker_client.containers.run.return_value = server
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="job",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "STARTING"
+    assert "after wait" in update.status_message
+
+
+@pytest.mark.asyncio
+async def test_create_never_job_cleans_up_on_wait_error(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Never")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    server = _one_shot_server_container(restart_policy="Never", exit_code=0)
+    server.wait.side_effect = RuntimeError("boom")
+    mock_docker_client.containers.run.return_value = server
+
+    with patch.object(
+        docker_backend,
+        "delete_deployment",
+        new_callable=AsyncMock,
+        return_value=BackendStatusUpdate(status="SUCCEEDED", status_message="deleted"),
+    ) as mock_delete:
+        update = await docker_backend.create_deployment(
+            workspace="default",
+            name="job",
+            config_name="cfg1",
+            labels={"managed-by": MANAGED_BY_LABEL},
+            backend_config={},
+        )
+
+    assert update.status == "FAILED"
+    mock_delete.assert_awaited_once_with("default", "job")
+
+
+@pytest.mark.asyncio
+async def test_create_always_still_returns_starting(
+    docker_backend: DockerDeploymentBackend,
+    mock_entities: AsyncMock,
+    mock_docker_client: MagicMock,
+) -> None:
+    mock_entities.get.return_value = sample_config(restart_policy="Always")
+    mock_docker_client.containers.get.side_effect = NotFound("missing")
+    mock_docker_client.containers.run.return_value = MagicMock(id="abc123")
+
+    update = await docker_backend.create_deployment(
+        workspace="default",
+        name="srv",
+        config_name="cfg1",
+        labels={"managed-by": MANAGED_BY_LABEL},
+        backend_config={},
+    )
+
+    assert update.status == "STARTING"
+    mock_docker_client.containers.run.return_value.wait.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_executor_config.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_executor_config.py
@@ -9,8 +9,8 @@ from pydantic import ValidationError
 
 def test_docker_executor_config_defaults() -> None:
     cfg = DockerExecutorConfig()
-    assert cfg.port_range_start == 9000
-    assert cfg.port_range_end == 9100
+    assert cfg.port_range_start == 49152
+    assert cfg.port_range_end == 49251
     assert cfg.resource_scope == DEFAULT_RESOURCE_SCOPE
     assert cfg.oneshot_observe_timeout_seconds == 5
 

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_executor_config.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_executor_config.py
@@ -12,6 +12,7 @@ def test_docker_executor_config_defaults() -> None:
     assert cfg.port_range_start == 9000
     assert cfg.port_range_end == 9100
     assert cfg.resource_scope == DEFAULT_RESOURCE_SCOPE
+    assert cfg.oneshot_observe_timeout_seconds == 5
 
 
 def test_docker_executor_config_rejects_inverted_port_range() -> None:

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_idempotency.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_idempotency.py
@@ -78,7 +78,14 @@ async def test_create_exited_one_shot_container_is_removed_and_recreated(
     existing.attrs = container_attrs(status="exited", exit_code=0)
     mock_docker_client.containers.get.return_value = existing
     mock_entities.get.return_value = sample_config(restart_policy=restart_policy)
-    mock_docker_client.containers.run.return_value = MagicMock(id="fresh456")
+    fresh = MagicMock(id="fresh456")
+    fresh.labels = _matching_labels(name="srv-puller", restart_policy=restart_policy)
+    fresh.attrs = container_attrs(exit_code=0)
+    if restart_policy == "Never":
+        fresh.wait.return_value = {"StatusCode": 0}
+    else:
+        fresh.status = "running"
+    mock_docker_client.containers.run.return_value = fresh
 
     update = await docker_backend.create_deployment(
         workspace="default",
@@ -88,7 +95,13 @@ async def test_create_exited_one_shot_container_is_removed_and_recreated(
         backend_config={},
     )
 
-    assert update.status == "STARTING"
+    if restart_policy == "Never":
+        assert update.status == "SUCCEEDED"
+        assert update.exit_code == 0
+        fresh.wait.assert_called_once()
+    else:
+        assert update.status == "STARTING"
+        fresh.wait.assert_not_called()
     existing.remove.assert_called_once_with(force=True)
     mock_docker_client.containers.run.assert_called_once()
 

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_ports.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_ports.py
@@ -24,47 +24,50 @@ def test_is_port_free_skips_check_for_remote_host(monkeypatch: pytest.MonkeyPatc
     assert is_port_free(1) is True
 
 
-def test_is_port_free_returns_false_when_bind_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+class FakeSock:
+    """Records what ``is_port_free`` does to its probe socket."""
+
+    def __init__(self, *, bind_error: OSError | None = None) -> None:
+        self.bind_error = bind_error
+        self.bound: list[tuple[str, int]] = []
+        self.sockopts: list[tuple[object, ...]] = []
+
+    def __enter__(self) -> FakeSock:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+    def setsockopt(self, *args: object) -> None:
+        self.sockopts.append(args)
+
+    def bind(self, addr: tuple[str, int]) -> None:
+        if self.bind_error is not None:
+            raise self.bind_error
+        self.bound.append(addr)
+
+
+def _patch_local_probe(monkeypatch: pytest.MonkeyPatch, sock: FakeSock) -> None:
     from nemo_deployments_plugin.backends.docker import ports as ports_mod
 
-    class FakeSock:
-        def __enter__(self) -> FakeSock:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-        def setsockopt(self, *args: object, **kwargs: object) -> None:
-            return None
-
-        def bind(self, addr: tuple[str, int]) -> None:
-            raise OSError("Address already in use")
-
     monkeypatch.setattr(ports_mod, "is_remote_docker_host", lambda: False)
-    monkeypatch.setattr(ports_mod.socket, "socket", lambda *args, **kwargs: FakeSock())
+    monkeypatch.setattr(ports_mod.socket, "socket", lambda *args, **kwargs: sock)
+
+
+def test_is_port_free_returns_false_when_bind_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_local_probe(monkeypatch, FakeSock(bind_error=OSError("Address already in use")))
     assert is_port_free(9000) is False
 
 
-def test_is_port_free_returns_true_when_bind_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
-    from nemo_deployments_plugin.backends.docker import ports as ports_mod
+def test_is_port_free_probes_wildcard_address_without_reuseaddr(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Docker publishes on 0.0.0.0, and SO_REUSEADDR would let the probe bind a port
+    # a wildcard publisher already holds, reporting it free.
+    sock = FakeSock()
+    _patch_local_probe(monkeypatch, sock)
 
-    class FakeSock:
-        def __enter__(self) -> FakeSock:
-            return self
-
-        def __exit__(self, *args: object) -> None:
-            return None
-
-        def setsockopt(self, *args: object, **kwargs: object) -> None:
-            return None
-
-        def bind(self, addr: tuple[str, int]) -> None:
-            assert addr == ("127.0.0.1", 9000)
-            return None
-
-    monkeypatch.setattr(ports_mod, "is_remote_docker_host", lambda: False)
-    monkeypatch.setattr(ports_mod.socket, "socket", lambda *args, **kwargs: FakeSock())
     assert is_port_free(9000) is True
+    assert sock.bound == [("0.0.0.0", 9000)]
+    assert sock.sockopts == []
 
 
 @pytest.mark.asyncio
@@ -79,6 +82,27 @@ async def test_find_available_port_skips_used(mock_docker_client: MagicMock, mon
 
     port = await find_available_port(mock_docker_client, 9000, 9002)
     assert port == 9002
+
+
+@pytest.mark.asyncio
+async def test_find_available_port_skips_unmanaged_containers(
+    mock_docker_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Foreign containers (e.g. a test-fixture ClickHouse) compete for host ports too."""
+    from nemo_deployments_plugin.backends.docker import ports as ports_mod
+    from nemo_deployments_plugin.backends.docker.ports import find_available_port
+
+    foreign = MagicMock()
+    foreign.labels = {}
+    foreign.ports = {"9000/tcp": [{"HostPort": "9000"}]}
+    mock_docker_client.containers.list.return_value = [foreign]
+    # The daemon's own reservation is invisible to a host-socket probe.
+    monkeypatch.setattr(ports_mod, "is_port_free", lambda port: True)
+
+    port = await find_available_port(mock_docker_client, 9000, 9002)
+
+    assert port == 9001
+    assert mock_docker_client.containers.list.call_args.kwargs == {"all": True}
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_ports.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_ports.py
@@ -59,14 +59,14 @@ def test_is_port_free_returns_false_when_bind_fails(monkeypatch: pytest.MonkeyPa
     assert is_port_free(9000) is False
 
 
-def test_is_port_free_probes_wildcard_address_without_reuseaddr(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Docker publishes on 0.0.0.0, and SO_REUSEADDR would let the probe bind a port
-    # a wildcard publisher already holds, reporting it free.
+def test_is_port_free_probes_loopback_without_reuseaddr(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A Docker wildcard publisher blocks this loopback bind. Avoiding SO_REUSEADDR
+    # is what prevents the probe from incorrectly reporting the port free.
     sock = FakeSock()
     _patch_local_probe(monkeypatch, sock)
 
     assert is_port_free(9000) is True
-    assert sock.bound == [("0.0.0.0", 9000)]
+    assert sock.bound == [("127.0.0.1", 9000)]
     assert sock.sockopts == []
 
 


### PR DESCRIPTION
## Summary
- For `restart_policy=Never`, wait for the primary container to exit at create time and return `SUCCEEDED`/`FAILED` with the exit code (bounded by `docker_timeout`).
- For `OnFailure`, immediately inspect after create; map already-exited containers with the same backoff logic as `read_status`.
- Shares exit mapping via `_status_from_exited_container` so create and read stay aligned; no die-event replay and no e2e sleep workaround.

Addresses the fast-exit flake discussed for `e2e/test_nemo_deployments_docker.py` (and related to the approach in #868) by observing live container state instead of reconstructing status from Docker events.

## Test plan
- [x] Unit: `plugins/nemo-deployments/tests/unit/backends/docker/` (73 passed)
- [x] Integration against a real Docker daemon: `plugins/nemo-deployments/tests/integration/backends/docker/` (3 passed)
- [ ] Optional: e2e `test_docker_job_deployment_reaches_succeeded` with the existing fast alpine workload (no sleep)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-shot deployments can now return `SUCCEEDED`/`FAILED` immediately after container creation when the container has already exited.
  * Added `oneshot_observe_timeout_seconds` (default **5**, min **1**) to limit the initial observe window before deferring to later status polling.
* **Bug Fixes**
  * Improved `Never`/`OnFailure` status mapping using exit code, restart count, and backoff-related retry decisions.
  * More robust handling of init/one-shot termination timeouts or communication issues, including improved cleanup on unexpected monitoring failures.
* **Tests**
  * Expanded Docker backend unit/integration and idempotency coverage for the above scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->