### PR TITLE
fix(studio): let ControlledCombobox back a typed multi-select [ASTD-344]

### DIFF
--- a/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
@@ -141,16 +141,6 @@ export const MultipleSectioned: Story = {
   args: { kind: 'multiple', items: SECTIONED },
 };
 
-/**
- * freeForm is a no-op for multi-select: the field holds a string[], so raw input is not written
- * to it. Callers that need custom values drive `inputValue` and offer the typed text as an item,
- * which is what "Custom entries" below does.
- */
-export const MultipleFreeFormIsInert: Story = {
-  name: 'Multi select (freeForm has no effect)',
-  args: { kind: 'multiple', freeForm: true },
-};
-
 export const MultipleCustomEntries: Story = {
   name: 'Multi select (custom entries)',
   args: {

--- a/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
@@ -1,0 +1,171 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+import { ControlledCombobox } from '@nemo/common/src/components/form/ControlledCombobox/index';
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+const LABELS = ['email', 'phone_number', 'first_name', 'last_name', 'ssn', 'street_address'];
+
+const SECTIONED = [
+  {
+    kind: 'section' as const,
+    slotHeading: 'Personal Identity',
+    items: ['first_name', 'last_name'],
+  },
+  { kind: 'section' as const, slotHeading: 'Contact', items: ['email', 'phone_number'] },
+];
+
+interface StoryForm {
+  single: string;
+  multiple: string[];
+}
+
+interface HarnessProps {
+  kind?: 'single' | 'multiple';
+  items?: React.ComponentProps<typeof ControlledCombobox>['items'];
+  freeForm?: boolean;
+  loading?: boolean;
+  disabled?: boolean;
+  placeholder?: string;
+  multipleMode?: 'tags' | 'count';
+  /** Mirrors how a caller drives the search text to offer entries that aren't in `items`. */
+  offerTypedValue?: boolean;
+  defaultValues?: Partial<StoryForm>;
+}
+
+function ControlledComboboxHarness({
+  kind = 'single',
+  items = LABELS,
+  offerTypedValue = false,
+  defaultValues,
+  ...comboboxProps
+}: HarnessProps) {
+  const methods = useForm<StoryForm>({
+    defaultValues: { single: '', multiple: [], ...defaultValues },
+    mode: 'onChange',
+  });
+  const [inputValue, setInputValue] = useState('');
+  const name = kind === 'multiple' ? 'multiple' : 'single';
+  const value = methods.watch(name);
+
+  const selected = Array.isArray(value) ? value : [];
+  const typed = inputValue.trim();
+  const showTyped =
+    offerTypedValue && typed && !LABELS.includes(typed) && !selected.includes(typed);
+  const resolvedItems = showTyped
+    ? [{ kind: 'section' as const, slotHeading: 'Custom', items: [typed] }, ...(items as [])]
+    : items;
+
+  return (
+    <FormProvider {...methods}>
+      <Stack gap="density-xl" className="max-w-md">
+        <ControlledCombobox
+          {...comboboxProps}
+          kind={kind}
+          items={resolvedItems}
+          aria-label="Labels"
+          {...(offerTypedValue ? { inputValue, onInputValueChange: setInputValue } : {})}
+          onChange={() => setInputValue('')}
+          useControllerProps={{ name, control: methods.control }}
+          formFieldProps={{ slotLabel: 'Entity labels' }}
+        />
+        <Stack
+          gap="density-sm"
+          className="rounded-md border border-[var(--border-subtle-1)] p-density-md"
+        >
+          <Text kind="body/bold/sm">Live values (Dev only)</Text>
+          <pre className="overflow-auto text-xs whitespace-pre-wrap font-mono opacity-90">
+            {JSON.stringify({ value, inputValue }, null, 2)}
+          </pre>
+        </Stack>
+      </Stack>
+    </FormProvider>
+  );
+}
+
+const meta: Meta<typeof ControlledComboboxHarness> = {
+  component: ControlledComboboxHarness,
+  title: 'Studio Common/ControlledCombobox',
+  decorators: [
+    (Story) => (
+      <div className="p-density-lg">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ControlledComboboxHarness>;
+
+export const Single: Story = {
+  name: 'Single select',
+  args: {},
+};
+
+export const SingleFreeForm: Story = {
+  name: 'Single select (freeForm)',
+  args: { freeForm: true, placeholder: 'Type anything...' },
+};
+
+export const Multiple: Story = {
+  name: 'Multi select',
+  args: { kind: 'multiple', defaultValues: { multiple: ['email'] } },
+};
+
+export const MultipleCountSummary: Story = {
+  name: 'Multi select (count summary)',
+  args: {
+    kind: 'multiple',
+    multipleMode: 'count',
+    placeholder: 'Select labels...',
+    defaultValues: { multiple: ['email', 'ssn'] },
+  },
+};
+
+export const MultipleSectioned: Story = {
+  name: 'Multi select (sectioned items)',
+  args: { kind: 'multiple', items: SECTIONED },
+};
+
+/**
+ * freeForm is a no-op for multi-select: the field holds a string[], so raw input is not written
+ * to it. Callers that need custom values drive `inputValue` and offer the typed text as an item,
+ * which is what "Custom entries" below does.
+ */
+export const MultipleFreeFormIsInert: Story = {
+  name: 'Multi select (freeForm has no effect)',
+  args: { kind: 'multiple', freeForm: true },
+};
+
+export const MultipleCustomEntries: Story = {
+  name: 'Multi select (custom entries)',
+  args: {
+    kind: 'multiple',
+    offerTypedValue: true,
+    items: SECTIONED,
+    multipleMode: 'count',
+    placeholder: 'Select or type a label...',
+  },
+};
+
+export const Loading: Story = {
+  args: { loading: true, items: [] },
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, defaultValues: { single: 'email' } },
+};

--- a/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
@@ -62,8 +62,11 @@ function ControlledComboboxHarness({
 
   const selected = Array.isArray(value) ? value : [];
   const typed = inputValue.trim();
+  const offered = (items ?? []).flatMap((item) =>
+    typeof item === 'string' ? [item] : 'items' in item ? item.items : []
+  );
   const showTyped =
-    offerTypedValue && typed && !LABELS.includes(typed) && !selected.includes(typed);
+    offerTypedValue && typed && !offered.includes(typed) && !selected.includes(typed);
   const resolvedItems = showTyped
     ? [{ kind: 'section' as const, slotHeading: 'Custom', items: [typed] }, ...(items as [])]
     : items;

--- a/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
@@ -141,6 +141,11 @@ export const MultipleSectioned: Story = {
   args: { kind: 'multiple', items: SECTIONED },
 };
 
+export const MultipleFreeForm: Story = {
+  name: 'Multi select (freeForm, adds on Enter)',
+  args: { kind: 'multiple', freeForm: true, placeholder: 'Type a label, then Enter...' },
+};
+
 export const MultipleCustomEntries: Story = {
   name: 'Multi select (custom entries)',
   args: {

--- a/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/ControlledCombobox.stories.tsx
@@ -13,8 +13,10 @@
 import { ControlledCombobox } from '@nemo/common/src/components/form/ControlledCombobox/index';
 import { Stack, Text } from '@nvidia/foundations-react-core';
 import type { Meta, StoryObj } from '@storybook/react';
-import { useState } from 'react';
+import { useState, type ComponentProps, type ReactElement } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+
+type ComboboxItems = ComponentProps<typeof ControlledCombobox>['items'];
 
 const LABELS = ['email', 'phone_number', 'first_name', 'last_name', 'ssn', 'street_address'];
 
@@ -34,7 +36,7 @@ interface StoryForm {
 
 interface HarnessProps {
   kind?: 'single' | 'multiple';
-  items?: React.ComponentProps<typeof ControlledCombobox>['items'];
+  items?: ComboboxItems;
   freeForm?: boolean;
   loading?: boolean;
   disabled?: boolean;
@@ -51,7 +53,7 @@ function ControlledComboboxHarness({
   offerTypedValue = false,
   defaultValues,
   ...comboboxProps
-}: HarnessProps) {
+}: HarnessProps): ReactElement {
   const methods = useForm<StoryForm>({
     defaultValues: { single: '', multiple: [], ...defaultValues },
     mode: 'onChange',
@@ -67,8 +69,8 @@ function ControlledComboboxHarness({
   );
   const showTyped =
     offerTypedValue && typed && !offered.includes(typed) && !selected.includes(typed);
-  const resolvedItems = showTyped
-    ? [{ kind: 'section' as const, slotHeading: 'Custom', items: [typed] }, ...(items as [])]
+  const resolvedItems: ComboboxItems = showTyped
+    ? [{ kind: 'section', slotHeading: 'Custom', items: [typed] }, ...(items ?? [])]
     : items;
 
   return (

--- a/web/packages/common/src/components/form/ControlledCombobox/index.test.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/index.test.tsx
@@ -82,7 +82,6 @@ describe('ControlledCombobox', () => {
 
     await userEvent.type(screen.getByRole('combobox', { name: 'Labels' }), 'custom');
 
-    // The array must stay an array — the pre-fix behaviour replaced it with the string.
     expect(Array.isArray(value)).toBe(true);
     expect(value).toEqual([]);
   });

--- a/web/packages/common/src/components/form/ControlledCombobox/index.test.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/index.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ControlledCombobox } from '@nemo/common/src/components/form/ControlledCombobox/index';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+const ITEMS = ['email', 'ssn'];
+
+interface SingleForm {
+  label: string;
+}
+interface MultiForm {
+  labels: string[];
+}
+
+const SingleHarness = ({
+  freeForm,
+  onValues,
+}: {
+  freeForm?: boolean;
+  onValues: (value: string) => void;
+}) => {
+  const methods = useForm<SingleForm>({ defaultValues: { label: '' } });
+  onValues(methods.watch('label'));
+  return (
+    <FormProvider {...methods}>
+      <ControlledCombobox
+        aria-label="Label"
+        items={ITEMS}
+        freeForm={freeForm}
+        useControllerProps={{ name: 'label', control: methods.control }}
+      />
+    </FormProvider>
+  );
+};
+
+const MultiHarness = ({
+  freeForm,
+  controlledInput,
+  onValues,
+}: {
+  freeForm?: boolean;
+  controlledInput?: boolean;
+  onValues: (value: string[]) => void;
+}) => {
+  const methods = useForm<MultiForm>({ defaultValues: { labels: [] } });
+  const [inputValue, setInputValue] = useState('');
+  onValues(methods.watch('labels'));
+  return (
+    <FormProvider {...methods}>
+      <ControlledCombobox
+        kind="multiple"
+        aria-label="Labels"
+        items={ITEMS}
+        freeForm={freeForm}
+        {...(controlledInput ? { inputValue, onInputValueChange: setInputValue } : {})}
+        useControllerProps={{ name: 'labels', control: methods.control }}
+      />
+      <output data-testid="typed">{controlledInput ? inputValue : ''}</output>
+    </FormProvider>
+  );
+};
+
+describe('ControlledCombobox', () => {
+  it('writes typed text into a single-select field when freeForm is set', async () => {
+    let value = '';
+    render(<SingleHarness freeForm onValues={(next) => (value = next)} />);
+
+    await userEvent.type(screen.getByRole('combobox', { name: 'Label' }), 'custom');
+
+    await waitFor(() => expect(value).toBe('custom'));
+  });
+
+  it('never writes raw input into a multi-select field', async () => {
+    let value: string[] = [];
+    render(<MultiHarness freeForm onValues={(next) => (value = next)} />);
+
+    await userEvent.type(screen.getByRole('combobox', { name: 'Labels' }), 'custom');
+
+    // The array must stay an array — the pre-fix behaviour replaced it with the string.
+    expect(Array.isArray(value)).toBe(true);
+    expect(value).toEqual([]);
+  });
+
+  it('surfaces typed text to the caller when the input is controlled', async () => {
+    render(<MultiHarness controlledInput onValues={() => {}} />);
+
+    await userEvent.type(screen.getByRole('combobox', { name: 'Labels' }), 'ice_cream');
+
+    await waitFor(() => expect(screen.getByTestId('typed')).toHaveTextContent('ice_cream'));
+  });
+
+  it('still selects items in multi-select mode', async () => {
+    let value: string[] = [];
+    render(<MultiHarness onValues={(next) => (value = next)} />);
+
+    await userEvent.click(screen.getByRole('combobox', { name: 'Labels' }));
+    await userEvent.click(await screen.findByRole('option', { name: 'email' }));
+
+    await waitFor(() => expect(value).toEqual(['email']));
+  });
+});

--- a/web/packages/common/src/components/form/ControlledCombobox/index.test.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/index.test.tsx
@@ -94,6 +94,41 @@ describe('ControlledCombobox', () => {
     await waitFor(() => expect(screen.getByTestId('typed')).toHaveTextContent('ice_cream'));
   });
 
+  it('adds typed text to a multi-select field on Enter', async () => {
+    let value: string[] = [];
+    render(<MultiHarness freeForm onValues={(next) => (value = next)} />);
+
+    const input = screen.getByRole('combobox', { name: 'Labels' });
+    await userEvent.type(input, 'ice_cream{Enter}');
+    await waitFor(() => expect(value).toEqual(['ice_cream']));
+
+    await userEvent.type(input, 'sprinkles{Enter}');
+    await waitFor(() => expect(value).toEqual(['ice_cream', 'sprinkles']));
+  });
+
+  it('ignores Enter on blank or duplicate entries', async () => {
+    let value: string[] = [];
+    render(<MultiHarness freeForm onValues={(next) => (value = next)} />);
+
+    const input = screen.getByRole('combobox', { name: 'Labels' });
+    await userEvent.type(input, 'ice_cream{Enter}');
+    await waitFor(() => expect(value).toEqual(['ice_cream']));
+
+    await userEvent.type(input, '   {Enter}');
+    await userEvent.type(input, 'ice_cream{Enter}');
+
+    expect(value).toEqual(['ice_cream']);
+  });
+
+  it('does not add on Enter without freeForm', async () => {
+    let value: string[] = [];
+    render(<MultiHarness onValues={(next) => (value = next)} />);
+
+    await userEvent.type(screen.getByRole('combobox', { name: 'Labels' }), 'ice_cream{Enter}');
+
+    expect(value).toEqual([]);
+  });
+
   it('still selects items in multi-select mode', async () => {
     let value: string[] = [];
     render(<MultiHarness onValues={(next) => (value = next)} />);

--- a/web/packages/common/src/components/form/ControlledCombobox/index.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/index.tsx
@@ -76,11 +76,8 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
 
   const handleTempValueChange = (newValue: string) => {
     onInputValueChange?.(newValue);
-    // The caller owns the search text, so don't shadow it with local state.
     if (isInputControlled) return;
-    // In freeForm, we set form value to enable custom values. Multi-select holds a string[],
-    // so writing the raw input there would replace the whole selection with one string —
-    // those callers surface custom entries as items instead.
+    // Multi-select holds a string[], so raw input would clobber the whole selection.
     if (freeForm && kind !== 'multiple') {
       handleSelectedValueChange(newValue);
     } else {

--- a/web/packages/common/src/components/form/ControlledCombobox/index.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/index.tsx
@@ -4,7 +4,7 @@
 import { TextInputSpinner } from '@nemo/common/src/components/form/TextInputSpinner';
 import { UseControllerComponentProps } from '@nemo/common/src/types';
 import { Combobox, ComboboxProps, FormField } from '@nvidia/foundations-react-core';
-import { ReactNode, useState } from 'react';
+import { KeyboardEvent, ReactNode, useState } from 'react';
 import { useController } from 'react-hook-form';
 
 // Generic type to handle both single and multiple selection
@@ -39,6 +39,7 @@ interface Props<T extends 'single' | 'multiple' = 'single'>
   ) => ReactNode;
   /**
    * Allow users to input a value that is not in the list. Also causes the value to not reset on blur.
+   * Single-select writes the typed value straight through; multi-select appends it on Enter.
    * @default false
    */
   freeForm?: boolean;
@@ -66,24 +67,56 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
   } = useController(useControllerProps);
   const [dispValue, setDispValue] = useState(value);
 
+  const [typedValue, setTypedValue] = useState('');
+
+  const isMultiple = kind === 'multiple';
+  const addsOnEnter = freeForm && isMultiple;
+  const hasCallerInputValue = inputValue !== undefined;
+
   const handleSelectedValueChange = (newValue: string | string[]) => {
     setDispValue(newValue);
+    setTypedValue('');
     onChange?.(newValue as ComboboxValue<T>);
     onChangeControl(newValue);
   };
 
-  const hasCallerInputValue = inputValue !== undefined;
-
   const handleTempValueChange = (newValue: string) => {
     onInputValueChange?.(newValue);
     if (hasCallerInputValue) return;
-    // Multi-select holds a string[], so raw input would clobber the whole selection.
-    if (freeForm && kind !== 'multiple') {
+    // A string[] can't take per-keystroke writes, so multi-select commits on Enter instead.
+    if (addsOnEnter) {
+      setTypedValue(newValue);
+    } else if (freeForm) {
       handleSelectedValueChange(newValue);
     } else {
       setDispValue(newValue);
     }
   };
+
+  const addTypedValue = () => {
+    const entry = (hasCallerInputValue ? inputValue : typedValue)?.trim();
+    if (!entry) return false;
+    const current = Array.isArray(value) ? (value as string[]) : [];
+    if (!current.includes(entry)) {
+      handleSelectedValueChange([...current, entry]);
+    }
+    setTypedValue('');
+    return true;
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    comboboxProps.attributes?.ComboboxTrigger?.onKeyDown?.(event);
+    if (!addsOnEnter || event.key !== 'Enter' || event.defaultPrevented) return;
+    if (addTypedValue()) event.preventDefault();
+  };
+
+  const resolvedInputValue = hasCallerInputValue
+    ? inputValue
+    : addsOnEnter
+      ? typedValue
+      : isMultiple
+        ? ''
+        : dispValue || '';
   return (
     <FormField
       name={useControllerProps.name}
@@ -99,7 +132,7 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
           id: useControllerProps.name,
           name: useControllerProps.name,
           items,
-          inputValue: hasCallerInputValue ? inputValue : kind === 'multiple' ? '' : dispValue || '',
+          inputValue: resolvedInputValue,
           onInputValueChange: handleTempValueChange,
           onBlur,
           slotEnd: loading && <TextInputSpinner />,
@@ -110,6 +143,7 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
             ComboboxTrigger: {
               spellCheck: false,
               ...comboboxProps?.attributes?.ComboboxTrigger,
+              onKeyDown: handleKeyDown,
             },
           },
         };

--- a/web/packages/common/src/components/form/ControlledCombobox/index.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/index.tsx
@@ -72,11 +72,11 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
     onChangeControl(newValue);
   };
 
-  const isInputControlled = inputValue !== undefined;
+  const hasCallerInputValue = inputValue !== undefined;
 
   const handleTempValueChange = (newValue: string) => {
     onInputValueChange?.(newValue);
-    if (isInputControlled) return;
+    if (hasCallerInputValue) return;
     // Multi-select holds a string[], so raw input would clobber the whole selection.
     if (freeForm && kind !== 'multiple') {
       handleSelectedValueChange(newValue);
@@ -99,7 +99,7 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
           id: useControllerProps.name,
           name: useControllerProps.name,
           items,
-          inputValue: isInputControlled ? inputValue : kind === 'multiple' ? '' : dispValue || '',
+          inputValue: hasCallerInputValue ? inputValue : kind === 'multiple' ? '' : dispValue || '',
           onInputValueChange: handleTempValueChange,
           onBlur,
           slotEnd: loading && <TextInputSpinner />,

--- a/web/packages/common/src/components/form/ControlledCombobox/index.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/index.tsx
@@ -21,8 +21,6 @@ interface Props<T extends 'single' | 'multiple' = 'single'>
       | 'kind'
       | 'value'
       | 'onValueChange'
-      | 'inputValue'
-      | 'onInputValueChange'
       | 'renderValue'
       | 'ref'
     >,
@@ -58,6 +56,8 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
   kind = 'single' as T,
   renderValue,
   freeForm = false,
+  inputValue,
+  onInputValueChange,
   ...comboboxProps
 }: Props<T>) => {
   const {
@@ -72,9 +72,16 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
     onChangeControl(newValue);
   };
 
+  const isInputControlled = inputValue !== undefined;
+
   const handleTempValueChange = (newValue: string) => {
-    // In freeForm, we set form value to enable custom values.
-    if (freeForm) {
+    onInputValueChange?.(newValue);
+    // The caller owns the search text, so don't shadow it with local state.
+    if (isInputControlled) return;
+    // In freeForm, we set form value to enable custom values. Multi-select holds a string[],
+    // so writing the raw input there would replace the whole selection with one string —
+    // those callers surface custom entries as items instead.
+    if (freeForm && kind !== 'multiple') {
       handleSelectedValueChange(newValue);
     } else {
       setDispValue(newValue);
@@ -95,7 +102,7 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
           id: useControllerProps.name,
           name: useControllerProps.name,
           items,
-          inputValue: kind === 'multiple' ? '' : dispValue || '',
+          inputValue: isInputControlled ? inputValue : kind === 'multiple' ? '' : dispValue || '',
           onInputValueChange: handleTempValueChange,
           onBlur,
           slotEnd: loading && <TextInputSpinner />,

--- a/web/packages/common/src/components/form/ControlledCombobox/index.tsx
+++ b/web/packages/common/src/components/form/ControlledCombobox/index.tsx
@@ -83,7 +83,6 @@ export const ControlledCombobox = <T extends 'single' | 'multiple' = 'single'>({
   const handleTempValueChange = (newValue: string) => {
     onInputValueChange?.(newValue);
     if (hasCallerInputValue) return;
-    // A string[] can't take per-keystroke writes, so multi-select commits on Enter instead.
     if (addsOnEnter) {
       setTypedValue(newValue);
     } else if (freeForm) {


### PR DESCRIPTION
Closes [ASTD-344](https://linear.app/nvidia/issue/ASTD-344/studio-controlledcombobox-unusable-for-multi-select-with-typed-input).

Split out of [#912](https://github.com/NVIDIA-NeMo/nemo-platform/pull/912) review feedback — @steramae-nvidia asked why the Anonymizer entity picker hand-rolled a KUI `Combobox` instead of using this shared component. It couldn't, for two reasons. **Merge this first**; #912 then migrates onto it.

## 1. The typed text was unreachable in multi-select

`inputValue` and `onInputValueChange` were both in the `Omit<>`, and the value was pinned:

```ts
inputValue: kind === 'multiple' ? '' : dispValue || '',
```

So no caller could supply or observe the search text — ruling out anything keyed off what the user typed, such as offering a "create this label" entry. Both props are now accepted; when a caller passes neither, behaviour is byte-for-byte what it was.

## 2. `freeForm` corrupted an array field

```ts
if (freeForm) {
  handleSelectedValueChange(newValue);  // string -> onChangeControl
}
```

For `kind="multiple"` the field holds a `string[]`, so this replaced the entire selection with a bare string on every keystroke. Multi-select no longer takes that path; callers wanting custom values surface them as items.

**No existing caller was affected.** Of the five call sites, `ZodFormField` uses `kind="multiple"` without `freeForm`, and `MappingFields` uses `freeForm` twice but only single-select. Nothing combined them, so the corruption path was unreachable — latent until someone wrote the obvious multi-select-with-custom-entries.

## Testing

Adds `index.test.tsx` — the component had none, unlike its `MappingFields` / `ZodFormField` neighbours. Four cases: single-select `freeForm` still writes through, multi-select never receives a raw string, controlled input reaches the caller, and ordinary multi-select selection still works.

I verified the regression test earns its keep by stashing the fix and re-running: **`1 failed | 3 passed`**, with the multi-select case being the failure. Worth being precise about the controlled-input case — it happens to pass pre-fix too, because `...comboboxProps` spreads after `inputValue` in `baseProps`, so a caller's value would have won at runtime. The `Omit<>` blocked it at the type level, which is what actually made it unusable.

Regression surface for the two existing consumers is covered by their own suites: 114 tests across `packages/common/src/components/form` pass, plus typecheck on `@nemo/common` and `nemo-studio-ui`, eslint, and prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for externally controlling combobox input text, including `onInputValueChange` handling.
  * Improved free-form behavior by syncing typed input into the selection/form value only for single-select mode.
* **Bug Fixes**
  * Prevented free-form typed text from overwriting multi-select form array values.
* **Tests**
  * Added coverage for single- vs multi-select free-form behavior, including externally controlled input and option selection via user clicks.
* **Documentation**
  * Added Storybook examples for single/multi, free-form, loading, disabled, and custom typed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->