### PR TITLE
fix(models): slow models controller step and inaccurate controller health check

### DIFF
--- a/packages/nmp_common/src/nmp/common/controller/__init__.py
+++ b/packages/nmp_common/src/nmp/common/controller/__init__.py
@@ -5,6 +5,8 @@
 
 from nmp.common.controller.controller import (
     Controller,
+    Heartbeat,
+    HeartbeatMixin,
     Loop,
     LoopWaiter,
     ProvidesLastExecutionTime,
@@ -16,6 +18,8 @@ from nmp.common.controller.controller_manager import ControllerManager
 __all__ = [
     "Controller",
     "ControllerManager",
+    "Heartbeat",
+    "HeartbeatMixin",
     "Loop",
     "LoopWaiter",
     "ProvidesLastExecutionTime",

--- a/packages/nmp_common/src/nmp/common/controller/controller.py
+++ b/packages/nmp_common/src/nmp/common/controller/controller.py
@@ -19,43 +19,31 @@ logger = getLogger(__name__)
 class Heartbeat:
     """Timestamp of the last observed progress in a control loop.
 
-    A single loop iteration may take considerably longer than the loop's poll
-    interval when there is a lot of work to do. ``Heartbeat`` records the most
-    recent point at which the loop demonstrably made progress, which lets the
-    liveness check in :class:`Loop` distinguish a loop that is working through a
-    large batch from one that is stuck.
+    Lets :class:`Loop` tell a loop working through a large batch apart from one
+    that is stuck, since a single iteration can outlast the poll interval.
     """
 
     def __init__(self) -> None:
         self._last = datetime.now(timezone.utc)
 
     def beat(self) -> None:
-        """Record that progress was just made."""
         self._last = datetime.now(timezone.utc)
 
     def last(self) -> datetime:
-        """Return the time of the most recently recorded progress."""
         return self._last
 
 
 class HeartbeatMixin:
-    """Gives a controller a way to report incremental progress.
+    """Lets a controller report progress while a single ``step()`` is still running.
 
-    Controllers whose ``step()`` iterates over a variable number of items should
-    mix this in and call :meth:`emit_heartbeat` as each item is finished. Nested
-    collaborators are handed the bound :meth:`emit_heartbeat` method rather than
-    the :class:`Heartbeat` itself, so they report progress without depending on
-    how liveness is measured.
-
-    ``_heartbeat`` is a class-level default so that mixing this in never obliges
-    a subclass to call ``super().__init__()``. :meth:`attach_heartbeat` binds the
-    instance that :class:`Loop` measures; emitting before then is a no-op.
+    Mixed into controllers whose ``step()`` iterates a variable number of items.
     """
 
-    _heartbeat: "Heartbeat | None" = None
+    # Class-level default so mixing this in never obliges a subclass to call
+    # super().__init__(); emitting before attach_heartbeat() is a no-op.
+    _heartbeat: Heartbeat | None = None
 
     def attach_heartbeat(self, heartbeat: Heartbeat) -> None:
-        """Bind the heartbeat that this controller reports progress to."""
         self._heartbeat = heartbeat
 
     def emit_heartbeat(self) -> None:
@@ -108,10 +96,9 @@ class ProvidesLastExecutionTime(ABC):
 class TrackLastExecutionTime(Controller, ProvidesLastExecutionTime):
     """Tracks when the wrapped controller last made progress.
 
-    Entering ``step()`` counts as progress. A controller that also mixes in
-    :class:`HeartbeatMixin` shares this wrapper's :class:`Heartbeat`, so progress
-    it reports part-way through a long iteration is visible here too. There is
-    only ever one timestamp, and it means "last observed progress".
+    Entering ``step()`` counts as progress; a controller mixing in
+    :class:`HeartbeatMixin` shares this wrapper's :class:`Heartbeat` so its
+    mid-iteration progress lands on the same single timestamp.
     """
 
     def __init__(self, controller: Controller):

--- a/packages/nmp_common/src/nmp/common/controller/controller.py
+++ b/packages/nmp_common/src/nmp/common/controller/controller.py
@@ -16,6 +16,59 @@ from nmp.common.observability.context import AppContext, initialize_app_ctx
 logger = getLogger(__name__)
 
 
+class Heartbeat:
+    """Timestamp of the last observed progress in a control loop.
+
+    A single loop iteration may take considerably longer than the loop's poll
+    interval when there is a lot of work to do. ``Heartbeat`` records the most
+    recent point at which the loop demonstrably made progress, which lets the
+    liveness check in :class:`Loop` distinguish a loop that is working through a
+    large batch from one that is stuck.
+    """
+
+    def __init__(self) -> None:
+        self._last = datetime.now(timezone.utc)
+
+    def beat(self) -> None:
+        """Record that progress was just made."""
+        self._last = datetime.now(timezone.utc)
+
+    def last(self) -> datetime:
+        """Return the time of the most recently recorded progress."""
+        return self._last
+
+
+class HeartbeatMixin:
+    """Gives a controller a way to report incremental progress.
+
+    Controllers whose ``step()`` iterates over a variable number of items should
+    mix this in and call :meth:`emit_heartbeat` as each item is finished. Nested
+    collaborators are handed the bound :meth:`emit_heartbeat` method rather than
+    the :class:`Heartbeat` itself, so they report progress without depending on
+    how liveness is measured.
+
+    ``_heartbeat`` is a class-level default so that mixing this in never obliges
+    a subclass to call ``super().__init__()``. :meth:`attach_heartbeat` binds the
+    instance that :class:`Loop` measures; emitting before then is a no-op.
+    """
+
+    _heartbeat: "Heartbeat | None" = None
+
+    def attach_heartbeat(self, heartbeat: Heartbeat) -> None:
+        """Bind the heartbeat that this controller reports progress to."""
+        self._heartbeat = heartbeat
+
+    def emit_heartbeat(self) -> None:
+        """Report that a unit of work finished.
+
+        Only call this once work has actually completed. Emitting on a timer, or
+        around a call that may block, would report progress that did not happen
+        and defeat the liveness check.
+        """
+        if self._heartbeat is not None:
+            self._heartbeat.beat()
+
+
 class Controller(ABC):
     """Step represents a function intended to be run in a loop."""
 
@@ -53,17 +106,25 @@ class ProvidesLastExecutionTime(ABC):
 
 
 class TrackLastExecutionTime(Controller, ProvidesLastExecutionTime):
-    """TrackLastExecutionTime"""
+    """Tracks when the wrapped controller last made progress.
+
+    Entering ``step()`` counts as progress. A controller that also mixes in
+    :class:`HeartbeatMixin` shares this wrapper's :class:`Heartbeat`, so progress
+    it reports part-way through a long iteration is visible here too. There is
+    only ever one timestamp, and it means "last observed progress".
+    """
 
     def __init__(self, controller: Controller):
-        self._last_runtime = datetime.now(timezone.utc)
         self._internal = controller
+        self._heartbeat = Heartbeat()
+        if isinstance(controller, HeartbeatMixin):
+            controller.attach_heartbeat(self._heartbeat)
 
     def last_execution_time(self) -> datetime:
-        return self._last_runtime
+        return self._heartbeat.last()
 
     def step(self):
-        self._last_runtime = datetime.now(timezone.utc)
+        self._heartbeat.beat()
         self._internal.step()
 
     @property
@@ -114,6 +175,7 @@ class Loop(threading.Thread):
         self._internal = controller
         self._stop_signal = stop_signal if stop_signal is not None else threading.Event()
         self._shutdown_func = shutdown_func
+        self._unhealthy_reason: str | None = None
 
         # Capture the current context so it can be used in the thread
         self._context = contextvars.copy_context()
@@ -144,6 +206,11 @@ class Loop(threading.Thread):
         self._stop_signal.set()
 
     @property
+    def unhealthy_reason(self) -> str | None:
+        """Why the most recent :attr:`is_healthy` evaluation failed, if it did."""
+        return self._unhealthy_reason
+
+    @property
     def is_healthy(self) -> bool:
         """Check if the internal controller is healthy.
 
@@ -152,6 +219,7 @@ class Loop(threading.Thread):
         """
         # Thread must be alive
         if not self.is_alive():
+            self._unhealthy_reason = "loop thread is not alive"
             logger.debug(f"Controller thread {self.name} is not alive")
             return False
 
@@ -163,6 +231,7 @@ class Loop(threading.Thread):
             max_delay = sleep_secs * 3  # Allow 3 sleep windows before marking unhealthy
             time_since_last = (now - last_execution).total_seconds()
             if time_since_last > max_delay:
+                self._unhealthy_reason = f"no progress for {time_since_last:.2f}s (max allowed: {max_delay:.2f}s)"
                 logger.debug(
                     f"Controller thread {self.name} has not executed in {time_since_last:.2f}s "
                     f"(max allowed: {max_delay:.2f}s)"
@@ -170,7 +239,9 @@ class Loop(threading.Thread):
                 return False
 
         if not self._internal.is_healthy:
+            self._unhealthy_reason = "controller reported itself unhealthy"
             logger.debug(f"Controller thread {self.name} internal controller is unhealthy")
             return False
 
+        self._unhealthy_reason = None
         return True

--- a/packages/nmp_common/src/nmp/common/controller/controller_manager.py
+++ b/packages/nmp_common/src/nmp/common/controller/controller_manager.py
@@ -31,6 +31,7 @@ class ControllerManager:
         if ControllerManager._instance is not None:
             raise RuntimeError("Use ControllerManager.get_instance() to get the singleton instance")
         self._loops: Dict[str, Loop] = {}
+        self._reported_health: Dict[str, bool] = {}
 
     @classmethod
     def get_instance(cls) -> "ControllerManager":
@@ -42,6 +43,7 @@ class ControllerManager:
         if cls._instance is None:
             cls._instance = cls.__new__(cls)
             cls._instance._loops = {}
+            cls._instance._reported_health = {}
         return cls._instance
 
     def register(self, name: str, loop: Loop) -> None:
@@ -75,6 +77,7 @@ class ControllerManager:
         if name not in self._loops:
             raise KeyError(f"No loop with name '{name}' is registered")
         del self._loops[name]
+        self._reported_health.pop(name, None)
         logger.info(f"Unregistered loop: {name}")
 
     def get_loop(self, name: str) -> Loop:
@@ -134,11 +137,13 @@ class ControllerManager:
                     if not is_healthy:
                         all_healthy = False
                         logger.debug(f"Loop '{name}' is unhealthy")
+                    self._log_health_transition(name, is_healthy, getattr(loop, "unhealthy_reason", None))
                 except Exception as e:
                     if detailed:
                         health_status[name] = False
                     all_healthy = False
                     logger.error(f"Error checking health of loop '{name}': {e}", exc_info=True)
+                    self._log_health_transition(name, False, f"health check raised: {e}")
             else:
                 # No is_healthy property, assume healthy
                 if detailed:
@@ -147,6 +152,25 @@ class ControllerManager:
 
         return all_healthy, health_status if detailed else {}
 
+    def _log_health_transition(self, name: str, is_healthy: bool, reason: str | None) -> None:
+        """Log only when a loop's health changes.
+
+        Health is evaluated on every readiness probe, so logging each unhealthy
+        evaluation would be far too noisy to be useful. Reporting the edges makes
+        the loop responsible for a degraded process identifiable from the logs
+        alone.
+        """
+        previous = self._reported_health.get(name)
+        if previous == is_healthy:
+            return
+
+        self._reported_health[name] = is_healthy
+        if is_healthy:
+            if previous is not None:
+                logger.info(f"Control loop '{name}' is healthy again")
+        else:
+            logger.warning(f"Control loop '{name}' is unhealthy: {reason or 'reason unavailable'}")
+
     def clear(self) -> None:
         """Clear all registered loops.
 
@@ -154,4 +178,5 @@ class ControllerManager:
         """
         count = len(self._loops)
         self._loops.clear()
+        self._reported_health.clear()
         logger.info(f"Cleared {count} registered loop(s)")

--- a/packages/nmp_common/tests/controller/test_controller.py
+++ b/packages/nmp_common/tests/controller/test_controller.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the control loop liveness model."""
+
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+
+from nmp.common.controller import (
+    Controller,
+    Heartbeat,
+    HeartbeatMixin,
+    Loop,
+    TimedLoopWaiter,
+    TrackLastExecutionTime,
+)
+
+
+class _PlainController(Controller):
+    """Controller that reports no progress beyond entering step()."""
+
+    def __init__(self) -> None:
+        self.steps = 0
+
+    def step(self):
+        self.steps += 1
+
+
+class _ItemController(HeartbeatMixin, Controller):
+    """Controller that reports progress as it works through a batch."""
+
+    def __init__(self, items: int, seconds_per_item: float = 0.0) -> None:
+        self.items = items
+        self.seconds_per_item = seconds_per_item
+        self.processed = 0
+
+    def step(self):
+        for _ in range(self.items):
+            if self.seconds_per_item:
+                time.sleep(self.seconds_per_item)
+            self.processed += 1
+            self.emit_heartbeat()
+
+
+def test_heartbeat_beat_advances_last():
+    heartbeat = Heartbeat()
+    before = heartbeat.last()
+    heartbeat.beat()
+    assert heartbeat.last() >= before
+
+
+def test_wrapper_shares_its_heartbeat_with_a_reporting_controller():
+    controller = _ItemController(items=0)
+    wrapper = TrackLastExecutionTime(controller)
+
+    # Backdate so a beat from the controller is observable.
+    wrapper._heartbeat._last = datetime.now(timezone.utc) - timedelta(seconds=60)
+    stale = wrapper.last_execution_time()
+
+    controller.emit_heartbeat()
+
+    assert wrapper.last_execution_time() > stale
+
+
+def test_emit_heartbeat_before_attach_is_a_noop():
+    controller = _ItemController(items=0)
+    # Never wrapped, so no heartbeat is attached.
+    controller.emit_heartbeat()
+
+
+def test_controller_without_the_mixin_still_tracks_step_entry():
+    controller = _PlainController()
+    wrapper = TrackLastExecutionTime(controller)
+
+    wrapper._heartbeat._last = datetime.now(timezone.utc) - timedelta(seconds=60)
+    stale = wrapper.last_execution_time()
+
+    wrapper.step()
+
+    assert controller.steps == 1
+    assert wrapper.last_execution_time() > stale
+
+
+def _run_loop_until(loop: Loop, predicate, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    raise AssertionError("condition not reached before timeout")
+
+
+def test_loop_stays_healthy_while_a_long_step_reports_progress():
+    """A step far exceeding its interval stays healthy as long as it progresses."""
+    stop_signal = threading.Event()
+    # Interval 0.05s allows 0.15s without progress; the step runs ~0.5s total but
+    # reports progress every ~0.01s.
+    controller = _ItemController(items=50, seconds_per_item=0.01)
+    wrapper = TrackLastExecutionTime(controller)
+    loop = Loop(TimedLoopWaiter(0.05, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
+    loop.name = "progressing"
+
+    loop.start()
+    try:
+        _run_loop_until(loop, lambda: controller.processed > 25)
+        # Well past 3x the interval into a single step, yet still healthy.
+        assert loop.is_healthy
+        assert loop.unhealthy_reason is None
+    finally:
+        stop_signal.set()
+        loop.join(timeout=5)
+
+
+def test_loop_goes_unhealthy_when_a_step_reports_no_progress():
+    """A step that blocks without reporting progress is still detected."""
+    stop_signal = threading.Event()
+    started = threading.Event()
+    release = threading.Event()
+
+    class _StuckController(HeartbeatMixin, Controller):
+        def step(self):
+            started.set()
+            release.wait(timeout=5)
+
+    wrapper = TrackLastExecutionTime(_StuckController())
+    loop = Loop(TimedLoopWaiter(0.05, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
+    loop.name = "stuck"
+
+    loop.start()
+    try:
+        assert started.wait(timeout=5)
+        _run_loop_until(loop, lambda: not loop.is_healthy)
+        assert loop.unhealthy_reason is not None
+        assert "no progress" in loop.unhealthy_reason
+    finally:
+        release.set()
+        stop_signal.set()
+        loop.join(timeout=5)
+
+
+def test_loop_reports_reason_when_thread_is_not_alive():
+    stop_signal = threading.Event()
+    wrapper = TrackLastExecutionTime(_PlainController())
+    loop = Loop(TimedLoopWaiter(0.05, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
+    loop.name = "never-started"
+
+    assert not loop.is_healthy
+    assert loop.unhealthy_reason == "loop thread is not alive"
+
+
+def test_loop_reports_reason_when_controller_declares_itself_unhealthy():
+    stop_signal = threading.Event()
+
+    class _SelfUnhealthy(HeartbeatMixin, Controller):
+        def step(self):
+            self.emit_heartbeat()
+
+        @property
+        def is_healthy(self) -> bool:
+            return False
+
+    wrapper = TrackLastExecutionTime(_SelfUnhealthy())
+    loop = Loop(TimedLoopWaiter(0.05, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
+    loop.name = "self-unhealthy"
+
+    loop.start()
+    try:
+        _run_loop_until(loop, lambda: not loop.is_healthy)
+        assert loop.unhealthy_reason == "controller reported itself unhealthy"
+    finally:
+        stop_signal.set()
+        loop.join(timeout=5)

--- a/packages/nmp_common/tests/controller/test_controller.py
+++ b/packages/nmp_common/tests/controller/test_controller.py
@@ -1,12 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the control loop liveness model."""
+"""Tests for the control loop liveness model.
+
+The liveness check is pure logic over a timestamp, the poll interval, and whether
+the loop thread is alive, so these tests drive the clock rather than sleep on it.
+"""
 
 import threading
-import time
 from datetime import datetime, timedelta, timezone
 
+import time_machine
 from nmp.common.controller import (
     Controller,
     Heartbeat,
@@ -15,6 +19,11 @@ from nmp.common.controller import (
     TimedLoopWaiter,
     TrackLastExecutionTime,
 )
+
+# Matches the models controller's default, so the 3x window below is 15s.
+INTERVAL_SECONDS = 5.0
+BUDGET = timedelta(seconds=INTERVAL_SECONDS * 3)
+START = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
 
 class _PlainController(Controller):
@@ -27,131 +36,136 @@ class _PlainController(Controller):
         self.steps += 1
 
 
-class _ItemController(HeartbeatMixin, Controller):
+class _ReportingController(HeartbeatMixin, Controller):
     """Controller that reports progress as it works through a batch."""
 
-    def __init__(self, items: int, seconds_per_item: float = 0.0) -> None:
-        self.items = items
-        self.seconds_per_item = seconds_per_item
+    def __init__(self) -> None:
         self.processed = 0
 
     def step(self):
-        for _ in range(self.items):
-            if self.seconds_per_item:
-                time.sleep(self.seconds_per_item)
-            self.processed += 1
-            self.emit_heartbeat()
+        self.process_one()
+
+    def process_one(self) -> None:
+        self.processed += 1
+        self.emit_heartbeat()
+
+
+def _build_loop(controller: Controller, *, alive: bool = True) -> tuple[Loop, TrackLastExecutionTime]:
+    """Wrap a controller in a Loop without starting a thread.
+
+    Thread liveness is a separate branch of the health check with its own test, so
+    it is pinned here to keep the staleness assertions unambiguous.
+    """
+    stop_signal = threading.Event()
+    wrapper = TrackLastExecutionTime(controller)
+    loop = Loop(TimedLoopWaiter(INTERVAL_SECONDS, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
+    loop.name = "test-loop"
+    if alive:
+        loop.is_alive = lambda: True  # type: ignore[method-assign]
+    return loop, wrapper
 
 
 def test_heartbeat_beat_advances_last():
-    heartbeat = Heartbeat()
-    before = heartbeat.last()
-    heartbeat.beat()
-    assert heartbeat.last() >= before
+    with time_machine.travel(START, tick=False) as clock:
+        heartbeat = Heartbeat()
+        assert heartbeat.last() == START
+
+        clock.shift(timedelta(seconds=30))
+        heartbeat.beat()
+
+        assert heartbeat.last() == START + timedelta(seconds=30)
 
 
 def test_wrapper_shares_its_heartbeat_with_a_reporting_controller():
-    controller = _ItemController(items=0)
-    wrapper = TrackLastExecutionTime(controller)
+    with time_machine.travel(START, tick=False) as clock:
+        controller = _ReportingController()
+        wrapper = TrackLastExecutionTime(controller)
+        assert wrapper.last_execution_time() == START
 
-    # Backdate so a beat from the controller is observable.
-    wrapper._heartbeat._last = datetime.now(timezone.utc) - timedelta(seconds=60)
-    stale = wrapper.last_execution_time()
+        clock.shift(timedelta(seconds=10))
+        controller.emit_heartbeat()
 
-    controller.emit_heartbeat()
-
-    assert wrapper.last_execution_time() > stale
+        assert wrapper.last_execution_time() == START + timedelta(seconds=10)
 
 
 def test_emit_heartbeat_before_attach_is_a_noop():
-    controller = _ItemController(items=0)
     # Never wrapped, so no heartbeat is attached.
-    controller.emit_heartbeat()
+    _ReportingController().emit_heartbeat()
 
 
 def test_controller_without_the_mixin_still_tracks_step_entry():
-    controller = _PlainController()
-    wrapper = TrackLastExecutionTime(controller)
+    with time_machine.travel(START, tick=False) as clock:
+        controller = _PlainController()
+        wrapper = TrackLastExecutionTime(controller)
 
-    wrapper._heartbeat._last = datetime.now(timezone.utc) - timedelta(seconds=60)
-    stale = wrapper.last_execution_time()
+        clock.shift(timedelta(seconds=10))
+        wrapper.step()
 
-    wrapper.step()
-
-    assert controller.steps == 1
-    assert wrapper.last_execution_time() > stale
-
-
-def _run_loop_until(loop: Loop, predicate, timeout: float = 5.0) -> None:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if predicate():
-            return
-        time.sleep(0.01)
-    raise AssertionError("condition not reached before timeout")
+        assert controller.steps == 1
+        assert wrapper.last_execution_time() == START + timedelta(seconds=10)
 
 
 def test_loop_stays_healthy_while_a_long_step_reports_progress():
-    """A step far exceeding its interval stays healthy as long as it progresses."""
-    stop_signal = threading.Event()
-    # Interval 0.05s allows 0.15s without progress; the step runs ~0.5s total but
-    # reports progress every ~0.01s.
-    controller = _ItemController(items=50, seconds_per_item=0.01)
-    wrapper = TrackLastExecutionTime(controller)
-    loop = Loop(TimedLoopWaiter(0.05, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
-    loop.name = "progressing"
+    """A step far exceeding its interval stays healthy as long as it progresses.
 
-    loop.start()
-    try:
-        _run_loop_until(loop, lambda: controller.processed > 25)
-        # Well past 3x the interval into a single step, yet still healthy.
-        assert loop.is_healthy
-        assert loop.unhealthy_reason is None
-    finally:
-        stop_signal.set()
-        loop.join(timeout=5)
+    This is the case a single heartbeat per step cannot express: the step has not
+    returned, yet the loop is demonstrably working.
+    """
+    with time_machine.travel(START, tick=False) as clock:
+        controller = _ReportingController()
+        loop, _ = _build_loop(controller)
+
+        # Work through a batch that takes several times the poll interval, reporting
+        # progress at intervals shorter than the window.
+        for _ in range(12):
+            clock.shift(BUDGET / 2)
+            controller.process_one()
+            assert loop.is_healthy
+            assert loop.unhealthy_reason is None
+
+        assert controller.processed == 12
 
 
 def test_loop_goes_unhealthy_when_a_step_reports_no_progress():
-    """A step that blocks without reporting progress is still detected."""
-    stop_signal = threading.Event()
-    started = threading.Event()
-    release = threading.Event()
+    """A step that stops making progress is still detected."""
+    with time_machine.travel(START, tick=False) as clock:
+        loop, _ = _build_loop(_ReportingController())
+        assert loop.is_healthy
 
-    class _StuckController(HeartbeatMixin, Controller):
-        def step(self):
-            started.set()
-            release.wait(timeout=5)
+        # Just inside the window.
+        clock.shift(BUDGET - timedelta(seconds=1))
+        assert loop.is_healthy
 
-    wrapper = TrackLastExecutionTime(_StuckController())
-    loop = Loop(TimedLoopWaiter(0.05, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
-    loop.name = "stuck"
-
-    loop.start()
-    try:
-        assert started.wait(timeout=5)
-        _run_loop_until(loop, lambda: not loop.is_healthy)
+        # And past it.
+        clock.shift(timedelta(seconds=2))
+        assert not loop.is_healthy
         assert loop.unhealthy_reason is not None
         assert "no progress" in loop.unhealthy_reason
-    finally:
-        release.set()
-        stop_signal.set()
-        loop.join(timeout=5)
+
+
+def test_loop_recovers_once_progress_resumes_without_the_step_returning():
+    with time_machine.travel(START, tick=False) as clock:
+        controller = _ReportingController()
+        loop, _ = _build_loop(controller)
+
+        clock.shift(BUDGET + timedelta(seconds=1))
+        assert not loop.is_healthy
+
+        controller.process_one()
+
+        assert loop.is_healthy
+        assert loop.unhealthy_reason is None
 
 
 def test_loop_reports_reason_when_thread_is_not_alive():
-    stop_signal = threading.Event()
-    wrapper = TrackLastExecutionTime(_PlainController())
-    loop = Loop(TimedLoopWaiter(0.05, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
-    loop.name = "never-started"
+    # Built but never started, so the real is_alive() is False.
+    loop, _ = _build_loop(_PlainController(), alive=False)
 
     assert not loop.is_healthy
     assert loop.unhealthy_reason == "loop thread is not alive"
 
 
 def test_loop_reports_reason_when_controller_declares_itself_unhealthy():
-    stop_signal = threading.Event()
-
     class _SelfUnhealthy(HeartbeatMixin, Controller):
         def step(self):
             self.emit_heartbeat()
@@ -160,14 +174,8 @@ def test_loop_reports_reason_when_controller_declares_itself_unhealthy():
         def is_healthy(self) -> bool:
             return False
 
-    wrapper = TrackLastExecutionTime(_SelfUnhealthy())
-    loop = Loop(TimedLoopWaiter(0.05, stop_signal=stop_signal), wrapper, stop_signal=stop_signal)
-    loop.name = "self-unhealthy"
+    with time_machine.travel(START, tick=False):
+        loop, _ = _build_loop(_SelfUnhealthy())
 
-    loop.start()
-    try:
-        _run_loop_until(loop, lambda: not loop.is_healthy)
+        assert not loop.is_healthy
         assert loop.unhealthy_reason == "controller reported itself unhealthy"
-    finally:
-        stop_signal.set()
-        loop.join(timeout=5)

--- a/packages/nmp_common/tests/controller/test_controller_manager.py
+++ b/packages/nmp_common/tests/controller/test_controller_manager.py
@@ -288,3 +288,77 @@ def test_stop_without_shutdown_func():
 
     assert not loop.is_alive()
     assert controller.step_count > 0
+
+
+class _ToggleLoop:
+    """Loop stand-in whose health and reason are set by the test."""
+
+    def __init__(self, healthy: bool = True, reason: str | None = None) -> None:
+        self.is_healthy = healthy
+        self.unhealthy_reason = reason
+
+
+def test_health_transition_logs_only_on_change(caplog):
+    """Health is evaluated on every probe, so only the edges may be logged."""
+    manager = ControllerManager.get_instance()
+    manager.clear()
+    loop = _ToggleLoop(healthy=True)
+    manager.register("toggle", loop)
+
+    with caplog.at_level("INFO"):
+        manager.validate_all_healthy()
+        manager.validate_all_healthy()
+        assert [r for r in caplog.records if "toggle" in r.getMessage()] == []
+
+        loop.is_healthy = False
+        loop.unhealthy_reason = "no progress for 44.20s (max allowed: 15.00s)"
+        manager.validate_all_healthy()
+        manager.validate_all_healthy()
+        manager.validate_all_healthy()
+
+        warnings = [r for r in caplog.records if r.levelname == "WARNING" and "toggle" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "no progress for 44.20s" in warnings[0].getMessage()
+
+        loop.is_healthy = True
+        loop.unhealthy_reason = None
+        manager.validate_all_healthy()
+        manager.validate_all_healthy()
+
+        recoveries = [r for r in caplog.records if r.levelname == "INFO" and "healthy again" in r.getMessage()]
+        assert len(recoveries) == 1
+
+    manager.clear()
+
+
+def test_health_transition_reports_placeholder_when_reason_missing(caplog):
+    manager = ControllerManager.get_instance()
+    manager.clear()
+    manager.register("no-reason", _ToggleLoop(healthy=False, reason=None))
+
+    with caplog.at_level("WARNING"):
+        manager.validate_all_healthy()
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING" and "no-reason" in r.getMessage()]
+    assert len(warnings) == 1
+    assert "reason unavailable" in warnings[0].getMessage()
+
+    manager.clear()
+
+
+def test_clear_resets_transition_state(caplog):
+    """After clear(), a re-registered unhealthy loop is reported again."""
+    manager = ControllerManager.get_instance()
+    manager.clear()
+    manager.register("recycled", _ToggleLoop(healthy=False, reason="stuck"))
+    with caplog.at_level("WARNING"):
+        manager.validate_all_healthy()
+    manager.clear()
+
+    manager.register("recycled", _ToggleLoop(healthy=False, reason="stuck"))
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        manager.validate_all_healthy()
+
+    assert [r for r in caplog.records if "recycled" in r.getMessage()]
+    manager.clear()

--- a/services/core/entities/src/nmp/core/entities/controllers/workspace_cleanup.py
+++ b/services/core/entities/src/nmp/core/entities/controllers/workspace_cleanup.py
@@ -11,7 +11,7 @@ from nemo_platform_plugin.files.client import AsyncFilesClient
 from nemo_platform_plugin.jobs.client import AsyncJobsClient
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nmp.common.api.filter import ComparisonOperation, FilterOperator
-from nmp.common.controller.controller import Controller
+from nmp.common.controller.controller import Controller, HeartbeatMixin
 from nmp.common.observability import start_span_with_ctx
 from nmp.core.entities.app.ctx import WorkspaceCleanupContext
 from nmp.core.entities.app.repository.workspace import WorkspaceRepositoryInterface
@@ -27,7 +27,7 @@ _TERMINAL_JOB_STATUSES: frozenset[PlatformJobStatus] = frozenset(
 )
 
 
-class WorkspaceCleanup(Controller):
+class WorkspaceCleanup(HeartbeatMixin, Controller):
     def __init__(
         self,
         nmp_sdk: AsyncNeMoPlatform,
@@ -101,8 +101,11 @@ class WorkspaceCleanup(Controller):
                     return
 
                 await self._cleanup_jobs(workspace)
+                self.emit_heartbeat()
                 await self._cleanup_deployments(workspace)
+                self.emit_heartbeat()
                 await self._cleanup_filesets(workspace)
+                self.emit_heartbeat()
 
                 await self._workspace_repository.delete_workspace(name=workspace.name)
                 logger.info(f"Successfully deleted workspace: {workspace.name}")
@@ -147,6 +150,8 @@ class WorkspaceCleanup(Controller):
                     )
                 except Exception as e:
                     logger.warning(f"Failed to delete job {job.name}: {e}")
+                finally:
+                    self.emit_heartbeat()
 
         except Exception as e:
             logger.error(f"Failed to list jobs for workspace {workspace.name}: {e}")
@@ -168,6 +173,8 @@ class WorkspaceCleanup(Controller):
                     )
                 except Exception as e:
                     logger.warning(f"Failed to delete deployment {deployment.name}: {e}")
+                finally:
+                    self.emit_heartbeat()
 
         except Exception as e:
             logger.error(f"Failed to list deployments for workspace {workspace.name}: {e}")
@@ -189,6 +196,8 @@ class WorkspaceCleanup(Controller):
                     )
                 except Exception as e:
                     logger.warning(f"Failed to delete fileset {fileset.name}: {e}")
+                finally:
+                    self.emit_heartbeat()
 
         except Exception as e:
             logger.error(f"Failed to list filesets for workspace {workspace.name}: {e}")

--- a/services/core/jobs/src/nmp/core/jobs/controllers/reconciler.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/reconciler.py
@@ -15,7 +15,7 @@ from nemo_platform_plugin.jobs.types import (
     PlatformJobStatusUpdateRequest,
     PlatformJobStepWithContext,
 )
-from nmp.common.controller import Controller
+from nmp.common.controller import Controller, HeartbeatMixin
 from nmp.common.jobs.schemas import PlatformJobStatus
 from nmp.common.observability import scoped_app_ctx, start_span_with_ctx
 from nmp.core.jobs.app.ctx import JobBackendContext, JobContext
@@ -29,7 +29,7 @@ meter = metrics.get_meter(__name__)
 logger = logging.getLogger(__name__)
 
 
-class JobReconciler(Controller):
+class JobReconciler(HeartbeatMixin, Controller):
     def __init__(
         self,
         backend_registry: BackendRegistry,
@@ -76,6 +76,7 @@ class JobReconciler(Controller):
                 ]
                 steps_to_reconcile = self.get_steps_for_reconciliation(statuses)
                 self._is_healthy = True
+                self.emit_heartbeat()
             except NemoClientError:
                 self._is_healthy = False
                 logger.exception("Could not fetch job steps for reconciliation", exc_info=True)
@@ -166,6 +167,10 @@ class JobReconciler(Controller):
                             "error_type": "unknown",
                         },
                     )
+                finally:
+                    # Working through the queue is progress whether or not an
+                    # individual step could be reconciled.
+                    self.emit_heartbeat()
 
         # Perform any necessary cleanup steps for expired jobs
         logger.debug("Running job cleanup for expired job steps")
@@ -175,6 +180,8 @@ class JobReconciler(Controller):
                     backend.cleanup_steps()
                 except Exception:
                     logger.exception("Could not complete cleanup steps for backend", exc_info=True)
+                finally:
+                    self.emit_heartbeat()
 
     def _update_step_status_with_timing(
         self,

--- a/services/core/jobs/src/nmp/core/jobs/controllers/scheduler.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/scheduler.py
@@ -16,7 +16,7 @@ from nemo_platform_plugin.jobs.types import (
     PlatformJobStatusUpdateRequest,
     PlatformJobStepWithContext,
 )
-from nmp.common.controller import Controller
+from nmp.common.controller import Controller, HeartbeatMixin
 from nmp.common.jobs.schemas import PlatformJobStatus
 from nmp.common.observability import start_span_with_ctx
 from nmp.core.jobs.app.ctx import JobBackendContext, JobContext
@@ -34,7 +34,7 @@ DEFAULT_PROFILE = "default"
 DEFAULT_PROVIDER = "cpu"
 
 
-class JobScheduler(Controller):
+class JobScheduler(HeartbeatMixin, Controller):
     def __init__(
         self,
         backend_registry: BackendRegistry,
@@ -76,6 +76,7 @@ class JobScheduler(Controller):
             try:
                 steps = self.get_steps_for_scheduling()
                 self._is_healthy = True
+                self.emit_heartbeat()
             except NemoClientError:
                 self._is_healthy = False
                 logger.exception("Could not fetch job steps for scheduling", exc_info=True)
@@ -177,6 +178,10 @@ class JobScheduler(Controller):
                         status_details={"message": str(e)},
                         error_details={"message": str(e), "error": traceback.format_exc()},
                     )
+                finally:
+                    # Working through the queue is progress whether or not an
+                    # individual step could be scheduled.
+                    self.emit_heartbeat()
 
     def _update_step_status_with_timing(
         self,

--- a/services/core/models/src/nmp/core/models/controllers/deployment_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/deployment_reconciler.py
@@ -799,6 +799,17 @@ class ModelDeploymentReconciler:
                     _model_ref = parse_entity_ref(served_model.model_entity_id)
                     model_workspace, model_name = _model_ref.workspace, _model_ref.name
 
+                    if not self._entity_cache.loaded:
+                        # Without a snapshot, a lookup miss is indistinguishable from
+                        # "does not exist", and dropping the unlink here would leave a
+                        # dangling provider reference once the provider is deleted.
+                        logger.warning(
+                            "Model Entity cache holds no snapshot; skipping unlink of %s from %s",
+                            provider_id,
+                            served_model.model_entity_id,
+                        )
+                        continue
+
                     model_entity = self._entity_cache.get(model_workspace, model_name)
                     if model_entity is None:
                         logger.debug(f"Model Entity {served_model.model_entity_id} not found, nothing to unlink")

--- a/services/core/models/src/nmp/core/models/controllers/deployment_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/deployment_reconciler.py
@@ -20,6 +20,7 @@ from nmp.core.models.controllers.backends.backends import DeploymentStatusUpdate
 from nmp.core.models.controllers.backends.common import deleting_elapsed_seconds
 from nmp.core.models.controllers.backends.registry import BackendRegistry
 from nmp.core.models.controllers.context import ModelContext
+from nmp.core.models.controllers.entity_cache import ModelEntityCache
 
 logger = getLogger(__name__)
 
@@ -144,6 +145,8 @@ class ModelDeploymentReconciler:
         models_sdk: AsyncNeMoPlatform,
         backend_registry: BackendRegistry,
         controller_config: ControllerConfig,
+        entity_cache: ModelEntityCache,
+        emit_heartbeat: Callable[[], None],
     ) -> None:
         """Initialize the deployment reconciler.
 
@@ -151,10 +154,15 @@ class ModelDeploymentReconciler:
             models_sdk: SDK client for Models API interactions
             backend_registry: Registry of available service backends
             controller_config: Controller configuration containing deployment settings
+            entity_cache: Model Entity reads and staged writes for the current phase
+            emit_heartbeat: Called as each unit of work finishes so a long pass is
+                distinguishable from a stalled one
         """
         self._models_sdk = models_sdk
         self._backend_registry = backend_registry
         self._controller_config = controller_config
+        self._entity_cache = entity_cache
+        self._emit_heartbeat = emit_heartbeat
         self._drift_recovery_cache = DriftRecoveryCache(
             max_attempts=controller_config.drift_recovery_max_attempts,
             base_delay_seconds=controller_config.drift_recovery_base_delay_seconds,
@@ -242,6 +250,8 @@ class ModelDeploymentReconciler:
                         await self._handle_deleted_deployment(deployment)
             except Exception as e:
                 logger.exception(f"Error processing deployment {model_deployment_id}: {e}")
+            finally:
+                self._emit_heartbeat()
 
     async def reconcile_orphans(self, known_deployment_ids: set[str]) -> None:
         """Delete backend deployments that are not in the known set (orphans).
@@ -277,6 +287,8 @@ class ModelDeploymentReconciler:
                     e,
                     exc_info=True,
                 )
+            finally:
+                self._emit_heartbeat()
 
     async def gc_error_deployments(self, error_deployments: list[ModelDeployment]) -> None:
         """Garbage-collect backend resources for ERROR deployments past their TTL.
@@ -381,6 +393,8 @@ class ModelDeploymentReconciler:
                     extra={"deployment": deployment_id},
                     exc_info=True,
                 )
+            finally:
+                self._emit_heartbeat()
 
     async def _reconcile_individual_deployment(
         self,
@@ -785,21 +799,13 @@ class ModelDeploymentReconciler:
                     _model_ref = parse_entity_ref(served_model.model_entity_id)
                     model_workspace, model_name = _model_ref.workspace, _model_ref.name
 
-                    # Get the Model Entity
-                    model_entity = await self._models_sdk.models.retrieve(
-                        name=model_name,
-                        workspace=model_workspace,
-                    )
+                    model_entity = self._entity_cache.get(model_workspace, model_name)
+                    if model_entity is None:
+                        logger.debug(f"Model Entity {served_model.model_entity_id} not found, nothing to unlink")
+                        continue
 
-                    # Remove this provider from the model_providers list
-                    current_providers = model_entity.model_providers or []
-                    if provider_id in current_providers:
-                        updated_providers = [p for p in current_providers if p != provider_id]
-                        await self._models_sdk.models.update(
-                            name=model_name,
-                            workspace=model_workspace,
-                            model_providers=updated_providers,
-                        )
+                    if provider_id in (model_entity.model_providers or []):
+                        self._entity_cache.stage_provider_unlink(model_workspace, model_name, provider_id)
                         logger.info(f"Removed provider {provider_id} from Model Entity {served_model.model_entity_id}")
                     else:
                         logger.debug(
@@ -810,6 +816,8 @@ class ModelDeploymentReconciler:
                     logger.warning(
                         f"Failed to cleanup Model Entity {served_model.model_entity_id} for provider {provider_id}: {e}"
                     )
+                finally:
+                    self._emit_heartbeat()
 
         except NotFoundError:
             logger.debug(f"Provider {provider_id} not found during cleanup, skipping Model Entity cleanup")

--- a/services/core/models/src/nmp/core/models/controllers/entity_cache.py
+++ b/services/core/models/src/nmp/core/models/controllers/entity_cache.py
@@ -39,6 +39,9 @@ class _PendingEntity:
     link_providers: list[str] = field(default_factory=list)
     unlink_providers: list[str] = field(default_factory=list)
     field_updates: dict = field(default_factory=dict)
+    # Number of times a flush has tried to apply this entry. Distinguishes a
+    # change that was never flushed from one that was flushed and failed.
+    attempts: int = 0
 
 
 class UnflushedMutationsError(RuntimeError):
@@ -75,12 +78,19 @@ class ModelEntityCache:
     async def refresh(self) -> None:
         """Re-read every Model Entity across all workspaces.
 
+        Changes that a flush already tried and failed to apply are kept and
+        retried on a later flush. Because staged changes are expressed as
+        differences rather than absolute state, replaying them against a newer
+        snapshot stays correct.
+
         Raises:
-            UnflushedMutationsError: If changes are still staged.
+            UnflushedMutationsError: If changes are staged that no flush has tried
+                to apply yet, which would lose them silently.
         """
-        if self._pending:
+        never_attempted = [key for key, staged in self._pending.items() if staged.attempts == 0]
+        if never_attempted:
             raise UnflushedMutationsError(
-                f"{len(self._pending)} staged Model Entity change(s) must be flushed before refreshing the cache"
+                f"{len(never_attempted)} staged Model Entity change(s) must be flushed before refreshing the cache"
             )
 
         entities: dict[tuple[str, str], ModelEntity] = {}
@@ -168,10 +178,15 @@ class ModelEntityCache:
 
         Entities whose staged state already matches the snapshot are skipped, so a
         pass that changes nothing performs no writes.
-        """
-        pending, self._pending = self._pending, {}
 
-        for (workspace, name), staged in pending.items():
+        An entity that fails to write keeps its staged change so a later flush can
+        retry it. Some changes cannot be recomputed by a later pass -- unlinking a
+        provider that is about to be deleted is derived from that provider, which
+        will be gone -- so dropping a failure would leave the entity permanently
+        inconsistent.
+        """
+        for (workspace, name), staged in list(self._pending.items()):
+            staged.attempts += 1
             existing = self._entities.get((workspace, name))
             try:
                 if existing is None:
@@ -179,13 +194,17 @@ class ModelEntityCache:
                 else:
                     await self._update(workspace, name, staged, existing)
             except Exception:
-                # One entity must not stop the rest; the next pass retries.
+                # One entity must not stop the rest, and the change is kept for a
+                # later attempt rather than discarded.
                 logger.warning(
-                    "Failed to apply Model Entity changes for %s/%s",
+                    "Failed to apply Model Entity changes for %s/%s, will retry (attempt %d)",
                     workspace,
                     name,
+                    staged.attempts,
                     exc_info=True,
                 )
+            else:
+                del self._pending[(workspace, name)]
             finally:
                 self._emit_heartbeat()
 

--- a/services/core/models/src/nmp/core/models/controllers/entity_cache.py
+++ b/services/core/models/src/nmp/core/models/controllers/entity_cache.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Batched reads and writes of Model Entities for a single reconciliation phase.
+
+Reconciling providers and deployments requires looking at the Model Entity behind
+every served model, and often needs to link or unlink a provider on it. Doing that
+one entity at a time costs two round trips per served model per pass, which grows
+with the product of providers and the size of their model catalogues.
+
+:class:`ModelEntityCache` reads the entities once per phase and accumulates the
+intended changes, so each entity is written at most once and only when something
+actually differs. Because the desired state for an entity is assembled in memory
+before it is written, concurrent contributions from several providers cannot
+overwrite one another.
+"""
+
+from dataclasses import dataclass, field
+from logging import getLogger
+
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform._exceptions import ConflictError, NotFoundError
+from nemo_platform.types.models.model_entity import ModelEntity
+
+logger = getLogger(__name__)
+
+# Entity lists are read whole, so prefer few large pages over many small ones.
+_PAGE_SIZE = 1000
+
+
+@dataclass
+class _PendingEntity:
+    """Changes staged for one Model Entity within a phase."""
+
+    workspace: str
+    name: str
+    create_kwargs: dict | None = None
+    link_providers: list[str] = field(default_factory=list)
+    unlink_providers: list[str] = field(default_factory=list)
+    field_updates: dict = field(default_factory=dict)
+
+
+class UnflushedMutationsError(RuntimeError):
+    """Raised when the cache is refreshed while changes are still staged.
+
+    Re-reading would discard the staged changes and reload the very state they
+    were derived from, so the caller must flush first.
+    """
+
+
+class ModelEntityCache:
+    """A per-phase snapshot of Model Entities plus the changes staged against it.
+
+    Usage is strictly ``refresh()`` -> read/stage -> ``flush()``. Reads see staged
+    changes layered over the snapshot, so a caller that stages a change and then
+    reads the same entity within a phase observes its own write.
+    """
+
+    def __init__(self, models_sdk: AsyncNeMoPlatform) -> None:
+        self._models_sdk = models_sdk
+        self._entities: dict[tuple[str, str], ModelEntity] = {}
+        self._pending: dict[tuple[str, str], _PendingEntity] = {}
+        self._loaded = False
+
+    async def refresh(self) -> None:
+        """Re-read every Model Entity across all workspaces.
+
+        Raises:
+            UnflushedMutationsError: If changes are still staged.
+        """
+        if self._pending:
+            raise UnflushedMutationsError(
+                f"{len(self._pending)} staged Model Entity change(s) must be flushed before refreshing the cache"
+            )
+
+        entities: dict[tuple[str, str], ModelEntity] = {}
+        async for entity in self._models_sdk.models.list(workspace="-", page_size=_PAGE_SIZE):
+            entities[(entity.workspace, entity.name)] = entity
+
+        self._entities = entities
+        self._loaded = True
+        logger.debug("Model Entity cache loaded %d entities", len(entities))
+
+    @property
+    def loaded(self) -> bool:
+        """Whether the cache holds a snapshot."""
+        return self._loaded
+
+    def get(self, workspace: str, name: str) -> ModelEntity | None:
+        """Return an entity as it will exist once staged changes are flushed.
+
+        Returns ``None`` when the entity neither exists nor is staged for creation.
+        """
+        key = (workspace, name)
+        entity = self._entities.get(key)
+        pending = self._pending.get(key)
+        if pending is None:
+            return entity
+
+        if entity is None:
+            # An entity staged for creation is reported as absent rather than
+            # fabricated. Callers stage what they want and the staged changes are
+            # merged, so a second caller reaching the same conclusion is harmless.
+            return None
+
+        providers = [p for p in (entity.model_providers or []) if p not in pending.unlink_providers]
+        providers.extend(p for p in pending.link_providers if p not in providers)
+        return entity.model_copy(update={"model_providers": providers, **pending.field_updates})
+
+    def _pending_for(self, workspace: str, name: str) -> _PendingEntity:
+        key = (workspace, name)
+        if key not in self._pending:
+            self._pending[key] = _PendingEntity(workspace=workspace, name=name)
+        return self._pending[key]
+
+    def stage_create(self, workspace: str, name: str, **create_kwargs) -> None:
+        """Stage creation of an entity that does not exist yet.
+
+        Repeated calls for the same entity keep the first set of attributes; the
+        providers that asked for it are merged by :meth:`stage_provider_link`.
+        """
+        pending = self._pending_for(workspace, name)
+        if pending.create_kwargs is None:
+            pending.create_kwargs = dict(create_kwargs)
+
+    def stage_provider_link(self, workspace: str, name: str, provider_id: str) -> None:
+        """Stage a provider reference to be present on an entity."""
+        pending = self._pending_for(workspace, name)
+        if provider_id in pending.unlink_providers:
+            pending.unlink_providers.remove(provider_id)
+        if provider_id not in pending.link_providers:
+            pending.link_providers.append(provider_id)
+
+    def stage_provider_unlink(self, workspace: str, name: str, provider_id: str) -> None:
+        """Stage a provider reference to be absent from an entity."""
+        pending = self._pending_for(workspace, name)
+        if provider_id in pending.link_providers:
+            pending.link_providers.remove(provider_id)
+        if provider_id not in pending.unlink_providers:
+            pending.unlink_providers.append(provider_id)
+
+    def stage_field_updates(self, workspace: str, name: str, **updates) -> None:
+        """Stage attribute values to write.
+
+        Whether a value ought to be written is the caller's decision, since only
+        the caller knows what counts as already-set for a given attribute. Values
+        of ``None`` are dropped so callers can pass optional values through
+        directly.
+        """
+        pending = self._pending_for(workspace, name)
+        for key, value in updates.items():
+            if value is not None:
+                pending.field_updates.setdefault(key, value)
+
+    async def flush(self) -> None:
+        """Apply staged changes, writing each entity at most once.
+
+        Entities whose staged state already matches the snapshot are skipped, so a
+        pass that changes nothing performs no writes.
+        """
+        pending, self._pending = self._pending, {}
+
+        for (workspace, name), staged in pending.items():
+            existing = self._entities.get((workspace, name))
+            try:
+                if existing is None:
+                    await self._create(workspace, name, staged)
+                else:
+                    await self._update(workspace, name, staged, existing)
+            except Exception:
+                # One entity must not stop the rest; the next pass retries.
+                logger.warning(
+                    "Failed to apply Model Entity changes for %s/%s",
+                    workspace,
+                    name,
+                    exc_info=True,
+                )
+
+    async def _create(self, workspace: str, name: str, staged: _PendingEntity) -> None:
+        if staged.create_kwargs is None:
+            # Only a link/unlink was staged for an entity that does not exist.
+            logger.debug("Skipping Model Entity changes for missing entity %s/%s", workspace, name)
+            return
+
+        create_kwargs = {k: v for k, v in staged.create_kwargs.items() if k not in ("name", "workspace")}
+        create_kwargs.update(staged.field_updates)
+        if staged.link_providers:
+            create_kwargs["model_providers"] = list(staged.link_providers)
+
+        try:
+            created = await self._models_sdk.models.create(workspace=workspace, name=name, **create_kwargs)
+        except ConflictError:
+            # Created concurrently; adopt it and apply the staged changes instead.
+            logger.debug("Model Entity %s/%s already exists, applying staged changes", workspace, name)
+            try:
+                existing = await self._models_sdk.models.retrieve(workspace=workspace, name=name)
+            except NotFoundError:
+                return
+            self._entities[(workspace, name)] = existing
+            await self._update(workspace, name, staged, existing)
+            return
+
+        if created is not None:
+            self._entities[(workspace, name)] = created
+        logger.debug("Created Model Entity %s/%s", workspace, name)
+
+    async def _update(self, workspace: str, name: str, staged: _PendingEntity, existing: ModelEntity) -> None:
+        update_params: dict = {}
+
+        current_providers = list(existing.model_providers or [])
+        desired_providers = [p for p in current_providers if p not in staged.unlink_providers]
+        desired_providers.extend(p for p in staged.link_providers if p not in desired_providers)
+        if desired_providers != current_providers:
+            update_params["model_providers"] = desired_providers
+
+        update_params.update(staged.field_updates)
+
+        if not update_params:
+            logger.debug("Model Entity %s/%s already matches desired state", workspace, name)
+            return
+
+        updated = await self._models_sdk.models.update(workspace=workspace, name=name, **update_params)
+        if updated is not None:
+            self._entities[(workspace, name)] = updated
+        logger.debug("Updated Model Entity %s/%s: %s", workspace, name, sorted(update_params))

--- a/services/core/models/src/nmp/core/models/controllers/entity_cache.py
+++ b/services/core/models/src/nmp/core/models/controllers/entity_cache.py
@@ -17,6 +17,7 @@ overwrite one another.
 
 from dataclasses import dataclass, field
 from logging import getLogger
+from typing import Callable
 
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform._exceptions import ConflictError, NotFoundError
@@ -56,8 +57,17 @@ class ModelEntityCache:
     reads the same entity within a phase observes its own write.
     """
 
-    def __init__(self, models_sdk: AsyncNeMoPlatform) -> None:
+    def __init__(self, models_sdk: AsyncNeMoPlatform, emit_heartbeat: Callable[[], None]) -> None:
+        """Initialize the cache.
+
+        Args:
+            models_sdk: SDK client for Models API interactions
+            emit_heartbeat: Called as each entity is read or written. Reading and
+                writing are both proportional to the number of entities, so they
+                have to report progress or a large batch looks like a stall.
+        """
         self._models_sdk = models_sdk
+        self._emit_heartbeat = emit_heartbeat
         self._entities: dict[tuple[str, str], ModelEntity] = {}
         self._pending: dict[tuple[str, str], _PendingEntity] = {}
         self._loaded = False
@@ -76,6 +86,7 @@ class ModelEntityCache:
         entities: dict[tuple[str, str], ModelEntity] = {}
         async for entity in self._models_sdk.models.list(workspace="-", page_size=_PAGE_SIZE):
             entities[(entity.workspace, entity.name)] = entity
+            self._emit_heartbeat()
 
         self._entities = entities
         self._loaded = True
@@ -175,6 +186,8 @@ class ModelEntityCache:
                     name,
                     exc_info=True,
                 )
+            finally:
+                self._emit_heartbeat()
 
     async def _create(self, workspace: str, name: str, staged: _PendingEntity) -> None:
         if staged.create_kwargs is None:

--- a/services/core/models/src/nmp/core/models/controllers/models_controller.py
+++ b/services/core/models/src/nmp/core/models/controllers/models_controller.py
@@ -453,39 +453,42 @@ class ModelsController(HeartbeatMixin, Controller):
         logger.debug("Models controller step starting")
 
         await self._entity_cache.refresh()
-        deployment_contexts = await self.retrieve_non_terminal_deployments()
-        self.emit_heartbeat()
+        try:
+            deployment_contexts = await self.retrieve_non_terminal_deployments()
+            self.emit_heartbeat()
 
-        # Check stop signal before reconciling deployments
-        if self._is_stopping():
-            logger.debug("Stop signal received, skipping reconciliation")
+            # Check stop signal before reconciling deployments
+            if self._is_stopping():
+                logger.debug("Stop signal received, skipping reconciliation")
+                return
+
+            if deployment_contexts:
+                logger.debug(f"Found {len(deployment_contexts)} total deployment(s) in non-terminal states")
+                await self._deployment_reconciler.reconcile_deployments(deployment_contexts)
+
+            known_deployment_ids = {
+                f"{ctx.model_deployment.workspace}/{ctx.model_deployment.name}" for ctx in deployment_contexts
+            }
+            await self._deployment_reconciler.reconcile_orphans(known_deployment_ids)
+            self.emit_heartbeat()
+
+            # Check stop signal before ERROR GC
+            if self._is_stopping():
+                logger.debug("Stop signal received, skipping ERROR GC and provider queries")
+                return
+
+            error_deployments = await self.retrieve_error_deployments()
+            if error_deployments:
+                logger.debug(
+                    "Found %d ERROR deployment(s) for GC evaluation",
+                    len(error_deployments),
+                )
+                await self._deployment_reconciler.gc_error_deployments(error_deployments)
+        finally:
+            # Unconditional: a phase that ends early or raises must still apply what
+            # it staged, otherwise the changes are stranded and the next refresh
+            # refuses to run.
             await self._entity_cache.flush()
-            return
-
-        if deployment_contexts:
-            logger.debug(f"Found {len(deployment_contexts)} total deployment(s) in non-terminal states")
-            await self._deployment_reconciler.reconcile_deployments(deployment_contexts)
-
-        known_deployment_ids = {
-            f"{ctx.model_deployment.workspace}/{ctx.model_deployment.name}" for ctx in deployment_contexts
-        }
-        await self._deployment_reconciler.reconcile_orphans(known_deployment_ids)
-        self.emit_heartbeat()
-
-        # Check stop signal before ERROR GC
-        if self._is_stopping():
-            logger.debug("Stop signal received, skipping ERROR GC and provider queries")
-            await self._entity_cache.flush()
-            return
-
-        error_deployments = await self.retrieve_error_deployments()
-        if error_deployments:
-            logger.debug(
-                "Found %d ERROR deployment(s) for GC evaluation",
-                len(error_deployments),
-            )
-            await self._deployment_reconciler.gc_error_deployments(error_deployments)
-        await self._entity_cache.flush()
         self.emit_heartbeat()
 
         # Check stop signal before querying providers
@@ -494,14 +497,13 @@ class ModelsController(HeartbeatMixin, Controller):
             return
 
         await self._entity_cache.refresh()
-        provider_contexts = await self.retrieve_model_providers()
-        if provider_contexts is None:
-            logger.debug("Skipping provider reconciliation because provider listing failed")
-            await self._entity_cache.flush()
-            return
-        logger.debug("Found %d total model provider(s)", len(provider_contexts))
-        self.emit_heartbeat()
         try:
+            provider_contexts = await self.retrieve_model_providers()
+            if provider_contexts is None:
+                logger.debug("Skipping provider reconciliation because provider listing failed")
+                return
+            logger.debug("Found %d total model provider(s)", len(provider_contexts))
+            self.emit_heartbeat()
             await self._provider_reconciler.reconcile_model_providers(provider_contexts)
         finally:
             await self._entity_cache.flush()

--- a/services/core/models/src/nmp/core/models/controllers/models_controller.py
+++ b/services/core/models/src/nmp/core/models/controllers/models_controller.py
@@ -12,7 +12,7 @@ from nemo_platform.types.inference import ModelDeploymentStatus
 from nemo_platform.types.inference.model_deployment import ModelDeployment
 from nemo_platform.types.inference.model_deployment_config import ModelDeploymentConfig
 from nemo_platform.types.models.model_entity import ModelEntity
-from nmp.common.controller import Controller
+from nmp.common.controller import Controller, HeartbeatMixin
 from nmp.common.entities.utils import parse_entity_ref
 from nmp.common.sdk_factory import get_async_platform_sdk
 from nmp.core.models.app import parse_model_name_revision
@@ -21,6 +21,7 @@ from nmp.core.models.controllers.backends.backends import ServiceBackend
 from nmp.core.models.controllers.backends.registry import BackendRegistry
 from nmp.core.models.controllers.context import ModelContext
 from nmp.core.models.controllers.deployment_reconciler import ModelDeploymentReconciler
+from nmp.core.models.controllers.entity_cache import ModelEntityCache
 from nmp.core.models.controllers.provider_reconciler import ModelProviderReconciler
 
 logger = getLogger(__name__)
@@ -34,7 +35,7 @@ NON_TERMINAL_STATES: list[ModelDeploymentStatus] = [
 ]
 
 
-class ModelsController(Controller):
+class ModelsController(HeartbeatMixin, Controller):
     """
     Models Controller manages the lifecycle of ModelDeployment objects.
 
@@ -65,15 +66,23 @@ class ModelsController(Controller):
         )
         self._service_backends = backend_registry.list_backends()
 
+        # Shared by both reconcilers; re-read at the start of each phase that
+        # writes entities so neither phase works from state the other has changed.
+        self._entity_cache = ModelEntityCache(models_sdk=self._models_sdk)
+
         # Initialize reconcilers
         self._deployment_reconciler = ModelDeploymentReconciler(
             models_sdk=self._models_sdk,
             backend_registry=backend_registry,
             controller_config=models_config.controller,
+            entity_cache=self._entity_cache,
+            emit_heartbeat=self.emit_heartbeat,
         )
         self._provider_reconciler = ModelProviderReconciler(
             models_sdk=self._models_sdk,
             controller_config=models_config.controller,
+            entity_cache=self._entity_cache,
+            emit_heartbeat=self.emit_heartbeat,
         )
 
         logger.info("Models Controller initialized")
@@ -224,10 +233,18 @@ class ModelsController(Controller):
 
             logger.debug(f"Querying Models API for model entity: {workspace}/{full_model_name}")
 
-            model_entity = await self._models_sdk.models.retrieve(
-                name=full_model_name,
-                workspace=workspace,
-            )
+            if revision or not self._entity_cache.loaded:
+                # A revision resolves server-side and does not correspond to an
+                # cache key, so it has to be fetched directly.
+                model_entity = await self._models_sdk.models.retrieve(
+                    name=full_model_name,
+                    workspace=workspace,
+                )
+            else:
+                model_entity = self._entity_cache.get(workspace, model_name)
+                if model_entity is None:
+                    logger.debug(f"No model entity found in Models API: {workspace}/{full_model_name}")
+                    return None
 
             if model_entity:
                 logger.debug(f"Successfully retrieved model entity from Models API: {workspace}/{model_name}")
@@ -419,13 +436,30 @@ class ModelsController(Controller):
             return []
 
     async def async_controller_step(self) -> None:
-        """Execute one async iteration of the Models Controller loop."""
+        """Execute one async iteration of the Models Controller loop.
+
+        Deployment and provider reconciliation both read and write Model Entities,
+        and the deployment phase can unlink a provider that the provider phase
+        would otherwise re-link. The entity cache is therefore re-read at the
+        start of each phase and flushed at the end of it, so each phase sees the
+        results of the previous one. Any new phase that writes entities needs the
+        same treatment.
+
+        Staged changes are applied even when the step bails out early. Provider
+        deletion stages the removal of its entity links, and the provider itself is
+        already gone by then, so discarding those would leave the links behind with
+        nothing left to trigger another attempt.
+        """
         logger.debug("Models controller step starting")
+
+        await self._entity_cache.refresh()
         deployment_contexts = await self.retrieve_non_terminal_deployments()
+        self.emit_heartbeat()
 
         # Check stop signal before reconciling deployments
         if self._is_stopping():
             logger.debug("Stop signal received, skipping reconciliation")
+            await self._entity_cache.flush()
             return
 
         if deployment_contexts:
@@ -436,10 +470,12 @@ class ModelsController(Controller):
             f"{ctx.model_deployment.workspace}/{ctx.model_deployment.name}" for ctx in deployment_contexts
         }
         await self._deployment_reconciler.reconcile_orphans(known_deployment_ids)
+        self.emit_heartbeat()
 
         # Check stop signal before ERROR GC
         if self._is_stopping():
             logger.debug("Stop signal received, skipping ERROR GC and provider queries")
+            await self._entity_cache.flush()
             return
 
         error_deployments = await self.retrieve_error_deployments()
@@ -449,18 +485,26 @@ class ModelsController(Controller):
                 len(error_deployments),
             )
             await self._deployment_reconciler.gc_error_deployments(error_deployments)
+        await self._entity_cache.flush()
+        self.emit_heartbeat()
 
         # Check stop signal before querying providers
         if self._is_stopping():
             logger.debug("Stop signal received, skipping provider queries")
             return
 
+        await self._entity_cache.refresh()
         provider_contexts = await self.retrieve_model_providers()
         if provider_contexts is None:
             logger.debug("Skipping provider reconciliation because provider listing failed")
+            await self._entity_cache.flush()
             return
         logger.debug("Found %d total model provider(s)", len(provider_contexts))
-        await self._provider_reconciler.reconcile_model_providers(provider_contexts)
+        self.emit_heartbeat()
+        try:
+            await self._provider_reconciler.reconcile_model_providers(provider_contexts)
+        finally:
+            await self._entity_cache.flush()
 
         logger.debug(
             "Models controller step completed: %d deployment(s), %d provider(s)",

--- a/services/core/models/src/nmp/core/models/controllers/models_controller.py
+++ b/services/core/models/src/nmp/core/models/controllers/models_controller.py
@@ -68,7 +68,7 @@ class ModelsController(HeartbeatMixin, Controller):
 
         # Shared by both reconcilers; re-read at the start of each phase that
         # writes entities so neither phase works from state the other has changed.
-        self._entity_cache = ModelEntityCache(models_sdk=self._models_sdk)
+        self._entity_cache = ModelEntityCache(models_sdk=self._models_sdk, emit_heartbeat=self.emit_heartbeat)
 
         # Initialize reconcilers
         self._deployment_reconciler = ModelDeploymentReconciler(

--- a/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
@@ -372,6 +372,7 @@ class ModelProviderReconciler:
             workspace="-", page_size=_VIRTUAL_MODEL_PAGE_SIZE
         ):
             vm_snapshot.append(virtual_model)
+            self._emit_heartbeat()
         existing_vm_names = {(vm.workspace, vm.name) for vm in vm_snapshot}
         logger.debug("Loaded %d VirtualModel(s) for provider reconciliation", len(vm_snapshot))
         return vm_snapshot, existing_vm_names

--- a/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
@@ -336,7 +336,10 @@ class ModelProviderReconciler:
         # as read: orphan cleanup only ever considers VirtualModels that predate
         # the pass, and keeping it separate means a VirtualModel created here can
         # never be mistaken for a deletion candidate.
-        vm_snapshot, existing_vm_names = await self._load_virtual_models()
+        # A listing failure must not cost us discovery, provider status, or entity
+        # linking; only the VirtualModel work depends on it.
+        virtual_models = await self._load_virtual_models()
+        existing_vm_names = virtual_models[1] if virtual_models is not None else None
 
         for ctx in provider_contexts:
             provider = ctx.model_provider
@@ -356,23 +359,34 @@ class ModelProviderReconciler:
 
         # Runs after every provider so the active set reflects the served_models
         # resolved during this pass rather than the previously persisted values.
+        if virtual_models is None:
+            logger.warning("Skipping orphaned VirtualModel cleanup because the VirtualModel listing failed")
+            return
         try:
-            await self._cleanup_orphaned_virtual_models(provider_contexts, vm_snapshot)
+            await self._cleanup_orphaned_virtual_models(provider_contexts, virtual_models[0])
         except Exception:
             logger.exception("Unexpected error cleaning up orphaned autoprovisioned VirtualModels")
 
-    async def _load_virtual_models(self) -> tuple[list[VirtualModel], set[tuple[str, str]]]:
+    async def _load_virtual_models(self) -> tuple[list[VirtualModel], set[tuple[str, str]]] | None:
         """Read every VirtualModel once, returning the list and an existence set.
 
         The existence set covers all VirtualModels, not just autoprovisioned ones,
         so a name already taken by a user-managed VirtualModel is left untouched.
+
+        Returns ``None`` if the listing failed, which callers read as "the
+        VirtualModel state is unknown this pass" and skip VirtualModel work rather
+        than acting on a partial view.
         """
         vm_snapshot: list[VirtualModel] = []
-        async for virtual_model in self._models_sdk.inference.virtual_models.list(
-            workspace="-", page_size=_VIRTUAL_MODEL_PAGE_SIZE
-        ):
-            vm_snapshot.append(virtual_model)
-            self._emit_heartbeat()
+        try:
+            async for virtual_model in self._models_sdk.inference.virtual_models.list(
+                workspace="-", page_size=_VIRTUAL_MODEL_PAGE_SIZE
+            ):
+                vm_snapshot.append(virtual_model)
+                self._emit_heartbeat()
+        except Exception:
+            logger.warning("Failed to list VirtualModels for provider reconciliation", exc_info=True)
+            return None
         existing_vm_names = {(vm.workspace, vm.name) for vm in vm_snapshot}
         logger.debug("Loaded %d VirtualModel(s) for provider reconciliation", len(vm_snapshot))
         return vm_snapshot, existing_vm_names
@@ -383,7 +397,7 @@ class ModelProviderReconciler:
         provider: ModelProvider,
         provider_id: str,
         now: datetime,
-        existing_vm_names: set[tuple[str, str]],
+        existing_vm_names: set[tuple[str, str]] | None,
     ) -> None:
         """Reconcile a single provider. Extracted for per-provider exception isolation.
 
@@ -992,7 +1006,7 @@ class ModelProviderReconciler:
             self._entity_cache.stage_field_updates(model_workspace, model_name, **updates)
 
     async def _ensure_passthrough_virtual_model(
-        self, workspace: str, model_name: str, existing_vm_names: set[tuple[str, str]]
+        self, workspace: str, model_name: str, existing_vm_names: set[tuple[str, str]] | None
     ) -> None:
         """Auto-create a passthrough VirtualModel for a model entity if one does not exist.
 
@@ -1013,10 +1027,20 @@ class ModelProviderReconciler:
         Args:
             workspace: Workspace of the model entity.
             model_name: Name of the model entity (also used as the VirtualModel name).
-            existing_vm_names: ``(workspace, name)`` of every known VirtualModel.
+            existing_vm_names: ``(workspace, name)`` of every known VirtualModel, or
+                ``None`` when the VirtualModel state could not be read this pass.
         """
+        if existing_vm_names is None:
+            return
+
         if (workspace, model_name) in existing_vm_names:
-            logger.debug("Passthrough VirtualModel %s/%s already exists", workspace, model_name)
+            # The name may belong to a user-managed VirtualModel pointing somewhere
+            # else, so do not claim the passthrough itself exists.
+            logger.debug(
+                "Skipping passthrough VirtualModel for %s/%s: the name is already in use",
+                workspace,
+                model_name,
+            )
             return
 
         try:

--- a/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
@@ -7,7 +7,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from logging import getLogger
-from typing import TypedDict
+from typing import Callable, TypedDict
 
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform._exceptions import APIStatusError, ConflictError, NotFoundError
@@ -15,6 +15,7 @@ from nemo_platform.types.inference import ServedModelMapping
 from nemo_platform.types.inference.model_deployment import ModelDeployment
 from nemo_platform.types.inference.model_deployment_config import ModelDeploymentConfig
 from nemo_platform.types.inference.model_provider import ModelProvider
+from nemo_platform.types.inference.virtual_model import VirtualModel
 from nemo_platform.types.models.model_entity import ModelEntity
 from nmp.common.datetime_utils import ensure_utc
 from nmp.common.entities.constants import NAME_PATTERN
@@ -27,9 +28,13 @@ from nmp.core.models.app import (
 )
 from nmp.core.models.config import ControllerConfig
 from nmp.core.models.controllers.context import ModelContext
+from nmp.core.models.controllers.entity_cache import ModelEntityCache
 from nmp.core.models.schemas import BackendFormat, ModelProviderStatus
 
 logger = getLogger(__name__)
+
+# The VirtualModel list endpoint caps page_size at 200.
+_VIRTUAL_MODEL_PAGE_SIZE = 200
 
 # Use entity store's NAME_PATTERN so we only create/link names the entity store accepts
 _VALID_MODEL_ENTITY_NAME_PATTERN = re.compile(NAME_PATTERN)
@@ -278,15 +283,26 @@ class ModelProviderReconciler:
     Model Entities are created and linked appropriately.
     """
 
-    def __init__(self, models_sdk: AsyncNeMoPlatform, controller_config: ControllerConfig) -> None:
+    def __init__(
+        self,
+        models_sdk: AsyncNeMoPlatform,
+        controller_config: ControllerConfig,
+        entity_cache: ModelEntityCache,
+        emit_heartbeat: Callable[[], None],
+    ) -> None:
         """Initialize the provider reconciler.
 
         Args:
             models_sdk: SDK client for Models API interactions
             controller_config: Models controller configuration (discovery timeout/retry policy)
+            entity_cache: Model Entity reads and staged writes for the current phase
+            emit_heartbeat: Called as each unit of work finishes so a long pass is
+                distinguishable from a stalled one
         """
         self._models_sdk = models_sdk
         self._controller_config = controller_config
+        self._entity_cache = entity_cache
+        self._emit_heartbeat = emit_heartbeat
         self._discovery_sdk = models_sdk.with_options(
             max_retries=controller_config.provider_discovery_max_retries,
         )
@@ -313,6 +329,15 @@ class ModelProviderReconciler:
         """
         now = datetime.now(timezone.utc)
 
+        # Read the VirtualModels once for the whole pass. ``existing_vm_names``
+        # answers "does this one already exist" without a create-and-catch-conflict
+        # per served model, and grows as VirtualModels are created so providers
+        # sharing a workspace do not each try the same name. ``vm_snapshot`` stays
+        # as read: orphan cleanup only ever considers VirtualModels that predate
+        # the pass, and keeping it separate means a VirtualModel created here can
+        # never be mistaken for a deletion candidate.
+        vm_snapshot, existing_vm_names = await self._load_virtual_models()
+
         for ctx in provider_contexts:
             provider = ctx.model_provider
             if provider is None:
@@ -320,17 +345,36 @@ class ModelProviderReconciler:
                 continue
             provider_id = f"{provider.workspace}/{provider.name}"
             try:
-                await self._reconcile_single_provider(ctx, provider, provider_id, now)
+                await self._reconcile_single_provider(ctx, provider, provider_id, now, existing_vm_names)
             except Exception:
                 logger.exception(
                     "Unexpected error reconciling provider",
                     extra={"provider": provider_id},
                 )
+            finally:
+                self._emit_heartbeat()
 
+        # Runs after every provider so the active set reflects the served_models
+        # resolved during this pass rather than the previously persisted values.
         try:
-            await self._cleanup_orphaned_virtual_models(provider_contexts)
+            await self._cleanup_orphaned_virtual_models(provider_contexts, vm_snapshot)
         except Exception:
             logger.exception("Unexpected error cleaning up orphaned autoprovisioned VirtualModels")
+
+    async def _load_virtual_models(self) -> tuple[list[VirtualModel], set[tuple[str, str]]]:
+        """Read every VirtualModel once, returning the list and an existence set.
+
+        The existence set covers all VirtualModels, not just autoprovisioned ones,
+        so a name already taken by a user-managed VirtualModel is left untouched.
+        """
+        vm_snapshot: list[VirtualModel] = []
+        async for virtual_model in self._models_sdk.inference.virtual_models.list(
+            workspace="-", page_size=_VIRTUAL_MODEL_PAGE_SIZE
+        ):
+            vm_snapshot.append(virtual_model)
+        existing_vm_names = {(vm.workspace, vm.name) for vm in vm_snapshot}
+        logger.debug("Loaded %d VirtualModel(s) for provider reconciliation", len(vm_snapshot))
+        return vm_snapshot, existing_vm_names
 
     async def _reconcile_single_provider(
         self,
@@ -338,8 +382,15 @@ class ModelProviderReconciler:
         provider: ModelProvider,
         provider_id: str,
         now: datetime,
+        existing_vm_names: set[tuple[str, str]],
     ) -> None:
-        """Reconcile a single provider. Extracted for per-provider exception isolation."""
+        """Reconcile a single provider. Extracted for per-provider exception isolation.
+
+        Leaving ``ctx.served_models`` as ``None`` on any early return is deliberate:
+        orphan cleanup reads it as "this provider was not resolved this pass" and
+        falls back to the persisted served_models. Setting it to an empty list
+        instead would present every one of the provider's models as inactive.
+        """
         ctx.served_models = None
 
         # LOST providers are permanently failed; skip until user deletes and recreates.
@@ -446,7 +497,8 @@ class ModelProviderReconciler:
             if "&adapters/" in served_model.model_entity_id:
                 continue
             ref = parse_entity_ref(served_model.model_entity_id)
-            await self._ensure_passthrough_virtual_model(ref.workspace, ref.name)
+            await self._ensure_passthrough_virtual_model(ref.workspace, ref.name, existing_vm_names)
+            self._emit_heartbeat()
 
     # -------------------------------------------------------------------------
     # Status machine
@@ -701,6 +753,7 @@ class ModelProviderReconciler:
                 provider_id=provider_id,
                 ctx=ctx,
             )
+            self._emit_heartbeat()
 
     def _generate_external_served_model_mappings(
         self,
@@ -887,27 +940,10 @@ class ModelProviderReconciler:
                 the entity for this specific model_name (since we may be creating entities for
                 multiple discovered models like LoRAs)
         """
-        # Try to get the model entity for this specific model_name (may not exist yet).
-        # This is per-discovered-model, so we can't use the one from context.
-        existing_model_entity = None
-        try:
-            existing_model_entity = await self._models_sdk.models.retrieve(
-                workspace=model_workspace,
-                name=model_name,
-            )
-        except NotFoundError:
-            pass
-        except Exception as e:
-            # Transient API/network errors must not fail the whole controller step (health).
-            # Without a successful retrieve we cannot safely update or create; retry next loop.
-            logger.warning(
-                "Failed to retrieve Model Entity %s/%s during provider reconciliation: %s",
-                model_workspace,
-                model_name,
-                e,
-                exc_info=True,
-            )
-            return
+        # Read through the cache so the entity behind every served model does not
+        # cost a round trip, and so several providers contributing to the same
+        # entity are merged into a single write.
+        existing_model_entity = self._entity_cache.get(model_workspace, model_name)
 
         details = await self._build_artifact_details(
             model_name,
@@ -918,60 +954,55 @@ class ModelProviderReconciler:
             ctx.model_deployment_config,
         )
 
-        try:
-            if existing_model_entity:
-                current_providers = existing_model_entity.model_providers or []
-                update_params: dict[str, object] = {
-                    "name": model_name,
-                    "workspace": model_workspace,
-                }
+        fileset = None
+        if details.fileset_url:
+            fileset = details.fileset_url.removeprefix("hf://").removeprefix("fileset://")
 
-                if provider_id not in current_providers:
-                    update_params["model_providers"] = current_providers + [provider_id]
-                if details.fileset_url and not existing_model_entity.fileset:
-                    update_params["fileset"] = details.fileset_url.removeprefix("hf://").removeprefix("fileset://")
-                if details.api_endpoint and not existing_model_entity.api_endpoint:
-                    update_params["api_endpoint"] = details.api_endpoint
-                # Treat None as missing here so legacy autodiscovered entities get
-                # backfilled. User corrections should set a concrete enum value.
-                if not _has_backend_format(existing_model_entity):
-                    update_params["backend_format"] = _infer_backend_format(model_name)
-
-                if len(update_params) == 2:
-                    logger.debug(
-                        f"Provider {provider_id} already linked to Model Entity {model_workspace}/{model_name}"
-                    )
-                    return
-
-                await self._models_sdk.models.update(**update_params)
-                logger.debug(f"Added provider {provider_id} to existing Model Entity {model_workspace}/{model_name}")
-                return
-
+        if existing_model_entity is None:
             logger.debug(f"Creating Model Entity {model_workspace}/{model_name} for provider {provider_id}")
-            create_kwargs: dict = {
-                "name": model_name,
-                "description": f"Auto-discovered model from provider {provider_id}",
-                "model_providers": [provider_id],
-                "backend_format": _infer_backend_format(model_name),
-            }
+            self._entity_cache.stage_create(
+                model_workspace,
+                model_name,
+                description=f"Auto-discovered model from provider {provider_id}",
+                backend_format=_infer_backend_format(model_name),
+            )
+            self._entity_cache.stage_provider_link(model_workspace, model_name, provider_id)
+            self._entity_cache.stage_field_updates(
+                model_workspace,
+                model_name,
+                fileset=fileset,
+                api_endpoint=details.api_endpoint,
+            )
+            return
 
-            if details.fileset_url:
-                create_kwargs["fileset"] = details.fileset_url.removeprefix("hf://").removeprefix("fileset://")
-            if details.api_endpoint:
-                create_kwargs["api_endpoint"] = details.api_endpoint
+        self._entity_cache.stage_provider_link(model_workspace, model_name, provider_id)
 
-            await self._models_sdk.models.create(workspace=model_workspace, **create_kwargs)
-            logger.debug(f"Created Model Entity {model_workspace}/{model_name} linked to provider {provider_id}")
-        except Exception as e:
-            logger.error(f"Failed to ensure Model Entity {model_workspace}/{model_name}: {e}")
+        # Only fill in what the entity is missing, so a value a user corrected is
+        # never overwritten. ``backend_format`` treats None as missing so entities
+        # registered before it existed get backfilled.
+        updates: dict = {}
+        if fileset and not existing_model_entity.fileset:
+            updates["fileset"] = fileset
+        if details.api_endpoint and not existing_model_entity.api_endpoint:
+            updates["api_endpoint"] = details.api_endpoint
+        if not _has_backend_format(existing_model_entity):
+            updates["backend_format"] = _infer_backend_format(model_name)
+        if updates:
+            self._entity_cache.stage_field_updates(model_workspace, model_name, **updates)
 
-    async def _ensure_passthrough_virtual_model(self, workspace: str, model_name: str) -> None:
+    async def _ensure_passthrough_virtual_model(
+        self, workspace: str, model_name: str, existing_vm_names: set[tuple[str, str]]
+    ) -> None:
         """Auto-create a passthrough VirtualModel for a model entity if one does not exist.
 
         A passthrough VirtualModel has an empty middleware pipeline and sets
         ``default_model_entity`` to ``"{workspace}/{model_name}"``, so inference
         requests addressed to ``"workspace/model_name"`` resolve directly to
         the underlying model entity without any plugin intervention.
+
+        ``existing_vm_names`` short-circuits names that are already taken, and is
+        updated on creation so the same name is not attempted twice in one pass.
+        A name held by a user-managed VirtualModel is left as it is.
 
         This is idempotent: a :class:`~nemo_platform.ConflictError` (409) means
         the VirtualModel already exists and is silently ignored.  Any other
@@ -981,7 +1012,12 @@ class ModelProviderReconciler:
         Args:
             workspace: Workspace of the model entity.
             model_name: Name of the model entity (also used as the VirtualModel name).
+            existing_vm_names: ``(workspace, name)`` of every known VirtualModel.
         """
+        if (workspace, model_name) in existing_vm_names:
+            logger.debug("Passthrough VirtualModel %s/%s already exists", workspace, model_name)
+            return
+
         try:
             await self._models_sdk.inference.virtual_models.create(
                 workspace=workspace,
@@ -1003,9 +1039,20 @@ class ModelProviderReconciler:
                 model_name,
                 exc_info=True,
             )
+        finally:
+            # Record the name either way: on success it now exists, and on failure
+            # retrying it within the same pass would fail the same way.
+            existing_vm_names.add((workspace, model_name))
 
-    async def _cleanup_orphaned_virtual_models(self, provider_contexts: list[ModelContext]) -> None:
-        """Delete autoprovisioned VirtualModels whose backing entities are no longer served."""
+    async def _cleanup_orphaned_virtual_models(
+        self, provider_contexts: list[ModelContext], vm_snapshot: list[VirtualModel]
+    ) -> None:
+        """Delete autoprovisioned VirtualModels whose backing entities are no longer served.
+
+        Only VirtualModels present when the pass began are considered, so anything
+        created during the pass -- by this reconciler or anyone else -- is evaluated
+        on a later pass rather than raced against.
+        """
         active_model_entity_ids: set[str] = set()
         for ctx in provider_contexts:
             provider = ctx.model_provider
@@ -1019,8 +1066,8 @@ class ModelProviderReconciler:
                 if model_entity_id:
                     active_model_entity_ids.add(model_entity_id)
 
-        virtual_models = self._models_sdk.inference.virtual_models.list(workspace="-", page_size=200)
-        async for virtual_model in virtual_models:
+        for virtual_model in vm_snapshot:
+            self._emit_heartbeat()
             if not virtual_model.autoprovisioned:
                 continue
 
@@ -1037,6 +1084,13 @@ class ModelProviderReconciler:
                 )
                 logger.info(
                     "Deleted orphaned autoprovisioned VirtualModel %s/%s",
+                    virtual_model.workspace,
+                    virtual_model.name,
+                )
+            except NotFoundError:
+                # Already gone; the snapshot predates the deletion.
+                logger.debug(
+                    "Orphaned autoprovisioned VirtualModel %s/%s no longer exists",
                     virtual_model.workspace,
                     virtual_model.name,
                 )

--- a/services/core/models/src/nmp/core/models/sidecars/adapters/main.py
+++ b/services/core/models/src/nmp/core/models/sidecars/adapters/main.py
@@ -127,20 +127,24 @@ class AdaptersController(HeartbeatMixin, Controller):
             self.emit_heartbeat()
 
             for name in set(os.listdir(self.nim_peft_source)) - dirs_to_keep:
-                # Staging temp dirs (".{dir}.tmp") were never loaded into vLLM;
-                # just reap them.
-                if name.startswith("."):
-                    shutil.rmtree(f"{self.nim_peft_source}/{name}")
-                    continue
-                # Unload from vLLM before deleting on disk so a removed/disabled
-                # adapter stops being served (no-op for NIM). Only delete the
-                # directory once the unload is confirmed (or vLLM has no endpoint):
-                # if vLLM is currently unreachable, keep the dir so the unload is
-                # retried next cycle rather than orphaning a still-loaded adapter
-                # in vLLM until it restarts (the dir is the only state driving GC).
-                if self._unload_vllm_adapter(name):
-                    shutil.rmtree(f"{self.nim_peft_source}/{name}")
-                self.emit_heartbeat()
+                try:
+                    # Staging temp dirs (".{dir}.tmp") were never loaded into vLLM;
+                    # just reap them.
+                    if name.startswith("."):
+                        shutil.rmtree(f"{self.nim_peft_source}/{name}")
+                        continue
+                    # Unload from vLLM before deleting on disk so a removed/disabled
+                    # adapter stops being served (no-op for NIM). Only delete the
+                    # directory once the unload is confirmed (or vLLM has no endpoint):
+                    # if vLLM is currently unreachable, keep the dir so the unload is
+                    # retried next cycle rather than orphaning a still-loaded adapter
+                    # in vLLM until it restarts (the dir is the only state driving GC).
+                    if self._unload_vllm_adapter(name):
+                        shutil.rmtree(f"{self.nim_peft_source}/{name}")
+                finally:
+                    # Reaping any directory is progress, including the ones the
+                    # early continue above handles.
+                    self.emit_heartbeat()
 
         except Exception:
             logger.exception(f"Failed to fetch {self.workspace}/{self.model_name}'s model_entity")

--- a/services/core/models/src/nmp/core/models/sidecars/adapters/main.py
+++ b/services/core/models/src/nmp/core/models/sidecars/adapters/main.py
@@ -17,7 +17,14 @@ from nemo_platform import NeMoPlatform, NotFoundError
 from nemo_platform.types.models import ModelEntity
 from nemo_platform.types.models.adapter import Adapter
 from nmp.common.config import get_platform_config
-from nmp.common.controller import Controller, ControllerManager, Loop, TimedLoopWaiter, TrackLastExecutionTime
+from nmp.common.controller import (
+    Controller,
+    ControllerManager,
+    HeartbeatMixin,
+    Loop,
+    TimedLoopWaiter,
+    TrackLastExecutionTime,
+)
 from nmp.common.sdk_factory import get_platform_sdk
 
 stop_signal = threading.Event()
@@ -30,7 +37,7 @@ logger = logging.getLogger(__name__)
 ADAPTER_META_FILENAME = "nmp_adapter_meta.json"
 
 
-class AdaptersController(Controller):
+class AdaptersController(HeartbeatMixin, Controller):
     def __init__(self, stop_signal: threading.Event | None = None):
         self.nim_peft_source = os.getenv("NIM_PEFT_SOURCE", "")
         if not self.nim_peft_source:
@@ -115,7 +122,9 @@ class AdaptersController(Controller):
         try:
             dirs_to_keep: set[str] = set()
             self._update_lora_adapters(dirs_to_keep)
+            self.emit_heartbeat()
             self._update_prompt_tuned_models(dirs_to_keep)
+            self.emit_heartbeat()
 
             for name in set(os.listdir(self.nim_peft_source)) - dirs_to_keep:
                 # Staging temp dirs (".{dir}.tmp") were never loaded into vLLM;
@@ -131,6 +140,7 @@ class AdaptersController(Controller):
                 # in vLLM until it restarts (the dir is the only state driving GC).
                 if self._unload_vllm_adapter(name):
                     shutil.rmtree(f"{self.nim_peft_source}/{name}")
+                self.emit_heartbeat()
 
         except Exception:
             logger.exception(f"Failed to fetch {self.workspace}/{self.model_name}'s model_entity")
@@ -156,6 +166,7 @@ class AdaptersController(Controller):
                     os.makedirs(prompt_tuned_model_dir, exist_ok=True)
                 with open(f"{prompt_tuned_model_dir}/config.json", "w") as f:
                     f.write(model_entity.prompt.model_dump_json())
+            self.emit_heartbeat()
 
     def _rewrite_adapter_base_model(self, adapter_dir: str) -> bool:
         """Rewrite ``adapter_config.json``'s ``base_model_name_or_path`` to the
@@ -432,6 +443,7 @@ class AdaptersController(Controller):
             # is (idempotently) reloaded so it survives a vLLM restart without flapping.
             if os.path.isdir(adapter_dir):
                 self._ensure_vllm_adapter_loaded(dir_name, adapter_dir, reload=(published and dir_existed))
+            self.emit_heartbeat()
 
 
 def get_health_status() -> dict:

--- a/services/core/models/tests/unit/controllers/conftest.py
+++ b/services/core/models/tests/unit/controllers/conftest.py
@@ -198,3 +198,47 @@ def assert_helpers():
             assert_helpers.assert_controller_healthy(controller)
     """
     return AssertHelpers
+
+
+class AsyncPaginator:
+    """Async iterator standing in for the SDK's paginated list() responses."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+_ENTITY_FIELDS = ("model_providers", "fileset", "api_endpoint", "backend_format")
+
+
+def make_entity(workspace: str, name: str, **attrs):
+    """Model Entity stand-in addressable by ModelEntityCache.
+
+    ``model_copy`` mirrors the real model in carrying every field across, which the
+    cache relies on when overlaying staged changes onto a snapshot.
+    """
+    fields = {field: attrs.get(field) for field in _ENTITY_FIELDS}
+    entity = MagicMock()
+    entity.workspace = workspace
+    entity.name = name
+    for field, value in fields.items():
+        setattr(entity, field, value)
+
+    def _copy(update):
+        return make_entity(workspace, name, **{**fields, **update})
+
+    entity.model_copy = MagicMock(side_effect=_copy)
+    return entity
+
+
+async def seed_entity_cache(mock_models_sdk, entity_cache, entities=()):
+    """Load the cache from the mock SDK so lookups resolve to ``entities``."""
+    mock_models_sdk.models.list = MagicMock(return_value=AsyncPaginator(list(entities)))
+    await entity_cache.refresh()

--- a/services/core/models/tests/unit/controllers/test_deployment_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_deployment_reconciler.py
@@ -72,7 +72,7 @@ def controller_config():
 @pytest.fixture
 def entity_cache(mock_models_sdk):
     """Model Entity cache backed by the mock SDK."""
-    return ModelEntityCache(models_sdk=mock_models_sdk)
+    return ModelEntityCache(models_sdk=mock_models_sdk, emit_heartbeat=lambda: None)
 
 
 @pytest.fixture
@@ -1751,7 +1751,7 @@ def gc_reconciler(mock_models_sdk, mock_backend_registry):
         models_sdk=mock_models_sdk,
         backend_registry=mock_backend_registry,
         controller_config=config,
-        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk, emit_heartbeat=lambda: None),
         emit_heartbeat=lambda: None,
     )
     mock_backend = MagicMock()
@@ -1930,7 +1930,7 @@ async def test_gc_custom_ttl_respected(mock_models_sdk, mock_backend_registry):
         models_sdk=mock_models_sdk,
         backend_registry=mock_backend_registry,
         controller_config=config,
-        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk, emit_heartbeat=lambda: None),
         emit_heartbeat=lambda: None,
     )
 
@@ -2019,7 +2019,7 @@ async def test_gc_ttl_boundary_parametrized(mock_models_sdk, mock_backend_regist
         models_sdk=mock_models_sdk,
         backend_registry=mock_backend_registry,
         controller_config=config,
-        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk, emit_heartbeat=lambda: None),
         emit_heartbeat=lambda: None,
     )
 

--- a/services/core/models/tests/unit/controllers/test_deployment_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_deployment_reconciler.py
@@ -18,35 +18,14 @@ from nmp.core.models.controllers.deployment_reconciler import ModelDeploymentRec
 from nmp.core.models.controllers.entity_cache import ModelEntityCache
 from nmp.core.models.schemas import ModelDeployment
 
+from .conftest import AsyncPaginator, make_entity, seed_entity_cache
 
-class _AsyncPaginator:
-    """Tiny async iterator for SDK list() calls in reconciler tests."""
-
-    def __init__(self, items):
-        self._items = list(items)
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if not self._items:
-            raise StopAsyncIteration
-        return self._items.pop(0)
-
-
-async def seed_entity_cache(mock_models_sdk, entity_cache, entities=()):
-    """Load the cache from the mock SDK so lookups resolve to ``entities``."""
-    mock_models_sdk.models.list = MagicMock(return_value=_AsyncPaginator(list(entities)))
-    await entity_cache.refresh()
+_AsyncPaginator = AsyncPaginator
 
 
 def _entity(workspace, name, model_providers):
     """Model Entity stand-in addressable by the cache."""
-    entity = MagicMock()
-    entity.workspace = workspace
-    entity.name = name
-    entity.model_providers = model_providers
-    return entity
+    return make_entity(workspace, name, model_providers=model_providers)
 
 
 @pytest.fixture

--- a/services/core/models/tests/unit/controllers/test_deployment_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_deployment_reconciler.py
@@ -15,13 +15,46 @@ from nmp.core.models.controllers.backends.backends import DeploymentStatusUpdate
 from nmp.core.models.controllers.backends.registry import BackendRegistry
 from nmp.core.models.controllers.context import ModelContext
 from nmp.core.models.controllers.deployment_reconciler import ModelDeploymentReconciler
+from nmp.core.models.controllers.entity_cache import ModelEntityCache
 from nmp.core.models.schemas import ModelDeployment
+
+
+class _AsyncPaginator:
+    """Tiny async iterator for SDK list() calls in reconciler tests."""
+
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+async def seed_entity_cache(mock_models_sdk, entity_cache, entities=()):
+    """Load the cache from the mock SDK so lookups resolve to ``entities``."""
+    mock_models_sdk.models.list = MagicMock(return_value=_AsyncPaginator(list(entities)))
+    await entity_cache.refresh()
+
+
+def _entity(workspace, name, model_providers):
+    """Model Entity stand-in addressable by the cache."""
+    entity = MagicMock()
+    entity.workspace = workspace
+    entity.name = name
+    entity.model_providers = model_providers
+    return entity
 
 
 @pytest.fixture
 def mock_models_sdk():
     """Create a mock AsyncNeMoPlatform SDK."""
-    return MagicMock(spec=AsyncNeMoPlatform)
+    sdk = MagicMock(spec=AsyncNeMoPlatform)
+    sdk.models.list = MagicMock(return_value=_AsyncPaginator([]))
+    return sdk
 
 
 @pytest.fixture
@@ -37,12 +70,26 @@ def controller_config():
 
 
 @pytest.fixture
-def reconciler(mock_models_sdk, mock_backend_registry, controller_config):
+def entity_cache(mock_models_sdk):
+    """Model Entity cache backed by the mock SDK."""
+    return ModelEntityCache(models_sdk=mock_models_sdk)
+
+
+@pytest.fixture
+def heartbeat_calls():
+    """Collects heartbeat emissions so tests can assert progress was reported."""
+    return []
+
+
+@pytest.fixture
+def reconciler(mock_models_sdk, mock_backend_registry, controller_config, entity_cache, heartbeat_calls):
     """Create a ModelDeploymentReconciler instance."""
     return ModelDeploymentReconciler(
         models_sdk=mock_models_sdk,
         backend_registry=mock_backend_registry,
         controller_config=controller_config,
+        entity_cache=entity_cache,
+        emit_heartbeat=lambda: heartbeat_calls.append(1),
     )
 
 
@@ -916,34 +963,24 @@ async def test_cleanup_model_entities_removes_provider_from_entities(reconciler)
         MagicMock(model_entity_id="test-ns/model-2"),
     ]
 
-    # Mock model entities
-    mock_model_1 = MagicMock()
-    mock_model_1.model_providers = ["test-ns/provider-1", "other-ns/other-provider"]
-
-    mock_model_2 = MagicMock()
-    mock_model_2.model_providers = ["test-ns/provider-1"]
-
     reconciler._models_sdk.inference.providers.retrieve = AsyncMock(return_value=mock_provider)
-    reconciler._models_sdk.models.retrieve = AsyncMock(side_effect=[mock_model_1, mock_model_2])
+    await seed_entity_cache(
+        reconciler._models_sdk,
+        reconciler._entity_cache,
+        [
+            _entity("test-ns", "model-1", ["test-ns/provider-1", "other-ns/other-provider"]),
+            _entity("test-ns", "model-2", ["test-ns/provider-1"]),
+        ],
+    )
     reconciler._models_sdk.models.update = AsyncMock()
 
     # Call cleanup
     await reconciler._cleanup_model_entities_for_provider("test-ns", "provider-1", "test-ns/provider-1")
+    await reconciler._entity_cache.flush()
 
     # Verify provider was retrieved
     reconciler._models_sdk.inference.providers.retrieve.assert_called_once_with(
         name="provider-1",
-        workspace="test-ns",
-    )
-
-    # Verify model entities were retrieved
-    assert reconciler._models_sdk.models.retrieve.call_count == 2
-    reconciler._models_sdk.models.retrieve.assert_any_call(
-        name="model-1",
-        workspace="test-ns",
-    )
-    reconciler._models_sdk.models.retrieve.assert_any_call(
-        name="model-2",
         workspace="test-ns",
     )
 
@@ -969,17 +1006,16 @@ async def test_cleanup_model_entities_no_served_models(reconciler):
     mock_provider.served_models = []
 
     reconciler._models_sdk.inference.providers.retrieve = AsyncMock(return_value=mock_provider)
-    reconciler._models_sdk.models.retrieve = AsyncMock()
     reconciler._models_sdk.models.update = AsyncMock()
 
     # Call cleanup
     await reconciler._cleanup_model_entities_for_provider("test-ns", "provider-1", "test-ns/provider-1")
+    await reconciler._entity_cache.flush()
 
     # Verify provider was retrieved
     reconciler._models_sdk.inference.providers.retrieve.assert_called_once()
 
     # Verify no model entity operations were performed
-    reconciler._models_sdk.models.retrieve.assert_not_called()
     reconciler._models_sdk.models.update.assert_not_called()
 
 
@@ -989,14 +1025,13 @@ async def test_cleanup_model_entities_provider_not_found(reconciler):
     reconciler._models_sdk.inference.providers.retrieve = AsyncMock(
         side_effect=NotFoundError("Provider not found", response=MagicMock(), body=None)
     )
-    reconciler._models_sdk.models.retrieve = AsyncMock()
     reconciler._models_sdk.models.update = AsyncMock()
 
     # Call cleanup - should not raise
     await reconciler._cleanup_model_entities_for_provider("test-ns", "provider-1", "test-ns/provider-1")
+    await reconciler._entity_cache.flush()
 
     # Verify no model entity operations were performed
-    reconciler._models_sdk.models.retrieve.assert_not_called()
     reconciler._models_sdk.models.update.assert_not_called()
 
 
@@ -1009,27 +1044,25 @@ async def test_cleanup_model_entities_provider_not_in_list(reconciler):
         MagicMock(model_entity_id="test-ns/model-1"),
     ]
 
-    # Mock model entity without this provider in its list
-    mock_model = MagicMock()
-    mock_model.model_providers = ["other-ns/other-provider"]
-
     reconciler._models_sdk.inference.providers.retrieve = AsyncMock(return_value=mock_provider)
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=mock_model)
+    await seed_entity_cache(
+        reconciler._models_sdk,
+        reconciler._entity_cache,
+        [_entity("test-ns", "model-1", ["other-ns/other-provider"])],
+    )
     reconciler._models_sdk.models.update = AsyncMock()
 
     # Call cleanup
     await reconciler._cleanup_model_entities_for_provider("test-ns", "provider-1", "test-ns/provider-1")
-
-    # Verify model entity was retrieved
-    reconciler._models_sdk.models.retrieve.assert_called_once()
+    await reconciler._entity_cache.flush()
 
     # Verify model entity was NOT updated (provider wasn't in the list)
     reconciler._models_sdk.models.update.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_cleanup_model_entities_handles_model_retrieval_failure(reconciler):
-    """Test that cleanup continues processing other models when one retrieval fails."""
+async def test_cleanup_model_entities_skips_missing_entity_and_continues(reconciler):
+    """A served model with no Model Entity is skipped without affecting the others."""
     # Mock provider with multiple served_models
     mock_provider = MagicMock()
     mock_provider.served_models = [
@@ -1037,26 +1070,23 @@ async def test_cleanup_model_entities_handles_model_retrieval_failure(reconciler
         MagicMock(model_entity_id="test-ns/model-2"),
     ]
 
-    # First retrieval fails, second succeeds
-    mock_model_2 = MagicMock()
-    mock_model_2.model_providers = ["test-ns/provider-1"]
-
     reconciler._models_sdk.inference.providers.retrieve = AsyncMock(return_value=mock_provider)
-    reconciler._models_sdk.models.retrieve = AsyncMock(
-        side_effect=[NotFoundError("Model not found", response=MagicMock(), body=None), mock_model_2]
+    # Only model-2 exists.
+    await seed_entity_cache(
+        reconciler._models_sdk,
+        reconciler._entity_cache,
+        [_entity("test-ns", "model-2", ["test-ns/provider-1"])],
     )
     reconciler._models_sdk.models.update = AsyncMock()
 
     # Call cleanup - should not raise
     await reconciler._cleanup_model_entities_for_provider("test-ns", "provider-1", "test-ns/provider-1")
+    await reconciler._entity_cache.flush()
 
-    # Verify both models were attempted to be retrieved
-    assert reconciler._models_sdk.models.retrieve.call_count == 2
-
-    # Verify only the second model was updated
+    # Verify only the existing model was updated
     reconciler._models_sdk.models.update.assert_called_once_with(
-        name="model-2",
         workspace="test-ns",
+        name="model-2",
         model_providers=[],
     )
 
@@ -1071,20 +1101,21 @@ async def test_cleanup_model_entities_handles_model_update_failure(reconciler):
         MagicMock(model_entity_id="test-ns/model-2"),
     ]
 
-    # Mock model entities
-    mock_model_1 = MagicMock()
-    mock_model_1.model_providers = ["test-ns/provider-1"]
-
-    mock_model_2 = MagicMock()
-    mock_model_2.model_providers = ["test-ns/provider-1"]
-
     reconciler._models_sdk.inference.providers.retrieve = AsyncMock(return_value=mock_provider)
-    reconciler._models_sdk.models.retrieve = AsyncMock(side_effect=[mock_model_1, mock_model_2])
+    await seed_entity_cache(
+        reconciler._models_sdk,
+        reconciler._entity_cache,
+        [
+            _entity("test-ns", "model-1", ["test-ns/provider-1"]),
+            _entity("test-ns", "model-2", ["test-ns/provider-1"]),
+        ],
+    )
     # First update fails, second succeeds
     reconciler._models_sdk.models.update = AsyncMock(side_effect=[Exception("Update failed"), None])
 
     # Call cleanup - should not raise
     await reconciler._cleanup_model_entities_for_provider("test-ns", "provider-1", "test-ns/provider-1")
+    await reconciler._entity_cache.flush()
 
     # Verify both models were attempted to be updated
     assert reconciler._models_sdk.models.update.call_count == 2
@@ -1099,19 +1130,17 @@ async def test_cleanup_model_entities_with_null_model_providers(reconciler):
         MagicMock(model_entity_id="test-ns/model-1"),
     ]
 
-    # Mock model entity with None model_providers
-    mock_model = MagicMock()
-    mock_model.model_providers = None
-
     reconciler._models_sdk.inference.providers.retrieve = AsyncMock(return_value=mock_provider)
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=mock_model)
+    await seed_entity_cache(
+        reconciler._models_sdk,
+        reconciler._entity_cache,
+        [_entity("test-ns", "model-1", None)],
+    )
     reconciler._models_sdk.models.update = AsyncMock()
 
     # Call cleanup - should not raise
     await reconciler._cleanup_model_entities_for_provider("test-ns", "provider-1", "test-ns/provider-1")
-
-    # Verify model entity was retrieved
-    reconciler._models_sdk.models.retrieve.assert_called_once()
+    await reconciler._entity_cache.flush()
 
     # Verify model entity was NOT updated (provider wasn't in the empty/null list)
     reconciler._models_sdk.models.update.assert_not_called()
@@ -1722,6 +1751,8 @@ def gc_reconciler(mock_models_sdk, mock_backend_registry):
         models_sdk=mock_models_sdk,
         backend_registry=mock_backend_registry,
         controller_config=config,
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        emit_heartbeat=lambda: None,
     )
     mock_backend = MagicMock()
     mock_backend.delete_model_deployment = AsyncMock(
@@ -1899,6 +1930,8 @@ async def test_gc_custom_ttl_respected(mock_models_sdk, mock_backend_registry):
         models_sdk=mock_models_sdk,
         backend_registry=mock_backend_registry,
         controller_config=config,
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        emit_heartbeat=lambda: None,
     )
 
     mock_backend = MagicMock()
@@ -1986,6 +2019,8 @@ async def test_gc_ttl_boundary_parametrized(mock_models_sdk, mock_backend_regist
         models_sdk=mock_models_sdk,
         backend_registry=mock_backend_registry,
         controller_config=config,
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        emit_heartbeat=lambda: None,
     )
 
     mock_backend = MagicMock()

--- a/services/core/models/tests/unit/controllers/test_entity_cache.py
+++ b/services/core/models/tests/unit/controllers/test_entity_cache.py
@@ -10,36 +10,17 @@ from nemo_platform import AsyncNeMoPlatform
 from nemo_platform._exceptions import ConflictError, NotFoundError
 from nmp.core.models.controllers.entity_cache import ModelEntityCache, UnflushedMutationsError
 
-
-class _AsyncPaginator:
-    def __init__(self, items):
-        self._items = list(items)
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if not self._items:
-            raise StopAsyncIteration
-        return self._items.pop(0)
+from .conftest import AsyncPaginator, make_entity, seed_entity_cache
 
 
 def _entity(workspace="ws", name="model", model_providers=None, **attrs):
-    entity = MagicMock()
-    entity.workspace = workspace
-    entity.name = name
-    entity.model_providers = model_providers
-    entity.fileset = attrs.get("fileset")
-    entity.api_endpoint = attrs.get("api_endpoint")
-    entity.backend_format = attrs.get("backend_format")
-    entity.model_copy = MagicMock(side_effect=lambda update: _entity(workspace, name, update.get("model_providers")))
-    return entity
+    return make_entity(workspace, name, model_providers=model_providers, **attrs)
 
 
 @pytest.fixture
 def mock_models_sdk():
     sdk = MagicMock(spec=AsyncNeMoPlatform)
-    sdk.models.list = MagicMock(return_value=_AsyncPaginator([]))
+    sdk.models.list = MagicMock(return_value=AsyncPaginator([]))
     sdk.models.create = AsyncMock(return_value=None)
     sdk.models.update = AsyncMock(return_value=None)
     sdk.models.retrieve = AsyncMock()
@@ -58,8 +39,7 @@ def cache(mock_models_sdk, heartbeat_calls):
 
 
 async def _load(mock_models_sdk, cache, entities=()):
-    mock_models_sdk.models.list = MagicMock(return_value=_AsyncPaginator(list(entities)))
-    await cache.refresh()
+    await seed_entity_cache(mock_models_sdk, cache, entities)
 
 
 @pytest.mark.asyncio
@@ -197,6 +177,73 @@ async def test_one_failing_entity_does_not_stop_the_others(mock_models_sdk, cach
 
 
 @pytest.mark.asyncio
+async def test_failed_write_is_kept_for_retry_and_succeeds_later(mock_models_sdk, cache):
+    """A write that fails must not be lost.
+
+    Some staged changes cannot be recomputed by a later pass -- unlinking a provider
+    that is being deleted is derived from that provider -- so a dropped failure
+    would leave the entity permanently inconsistent.
+    """
+    await _load(mock_models_sdk, cache, [_entity("ws", "m1", ["ws/p1"]), _entity("ws", "m2", ["ws/p1"])])
+    mock_models_sdk.models.update = AsyncMock(side_effect=[Exception("boom"), None])
+
+    cache.stage_provider_unlink("ws", "m1", "ws/p1")
+    cache.stage_provider_unlink("ws", "m2", "ws/p1")
+    await cache.flush()
+
+    # The successful entity is done; the failed one is still staged.
+    assert cache.get("ws", "m1").model_providers == []
+    assert ("ws", "m1") in cache._pending
+    assert ("ws", "m2") not in cache._pending
+
+    # A later flush retries it, and this time it lands.
+    mock_models_sdk.models.update = AsyncMock(return_value=None)
+    await cache.flush()
+
+    mock_models_sdk.models.update.assert_awaited_once_with(workspace="ws", name="m1", model_providers=[])
+    assert cache._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_refresh_allows_retained_failures_but_still_rejects_unflushed_work(mock_models_sdk, cache):
+    """Refresh distinguishes "flushed and failed" from "staged and forgotten"."""
+    await _load(mock_models_sdk, cache, [_entity("ws", "m1", ["ws/p1"])])
+    mock_models_sdk.models.update = AsyncMock(side_effect=Exception("boom"))
+
+    cache.stage_provider_unlink("ws", "m1", "ws/p1")
+    await cache.flush()
+    assert ("ws", "m1") in cache._pending
+
+    # A retained failure does not block the next phase from re-reading.
+    await _load(mock_models_sdk, cache, [_entity("ws", "m1", ["ws/p1"])])
+
+    # Work that no flush has attempted still does.
+    cache.stage_provider_link("ws", "m2", "ws/p2")
+    with pytest.raises(UnflushedMutationsError):
+        await cache.refresh()
+
+
+@pytest.mark.asyncio
+async def test_retained_failure_replays_against_a_newer_snapshot(mock_models_sdk, cache):
+    """Staged changes are differences, so replaying them after a refresh stays correct."""
+    await _load(mock_models_sdk, cache, [_entity("ws", "m1", ["ws/p1", "ws/p2"])])
+    mock_models_sdk.models.update = AsyncMock(side_effect=Exception("boom"))
+
+    cache.stage_provider_unlink("ws", "m1", "ws/p1")
+    await cache.flush()
+
+    # Snapshot moves on: another writer added a third provider meanwhile.
+    await _load(mock_models_sdk, cache, [_entity("ws", "m1", ["ws/p1", "ws/p2", "ws/p3"])])
+    mock_models_sdk.models.update = AsyncMock(return_value=None)
+    await cache.flush()
+
+    # The unlink applies to the newer state rather than reinstating the old list.
+    mock_models_sdk.models.update.assert_awaited_once_with(
+        workspace="ws", name="m1", model_providers=["ws/p2", "ws/p3"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_flush_clears_staged_changes(mock_models_sdk, cache):
     await _load(mock_models_sdk, cache, [_entity("ws", "model", [])])
 
@@ -252,7 +299,7 @@ async def test_refresh_after_flush_does_not_reapply_earlier_state(mock_models_sd
     store = {("ws", "model"): _entity("ws", "model", ["ws/p1"])}
 
     def _list(**_kwargs):
-        return _AsyncPaginator(list(store.values()))
+        return AsyncPaginator(list(store.values()))
 
     async def _update(*, workspace, name, **params):
         current = store[(workspace, name)]
@@ -311,3 +358,27 @@ async def test_flush_reports_progress_even_when_an_entity_write_fails(mock_model
     await cache.flush()
 
     assert len(heartbeat_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_conflict_adoption_does_not_overwrite_the_existing_entity_attributes(mock_models_sdk, cache):
+    """Adopting a concurrently-created entity leaves its own attributes alone.
+
+    Attributes supplied for creation describe an entity we expected to create. When
+    another writer got there first, theirs win; the owning reconciler re-evaluates
+    what is still missing on a later pass.
+    """
+    await _load(mock_models_sdk, cache)
+    mock_models_sdk.models.create = AsyncMock(side_effect=ConflictError("exists", response=MagicMock(), body=None))
+    mock_models_sdk.models.retrieve = AsyncMock(
+        return_value=_entity("ws", "model", ["ws/other"], backend_format="ANTHROPIC_MESSAGES")
+    )
+
+    cache.stage_create("ws", "model", description="ours", backend_format="OPENAI_CHAT")
+    cache.stage_provider_link("ws", "model", "ws/p1")
+    await cache.flush()
+
+    # Only the provider link is written; description/backend_format are not forced.
+    mock_models_sdk.models.update.assert_awaited_once_with(
+        workspace="ws", name="model", model_providers=["ws/other", "ws/p1"]
+    )

--- a/services/core/models/tests/unit/controllers/test_entity_cache.py
+++ b/services/core/models/tests/unit/controllers/test_entity_cache.py
@@ -1,0 +1,267 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ModelEntityCache."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform._exceptions import ConflictError, NotFoundError
+from nmp.core.models.controllers.entity_cache import ModelEntityCache, UnflushedMutationsError
+
+
+class _AsyncPaginator:
+    def __init__(self, items):
+        self._items = list(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+
+def _entity(workspace="ws", name="model", model_providers=None, **attrs):
+    entity = MagicMock()
+    entity.workspace = workspace
+    entity.name = name
+    entity.model_providers = model_providers
+    entity.fileset = attrs.get("fileset")
+    entity.api_endpoint = attrs.get("api_endpoint")
+    entity.backend_format = attrs.get("backend_format")
+    entity.model_copy = MagicMock(side_effect=lambda update: _entity(workspace, name, update.get("model_providers")))
+    return entity
+
+
+@pytest.fixture
+def mock_models_sdk():
+    sdk = MagicMock(spec=AsyncNeMoPlatform)
+    sdk.models.list = MagicMock(return_value=_AsyncPaginator([]))
+    sdk.models.create = AsyncMock(return_value=None)
+    sdk.models.update = AsyncMock(return_value=None)
+    sdk.models.retrieve = AsyncMock()
+    return sdk
+
+
+@pytest.fixture
+def cache(mock_models_sdk):
+    return ModelEntityCache(models_sdk=mock_models_sdk)
+
+
+async def _load(mock_models_sdk, cache, entities=()):
+    mock_models_sdk.models.list = MagicMock(return_value=_AsyncPaginator(list(entities)))
+    await cache.refresh()
+
+
+@pytest.mark.asyncio
+async def test_refresh_loads_entities_keyed_by_workspace_and_name(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache, [_entity("ws-a", "m1"), _entity("ws-b", "m1")])
+
+    assert cache.loaded
+    assert cache.get("ws-a", "m1") is not None
+    assert cache.get("ws-b", "m1") is not None
+    assert cache.get("ws-c", "m1") is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_rejects_unflushed_mutations(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache)
+    cache.stage_provider_link("ws", "model", "ws/p1")
+
+    with pytest.raises(UnflushedMutationsError):
+        await cache.refresh()
+
+
+@pytest.mark.asyncio
+async def test_get_reflects_staged_provider_link_within_a_phase(mock_models_sdk, cache):
+    """A read after a stage in the same phase must observe the staged change."""
+    await _load(mock_models_sdk, cache, [_entity("ws", "model", ["ws/p1"])])
+
+    cache.stage_provider_link("ws", "model", "ws/p2")
+
+    assert cache.get("ws", "model").model_providers == ["ws/p1", "ws/p2"]
+
+
+@pytest.mark.asyncio
+async def test_get_reflects_staged_provider_unlink_within_a_phase(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache, [_entity("ws", "model", ["ws/p1", "ws/p2"])])
+
+    cache.stage_provider_unlink("ws", "model", "ws/p1")
+
+    assert cache.get("ws", "model").model_providers == ["ws/p2"]
+
+
+@pytest.mark.asyncio
+async def test_entity_staged_for_creation_still_reads_as_absent(mock_models_sdk, cache):
+    """A staged creation is not fabricated, so callers keep treating it as new."""
+    await _load(mock_models_sdk, cache)
+
+    cache.stage_create("ws", "new-model", description="d", backend_format="OPENAI_CHAT")
+    cache.stage_provider_link("ws", "new-model", "ws/p1")
+
+    assert cache.get("ws", "new-model") is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_providers_produce_a_single_update(mock_models_sdk, cache):
+    """An entity linked by several providers is written once, not once per provider."""
+    await _load(mock_models_sdk, cache, [_entity("ws", "model", [])])
+
+    cache.stage_provider_link("ws", "model", "ws/p1")
+    cache.stage_provider_link("ws", "model", "ws/p2")
+    await cache.flush()
+
+    mock_models_sdk.models.update.assert_awaited_once_with(
+        workspace="ws", name="model", model_providers=["ws/p1", "ws/p2"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_write_when_already_converged(mock_models_sdk, cache):
+    """Staging state that already matches the entity performs no write."""
+    await _load(mock_models_sdk, cache, [_entity("ws", "model", ["ws/p1"])])
+
+    cache.stage_provider_link("ws", "model", "ws/p1")
+    await cache.flush()
+
+    mock_models_sdk.models.update.assert_not_awaited()
+    mock_models_sdk.models.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_two_providers_creating_the_same_entity_collapse_to_one_create(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache)
+
+    cache.stage_create("ws", "model", description="from p1", backend_format="OPENAI_CHAT")
+    cache.stage_provider_link("ws", "model", "ws/p1")
+    cache.stage_create("ws", "model", description="from p2", backend_format="OPENAI_CHAT")
+    cache.stage_provider_link("ws", "model", "ws/p2")
+    await cache.flush()
+
+    mock_models_sdk.models.create.assert_awaited_once_with(
+        workspace="ws",
+        name="model",
+        description="from p1",
+        backend_format="OPENAI_CHAT",
+        model_providers=["ws/p1", "ws/p2"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_conflict_falls_back_to_updating_the_existing_entity(mock_models_sdk, cache):
+    """An entity created concurrently is adopted rather than reported as an error."""
+    await _load(mock_models_sdk, cache)
+    mock_models_sdk.models.create = AsyncMock(side_effect=ConflictError("exists", response=MagicMock(), body=None))
+    mock_models_sdk.models.retrieve = AsyncMock(return_value=_entity("ws", "model", ["ws/other"]))
+
+    cache.stage_create("ws", "model", description="d", backend_format="OPENAI_CHAT")
+    cache.stage_provider_link("ws", "model", "ws/p1")
+    await cache.flush()
+
+    mock_models_sdk.models.update.assert_awaited_once_with(
+        workspace="ws", name="model", model_providers=["ws/other", "ws/p1"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_conflict_with_vanished_entity_is_ignored(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache)
+    mock_models_sdk.models.create = AsyncMock(side_effect=ConflictError("exists", response=MagicMock(), body=None))
+    mock_models_sdk.models.retrieve = AsyncMock(side_effect=NotFoundError("gone", response=MagicMock(), body=None))
+
+    cache.stage_create("ws", "model", description="d")
+    await cache.flush()
+
+    mock_models_sdk.models.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_one_failing_entity_does_not_stop_the_others(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache, [_entity("ws", "m1", []), _entity("ws", "m2", [])])
+    mock_models_sdk.models.update = AsyncMock(side_effect=[Exception("boom"), None])
+
+    cache.stage_provider_link("ws", "m1", "ws/p1")
+    cache.stage_provider_link("ws", "m2", "ws/p1")
+    await cache.flush()
+
+    assert mock_models_sdk.models.update.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_flush_clears_staged_changes(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache, [_entity("ws", "model", [])])
+
+    cache.stage_provider_link("ws", "model", "ws/p1")
+    await cache.flush()
+    mock_models_sdk.models.update.reset_mock()
+
+    # Nothing left staged, so a second flush writes nothing and a refresh is allowed.
+    await cache.flush()
+    mock_models_sdk.models.update.assert_not_awaited()
+    await cache.refresh()
+
+
+@pytest.mark.asyncio
+async def test_link_then_unlink_for_the_same_provider_cancels_out(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache, [_entity("ws", "model", ["ws/p1"])])
+
+    cache.stage_provider_unlink("ws", "model", "ws/p1")
+    cache.stage_provider_link("ws", "model", "ws/p1")
+    await cache.flush()
+
+    mock_models_sdk.models.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_field_updates_are_written_as_staged(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache, [_entity("ws", "model", ["ws/p1"])])
+
+    cache.stage_field_updates("ws", "model", fileset="hub/model", api_endpoint=None)
+    await cache.flush()
+
+    mock_models_sdk.models.update.assert_awaited_once_with(workspace="ws", name="model", fileset="hub/model")
+
+
+@pytest.mark.asyncio
+async def test_staged_change_for_missing_entity_without_create_is_skipped(mock_models_sdk, cache):
+    await _load(mock_models_sdk, cache)
+
+    cache.stage_provider_unlink("ws", "ghost", "ws/p1")
+    await cache.flush()
+
+    mock_models_sdk.models.create.assert_not_awaited()
+    mock_models_sdk.models.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_flush_does_not_reapply_earlier_state(mock_models_sdk, cache):
+    """A link removed in one phase is not reinstated by the next phase.
+
+    The second phase must decide from a snapshot that already reflects the first
+    phase's writes, otherwise it would re-add what was just removed.
+    """
+    store = {("ws", "model"): _entity("ws", "model", ["ws/p1"])}
+
+    def _list(**_kwargs):
+        return _AsyncPaginator(list(store.values()))
+
+    async def _update(*, workspace, name, **params):
+        current = store[(workspace, name)]
+        store[(workspace, name)] = _entity(workspace, name, params.get("model_providers", current.model_providers))
+        return store[(workspace, name)]
+
+    mock_models_sdk.models.list = MagicMock(side_effect=_list)
+    mock_models_sdk.models.update = AsyncMock(side_effect=_update)
+
+    # Phase one removes the provider link and applies it.
+    await cache.refresh()
+    cache.stage_provider_unlink("ws", "model", "ws/p1")
+    await cache.flush()
+    assert store[("ws", "model")].model_providers == []
+
+    # Phase two re-reads, so it sees the removal instead of the stale link.
+    await cache.refresh()
+    assert cache.get("ws", "model").model_providers == []

--- a/services/core/models/tests/unit/controllers/test_entity_cache.py
+++ b/services/core/models/tests/unit/controllers/test_entity_cache.py
@@ -47,8 +47,14 @@ def mock_models_sdk():
 
 
 @pytest.fixture
-def cache(mock_models_sdk):
-    return ModelEntityCache(models_sdk=mock_models_sdk)
+def heartbeat_calls():
+    """Collects heartbeat emissions so tests can assert progress was reported."""
+    return []
+
+
+@pytest.fixture
+def cache(mock_models_sdk, heartbeat_calls):
+    return ModelEntityCache(models_sdk=mock_models_sdk, emit_heartbeat=lambda: heartbeat_calls.append(1))
 
 
 async def _load(mock_models_sdk, cache, entities=()):
@@ -265,3 +271,43 @@ async def test_refresh_after_flush_does_not_reapply_earlier_state(mock_models_sd
     # Phase two re-reads, so it sees the removal instead of the stale link.
     await cache.refresh()
     assert cache.get("ws", "model").model_providers == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_reports_progress_per_entity_read(mock_models_sdk, cache, heartbeat_calls):
+    """Reading a large batch has to report progress as it goes."""
+    await _load(mock_models_sdk, cache, [_entity("ws", f"m{i}") for i in range(25)])
+
+    assert len(heartbeat_calls) == 25
+
+
+@pytest.mark.asyncio
+async def test_flush_reports_progress_per_entity_written(mock_models_sdk, cache, heartbeat_calls):
+    """Writing a large batch has to report progress as it goes.
+
+    Writes are the slowest part of a pass, so a flush that reported nothing would
+    make a long but advancing pass indistinguishable from a stalled one.
+    """
+    await _load(mock_models_sdk, cache, [_entity("ws", f"m{i}", []) for i in range(25)])
+    heartbeat_calls.clear()
+
+    for i in range(25):
+        cache.stage_provider_link("ws", f"m{i}", "ws/p1")
+    await cache.flush()
+
+    assert mock_models_sdk.models.update.await_count == 25
+    assert len(heartbeat_calls) == 25
+
+
+@pytest.mark.asyncio
+async def test_flush_reports_progress_even_when_an_entity_write_fails(mock_models_sdk, cache, heartbeat_calls):
+    """Moving past a failed entity is still progress."""
+    await _load(mock_models_sdk, cache, [_entity("ws", "m1", []), _entity("ws", "m2", [])])
+    mock_models_sdk.models.update = AsyncMock(side_effect=[Exception("boom"), None])
+    heartbeat_calls.clear()
+
+    cache.stage_provider_link("ws", "m1", "ws/p1")
+    cache.stage_provider_link("ws", "m2", "ws/p1")
+    await cache.flush()
+
+    assert len(heartbeat_calls) == 2

--- a/services/core/models/tests/unit/controllers/test_models_controller_unit.py
+++ b/services/core/models/tests/unit/controllers/test_models_controller_unit.py
@@ -750,3 +750,67 @@ async def test_step_emits_heartbeats_between_phases(mock_sdk_class_patch, mock_g
     await controller.async_controller_step()
 
     assert len(beats) >= 4
+
+
+@pytest.mark.asyncio
+async def test_step_flushes_when_deployment_reconciliation_raises(
+    mock_sdk_class_patch, mock_get_config_patch, mock_backend_registry
+):
+    """A raising deployment phase must still apply what it staged.
+
+    Leaving changes staged would make every later refresh reject, so a single
+    failure here would stop the controller from recovering at all.
+    """
+    controller = ModelsController(backend_registry=mock_backend_registry)
+
+    calls: list[str] = []
+    controller._entity_cache.refresh = AsyncMock(side_effect=lambda: calls.append("refresh"))
+    controller._entity_cache.flush = AsyncMock(side_effect=lambda: calls.append("flush"))
+
+    controller.retrieve_non_terminal_deployments = AsyncMock(return_value=[])
+    controller._deployment_reconciler.reconcile_orphans = AsyncMock(side_effect=RuntimeError("backend exploded"))
+
+    with pytest.raises(RuntimeError):
+        await controller.async_controller_step()
+
+    assert calls == ["refresh", "flush"]
+
+
+@pytest.mark.asyncio
+async def test_step_flushes_when_provider_reconciliation_raises(
+    mock_sdk_class_patch, mock_get_config_patch, mock_backend_registry
+):
+    """Same guarantee for the provider phase."""
+    controller = ModelsController(backend_registry=mock_backend_registry)
+
+    calls: list[str] = []
+    controller._entity_cache.refresh = AsyncMock(side_effect=lambda: calls.append("refresh"))
+    controller._entity_cache.flush = AsyncMock(side_effect=lambda: calls.append("flush"))
+
+    controller.retrieve_non_terminal_deployments = AsyncMock(return_value=[])
+    controller.retrieve_error_deployments = AsyncMock(return_value=[])
+    controller._deployment_reconciler.reconcile_orphans = AsyncMock()
+    controller.retrieve_model_providers = AsyncMock(return_value=[])
+    controller._provider_reconciler.reconcile_model_providers = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(RuntimeError):
+        await controller.async_controller_step()
+
+    assert calls == ["refresh", "flush", "refresh", "flush"]
+
+
+@pytest.mark.asyncio
+async def test_step_aborts_before_reconciliation_when_the_entity_cache_cannot_load(
+    mock_sdk_class_patch, mock_get_config_patch, mock_backend_registry
+):
+    """An unreadable entity list stops the step rather than reconciling blind."""
+    controller = ModelsController(backend_registry=mock_backend_registry)
+    controller._entity_cache.refresh = AsyncMock(side_effect=RuntimeError("entity list unavailable"))
+    controller._deployment_reconciler.reconcile_deployments = AsyncMock()
+    controller._provider_reconciler.reconcile_model_providers = AsyncMock()
+
+    with pytest.raises(RuntimeError):
+        await controller.async_controller_step()
+
+    controller._deployment_reconciler.reconcile_deployments.assert_not_awaited()
+    controller._provider_reconciler.reconcile_model_providers.assert_not_awaited()

--- a/services/core/models/tests/unit/controllers/test_models_controller_unit.py
+++ b/services/core/models/tests/unit/controllers/test_models_controller_unit.py
@@ -679,3 +679,74 @@ async def test_async_controller_step_stop_signal_skips_gc(
 
         controller._deployment_reconciler.gc_error_deployments.assert_not_called()
         controller._provider_reconciler.reconcile_model_providers.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_step_refreshes_the_entity_cache_for_each_writing_phase(
+    mock_sdk_class_patch, mock_get_config_patch, mock_backend_registry
+):
+    """Each phase that writes Model Entities must start from a fresh snapshot.
+
+    Deployment reconciliation can unlink a provider that provider reconciliation
+    would otherwise re-link, so the staged changes of the first phase have to be
+    applied and re-read before the second phase decides anything.
+    """
+    controller = ModelsController(backend_registry=mock_backend_registry)
+
+    calls: list[str] = []
+    controller._entity_cache.refresh = AsyncMock(side_effect=lambda: calls.append("refresh"))
+    controller._entity_cache.flush = AsyncMock(side_effect=lambda: calls.append("flush"))
+
+    controller.retrieve_non_terminal_deployments = AsyncMock(return_value=[])
+    controller.retrieve_error_deployments = AsyncMock(return_value=[])
+    controller.retrieve_model_providers = AsyncMock(return_value=[])
+    controller._deployment_reconciler.reconcile_orphans = AsyncMock()
+    controller._provider_reconciler.reconcile_model_providers = AsyncMock(
+        side_effect=lambda contexts: calls.append("reconcile_providers")
+    )
+
+    await controller.async_controller_step()
+
+    assert calls == ["refresh", "flush", "refresh", "reconcile_providers", "flush"]
+
+
+@pytest.mark.asyncio
+async def test_step_flushes_before_refreshing_after_provider_listing_failure(
+    mock_sdk_class_patch, mock_get_config_patch, mock_backend_registry
+):
+    """Bailing out mid-step must not leave staged changes behind for the next step."""
+    controller = ModelsController(backend_registry=mock_backend_registry)
+
+    calls: list[str] = []
+    controller._entity_cache.refresh = AsyncMock(side_effect=lambda: calls.append("refresh"))
+    controller._entity_cache.flush = AsyncMock(side_effect=lambda: calls.append("flush"))
+
+    controller.retrieve_non_terminal_deployments = AsyncMock(return_value=[])
+    controller.retrieve_error_deployments = AsyncMock(return_value=[])
+    controller._deployment_reconciler.reconcile_orphans = AsyncMock()
+    # None signals that providers could not be listed.
+    controller.retrieve_model_providers = AsyncMock(return_value=None)
+
+    await controller.async_controller_step()
+
+    assert calls.count("flush") == calls.count("refresh")
+
+
+@pytest.mark.asyncio
+async def test_step_emits_heartbeats_between_phases(mock_sdk_class_patch, mock_get_config_patch, mock_backend_registry):
+    """A step reports progress as it moves between phases."""
+    controller = ModelsController(backend_registry=mock_backend_registry)
+    beats: list[int] = []
+    controller.attach_heartbeat(MagicMock(beat=lambda: beats.append(1)))
+
+    controller._entity_cache.refresh = AsyncMock()
+    controller._entity_cache.flush = AsyncMock()
+    controller.retrieve_non_terminal_deployments = AsyncMock(return_value=[])
+    controller.retrieve_error_deployments = AsyncMock(return_value=[])
+    controller.retrieve_model_providers = AsyncMock(return_value=[])
+    controller._deployment_reconciler.reconcile_orphans = AsyncMock()
+    controller._provider_reconciler.reconcile_model_providers = AsyncMock()
+
+    await controller.async_controller_step()
+
+    assert len(beats) >= 4

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -14,6 +14,7 @@ from nemo_platform.types.inference import ServedModelMapping
 from nemo_platform.types.inference.model_provider import ModelProvider
 from nmp.core.models.config import ControllerConfig
 from nmp.core.models.controllers.context import ModelContext
+from nmp.core.models.controllers.entity_cache import ModelEntityCache
 from nmp.core.models.controllers.provider_reconciler import (
     PROVIDER_ERROR_RETRY_INTERVAL_SECONDS,
     PROVIDER_ERROR_THRESHOLD_SECONDS,
@@ -112,15 +113,45 @@ def mock_models_sdk():
     sdk.inference.virtual_models.create = AsyncMock(return_value=None)
     sdk.inference.virtual_models.delete = AsyncMock(return_value=None)
     sdk.inference.virtual_models.list = MagicMock(return_value=_AsyncPaginator([]))
+    sdk.models.list = MagicMock(return_value=_AsyncPaginator([]))
     sdk.inference.gateway.provider.get = AsyncMock()
     sdk.with_options = MagicMock(return_value=sdk)
     return sdk
 
 
 @pytest.fixture
-def reconciler(mock_models_sdk, controller_config):
+def entity_cache(mock_models_sdk):
+    """Model Entity cache backed by the mock SDK, pre-loaded and empty."""
+    return ModelEntityCache(models_sdk=mock_models_sdk)
+
+
+@pytest.fixture
+def heartbeat_calls():
+    """Collects heartbeat emissions so tests can assert progress was reported."""
+    return []
+
+
+@pytest.fixture
+def reconciler(mock_models_sdk, controller_config, entity_cache, heartbeat_calls):
     """Create a ModelProviderReconciler instance."""
-    return ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=controller_config)
+    return ModelProviderReconciler(
+        models_sdk=mock_models_sdk,
+        controller_config=controller_config,
+        entity_cache=entity_cache,
+        emit_heartbeat=lambda: heartbeat_calls.append(1),
+    )
+
+
+async def seed_entity_cache(mock_models_sdk, entity_cache, entities=()):
+    """Load the cache from the mock SDK so lookups resolve to ``entities``."""
+    mock_models_sdk.models.list = MagicMock(return_value=_AsyncPaginator(list(entities)))
+    await entity_cache.refresh()
+
+
+async def reconcile_and_flush(reconciler, entity_cache, provider_contexts):
+    """Run a provider pass and apply the Model Entity writes it staged."""
+    await reconciler.reconcile_model_providers(provider_contexts)
+    await entity_cache.flush()
 
 
 # ============================================================================
@@ -165,7 +196,12 @@ async def test_discover_models_passes_configured_timeout(mock_models_sdk):
         return_value={"object": "list", "data": [{"id": "model-1"}]}
     )
     config = ControllerConfig(provider_discovery_timeout_seconds=240)
-    reconciler = ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=config)
+    reconciler = ModelProviderReconciler(
+        models_sdk=mock_models_sdk,
+        controller_config=config,
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        emit_heartbeat=lambda: None,
+    )
 
     await reconciler._discover_models(_make_discoverable_provider())
 
@@ -198,7 +234,12 @@ async def test_discover_models_uses_discovery_sdk_with_configured_retries(
     """Discovery SDK should honor controller_config.provider_discovery_max_retries."""
     discovery_sdk = _configure_discovery_sdk(mock_models_sdk)
     config = ControllerConfig(provider_discovery_max_retries=max_retries)
-    reconciler = ModelProviderReconciler(models_sdk=mock_models_sdk, controller_config=config)
+    reconciler = ModelProviderReconciler(
+        models_sdk=mock_models_sdk,
+        controller_config=config,
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        emit_heartbeat=lambda: None,
+    )
 
     await reconciler._discover_models(_make_discoverable_provider())
 
@@ -618,9 +659,6 @@ async def test_get_artifact_details_handles_exception(reconciler):
 async def test_ensure_model_entity_creates_new_entity(reconciler):
     """Test creating a new model entity when it doesn't exist."""
     # Mock entity doesn't exist
-    reconciler._models_sdk.models.retrieve = AsyncMock(
-        side_effect=NotFoundError("Not found", response=MagicMock(), body=None)
-    )
     reconciler._models_sdk.models.create = AsyncMock()
 
     # Mock context
@@ -640,6 +678,7 @@ async def test_ensure_model_entity_creates_new_entity(reconciler):
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
     # Verify entity creation was called
     reconciler._models_sdk.models.create.assert_called_once_with(
@@ -661,7 +700,10 @@ async def test_ensure_model_entity_updates_existing_adds_provider(reconciler):
     existing_entity.fileset = None
     existing_entity.api_endpoint = None
 
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=existing_entity)
+    existing_entity.workspace = "test-ns"
+    existing_entity.name = "test-model"
+    reconciler._models_sdk.models.list = MagicMock(return_value=_AsyncPaginator([existing_entity]))
+    await reconciler._entity_cache.refresh()
     reconciler._models_sdk.models.update = AsyncMock()
 
     ctx = ModelContext(
@@ -678,6 +720,7 @@ async def test_ensure_model_entity_updates_existing_adds_provider(reconciler):
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
     # Verify update was called to add provider
     reconciler._models_sdk.models.update.assert_called_once_with(
@@ -696,7 +739,10 @@ async def test_ensure_model_entity_skips_if_provider_already_linked(reconciler):
     existing_entity.model_providers = ["test-ns/test-provider", "other-ns/other-provider"]
     existing_entity.backend_format = "OPENAI_CHAT"
 
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=existing_entity)
+    existing_entity.workspace = "test-ns"
+    existing_entity.name = "test-model"
+    reconciler._models_sdk.models.list = MagicMock(return_value=_AsyncPaginator([existing_entity]))
+    await reconciler._entity_cache.refresh()
     reconciler._models_sdk.models.update = AsyncMock()
 
     ctx = ModelContext(
@@ -713,6 +759,7 @@ async def test_ensure_model_entity_skips_if_provider_already_linked(reconciler):
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
     # Verify update was NOT called
     reconciler._models_sdk.models.update.assert_not_called()
@@ -727,7 +774,10 @@ async def test_ensure_model_entity_backfills_missing_backend_format(reconciler):
     existing_entity.api_endpoint = None
     existing_entity.backend_format = None
 
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=existing_entity)
+    existing_entity.workspace = "test-ns"
+    existing_entity.name = "anthropic.claude-3-5-sonnet"
+    reconciler._models_sdk.models.list = MagicMock(return_value=_AsyncPaginator([existing_entity]))
+    await reconciler._entity_cache.refresh()
     reconciler._models_sdk.models.update = AsyncMock()
 
     ctx = ModelContext(
@@ -744,6 +794,7 @@ async def test_ensure_model_entity_backfills_missing_backend_format(reconciler):
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
     reconciler._models_sdk.models.update.assert_called_once_with(
         name="anthropic.claude-3-5-sonnet",
@@ -761,7 +812,10 @@ async def test_ensure_model_entity_adds_artifact_to_existing_without_artifact(re
     existing_entity.fileset = None
     existing_entity.api_endpoint = None
 
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=existing_entity)
+    existing_entity.workspace = "test-ns"
+    existing_entity.name = "test-model"
+    reconciler._models_sdk.models.list = MagicMock(return_value=_AsyncPaginator([existing_entity]))
+    await reconciler._entity_cache.refresh()
     reconciler._models_sdk.models.update = AsyncMock()
 
     ctx = ModelContext(
@@ -780,6 +834,7 @@ async def test_ensure_model_entity_adds_artifact_to_existing_without_artifact(re
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
     # Verify update includes artifact
     reconciler._models_sdk.models.update.assert_called_once_with(
@@ -800,7 +855,10 @@ async def test_ensure_model_entity_doesnt_overwrite_existing_artifact(reconciler
     existing_entity.fileset = "existing://artifact"
     existing_entity.api_endpoint = None
 
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=existing_entity)
+    existing_entity.workspace = "test-ns"
+    existing_entity.name = "test-model"
+    reconciler._models_sdk.models.list = MagicMock(return_value=_AsyncPaginator([existing_entity]))
+    await reconciler._entity_cache.refresh()
     reconciler._models_sdk.models.update = AsyncMock()
 
     ctx = ModelContext(
@@ -819,6 +877,7 @@ async def test_ensure_model_entity_doesnt_overwrite_existing_artifact(reconciler
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
     # Verify update does NOT include fileset (since it already exists)
     call_kwargs = reconciler._models_sdk.models.update.call_args.kwargs
@@ -834,7 +893,10 @@ async def test_ensure_model_entity_doesnt_overwrite_existing_backend_format(reco
     existing_entity.api_endpoint = None
     existing_entity.backend_format = "ANTHROPIC_MESSAGES"
 
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=existing_entity)
+    existing_entity.workspace = "test-ns"
+    existing_entity.name = "test-model"
+    reconciler._models_sdk.models.list = MagicMock(return_value=_AsyncPaginator([existing_entity]))
+    await reconciler._entity_cache.refresh()
     reconciler._models_sdk.models.update = AsyncMock()
 
     ctx = ModelContext(
@@ -851,6 +913,7 @@ async def test_ensure_model_entity_doesnt_overwrite_existing_backend_format(reco
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
     call_kwargs = reconciler._models_sdk.models.update.call_args.kwargs
     assert "backend_format" not in call_kwargs
@@ -865,7 +928,10 @@ async def test_ensure_model_entity_handles_null_model_providers(reconciler):
     existing_entity.fileset = None
     existing_entity.api_endpoint = None
 
-    reconciler._models_sdk.models.retrieve = AsyncMock(return_value=existing_entity)
+    existing_entity.workspace = "test-ns"
+    existing_entity.name = "test-model"
+    reconciler._models_sdk.models.list = MagicMock(return_value=_AsyncPaginator([existing_entity]))
+    await reconciler._entity_cache.refresh()
     reconciler._models_sdk.models.update = AsyncMock()
 
     ctx = ModelContext(
@@ -882,6 +948,7 @@ async def test_ensure_model_entity_handles_null_model_providers(reconciler):
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
     # Verify update was called with provider as first in list
     reconciler._models_sdk.models.update.assert_called_once_with(
@@ -915,39 +982,30 @@ async def test_ensure_model_entity_handles_create_exception(reconciler):
             provider_id="test-ns/test-provider",
             ctx=ctx,
         )
+    await reconciler._entity_cache.flush()
 
 
 @pytest.mark.asyncio
-async def test_ensure_model_entity_handles_retrieve_non_not_found_exception(reconciler):
-    """Retrieve failures other than NotFound must not propagate; skip create/update until next loop."""
+async def test_entity_cache_load_failure_prevents_any_entity_writes(reconciler, mock_models_sdk):
+    """An unreadable entity list must abort before anything is created or updated."""
     mock_response = MagicMock()
     mock_response.status_code = 503
-    reconciler._models_sdk.models.retrieve = AsyncMock(
+    mock_models_sdk.models.list = MagicMock(
         side_effect=APIStatusError(
             "Service unavailable",
             response=mock_response,
             body={"detail": "upstream error"},
         )
     )
-    reconciler._models_sdk.models.create = AsyncMock()
+    mock_models_sdk.models.create = AsyncMock()
+    mock_models_sdk.models.update = AsyncMock()
 
-    ctx = ModelContext(
-        model_provider=MagicMock(host_url="https://api.com"),
-        model_deployment=None,
-        model_deployment_config=None,
-        model_entity=None,
-    )
+    with pytest.raises(APIStatusError):
+        await reconciler._entity_cache.refresh()
 
-    with patch.object(reconciler, "_build_artifact_details", return_value=ArtifactDetails()) as mock_compile:
-        await reconciler._ensure_model_entity_for_provider(
-            model_workspace="test-ns",
-            model_name="test-model",
-            provider_id="test-ns/test-provider",
-            ctx=ctx,
-        )
-
-    mock_compile.assert_not_called()
-    reconciler._models_sdk.models.create.assert_not_called()
+    await reconciler._entity_cache.flush()
+    mock_models_sdk.models.create.assert_not_called()
+    mock_models_sdk.models.update.assert_not_called()
 
 
 # ============================================================================
@@ -1822,7 +1880,7 @@ async def test_discovery_transient_error_carries_message(reconciler, mock_models
 @pytest.mark.asyncio
 async def test_ensure_passthrough_virtual_model_creates_when_not_exists(reconciler, mock_models_sdk):
     """Creates a passthrough VirtualModel with the correct arguments."""
-    await reconciler._ensure_passthrough_virtual_model("my-ws", "llama-3b")
+    await reconciler._ensure_passthrough_virtual_model("my-ws", "llama-3b", set())
 
     mock_models_sdk.inference.virtual_models.create.assert_awaited_once_with(
         workspace="my-ws",
@@ -1842,7 +1900,7 @@ async def test_ensure_passthrough_virtual_model_ignores_conflict_error(reconcile
     )
 
     # Should not raise
-    await reconciler._ensure_passthrough_virtual_model("my-ws", "llama-3b")
+    await reconciler._ensure_passthrough_virtual_model("my-ws", "llama-3b", set())
 
 
 @pytest.mark.asyncio
@@ -1852,7 +1910,7 @@ async def test_ensure_passthrough_virtual_model_logs_warning_on_unexpected_error
 
     with caplog.at_level(logging.WARNING):
         # Should not raise
-        await reconciler._ensure_passthrough_virtual_model("my-ws", "llama-3b")
+        await reconciler._ensure_passthrough_virtual_model("my-ws", "llama-3b", set())
 
     assert any("my-ws" in r.message and "llama-3b" in r.message for r in caplog.records)
 
@@ -1918,6 +1976,31 @@ def _virtual_model(
     return vm
 
 
+def _existing_entity(workspace: str, name: str, **attrs):
+    """Model Entity stand-in addressable by the cache.
+
+    ``model_copy`` mirrors the real model's behaviour of carrying every field
+    across, which the cache relies on when overlaying staged changes.
+    """
+    fields = {
+        "workspace": workspace,
+        "name": name,
+        "model_providers": attrs.get("model_providers"),
+        "fileset": attrs.get("fileset"),
+        "api_endpoint": attrs.get("api_endpoint"),
+        "backend_format": attrs.get("backend_format"),
+    }
+    entity = MagicMock()
+    for key, value in fields.items():
+        setattr(entity, key, value)
+    entity.model_copy = MagicMock(
+        side_effect=lambda update: _existing_entity(
+            workspace, name, **{**{k: v for k, v in fields.items() if k not in ("workspace", "name")}, **update}
+        )
+    )
+    return entity
+
+
 def _provider_context(
     *,
     workspace: str = "ws",
@@ -1978,7 +2061,8 @@ async def test_cleanup_keeps_autoprovisioned_virtual_model_served_by_remaining_p
         )
     )
 
-    await reconciler._cleanup_orphaned_virtual_models([ctx])
+    vm_snapshot, _ = await reconciler._load_virtual_models()
+    await reconciler._cleanup_orphaned_virtual_models([ctx], vm_snapshot)
 
     mock_models_sdk.inference.virtual_models.delete.assert_not_awaited()
 
@@ -1998,7 +2082,8 @@ async def test_cleanup_keeps_autoprovisioned_virtual_model_without_default_model
         )
     )
 
-    await reconciler._cleanup_orphaned_virtual_models([])
+    vm_snapshot, _ = await reconciler._load_virtual_models()
+    await reconciler._cleanup_orphaned_virtual_models([], vm_snapshot)
 
     mock_models_sdk.inference.virtual_models.delete.assert_not_awaited()
 
@@ -2024,7 +2109,8 @@ async def test_cleanup_lost_provider_does_not_protect_autoprovisioned_virtual_mo
         )
     )
 
-    await reconciler._cleanup_orphaned_virtual_models([ctx])
+    vm_snapshot, _ = await reconciler._load_virtual_models()
+    await reconciler._cleanup_orphaned_virtual_models([ctx], vm_snapshot)
 
     mock_models_sdk.inference.virtual_models.delete.assert_awaited_once_with(name="model-a", workspace="ws")
 
@@ -2044,7 +2130,8 @@ async def test_cleanup_never_deletes_user_created_virtual_model(reconciler, mock
         )
     )
 
-    await reconciler._cleanup_orphaned_virtual_models([])
+    vm_snapshot, _ = await reconciler._load_virtual_models()
+    await reconciler._cleanup_orphaned_virtual_models([], vm_snapshot)
 
     mock_models_sdk.inference.virtual_models.delete.assert_not_awaited()
 
@@ -2066,7 +2153,8 @@ async def test_cleanup_delete_failure_is_logged_and_non_fatal(reconciler, mock_m
     mock_models_sdk.inference.virtual_models.delete = AsyncMock(side_effect=RuntimeError("delete failed"))
 
     with caplog.at_level(logging.WARNING):
-        await reconciler._cleanup_orphaned_virtual_models([])
+        vm_snapshot, _ = await reconciler._load_virtual_models()
+    await reconciler._cleanup_orphaned_virtual_models([], vm_snapshot)
 
     mock_models_sdk.inference.virtual_models.delete.assert_awaited_once_with(name="model-a", workspace="ws")
     assert any("Failed to delete orphaned autoprovisioned VirtualModel ws/model-a" in r.message for r in caplog.records)
@@ -2191,18 +2279,7 @@ async def test_reconcile_creates_virtual_models_even_when_update_status_fails(re
 
     # update_status raises — VirtualModel creation must still run
     mock_models_sdk.inference.providers.update_status = AsyncMock(side_effect=Exception("service unavailable"))
-    mock_models_sdk.inference.virtual_models.list = MagicMock(
-        return_value=_AsyncPaginator(
-            [
-                _virtual_model(
-                    "model-x",
-                    workspace="test-ns",
-                    default_model_entity="test-ns/model-x",
-                    autoprovisioned=True,
-                )
-            ]
-        )
-    )
+    mock_models_sdk.inference.virtual_models.list = MagicMock(return_value=_AsyncPaginator([]))
 
     with patch.object(
         reconciler,
@@ -2650,3 +2727,263 @@ def test_deployment_prompt_tuned_strips_provider_workspace_prefix(reconciler):
 )
 def test_is_valid_served_model_entity_id(model_entity_id, expected):
     assert _is_valid_served_model_entity_id(model_entity_id) is expected
+
+
+# ============================================================================
+# Pass ordering and batching
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_virtual_model_list_is_read_once_per_pass(reconciler, mock_models_sdk):
+    """Existing VirtualModels are read once, not once per served model."""
+    provider = MagicMock()
+    provider.workspace = "test-ns"
+    provider.name = "test-provider"
+    provider.model_deployment_id = None
+    provider.enabled_models = None
+    provider.served_models = []
+    ctx = ModelContext(
+        model_provider=provider,
+        model_deployment=None,
+        model_deployment_config=None,
+        model_entity=None,
+    )
+
+    mock_models_sdk.inference.virtual_models.list = MagicMock(return_value=_AsyncPaginator([]))
+    with patch.object(
+        reconciler,
+        "_discover_models",
+        return_value=DiscoverySuccess(_discovery_models_from_ids(["m1", "m2", "m3"])),
+    ):
+        await reconciler.reconcile_model_providers([ctx])
+
+    mock_models_sdk.inference.virtual_models.list.assert_called_once_with(workspace="-", page_size=200)
+
+
+@pytest.mark.asyncio
+async def test_existing_virtual_model_is_not_recreated(reconciler, mock_models_sdk):
+    """A VirtualModel already present is left alone instead of re-attempted."""
+    existing = _virtual_model("m1", workspace="test-ns", default_model_entity="test-ns/m1")
+    mock_models_sdk.inference.virtual_models.list = MagicMock(return_value=_AsyncPaginator([existing]))
+
+    vm_snapshot, existing_vm_names = await reconciler._load_virtual_models()
+    await reconciler._ensure_passthrough_virtual_model("test-ns", "m1", existing_vm_names)
+
+    mock_models_sdk.inference.virtual_models.create.assert_not_awaited()
+    assert vm_snapshot == [existing]
+
+
+@pytest.mark.asyncio
+async def test_user_managed_virtual_model_name_is_not_recreated(reconciler, mock_models_sdk):
+    """A name held by a non-autoprovisioned VirtualModel is still treated as taken."""
+    manual = _virtual_model("m1", workspace="test-ns", default_model_entity="other/thing", autoprovisioned=False)
+    mock_models_sdk.inference.virtual_models.list = MagicMock(return_value=_AsyncPaginator([manual]))
+
+    _, existing_vm_names = await reconciler._load_virtual_models()
+    await reconciler._ensure_passthrough_virtual_model("test-ns", "m1", existing_vm_names)
+
+    mock_models_sdk.inference.virtual_models.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_virtual_model_created_in_pass_is_not_attempted_twice(reconciler, mock_models_sdk):
+    """Two providers in one workspace serving the same model create it once."""
+    existing_vm_names: set[tuple[str, str]] = set()
+
+    await reconciler._ensure_passthrough_virtual_model("test-ns", "m1", existing_vm_names)
+    await reconciler._ensure_passthrough_virtual_model("test-ns", "m1", existing_vm_names)
+
+    mock_models_sdk.inference.virtual_models.create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_virtual_model_created_in_pass_is_never_deleted_as_orphan(reconciler, mock_models_sdk):
+    """A VirtualModel created during the pass is not a cleanup candidate."""
+    provider = MagicMock()
+    provider.workspace = "test-ns"
+    provider.name = "test-provider"
+    provider.model_deployment_id = None
+    provider.enabled_models = None
+    provider.served_models = []
+    ctx = ModelContext(
+        model_provider=provider,
+        model_deployment=None,
+        model_deployment_config=None,
+        model_entity=None,
+    )
+
+    # Nothing exists up front, so the pass creates the VirtualModel itself.
+    mock_models_sdk.inference.virtual_models.list = MagicMock(return_value=_AsyncPaginator([]))
+    with patch.object(
+        reconciler,
+        "_discover_models",
+        return_value=DiscoverySuccess(_discovery_models_from_ids(["m1"])),
+    ):
+        await reconciler.reconcile_model_providers([ctx])
+
+    mock_models_sdk.inference.virtual_models.create.assert_awaited_once()
+    mock_models_sdk.inference.virtual_models.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_tolerates_virtual_model_deleted_concurrently(reconciler, mock_models_sdk):
+    """A VirtualModel removed after the snapshot was taken is not an error."""
+    mock_models_sdk.inference.virtual_models.list = MagicMock(
+        return_value=_AsyncPaginator([_virtual_model("model-a", default_model_entity="ws/model-a")])
+    )
+    mock_models_sdk.inference.virtual_models.delete = AsyncMock(
+        side_effect=NotFoundError("gone", response=MagicMock(), body=None)
+    )
+
+    vm_snapshot, _ = await reconciler._load_virtual_models()
+    await reconciler._cleanup_orphaned_virtual_models([], vm_snapshot)
+
+    mock_models_sdk.inference.virtual_models.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_provider_skipped_before_discovery_keeps_served_models_unresolved(reconciler, mock_models_sdk):
+    """An unresolved provider leaves served_models as None so cleanup falls back.
+
+    Setting it to an empty list instead would present every model the provider
+    serves as inactive and delete all of its VirtualModels.
+    """
+    ctx = _provider_context(
+        status=ModelProviderStatus.ERROR,
+        served_models=[ServedModelMapping(model_entity_id="ws/model-a", served_model_name="model-a")],
+    )
+    ctx.model_provider.updated_at = datetime.now(timezone.utc)
+    ctx.model_provider.created_at = datetime.now(timezone.utc)
+    ctx.served_models = []
+
+    mock_models_sdk.inference.virtual_models.list = MagicMock(
+        return_value=_AsyncPaginator([_virtual_model("model-a", default_model_entity="ws/model-a")])
+    )
+
+    await reconciler.reconcile_model_providers([ctx])
+
+    # Still within the retry cooldown, so discovery never ran and nothing was deleted.
+    assert ctx.served_models is None
+    mock_models_sdk.inference.virtual_models.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_entity_linked_by_two_providers_is_written_once(reconciler, mock_models_sdk, entity_cache):
+    """Two providers serving one model produce a single Model Entity write."""
+    # Already carries everything except the provider links, so the only pending
+    # change is the link each provider contributes.
+    await seed_entity_cache(
+        mock_models_sdk,
+        entity_cache,
+        [
+            _existing_entity(
+                "test-ns",
+                "shared-model",
+                model_providers=[],
+                backend_format="OPENAI_CHAT",
+                api_endpoint={"url": "https://api.com", "model_id": "shared-model", "format": "openai"},
+            )
+        ],
+    )
+    mock_models_sdk.models.update = AsyncMock()
+
+    ctxs = []
+    for provider_name in ("provider-a", "provider-b"):
+        provider = MagicMock()
+        provider.workspace = "test-ns"
+        provider.name = provider_name
+        provider.model_deployment_id = None
+        provider.enabled_models = None
+        provider.served_models = []
+        ctxs.append(
+            ModelContext(
+                model_provider=provider,
+                model_deployment=None,
+                model_deployment_config=None,
+                model_entity=None,
+            )
+        )
+
+    with patch.object(
+        reconciler,
+        "_discover_models",
+        return_value=DiscoverySuccess(_discovery_models_from_ids(["shared-model"])),
+    ):
+        await reconcile_and_flush(reconciler, entity_cache, ctxs)
+
+    mock_models_sdk.models.update.assert_awaited_once_with(
+        workspace="test-ns",
+        name="shared-model",
+        model_providers=["test-ns/provider-a", "test-ns/provider-b"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_converged_entities_are_not_rewritten(reconciler, mock_models_sdk, entity_cache):
+    """A pass that changes nothing performs no Model Entity writes."""
+    await seed_entity_cache(
+        mock_models_sdk,
+        entity_cache,
+        [
+            _existing_entity(
+                "test-ns",
+                "m1",
+                model_providers=["test-ns/test-provider"],
+                backend_format="OPENAI_CHAT",
+                api_endpoint={"url": "https://api.com", "model_id": "m1", "format": "openai"},
+            )
+        ],
+    )
+    mock_models_sdk.models.update = AsyncMock()
+    mock_models_sdk.models.create = AsyncMock()
+
+    provider = MagicMock()
+    provider.workspace = "test-ns"
+    provider.name = "test-provider"
+    provider.model_deployment_id = None
+    provider.enabled_models = None
+    provider.served_models = [ServedModelMapping(model_entity_id="test-ns/m1", served_model_name="m1")]
+    ctx = ModelContext(
+        model_provider=provider,
+        model_deployment=None,
+        model_deployment_config=None,
+        model_entity=None,
+    )
+
+    with patch.object(
+        reconciler,
+        "_discover_models",
+        return_value=DiscoverySuccess(_discovery_models_from_ids(["m1"])),
+    ):
+        await reconcile_and_flush(reconciler, entity_cache, ctx and [ctx])
+
+    mock_models_sdk.models.update.assert_not_awaited()
+    mock_models_sdk.models.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_provider_pass_emits_heartbeats(reconciler, mock_models_sdk, heartbeat_calls):
+    """Progress is reported as the pass works through providers and models."""
+    provider = MagicMock()
+    provider.workspace = "test-ns"
+    provider.name = "test-provider"
+    provider.model_deployment_id = None
+    provider.enabled_models = None
+    provider.served_models = []
+    ctx = ModelContext(
+        model_provider=provider,
+        model_deployment=None,
+        model_deployment_config=None,
+        model_entity=None,
+    )
+
+    with patch.object(
+        reconciler,
+        "_discover_models",
+        return_value=DiscoverySuccess(_discovery_models_from_ids(["m1", "m2", "m3"])),
+    ):
+        await reconciler.reconcile_model_providers([ctx])
+
+    # One per entity ensured, one per VirtualModel ensured, one per provider.
+    assert len(heartbeat_calls) >= 7

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -31,25 +31,15 @@ from nmp.core.models.controllers.provider_reconciler import (
 )
 from nmp.core.models.schemas import ModelProviderStatus
 
+from .conftest import AsyncPaginator, make_entity, seed_entity_cache
+
 
 def _discovery_models_from_ids(ids: list[str]) -> list[dict]:
     """Build GET /v1/models data[] entries (id only; root/parent omitted in external-path tests)."""
     return [{"id": i, "root": None, "parent": None} for i in ids]
 
 
-class _AsyncPaginator:
-    """Tiny async iterator for SDK list() calls in reconciler tests."""
-
-    def __init__(self, items):
-        self._items = list(items)
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        if not self._items:
-            raise StopAsyncIteration
-        return self._items.pop(0)
+_AsyncPaginator = AsyncPaginator
 
 
 def test_infer_backend_format():
@@ -140,12 +130,6 @@ def reconciler(mock_models_sdk, controller_config, entity_cache, heartbeat_calls
         entity_cache=entity_cache,
         emit_heartbeat=lambda: heartbeat_calls.append(1),
     )
-
-
-async def seed_entity_cache(mock_models_sdk, entity_cache, entities=()):
-    """Load the cache from the mock SDK so lookups resolve to ``entities``."""
-    mock_models_sdk.models.list = MagicMock(return_value=_AsyncPaginator(list(entities)))
-    await entity_cache.refresh()
 
 
 async def reconcile_and_flush(reconciler, entity_cache, provider_contexts):
@@ -986,8 +970,12 @@ async def test_ensure_model_entity_handles_create_exception(reconciler):
 
 
 @pytest.mark.asyncio
-async def test_entity_cache_load_failure_prevents_any_entity_writes(reconciler, mock_models_sdk):
-    """An unreadable entity list must abort before anything is created or updated."""
+async def test_entity_cache_load_failure_propagates_and_stages_nothing(reconciler, mock_models_sdk):
+    """An unreadable entity list surfaces to the caller with nothing staged.
+
+    The controller loads the cache at the start of the phase, so this failure aborts
+    the step before reconciliation runs; see the models controller tests for that.
+    """
     mock_response = MagicMock()
     mock_response.status_code = 503
     mock_models_sdk.models.list = MagicMock(
@@ -1006,6 +994,45 @@ async def test_entity_cache_load_failure_prevents_any_entity_writes(reconciler, 
     await reconciler._entity_cache.flush()
     mock_models_sdk.models.create.assert_not_called()
     mock_models_sdk.models.update.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_virtual_model_listing_failure_does_not_abort_provider_reconciliation(
+    reconciler, mock_models_sdk, entity_cache
+):
+    """A VirtualModel listing failure must not cost discovery, status, or entity work."""
+    await seed_entity_cache(mock_models_sdk, entity_cache, [])
+    provider = MagicMock()
+    provider.workspace = "test-ns"
+    provider.name = "test-provider"
+    provider.model_deployment_id = None
+    provider.enabled_models = None
+    provider.served_models = []
+    ctx = ModelContext(
+        model_provider=provider,
+        model_deployment=None,
+        model_deployment_config=None,
+        model_entity=None,
+    )
+
+    mock_models_sdk.inference.virtual_models.list = MagicMock(side_effect=Exception("listing unavailable"))
+    mock_models_sdk.models.create = AsyncMock()
+    mock_models_sdk.inference.providers.update_status = AsyncMock()
+
+    with patch.object(
+        reconciler,
+        "_discover_models",
+        return_value=DiscoverySuccess(_discovery_models_from_ids(["m1"])),
+    ):
+        await reconciler.reconcile_model_providers([ctx])
+    await entity_cache.flush()
+
+    # Provider status and entity linking still happened.
+    mock_models_sdk.inference.providers.update_status.assert_awaited()
+    mock_models_sdk.models.create.assert_awaited_once()
+    # VirtualModel work was skipped rather than acted on with an unknown state.
+    mock_models_sdk.inference.virtual_models.create.assert_not_awaited()
+    mock_models_sdk.inference.virtual_models.delete.assert_not_awaited()
 
 
 # ============================================================================
@@ -1977,28 +2004,8 @@ def _virtual_model(
 
 
 def _existing_entity(workspace: str, name: str, **attrs):
-    """Model Entity stand-in addressable by the cache.
-
-    ``model_copy`` mirrors the real model's behaviour of carrying every field
-    across, which the cache relies on when overlaying staged changes.
-    """
-    fields = {
-        "workspace": workspace,
-        "name": name,
-        "model_providers": attrs.get("model_providers"),
-        "fileset": attrs.get("fileset"),
-        "api_endpoint": attrs.get("api_endpoint"),
-        "backend_format": attrs.get("backend_format"),
-    }
-    entity = MagicMock()
-    for key, value in fields.items():
-        setattr(entity, key, value)
-    entity.model_copy = MagicMock(
-        side_effect=lambda update: _existing_entity(
-            workspace, name, **{**{k: v for k, v in fields.items() if k not in ("workspace", "name")}, **update}
-        )
-    )
-    return entity
+    """Model Entity stand-in addressable by the cache."""
+    return make_entity(workspace, name, **attrs)
 
 
 def _provider_context(

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -122,7 +122,7 @@ def mock_models_sdk():
 @pytest.fixture
 def entity_cache(mock_models_sdk):
     """Model Entity cache backed by the mock SDK, pre-loaded and empty."""
-    return ModelEntityCache(models_sdk=mock_models_sdk)
+    return ModelEntityCache(models_sdk=mock_models_sdk, emit_heartbeat=lambda: None)
 
 
 @pytest.fixture
@@ -199,7 +199,7 @@ async def test_discover_models_passes_configured_timeout(mock_models_sdk):
     reconciler = ModelProviderReconciler(
         models_sdk=mock_models_sdk,
         controller_config=config,
-        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk, emit_heartbeat=lambda: None),
         emit_heartbeat=lambda: None,
     )
 
@@ -237,7 +237,7 @@ async def test_discover_models_uses_discovery_sdk_with_configured_retries(
     reconciler = ModelProviderReconciler(
         models_sdk=mock_models_sdk,
         controller_config=config,
-        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk),
+        entity_cache=ModelEntityCache(models_sdk=mock_models_sdk, emit_heartbeat=lambda: None),
         emit_heartbeat=lambda: None,
     )
 


### PR DESCRIPTION
## Problem

### How control loops decide whether they are healthy

Background work in the platform runs as control loops. Each loop is a thread that repeats the same cycle forever: run one `step()`, sleep for its poll interval, run the next `step()`. The models controller's interval defaults to 5 seconds.

The framework needs some way to tell whether a loop is still alive, so it records a timestamp each time a step begins — a heartbeat. Readiness compares that timestamp against a deadline of `3 x interval`, which for the models controller is 15 seconds. If the loop has not produced a heartbeat within 15 seconds it is reported unhealthy, `/health/ready` returns 503, and Kubernetes takes the pod out of service.

That works as long as a step reliably finishes well inside 15 seconds. The heartbeat was only sent once per step, so the deadline was really a bet that no step would ever take longer than three intervals.

### What went wrong

Models controller steps were taking roughly 54 seconds. Since the only heartbeat came at the start of a step, the loop looked alive for the first 15 seconds of each cycle and stalled for the remaining ~44. Readiness therefore alternated between passing and failing on a roughly 59-second cycle, and the controller pod spent most of its time marked unhealthy and pulled out of the Service — even though it was working the whole time, just slowly.

There are two separate defects behind that, and this PR addresses both:

1. The health model could not tell "slow" apart from "stuck", because progress was only reported once per step.
2. The models controller step was far slower than the work actually required.

## Fix 1: report progress more than once per step

A step that has 400 items to get through legitimately takes longer than three poll intervals. What matters for liveness is not "did the step finish" but "is the loop still getting somewhere". So controllers now report progress as each unit of work completes, rather than only when a step begins.

How it is put together:

- `Heartbeat` holds a single timestamp meaning "last observed progress".
- `HeartbeatMixin` gives a controller an `emit_heartbeat()` method to call as it finishes each item.
- `TrackLastExecutionTime` owns the `Heartbeat` and hands it to the wrapped controller when it wraps it. Entering `step()` still counts as progress, so a controller that reports nothing behaves exactly as it did before and no existing call site changed.
- Nested helpers (the reconcilers) receive the bound `emit_heartbeat` method rather than the `Heartbeat` itself, so they report progress without knowing anything about how liveness is measured.
- The liveness check in `Loop` is untouched. It already read this timestamp; the timestamp is simply updated more often now.

The important property is that beats only ever follow completed work — never a timer, never around a call that might block. A single call that hangs forever still stops the clock and is still caught. Only slow-but-advancing work is now treated as healthy.

Wired into the jobs scheduler and reconciler, workspace cleanup, the models controller, and the adapters sidecar.

Separately, when a loop does go unhealthy it now says so in the log. Previously the only record was at DEBUG, so a pod failing readiness produced no visible explanation. `Loop` records why the check failed and `ControllerManager` logs the change with the loop name and the reason, on transition only, so it is not repeated on every probe.

## Fix 2: make the models controller step faster

### Where the time went

Provider reconciliation walks every model a provider serves and, for each one, makes sure two things exist: a Model Entity for it, and a passthrough VirtualModel pointing at that entity. It was doing this one model at a time:

- one `GET` to read the Model Entity, and
- one `POST` attempting to create the VirtualModel, relying on a 409 conflict to mean "already there".

In a development workspace with 4 providers each serving 102 models, that is 408 served models and **816 sequential API calls per step**, every 5 seconds. At the measured ~60 ms per call that is most of a minute. In the steady state nothing needed changing, so essentially all of it was re-confirming state that was already correct.

Reading the same data in bulk instead is dramatically cheaper. Measured against that workspace:

| | Calls | Time |
|---|---|---|
| Read 404 Model Entities one at a time | 404 | **37.7 s** |
| Read all 404 in one paginated list | 1 | **0.33 s** |
| Read all 306 VirtualModels (`page_size=200`) | 2 | **0.33 s** |

### What changed

**`ModelEntityCache`** (new) reads the Model Entities once per reconciliation phase and collects up the intended changes instead of writing them as it goes:

- each entity is written at most once, and only if something actually differs — so a converged pass performs no writes at all
- the desired state for an entity is assembled in memory, so several providers contributing to the same entity are merged into one write rather than overwriting each other
- reads see staged changes layered over the snapshot, so code that stages a change and then reads the same entity sees its own write
- `refresh()` refuses to re-read while changes are still staged, which makes the required ordering a failure rather than a convention

Both deployment and provider reconciliation read and write these entities, and the deployment phase can remove a provider link that the provider phase would otherwise put back. So the cache is refreshed at the start of each phase that writes entities and flushed at the end of that phase, meaning neither phase ever decides based on state the other has already changed.

**VirtualModels are read once per pass.** Orphan cleanup was already listing all of them on every step, so reusing that read costs nothing and removes all 408 create attempts. The existence set covers every VirtualModel rather than only auto-provisioned ones, so a name already held by a user-managed VirtualModel is still left alone. Cleanup consumes the same snapshot and still runs after every provider, because it depends on the served models resolved during the pass.

### Result

Per-step API calls no longer scale with the number of served models. In the steady state the pass drops from ~826 calls to roughly a dozen, and from ~54 seconds to a couple of seconds — comfortably inside the 15-second liveness deadline, with Fix 1 covering the cold-start case where there genuinely is a lot to create.

## Notes for reviewers

- Each provider's `update_status` now lands before its entity links are written, since the flush moved to end-of-phase. Publishing `served_models` independently of entity initialization is existing behaviour.
- Staged changes are applied even when a step bails out early: provider deletion stages the removal of its entity links and the provider itself is already gone, so discarding them would leave the links behind with nothing to trigger another attempt.
- Reporting progress means a step that advances slowly forever will not be flagged. That is intended, and is the point of the change.

## Testing

- `ModelEntityCache`: overlay reads, refresh-while-staged rejection, single write for an entity linked by two providers, no write when converged, two providers creating one entity collapsing to a single create, conflict adoption, per-entity failure isolation, and a phase-ordering test that a removed link is not reinstated by the next phase.
- Liveness: a long step reporting progress stays healthy, a step reporting none goes unhealthy, and health changes log once per edge.
- Provider reconciliation ordering: VirtualModels read once per pass, existing and user-managed names not recreated, one created mid-pass never deleted as an orphan, concurrent deletion tolerated, and unresolved providers leaving `served_models` unset so cleanup falls back to persisted values.
- 1233 tests covering the changed code pass; `ruff check`, `ruff format --check`, and `ty check` are clean against baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added heartbeat-based progress tracking for controllers to support more accurate health monitoring of long-running work.
  * Controllers now emit heartbeats across workspace cleanup, job reconciliation/scheduling, adapter reconciliation, and model reconciliation.

* **Bug Fixes**
  * Health monitoring now surfaces exact unhealthy reasons (including stalled progress or inactive loop threads).
  * Continued progress reporting even when per-item cleanup or reconciliation operations fail.

* **Improvements**
  * Reduced repeated unhealthy logging by only reporting health transitions; improved recovery reporting when conditions return to healthy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->