### PR TITLE
ci: give every job a timeout-minutes [ASTD-345]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,7 @@ jobs:
   changes:
     name: Detect Path Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       openapi: ${{ steps.changes.outputs.openapi }}
       test: ${{ steps.changes.outputs.test }}
@@ -55,6 +56,7 @@ jobs:
   actionlint:
     name: Run actionlint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -81,6 +83,7 @@ jobs:
       github.event_name == 'pull_request' &&
       needs.changes.outputs.ngc-metadata == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -103,6 +106,7 @@ jobs:
         needs.changes.outputs.docker == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -532,6 +536,7 @@ jobs:
         needs.changes.outputs.helm == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     env:
@@ -590,6 +595,7 @@ jobs:
         needs.changes.outputs.helm == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     env:
@@ -716,6 +722,7 @@ jobs:
   lint:
     name: Lint all
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install uv
@@ -760,6 +767,7 @@ jobs:
   policy-wasm:
     name: Build OPA policy WASM
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: ./.github/actions/build-policy-wasm
@@ -779,6 +787,7 @@ jobs:
         needs.changes.outputs.tools == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -804,6 +813,7 @@ jobs:
     name: Python unit tests
     needs: [policy-wasm]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -843,6 +853,7 @@ jobs:
     name: Python integration tests
     needs: [policy-wasm]
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -902,6 +913,7 @@ jobs:
         needs.changes.outputs.auth-idp == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
@@ -1329,6 +1341,7 @@ jobs:
         needs.changes.outputs.openapi == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: web
@@ -1360,6 +1373,7 @@ jobs:
         needs.changes.outputs.web-studio == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     defaults:
       run:
         working-directory: web
@@ -1391,6 +1405,7 @@ jobs:
         needs.changes.outputs.web-studio == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: web
@@ -1416,6 +1431,7 @@ jobs:
         needs.changes.outputs.web-studio == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: web
@@ -1442,6 +1458,7 @@ jobs:
         needs.changes.outputs.web-studio == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: web
@@ -1469,6 +1486,7 @@ jobs:
         needs.changes.outputs.web-studio == 'true'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: web
@@ -1489,6 +1507,7 @@ jobs:
     name: Studio UI E2E tests
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: web
@@ -1643,6 +1662,7 @@ jobs:
         needs.python-integration-test.result == 'failure'
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       pull-requests: write
       contents: read
@@ -1693,6 +1713,7 @@ jobs:
 
   opa-policy-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1707,6 +1728,7 @@ jobs:
 
   require-nvskills:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
       - name: Require trusted NVSkills signature for skills changes
@@ -1790,6 +1812,7 @@ jobs:
       - guardrails-benchmark-analyze
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Closes [ASTD-345](https://linear.app/nvidia/issue/ASTD-345/ci-jobs-without-timeout-minutes-can-park-the-merge-queue-for-hours).

23 of the 35 jobs in `ci.yaml` declared no `timeout-minutes`, so they inherited GitHub's **6-hour** default. A hang in any of them blocks its run — and in a merge-queue run, the queue itself — until a human notices and cancels.

## What prompted it

Merge-queue run [30388067206](https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/30388067206) for #936 stalled on **Python unit tests**: all 47 other jobs finished, that one sat in `Run unit tests` with no step progress for 25+ minutes. The same job took **5.7m / 5.7m / 5.9m** on the three preceding successful `main` runs. #936 only touches `web/packages/common`, so the hang was unrelated to it. Cancelling by hand freed the queue; nothing in the workflow would have, for up to six hours.

## Sizing

Values come from observed maxima on recent successful runs, with generous headroom — the goal is "obviously wedged", not "tight budget":

| job | observed max | timeout |
| --- | --- | --- |
| `python-integration-test` | 13.4m | 45 |
| `web-studio-e2e` | — | 45 |
| `web-test` | 11.2m | 30 |
| `lint` | 4.8m | 30 |
| `python-unit-test` | 5.9m | 20 |
| `python-unit-test-tools`, `web-sdk-gen`, `helm-chart-verifier` | ≤1.7m | 20 |
| `web-typecheck`, `web-lint`, `web-format`, `web-studio-deps`, `policy-wasm`, `python-auth-idp-static-test`, `helm-lint`, `docker-bake-graph`, `ngc-metadata-test` | ≤1.7m | 15 |
| `changes`, `actionlint`, `opa-policy-test`, `require-nvskills`, `ci-status`, `coverage-comment` | ≤0.3m | 10 |

The 12 jobs that already declared timeouts (15–120m) are untouched, so this brings the rest in line with an existing convention rather than inventing one.

## Verification

Diff is 23 insertions, one `timeout-minutes` per job immediately after `runs-on`, no other lines touched. Checked: YAML parses, all 35 jobs now carry a timeout, no duplicate keys, no out-of-range values, consistent indentation, and no pre-existing timeout was modified or removed.

I couldn't run `actionlint` locally (fetching the release binary is blocked in my sandbox), so the workflow's own `actionlint` job is the authoritative check here.

## Not addressed

This makes a hang fail fast; it doesn't explain **why** `python-unit-test` hung. If it recurs at the same step it deserves its own investigation — `make test-unit-ci` runs with `PYTEST_WORKERS: 4`, and a wedged worker would present exactly like this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit time limits to a broad range of automated validation and testing jobs.
  * Helps prevent stalled checks and ensures the continuous integration process completes more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->