### PR TITLE
fix(cli): update install directory for skills

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -509,7 +509,8 @@ nemo skills show [OPTIONS] NAME
 Install Nemo skill files for an AI coding agent.
 
 By default, installs all skills to project scope.
-Use --skill to select specific skills, --user for user scope.
+Use --skill to select specific skills, --user for user scope, or
+--project-dir to explicitly select the project install directory.
 
 **Examples:**
 
@@ -517,6 +518,7 @@ Use --skill to select specific skills, --user for user scope.
 nemo skills install --agent claude
 nemo skills install --agent claude --user
 nemo skills install --agent claude --skill inference
+nemo skills install --agent claude --project-dir /path/to/project
 ```
 
 **Usage:**
@@ -530,6 +532,7 @@ nemo skills install [OPTIONS]
 * `--agent, -a`: Agent to install for (required). Supported: claude, codex, cursor, opencode
 * `--skill, -s`: Install specific skill(s) only. Can be repeated.
 * `--user`: Install to user scope (default: project scope)
+* `--project-dir, --project-root <DIRECTORY>`: Project directory to install into (default: current working directory)
 
 **Help:**
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/skills/cli.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/skills/cli.py
@@ -47,15 +47,9 @@ def skills_callback(ctx: typer.Context) -> None:
         typer.echo(ctx.get_help())
 
 
-def _find_project_root() -> Path:
-    """Find the project root by looking for a .git directory, falling back to cwd."""
-    cwd = Path.cwd()
-    current = cwd
-    while current != current.parent:
-        if (current / ".git").exists():
-            return current
-        current = current.parent
-    return cwd
+def _find_project_root(project_dir: Path | None = None) -> Path:
+    """Resolve the project install directory without inspecting parent directories."""
+    return project_dir if project_dir is not None else Path.cwd()
 
 
 # Distributions that ship the platform's own bundled skills. Both names show
@@ -268,16 +262,30 @@ def install(
         bool,
         typer.Option("--user", help="Install to user scope (default: project scope)"),
     ] = False,
+    project_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--project-dir",
+            "--project-root",
+            help="Project directory to install into (default: current working directory)",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True,
+        ),
+    ] = None,
 ) -> None:
     """Install Nemo skill files for an AI coding agent.
 
     By default, installs all skills to project scope.
-    Use --skill to select specific skills, --user for user scope.
+    Use --skill to select specific skills, --user for user scope, or
+    --project-dir to explicitly select the project install directory.
 
     Examples:
       nemo skills install --agent claude
       nemo skills install --agent claude --user
       nemo skills install --agent claude --skill inference
+      nemo skills install --agent claude --project-dir /path/to/project
     """
     try:
         installer = get_installer(agent)
@@ -296,7 +304,7 @@ def install(
         raise typer.Exit(code=1)
 
     skills = _resolve_skills(skill)
-    project_root = _find_project_root()
+    project_root = _find_project_root(project_dir)
     result_paths = installer.install(scope, project_root, skills)
     typer.echo(f"Installed {len(skills)} skill(s) for {installer.display_name}:")
     for path in result_paths:

--- a/packages/nemo_platform_ext/tests/cli/commands/skills/test_cli.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/skills/test_cli.py
@@ -212,7 +212,6 @@ class TestInstall:
         assert result.exit_code != 0
 
     def test_install_claude_project_creates_multiple_files(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent claude")
         assert_exit_code(result, 0)
@@ -223,22 +222,67 @@ class TestInstall:
         assert "Installed" in result.stdout
 
     def test_install_selective_skills(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent claude --skill inference")
         assert_exit_code(result, 0)
         assert (tmp_path / ".claude" / "skills" / "nemo-inference" / "SKILL.md").exists()
         assert not (tmp_path / ".claude" / "skills" / "nemo-setup" / "SKILL.md").exists()
 
-    def test_install_invalid_skill_name_errors(self, tmp_path: Path, monkeypatch):
+    @pytest.mark.parametrize(
+        ("agent", "relative_path"),
+        [
+            ("claude", ".claude/skills/nemo-inference/SKILL.md"),
+            ("codex", ".agents/skills/nemo-inference/SKILL.md"),
+            ("cursor", ".cursor/rules/nemo-inference/SKILL.md"),
+            ("opencode", ".opencode/commands/nemo-inference/SKILL.md"),
+        ],
+    )
+    def test_install_uses_cwd_when_parent_has_git_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        agent: str,
+        relative_path: str,
+    ):
         (tmp_path / ".git").mkdir()
+        project_dir = tmp_path / "project" / "subdir"
+        project_dir.mkdir(parents=True)
+        monkeypatch.chdir(project_dir)
+
+        result = runner.invoke(app, ["skills", "install", "--agent", agent, "--skill", "inference"])
+
+        assert_exit_code(result, 0)
+        expected_path = project_dir / relative_path
+        assert expected_path.exists()
+        assert str(expected_path) in result.stdout
+        assert not (tmp_path / relative_path).exists()
+
+    @pytest.mark.parametrize("option", ["--project-dir", "--project-root"])
+    def test_install_accepts_explicit_project_dir(self, tmp_path: Path, monkeypatch, option: str):
+        cwd = tmp_path / "cwd"
+        project_dir = tmp_path / "project"
+        cwd.mkdir()
+        project_dir.mkdir()
+        monkeypatch.chdir(cwd)
+
+        result = runner.invoke(
+            app,
+            ["skills", "install", "--agent", "claude", "--skill", "inference", option, str(project_dir)],
+        )
+
+        assert_exit_code(result, 0)
+        expected_path = project_dir / ".claude" / "skills" / "nemo-inference" / "SKILL.md"
+        assert expected_path.exists()
+        assert str(expected_path) in result.stdout
+        assert not (cwd / ".claude").exists()
+
+    def test_install_invalid_skill_name_errors(self, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent claude --skill nonexistent")
         assert_exit_code(result, 1)
         assert "Unknown skill" in result.output
 
     def test_install_duplicate_skill_error_is_clean(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(
             "nemo_platform_ext.cli.commands.skills.cli.load_skills",
@@ -249,7 +293,6 @@ class TestInstall:
         assert "Error: duplicate skill" in result.output
 
     def test_install_plugin_skill_copies_companion_files(self, tmp_path: Path, monkeypatch, example_plugin_skills):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent claude --skill example-debug")
         assert_exit_code(result, 0)
@@ -258,7 +301,6 @@ class TestInstall:
         assert (skill_dir / "resources" / "notes.md").exists()
 
     def test_install_codex_writes_per_skill_directories(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent codex")
         assert_exit_code(result, 0)
@@ -269,14 +311,12 @@ class TestInstall:
         assert not (tmp_path / "AGENTS.md").exists()
 
     def test_install_unknown_agent_errors(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent unknown")
         assert_exit_code(result, 1)
         assert "Unsupported agent" in result.output
 
     def test_install_cursor_user_scope_errors(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent cursor --user")
         assert_exit_code(result, 1)
@@ -284,20 +324,25 @@ class TestInstall:
 
 
 class TestFindProjectRoot:
-    def test_finds_git_root(self, tmp_path: Path, monkeypatch):
+    def test_uses_cwd_even_when_parent_has_git_directory(self, tmp_path: Path, monkeypatch):
         (tmp_path / ".git").mkdir()
         subdir = tmp_path / "a" / "b"
         subdir.mkdir(parents=True)
         monkeypatch.chdir(subdir)
         from nemo_platform_ext.cli.commands.skills.cli import _find_project_root
 
-        assert _find_project_root() == tmp_path
+        assert _find_project_root() == subdir
 
-    def test_falls_back_to_cwd_without_git(self, tmp_path: Path, monkeypatch):
+    def test_uses_cwd_without_git(self, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         from nemo_platform_ext.cli.commands.skills.cli import _find_project_root
 
         assert _find_project_root() == tmp_path
+
+    def test_uses_explicit_project_dir(self, tmp_path: Path):
+        from nemo_platform_ext.cli.commands.skills.cli import _find_project_root
+
+        assert _find_project_root(tmp_path) == tmp_path
 
 
 class TestHelpText:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/skills/cli.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/skills/cli.py
@@ -47,15 +47,9 @@ def skills_callback(ctx: typer.Context) -> None:
         typer.echo(ctx.get_help())
 
 
-def _find_project_root() -> Path:
-    """Find the project root by looking for a .git directory, falling back to cwd."""
-    cwd = Path.cwd()
-    current = cwd
-    while current != current.parent:
-        if (current / ".git").exists():
-            return current
-        current = current.parent
-    return cwd
+def _find_project_root(project_dir: Path | None = None) -> Path:
+    """Resolve the project install directory without inspecting parent directories."""
+    return project_dir if project_dir is not None else Path.cwd()
 
 
 # Distributions that ship the platform's own bundled skills. Both names show
@@ -268,16 +262,30 @@ def install(
         bool,
         typer.Option("--user", help="Install to user scope (default: project scope)"),
     ] = False,
+    project_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--project-dir",
+            "--project-root",
+            help="Project directory to install into (default: current working directory)",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True,
+        ),
+    ] = None,
 ) -> None:
     """Install Nemo skill files for an AI coding agent.
 
     By default, installs all skills to project scope.
-    Use --skill to select specific skills, --user for user scope.
+    Use --skill to select specific skills, --user for user scope, or
+    --project-dir to explicitly select the project install directory.
 
     Examples:
       nemo skills install --agent claude
       nemo skills install --agent claude --user
       nemo skills install --agent claude --skill inference
+      nemo skills install --agent claude --project-dir /path/to/project
     """
     try:
         installer = get_installer(agent)
@@ -296,7 +304,7 @@ def install(
         raise typer.Exit(code=1)
 
     skills = _resolve_skills(skill)
-    project_root = _find_project_root()
+    project_root = _find_project_root(project_dir)
     result_paths = installer.install(scope, project_root, skills)
     typer.echo(f"Installed {len(skills)} skill(s) for {installer.display_name}:")
     for path in result_paths:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/skills/test_cli.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/skills/test_cli.py
@@ -212,7 +212,6 @@ class TestInstall:
         assert result.exit_code != 0
 
     def test_install_claude_project_creates_multiple_files(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent claude")
         assert_exit_code(result, 0)
@@ -223,22 +222,67 @@ class TestInstall:
         assert "Installed" in result.stdout
 
     def test_install_selective_skills(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent claude --skill inference")
         assert_exit_code(result, 0)
         assert (tmp_path / ".claude" / "skills" / "nemo-inference" / "SKILL.md").exists()
         assert not (tmp_path / ".claude" / "skills" / "nemo-setup" / "SKILL.md").exists()
 
-    def test_install_invalid_skill_name_errors(self, tmp_path: Path, monkeypatch):
+    @pytest.mark.parametrize(
+        ("agent", "relative_path"),
+        [
+            ("claude", ".claude/skills/nemo-inference/SKILL.md"),
+            ("codex", ".agents/skills/nemo-inference/SKILL.md"),
+            ("cursor", ".cursor/rules/nemo-inference/SKILL.md"),
+            ("opencode", ".opencode/commands/nemo-inference/SKILL.md"),
+        ],
+    )
+    def test_install_uses_cwd_when_parent_has_git_directory(
+        self,
+        tmp_path: Path,
+        monkeypatch,
+        agent: str,
+        relative_path: str,
+    ):
         (tmp_path / ".git").mkdir()
+        project_dir = tmp_path / "project" / "subdir"
+        project_dir.mkdir(parents=True)
+        monkeypatch.chdir(project_dir)
+
+        result = runner.invoke(app, ["skills", "install", "--agent", agent, "--skill", "inference"])
+
+        assert_exit_code(result, 0)
+        expected_path = project_dir / relative_path
+        assert expected_path.exists()
+        assert str(expected_path) in result.stdout
+        assert not (tmp_path / relative_path).exists()
+
+    @pytest.mark.parametrize("option", ["--project-dir", "--project-root"])
+    def test_install_accepts_explicit_project_dir(self, tmp_path: Path, monkeypatch, option: str):
+        cwd = tmp_path / "cwd"
+        project_dir = tmp_path / "project"
+        cwd.mkdir()
+        project_dir.mkdir()
+        monkeypatch.chdir(cwd)
+
+        result = runner.invoke(
+            app,
+            ["skills", "install", "--agent", "claude", "--skill", "inference", option, str(project_dir)],
+        )
+
+        assert_exit_code(result, 0)
+        expected_path = project_dir / ".claude" / "skills" / "nemo-inference" / "SKILL.md"
+        assert expected_path.exists()
+        assert str(expected_path) in result.stdout
+        assert not (cwd / ".claude").exists()
+
+    def test_install_invalid_skill_name_errors(self, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent claude --skill nonexistent")
         assert_exit_code(result, 1)
         assert "Unknown skill" in result.output
 
     def test_install_duplicate_skill_error_is_clean(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(
             "nemo_platform.cli.commands.skills.cli.load_skills",
@@ -249,7 +293,6 @@ class TestInstall:
         assert "Error: duplicate skill" in result.output
 
     def test_install_plugin_skill_copies_companion_files(self, tmp_path: Path, monkeypatch, example_plugin_skills):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent claude --skill example-debug")
         assert_exit_code(result, 0)
@@ -258,7 +301,6 @@ class TestInstall:
         assert (skill_dir / "resources" / "notes.md").exists()
 
     def test_install_codex_writes_per_skill_directories(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent codex")
         assert_exit_code(result, 0)
@@ -269,14 +311,12 @@ class TestInstall:
         assert not (tmp_path / "AGENTS.md").exists()
 
     def test_install_unknown_agent_errors(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent unknown")
         assert_exit_code(result, 1)
         assert "Unsupported agent" in result.output
 
     def test_install_cursor_user_scope_errors(self, tmp_path: Path, monkeypatch):
-        (tmp_path / ".git").mkdir()
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, "skills install --agent cursor --user")
         assert_exit_code(result, 1)
@@ -284,20 +324,25 @@ class TestInstall:
 
 
 class TestFindProjectRoot:
-    def test_finds_git_root(self, tmp_path: Path, monkeypatch):
+    def test_uses_cwd_even_when_parent_has_git_directory(self, tmp_path: Path, monkeypatch):
         (tmp_path / ".git").mkdir()
         subdir = tmp_path / "a" / "b"
         subdir.mkdir(parents=True)
         monkeypatch.chdir(subdir)
         from nemo_platform.cli.commands.skills.cli import _find_project_root
 
-        assert _find_project_root() == tmp_path
+        assert _find_project_root() == subdir
 
-    def test_falls_back_to_cwd_without_git(self, tmp_path: Path, monkeypatch):
+    def test_uses_cwd_without_git(self, tmp_path: Path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         from nemo_platform.cli.commands.skills.cli import _find_project_root
 
         assert _find_project_root() == tmp_path
+
+    def test_uses_explicit_project_dir(self, tmp_path: Path):
+        from nemo_platform.cli.commands.skills.cli import _find_project_root
+
+        assert _find_project_root(tmp_path) == tmp_path
 
 
 class TestHelpText:


### PR DESCRIPTION
## Summary

Fix project-scoped `nemo skills install` commands writing skills into an unrelated ancestor directory containing a stray `.git`.

## Changes

- Default project-scoped installs to the current working directory.
- Stop searching parent directories for `.git`.
- Add `--project-dir` with `--project-root` as an alias for explicit targeting.
- Mirror the change into the vendored SDK.
- Add regression coverage for Claude, Codex, Cursor, and OpenCode.

## Testing

- `38 passed` — canonical skills CLI tests
- `9 passed` — targeted vendored SDK regression tests
- Ruff lint and format checks passed
- `git diff --check` passed

## Example

```bash
mkdir -p /tmp/.git /tmp/proj/sub
cd /tmp/proj/sub

nemo skills install --agent claude --skill inference
```
The skill is now installed under:
```bash
/tmp/proj/sub/.claude/skills/nemo-inference/SKILL.md
```

An explicit destination can also be supplied:
```bash
nemo skills install \
  --agent claude \
  --skill inference \
  --project-dir /path/to/project
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--project-dir` and `--project-root` options to `nemo skills install`.
  * Skills can now be installed into a specifically selected project directory.
  * Without an explicit directory, installation uses the current working directory.

* **Documentation**
  * Updated CLI help text, examples, and reference documentation with the new options and behavior.

* **Bug Fixes**
  * Prevented unintended installation into a parent directory based on its `.git` folder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->