### PR TITLE
feat: usage telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ nemo setup
 
 `nemo setup` starts local services, registers your LLM provider, discovers available models, installs agent skills, and deploys a sample agent (see more below).
 
+Review [Telemetry and Privacy](docs/telemetry-and-privacy.mdx) for the omnibus disclosure covering anonymous telemetry, bundled library telemetry, third-party endpoint notes, and opt-out controls.
+
 See **[SETUP.md](SETUP.md)** for the full source setup playbook (local data dir, DB reset, manual service start, troubleshooting).
 
 Verify:
@@ -176,6 +178,7 @@ The demo agent uses `${NEMO_DEFAULT_MODEL}` for both execution and the judge LLM
 
 Full documentation: [NeMo Platform docs](https://docs.nvidia.com/nemo-platform)
 
+- [Telemetry and privacy](https://docs.nvidia.com/nemo-platform/documentation/telemetry-and-privacy): anonymous telemetry, data collection, and opt-out controls.
 - [Setup](https://docs.nvidia.com/nemo-platform/documentation/get-started): installation, providers, SDK.
 - [CLI reference](https://docs.nvidia.com/nemo-platform/documentation/reference/cli-reference): all commands.
 - [API reference](https://docs.nvidia.com/nemo-platform/documentation/reference/api-reference): REST endpoints.

--- a/docs/cli/configuration.mdx
+++ b/docs/cli/configuration.mdx
@@ -155,3 +155,79 @@ nemo models <Tab>
 ```
 
 If completion isn't working, make sure you've restarted your shell and that your shell supports programmable completion. For Bash, ensure `bash-completion` is installed on your system.
+
+## Telemetry
+
+NeMo Platform collects anonymous usage data to improve the product. On your first run, the CLI prints a notice to standard error explaining what data is collected and how to opt out.
+
+For the full product disclosure, including bundled library telemetry and third-party endpoint notes, see [Telemetry and Privacy](/documentation/telemetry-and-privacy).
+
+### What Data Is Collected
+
+The CLI and bundled plugins emit anonymous usage events. No prompts, user data, personal information, or file contents leave your machine.
+
+Collected data includes:
+
+- Command and job names you invoke
+- Completion status and duration of commands and jobs
+- Plugin and tool names you use
+- Provider type, bucketed model discovery counts, and whether job model data was reported
+- Input and output token counts per job (where available)
+- Package version and CPU architecture
+
+The events are batched and sent to NVIDIA's telemetry endpoint with no user identifiers, device fingerprints, hostnames, or machine-derived identifiers attached.
+
+The only linking value is a random session identifier stored in local platform state. It carries no user or device identity and is automatically rotated every 30 days; if the local state file is missing a creation date, NeMo Platform replaces it with a new identifier.
+
+### What Data Is Not Collected
+
+- User data, prompts, or model outputs
+- File contents or references
+- Usernames, email addresses, IP addresses, or hostnames
+- Machine fingerprints or unique identifiers
+
+### Opting Out
+
+Disable telemetry using any of these three methods (they all work):
+
+#### 1. Environment Variable
+
+```bash
+export NEMO_TELEMETRY_ENABLED=false
+```
+
+Then run any `nemo` command. This disables telemetry for the CLI and bundled plugins for the current shell session and child processes. To persist it for future shell sessions, add the export to your shell startup configuration.
+
+#### 2. Configuration File
+
+Add this to your configuration file at `~/.config/nmp/config.yaml`:
+
+```yaml
+telemetry_enabled: false
+```
+
+#### 3. Per-Command Flag
+
+```bash
+nemo --no-telemetry workspaces list
+```
+
+The `--no-telemetry` flag disables telemetry for a single command only.
+
+<Note>
+
+These three layers are independent. NeMo Platform sends telemetry only when you have not disabled it in any of them. Setting any one layer to off disables telemetry, and no layer turns it back on. For example, if you leave the environment variable unset but set `telemetry_enabled: false` in your config file, telemetry stays off.
+
+</Note>
+
+### Bundled Plugins
+
+NeMo Platform ships with plugins that emit their own anonymous usage telemetry. The `NEMO_TELEMETRY_ENABLED` environment variable is the recommended single off switch: set it to `false` to disable telemetry for the CLI and for NeMo tools that share this telemetry system. The config file setting and the `--no-telemetry` flag apply to the CLI.
+
+### First-Run Notice
+
+On your first run, the CLI writes this notice to standard error:
+
+> NeMo Platform collects anonymous usage data to improve the product. No prompts, data, or personal information leave your machine. Turn it off at any time with NEMO_TELEMETRY_ENABLED=false.
+
+The notice appears only once, and you can opt out at any time using one of the methods above.

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -30,6 +30,7 @@ nemo [GLOBAL OPTIONS] COMMAND [ARGS]...
 * `--timestamp-format <CHOICE>`: Timestamp format for table/markdown/csv output [possible values: relative, iso8601]
 * `--verbose, -v`: Enable verbose messaging. This only impacts logs that are visible, it doesn't change any data outputs.
 * `--agent-mode, -A`: Enable agent-friendly output mode with extra context for coding agents.
+* `--no-telemetry`: Disable anonymous usage telemetry for this invocation.
 
 **Help:**
 

--- a/docs/fern/snippets/_snippets/cli-summary.mdx
+++ b/docs/fern/snippets/_snippets/cli-summary.mdx
@@ -12,6 +12,7 @@ description: ""
 | `--timestamp-format <CHOICE>` | Timestamp format for table/markdown/csv output [possible values: relative, iso8601] |
 | `--verbose, -v` | Enable verbose messaging. This only impacts logs that are visible, it doesn't change any data outputs. |
 | `--agent-mode, -A` | Enable agent-friendly output mode with extra context for coding agents. |
+| `--no-telemetry` | Disable anonymous usage telemetry for this invocation. |
 
 **Commands** are organized into categories:
 

--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -3,6 +3,8 @@ navigation:
     contents:
       - page: Home
         path: ../../index.mdx
+      - page: Telemetry and Privacy
+        path: ../../telemetry-and-privacy.mdx
       - section: Get Started
         path: ../../get-started/setup.mdx
         contents:

--- a/docs/set-up/index.mdx
+++ b/docs/set-up/index.mdx
@@ -18,7 +18,7 @@ This Platform Setup chapter is for the following personas.
 
 The NeMo Platform Helm chart is published in the `nvidia/nemo-platform` NGC org. The chart deploys the platform API, controllers, storage integration, and dependencies required for a full self-managed deployment.
 
-Customize the installation by updating a pinned `values.yaml` file for your target cluster. For chart assets and additional details, see the [NeMo Platform artifacts in NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/nemo-platform).
+Customize the installation by updating a pinned `values.yaml` file for your target cluster. For chart assets and additional details, see the [NeMo Platform artifacts in NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo-platform/helm-charts/nemo-platform).
 
 The install guide uses `NMP_HELM_CHART_VERSION` so every install and upgrade is tied to a specific chart version.
 

--- a/docs/telemetry-and-privacy.mdx
+++ b/docs/telemetry-and-privacy.mdx
@@ -1,0 +1,125 @@
+---
+title: "Telemetry and Privacy"
+description: "Anonymous telemetry collected by NeMo Platform and bundled NeMo libraries, and how to opt out."
+---
+
+NeMo Platform and its bundled library plugins include optional anonymous telemetry
+to help NVIDIA improve reliability, usability, and product direction. No user
+content, credentials, prompts, model outputs, file contents, or personally
+identifiable information is collected by these telemetry events.
+
+You can opt out at any time. When you run components through NeMo Platform, the
+platform telemetry controls are the recommended broad opt-out for the CLI and
+bundled plugins that share this telemetry system. When you use a library
+standalone, configure telemetry separately for that library.
+
+Opting out of NeMo telemetry does not affect data collection by inference
+endpoints you separately configure, such as NVIDIA Build, OpenRouter, or local
+model servers. Those endpoints are governed by their own terms and privacy
+practices.
+
+## What Is Collected
+
+All telemetry is operational or configuration-level. Telemetry event payloads do
+not include user inputs, file contents, model responses, user identifiers, device
+fingerprints, hostnames, or machine-derived identifiers.
+
+| Component | Identifier | Data collected |
+| --- | --- | --- |
+| NeMo Platform | Random session identifier stored in local platform state and rotated every 30 days. If the state file has no creation date, an invalid creation date, or an expired creation date, NeMo Platform creates a new identifier. | Session identifier; onboarding step name, outcome, and invocation method; CLI command name, duration, and outcome; job type, duration, plugin references, model-data present/absent bucket, and token counts when available; CI flag; coding-agent flag; package version; CPU architecture. |
+| Anonymizer | Per-session rotating identifier, not persistent across sessions. | Job-level operational metrics, such as final run status, processing time, record counts, token counts, configuration parameters, deployment type, and model endpoint information. |
+| Data Designer | Per-session rotating identifier, not persistent across sessions. | Model names used and input/output token counts. |
+| Guardrails | Per-session rotating identifier, not persistent across sessions. | Configuration and environment metrics, such as library version, Python version, operating system, Colang version, LLM engine names, rail configuration, active features, and deployment context. |
+| Safe Synthesizer | Per-session rotating identifier, not persistent across sessions. | Run-level operational metrics, such as final run status, processing time, record counts, token counts, configuration parameters, top-level quality and privacy scores, base model, deployment type, and GPU type. |
+
+Aggregate data, such as model usage distribution and total token counts, may be
+shared publicly with the community. Telemetry is used to prioritize product
+improvements, not to track individual users.
+
+## Opt Out
+
+### NeMo Platform
+
+Disable NeMo Platform telemetry with any one of these controls:
+
+```bash
+export NEMO_TELEMETRY_ENABLED=false
+```
+
+```yaml
+telemetry_enabled: false
+```
+
+```bash
+nemo --no-telemetry workspaces list
+```
+
+The environment variable disables telemetry for the CLI and bundled plugins that
+share the platform telemetry controls. The configuration file setting
+`telemetry_enabled: false` goes in `~/.config/nmp/config.yaml`. The
+`--no-telemetry` flag disables telemetry for one CLI invocation.
+
+For CLI-specific behavior, see [CLI configuration](/documentation/cli/configuration#telemetry).
+
+### Data Designer
+
+When you use Data Designer through NeMo Platform, use the platform controls
+above. For standalone library usage, configure telemetry using the standalone
+Data Designer library's documented opt-out controls.
+
+### Anonymizer
+
+When you use Anonymizer through NeMo Platform, use the platform controls above.
+Standalone Anonymizer configs can disable telemetry with the `emit_telemetry`
+field:
+
+```python
+from anonymizer.config.anonymizer_config import AnonymizerConfig
+from anonymizer.config.replace_strategies import Redact
+
+config = AnonymizerConfig(replace=Redact(), emit_telemetry=False)
+```
+
+### Safe Synthesizer
+
+When you use Safe Synthesizer through NeMo Platform, use the platform controls
+above. Standalone Safe Synthesizer configs can disable telemetry with the
+`emit_telemetry` field:
+
+```yaml
+emit_telemetry: false
+```
+
+### Guardrails
+
+Set any one of the following before the Guardrails library starts:
+
+```bash
+export NEMO_GUARDRAILS_NO_USAGE_STATS=1
+```
+
+```bash
+export DO_NOT_TRACK=1
+```
+
+```bash
+mkdir -p ~/.config/nemoguardrails
+touch ~/.config/nemoguardrails/do_not_track
+```
+
+Changing the environment variable or creating the `do_not_track` marker after
+the library has started does not stop an already-running heartbeat thread.
+
+## Third-Party Endpoints
+
+NeMo Platform and bundled library plugins can use third-party inference endpoints
+such as NVIDIA Build, OpenRouter, or local model servers. If you configure one of
+these endpoints:
+
+- That endpoint's terms of service and privacy practices apply independently of
+  NeMo Platform.
+- NeMo telemetry opt-out controls do not extend to data collection by your chosen
+  inference endpoint.
+- NVIDIA Build is intended for evaluation and testing only and may not be used in
+  production environments. Do not submit confidential information or personal
+  data when using NVIDIA Build.

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/app.py
@@ -220,6 +220,14 @@ def main(
             hidden=True,
         ),
     ] = False,
+    no_telemetry: Annotated[
+        bool,
+        typer.Option(
+            "--no-telemetry",
+            help="Disable anonymous usage telemetry for this invocation.",
+            rich_help_panel="Global Options",
+        ),
+    ] = False,
 ) -> None:
     """
     Command-line interface for NeMo Platform.
@@ -252,6 +260,12 @@ def main(
         env_val = os.environ.get("NMP_AGENT_MODE", "").lower()
         agent_mode = env_val in ("1", "true", "yes")
     ctx.obj.agent_mode = agent_mode
+
+    # Capture command name + agent mode for the command_invoked telemetry event, wire
+    # the per-invocation opt-out, and print the first-run notice. Best effort inside.
+    from nemo_platform_ext.cli.telemetry import runtime as telemetry_runtime
+
+    telemetry_runtime.on_callback(ctx, no_telemetry=no_telemetry)
 
     # Build ConfigParams from CLI args
     overrides: ConfigParams = {}

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -42,6 +42,8 @@ from nemo_platform_ext.cli.commands.skills.base import Scope, Skill
 from nemo_platform_ext.cli.commands.skills.registry import get_installer, load_skills
 from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_ext.cli.core.errors import handle_errors
+from nemo_platform_ext.cli.telemetry import emit
+from nemo_platform_ext.cli.telemetry.events import OnboardingStepEvent, TaskStatusEnum
 from nemo_platform_ext.client.tls import client_verify_from_env
 from nemo_platform_ext.config.config import Config
 from nemo_platform_ext.config.models import DEFAULT_BASE_URL, ConfigFile, ConfigParams, LocalServicesConfig
@@ -133,6 +135,14 @@ KNOWN_PROVIDERS: tuple[KnownProvider, ...] = (
 )
 
 _KNOWN_PROVIDERS_BY_NAME: dict[str, KnownProvider] = {p.name: p for p in KNOWN_PROVIDERS}
+
+
+def _provider_type_for_connection(name: str, host_url: str) -> str:
+    known = _KNOWN_PROVIDERS_BY_NAME.get(name)
+    if known is not None and known.host_url.rstrip("/") == host_url.rstrip("/"):
+        return known.name
+    return "custom"
+
 
 # ---------------------------------------------------------------------------
 # Onboarding paths — shown after setup completes
@@ -536,7 +546,21 @@ def _create_provider(
             kwargs["required_extra_headers"] = {header_name.strip(): header_value.strip()}
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
-    client.inference.providers.create(**kwargs)
+    provider_type = _provider_type_for_connection(name, host_url)
+    try:
+        client.inference.providers.create(**kwargs)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(
+                step="provider_connected", task_status=TaskStatusEnum.ERROR, provider_type=provider_type
+            )
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="provider_connected", task_status=TaskStatusEnum.COMPLETED, provider_type=provider_type
+        )
+    )
 
 
 def _update_provider(
@@ -556,14 +580,76 @@ def _update_provider(
         kwargs["api_key_secret_name"] = secret_name
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
-    client.inference.providers.update(name, **kwargs)
+    provider_type = _provider_type_for_connection(name, host_url)
+    try:
+        client.inference.providers.update(name, **kwargs)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(
+                step="provider_connected", task_status=TaskStatusEnum.ERROR, provider_type=provider_type
+            )
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="provider_connected", task_status=TaskStatusEnum.COMPLETED, provider_type=provider_type
+        )
+    )
 
 
 _PROVIDER_UNHEALTHY_STATUSES = frozenset({"ERROR", "LOST"})
 _NON_COMPLIANT_MARKER = "Non-OpenAI compliant"
 
 
+def _bucket_model_count(count: int) -> str:
+    """Bucket a discovered-model count into a coarse range for telemetry.
+
+    Keeps the emitted value low-cardinality (no exact counts leave the machine).
+    """
+    if count <= 0:
+        return "0"
+    if count <= 5:
+        return "1-5"
+    if count <= 20:
+        return "6-20"
+    if count <= 50:
+        return "21-50"
+    if count <= 100:
+        return "51-100"
+    if count <= 250:
+        return "101-250"
+    return "251+"
+
+
 def _wait_for_models(
+    client: NeMoPlatform,
+    provider_name: str,
+    workspace: str,
+    host_url: str = "",
+    round_seconds: int = _MODEL_DISCOVERY_ROUND_SECONDS,
+    max_rounds: int = _MODEL_DISCOVERY_MAX_ROUNDS,
+) -> list[str]:
+    """Poll for served models and emit one ``models_discovered`` event.
+
+    Thin telemetry wrapper around :func:`_wait_for_models_impl`: COMPLETED with
+    the discovered-count bucket on success, ERROR (re-raised) if polling blows up.
+    """
+    try:
+        models = _wait_for_models_impl(client, provider_name, workspace, host_url, round_seconds, max_rounds)
+    except Exception:
+        emit.emit_event(OnboardingStepEvent(step="models_discovered", task_status=TaskStatusEnum.ERROR))
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="models_discovered",
+            task_status=TaskStatusEnum.COMPLETED,
+            models_discovered_bucket=_bucket_model_count(len(models)),
+        )
+    )
+    return models
+
+
+def _wait_for_models_impl(
     client: NeMoPlatform,
     provider_name: str,
     workspace: str,
@@ -1098,20 +1184,30 @@ def _run_skill_install(
         console.print(f"  {WARN} No skills selected to install.")
         return
 
-    successes = 0
-    failures = 0
-    for agent in agents:
-        try:
-            installer = get_installer(agent)
-            installer.install(scope, project_root, chosen)
-            console.print(f"  {CHECK} Installed {len(chosen)} skill(s) for {agent}")
-            successes += 1
-        except Exception as exc:
-            console.print(f"  {WARN} Failed to install skills for {agent}: {exc}")
-            failures += 1
+    skills_target = ",".join(agents)
+    try:
+        successes = 0
+        failures = 0
+        for agent in agents:
+            try:
+                installer = get_installer(agent)
+                installer.install(scope, project_root, chosen)
+                console.print(f"  {CHECK} Installed {len(chosen)} skill(s) for {agent}")
+                successes += 1
+            except Exception as exc:
+                console.print(f"  {WARN} Failed to install skills for {agent}: {exc}")
+                failures += 1
 
-    if failures and not successes:
-        raise typer.Exit(1)
+        if failures and not successes:
+            raise typer.Exit(1)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="skills_installed", task_status=TaskStatusEnum.ERROR, skills_target=skills_target)
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(step="skills_installed", task_status=TaskStatusEnum.COMPLETED, skills_target=skills_target)
+    )
 
 
 def _parse_csv_flag(value: str | None) -> list[str] | None:
@@ -1330,6 +1426,30 @@ def _agents_api_ready(base_url: str, workspace: str, headers: dict[str, str] | N
 
 
 def _deploy_demo_agent(
+    base_url: str,
+    workspace: str,
+    config_path: Traversable,
+    default_model: str,
+    headers: dict[str, str] | None = None,
+) -> bool:
+    """Deploy the demo agent and emit one ``agent_deployed`` event.
+
+    Telemetry wrapper around :func:`_deploy_demo_agent_impl`: COMPLETED when the
+    deployment reaches running, ERROR when it fails, times out, or raises.
+    """
+    try:
+        deployed = _deploy_demo_agent_impl(base_url, workspace, config_path, default_model, headers=headers)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="agent_deployed", task_status=TaskStatusEnum.ERROR, agent_deployed=False)
+        )
+        raise
+    task_status = TaskStatusEnum.COMPLETED if deployed else TaskStatusEnum.ERROR
+    emit.emit_event(OnboardingStepEvent(step="agent_deployed", task_status=task_status, agent_deployed=deployed))
+    return deployed
+
+
+def _deploy_demo_agent_impl(
     base_url: str,
     workspace: str,
     config_path: Traversable,
@@ -1934,30 +2054,43 @@ def setup_command(
     skills_agents_list = _parse_csv_flag(skills_agents)
     skills_from_list = _parse_csv_flag(skills_from)
 
-    if auto:
-        _run_auto_mode(
-            cli_context,
-            client,
-            workspace,
-            base_url,
-            install_skills,
-            deploy_agent,
-            skills_agents=skills_agents_list,
-            skills_scope=skills_scope,
-            skills_from=skills_from_list,
-        )
-    else:
-        _run_interactive_mode(
-            cli_context,
-            client,
-            workspace,
-            base_url,
-            install_skills,
-            deploy_agent,
-            skills_agents=skills_agents_list,
-            skills_scope=skills_scope,
-            skills_from=skills_from_list,
-        )
+    try:
+        if auto:
+            _run_auto_mode(
+                cli_context,
+                client,
+                workspace,
+                base_url,
+                install_skills,
+                deploy_agent,
+                skills_agents=skills_agents_list,
+                skills_scope=skills_scope,
+                skills_from=skills_from_list,
+            )
+        else:
+            _run_interactive_mode(
+                cli_context,
+                client,
+                workspace,
+                base_url,
+                install_skills,
+                deploy_agent,
+                skills_agents=skills_agents_list,
+                skills_scope=skills_scope,
+                skills_from=skills_from_list,
+            )
+    except typer.Exit as exc:
+        # A clean user-cancel raises typer.Exit(0); that is a normal end of the
+        # flow, not a failure, so it must not corrupt the onboarding funnel.
+        # Only a non-zero exit code counts as ERROR. Re-raise unchanged either way.
+        status = TaskStatusEnum.COMPLETED if exc.exit_code == 0 else TaskStatusEnum.ERROR
+        emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=status))
+        raise
+    except Exception:
+        # Any real (non-Exit) failure: setup did not finish cleanly.
+        emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.ERROR))
+        raise
+    emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.COMPLETED))
 
 
 def _run_auto_mode(
@@ -1993,6 +2126,16 @@ def _run_auto_mode(
             break
         if attempt < _MODEL_DISCOVERY_MAX_ROUNDS - 1:
             console.print(f"  {WARN} Models not available yet, retrying...")
+
+    # Auto mode discovers models via an inline loop rather than _wait_for_models,
+    # so emit the models_discovered event here to cover the non-interactive path.
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="models_discovered",
+            task_status=TaskStatusEnum.COMPLETED,
+            models_discovered_bucket=_bucket_model_count(len(entity_ids)),
+        )
+    )
 
     default_model = os.environ.get("NEMO_DEFAULT_MODEL", "").strip()
     if not default_model and entity_ids:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/help_formatter.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/help_formatter.py
@@ -14,10 +14,12 @@ Clean help output with uv-inspired style:
 from __future__ import annotations
 
 import shutil
+import sys
+import time
 from contextvars import ContextVar
 from functools import wraps
 from io import StringIO
-from typing import Any, Callable, ParamSpec, Sequence, TypeVar
+from typing import Any, Callable, Mapping, ParamSpec, Sequence, TypeVar
 
 import click
 from click import Command
@@ -39,6 +41,8 @@ def _strip_required_suffix(help_text: str) -> tuple[str, bool]:
 class NmpErrorHandlingMixin:
     """Mixin that provides custom error handling for Click commands."""
 
+    _nmp_emit_command_invoked = False
+
     def main(
         self,
         args: list[str] | None = None,
@@ -47,36 +51,90 @@ class NmpErrorHandlingMixin:
         standalone_mode: bool = True,
         **extra: Any,
     ) -> Any:
-        """Override main to use custom error handling."""
-        from nemo_platform_ext.cli.core.errors import handle_exception
+        """Override main to use custom error handling and emit one telemetry event.
 
+        This is the single path every command type flows through (hand-registered,
+        OpenAPI-generated, plugin entry points), and Click only calls ``main()`` on the
+        root command object, so this is the natural choke point for a per-invocation
+        ``command_invoked`` event. The outcome->status mapping and the emit both live in
+        a ``finally`` so telemetry fires even when a command fails, and the emit body is
+        best-effort (never raises) so a telemetry bug can never change a command's exit
+        code or output.
+        """
+        from nemo_platform_ext.cli.core.errors import handle_exception
+        from nemo_platform_ext.cli.telemetry import runtime
+        from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+
+        # Only the root group drives telemetry. Nested groups never have main()
+        # called during dispatch, but this guard keeps the single-emit contract explicit.
+        is_telemetry_root = bool(getattr(self, "_nmp_emit_command_invoked", False))
+        help_requested = False
+        if is_telemetry_root:
+            runtime.reset()
+            # Reading help (e.g. ``nemo docs --help``) is not usage, so it must not emit
+            # a command_invoked event. Detect a help request from the resolved args; the
+            # help option names are the same ones every command registers via
+            # ``_context_settings_with_help``.
+            resolved_args = args if args is not None else sys.argv[1:]
+            help_requested = any(arg in HELP_OPTION_NAMES for arg in resolved_args)
+
+        start = time.monotonic()
+        status: TaskStatusEnum | None = None
         try:
-            result = super().main(  # type: ignore[misc]
-                args=args,
-                prog_name=prog_name,
-                complete_var=complete_var,
-                standalone_mode=False,
-                **extra,
-            )
-            # When standalone_mode=False, Click returns the exit code instead of raising
-            # SystemExit. We need to convert non-zero exit codes back to SystemExit
-            # when the original caller expected standalone_mode=True behavior.
-            if standalone_mode and isinstance(result, int) and result != 0:
-                raise SystemExit(result)
-            return result
-        except click.UsageError as e:
-            if standalone_mode:
-                handle_exception(e, e.ctx)
+            try:
+                result = super().main(  # type: ignore[misc]  # ty: ignore[unresolved-attribute]
+                    args=args,
+                    prog_name=prog_name,
+                    complete_var=complete_var,
+                    standalone_mode=False,
+                    **extra,
+                )
+                # When standalone_mode=False, Click returns the exit code instead of
+                # raising. A non-zero code is an error regardless of how the outer caller
+                # ultimately surfaces it.
+                status = TaskStatusEnum.ERROR if isinstance(result, int) and result != 0 else TaskStatusEnum.COMPLETED
+                # Convert non-zero exit codes back to SystemExit when the original caller
+                # expected standalone_mode=True behavior.
+                if standalone_mode and isinstance(result, int) and result != 0:
+                    raise SystemExit(result)
+                return result
+            except click.UsageError as e:
+                status = TaskStatusEnum.ERROR
+                if standalone_mode:
+                    handle_exception(e, e.ctx)
+                raise
+            except click.exceptions.Exit as e:
+                status = TaskStatusEnum.COMPLETED if e.exit_code == 0 else TaskStatusEnum.ERROR
+                if standalone_mode:
+                    raise SystemExit(e.exit_code)
+                raise
+            except click.Abort:
+                status = TaskStatusEnum.CANCELED
+                if standalone_mode:
+                    click.echo("Aborted!", err=True)
+                    raise SystemExit(1)
+                raise
+            except click.ClickException as e:
+                status = TaskStatusEnum.ERROR
+                if standalone_mode:
+                    handle_exception(e, getattr(e, "ctx", None))
+                raise
+        except SystemExit as e:
+            if status is None:
+                code = e.code
+                status = TaskStatusEnum.COMPLETED if code in (0, None) else TaskStatusEnum.ERROR
             raise
-        except click.exceptions.Exit as e:
-            if standalone_mode:
-                raise SystemExit(e.exit_code)
+        except KeyboardInterrupt:
+            if status is None:
+                status = TaskStatusEnum.CANCELED
             raise
-        except click.Abort:
-            if standalone_mode:
-                click.echo("Aborted!", err=True)
-                raise SystemExit(1)
+        except BaseException:
+            if status is None:
+                status = TaskStatusEnum.ERROR
             raise
+        finally:
+            if is_telemetry_root and not help_requested:
+                runtime.emit_command_invoked(status or TaskStatusEnum.COMPLETED, time.monotonic() - start)
 
 
 def _get_terminal_width() -> int:
@@ -85,7 +143,7 @@ def _get_terminal_width() -> int:
     return min(width - 2, 120)
 
 
-def _context_settings_with_help(context_settings: dict | None) -> dict:
+def _context_settings_with_help(context_settings: Mapping[str, Any] | None) -> dict[str, Any]:
     """Return context_settings with help_option_names defaulting to --help/-h."""
     settings = dict(context_settings or {})
     settings.setdefault("help_option_names", list(HELP_OPTION_NAMES))
@@ -271,7 +329,7 @@ class NmpOption(TyperOption):
 
         # Add value placeholder if needed
         if not self.is_flag and not self.count:
-            metavar = self.metavar or self.name.upper()
+            metavar = self.metavar or (self.name or "").upper()
             placeholder = click.style(f"<{metavar}>", fg="yellow")
             opts_str = f"{opts_str} {placeholder}"
 
@@ -290,8 +348,9 @@ class NmpOption(TyperOption):
                 has_real_default = True
 
         # Possible values (choices) and default - combine if both present
-        if hasattr(self.type, "choices") and self.type.choices:
-            choices = ", ".join(str(c) for c in self.type.choices)
+        type_choices = getattr(self.type, "choices", None)
+        if type_choices:
+            choices = ", ".join(str(c) for c in type_choices)
 
             # Check if we also have a default to combine
             if has_real_default:
@@ -519,11 +578,19 @@ class NmpGroup(NmpErrorHandlingMixin, TyperGroup):
 
         return f"Active context: {display_context.context_name} (workspace: {display_context.workspace})"
 
-    def command(self, *args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Command] | Command:  # pyright: ignore [reportIncompatibleMethodOverride]
+    def command(self, *args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Command] | Command:  # pyright: ignore [reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]
         """Override command decorator to use NmpCommand."""
         if "cls" not in kwargs:
             kwargs["cls"] = NmpCommand
         return super().command(*args, **kwargs)
+
+    def resolve_command(self, ctx: click.Context, args: list[str]) -> tuple[str | None, Command | None, list[str]]:
+        """Record the resolved subcommand name for telemetry, then resolve as usual."""
+        cmd_name, cmd, remaining = super().resolve_command(ctx, args)
+        from nemo_platform_ext.cli.telemetry import runtime
+
+        runtime.note_subcommand(cmd_name)
+        return cmd_name, cmd, remaining
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> Command | None:
         """Override to patch command classes to use NeMo Platform formatting."""

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/lazy_load.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/lazy_load.py
@@ -34,6 +34,8 @@ def attach_lazy_entries(
 class ManifestBackedNmpGroup(NmpGroup):
     """Group that renders lazy child metadata and loads real children on demand."""
 
+    _nmp_emit_command_invoked = True
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._lazy_entries: dict[str, TopLevelEntry] = {}

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/waiters.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/core/waiters.py
@@ -17,8 +17,9 @@
 
 from __future__ import annotations
 
+import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from nemo_platform import APIConnectionError, APIStatusError, APITimeoutError, NotFoundError
@@ -26,9 +27,24 @@ from rich.console import Console
 from rich.live import Live
 from rich.text import Text
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 _TRANSIENT_GATEWAY_STATUS_CODES = {429, 502, 503, 504}
+_SAFE_JOB_TYPE_BUCKETS = frozenset(
+    {
+        "agent",
+        "agents",
+        "anonymizer",
+        "audit",
+        "customization",
+        "data-designer",
+        "evaluation",
+        "evaluator",
+        "insights",
+        "job",
+    }
+)
 
 
 def _pause(seconds: float) -> None:
@@ -53,6 +69,90 @@ def _seconds_since_creation(entry_timestamp: datetime | str | None, created_at: 
 
 def _status_text(status: Any) -> str:
     return str(status or "")
+
+
+def _datetime_timestamp(value: datetime | str | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    try:
+        return value.timestamp()
+    except (TypeError, OSError):
+        return None
+
+
+def _job_duration_sec(job_status: Any, fallback_start_time: float) -> float:
+    now = time.time()
+    for attr in ("started_at", "start_time", "created_at"):
+        timestamp = _datetime_timestamp(getattr(job_status, attr, None))
+        if timestamp is not None:
+            return max(0.0, now - timestamp)
+    return max(0.0, now - fallback_start_time)
+
+
+def _model_data_bucket(raw_model: object) -> str:
+    model = str(raw_model).strip() if raw_model is not None else ""
+    return "defined" if model else "undefined"
+
+
+def _job_type_bucket(resource_label: str) -> str:
+    label = str(resource_label or "").strip().lower().replace("_", "-").replace(" ", "-")
+    return label if label in _SAFE_JOB_TYPE_BUCKETS else "custom"
+
+
+def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, start_time: float) -> None:
+    """Emit a ``job_run`` telemetry event for a terminal platform job.
+
+    Best effort: never raises and never affects the waiter's return value.
+    """
+    try:
+        from nemo_platform_ext.cli.telemetry.emit import emit_event
+        from nemo_platform_ext.cli.telemetry.events import JobRunEvent, TaskStatusEnum
+
+        status_map = {
+            "completed": TaskStatusEnum.COMPLETED,
+            "error": TaskStatusEnum.ERROR,
+            "cancelled": TaskStatusEnum.CANCELED,
+        }
+        task_status = status_map.get(status, TaskStatusEnum.UNDEFINED)
+
+        details = getattr(job_status, "status_details", None)
+        if not isinstance(details, dict):
+            details = {}
+
+        # Step names are user-controlled by PlatformJobStepSpec, even though our
+        # built-in compilers use static names like "audit-job" or "evaluate-suite".
+        # Emit only a low-cardinality bucket from command metadata.
+        job_type = _job_type_bucket(resource_label)
+
+        # Model names may be user-authored; emit only a coarse present/absent bucket.
+        model = _model_data_bucket(details.get("model"))
+        raw_input_tokens = details.get("input_tokens")
+        input_tokens = int(raw_input_tokens) if raw_input_tokens is not None else -1
+        raw_output_tokens = details.get("output_tokens")
+        output_tokens = int(raw_output_tokens) if raw_output_tokens is not None else -1
+
+        emit_event(
+            JobRunEvent(
+                task_status=task_status,
+                job_type=job_type,
+                duration_sec=_job_duration_sec(job_status, start_time),
+                plugins=[],
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        )
+    except Exception:
+        logger.debug("Failed to emit job_run telemetry event", exc_info=True)
 
 
 def _make_history_line(
@@ -270,11 +370,17 @@ def wait_for_platform_job(
 
             if current_status == "completed":
                 live.stop()
+                _emit_job_run_event(
+                    job_status, resource_label=resource_label, status=current_status, start_time=start_time
+                )
                 console.print(f"\n[green]✓ {resource_label.title()} completed![/green]")
                 return True
 
             if current_status in {"cancelled", "error"}:
                 live.stop()
+                _emit_job_run_event(
+                    job_status, resource_label=resource_label, status=current_status, start_time=start_time
+                )
                 console.print(f"\n[red]✗ {resource_label.title()} entered {current_status} state[/red]")
                 return False
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/events.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/events.py
@@ -3,7 +3,7 @@
 """Platform usage-telemetry event models.
 
 Field names and aliases follow the shared NeMo telemetry schema
-(aire/microservices/nemo-telemetry, schemas/anonymous_events.json, v1.9).
+(aire/microservices/nemo-telemetry, schemas/anonymous_events.json, v1.10).
 """
 
 from __future__ import annotations
@@ -60,7 +60,7 @@ class PlatformTelemetryEvent(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     _event_name: ClassVar[str] = "undefined"
-    _schema_version: ClassVar[str] = "1.9"
+    _schema_version: ClassVar[str] = "1.10"
 
     nemo_source: str = Field(default="platform", serialization_alias="nemoSource")
     task_status: TaskStatusEnum = Field(serialization_alias="taskStatus")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/runtime.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/telemetry/runtime.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-invocation telemetry state bridged between the Typer callback and the Click main wrapper.
+
+The Typer ``@app.callback`` sees the parsed context (command name, agent mode, opt-out
+flag) but not the command outcome. The ``NmpErrorHandlingMixin.main`` wrapper sees the
+outcome and duration but not the parsed flags. This module is the single small piece of
+state both sides read, so exactly one ``command_invoked`` event is emitted per invocation
+from the root command path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import click
+
+from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _InvocationState:
+    command_parts: list[str] = field(default_factory=list)
+    agent_mode: bool = False
+    started: bool = False
+    opted_out: bool = False
+
+
+state = _InvocationState()
+
+
+def reset() -> None:
+    """Clear invocation state. Called at the top of the root ``main()`` so CliRunner
+    invocations sharing a process never leak command names or flags between calls."""
+    state.command_parts = []
+    state.agent_mode = False
+    state.started = False
+    state.opted_out = False
+
+
+def on_callback(ctx: click.Context, *, no_telemetry: bool) -> None:
+    """Capture command name + agent mode from the root Typer callback.
+
+    Best effort: a telemetry bug must never break ``nemo <anything>``.
+    """
+    try:
+        from nemo_platform_ext.cli.telemetry.emit import maybe_print_first_run_notice, set_invocation_opt_out
+
+        set_invocation_opt_out(no_telemetry)
+        state.opted_out = no_telemetry
+        state.started = True
+        state.agent_mode = bool(getattr(ctx.obj, "agent_mode", False))
+        invoked = getattr(ctx, "invoked_subcommand", None)
+        if invoked:
+            state.command_parts = [invoked]
+        maybe_print_first_run_notice()
+    except Exception:  # noqa: BLE001
+        # Fail closed: if telemetry setup breaks, suppress this invocation's event.
+        state.opted_out = True
+        logger.debug("telemetry on_callback failed", exc_info=True)
+
+
+def note_subcommand(name: str | None) -> None:
+    """Append a resolved sub-subcommand name (e.g. the ``list`` in ``workspaces list``)."""
+    if state.started and name and name not in state.command_parts:
+        state.command_parts.append(name)
+
+
+def emit_command_invoked(task_status: TaskStatusEnum, duration_sec: float) -> None:
+    """Emit exactly one ``command_invoked`` event. Best effort; never raises."""
+    try:
+        if state.opted_out:
+            return
+        if not (state.started and state.command_parts):
+            # Bare ``--help`` and usage errors before a command resolves never emit.
+            return
+        from nemo_platform_ext.cli.telemetry.emit import emit_event
+        from nemo_platform_ext.cli.telemetry.events import CommandInvokedEvent
+
+        event = CommandInvokedEvent(
+            command=" ".join(state.command_parts),
+            duration_sec=max(0.0, duration_sec),
+            agent_mode=state.agent_mode,
+            task_status=task_status,
+        )
+        emit_event(event)
+    except Exception:  # noqa: BLE001
+        logger.debug("telemetry emit_command_invoked failed", exc_info=True)

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -94,6 +94,26 @@ from pydantic import SecretStr
 
 SETUP_MOD = "nemo_platform_ext.cli.commands.setup"
 
+
+@pytest.fixture(autouse=True)
+def _silence_telemetry():
+    """Silence stray telemetry side effects across this module.
+
+    These are direct-call unit tests with no telemetry intent. Several exercise
+    the real setup wrappers (`_create_provider`, `_wait_for_models`,
+    `_deploy_demo_agent`, `_auto_setup`), which call the real `emit_event`. With
+    telemetry enabled by default that constructs a `TelemetryHandler` and
+    schedules `_flush_events`, whose orphaned coroutine surfaces later as a
+    "coroutine ... was never awaited" RuntimeWarning (blamed on whichever
+    mock-heavy test triggers GC, not the emitting one). Patch emit_event at module
+    scope so no handler is ever built. No test in this file asserts on emit_event
+    (the telemetry assertions live in test_onboarding_events.py), so this weakens
+    nothing.
+    """
+    with patch("nemo_platform_ext.cli.telemetry.emit.emit_event"):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # KnownProvider catalog tests
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_ext/tests/cli/core/test_waiters.py
+++ b/packages/nemo_platform_ext/tests/cli/core/test_waiters.py
@@ -44,6 +44,13 @@ def _quiet_rich_output() -> Iterator[None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_telemetry() -> Iterator[None]:
+    """Neutralize best-effort job_run telemetry so waiter tests never do real I/O."""
+    with patch("nemo_platform_ext.cli.telemetry.emit.emit_event"):
+        yield
+
+
 @pytest.fixture
 def frozen_time() -> Iterator[MagicMock]:
     with patch(f"{WAITERS_MODULE}.time.time", return_value=0) as time:

--- a/packages/nemo_platform_ext/tests/cli/telemetry/conftest.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/conftest.py
@@ -8,14 +8,16 @@ from nemo_platform_ext.cli.telemetry.events import _CI_ENV_VARS
 
 
 @pytest.fixture(autouse=True)
-def _clear_ci_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Clear CI markers so telemetry tests are deterministic on developer machines and in CI.
+def _isolate_telemetry_env(_disable_cli_telemetry_by_default: None, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear inherited env that would make telemetry tests depend on the runner.
 
     Without this, tests that assert the default ``is_ci`` value pass locally but fail when the
     suite runs under GitHub Actions (which sets ``CI`` and ``GITHUB_ACTIONS``). Tests that
-    exercise CI detection set these variables explicitly, which overrides this fixture.
+    exercise CI detection or telemetry opt-out set those variables explicitly, which overrides
+    this fixture.
     """
     for var in _CI_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.delenv("NEMO_DEPLOYMENT_TYPE", raising=False)
+    monkeypatch.delenv("NEMO_TELEMETRY_ENABLED", raising=False)
     yield

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_command_hook.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_command_hook.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the command_invoked telemetry hook at the root command choke point."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import click
+import pytest
+from nemo_platform_ext.cli.app import app
+from nemo_platform_ext.cli.core.help_formatter import NmpErrorHandlingMixin
+from nemo_platform_ext.cli.telemetry import runtime
+from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class TestCommandInvokedHook:
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_successful_command_emits_completed(self, emit):
+        result = runner.invoke(app, ["docs", "--list"])
+        assert result.exit_code == 0
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.command.startswith("docs")
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.duration_sec >= 0
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_agent_mode_flag_captured(self, emit):
+        runner.invoke(app, ["--agent-mode", "docs", "--list"])
+        assert emit.call_args[0][0].agent_mode is True
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_failing_command_emits_error(self, emit):
+        with patch("nemo_platform_ext.cli.commands.docs._list_docs", side_effect=RuntimeError):
+            runner.invoke(app, ["docs", "--list"])
+        assert emit.call_count == 1
+        assert emit.call_args[0][0].task_status == TaskStatusEnum.ERROR
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_click_exception_emits_error_without_traceback(self, emit):
+        with patch("nemo_platform_ext.cli.commands.docs._list_docs", side_effect=click.ClickException("broken")):
+            result = runner.invoke(app, ["docs", "--list"])
+        assert result.exit_code == 1
+        assert "Error: broken" in result.stderr
+        assert "Traceback" not in result.output
+        assert emit.call_count == 1
+        assert emit.call_args[0][0].task_status == TaskStatusEnum.ERROR
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_keyboard_interrupt_emits_canceled(self, emit):
+        class InterruptingBase:
+            def main(self, **_kwargs):
+                runtime.state.started = True
+                runtime.state.command_parts = ["docs"]
+                raise KeyboardInterrupt
+
+        class InterruptingCommand(NmpErrorHandlingMixin, InterruptingBase):
+            _nmp_emit_command_invoked = True
+
+        with pytest.raises(KeyboardInterrupt):
+            InterruptingCommand().main(args=[], standalone_mode=True)
+        assert emit.call_count == 1
+        assert emit.call_args[0][0].task_status == TaskStatusEnum.CANCELED
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_no_telemetry_flag_suppresses(self, emit):
+        runner.invoke(app, ["--no-telemetry", "docs", "--list"])
+        emit.assert_not_called()
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_bare_help_does_not_emit(self, emit):
+        runner.invoke(app, ["--help"])
+        emit.assert_not_called()
+
+    @patch("nemo_platform_ext.cli.telemetry.emit.emit_event")
+    def test_group_help_does_not_emit(self, emit):
+        """``nemo <group> --help`` reads help; it is not usage and must not emit."""
+        result = runner.invoke(app, ["docs", "--help"])
+        assert result.exit_code == 0
+        emit.assert_not_called()

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_events.py
@@ -22,7 +22,7 @@ class TestCommandInvokedEvent:
         assert d["agentMode"] is False
         assert d["isCi"] is False
         assert e._event_name == "command_invoked"
-        assert e._schema_version == "1.9"
+        assert e._schema_version == "1.10"
 
     def test_no_free_text_fields_beyond_known(self):
         # privacy guard: the event cannot carry arbitrary payloads

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_job_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_job_events.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nemo_platform_ext.cli.core import waiters
+from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+
+WAITERS_MODULE = "nemo_platform_ext.cli.core.waiters"
+EMIT_TARGET = "nemo_platform_ext.cli.telemetry.emit.emit_event"
+
+
+class _DummyLive:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def __enter__(self) -> _DummyLive:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def update(self, *args: object) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _quiet_rich_output() -> Iterator[None]:
+    with (
+        patch(f"{WAITERS_MODULE}.Live", _DummyLive),
+        patch(f"{WAITERS_MODULE}.console.print"),
+    ):
+        yield
+
+
+@pytest.fixture
+def frozen_time() -> Iterator[MagicMock]:
+    with patch(f"{WAITERS_MODULE}.time.time", return_value=0) as time:
+        yield time
+
+
+@pytest.fixture
+def waiter_pause() -> Iterator[MagicMock]:
+    with patch(f"{WAITERS_MODULE}._pause") as pause:
+        yield pause
+
+
+def _completed_status() -> SimpleNamespace:
+    return SimpleNamespace(
+        status="completed",
+        steps=[
+            SimpleNamespace(name="audit-job"),
+            SimpleNamespace(name="evaluate"),
+            SimpleNamespace(name="evaluate-suite"),
+            SimpleNamespace(name="customer-project-step"),
+        ],
+        status_details={"input_tokens": 512, "output_tokens": 2048, "model": "nemotron-super-49b"},
+    )
+
+
+def test_completed_emits_single_job_run_event(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = _completed_status()
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customization") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "customization"
+    assert event.task_status is TaskStatusEnum.COMPLETED
+    assert event.input_tokens == 512
+    assert event.output_tokens == 2048
+    assert event.model == "defined"
+    assert event.plugins == []
+    assert "customer-project-step" not in event.job_type
+
+
+def test_static_step_name_is_not_emitted_as_job_type(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed", steps=[SimpleNamespace(name="audit-job")], status_details={}
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="audit") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "audit"
+    assert event.plugins == []
+
+
+def test_job_type_falls_back_to_resource_label_without_steps(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="completed", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customization") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "customization"
+    assert event.plugins == []
+
+
+def test_unsafe_resource_label_falls_back_to_custom(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[SimpleNamespace(name="private-customer-step")],
+        status_details={},
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert (
+            waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customer alpha project")
+            is True
+        )
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "custom"
+    assert event.plugins == []
+
+
+def test_status_details_defaults_when_absent(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="completed", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.input_tokens == -1
+    assert event.output_tokens == -1
+    assert event.model == "undefined"
+    assert event.plugins == []
+
+
+def test_null_status_details_still_emits(frozen_time: MagicMock) -> None:
+    """Explicit nulls must not drop the event; a real 0 token count must survive."""
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[],
+        status_details={"model": None, "input_tokens": 0, "output_tokens": None},
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.model == "undefined"
+    assert event.input_tokens == 0
+    assert event.output_tokens == -1
+
+
+def test_non_string_model_details_still_emit_safe_bucket(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[],
+        status_details={"model": {"name": "private-model"}, "input_tokens": 7, "output_tokens": 9},
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.model == "defined"
+    assert event.input_tokens == 7
+    assert event.output_tokens == 9
+
+
+def test_duration_uses_job_created_at_when_available() -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[],
+        status_details={},
+        created_at=datetime.fromtimestamp(90.0, tz=timezone.utc),
+    )
+
+    with (
+        patch(f"{WAITERS_MODULE}.time.time", side_effect=[100.0, 100.0, 100.0, 130.0]),
+        patch(EMIT_TARGET) as emit_event,
+    ):
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.duration_sec == 40.0
+
+
+def test_error_status_maps_to_error(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="error", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is False
+
+    emit_event.assert_called_once()
+    assert emit_event.call_args.args[0].task_status is TaskStatusEnum.ERROR
+
+
+def test_cancelled_status_maps_to_canceled(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="cancelled", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is False
+
+    emit_event.assert_called_once()
+    assert emit_event.call_args.args[0].task_status is TaskStatusEnum.CANCELED
+
+
+def test_timeout_emits_nothing_and_does_not_crash(waiter_pause: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="running", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", timeout=5, poll_interval=10) is False
+
+    emit_event.assert_not_called()

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_onboarding_events.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_onboarding_events.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for onboarding_step telemetry emitted from the setup flow.
+
+Each instrumented choke point in ``setup.py`` emits exactly one
+``OnboardingStepEvent``: COMPLETED on success, ERROR on failure with the
+original exception still propagating. ``emit_event`` is patched at its
+definition module so the module-attribute call in ``setup.py`` is intercepted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from nemo_platform.resources.inference.providers import ProvidersResource
+from nemo_platform_ext.cli.commands.setup import (
+    _bucket_model_count,
+    _create_provider,
+    _deploy_demo_agent,
+    _run_skill_install,
+    _update_provider,
+    _wait_for_models,
+    setup_command,
+)
+from nemo_platform_ext.cli.commands.skills.base import Scope, Skill
+from nemo_platform_ext.cli.telemetry.events import TaskStatusEnum
+
+SETUP_MOD = "nemo_platform_ext.cli.commands.setup"
+EMIT_TARGET = "nemo_platform_ext.cli.telemetry.emit.emit_event"
+
+
+@pytest.fixture
+def spinner_console():
+    """Patch setup.console with a mock status spinner context manager."""
+    mock_status = MagicMock()
+    with patch(f"{SETUP_MOD}.console") as mock_console:
+        mock_console.status.return_value.__enter__ = MagicMock(return_value=mock_status)
+        mock_console.status.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_console, mock_status
+
+
+def _providers_client() -> MagicMock:
+    client = MagicMock()
+    client.inference.providers = MagicMock(spec=ProvidersResource)
+    return client
+
+
+def _skill(name: str) -> Skill:
+    return Skill(
+        name=name,
+        description=f"{name} desc",
+        version="0.1",
+        content=f"# {name}",
+        raw=f"---\nname: {name}\n---\n# {name}",
+        source_plugin=None,
+    )
+
+
+class TestCreateProviderTelemetry:
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        client = _providers_client()
+        _create_provider(
+            client,
+            name="openai",
+            host_url="https://api.openai.com/v1",
+            secret_name="openai-api-key",
+            workspace="default",
+        )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.provider_type == "openai"
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        client = _providers_client()
+        client.inference.providers.create.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            _create_provider(
+                client,
+                name="anthropic",
+                host_url="https://api.anthropic.com",
+                secret_name="anthropic-api-key",
+                workspace="default",
+            )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.provider_type == "anthropic"
+
+    @patch(EMIT_TARGET)
+    def test_custom_provider_emits_fixed_custom_provider_type(self, emit):
+        client = _providers_client()
+        _create_provider(
+            client,
+            name="team-provider",
+            host_url="https://llm.example.test/v1",
+            secret_name="team-provider-api-key",
+            workspace="default",
+        )
+        event = emit.call_args[0][0]
+        assert event.provider_type == "custom"
+
+
+class TestUpdateProviderTelemetry:
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        client = _providers_client()
+        _update_provider(
+            client,
+            name="openai",
+            host_url="https://api.openai.com/v1",
+            secret_name="openai-api-key",
+            workspace="default",
+        )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.provider_type == "openai"
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        client = _providers_client()
+        client.inference.providers.update.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            _update_provider(
+                client,
+                name="team-provider",
+                host_url="https://llm.example.test/v1",
+                secret_name="team-provider-api-key",
+                workspace="default",
+            )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.provider_type == "custom"
+
+
+class TestWaitForModelsTelemetry:
+    @pytest.mark.usefixtures("spinner_console")
+    @patch(EMIT_TARGET)
+    def test_emits_completed_with_bucket(self, emit):
+        client = MagicMock()
+        models = [MagicMock(model_entity_id=f"default/model-{i}") for i in range(3)]
+        client.inference.providers.retrieve.return_value = MagicMock(served_models=models)
+
+        with (
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 0, 1]),
+        ):
+            result = _wait_for_models(client, "nvidia-build", "default", round_seconds=30, max_rounds=1)
+
+        assert result == [f"default/model-{i}" for i in range(3)]
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "models_discovered"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.models_discovered_bucket == "1-5"
+
+    @pytest.mark.usefixtures("spinner_console")
+    @patch(EMIT_TARGET)
+    def test_no_models_emits_bucket_zero(self, emit):
+        client = MagicMock()
+        client.inference.providers.retrieve.return_value = MagicMock(served_models=[])
+
+        with (
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 1, 2, 100]),
+        ):
+            result = _wait_for_models(client, "nvidia-build", "default", round_seconds=5, max_rounds=1)
+
+        assert result == []
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "models_discovered"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.models_discovered_bucket == "0"
+
+
+class TestRunSkillInstallTelemetry:
+    def _run(self, *, install_raises: bool):
+        installer = MagicMock()
+        if install_raises:
+            installer.install.side_effect = RuntimeError("install failed")
+        all_skills = {"alpha": _skill("alpha")}
+        with patch(f"{SETUP_MOD}.get_installer", return_value=installer):
+            _run_skill_install(
+                agents=["codex"],
+                scope=Scope.PROJECT,
+                skill_names=["alpha"],
+                all_skills=all_skills,
+                project_root=MagicMock(),
+            )
+
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        self._run(install_raises=False)
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "skills_installed"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert "codex" in event.skills_target
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        with pytest.raises(typer.Exit):
+            self._run(install_raises=True)
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "skills_installed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert "codex" in event.skills_target
+
+
+class TestDeployDemoAgentTelemetry:
+    def _responses(self, *, status_sequence):
+        create_resp = MagicMock(status_code=200)
+        create_resp.raise_for_status = MagicMock()
+        deploy_resp = MagicMock(status_code=200)
+        deploy_resp.raise_for_status = MagicMock()
+        deploy_resp.json.return_value = {"name": "calculator-agent-abc12345"}
+        status_resps = []
+        for s in status_sequence:
+            r = MagicMock(status_code=200)
+            r.json.return_value = {"name": "calculator-agent-abc12345", "status": s}
+            status_resps.append(r)
+        return [create_resp, deploy_resp] + status_resps
+
+    @pytest.mark.usefixtures("spinner_console")
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed_true(self, emit, tmp_path):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        responses = self._responses(status_sequence=["running"])
+        with (
+            patch(f"{SETUP_MOD}.httpx.get", side_effect=responses[2:]),
+            patch(f"{SETUP_MOD}.httpx.post", side_effect=responses[:2]),
+            patch(f"{SETUP_MOD}._agent_exists", return_value=False),
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 1, 2, 3]),
+        ):
+            result = _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+        assert result is True
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.agent_deployed is True
+
+    @pytest.mark.usefixtures("spinner_console")
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit, tmp_path):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        create_resp = MagicMock(status_code=500)
+        create_resp.raise_for_status = MagicMock(side_effect=RuntimeError("http 500"))
+        with (
+            patch(f"{SETUP_MOD}.httpx.post", return_value=create_resp),
+            patch(f"{SETUP_MOD}._agent_exists", return_value=False),
+        ):
+            with pytest.raises(RuntimeError):
+                _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.agent_deployed is False
+
+    @patch(EMIT_TARGET)
+    def test_false_deploy_outcome_emits_error_false(self, emit, tmp_path):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        with patch(f"{SETUP_MOD}._deploy_demo_agent_impl", return_value=False):
+            result = _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+
+        assert result is False
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.agent_deployed is False
+
+
+class TestBucketModelCount:
+    @pytest.mark.parametrize(
+        ("count", "expected"),
+        [
+            (0, "0"),
+            (1, "1-5"),
+            (5, "1-5"),
+            (6, "6-20"),
+            (20, "6-20"),
+            (21, "21-50"),
+            (50, "21-50"),
+            (51, "51-100"),
+            (100, "51-100"),
+            (101, "101-250"),
+            (250, "101-250"),
+            (251, "251+"),
+            (5000, "251+"),
+        ],
+    )
+    def test_buckets(self, count, expected):
+        assert _bucket_model_count(count) == expected
+
+
+class TestSetupFinishedTelemetry:
+    """setup_finished must reflect the real outcome of the dispatch.
+
+    A clean user-cancel raises typer.Exit(0); that is a normal end, not a
+    failure, so it must emit COMPLETED. Any non-zero Exit (or real exception)
+    emits ERROR. In every case the Exit propagates unchanged.
+    """
+
+    def _run(self, dispatch_exc):
+        """Drive setup_command to the auto/interactive dispatch, patching all
+        preamble so only the dispatch outcome matters. `dispatch_exc` is raised
+        from _run_interactive_mode; None means a clean finish."""
+        ctx = MagicMock(spec=typer.Context)
+        ctx.obj = MagicMock()
+        ctx.obj.get_base_url.return_value = "http://localhost:3000"
+
+        interactive = MagicMock()
+        if dispatch_exc is not None:
+            interactive.side_effect = dispatch_exc
+
+        with (
+            patch(f"{SETUP_MOD}.console"),
+            patch(f"{SETUP_MOD}.is_interactive", return_value=True),
+            patch(f"{SETUP_MOD}._maybe_start_services"),
+            patch(f"{SETUP_MOD}._check_platform_reachable_with_retries", return_value=True),
+            patch(f"{SETUP_MOD}._bootstrap_config_if_missing"),
+            patch(f"{SETUP_MOD}._run_interactive_mode", interactive),
+        ):
+            setup_command(ctx)
+
+    @patch(EMIT_TARGET)
+    def test_clean_exit_zero_emits_completed(self, emit):
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(typer.Exit(0))
+        assert exc_info.value.exit_code == 0
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.COMPLETED
+
+    @patch(EMIT_TARGET)
+    def test_default_exit_emits_completed(self, emit):
+        # typer.Exit() defaults to exit_code 0, so a bare Exit is a clean end too.
+        with pytest.raises(typer.Exit):
+            self._run(typer.Exit())
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.COMPLETED
+
+    @patch(EMIT_TARGET)
+    def test_nonzero_exit_emits_error(self, emit):
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(typer.Exit(1))
+        assert exc_info.value.exit_code == 1
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.ERROR
+
+    @patch(EMIT_TARGET)
+    def test_real_exception_emits_error(self, emit):
+        with pytest.raises(RuntimeError):
+            self._run(RuntimeError("boom"))
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.ERROR

--- a/packages/nemo_platform_ext/tests/cli/telemetry/test_wire_contract_smoke.py
+++ b/packages/nemo_platform_ext/tests/cli/telemetry/test_wire_contract_smoke.py
@@ -81,8 +81,8 @@ class TestWireContractSmoke:
             f"Envelope keys mismatch: {set(payload.keys()) ^ EXPECTED_ENVELOPE_KEYS}"
         )
 
-        # Schema version must be 1.9.
-        assert payload["eventSchemaVer"] == "1.9"
+        # Schema version must be 1.10.
+        assert payload["eventSchemaVer"] == "1.10"
 
         # Must be JSON serializable.
         json_str = json.dumps(payload)
@@ -118,8 +118,8 @@ class TestWireContractSmoke:
             f"Envelope keys mismatch: {set(payload.keys()) ^ EXPECTED_ENVELOPE_KEYS}"
         )
 
-        # Schema version must be 1.9.
-        assert payload["eventSchemaVer"] == "1.9"
+        # Schema version must be 1.10.
+        assert payload["eventSchemaVer"] == "1.10"
 
         # Must be JSON serializable.
         json_str = json.dumps(payload)
@@ -144,7 +144,7 @@ class TestWireContractSmoke:
             job_type="evaluate",
             duration_sec=15.75,
             plugins=["garak", "llm_judge"],
-            model="nemotron-4-8b",
+            model="defined",
             input_tokens=2048,
             output_tokens=512,
         )
@@ -156,8 +156,8 @@ class TestWireContractSmoke:
             f"Envelope keys mismatch: {set(payload.keys()) ^ EXPECTED_ENVELOPE_KEYS}"
         )
 
-        # Schema version must be 1.9.
-        assert payload["eventSchemaVer"] == "1.9"
+        # Schema version must be 1.10.
+        assert payload["eventSchemaVer"] == "1.10"
 
         # Must be JSON serializable.
         json_str = json.dumps(payload)
@@ -173,7 +173,7 @@ class TestWireContractSmoke:
         assert params["jobType"] == "evaluate"
         assert params["durationSec"] == 15.75
         assert params["plugins"] == ["garak", "llm_judge"]
-        assert params["model"] == "nemotron-4-8b"
+        assert params["model"] == "defined"
         assert params["inputTokens"] == 2048
         assert params["outputTokens"] == 512
         assert event_entry["name"] == "job_run"

--- a/packages/nemo_platform_ext/tests/conftest.py
+++ b/packages/nemo_platform_ext/tests/conftest.py
@@ -8,6 +8,12 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def _disable_cli_telemetry_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep CLI telemetry side effects out of non-telemetry tests."""
+    monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+
+
+@pytest.fixture(autouse=True)
 def isolated_config(request: pytest.FixtureRequest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Isolate tests from local config files and env vars.
 

--- a/plugins/nemo-customizer/openapi/openapi.yaml
+++ b/plugins/nemo-customizer/openapi/openapi.yaml
@@ -2076,6 +2076,7 @@ components:
             \ Defaults to AdamW with cosine annealing."
         learning_rate:
           type: number
+          exclusiveMinimum: 0.0
           title: Learning Rate
           description: Peak learning rate.
           default: 0.0001
@@ -2083,18 +2084,24 @@ components:
           title: Min Learning Rate
           description: Minimum LR for cosine decay.
           type: number
+          minimum: 0.0
         weight_decay:
           type: number
+          minimum: 0.0
           title: Weight Decay
           description: Weight decay coefficient.
           default: 0.01
         adam_beta1:
           type: number
+          exclusiveMaximum: 1.0
+          minimum: 0.0
           title: Adam Beta1
           description: Adam beta1.
           default: 0.9
         adam_beta2:
           type: number
+          exclusiveMaximum: 1.0
+          minimum: 0.0
           title: Adam Beta2
           description: Adam beta2.
           default: 0.999
@@ -2437,6 +2444,7 @@ components:
         name:
           title: Name
           type: string
+          maxLength: 255
       additionalProperties: false
       type: object
       title: RlOutputRequest

--- a/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
@@ -34,19 +34,29 @@ pytestmark = [
 
 ALPINE_IMAGE = "alpine:3.20"
 
-# Keep these tests in a dedicated range that nothing else in CI claims, separate
-# from both service ports and the product's dynamic/private default range.
+# Keep these tests in dedicated ranges that nothing else in CI claims, separate
+# from both service ports and the product's dynamic/private default range. Each
+# xdist worker gets its own 100-port slice.
 TEST_PORT_RANGE_START = 21000
-TEST_PORT_RANGE_END = 21100
+TEST_PORT_RANGE_SIZE = 100
 
 
-def _build_docker_backend(**config_overrides: Any) -> DockerDeploymentBackend:
+def _worker_port_base(worker_id: str) -> int:
+    if worker_id == "master":
+        worker_index = 0
+    else:
+        worker_index = int(worker_id.removeprefix("gw"))
+    return TEST_PORT_RANGE_START + worker_index * TEST_PORT_RANGE_SIZE
+
+
+def _build_docker_backend(worker_id: str = "master", **config_overrides: Any) -> DockerDeploymentBackend:
     mock_entities = AsyncMock()
     mock_sdk = MagicMock()
+    port_base = _worker_port_base(worker_id)
     executor_config: dict[str, Any] = {
         "pull_images": True,
-        "port_range_start": TEST_PORT_RANGE_START,
-        "port_range_end": TEST_PORT_RANGE_END,
+        "port_range_start": port_base,
+        "port_range_end": port_base + TEST_PORT_RANGE_SIZE - 1,
         **config_overrides,
     }
     with (
@@ -60,8 +70,8 @@ def _build_docker_backend(**config_overrides: Any) -> DockerDeploymentBackend:
 
 
 @pytest.fixture
-def docker_backend() -> DockerDeploymentBackend:
-    return _build_docker_backend()
+def docker_backend(worker_id: str) -> DockerDeploymentBackend:
+    return _build_docker_backend(worker_id)
 
 
 def _never_config() -> DeploymentConfig:
@@ -90,6 +100,7 @@ def _never_sleep_config(*, sleep_seconds: int) -> DeploymentConfig:
 
 
 def _docker_backend_with_observe_timeout(
+    worker_id: str,
     *,
     oneshot_observe_timeout_seconds: int,
 ) -> DockerDeploymentBackend:
@@ -163,7 +174,7 @@ async def test_never_deployment_succeeds(docker_backend: DockerDeploymentBackend
 
 
 @pytest.mark.asyncio
-async def test_never_deployment_outlives_observe_wait_then_succeeds() -> None:
+async def test_never_deployment_outlives_observe_wait_then_succeeds(worker_id: str) -> None:
     """Long Never jobs return STARTING on create and finish via read_status polling."""
     # The job has to outlive the observe wait by a wide enough margin that a
     # create_deployment which blocked until exit is unmistakable. The margin is
@@ -174,6 +185,7 @@ async def test_never_deployment_outlives_observe_wait_then_succeeds() -> None:
     job_sleep_seconds = 20
     observe_timeout_seconds = 1
     docker_backend = _docker_backend_with_observe_timeout(
+        worker_id,
         oneshot_observe_timeout_seconds=observe_timeout_seconds,
     )
     config = _never_sleep_config(sleep_seconds=job_sleep_seconds)

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/app.py
@@ -220,6 +220,14 @@ def main(
             hidden=True,
         ),
     ] = False,
+    no_telemetry: Annotated[
+        bool,
+        typer.Option(
+            "--no-telemetry",
+            help="Disable anonymous usage telemetry for this invocation.",
+            rich_help_panel="Global Options",
+        ),
+    ] = False,
 ) -> None:
     """
     Command-line interface for NeMo Platform.
@@ -252,6 +260,12 @@ def main(
         env_val = os.environ.get("NMP_AGENT_MODE", "").lower()
         agent_mode = env_val in ("1", "true", "yes")
     ctx.obj.agent_mode = agent_mode
+
+    # Capture command name + agent mode for the command_invoked telemetry event, wire
+    # the per-invocation opt-out, and print the first-run notice. Best effort inside.
+    from nemo_platform.cli.telemetry import runtime as telemetry_runtime
+
+    telemetry_runtime.on_callback(ctx, no_telemetry=no_telemetry)
 
     # Build ConfigParams from CLI args
     overrides: ConfigParams = {}

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -42,6 +42,8 @@ from nemo_platform.cli.commands.skills.base import Scope, Skill
 from nemo_platform.cli.commands.skills.registry import get_installer, load_skills
 from nemo_platform.cli.core.context import CLIContext
 from nemo_platform.cli.core.errors import handle_errors
+from nemo_platform.cli.telemetry import emit
+from nemo_platform.cli.telemetry.events import OnboardingStepEvent, TaskStatusEnum
 from nemo_platform.client.tls import client_verify_from_env
 from nemo_platform.config.config import Config
 from nemo_platform.config.models import DEFAULT_BASE_URL, ConfigFile, ConfigParams, LocalServicesConfig
@@ -133,6 +135,14 @@ KNOWN_PROVIDERS: tuple[KnownProvider, ...] = (
 )
 
 _KNOWN_PROVIDERS_BY_NAME: dict[str, KnownProvider] = {p.name: p for p in KNOWN_PROVIDERS}
+
+
+def _provider_type_for_connection(name: str, host_url: str) -> str:
+    known = _KNOWN_PROVIDERS_BY_NAME.get(name)
+    if known is not None and known.host_url.rstrip("/") == host_url.rstrip("/"):
+        return known.name
+    return "custom"
+
 
 # ---------------------------------------------------------------------------
 # Onboarding paths — shown after setup completes
@@ -536,7 +546,21 @@ def _create_provider(
             kwargs["required_extra_headers"] = {header_name.strip(): header_value.strip()}
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
-    client.inference.providers.create(**kwargs)
+    provider_type = _provider_type_for_connection(name, host_url)
+    try:
+        client.inference.providers.create(**kwargs)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(
+                step="provider_connected", task_status=TaskStatusEnum.ERROR, provider_type=provider_type
+            )
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="provider_connected", task_status=TaskStatusEnum.COMPLETED, provider_type=provider_type
+        )
+    )
 
 
 def _update_provider(
@@ -556,14 +580,76 @@ def _update_provider(
         kwargs["api_key_secret_name"] = secret_name
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
-    client.inference.providers.update(name, **kwargs)
+    provider_type = _provider_type_for_connection(name, host_url)
+    try:
+        client.inference.providers.update(name, **kwargs)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(
+                step="provider_connected", task_status=TaskStatusEnum.ERROR, provider_type=provider_type
+            )
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="provider_connected", task_status=TaskStatusEnum.COMPLETED, provider_type=provider_type
+        )
+    )
 
 
 _PROVIDER_UNHEALTHY_STATUSES = frozenset({"ERROR", "LOST"})
 _NON_COMPLIANT_MARKER = "Non-OpenAI compliant"
 
 
+def _bucket_model_count(count: int) -> str:
+    """Bucket a discovered-model count into a coarse range for telemetry.
+
+    Keeps the emitted value low-cardinality (no exact counts leave the machine).
+    """
+    if count <= 0:
+        return "0"
+    if count <= 5:
+        return "1-5"
+    if count <= 20:
+        return "6-20"
+    if count <= 50:
+        return "21-50"
+    if count <= 100:
+        return "51-100"
+    if count <= 250:
+        return "101-250"
+    return "251+"
+
+
 def _wait_for_models(
+    client: NeMoPlatform,
+    provider_name: str,
+    workspace: str,
+    host_url: str = "",
+    round_seconds: int = _MODEL_DISCOVERY_ROUND_SECONDS,
+    max_rounds: int = _MODEL_DISCOVERY_MAX_ROUNDS,
+) -> list[str]:
+    """Poll for served models and emit one ``models_discovered`` event.
+
+    Thin telemetry wrapper around :func:`_wait_for_models_impl`: COMPLETED with
+    the discovered-count bucket on success, ERROR (re-raised) if polling blows up.
+    """
+    try:
+        models = _wait_for_models_impl(client, provider_name, workspace, host_url, round_seconds, max_rounds)
+    except Exception:
+        emit.emit_event(OnboardingStepEvent(step="models_discovered", task_status=TaskStatusEnum.ERROR))
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="models_discovered",
+            task_status=TaskStatusEnum.COMPLETED,
+            models_discovered_bucket=_bucket_model_count(len(models)),
+        )
+    )
+    return models
+
+
+def _wait_for_models_impl(
     client: NeMoPlatform,
     provider_name: str,
     workspace: str,
@@ -1098,20 +1184,30 @@ def _run_skill_install(
         console.print(f"  {WARN} No skills selected to install.")
         return
 
-    successes = 0
-    failures = 0
-    for agent in agents:
-        try:
-            installer = get_installer(agent)
-            installer.install(scope, project_root, chosen)
-            console.print(f"  {CHECK} Installed {len(chosen)} skill(s) for {agent}")
-            successes += 1
-        except Exception as exc:
-            console.print(f"  {WARN} Failed to install skills for {agent}: {exc}")
-            failures += 1
+    skills_target = ",".join(agents)
+    try:
+        successes = 0
+        failures = 0
+        for agent in agents:
+            try:
+                installer = get_installer(agent)
+                installer.install(scope, project_root, chosen)
+                console.print(f"  {CHECK} Installed {len(chosen)} skill(s) for {agent}")
+                successes += 1
+            except Exception as exc:
+                console.print(f"  {WARN} Failed to install skills for {agent}: {exc}")
+                failures += 1
 
-    if failures and not successes:
-        raise typer.Exit(1)
+        if failures and not successes:
+            raise typer.Exit(1)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="skills_installed", task_status=TaskStatusEnum.ERROR, skills_target=skills_target)
+        )
+        raise
+    emit.emit_event(
+        OnboardingStepEvent(step="skills_installed", task_status=TaskStatusEnum.COMPLETED, skills_target=skills_target)
+    )
 
 
 def _parse_csv_flag(value: str | None) -> list[str] | None:
@@ -1330,6 +1426,30 @@ def _agents_api_ready(base_url: str, workspace: str, headers: dict[str, str] | N
 
 
 def _deploy_demo_agent(
+    base_url: str,
+    workspace: str,
+    config_path: Traversable,
+    default_model: str,
+    headers: dict[str, str] | None = None,
+) -> bool:
+    """Deploy the demo agent and emit one ``agent_deployed`` event.
+
+    Telemetry wrapper around :func:`_deploy_demo_agent_impl`: COMPLETED when the
+    deployment reaches running, ERROR when it fails, times out, or raises.
+    """
+    try:
+        deployed = _deploy_demo_agent_impl(base_url, workspace, config_path, default_model, headers=headers)
+    except Exception:
+        emit.emit_event(
+            OnboardingStepEvent(step="agent_deployed", task_status=TaskStatusEnum.ERROR, agent_deployed=False)
+        )
+        raise
+    task_status = TaskStatusEnum.COMPLETED if deployed else TaskStatusEnum.ERROR
+    emit.emit_event(OnboardingStepEvent(step="agent_deployed", task_status=task_status, agent_deployed=deployed))
+    return deployed
+
+
+def _deploy_demo_agent_impl(
     base_url: str,
     workspace: str,
     config_path: Traversable,
@@ -1934,30 +2054,43 @@ def setup_command(
     skills_agents_list = _parse_csv_flag(skills_agents)
     skills_from_list = _parse_csv_flag(skills_from)
 
-    if auto:
-        _run_auto_mode(
-            cli_context,
-            client,
-            workspace,
-            base_url,
-            install_skills,
-            deploy_agent,
-            skills_agents=skills_agents_list,
-            skills_scope=skills_scope,
-            skills_from=skills_from_list,
-        )
-    else:
-        _run_interactive_mode(
-            cli_context,
-            client,
-            workspace,
-            base_url,
-            install_skills,
-            deploy_agent,
-            skills_agents=skills_agents_list,
-            skills_scope=skills_scope,
-            skills_from=skills_from_list,
-        )
+    try:
+        if auto:
+            _run_auto_mode(
+                cli_context,
+                client,
+                workspace,
+                base_url,
+                install_skills,
+                deploy_agent,
+                skills_agents=skills_agents_list,
+                skills_scope=skills_scope,
+                skills_from=skills_from_list,
+            )
+        else:
+            _run_interactive_mode(
+                cli_context,
+                client,
+                workspace,
+                base_url,
+                install_skills,
+                deploy_agent,
+                skills_agents=skills_agents_list,
+                skills_scope=skills_scope,
+                skills_from=skills_from_list,
+            )
+    except typer.Exit as exc:
+        # A clean user-cancel raises typer.Exit(0); that is a normal end of the
+        # flow, not a failure, so it must not corrupt the onboarding funnel.
+        # Only a non-zero exit code counts as ERROR. Re-raise unchanged either way.
+        status = TaskStatusEnum.COMPLETED if exc.exit_code == 0 else TaskStatusEnum.ERROR
+        emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=status))
+        raise
+    except Exception:
+        # Any real (non-Exit) failure: setup did not finish cleanly.
+        emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.ERROR))
+        raise
+    emit.emit_event(OnboardingStepEvent(step="setup_finished", task_status=TaskStatusEnum.COMPLETED))
 
 
 def _run_auto_mode(
@@ -1993,6 +2126,16 @@ def _run_auto_mode(
             break
         if attempt < _MODEL_DISCOVERY_MAX_ROUNDS - 1:
             console.print(f"  {WARN} Models not available yet, retrying...")
+
+    # Auto mode discovers models via an inline loop rather than _wait_for_models,
+    # so emit the models_discovered event here to cover the non-interactive path.
+    emit.emit_event(
+        OnboardingStepEvent(
+            step="models_discovered",
+            task_status=TaskStatusEnum.COMPLETED,
+            models_discovered_bucket=_bucket_model_count(len(entity_ids)),
+        )
+    )
 
     default_model = os.environ.get("NEMO_DEFAULT_MODEL", "").strip()
     if not default_model and entity_ids:

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/help_formatter.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/help_formatter.py
@@ -14,10 +14,12 @@ Clean help output with uv-inspired style:
 from __future__ import annotations
 
 import shutil
+import sys
+import time
 from contextvars import ContextVar
 from functools import wraps
 from io import StringIO
-from typing import Any, Callable, ParamSpec, Sequence, TypeVar
+from typing import Any, Callable, Mapping, ParamSpec, Sequence, TypeVar
 
 import click
 from click import Command
@@ -39,6 +41,8 @@ def _strip_required_suffix(help_text: str) -> tuple[str, bool]:
 class NmpErrorHandlingMixin:
     """Mixin that provides custom error handling for Click commands."""
 
+    _nmp_emit_command_invoked = False
+
     def main(
         self,
         args: list[str] | None = None,
@@ -47,36 +51,90 @@ class NmpErrorHandlingMixin:
         standalone_mode: bool = True,
         **extra: Any,
     ) -> Any:
-        """Override main to use custom error handling."""
-        from nemo_platform.cli.core.errors import handle_exception
+        """Override main to use custom error handling and emit one telemetry event.
 
+        This is the single path every command type flows through (hand-registered,
+        OpenAPI-generated, plugin entry points), and Click only calls ``main()`` on the
+        root command object, so this is the natural choke point for a per-invocation
+        ``command_invoked`` event. The outcome->status mapping and the emit both live in
+        a ``finally`` so telemetry fires even when a command fails, and the emit body is
+        best-effort (never raises) so a telemetry bug can never change a command's exit
+        code or output.
+        """
+        from nemo_platform.cli.core.errors import handle_exception
+        from nemo_platform.cli.telemetry import runtime
+        from nemo_platform.cli.telemetry.events import TaskStatusEnum
+
+        # Only the root group drives telemetry. Nested groups never have main()
+        # called during dispatch, but this guard keeps the single-emit contract explicit.
+        is_telemetry_root = bool(getattr(self, "_nmp_emit_command_invoked", False))
+        help_requested = False
+        if is_telemetry_root:
+            runtime.reset()
+            # Reading help (e.g. ``nemo docs --help``) is not usage, so it must not emit
+            # a command_invoked event. Detect a help request from the resolved args; the
+            # help option names are the same ones every command registers via
+            # ``_context_settings_with_help``.
+            resolved_args = args if args is not None else sys.argv[1:]
+            help_requested = any(arg in HELP_OPTION_NAMES for arg in resolved_args)
+
+        start = time.monotonic()
+        status: TaskStatusEnum | None = None
         try:
-            result = super().main(  # type: ignore[misc]
-                args=args,
-                prog_name=prog_name,
-                complete_var=complete_var,
-                standalone_mode=False,
-                **extra,
-            )
-            # When standalone_mode=False, Click returns the exit code instead of raising
-            # SystemExit. We need to convert non-zero exit codes back to SystemExit
-            # when the original caller expected standalone_mode=True behavior.
-            if standalone_mode and isinstance(result, int) and result != 0:
-                raise SystemExit(result)
-            return result
-        except click.UsageError as e:
-            if standalone_mode:
-                handle_exception(e, e.ctx)
+            try:
+                result = super().main(  # type: ignore[misc]  # ty: ignore[unresolved-attribute]
+                    args=args,
+                    prog_name=prog_name,
+                    complete_var=complete_var,
+                    standalone_mode=False,
+                    **extra,
+                )
+                # When standalone_mode=False, Click returns the exit code instead of
+                # raising. A non-zero code is an error regardless of how the outer caller
+                # ultimately surfaces it.
+                status = TaskStatusEnum.ERROR if isinstance(result, int) and result != 0 else TaskStatusEnum.COMPLETED
+                # Convert non-zero exit codes back to SystemExit when the original caller
+                # expected standalone_mode=True behavior.
+                if standalone_mode and isinstance(result, int) and result != 0:
+                    raise SystemExit(result)
+                return result
+            except click.UsageError as e:
+                status = TaskStatusEnum.ERROR
+                if standalone_mode:
+                    handle_exception(e, e.ctx)
+                raise
+            except click.exceptions.Exit as e:
+                status = TaskStatusEnum.COMPLETED if e.exit_code == 0 else TaskStatusEnum.ERROR
+                if standalone_mode:
+                    raise SystemExit(e.exit_code)
+                raise
+            except click.Abort:
+                status = TaskStatusEnum.CANCELED
+                if standalone_mode:
+                    click.echo("Aborted!", err=True)
+                    raise SystemExit(1)
+                raise
+            except click.ClickException as e:
+                status = TaskStatusEnum.ERROR
+                if standalone_mode:
+                    handle_exception(e, getattr(e, "ctx", None))
+                raise
+        except SystemExit as e:
+            if status is None:
+                code = e.code
+                status = TaskStatusEnum.COMPLETED if code in (0, None) else TaskStatusEnum.ERROR
             raise
-        except click.exceptions.Exit as e:
-            if standalone_mode:
-                raise SystemExit(e.exit_code)
+        except KeyboardInterrupt:
+            if status is None:
+                status = TaskStatusEnum.CANCELED
             raise
-        except click.Abort:
-            if standalone_mode:
-                click.echo("Aborted!", err=True)
-                raise SystemExit(1)
+        except BaseException:
+            if status is None:
+                status = TaskStatusEnum.ERROR
             raise
+        finally:
+            if is_telemetry_root and not help_requested:
+                runtime.emit_command_invoked(status or TaskStatusEnum.COMPLETED, time.monotonic() - start)
 
 
 def _get_terminal_width() -> int:
@@ -85,7 +143,7 @@ def _get_terminal_width() -> int:
     return min(width - 2, 120)
 
 
-def _context_settings_with_help(context_settings: dict | None) -> dict:
+def _context_settings_with_help(context_settings: Mapping[str, Any] | None) -> dict[str, Any]:
     """Return context_settings with help_option_names defaulting to --help/-h."""
     settings = dict(context_settings or {})
     settings.setdefault("help_option_names", list(HELP_OPTION_NAMES))
@@ -271,7 +329,7 @@ class NmpOption(TyperOption):
 
         # Add value placeholder if needed
         if not self.is_flag and not self.count:
-            metavar = self.metavar or self.name.upper()
+            metavar = self.metavar or (self.name or "").upper()
             placeholder = click.style(f"<{metavar}>", fg="yellow")
             opts_str = f"{opts_str} {placeholder}"
 
@@ -290,8 +348,9 @@ class NmpOption(TyperOption):
                 has_real_default = True
 
         # Possible values (choices) and default - combine if both present
-        if hasattr(self.type, "choices") and self.type.choices:
-            choices = ", ".join(str(c) for c in self.type.choices)
+        type_choices = getattr(self.type, "choices", None)
+        if type_choices:
+            choices = ", ".join(str(c) for c in type_choices)
 
             # Check if we also have a default to combine
             if has_real_default:
@@ -519,11 +578,19 @@ class NmpGroup(NmpErrorHandlingMixin, TyperGroup):
 
         return f"Active context: {display_context.context_name} (workspace: {display_context.workspace})"
 
-    def command(self, *args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Command] | Command:  # pyright: ignore [reportIncompatibleMethodOverride]
+    def command(self, *args: Any, **kwargs: Any) -> Callable[[Callable[..., Any]], Command] | Command:  # pyright: ignore [reportIncompatibleMethodOverride]  # ty: ignore[invalid-method-override]
         """Override command decorator to use NmpCommand."""
         if "cls" not in kwargs:
             kwargs["cls"] = NmpCommand
         return super().command(*args, **kwargs)
+
+    def resolve_command(self, ctx: click.Context, args: list[str]) -> tuple[str | None, Command | None, list[str]]:
+        """Record the resolved subcommand name for telemetry, then resolve as usual."""
+        cmd_name, cmd, remaining = super().resolve_command(ctx, args)
+        from nemo_platform.cli.telemetry import runtime
+
+        runtime.note_subcommand(cmd_name)
+        return cmd_name, cmd, remaining
 
     def get_command(self, ctx: click.Context, cmd_name: str) -> Command | None:
         """Override to patch command classes to use NeMo Platform formatting."""

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/lazy_load.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/lazy_load.py
@@ -34,6 +34,8 @@ def attach_lazy_entries(
 class ManifestBackedNmpGroup(NmpGroup):
     """Group that renders lazy child metadata and loads real children on demand."""
 
+    _nmp_emit_command_invoked = True
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self._lazy_entries: dict[str, TopLevelEntry] = {}

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/core/waiters.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/core/waiters.py
@@ -17,8 +17,9 @@
 
 from __future__ import annotations
 
+import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from nemo_platform import APIConnectionError, APIStatusError, APITimeoutError, NotFoundError
@@ -26,9 +27,24 @@ from rich.console import Console
 from rich.live import Live
 from rich.text import Text
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 _TRANSIENT_GATEWAY_STATUS_CODES = {429, 502, 503, 504}
+_SAFE_JOB_TYPE_BUCKETS = frozenset(
+    {
+        "agent",
+        "agents",
+        "anonymizer",
+        "audit",
+        "customization",
+        "data-designer",
+        "evaluation",
+        "evaluator",
+        "insights",
+        "job",
+    }
+)
 
 
 def _pause(seconds: float) -> None:
@@ -53,6 +69,90 @@ def _seconds_since_creation(entry_timestamp: datetime | str | None, created_at: 
 
 def _status_text(status: Any) -> str:
     return str(status or "")
+
+
+def _datetime_timestamp(value: datetime | str | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    try:
+        return value.timestamp()
+    except (TypeError, OSError):
+        return None
+
+
+def _job_duration_sec(job_status: Any, fallback_start_time: float) -> float:
+    now = time.time()
+    for attr in ("started_at", "start_time", "created_at"):
+        timestamp = _datetime_timestamp(getattr(job_status, attr, None))
+        if timestamp is not None:
+            return max(0.0, now - timestamp)
+    return max(0.0, now - fallback_start_time)
+
+
+def _model_data_bucket(raw_model: object) -> str:
+    model = str(raw_model).strip() if raw_model is not None else ""
+    return "defined" if model else "undefined"
+
+
+def _job_type_bucket(resource_label: str) -> str:
+    label = str(resource_label or "").strip().lower().replace("_", "-").replace(" ", "-")
+    return label if label in _SAFE_JOB_TYPE_BUCKETS else "custom"
+
+
+def _emit_job_run_event(job_status: Any, *, resource_label: str, status: str, start_time: float) -> None:
+    """Emit a ``job_run`` telemetry event for a terminal platform job.
+
+    Best effort: never raises and never affects the waiter's return value.
+    """
+    try:
+        from nemo_platform.cli.telemetry.emit import emit_event
+        from nemo_platform.cli.telemetry.events import JobRunEvent, TaskStatusEnum
+
+        status_map = {
+            "completed": TaskStatusEnum.COMPLETED,
+            "error": TaskStatusEnum.ERROR,
+            "cancelled": TaskStatusEnum.CANCELED,
+        }
+        task_status = status_map.get(status, TaskStatusEnum.UNDEFINED)
+
+        details = getattr(job_status, "status_details", None)
+        if not isinstance(details, dict):
+            details = {}
+
+        # Step names are user-controlled by PlatformJobStepSpec, even though our
+        # built-in compilers use static names like "audit-job" or "evaluate-suite".
+        # Emit only a low-cardinality bucket from command metadata.
+        job_type = _job_type_bucket(resource_label)
+
+        # Model names may be user-authored; emit only a coarse present/absent bucket.
+        model = _model_data_bucket(details.get("model"))
+        raw_input_tokens = details.get("input_tokens")
+        input_tokens = int(raw_input_tokens) if raw_input_tokens is not None else -1
+        raw_output_tokens = details.get("output_tokens")
+        output_tokens = int(raw_output_tokens) if raw_output_tokens is not None else -1
+
+        emit_event(
+            JobRunEvent(
+                task_status=task_status,
+                job_type=job_type,
+                duration_sec=_job_duration_sec(job_status, start_time),
+                plugins=[],
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        )
+    except Exception:
+        logger.debug("Failed to emit job_run telemetry event", exc_info=True)
 
 
 def _make_history_line(
@@ -270,11 +370,17 @@ def wait_for_platform_job(
 
             if current_status == "completed":
                 live.stop()
+                _emit_job_run_event(
+                    job_status, resource_label=resource_label, status=current_status, start_time=start_time
+                )
                 console.print(f"\n[green]✓ {resource_label.title()} completed![/green]")
                 return True
 
             if current_status in {"cancelled", "error"}:
                 live.stop()
+                _emit_job_run_event(
+                    job_status, resource_label=resource_label, status=current_status, start_time=start_time
+                )
                 console.print(f"\n[red]✗ {resource_label.title()} entered {current_status} state[/red]")
                 return False
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/events.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/events.py
@@ -3,7 +3,7 @@
 """Platform usage-telemetry event models.
 
 Field names and aliases follow the shared NeMo telemetry schema
-(aire/microservices/nemo-telemetry, schemas/anonymous_events.json, v1.9).
+(aire/microservices/nemo-telemetry, schemas/anonymous_events.json, v1.10).
 """
 
 from __future__ import annotations
@@ -60,7 +60,7 @@ class PlatformTelemetryEvent(BaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     _event_name: ClassVar[str] = "undefined"
-    _schema_version: ClassVar[str] = "1.9"
+    _schema_version: ClassVar[str] = "1.10"
 
     nemo_source: str = Field(default="platform", serialization_alias="nemoSource")
     task_status: TaskStatusEnum = Field(serialization_alias="taskStatus")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/telemetry/runtime.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-invocation telemetry state bridged between the Typer callback and the Click main wrapper.
+
+The Typer ``@app.callback`` sees the parsed context (command name, agent mode, opt-out
+flag) but not the command outcome. The ``NmpErrorHandlingMixin.main`` wrapper sees the
+outcome and duration but not the parsed flags. This module is the single small piece of
+state both sides read, so exactly one ``command_invoked`` event is emitted per invocation
+from the root command path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+import click
+
+from nemo_platform.cli.telemetry.events import TaskStatusEnum
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _InvocationState:
+    command_parts: list[str] = field(default_factory=list)
+    agent_mode: bool = False
+    started: bool = False
+    opted_out: bool = False
+
+
+state = _InvocationState()
+
+
+def reset() -> None:
+    """Clear invocation state. Called at the top of the root ``main()`` so CliRunner
+    invocations sharing a process never leak command names or flags between calls."""
+    state.command_parts = []
+    state.agent_mode = False
+    state.started = False
+    state.opted_out = False
+
+
+def on_callback(ctx: click.Context, *, no_telemetry: bool) -> None:
+    """Capture command name + agent mode from the root Typer callback.
+
+    Best effort: a telemetry bug must never break ``nemo <anything>``.
+    """
+    try:
+        from nemo_platform.cli.telemetry.emit import maybe_print_first_run_notice, set_invocation_opt_out
+
+        set_invocation_opt_out(no_telemetry)
+        state.opted_out = no_telemetry
+        state.started = True
+        state.agent_mode = bool(getattr(ctx.obj, "agent_mode", False))
+        invoked = getattr(ctx, "invoked_subcommand", None)
+        if invoked:
+            state.command_parts = [invoked]
+        maybe_print_first_run_notice()
+    except Exception:  # noqa: BLE001
+        # Fail closed: if telemetry setup breaks, suppress this invocation's event.
+        state.opted_out = True
+        logger.debug("telemetry on_callback failed", exc_info=True)
+
+
+def note_subcommand(name: str | None) -> None:
+    """Append a resolved sub-subcommand name (e.g. the ``list`` in ``workspaces list``)."""
+    if state.started and name and name not in state.command_parts:
+        state.command_parts.append(name)
+
+
+def emit_command_invoked(task_status: TaskStatusEnum, duration_sec: float) -> None:
+    """Emit exactly one ``command_invoked`` event. Best effort; never raises."""
+    try:
+        if state.opted_out:
+            return
+        if not (state.started and state.command_parts):
+            # Bare ``--help`` and usage errors before a command resolves never emit.
+            return
+        from nemo_platform.cli.telemetry.emit import emit_event
+        from nemo_platform.cli.telemetry.events import CommandInvokedEvent
+
+        event = CommandInvokedEvent(
+            command=" ".join(state.command_parts),
+            duration_sec=max(0.0, duration_sec),
+            agent_mode=state.agent_mode,
+            task_status=task_status,
+        )
+        emit_event(event)
+    except Exception:  # noqa: BLE001
+        logger.debug("telemetry emit_command_invoked failed", exc_info=True)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -94,6 +94,26 @@ from pydantic import SecretStr
 
 SETUP_MOD = "nemo_platform.cli.commands.setup"
 
+
+@pytest.fixture(autouse=True)
+def _silence_telemetry():
+    """Silence stray telemetry side effects across this module.
+
+    These are direct-call unit tests with no telemetry intent. Several exercise
+    the real setup wrappers (`_create_provider`, `_wait_for_models`,
+    `_deploy_demo_agent`, `_auto_setup`), which call the real `emit_event`. With
+    telemetry enabled by default that constructs a `TelemetryHandler` and
+    schedules `_flush_events`, whose orphaned coroutine surfaces later as a
+    "coroutine ... was never awaited" RuntimeWarning (blamed on whichever
+    mock-heavy test triggers GC, not the emitting one). Patch emit_event at module
+    scope so no handler is ever built. No test in this file asserts on emit_event
+    (the telemetry assertions live in test_onboarding_events.py), so this weakens
+    nothing.
+    """
+    with patch("nemo_platform.cli.telemetry.emit.emit_event"):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # KnownProvider catalog tests
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/core/test_waiters.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/core/test_waiters.py
@@ -44,6 +44,13 @@ def _quiet_rich_output() -> Iterator[None]:
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_telemetry() -> Iterator[None]:
+    """Neutralize best-effort job_run telemetry so waiter tests never do real I/O."""
+    with patch("nemo_platform.cli.telemetry.emit.emit_event"):
+        yield
+
+
 @pytest.fixture
 def frozen_time() -> Iterator[MagicMock]:
     with patch(f"{WAITERS_MODULE}.time.time", return_value=0) as time:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/conftest.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/conftest.py
@@ -8,14 +8,16 @@ from nemo_platform.cli.telemetry.events import _CI_ENV_VARS
 
 
 @pytest.fixture(autouse=True)
-def _clear_ci_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Clear CI markers so telemetry tests are deterministic on developer machines and in CI.
+def _isolate_telemetry_env(_disable_cli_telemetry_by_default: None, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear inherited env that would make telemetry tests depend on the runner.
 
     Without this, tests that assert the default ``is_ci`` value pass locally but fail when the
     suite runs under GitHub Actions (which sets ``CI`` and ``GITHUB_ACTIONS``). Tests that
-    exercise CI detection set these variables explicitly, which overrides this fixture.
+    exercise CI detection or telemetry opt-out set those variables explicitly, which overrides
+    this fixture.
     """
     for var in _CI_ENV_VARS:
         monkeypatch.delenv(var, raising=False)
     monkeypatch.delenv("NEMO_DEPLOYMENT_TYPE", raising=False)
+    monkeypatch.delenv("NEMO_TELEMETRY_ENABLED", raising=False)
     yield

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_command_hook.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_command_hook.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the command_invoked telemetry hook at the root command choke point."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import click
+import pytest
+from nemo_platform.cli.app import app
+from nemo_platform.cli.core.help_formatter import NmpErrorHandlingMixin
+from nemo_platform.cli.telemetry import runtime
+from nemo_platform.cli.telemetry.events import TaskStatusEnum
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class TestCommandInvokedHook:
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_successful_command_emits_completed(self, emit):
+        result = runner.invoke(app, ["docs", "--list"])
+        assert result.exit_code == 0
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.command.startswith("docs")
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.duration_sec >= 0
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_agent_mode_flag_captured(self, emit):
+        runner.invoke(app, ["--agent-mode", "docs", "--list"])
+        assert emit.call_args[0][0].agent_mode is True
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_failing_command_emits_error(self, emit):
+        with patch("nemo_platform.cli.commands.docs._list_docs", side_effect=RuntimeError):
+            runner.invoke(app, ["docs", "--list"])
+        assert emit.call_count == 1
+        assert emit.call_args[0][0].task_status == TaskStatusEnum.ERROR
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_click_exception_emits_error_without_traceback(self, emit):
+        with patch("nemo_platform.cli.commands.docs._list_docs", side_effect=click.ClickException("broken")):
+            result = runner.invoke(app, ["docs", "--list"])
+        assert result.exit_code == 1
+        assert "Error: broken" in result.stderr
+        assert "Traceback" not in result.output
+        assert emit.call_count == 1
+        assert emit.call_args[0][0].task_status == TaskStatusEnum.ERROR
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_keyboard_interrupt_emits_canceled(self, emit):
+        class InterruptingBase:
+            def main(self, **_kwargs):
+                runtime.state.started = True
+                runtime.state.command_parts = ["docs"]
+                raise KeyboardInterrupt
+
+        class InterruptingCommand(NmpErrorHandlingMixin, InterruptingBase):
+            _nmp_emit_command_invoked = True
+
+        with pytest.raises(KeyboardInterrupt):
+            InterruptingCommand().main(args=[], standalone_mode=True)
+        assert emit.call_count == 1
+        assert emit.call_args[0][0].task_status == TaskStatusEnum.CANCELED
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_no_telemetry_flag_suppresses(self, emit):
+        runner.invoke(app, ["--no-telemetry", "docs", "--list"])
+        emit.assert_not_called()
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_bare_help_does_not_emit(self, emit):
+        runner.invoke(app, ["--help"])
+        emit.assert_not_called()
+
+    @patch("nemo_platform.cli.telemetry.emit.emit_event")
+    def test_group_help_does_not_emit(self, emit):
+        """``nemo <group> --help`` reads help; it is not usage and must not emit."""
+        result = runner.invoke(app, ["docs", "--help"])
+        assert result.exit_code == 0
+        emit.assert_not_called()

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_events.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_events.py
@@ -22,7 +22,7 @@ class TestCommandInvokedEvent:
         assert d["agentMode"] is False
         assert d["isCi"] is False
         assert e._event_name == "command_invoked"
-        assert e._schema_version == "1.9"
+        assert e._schema_version == "1.10"
 
     def test_no_free_text_fields_beyond_known(self):
         # privacy guard: the event cannot carry arbitrary payloads

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_job_events.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_job_events.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from nemo_platform.cli.core import waiters
+from nemo_platform.cli.telemetry.events import TaskStatusEnum
+
+WAITERS_MODULE = "nemo_platform.cli.core.waiters"
+EMIT_TARGET = "nemo_platform.cli.telemetry.emit.emit_event"
+
+
+class _DummyLive:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    def __enter__(self) -> _DummyLive:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+    def update(self, *args: object) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    def start(self) -> None:
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _quiet_rich_output() -> Iterator[None]:
+    with (
+        patch(f"{WAITERS_MODULE}.Live", _DummyLive),
+        patch(f"{WAITERS_MODULE}.console.print"),
+    ):
+        yield
+
+
+@pytest.fixture
+def frozen_time() -> Iterator[MagicMock]:
+    with patch(f"{WAITERS_MODULE}.time.time", return_value=0) as time:
+        yield time
+
+
+@pytest.fixture
+def waiter_pause() -> Iterator[MagicMock]:
+    with patch(f"{WAITERS_MODULE}._pause") as pause:
+        yield pause
+
+
+def _completed_status() -> SimpleNamespace:
+    return SimpleNamespace(
+        status="completed",
+        steps=[
+            SimpleNamespace(name="audit-job"),
+            SimpleNamespace(name="evaluate"),
+            SimpleNamespace(name="evaluate-suite"),
+            SimpleNamespace(name="customer-project-step"),
+        ],
+        status_details={"input_tokens": 512, "output_tokens": 2048, "model": "nemotron-super-49b"},
+    )
+
+
+def test_completed_emits_single_job_run_event(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = _completed_status()
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customization") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "customization"
+    assert event.task_status is TaskStatusEnum.COMPLETED
+    assert event.input_tokens == 512
+    assert event.output_tokens == 2048
+    assert event.model == "defined"
+    assert event.plugins == []
+    assert "customer-project-step" not in event.job_type
+
+
+def test_static_step_name_is_not_emitted_as_job_type(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed", steps=[SimpleNamespace(name="audit-job")], status_details={}
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="audit") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "audit"
+    assert event.plugins == []
+
+
+def test_job_type_falls_back_to_resource_label_without_steps(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="completed", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customization") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "customization"
+    assert event.plugins == []
+
+
+def test_unsafe_resource_label_falls_back_to_custom(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[SimpleNamespace(name="private-customer-step")],
+        status_details={},
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert (
+            waiters.wait_for_platform_job(jobs, "job-a", workspace="default", resource_label="customer alpha project")
+            is True
+        )
+
+    event = emit_event.call_args.args[0]
+    assert event.job_type == "custom"
+    assert event.plugins == []
+
+
+def test_status_details_defaults_when_absent(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="completed", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.input_tokens == -1
+    assert event.output_tokens == -1
+    assert event.model == "undefined"
+    assert event.plugins == []
+
+
+def test_null_status_details_still_emits(frozen_time: MagicMock) -> None:
+    """Explicit nulls must not drop the event; a real 0 token count must survive."""
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[],
+        status_details={"model": None, "input_tokens": 0, "output_tokens": None},
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.model == "undefined"
+    assert event.input_tokens == 0
+    assert event.output_tokens == -1
+
+
+def test_non_string_model_details_still_emit_safe_bucket(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[],
+        status_details={"model": {"name": "private-model"}, "input_tokens": 7, "output_tokens": 9},
+    )
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    emit_event.assert_called_once()
+    event = emit_event.call_args.args[0]
+    assert event.model == "defined"
+    assert event.input_tokens == 7
+    assert event.output_tokens == 9
+
+
+def test_duration_uses_job_created_at_when_available() -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(
+        status="completed",
+        steps=[],
+        status_details={},
+        created_at=datetime.fromtimestamp(90.0, tz=timezone.utc),
+    )
+
+    with (
+        patch(f"{WAITERS_MODULE}.time.time", side_effect=[100.0, 100.0, 100.0, 130.0]),
+        patch(EMIT_TARGET) as emit_event,
+    ):
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is True
+
+    event = emit_event.call_args.args[0]
+    assert event.duration_sec == 40.0
+
+
+def test_error_status_maps_to_error(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="error", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is False
+
+    emit_event.assert_called_once()
+    assert emit_event.call_args.args[0].task_status is TaskStatusEnum.ERROR
+
+
+def test_cancelled_status_maps_to_canceled(frozen_time: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="cancelled", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default") is False
+
+    emit_event.assert_called_once()
+    assert emit_event.call_args.args[0].task_status is TaskStatusEnum.CANCELED
+
+
+def test_timeout_emits_nothing_and_does_not_crash(waiter_pause: MagicMock) -> None:
+    jobs = MagicMock()
+    jobs.get_status.return_value = SimpleNamespace(status="running", steps=[], status_details={})
+
+    with patch(EMIT_TARGET) as emit_event:
+        assert waiters.wait_for_platform_job(jobs, "job-a", workspace="default", timeout=5, poll_interval=10) is False
+
+    emit_event.assert_not_called()

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_onboarding_events.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_onboarding_events.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for onboarding_step telemetry emitted from the setup flow.
+
+Each instrumented choke point in ``setup.py`` emits exactly one
+``OnboardingStepEvent``: COMPLETED on success, ERROR on failure with the
+original exception still propagating. ``emit_event`` is patched at its
+definition module so the module-attribute call in ``setup.py`` is intercepted.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from nemo_platform.resources.inference.providers import ProvidersResource
+from nemo_platform.cli.commands.setup import (
+    _bucket_model_count,
+    _create_provider,
+    _deploy_demo_agent,
+    _run_skill_install,
+    _update_provider,
+    _wait_for_models,
+    setup_command,
+)
+from nemo_platform.cli.commands.skills.base import Scope, Skill
+from nemo_platform.cli.telemetry.events import TaskStatusEnum
+
+SETUP_MOD = "nemo_platform.cli.commands.setup"
+EMIT_TARGET = "nemo_platform.cli.telemetry.emit.emit_event"
+
+
+@pytest.fixture
+def spinner_console():
+    """Patch setup.console with a mock status spinner context manager."""
+    mock_status = MagicMock()
+    with patch(f"{SETUP_MOD}.console") as mock_console:
+        mock_console.status.return_value.__enter__ = MagicMock(return_value=mock_status)
+        mock_console.status.return_value.__exit__ = MagicMock(return_value=False)
+        yield mock_console, mock_status
+
+
+def _providers_client() -> MagicMock:
+    client = MagicMock()
+    client.inference.providers = MagicMock(spec=ProvidersResource)
+    return client
+
+
+def _skill(name: str) -> Skill:
+    return Skill(
+        name=name,
+        description=f"{name} desc",
+        version="0.1",
+        content=f"# {name}",
+        raw=f"---\nname: {name}\n---\n# {name}",
+        source_plugin=None,
+    )
+
+
+class TestCreateProviderTelemetry:
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        client = _providers_client()
+        _create_provider(
+            client,
+            name="openai",
+            host_url="https://api.openai.com/v1",
+            secret_name="openai-api-key",
+            workspace="default",
+        )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.provider_type == "openai"
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        client = _providers_client()
+        client.inference.providers.create.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            _create_provider(
+                client,
+                name="anthropic",
+                host_url="https://api.anthropic.com",
+                secret_name="anthropic-api-key",
+                workspace="default",
+            )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.provider_type == "anthropic"
+
+    @patch(EMIT_TARGET)
+    def test_custom_provider_emits_fixed_custom_provider_type(self, emit):
+        client = _providers_client()
+        _create_provider(
+            client,
+            name="team-provider",
+            host_url="https://llm.example.test/v1",
+            secret_name="team-provider-api-key",
+            workspace="default",
+        )
+        event = emit.call_args[0][0]
+        assert event.provider_type == "custom"
+
+
+class TestUpdateProviderTelemetry:
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        client = _providers_client()
+        _update_provider(
+            client,
+            name="openai",
+            host_url="https://api.openai.com/v1",
+            secret_name="openai-api-key",
+            workspace="default",
+        )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.provider_type == "openai"
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        client = _providers_client()
+        client.inference.providers.update.side_effect = RuntimeError("boom")
+        with pytest.raises(RuntimeError):
+            _update_provider(
+                client,
+                name="team-provider",
+                host_url="https://llm.example.test/v1",
+                secret_name="team-provider-api-key",
+                workspace="default",
+            )
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "provider_connected"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.provider_type == "custom"
+
+
+class TestWaitForModelsTelemetry:
+    @pytest.mark.usefixtures("spinner_console")
+    @patch(EMIT_TARGET)
+    def test_emits_completed_with_bucket(self, emit):
+        client = MagicMock()
+        models = [MagicMock(model_entity_id=f"default/model-{i}") for i in range(3)]
+        client.inference.providers.retrieve.return_value = MagicMock(served_models=models)
+
+        with (
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 0, 1]),
+        ):
+            result = _wait_for_models(client, "nvidia-build", "default", round_seconds=30, max_rounds=1)
+
+        assert result == [f"default/model-{i}" for i in range(3)]
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "models_discovered"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.models_discovered_bucket == "1-5"
+
+    @pytest.mark.usefixtures("spinner_console")
+    @patch(EMIT_TARGET)
+    def test_no_models_emits_bucket_zero(self, emit):
+        client = MagicMock()
+        client.inference.providers.retrieve.return_value = MagicMock(served_models=[])
+
+        with (
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 1, 2, 100]),
+        ):
+            result = _wait_for_models(client, "nvidia-build", "default", round_seconds=5, max_rounds=1)
+
+        assert result == []
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "models_discovered"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.models_discovered_bucket == "0"
+
+
+class TestRunSkillInstallTelemetry:
+    def _run(self, *, install_raises: bool):
+        installer = MagicMock()
+        if install_raises:
+            installer.install.side_effect = RuntimeError("install failed")
+        all_skills = {"alpha": _skill("alpha")}
+        with patch(f"{SETUP_MOD}.get_installer", return_value=installer):
+            _run_skill_install(
+                agents=["codex"],
+                scope=Scope.PROJECT,
+                skill_names=["alpha"],
+                all_skills=all_skills,
+                project_root=MagicMock(),
+            )
+
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed(self, emit):
+        self._run(install_raises=False)
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "skills_installed"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert "codex" in event.skills_target
+
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit):
+        with pytest.raises(typer.Exit):
+            self._run(install_raises=True)
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "skills_installed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert "codex" in event.skills_target
+
+
+class TestDeployDemoAgentTelemetry:
+    def _responses(self, *, status_sequence):
+        create_resp = MagicMock(status_code=200)
+        create_resp.raise_for_status = MagicMock()
+        deploy_resp = MagicMock(status_code=200)
+        deploy_resp.raise_for_status = MagicMock()
+        deploy_resp.json.return_value = {"name": "calculator-agent-abc12345"}
+        status_resps = []
+        for s in status_sequence:
+            r = MagicMock(status_code=200)
+            r.json.return_value = {"name": "calculator-agent-abc12345", "status": s}
+            status_resps.append(r)
+        return [create_resp, deploy_resp] + status_resps
+
+    @pytest.mark.usefixtures("spinner_console")
+    @patch(EMIT_TARGET)
+    def test_success_emits_completed_true(self, emit, tmp_path):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        responses = self._responses(status_sequence=["running"])
+        with (
+            patch(f"{SETUP_MOD}.httpx.get", side_effect=responses[2:]),
+            patch(f"{SETUP_MOD}.httpx.post", side_effect=responses[:2]),
+            patch(f"{SETUP_MOD}._agent_exists", return_value=False),
+            patch(f"{SETUP_MOD}._pause"),
+            patch(f"{SETUP_MOD}.time.monotonic", side_effect=[0, 0, 1, 2, 3]),
+        ):
+            result = _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+        assert result is True
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.COMPLETED
+        assert event.agent_deployed is True
+
+    @pytest.mark.usefixtures("spinner_console")
+    @patch(EMIT_TARGET)
+    def test_failure_emits_error_and_reraises(self, emit, tmp_path):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        create_resp = MagicMock(status_code=500)
+        create_resp.raise_for_status = MagicMock(side_effect=RuntimeError("http 500"))
+        with (
+            patch(f"{SETUP_MOD}.httpx.post", return_value=create_resp),
+            patch(f"{SETUP_MOD}._agent_exists", return_value=False),
+        ):
+            with pytest.raises(RuntimeError):
+                _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.agent_deployed is False
+
+    @patch(EMIT_TARGET)
+    def test_false_deploy_outcome_emits_error_false(self, emit, tmp_path):
+        config = tmp_path / "calculator-agent.yml"
+        config.write_text("llms: {}\n")
+        with patch(f"{SETUP_MOD}._deploy_demo_agent_impl", return_value=False):
+            result = _deploy_demo_agent("http://localhost:8080", "default", config, default_model="m")
+
+        assert result is False
+        assert emit.call_count == 1
+        event = emit.call_args[0][0]
+        assert event.step == "agent_deployed"
+        assert event.task_status == TaskStatusEnum.ERROR
+        assert event.agent_deployed is False
+
+
+class TestBucketModelCount:
+    @pytest.mark.parametrize(
+        ("count", "expected"),
+        [
+            (0, "0"),
+            (1, "1-5"),
+            (5, "1-5"),
+            (6, "6-20"),
+            (20, "6-20"),
+            (21, "21-50"),
+            (50, "21-50"),
+            (51, "51-100"),
+            (100, "51-100"),
+            (101, "101-250"),
+            (250, "101-250"),
+            (251, "251+"),
+            (5000, "251+"),
+        ],
+    )
+    def test_buckets(self, count, expected):
+        assert _bucket_model_count(count) == expected
+
+
+class TestSetupFinishedTelemetry:
+    """setup_finished must reflect the real outcome of the dispatch.
+
+    A clean user-cancel raises typer.Exit(0); that is a normal end, not a
+    failure, so it must emit COMPLETED. Any non-zero Exit (or real exception)
+    emits ERROR. In every case the Exit propagates unchanged.
+    """
+
+    def _run(self, dispatch_exc):
+        """Drive setup_command to the auto/interactive dispatch, patching all
+        preamble so only the dispatch outcome matters. `dispatch_exc` is raised
+        from _run_interactive_mode; None means a clean finish."""
+        ctx = MagicMock(spec=typer.Context)
+        ctx.obj = MagicMock()
+        ctx.obj.get_base_url.return_value = "http://localhost:3000"
+
+        interactive = MagicMock()
+        if dispatch_exc is not None:
+            interactive.side_effect = dispatch_exc
+
+        with (
+            patch(f"{SETUP_MOD}.console"),
+            patch(f"{SETUP_MOD}.is_interactive", return_value=True),
+            patch(f"{SETUP_MOD}._maybe_start_services"),
+            patch(f"{SETUP_MOD}._check_platform_reachable_with_retries", return_value=True),
+            patch(f"{SETUP_MOD}._bootstrap_config_if_missing"),
+            patch(f"{SETUP_MOD}._run_interactive_mode", interactive),
+        ):
+            setup_command(ctx)
+
+    @patch(EMIT_TARGET)
+    def test_clean_exit_zero_emits_completed(self, emit):
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(typer.Exit(0))
+        assert exc_info.value.exit_code == 0
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.COMPLETED
+
+    @patch(EMIT_TARGET)
+    def test_default_exit_emits_completed(self, emit):
+        # typer.Exit() defaults to exit_code 0, so a bare Exit is a clean end too.
+        with pytest.raises(typer.Exit):
+            self._run(typer.Exit())
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.COMPLETED
+
+    @patch(EMIT_TARGET)
+    def test_nonzero_exit_emits_error(self, emit):
+        with pytest.raises(typer.Exit) as exc_info:
+            self._run(typer.Exit(1))
+        assert exc_info.value.exit_code == 1
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.ERROR
+
+    @patch(EMIT_TARGET)
+    def test_real_exception_emits_error(self, emit):
+        with pytest.raises(RuntimeError):
+            self._run(RuntimeError("boom"))
+        finished = [c.args[0] for c in emit.call_args_list if c.args[0].step == "setup_finished"]
+        assert len(finished) == 1
+        assert finished[0].task_status == TaskStatusEnum.ERROR

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_wire_contract_smoke.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/telemetry/test_wire_contract_smoke.py
@@ -81,8 +81,8 @@ class TestWireContractSmoke:
             f"Envelope keys mismatch: {set(payload.keys()) ^ EXPECTED_ENVELOPE_KEYS}"
         )
 
-        # Schema version must be 1.9.
-        assert payload["eventSchemaVer"] == "1.9"
+        # Schema version must be 1.10.
+        assert payload["eventSchemaVer"] == "1.10"
 
         # Must be JSON serializable.
         json_str = json.dumps(payload)
@@ -118,8 +118,8 @@ class TestWireContractSmoke:
             f"Envelope keys mismatch: {set(payload.keys()) ^ EXPECTED_ENVELOPE_KEYS}"
         )
 
-        # Schema version must be 1.9.
-        assert payload["eventSchemaVer"] == "1.9"
+        # Schema version must be 1.10.
+        assert payload["eventSchemaVer"] == "1.10"
 
         # Must be JSON serializable.
         json_str = json.dumps(payload)
@@ -144,7 +144,7 @@ class TestWireContractSmoke:
             job_type="evaluate",
             duration_sec=15.75,
             plugins=["garak", "llm_judge"],
-            model="nemotron-4-8b",
+            model="defined",
             input_tokens=2048,
             output_tokens=512,
         )
@@ -156,8 +156,8 @@ class TestWireContractSmoke:
             f"Envelope keys mismatch: {set(payload.keys()) ^ EXPECTED_ENVELOPE_KEYS}"
         )
 
-        # Schema version must be 1.9.
-        assert payload["eventSchemaVer"] == "1.9"
+        # Schema version must be 1.10.
+        assert payload["eventSchemaVer"] == "1.10"
 
         # Must be JSON serializable.
         json_str = json.dumps(payload)
@@ -173,7 +173,7 @@ class TestWireContractSmoke:
         assert params["jobType"] == "evaluate"
         assert params["durationSec"] == 15.75
         assert params["plugins"] == ["garak", "llm_judge"]
-        assert params["model"] == "nemotron-4-8b"
+        assert params["model"] == "defined"
         assert params["inputTokens"] == 2048
         assert params["outputTokens"] == 512
         assert event_entry["name"] == "job_run"

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/conftest.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/conftest.py
@@ -8,6 +8,12 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def _disable_cli_telemetry_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep CLI telemetry side effects out of non-telemetry tests."""
+    monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "false")
+
+
+@pytest.fixture(autouse=True)
 def isolated_config(request: pytest.FixtureRequest, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Isolate tests from local config files and env vars.
 

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/license/generator.py
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/license/generator.py
@@ -16,7 +16,7 @@ import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -296,14 +296,11 @@ def run_osv_scanner(lockfile: Path, output_file: Path, cwd: Optional[Path] = Non
         raise LicenseGenerationError("osv-scanner command not found")
 
 
-def _get_requirements_with_overrides(
-    requirements_file: Path, overrides: dict[str, str], local_packages: set[str]
-) -> list[dict[str, str]]:
-    """Return exported requirements that can be licensed from reviewed overrides."""
+def _iter_exported_requirements(requirements_file: Path) -> Iterator[Requirement]:
+    """Yield parsed top-level entries from a uv-exported requirements file."""
     if not requirements_file.exists():
-        return []
+        return
 
-    packages = []
     with open(requirements_file, encoding="utf-8") as f:
         for line in f:
             stripped = line.strip()
@@ -319,21 +316,35 @@ def _get_requirements_with_overrides(
                 logger.warning("Could not parse exported requirement: %s", requirement_text)
                 continue
 
-            name = requirement.name
-            if normalize_package_name(name) in local_packages:
-                continue
+            yield requirement
 
-            version = ""
-            for specifier in requirement.specifier:
-                if specifier.operator == "==":
-                    version = specifier.version
-                    break
 
-            override_key = get_override_key_for_package(name, version)
-            if override_key not in overrides:
-                continue
+def _get_exported_requirement_names(requirements_file: Path) -> set[str]:
+    """Return normalized package names present in an exported requirements file."""
+    return {normalize_package_name(requirement.name) for requirement in _iter_exported_requirements(requirements_file)}
 
-            packages.append({"name": name, "version": version, "license": overrides[override_key].upper()})
+
+def _get_requirements_with_overrides(
+    requirements_file: Path, overrides: dict[str, str], local_packages: set[str]
+) -> list[dict[str, str]]:
+    """Return exported requirements that can be licensed from reviewed overrides."""
+    packages = []
+    for requirement in _iter_exported_requirements(requirements_file):
+        name = requirement.name
+        if normalize_package_name(name) in local_packages:
+            continue
+
+        version = ""
+        for specifier in requirement.specifier:
+            if specifier.operator == "==":
+                version = specifier.version
+                break
+
+        override_key = get_override_key_for_package(name, version)
+        if override_key not in overrides:
+            continue
+
+        packages.append({"name": name, "version": version, "license": overrides[override_key].upper()})
 
     return packages
 
@@ -383,6 +394,9 @@ def format_licenses(
             # Use new formatter
             formatter = get_formatter(format_type)
 
+            requirements_file = osv_json.parent / "requirements-main.txt"
+            exported_requirement_names = _get_exported_requirement_names(requirements_file)
+
             # Extract package info from OSV data
             packages = []
             if "results" in data and len(data["results"]) > 0:
@@ -391,9 +405,15 @@ def format_licenses(
                     name = pkg.get("name", "")
                     version = pkg.get("version", "")
                     licenses = pkg_data.get("licenses", [])
+                    normalized_name = normalize_package_name(name)
 
                     # Skip local packages
-                    if normalize_package_name(name) in local_packages:
+                    if normalized_name in local_packages:
+                        continue
+
+                    # OSV can include conditional transitive dependencies that
+                    # uv did not export for this environment.
+                    if exported_requirement_names and normalized_name not in exported_requirement_names:
                         continue
 
                     # Check overrides (use base name so +cu129 variants match)
@@ -411,7 +431,6 @@ def format_licenses(
             # OSV can emit a partial package list when the service is degraded.
             # Keep output stable for reviewed licenses by filling only packages
             # that are present in the exported requirements and overrides.yaml.
-            requirements_file = osv_json.parent / "requirements-main.txt"
             packages.extend(_get_requirements_with_overrides(requirements_file, overrides, local_packages))
 
             # Deduplicate by name (keep first occurrence)

--- a/tools/nemo-platform-sdk-tools/tests/license/test_license_utils.py
+++ b/tools/nemo-platform-sdk-tools/tests/license/test_license_utils.py
@@ -228,6 +228,47 @@ class TestFormatLicenses:
             '{"name": "cloudpickle", "license": "BSD-3-CLAUSE", "compatible": true}'
         )
 
+    def test_format_licenses_ignores_osv_packages_missing_from_exported_requirements(self, tmp_path):
+        """OSV-only conditional packages should not affect generated license reports."""
+        from nemo_platform_sdk_tools.license.generator import format_licenses
+
+        license_dir = tmp_path / "third_party"
+        license_dir.mkdir()
+        osv_json = license_dir / "osv-licenses.json"
+        osv_json.write_text(
+            json.dumps(
+                {
+                    "results": [
+                        {
+                            "packages": [
+                                {
+                                    "package": {"name": "aiofiles", "version": "25.1.0"},
+                                    "licenses": ["Apache-2.0"],
+                                },
+                                {
+                                    "package": {"name": "backports-tarfile", "version": "1.2.0"},
+                                    "licenses": ["MIT"],
+                                },
+                            ]
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        (license_dir / "requirements-main.txt").write_text(
+            "aiofiles==25.1.0 ; python_version >= '3.12' \\\n"
+            "    --hash=sha256:0000000000000000000000000000000000000000000000000000000000000000\n",
+            encoding="utf-8",
+        )
+        output_file = license_dir / "licenses.jsonl"
+
+        format_licenses(osv_json, output_file, format_type="jsonl")
+
+        assert output_file.read_text(encoding="utf-8") == (
+            '{"name": "aiofiles", "license": "APACHE-2.0", "compatible": true}'
+        )
+
     def test_format_licenses_csv_uses_third_party_license_columns(self, tmp_path, monkeypatch):
         """CSV output is Package, License, License URL and supports custom output directories."""
         from nemo_platform_sdk_tools.license import generator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added anonymous usage telemetry for CLI command outcomes, onboarding/setup steps, and terminal platform job results.
  * Added global `--no-telemetry` to disable telemetry for the current invocation.
* **Documentation**
  * Added “Telemetry and Privacy” content (and linked it from the README/navigation), including what’s collected/excluded and how to opt out.
  * Updated CLI docs/global options to include `--no-telemetry`.
  * Refreshed setup guidance with a NeMo Platform artifacts in NGC reference.
* **Tests**
  * Expanded telemetry test coverage for command, job, and onboarding events, including opt-out and help behavior.
  * Updated telemetry contract expectations to schema version 1.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->