### PR TITLE
fix(models): model deployment wait for IGW ready

### DIFF
--- a/e2e/agents_deploy_helpers.py
+++ b/e2e/agents_deploy_helpers.py
@@ -231,6 +231,8 @@ def run_container_agent_deploy_and_invoke(
         endpoints = deployment.get("endpoints") or []
         assert endpoints and endpoints[0]["url"], deployment
 
+        sdk.models.wait_for_openai_model(model_name, workspace=workspace)
+
         response = sdk.agents.invoke(
             workspace=workspace,
             agent=agent_name,

--- a/packages/models/src/models/resources.py
+++ b/packages/models/src/models/resources.py
@@ -5,13 +5,18 @@
 
 import asyncio
 import time
+from collections.abc import Awaitable, Callable
 from datetime import datetime
+from typing import TypeVar
 
 from nemo_platform import NotFoundError
 from nemo_platform.resources.models import AsyncModelsResource as BaseAsyncModelsResource
 from nemo_platform.resources.models import ModelsResource as BaseModelsResource
 from nemo_platform.types.inference import ModelDeployment, ModelProvider
+from nemo_platform.types.inference.gateway.openai.v1 import OpenAIModelResp
 from nemo_platform.types.models import ModelEntity
+
+_T = TypeVar("_T")
 
 
 def _seconds_since_creation(entry_timestamp: datetime | str | None, created_at: datetime | None) -> int | None:
@@ -29,6 +34,90 @@ def _seconds_since_creation(entry_timestamp: datetime | str | None, created_at: 
         return int(entry_timestamp.timestamp() - created_at.timestamp())
     except (TypeError, OSError):
         return None
+
+
+def _openai_model_route_name(name: str, workspace: str) -> tuple[str, str]:
+    model_name = name.removeprefix(f"{workspace}/")
+    return model_name, f"{workspace}/{model_name}"
+
+
+class _PollPending(Exception):
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+def _poll_sleep_seconds(*, start_time: float, timeout: float, poll_interval: float) -> float | None:
+    remaining_timeout = timeout - (time.time() - start_time)
+    if remaining_timeout <= 0:
+        return None
+    return min(poll_interval, remaining_timeout)
+
+
+def _poll_until_ready(
+    attempt: Callable[[], _T],
+    *,
+    timeout: float,
+    poll_interval: float,
+    timeout_message: Callable[[Exception | str | None], str],
+) -> _T:
+    start_time = time.time()
+    last_error: Exception | str | None = None
+
+    while time.time() - start_time < timeout:
+        try:
+            return attempt()
+        except _PollPending as exc:
+            last_error = exc.reason
+        except NotFoundError as exc:
+            last_error = exc
+
+        sleep_seconds = _poll_sleep_seconds(
+            start_time=start_time,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+        if sleep_seconds is None:
+            break
+        time.sleep(sleep_seconds)
+
+    raise TimeoutError(timeout_message(last_error))
+
+
+async def _async_poll_until_ready(
+    attempt: Callable[[], Awaitable[_T]],
+    *,
+    timeout: float,
+    poll_interval: float,
+    timeout_message: Callable[[Exception | str | None], str],
+) -> _T:
+    start_time = time.time()
+    last_error: Exception | str | None = None
+
+    while time.time() - start_time < timeout:
+        try:
+            return await attempt()
+        except _PollPending as exc:
+            last_error = exc.reason
+        except NotFoundError as exc:
+            last_error = exc
+
+        sleep_seconds = _poll_sleep_seconds(
+            start_time=start_time,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+        if sleep_seconds is None:
+            break
+        await asyncio.sleep(sleep_seconds)
+
+    raise TimeoutError(timeout_message(last_error))
+
+
+def _require_openai_model_id(model: OpenAIModelResp, expected_model_id: str) -> OpenAIModelResp:
+    if model.id != expected_model_id:
+        raise _PollPending(f"expected id {expected_model_id!r}, got {model.id!r}")
+    return model
 
 
 class ModelsResource(BaseModelsResource):
@@ -278,6 +367,52 @@ class ModelsResource(BaseModelsResource):
         elapsed = int(time.time() - start_time)
         print(f"Gateway timeout after {elapsed}s\n")
         return False
+
+    def wait_for_openai_model(
+        self,
+        name: str,
+        *,
+        workspace: str | None = None,
+        timeout: float = 60,
+        poll_interval: float = 0.5,
+    ) -> OpenAIModelResp:
+        """
+        Wait for the inference gateway's OpenAI model route to resolve a model.
+
+        This verifies the gateway cache used by OpenAI chat completions when the
+        request model is ``workspace/model``. It is more specific than
+        :meth:`wait_for_gateway`, which only checks that the provider route is
+        ready.
+
+        Args:
+            name: Model entity name, with or without a ``workspace/`` prefix
+            workspace: Workspace of the model
+            timeout: Maximum time to wait in seconds
+            poll_interval: Time between route checks in seconds
+
+        Returns:
+            The OpenAI model route response once it matches ``workspace/name``.
+
+        Raises:
+            TimeoutError: If the route does not resolve the expected model in time.
+        """
+        if workspace is None:
+            workspace = self._client._get_workspace_path_param()
+        model_name, expected_model_id = _openai_model_route_name(name, workspace)
+
+        def attempt() -> OpenAIModelResp:
+            model = self._client.inference.gateway.openai.v1.models.get(name=model_name, workspace=workspace)
+            return _require_openai_model_id(model, expected_model_id)
+
+        return _poll_until_ready(
+            attempt,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            timeout_message=lambda last_error: (
+                f"OpenAI model {expected_model_id} not available in inference gateway after {timeout}s. "
+                f"Last error: {last_error}"
+            ),
+        )
 
     def wait_for_provider(
         self,
@@ -671,6 +806,52 @@ class AsyncModelsResource(BaseAsyncModelsResource):
         elapsed = int(time.time() - start_time)
         print(f"Gateway timeout after {elapsed}s\n")
         return False
+
+    async def wait_for_openai_model(
+        self,
+        name: str,
+        *,
+        workspace: str | None = None,
+        timeout: float = 60,
+        poll_interval: float = 0.5,
+    ) -> OpenAIModelResp:
+        """
+        Wait for the inference gateway's OpenAI model route to resolve a model.
+
+        This verifies the gateway cache used by OpenAI chat completions when the
+        request model is ``workspace/model``. It is more specific than
+        :meth:`wait_for_gateway`, which only checks that the provider route is
+        ready.
+
+        Args:
+            name: Model entity name, with or without a ``workspace/`` prefix
+            workspace: Workspace of the model
+            timeout: Maximum time to wait in seconds
+            poll_interval: Time between route checks in seconds
+
+        Returns:
+            The OpenAI model route response once it matches ``workspace/name``.
+
+        Raises:
+            TimeoutError: If the route does not resolve the expected model in time.
+        """
+        if workspace is None:
+            workspace = self._client._get_workspace_path_param()
+        model_name, expected_model_id = _openai_model_route_name(name, workspace)
+
+        async def attempt() -> OpenAIModelResp:
+            model = await self._client.inference.gateway.openai.v1.models.get(name=model_name, workspace=workspace)
+            return _require_openai_model_id(model, expected_model_id)
+
+        return await _async_poll_until_ready(
+            attempt,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            timeout_message=lambda last_error: (
+                f"OpenAI model {expected_model_id} not available in inference gateway after {timeout}s. "
+                f"Last error: {last_error}"
+            ),
+        )
 
     async def wait_for_provider(
         self,

--- a/packages/models/tests/test_client.py
+++ b/packages/models/tests/test_client.py
@@ -3,9 +3,11 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform, NotFoundError
 from nemo_platform.types.inference import ModelDeployment, ModelProvider
+from nemo_platform.types.inference.gateway.openai.v1 import OpenAIModelResp
 from nemo_platform.types.models import ModelEntity
 
 # ============================================================================
@@ -41,6 +43,28 @@ def async_sdk():
 def async_sdk_with_workspace():
     """Create async SDK with client-level workspace set."""
     return AsyncNeMoPlatform(base_url="https://nmp.example.com/", workspace="client-ws")
+
+
+def _not_found_error() -> NotFoundError:
+    request = httpx.Request("GET", "https://nmp.example.com/apis/inference-gateway/openai/v1/models/model-a")
+    response = httpx.Response(404, request=request)
+    return NotFoundError("not found", response=response, body={"detail": "not found"})
+
+
+class _FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleep_calls: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleep_calls.append(seconds)
+        self.now += seconds
+
+    async def async_sleep(self, seconds: float) -> None:
+        self.sleep(seconds)
 
 
 # ============================================================================
@@ -307,6 +331,88 @@ def test_get_openai_client_includes_auth_headers():
         assert default_headers["X-NMP-Principal-Id"] == "user@example.com"
 
 
+# Tests for wait_for_openai_model
+
+
+def test_wait_for_openai_model_uses_client_workspace_and_retries(sdk_with_workspace):
+    """Test that OpenAI model route readiness retries until the model is visible."""
+    model_response = OpenAIModelResp(id="client-ws/model-a", owned_by="test")
+
+    with patch.object(
+        sdk_with_workspace.inference.gateway.openai.v1.models,
+        "get",
+        side_effect=[_not_found_error(), model_response],
+    ) as mock_get:
+        result = sdk_with_workspace.models.wait_for_openai_model("model-a", timeout=1, poll_interval=0)
+
+    assert result == model_response
+    assert [call.kwargs for call in mock_get.call_args_list] == [
+        {"name": "model-a", "workspace": "client-ws"},
+        {"name": "model-a", "workspace": "client-ws"},
+    ]
+
+
+def test_wait_for_openai_model_accepts_qualified_name(sdk):
+    """Test that workspace-qualified names are normalized for the route path."""
+    model_response = OpenAIModelResp(id="ws/model-a", owned_by="test")
+
+    with patch.object(
+        sdk.inference.gateway.openai.v1.models,
+        "get",
+        return_value=model_response,
+    ) as mock_get:
+        result = sdk.models.wait_for_openai_model("ws/model-a", workspace="ws", timeout=1, poll_interval=0)
+
+    assert result == model_response
+    mock_get.assert_called_once_with(name="model-a", workspace="ws")
+
+
+def test_wait_for_openai_model_retries_unexpected_model_id(sdk):
+    """Test that a stale or mismatched route response is not treated as ready."""
+    stale_response = OpenAIModelResp(id="ws/other-model", owned_by="test")
+    model_response = OpenAIModelResp(id="ws/model-a", owned_by="test")
+
+    with patch.object(
+        sdk.inference.gateway.openai.v1.models,
+        "get",
+        side_effect=[stale_response, model_response],
+    ) as mock_get:
+        result = sdk.models.wait_for_openai_model("model-a", workspace="ws", timeout=1, poll_interval=0)
+
+    assert result == model_response
+    assert mock_get.call_count == 2
+
+
+def test_wait_for_openai_model_times_out(sdk):
+    """Test that timeout includes the expected model id in the error."""
+    with patch.object(
+        sdk.inference.gateway.openai.v1.models,
+        "get",
+        side_effect=_not_found_error(),
+    ):
+        with pytest.raises(TimeoutError, match="OpenAI model ws/model-a not available"):
+            sdk.models.wait_for_openai_model("model-a", workspace="ws", timeout=0.01, poll_interval=0)
+
+
+def test_wait_for_openai_model_bounds_sleep_to_remaining_timeout(sdk):
+    """Test that sync polling does not sleep beyond the configured timeout."""
+    clock = _FakeClock()
+
+    with (
+        patch.object(
+            sdk.inference.gateway.openai.v1.models,
+            "get",
+            side_effect=_not_found_error(),
+        ),
+        patch("nemo_platform.models.resources.time.time", side_effect=clock.time),
+        patch("nemo_platform.models.resources.time.sleep", side_effect=clock.sleep),
+    ):
+        with pytest.raises(TimeoutError, match="OpenAI model ws/model-a not available"):
+            sdk.models.wait_for_openai_model("model-a", workspace="ws", timeout=1.25, poll_interval=5)
+
+    assert clock.sleep_calls == [1.25]
+
+
 # ============================================================================
 # AsyncModelsResource Tests
 # ============================================================================
@@ -400,6 +506,42 @@ def test_get_async_openai_client_includes_auth_headers():
 
         assert default_headers["Authorization"] == "Bearer token-abc"
         assert default_headers["X-NMP-Principal-Id"] == "async-user@example.com"
+
+
+# Tests for async wait_for_openai_model
+
+
+@pytest.mark.asyncio
+async def test_async_wait_for_openai_model_retries_until_visible(async_sdk_with_workspace):
+    """Test async OpenAI model route readiness polling."""
+    model_response = OpenAIModelResp(id="client-ws/model-a", owned_by="test")
+    mock_get = AsyncMock(side_effect=[_not_found_error(), model_response])
+
+    with patch.object(async_sdk_with_workspace.inference.gateway.openai.v1.models, "get", mock_get):
+        result = await async_sdk_with_workspace.models.wait_for_openai_model("model-a", timeout=1, poll_interval=0)
+
+    assert result == model_response
+    assert [call.kwargs for call in mock_get.call_args_list] == [
+        {"name": "model-a", "workspace": "client-ws"},
+        {"name": "model-a", "workspace": "client-ws"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_wait_for_openai_model_bounds_sleep_to_remaining_timeout(async_sdk):
+    """Test that async polling does not sleep beyond the configured timeout."""
+    clock = _FakeClock()
+    mock_get = AsyncMock(side_effect=_not_found_error())
+
+    with (
+        patch.object(async_sdk.inference.gateway.openai.v1.models, "get", mock_get),
+        patch("nemo_platform.models.resources.time.time", side_effect=clock.time),
+        patch("nemo_platform.models.resources.asyncio.sleep", side_effect=clock.async_sleep),
+    ):
+        with pytest.raises(TimeoutError, match="OpenAI model ws/model-a not available"):
+            await async_sdk.models.wait_for_openai_model("model-a", workspace="ws", timeout=1.25, poll_interval=5)
+
+    assert clock.sleep_calls == [1.25]
 
 
 # Tests for async get_provider_route_openai_url_for_deployment

--- a/sdk/python/nemo-platform/src/nemo_platform/models/resources.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/models/resources.py
@@ -5,13 +5,18 @@
 
 import asyncio
 import time
+from collections.abc import Awaitable, Callable
 from datetime import datetime
+from typing import TypeVar
 
 from nemo_platform import NotFoundError
 from nemo_platform.resources.models import AsyncModelsResource as BaseAsyncModelsResource
 from nemo_platform.resources.models import ModelsResource as BaseModelsResource
 from nemo_platform.types.inference import ModelDeployment, ModelProvider
+from nemo_platform.types.inference.gateway.openai.v1 import OpenAIModelResp
 from nemo_platform.types.models import ModelEntity
+
+_T = TypeVar("_T")
 
 
 def _seconds_since_creation(entry_timestamp: datetime | str | None, created_at: datetime | None) -> int | None:
@@ -29,6 +34,90 @@ def _seconds_since_creation(entry_timestamp: datetime | str | None, created_at: 
         return int(entry_timestamp.timestamp() - created_at.timestamp())
     except (TypeError, OSError):
         return None
+
+
+def _openai_model_route_name(name: str, workspace: str) -> tuple[str, str]:
+    model_name = name.removeprefix(f"{workspace}/")
+    return model_name, f"{workspace}/{model_name}"
+
+
+class _PollPending(Exception):
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(reason)
+
+
+def _poll_sleep_seconds(*, start_time: float, timeout: float, poll_interval: float) -> float | None:
+    remaining_timeout = timeout - (time.time() - start_time)
+    if remaining_timeout <= 0:
+        return None
+    return min(poll_interval, remaining_timeout)
+
+
+def _poll_until_ready(
+    attempt: Callable[[], _T],
+    *,
+    timeout: float,
+    poll_interval: float,
+    timeout_message: Callable[[Exception | str | None], str],
+) -> _T:
+    start_time = time.time()
+    last_error: Exception | str | None = None
+
+    while time.time() - start_time < timeout:
+        try:
+            return attempt()
+        except _PollPending as exc:
+            last_error = exc.reason
+        except NotFoundError as exc:
+            last_error = exc
+
+        sleep_seconds = _poll_sleep_seconds(
+            start_time=start_time,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+        if sleep_seconds is None:
+            break
+        time.sleep(sleep_seconds)
+
+    raise TimeoutError(timeout_message(last_error))
+
+
+async def _async_poll_until_ready(
+    attempt: Callable[[], Awaitable[_T]],
+    *,
+    timeout: float,
+    poll_interval: float,
+    timeout_message: Callable[[Exception | str | None], str],
+) -> _T:
+    start_time = time.time()
+    last_error: Exception | str | None = None
+
+    while time.time() - start_time < timeout:
+        try:
+            return await attempt()
+        except _PollPending as exc:
+            last_error = exc.reason
+        except NotFoundError as exc:
+            last_error = exc
+
+        sleep_seconds = _poll_sleep_seconds(
+            start_time=start_time,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+        if sleep_seconds is None:
+            break
+        await asyncio.sleep(sleep_seconds)
+
+    raise TimeoutError(timeout_message(last_error))
+
+
+def _require_openai_model_id(model: OpenAIModelResp, expected_model_id: str) -> OpenAIModelResp:
+    if model.id != expected_model_id:
+        raise _PollPending(f"expected id {expected_model_id!r}, got {model.id!r}")
+    return model
 
 
 class ModelsResource(BaseModelsResource):
@@ -278,6 +367,52 @@ class ModelsResource(BaseModelsResource):
         elapsed = int(time.time() - start_time)
         print(f"Gateway timeout after {elapsed}s\n")
         return False
+
+    def wait_for_openai_model(
+        self,
+        name: str,
+        *,
+        workspace: str | None = None,
+        timeout: float = 60,
+        poll_interval: float = 0.5,
+    ) -> OpenAIModelResp:
+        """
+        Wait for the inference gateway's OpenAI model route to resolve a model.
+
+        This verifies the gateway cache used by OpenAI chat completions when the
+        request model is ``workspace/model``. It is more specific than
+        :meth:`wait_for_gateway`, which only checks that the provider route is
+        ready.
+
+        Args:
+            name: Model entity name, with or without a ``workspace/`` prefix
+            workspace: Workspace of the model
+            timeout: Maximum time to wait in seconds
+            poll_interval: Time between route checks in seconds
+
+        Returns:
+            The OpenAI model route response once it matches ``workspace/name``.
+
+        Raises:
+            TimeoutError: If the route does not resolve the expected model in time.
+        """
+        if workspace is None:
+            workspace = self._client._get_workspace_path_param()
+        model_name, expected_model_id = _openai_model_route_name(name, workspace)
+
+        def attempt() -> OpenAIModelResp:
+            model = self._client.inference.gateway.openai.v1.models.get(name=model_name, workspace=workspace)
+            return _require_openai_model_id(model, expected_model_id)
+
+        return _poll_until_ready(
+            attempt,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            timeout_message=lambda last_error: (
+                f"OpenAI model {expected_model_id} not available in inference gateway after {timeout}s. "
+                f"Last error: {last_error}"
+            ),
+        )
 
     def wait_for_provider(
         self,
@@ -671,6 +806,52 @@ class AsyncModelsResource(BaseAsyncModelsResource):
         elapsed = int(time.time() - start_time)
         print(f"Gateway timeout after {elapsed}s\n")
         return False
+
+    async def wait_for_openai_model(
+        self,
+        name: str,
+        *,
+        workspace: str | None = None,
+        timeout: float = 60,
+        poll_interval: float = 0.5,
+    ) -> OpenAIModelResp:
+        """
+        Wait for the inference gateway's OpenAI model route to resolve a model.
+
+        This verifies the gateway cache used by OpenAI chat completions when the
+        request model is ``workspace/model``. It is more specific than
+        :meth:`wait_for_gateway`, which only checks that the provider route is
+        ready.
+
+        Args:
+            name: Model entity name, with or without a ``workspace/`` prefix
+            workspace: Workspace of the model
+            timeout: Maximum time to wait in seconds
+            poll_interval: Time between route checks in seconds
+
+        Returns:
+            The OpenAI model route response once it matches ``workspace/name``.
+
+        Raises:
+            TimeoutError: If the route does not resolve the expected model in time.
+        """
+        if workspace is None:
+            workspace = self._client._get_workspace_path_param()
+        model_name, expected_model_id = _openai_model_route_name(name, workspace)
+
+        async def attempt() -> OpenAIModelResp:
+            model = await self._client.inference.gateway.openai.v1.models.get(name=model_name, workspace=workspace)
+            return _require_openai_model_id(model, expected_model_id)
+
+        return await _async_poll_until_ready(
+            attempt,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            timeout_message=lambda last_error: (
+                f"OpenAI model {expected_model_id} not available in inference gateway after {timeout}s. "
+                f"Last error: {last_error}"
+            ),
+        )
 
     async def wait_for_provider(
         self,

--- a/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
@@ -72,6 +72,17 @@ def _get_virtual_model_db_version(virtual_model: object) -> int | None:
     return None
 
 
+def _get_datetime_attr(obj: object, attr_name: str) -> datetime | None:
+    value = getattr(obj, attr_name, None)
+    if isinstance(value, datetime):
+        return ensure_utc(value)
+    return None
+
+
+def _get_virtual_model_observed_at(virtual_model: object) -> datetime | None:
+    return _get_datetime_attr(virtual_model, "updated_at") or _get_datetime_attr(virtual_model, "created_at")
+
+
 # ---------------------------------------------------------------------------
 # Discovery result types
 # ---------------------------------------------------------------------------
@@ -372,7 +383,7 @@ class ModelProviderReconciler:
             logger.warning("Skipping orphaned VirtualModel cleanup because the VirtualModel listing failed")
             return
         try:
-            await self._cleanup_orphaned_virtual_models(provider_contexts, virtual_models[0])
+            await self._cleanup_orphaned_virtual_models(provider_contexts, virtual_models[0], snapshot_taken_at=now)
         except Exception:
             logger.exception("Unexpected error cleaning up orphaned autoprovisioned VirtualModels")
 
@@ -1079,7 +1090,10 @@ class ModelProviderReconciler:
             existing_vm_names.add((workspace, model_name))
 
     async def _cleanup_orphaned_virtual_models(
-        self, provider_contexts: list[ModelContext], vm_snapshot: list[VirtualModel]
+        self,
+        provider_contexts: list[ModelContext],
+        vm_snapshot: list[VirtualModel],
+        snapshot_taken_at: datetime | None = None,
     ) -> None:
         """Delete autoprovisioned VirtualModels whose backing entities are no longer served.
 
@@ -1087,6 +1101,7 @@ class ModelProviderReconciler:
         created during the pass -- by this reconciler or anyone else -- is evaluated
         on a later pass rather than raced against.
         """
+        snapshot_taken_at = ensure_utc(snapshot_taken_at)
         active_model_entity_ids: set[str] = set()
         for ctx in provider_contexts:
             provider = ctx.model_provider
@@ -1109,6 +1124,15 @@ class ModelProviderReconciler:
                 virtual_model.default_model_entity is None
                 or virtual_model.default_model_entity in active_model_entity_ids
             ):
+                continue
+
+            observed_at = _get_virtual_model_observed_at(virtual_model)
+            if snapshot_taken_at is not None and observed_at is not None and observed_at > snapshot_taken_at:
+                logger.debug(
+                    "Skipping orphaned autoprovisioned VirtualModel %s/%s because it changed after the reconciliation snapshot",
+                    virtual_model.workspace,
+                    virtual_model.name,
+                )
                 continue
 
             expected_db_version = _get_virtual_model_db_version(virtual_model)

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -1988,6 +1988,9 @@ async def test_reconcile_creates_passthrough_virtual_models_for_all_served_model
 # ============================================================================
 
 
+_TIMESTAMP_UNSET = object()
+
+
 def _virtual_model(
     name: str,
     *,
@@ -1995,12 +1998,18 @@ def _virtual_model(
     default_model_entity: str | None = None,
     autoprovisioned: bool = True,
     db_version: int | None = 1,
+    created_at: datetime | None = None,
+    updated_at=_TIMESTAMP_UNSET,
 ):
+    now = datetime.now(timezone.utc)
+    created_at = created_at or now
     vm = MagicMock()
     vm.name = name
     vm.workspace = workspace
     vm.default_model_entity = default_model_entity
     vm.autoprovisioned = autoprovisioned
+    vm.created_at = created_at
+    vm.updated_at = created_at if updated_at is _TIMESTAMP_UNSET else updated_at
     if db_version is not None:
         vm.db_version = db_version
     return vm
@@ -2100,6 +2109,59 @@ async def test_cleanup_keeps_autoprovisioned_virtual_model_without_default_model
     await reconciler._cleanup_orphaned_virtual_models([], vm_snapshot)
 
     mock_models_sdk.inference.virtual_models.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("created_at", "updated_at", "should_delete"),
+    [
+        pytest.param(
+            datetime(2026, 1, 1, 11, 55, tzinfo=timezone.utc),
+            datetime(2026, 1, 1, 12, 5, tzinfo=timezone.utc),
+            False,
+            id="updated-at-after-snapshot-wins",
+        ),
+        pytest.param(
+            datetime(2026, 1, 1, 11, 55, tzinfo=timezone.utc),
+            None,
+            True,
+            id="explicit-none-updated-at-falls-back-to-created-at-before-snapshot",
+        ),
+        pytest.param(
+            datetime(2026, 1, 1, 12, 5, tzinfo=timezone.utc),
+            None,
+            False,
+            id="explicit-none-updated-at-falls-back-to-created-at-after-snapshot",
+        ),
+    ],
+)
+async def test_cleanup_uses_virtual_model_updated_at_then_created_at_for_snapshot_guard(
+    reconciler,
+    mock_models_sdk,
+    created_at,
+    updated_at,
+    should_delete,
+):
+    """The snapshot guard uses updated_at first, then explicit-None updated_at falls back to created_at."""
+    snapshot_taken_at = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    virtual_model = _virtual_model(
+        "model-a",
+        default_model_entity="ws/model-a",
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+    assert virtual_model.updated_at is updated_at
+
+    await reconciler._cleanup_orphaned_virtual_models([], [virtual_model], snapshot_taken_at=snapshot_taken_at)
+
+    if should_delete:
+        mock_models_sdk.inference.virtual_models.delete.assert_awaited_once_with(
+            name="model-a",
+            workspace="ws",
+            expected_db_version=1,
+        )
+    else:
+        mock_models_sdk.inference.virtual_models.delete.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added synchronous and asynchronous helpers that wait for an OpenAI model to become available.
  * Supports workspace-scoped and qualified model names.
  * Provides configurable polling intervals and timeouts with clear timeout details.

* **Bug Fixes**
  * Deployment invocation now waits for the model to be ready, reducing failures caused by readiness delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->