### PR TITLE
fix(jobs): cancel subprocess job steps orphaned by a controller restart

### DIFF
--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -480,6 +480,8 @@ jobs:
       working_directory: /tmp/nmp-subprocess-jobs
       # How long to wait after SIGTERM before force killing the process group. | default: 10
       graceful_shutdown_timeout_seconds: 10
+      # How long a step may go without updates before a restarted controller treats its subprocess as orphaned (platform stopped mid-run) and cancels the step. | default: 60
+      orphan_recovery_grace_seconds: 60
   # Interval in seconds for the job reconciler to run | default: 2
   reconcile_interval_seconds: 2
   # Interval in seconds for the job scheduler to run | default: 5

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
@@ -12,12 +12,17 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
-from nemo_platform_plugin.jobs.types import PlatformJobStepWithContext, PlatformJobTaskUpdate
+from nemo_platform_plugin.jobs.types import (
+    PlatformJobStepWithContext,
+    PlatformJobTaskResponse,
+    PlatformJobTaskUpdate,
+)
 from nmp.common.auth import AuthContext
 from nmp.common.config import get_platform_config
 from nmp.common.jobs.constants import (
@@ -58,6 +63,9 @@ SUBPROCESS_PID_STATUS_KEY = "pid"
 SUBPROCESS_PGID_STATUS_KEY = "pgid"
 SUBPROCESS_PERSISTENT_STORAGE_STATUS_KEY = "subprocess_persistent_storage_path"
 _MISSING_METADATA_PENDING_GRACE_SECONDS = 5
+_ORPHAN_TERMINATE_TIMEOUT_SECONDS = 2.0
+_ORPHAN_TERMINATE_POLL_SECONDS = 0.1
+_ORPHANED_MESSAGE = "Job was cancelled: the platform stopped while this job was running"
 SUBPROCESS_INHERITED_ENV_ALLOWLIST = frozenset(
     {
         "PATH",
@@ -76,6 +84,13 @@ class SubprocessJobExecutionProfileConfig(JobExecutionProfileConfig):
     graceful_shutdown_timeout_seconds: int = Field(
         default=10,
         description="How long to wait after SIGTERM before force killing the process group.",
+    )
+    orphan_recovery_grace_seconds: int = Field(
+        default=60,
+        description=(
+            "How long a step may go without updates before a restarted controller treats its subprocess "
+            "as orphaned (platform stopped mid-run) and cancels the step."
+        ),
     )
     cleanup_completed_jobs_immediately: bool = Field(
         default=False,
@@ -154,6 +169,10 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
         self._root_dir = Path(self._execution_profile_config.working_directory)
         self._root_dir.mkdir(parents=True, exist_ok=True)
         self._process_registry = SubprocessProcessRegistry()
+        # Subprocess execution state lives in this process's memory, so anything the jobs
+        # database still reports as running from before this timestamp was left behind by a
+        # previous controller (see _orphaned_step_update).
+        self._started_at = datetime.datetime.now(datetime.timezone.utc)
 
     def shutdown(self) -> None:
         for metadata in self._process_registry.values():
@@ -280,7 +299,11 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
                     status=PlatformJobStatus.PAUSED,
                     status_details={"message": "Subprocess not found, job paused"},
                 )
-            task_fallback = self._get_task_fallback_update(step)
+            tasks = self._list_tasks_safe(step)
+            orphaned = self._orphaned_step_update(step, tasks)
+            if orphaned is not None:
+                return orphaned
+            task_fallback = self._task_fallback_update(tasks)
             if task_fallback is not None:
                 return task_fallback
             if step.status == PlatformJobStatus.PENDING and not self._pending_step_missing_metadata_is_stale(step):
@@ -355,7 +378,57 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
                 shutil.rmtree(metadata.work_dir, ignore_errors=True)
                 self._process_registry.pop(key)
 
-    def _get_task_fallback_update(self, step: PlatformJobStepWithContext) -> JobUpdate | None:
+    @classmethod
+    def _task_fallback_update(cls, tasks: list[PlatformJobTaskResponse] | None) -> JobUpdate | None:
+        latest_task = cls._latest_task(tasks) if tasks else None
+        if latest_task is None:
+            return None
+
+        return JobUpdate(
+            status=latest_task.status,
+            status_details=latest_task.status_details,
+            error_details=latest_task.error_details or {},
+        )
+
+    def _orphaned_step_update(
+        self,
+        step: PlatformJobStepWithContext,
+        tasks: list[PlatformJobTaskResponse] | None,
+    ) -> JobUpdate | None:
+        """Cancel a step whose subprocess was left behind by a previous controller.
+
+        Subprocess execution state is process-local, so a controller restart (platform
+        stopped mid-run) leaves steps running in the database with nothing tracking them.
+        Anything that stopped being updated before this controller started, and has stayed
+        quiet past the grace period, is such a leftover: kill whatever is still running and
+        cancel the step so the job reaches a terminal state.
+        """
+        if tasks is None:
+            return None
+
+        latest_task = self._latest_task(tasks)
+        if latest_task is not None and PlatformJobStatus(latest_task.status).is_terminal():
+            return None
+
+        task_anchor = self._task_timestamp(latest_task) if latest_task is not None else None
+        anchor = task_anchor or step.updated_at or step.created_at
+        if not self._is_orphaned_anchor(anchor):
+            return None
+
+        logger.warning(
+            "Cancelling job step orphaned by a previous jobs controller",
+            extra={"job": step.job, "step": step.name, "workspace": step.workspace, "status": step.status},
+        )
+        if latest_task is not None:
+            self._terminate_orphaned_process(latest_task.status_details or {})
+            self._cancel_orphaned_task(step, latest_task)
+        return JobUpdate(
+            status=PlatformJobStatus.CANCELLED,
+            status_details={"message": _ORPHANED_MESSAGE},
+            error_details={},
+        )
+
+    def _list_tasks_safe(self, step: PlatformJobStepWithContext) -> list[PlatformJobTaskResponse] | None:
         try:
             tasks = self._jobs.list_job_step_tasks(
                 name=step.name,
@@ -368,21 +441,84 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
                 extra={"job": step.job, "step": step.name, "workspace": step.workspace},
             )
             return None
+        return list(tasks.data)
 
-        if not tasks.data:
+    @classmethod
+    def _latest_task(cls, tasks: list[PlatformJobTaskResponse]) -> PlatformJobTaskResponse | None:
+        if not tasks:
             return None
+        return max(
+            tasks,
+            key=lambda task: cls._task_timestamp(task) or datetime.datetime.min.replace(tzinfo=datetime.timezone.utc),
+        )
 
-        latest_task = max(
-            tasks.data,
-            key=lambda task: (
-                task.updated_at or task.created_at or datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
-            ),
-        )
-        return JobUpdate(
-            status=latest_task.status,
-            status_details=latest_task.status_details,
-            error_details=latest_task.error_details or {},
-        )
+    @staticmethod
+    def _task_timestamp(task: PlatformJobTaskResponse) -> datetime.datetime | None:
+        return task.updated_at or task.created_at
+
+    def _is_orphaned_anchor(self, anchor: datetime.datetime | None) -> bool:
+        if anchor is None:
+            return False
+        if anchor.tzinfo is None:
+            anchor = anchor.replace(tzinfo=datetime.timezone.utc)
+        if anchor >= self._started_at:
+            return False
+        grace = datetime.timedelta(seconds=self._execution_profile_config.orphan_recovery_grace_seconds)
+        return (anchor + grace) < datetime.datetime.now(datetime.timezone.utc)
+
+    def _cancel_orphaned_task(self, step: PlatformJobStepWithContext, task: PlatformJobTaskResponse) -> None:
+        task_name = task.name
+        if not task_name:
+            return
+        try:
+            self._jobs.update_job_step_task(
+                name=task_name,
+                workspace=step.workspace,
+                job=step.job,
+                step=step.name,
+                body=PlatformJobTaskUpdate(
+                    status=PlatformJobStatus.CANCELLED,
+                    status_details={**(task.status_details or {}), "message": _ORPHANED_MESSAGE},
+                    error_details={},
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to cancel orphaned subprocess task",
+                extra={"job": step.job, "step": step.name, "workspace": step.workspace, "task": task_name},
+            )
+
+    @staticmethod
+    def _terminate_orphaned_process(status_details: dict) -> None:
+        """Best-effort kill of a process group left behind by a previous controller."""
+        pid = status_details.get(SUBPROCESS_PID_STATUS_KEY)
+        pgid = status_details.get(SUBPROCESS_PGID_STATUS_KEY)
+        if not isinstance(pid, int) or not isinstance(pgid, int):
+            return
+        try:
+            # Guard against PID reuse: a recycled PID is very unlikely to also lead the same group.
+            if os.getpgid(pid) != pgid:
+                return
+            os.killpg(pgid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            return
+        except Exception:
+            logger.exception("Failed to signal orphaned subprocess group", extra={"pid": pid, "pgid": pgid})
+            return
+
+        deadline = time.monotonic() + _ORPHAN_TERMINATE_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            time.sleep(_ORPHAN_TERMINATE_POLL_SECONDS)
+            try:
+                os.getpgid(pid)
+            except ProcessLookupError:
+                return
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            return
+        except Exception:
+            logger.exception("Failed to kill orphaned subprocess group", extra={"pid": pid, "pgid": pgid})
 
     @staticmethod
     def _pending_step_missing_metadata_is_stale(step: PlatformJobStepWithContext) -> bool:

--- a/services/core/jobs/tests/controllers/test_subprocess_backend.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_backend.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import subprocess
 import sys
 import time
 from datetime import datetime, timedelta, timezone
@@ -407,7 +408,7 @@ def test_sync_uses_persisted_task_when_local_metadata_is_missing(
     assert update.error_details == {}
 
 
-def test_get_task_fallback_update_handles_missing_task_timestamps(
+def test_task_fallback_update_handles_missing_task_timestamps(
     mock_nmp_client, mock_jobs_client, tmp_path, mock_platform_config, test_step_active
 ):
     backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
@@ -433,7 +434,7 @@ def test_get_task_fallback_update_handles_missing_task_timestamps(
         )
     )
 
-    update = backend._get_task_fallback_update(step)
+    update = backend._task_fallback_update(backend._list_tasks_safe(step))
 
     assert update is not None
     assert update.status == PlatformJobStatus.ACTIVE
@@ -452,6 +453,161 @@ def test_sync_keeps_recent_pending_step_pending_when_local_metadata_is_missing(
 
     assert update.status == PlatformJobStatus.PENDING
     assert update.error_details == {}
+
+
+def _orphaned_task(status: PlatformJobStatus, age_seconds: int, **overrides):
+    timestamp = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+    fields = {
+        "name": "task-orphan",
+        "status": status.value,
+        "status_details": {"message": "Job is running"},
+        "error_details": {},
+        "created_at": timestamp,
+        "updated_at": timestamp,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+def test_sync_cancels_active_step_orphaned_by_previous_controller(
+    mock_nmp_client, mock_jobs_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "sleep 10"])
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(
+        SimpleNamespace(data=[_orphaned_task(PlatformJobStatus.ACTIVE, age_seconds=3600)])
+    )
+
+    update = backend.sync(step)
+
+    assert update.status == PlatformJobStatus.CANCELLED
+    assert update.status_details == {"message": "Job was cancelled: the platform stopped while this job was running"}
+    last_call = mock_jobs_client.update_job_step_task.call_args
+    assert last_call.kwargs["name"] == "task-orphan"
+    assert last_call.kwargs["body"].status == PlatformJobStatus.CANCELLED
+
+
+def test_sync_cancels_orphaned_step_without_tasks(
+    mock_nmp_client, mock_jobs_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "sleep 10"])
+    step.updated_at = datetime.now(timezone.utc) - timedelta(seconds=3600)
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(SimpleNamespace(data=[]))
+
+    update = backend.sync(step)
+
+    assert update.status == PlatformJobStatus.CANCELLED
+    mock_jobs_client.update_job_step_task.assert_not_called()
+
+
+def test_sync_does_not_cancel_step_updated_within_grace_period(
+    mock_nmp_client, mock_jobs_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "sleep 10"])
+    grace = backend._execution_profile_config.orphan_recovery_grace_seconds
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(
+        SimpleNamespace(data=[_orphaned_task(PlatformJobStatus.ACTIVE, age_seconds=grace // 2)])
+    )
+
+    update = backend.sync(step)
+
+    assert update.status == PlatformJobStatus.ACTIVE
+
+
+def test_sync_does_not_cancel_step_owned_by_a_live_controller(
+    mock_nmp_client, mock_jobs_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    backend._started_at = datetime.now(timezone.utc) - timedelta(days=1)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "sleep 10"])
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(
+        SimpleNamespace(data=[_orphaned_task(PlatformJobStatus.ACTIVE, age_seconds=3600)])
+    )
+
+    update = backend.sync(step)
+
+    assert update.status == PlatformJobStatus.ACTIVE
+
+
+def test_sync_keeps_terminal_task_status_for_missing_metadata(
+    mock_nmp_client, mock_jobs_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "true"])
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(
+        SimpleNamespace(
+            data=[
+                _orphaned_task(
+                    PlatformJobStatus.COMPLETED,
+                    age_seconds=3600,
+                    status_details={"message": "Job completed successfully with exit code 0"},
+                )
+            ]
+        )
+    )
+
+    update = backend.sync(step)
+
+    assert update.status == PlatformJobStatus.COMPLETED
+
+
+def test_orphan_recovery_kills_leftover_process_group(
+    mock_nmp_client, mock_jobs_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "sleep 30"])
+    leftover = subprocess.Popen(["/bin/sh", "-c", "sleep 30"], start_new_session=True)
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(
+        SimpleNamespace(
+            data=[
+                _orphaned_task(
+                    PlatformJobStatus.ACTIVE,
+                    age_seconds=3600,
+                    status_details={"pid": leftover.pid, "pgid": os.getpgid(leftover.pid)},
+                )
+            ]
+        )
+    )
+
+    try:
+        update = backend.sync(step)
+
+        assert update.status == PlatformJobStatus.CANCELLED
+        assert leftover.wait(timeout=5) is not None
+    finally:
+        if leftover.poll() is None:
+            leftover.kill()
+            leftover.wait(timeout=5)
+
+
+def test_orphan_recovery_skips_kill_when_recorded_pid_is_not_group_leader(
+    mock_nmp_client, mock_jobs_client, tmp_path, mock_platform_config, test_step_active
+):
+    backend = _subprocess_backend(mock_nmp_client, tmp_path, mock_platform_config)
+    step = _step_with_command(test_step_active, ["/bin/sh", "-c", "sleep 30"])
+    unrelated = subprocess.Popen(["/bin/sh", "-c", "sleep 5"], start_new_session=True)
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(
+        SimpleNamespace(
+            data=[
+                _orphaned_task(
+                    PlatformJobStatus.ACTIVE,
+                    age_seconds=3600,
+                    status_details={"pid": unrelated.pid, "pgid": os.getpgid(unrelated.pid) + 1},
+                )
+            ]
+        )
+    )
+
+    try:
+        update = backend.sync(step)
+
+        assert update.status == PlatformJobStatus.CANCELLED
+        assert unrelated.poll() is None
+    finally:
+        unrelated.kill()
+        unrelated.wait(timeout=5)
 
 
 def test_pending_step_missing_metadata_stale_check_accepts_typed_timestamp(test_step_pending):


### PR DESCRIPTION
## What

Jobs that were running when the platform went down stayed `active` forever.

The subprocess backend (the default executor for local `docker`/`none` runtimes) keeps execution state in controller memory. On restart the registry is empty, so `sync()` fell through to the task fallback and echoed back the last persisted task status — usually `active`. The step, its attempt, and the job never reached a terminal state, and the detached subprocess (`start_new_session=True`) kept running unmanaged.

Docker, Kubernetes and Volcano are unaffected: their workloads outlive the controller and are re-adopted by name/label (the Docker owner id is derived from the data dir, so it is stable across restarts).

## How

During `sync()`, when there is no local metadata for a step, treat it as orphaned when **both** hold:

1. its latest task (or the step itself, if it has no tasks) is non-terminal and last changed **before this controller started**, and
2. it has stayed quiet longer than `orphan_recovery_grace_seconds`.

An orphaned step is cancelled with `"Job was cancelled: the platform stopped while this job was running"`, its task record is cancelled too, and any process group recorded in the task status details is terminated (SIGTERM, 2s poll, then SIGKILL, guarded by `os.getpgid(pid) == pgid` against PID reuse). The step status rolls up to the attempt and job through the existing `update_job_status_from_step` path.

Both conditions are needed so that a second, live controller sharing the database is left alone: an attached controller rewrites its task records on every reconcile pass, so its steps never look quiet.

Also folded the two task fetches (orphan check + fallback) into one call, so reconciliation makes no extra API requests.

## Config

New `jobs.executors[].config.orphan_recovery_grace_seconds`, default 60s. Config reference regenerated.

## Testing

7 new cases in `test_subprocess_backend.py`: orphan cancellation with and without tasks, grace window respected, live-controller steps untouched, terminal task status preserved, real process-group kill, and the PID-reuse guard. `services/core/jobs/tests` — 467 passed, 17 skipped. `ruff` and `ty` clean.

Manually verified end-to-end against a local platform:
- On `main`: started a long-running `cpu/default` job (translated to a `subprocess` step), killed the controller mid-run, restarted it. The step/job stayed `active` forever and the orphaned subprocess kept running unmanaged — reproducing the bug.
- On this branch: same scenario, with `orphan_recovery_grace_seconds` lowered for a fast repro. After the grace period the step and job transitioned to `cancelled` with `"Job was cancelled: the platform stopped while this job was running"`, and the orphaned subprocess was actually killed.
