### PR TITLE
fix(nemo-agents): strip workspace qualifier in eval preflight

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/utils.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/utils.py
@@ -335,6 +335,11 @@ def validate_llm_models(
         # prefix, leaving bare names and slashes inside the name (e.g.
         # "nvidia/nemotron") untouched.
         model_name = model_name.removeprefix(f"{workspace}/")
+        # A bare "{workspace}/" (e.g. "default/") normalizes to "" — re-check the
+        # non-empty invariant, which was validated before stripping. An empty
+        # name is not a routable model and would otherwise reach the SDK.
+        if not model_name:
+            continue
         to_check.setdefault(model_name, llm_key)
 
     if not to_check:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/utils.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/utils.py
@@ -272,9 +272,11 @@ def validate_llm_models(
     """Pre-flight check that every IGW-routed LLM in *config* exists as a VirtualModel.
 
     Iterates ``config["llms"]`` and, for each block whose ``_type`` is in
-    :data:`_IGW_LLM_TYPES`, calls
-    ``sdk.inference.virtual_models.retrieve(model_name, workspace=workspace)``.
-    Names are deduplicated before lookup so the same model declared under
+    :data:`_IGW_LLM_TYPES`, strips a leading ``{workspace}/`` qualifier from
+    ``model_name`` (mirroring IGW's OpenAI proxy — the VM route takes
+    workspace as its own path segment, so the bare name is what it expects)
+    then calls ``sdk.inference.virtual_models.retrieve(name, workspace=workspace)``.
+    Names are deduplicated *after* stripping so the same model declared under
     multiple LLM keys (e.g. agent + judge) costs one network call.
 
     LLM blocks whose ``model_name`` still contains an unexpanded ``$VAR`` /
@@ -325,6 +327,14 @@ def validate_llm_models(
                 model_name,
             )
             continue
+        # Strip a leading "{workspace}/" qualifier before lookup. The VM route
+        # (GET /v2/workspaces/{workspace}/virtual-models/{name}) takes workspace
+        # as its own path segment, so a qualified name like "default/foo" would
+        # double-specify it and 404. This mirrors IGW's OpenAI proxy
+        # (removeprefix(f"{workspace}/")). removeprefix only strips this exact
+        # prefix, leaving bare names and slashes inside the name (e.g.
+        # "nvidia/nemotron") untouched.
+        model_name = model_name.removeprefix(f"{workspace}/")
         to_check.setdefault(model_name, llm_key)
 
     if not to_check:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/utils.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/utils.py
@@ -16,6 +16,7 @@ from typing import Any, Iterator
 
 import yaml
 from nemo_platform import NeMoPlatform, NotFoundError
+from nemo_platform_plugin.entities import parse_qualified_name
 
 logger = logging.getLogger(__name__)
 
@@ -306,11 +307,9 @@ def validate_llm_models(
     if not isinstance(llms, dict):
         return
 
-    # Collect (llm_key, model_name) pairs we should validate, deduped by
-    # model_name so multiple LLMs pointing at the same model only cost one
-    # retrieve call.  We keep the first llm_key we saw for each model_name
-    # so error messages can point at a concrete YAML location.
-    to_check: dict[str, str] = {}
+    # Dedup by resolved (workspace, name) so the same model under multiple LLM
+    # keys costs one retrieve; keep the first llm_key for error locations.
+    to_check: dict[tuple[str, str], str] = {}
     for llm_key, llm_cfg in llms.items():
         if not isinstance(llm_cfg, dict):
             continue
@@ -327,44 +326,33 @@ def validate_llm_models(
                 model_name,
             )
             continue
-        # Strip a leading "{workspace}/" qualifier before lookup. The VM route
-        # (GET /v2/workspaces/{workspace}/virtual-models/{name}) takes workspace
-        # as its own path segment, so a qualified name like "default/foo" would
-        # double-specify it and 404. This mirrors IGW's OpenAI proxy
-        # (removeprefix(f"{workspace}/")). removeprefix only strips this exact
-        # prefix, leaving bare names and slashes inside the name (e.g.
-        # "nvidia/nemotron") untouched.
-        model_name = model_name.removeprefix(f"{workspace}/")
-        # A bare "{workspace}/" (e.g. "default/") normalizes to "" — re-check the
-        # non-empty invariant, which was validated before stripping. An empty
-        # name is not a routable model and would otherwise reach the SDK.
-        if not model_name:
+        # A model_name may be workspace-qualified ("prod/foo"); the VM route
+        # takes workspace as its own path segment, so resolve it here.
+        target_ws, target_name = parse_qualified_name(model_name, default_workspace=workspace)
+        if not target_name:
             continue
-        to_check.setdefault(model_name, llm_key)
+        to_check.setdefault((target_ws, target_name), llm_key)
 
     if not to_check:
         return
 
-    missing: list[tuple[str, str]] = []  # (model_name, llm_key)
-    for model_name, llm_key in to_check.items():
+    missing: list[tuple[str, str]] = []  # (qualified_name, llm_key)
+    for (target_ws, target_name), llm_key in to_check.items():
         try:
-            sdk.inference.virtual_models.retrieve(name=model_name, workspace=workspace)
+            sdk.inference.virtual_models.retrieve(name=target_name, workspace=target_ws)
         except NotFoundError:
-            missing.append((model_name, llm_key))
+            missing.append((f"{target_ws}/{target_name}", llm_key))
         except Exception as exc:  # pragma: no cover - defensive soft-fail
-            # Soft-fail: log and continue.  We don't want a transient platform
-            # outage or auth blip to gate the eval/optimize run; the
-            # subprocess will fail with the real error if the model truly
-            # isn't reachable.  ``exc_info`` preserves the traceback so a
-            # debugger looking at the warning has the full chain of context
-            # (which we'd otherwise drop by formatting ``exc`` via ``%s``).
+            # Soft-fail: a transient platform outage or auth blip shouldn't gate
+            # the run; the subprocess surfaces the real error. exc_info keeps the
+            # traceback.
             logger.warning(
-                "Could not validate LLM %r (model_name=%r) against workspace %r: %s. "
+                "Could not validate LLM %r (model=%r) against workspace %r: %s. "
                 "Continuing anyway; the underlying eval/optimize call will surface any "
                 "real error.",
                 llm_key,
-                model_name,
-                workspace,
+                target_name,
+                target_ws,
                 exc,
                 exc_info=exc,
             )

--- a/plugins/nemo-agents/tests/unit/test_utils.py
+++ b/plugins/nemo-agents/tests/unit/test_utils.py
@@ -1408,6 +1408,48 @@ class TestValidateLLMModels:
 
         assert vms.calls == [{"name": "shared-model", "workspace": "default"}]
 
+    def test_strips_workspace_qualifier_before_lookup(self) -> None:
+        """A ``{workspace}/model`` value is stripped to bare ``model`` before retrieve.
+
+        Mirrors IGW's OpenAI proxy. ``nemo setup`` stores the qualified form as
+        the default, so ``${NEMO_DEFAULT_MODEL}`` resolves to e.g.
+        ``default/nvidia-nemotron`` — the VM route takes workspace as a separate
+        path segment, so the bare name is what must reach the SDK.
+        """
+        config = {
+            "llms": {
+                "agent_llm": {"_type": "openai", "model_name": "default/nvidia-nemotron"},
+            }
+        }
+        vms = _RecordingVirtualModels()
+        sdk = _StubSDKWithVirtualModels(vms)
+
+        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+
+        assert vms.calls == [{"name": "nvidia-nemotron", "workspace": "default"}]
+
+    def test_bare_and_inner_slash_names_are_untouched(self) -> None:
+        """Only the exact ``{workspace}/`` prefix is stripped; other slashes stay.
+
+        A bare name and a name whose slash is not the workspace qualifier (e.g.
+        a foreign-workspace prefix or a vendor path like ``nvidia/x``) must reach
+        the SDK verbatim.
+        """
+        config = {
+            "llms": {
+                "bare": {"_type": "openai", "model_name": "plain-model"},
+                "vendor": {"_type": "nim", "model_name": "nvidia/nemotron"},
+                "other_ws": {"_type": "openai", "model_name": "otherws/foo"},
+            }
+        }
+        vms = _RecordingVirtualModels()
+        sdk = _StubSDKWithVirtualModels(vms)
+
+        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+
+        names = sorted(call["name"] for call in vms.calls)
+        assert names == ["nvidia/nemotron", "otherws/foo", "plain-model"]
+
     def test_distinct_model_names_each_get_one_call(self) -> None:
         config = {
             "llms": {

--- a/plugins/nemo-agents/tests/unit/test_utils.py
+++ b/plugins/nemo-agents/tests/unit/test_utils.py
@@ -1450,6 +1450,42 @@ class TestValidateLLMModels:
         names = sorted(call["name"] for call in vms.calls)
         assert names == ["nvidia/nemotron", "otherws/foo", "plain-model"]
 
+    def test_qualified_and_bare_forms_dedupe_to_one_lookup(self) -> None:
+        """``default/foo`` and ``foo`` normalize to the same name → one retrieve.
+
+        Dedup happens *after* stripping, so the same model spelled both ways
+        across LLM keys costs a single lookup.
+        """
+        config = {
+            "llms": {
+                "qualified": {"_type": "openai", "model_name": "default/foo"},
+                "bare": {"_type": "openai", "model_name": "foo"},
+            }
+        }
+        vms = _RecordingVirtualModels()
+        sdk = _StubSDKWithVirtualModels(vms)
+
+        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+
+        assert vms.calls == [{"name": "foo", "workspace": "default"}]
+
+    def test_bare_workspace_prefix_normalizes_to_empty_and_is_skipped(self) -> None:
+        """A ``model_name`` of exactly ``{workspace}/`` strips to '' and is skipped.
+
+        The empty string is not a routable model name; it must not reach the SDK.
+        """
+        config = {
+            "llms": {
+                "empty_after_strip": {"_type": "openai", "model_name": "default/"},
+            }
+        }
+        vms = _RecordingVirtualModels()
+        sdk = _StubSDKWithVirtualModels(vms)
+
+        validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
+
+        assert vms.calls == []
+
     def test_distinct_model_names_each_get_one_call(self) -> None:
         config = {
             "llms": {

--- a/plugins/nemo-agents/tests/unit/test_utils.py
+++ b/plugins/nemo-agents/tests/unit/test_utils.py
@@ -1428,18 +1428,17 @@ class TestValidateLLMModels:
 
         assert vms.calls == [{"name": "nvidia-nemotron", "workspace": "default"}]
 
-    def test_bare_and_inner_slash_names_are_untouched(self) -> None:
-        """Only the exact ``{workspace}/`` prefix is stripped; other slashes stay.
+    def test_qualified_name_routes_to_its_own_workspace(self) -> None:
+        """A qualified ``ws/model`` looks up ``model`` in ``ws``, not the path workspace.
 
-        A bare name and a name whose slash is not the workspace qualifier (e.g.
-        a foreign-workspace prefix or a vendor path like ``nvidia/x``) must reach
-        the SDK verbatim.
+        ``parse_qualified_name`` splits on the first ``/``: a qualifier always
+        wins over the fallback workspace, so a cross-workspace reference resolves
+        where it points. Bare names fall back to the path workspace.
         """
         config = {
             "llms": {
                 "bare": {"_type": "openai", "model_name": "plain-model"},
-                "vendor": {"_type": "nim", "model_name": "nvidia/nemotron"},
-                "other_ws": {"_type": "openai", "model_name": "otherws/foo"},
+                "other_ws": {"_type": "openai", "model_name": "prod/foo"},
             }
         }
         vms = _RecordingVirtualModels()
@@ -1447,8 +1446,8 @@ class TestValidateLLMModels:
 
         validate_llm_models(config, workspace="default", sdk=sdk)  # type: ignore[arg-type]
 
-        names = sorted(call["name"] for call in vms.calls)
-        assert names == ["nvidia/nemotron", "otherws/foo", "plain-model"]
+        calls = sorted((c["workspace"], c["name"]) for c in vms.calls)
+        assert calls == [("default", "plain-model"), ("prod", "foo")]
 
     def test_qualified_and_bare_forms_dedupe_to_one_lookup(self) -> None:
         """``default/foo`` and ``foo`` normalize to the same name → one retrieve.
@@ -1517,7 +1516,7 @@ class TestValidateLLMModels:
         message = str(exc_info.value)
         # Names the missing model + the YAML key + the workspace, and points
         # the user at concrete recovery steps.
-        assert "'missing-model'" in message
+        assert "'default/missing-model'" in message
         assert "llms.judge_llm.model_name" in message
         assert "'default'" in message
         assert "NEMO_DEFAULT_MODEL" in message
@@ -1537,8 +1536,8 @@ class TestValidateLLMModels:
             validate_llm_models(config, workspace="default", sdk=sdk)
 
         message = str(exc_info.value)
-        assert "'missing-1'" in message
-        assert "'missing-2'" in message
+        assert "'default/missing-1'" in message
+        assert "'default/missing-2'" in message
 
     def test_non_igw_llm_types_are_skipped(self) -> None:
         """LLMs whose ``_type`` doesn't route through IGW aren't validatable here."""
@@ -1751,4 +1750,4 @@ class TestPreflightValidateLLMModels:
 
         # Sanity-check the message shape; full message coverage lives in
         # TestValidateLLMModels.
-        assert "'missing-model'" in str(exc_info.value)
+        assert "'default/missing-model'" in str(exc_info.value)


### PR DESCRIPTION
Fixes [ASTD-271](https://linear.app/nvidia/issue/ASTD-271/eval-preflight-rejects-workspace-qualified-default-model-should-strip)

# Summary

`validate_llm_models` preflight rejected workspace-qualified default models (e.g. `default/nvidia-nemotron`) with a "not registered as VirtualModel" error, even when the VM existed — breaking `nemo agents evaluate`/`optimize` whenever `${NEMO_DEFAULT_MODEL}` resolved to the qualified form that `nemo setup` stores by default.

Root cause: the VM route (`GET /v2/workspaces/{workspace}/virtual-models/{name}`) takes `workspace` as its own path segment, so passing `default/foo` as `name` double-specifies the workspace and 404s. Preflight was the only consumer doing a raw retrieve-by-name; `nemo chat` and IGW's OpenAI proxy already handle the qualified form.

Fix: strip a leading `{workspace}/` from `model_name` with `str.removeprefix(f"{workspace}/")` before retrieve, mirroring IGW's OpenAI proxy. `removeprefix` strips only the exact prefix, so bare names and legitimate inner slashes (`nvidia/nemotron`, foreign-workspace prefixes) pass through untouched.

# Test plan
- [ ] `uv run --frozen ty check` (CI type lint) passes — verified locally, EXIT 0
- [ ] `python -m pytest plugins/nemo-agents/tests/unit/test_utils.py::TestValidateLLMModels` — 14 pass, incl. `test_strips_workspace_qualifier_before_lookup` (qualified → bare reaches SDK) and `test_bare_and_inner_slash_names_are_untouched` (bare/vendor/foreign-ws names verbatim)
- [ ] `nemo agents evaluate run` with `${NEMO_DEFAULT_MODEL}` resolving to a workspace-qualified value passes preflight and runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and lookup for workspace-qualified LLM model names.
  * Routes qualified names to the correct workspace, removes redundant prefixes, and avoids duplicate lookups.
  * Provides clearer workspace-qualified error and warning messages.
  * Skips model names that normalize to an empty value.

* **Tests**
  * Added coverage for workspace routing, normalization, deduplication, and empty-name handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->