### PR TITLE
feat: add network policies for helm chart

### DIFF
--- a/.github/actions/setup-kind-cluster/action.yaml
+++ b/.github/actions/setup-kind-cluster/action.yaml
@@ -33,6 +33,22 @@ inputs:
     description: Helm values file path (relative to repo root)
     required: false
     default: e2e/k8s/values/kind.yaml
+  helm-extra-args:
+    description: Extra arguments passed to Helm install, for example additional -f values files
+    required: false
+    default: ""
+  kind-enable-network-policies:
+    description: Create Kind without the default CNI and install Calico for NetworkPolicy enforcement
+    required: false
+    default: "false"
+  kind-enable-gateway:
+    description: Install Gateway API, run cloud-provider-kind, and create the test Gateway
+    required: false
+    default: "true"
+  wait-for-api:
+    description: Wait for the Gateway-routed API endpoint after installing NeMo Platform
+    required: false
+    default: "true"
   kind-image-pull-token:
     description: Token for pulling images into Kind
     required: true
@@ -119,6 +135,8 @@ runs:
         KUBE_NAMESPACE: ${{ inputs['kube-namespace'] }}
         NGC_API_KEY: ${{ inputs['ngc-api-key'] }}
         GITHUB_TOKEN: ${{ inputs['kind-image-pull-token'] }}
+        KIND_ENABLE_GATEWAY: ${{ inputs['kind-enable-gateway'] }}
+        KIND_ENABLE_NETWORK_POLICIES: ${{ inputs['kind-enable-network-policies'] }}
       run: bash e2e/k8s/scripts/setup_local_kind_cpu.sh
 
     - name: Set default kubectl namespace
@@ -128,6 +146,7 @@ runs:
       run: kubectl config set-context --current --namespace="${NAMESPACE}"
 
     - name: Verify Gateway API setup
+      if: ${{ inputs['kind-enable-gateway'] == 'true' }}
       shell: bash
       env:
         NAMESPACE: ${{ inputs['kube-namespace'] }}
@@ -164,6 +183,7 @@ runs:
         NMP_E2E_REGISTRY: ${{ inputs['image-registry'] }}
         NMP_E2E_TAG: ${{ inputs['image-tag'] }}
         HELM_VALUES: ${{ inputs['helm-values'] }}
+        HELM_EXTRA_ARGS: ${{ inputs['helm-extra-args'] }}
         REQUIRE_NMP_E2E_IMAGES: "true"
         POSTGRES_IMAGE: docker.io/library/postgres
         BUSYBOX_IMAGE: docker.io/library/busybox:stable
@@ -180,7 +200,7 @@ runs:
         fi
 
     - name: Wait for API
-      if: ${{ inputs['install-nemo-platform'] == 'true' }}
+      if: ${{ inputs['install-nemo-platform'] == 'true' && inputs['wait-for-api'] == 'true' }}
       shell: bash
       env:
         NMP_E2E_CLUSTER_URL: ${{ env.NMP_E2E_CLUSTER_URL }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -648,6 +648,78 @@ jobs:
           artifact-name: kind-gym-e2e-kubernetes-artifacts
           junit-report: report-kubernetes-gym-e2e.xml
           services-log-dir: ${{ runner.temp }}/e2e-services-logs
+  
+  kind-network-policy-smoke:
+    name: Kind NetworkPolicy smoke
+    needs: [changes, build-cpu-smoke-images]
+    if: >
+      !cancelled() &&
+      needs.build-cpu-smoke-images.result == 'success' &&
+      needs.build-cpu-smoke-images.outputs.publish_images == 'true' && (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs.helm == 'true' ||
+        needs.changes.outputs.e2e == 'true'
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
+    env:
+      KIND_CLUSTER_NAME: gha-${{ github.run_id }}-${{ github.run_attempt }}-network-policy
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Kind cluster with NetworkPolicy enforcement
+        uses: ./.github/actions/setup-kind-cluster
+        with:
+          kind-cluster-name: ${{ env.KIND_CLUSTER_NAME }}
+          image-registry: ${{ needs.build-cpu-smoke-images.outputs.image_registry }}
+          image-tag: ${{ needs.build-cpu-smoke-images.outputs.image_tag }}
+          kind-image-pull-token: ${{ github.token }}
+          kind-image-pull-user: ${{ github.actor }}
+          kind-enable-gateway: "false"
+          kind-enable-network-policies: "true"
+          helm-extra-args: -f e2e/k8s/values/network-policies.yaml
+          wait-for-api: "false"
+
+      - name: Run NetworkPolicy smoke test
+        shell: bash
+        env:
+          NAMESPACE: nemo-platform
+          CHAINSAW_REPORT_FORMAT: XML
+          CHAINSAW_REPORT_NAME: report-network-policy-smoke
+          CHAINSAW_REPORT_PATH: .
+        run: |
+          if e2e/k8s/scripts/test_network_policies.sh; then
+            if [ ! -f report-network-policy-smoke.xml ]; then
+              printf '<testsuite name="network-policy-smoke" tests="1" failures="0"/>%s' $'\n' > report-network-policy-smoke.xml
+            fi
+            exit 0
+          fi
+          status="$?"
+          if [ ! -f report-network-policy-smoke.xml ]; then
+            cat > report-network-policy-smoke.xml <<'EOF'
+          <testsuite name="network-policy-smoke" tests="1" failures="1">
+            <testcase name="network-policy-smoke">
+              <failure message="network policy smoke test failed">See the workflow log and Kubernetes artifact bundle.</failure>
+            </testcase>
+          </testsuite>
+          EOF
+          fi
+          exit "${status}"
+
+      - name: Finalize Kind e2e
+        if: always()
+        uses: ./.github/actions/finalize-kind-e2e
+        with:
+          kind-cluster-name: ${{ env.KIND_CLUSTER_NAME }}
+          artifact-name: kind-network-policy-smoke-artifacts
+          junit-report: report-network-policy-smoke.xml
+          services-log-dir: ${{ runner.temp }}/e2e-services-logs
 
   helm-lint:
     name: Helm lint
@@ -2110,6 +2182,7 @@ jobs:
       - build-cpu-smoke-images
       - kind-cpu-smoke
       - kind-gym-e2e
+      - kind-network-policy-smoke
       - helm-lint
       - helm-chart-verifier
       - lint

--- a/Makefile
+++ b/Makefile
@@ -620,8 +620,8 @@ test-e2e-kubernetes: ## Run e2e tests against Kubernetes (set NMP_E2E_CLUSTER_UR
 	$(UV) run --frozen pytest e2e --kubernetes -v -n 2 --junitxml=report-kubernetes.xml
 
 .PHONY: test-e2e-kubernetes-network-policies
-test-e2e-kubernetes-network-policies: ## Set up local kind with Calico and run the Helm NetworkPolicy smoke test
-	@echo "Running Kubernetes NetworkPolicy e2e smoke test..."
+test-e2e-kubernetes-network-policies: ## Set up local kind with Calico and run the Chainsaw NetworkPolicy smoke test
+	@echo "Running Chainsaw NetworkPolicy e2e smoke test..."
 	e2e/k8s/scripts/run_network_policy_e2e.sh
 
 .PHONY: test-e2e-kubernetes-auth

--- a/Makefile
+++ b/Makefile
@@ -619,6 +619,11 @@ test-e2e-kubernetes: ## Run e2e tests against Kubernetes (set NMP_E2E_CLUSTER_UR
 	@echo "Running e2e tests with Kubernetes..."
 	$(UV) run --frozen pytest e2e --kubernetes -v -n 2 --junitxml=report-kubernetes.xml
 
+.PHONY: test-e2e-kubernetes-network-policies
+test-e2e-kubernetes-network-policies: ## Set up local kind with Calico and run the Helm NetworkPolicy smoke test
+	@echo "Running Kubernetes NetworkPolicy e2e smoke test..."
+	e2e/k8s/scripts/run_network_policy_e2e.sh
+
 .PHONY: test-e2e-kubernetes-auth
 test-e2e-kubernetes-auth: ## Run e2e tests against Kubernetes with auth enabled (set NMP_E2E_CLUSTER_URL)
 	@echo "Running e2e tests with Kubernetes and feature auth enabled..."

--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -44,6 +44,8 @@ navigation:
                     path: ../../set-up/helm/prerequisites.mdx
                   - page: Install
                     path: ../../set-up/helm/install.mdx
+                  - page: NetworkPolicy Smoke Test
+                    path: ../../set-up/helm/network-policy-smoke-test.mdx
                   - page: Database Setup
                     path: ../../set-up/helm/database-setup.mdx
                   - page: Persistent Volumes

--- a/docs/set-up/helm/index.mdx
+++ b/docs/set-up/helm/index.mdx
@@ -27,6 +27,13 @@ Install the NeMo Platform using the Helm chart.
 <small><span class="md-tag">cluster-admin</span> <span class="md-tag">on-prem</span> <span class="md-tag">cloud</span></small>
 
 </Card>
+<Card title="NetworkPolicy Smoke Test" href="/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test">
+
+Verify optional Helm NetworkPolicies on a local Kind cluster with Calico.
+
+<small><span class="md-tag">cluster-admin</span> <span class="md-tag">kind</span> <span class="md-tag">networking</span></small>
+
+</Card>
 <Card title="Database Setup" href="/documentation/self-managed-deployment/setup/helm/database-setup">
 
 Set up an external database for the NeMo Platform.

--- a/docs/set-up/helm/index.mdx
+++ b/docs/set-up/helm/index.mdx
@@ -29,7 +29,7 @@ Install the NeMo Platform using the Helm chart.
 </Card>
 <Card title="NetworkPolicy Smoke Test" href="/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test">
 
-Verify optional Helm NetworkPolicies on a local Kind cluster with Calico.
+Verify Helm NetworkPolicies on a local Kind cluster with Calico and Chainsaw.
 
 <small><span class="md-tag">cluster-admin</span> <span class="md-tag">kind</span> <span class="md-tag">networking</span></small>
 

--- a/docs/set-up/helm/network-policy-smoke-test.mdx
+++ b/docs/set-up/helm/network-policy-smoke-test.mdx
@@ -4,13 +4,15 @@ description: ""
 ---
 <a id="network-policy-smoke-test"></a>
 
-Use this how-to to verify the optional Helm `networkPolicies` values on a local
-Kind cluster with Calico enforcing Kubernetes NetworkPolicy resources.
+Use this how-to to verify the Helm `networkPolicies` values on a local Kind
+cluster with Calico enforcing Kubernetes NetworkPolicy resources and Chainsaw
+running the behavioral assertions.
 
 ## Prerequisites
 
 - A source checkout of `NVIDIA-NeMo/nemo-platform`
 - `docker`, `kind`, `kubectl`, and `helm` available on your workstation
+- A local `chainsaw` binary, or Docker access to `ghcr.io/kyverno/chainsaw:v0.2.3`
 - `NGC_API_KEY` with access to the NeMo Platform chart and container images
 - Permission to create and delete the local Kind cluster and Kubernetes namespaces
 
@@ -31,9 +33,9 @@ e2e/k8s/scripts/run_network_policy_e2e.sh
 ```
 
 The script creates or validates a Kind cluster, installs Calico as the enforcing
-CNI, installs the chart with `e2e/k8s/values/network-policies.yaml`, and runs
-in-cluster probes that verify allowed API/controller traffic and denied
-unlabelled or managed-job egress traffic.
+CNI, installs the chart with `e2e/k8s/values/network-policies.yaml`, and runs a
+Chainsaw test suite that creates probe pods to verify allowed API/controller
+traffic and denied unlabelled or managed-job egress traffic.
 
 </Tab>
 
@@ -64,6 +66,10 @@ for workspace in client.workspaces.list().data:
 
 Set `CALICO_IMAGE_REGISTRY` to override the Calico registry used by the Kind
 setup script. The default is `docker.io/calico`.
+
+Set `CHAINSAW_IMAGE` to override the Chainsaw container image used when a local
+`chainsaw` binary is not installed. The default is
+`ghcr.io/kyverno/chainsaw:v0.2.3`.
 
 When testing source changes, set `NMP_E2E_REGISTRY` and `NMP_E2E_TAG` to a
 branch-built `nmp-api` image. CI supplies these from the CPU smoke image build.

--- a/docs/set-up/helm/network-policy-smoke-test.mdx
+++ b/docs/set-up/helm/network-policy-smoke-test.mdx
@@ -1,4 +1,6 @@
 ---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 title: "NetworkPolicy Smoke Test"
 description: ""
 ---

--- a/docs/set-up/helm/network-policy-smoke-test.mdx
+++ b/docs/set-up/helm/network-policy-smoke-test.mdx
@@ -1,0 +1,79 @@
+---
+title: "NetworkPolicy Smoke Test"
+description: ""
+---
+<a id="network-policy-smoke-test"></a>
+
+Use this how-to to verify the optional Helm `networkPolicies` values on a local
+Kind cluster with Calico enforcing Kubernetes NetworkPolicy resources.
+
+## Prerequisites
+
+- A source checkout of `NVIDIA-NeMo/nemo-platform`
+- `docker`, `kind`, `kubectl`, and `helm` available on your workstation
+- `NGC_API_KEY` with access to the NeMo Platform chart and container images
+- Permission to create and delete the local Kind cluster and Kubernetes namespaces
+
+## Run The Smoke Test
+
+<Tabs>
+
+<Tab title="CLI">
+
+Set the image and namespace inputs, then run the source-checkout smoke script:
+
+```sh
+export NGC_API_KEY=<your-ngc-api-key>
+export KIND_CLUSTER_NAME=nmp-network-policy
+export KUBE_NAMESPACE=nemo-platform
+
+e2e/k8s/scripts/run_network_policy_e2e.sh
+```
+
+The script creates or validates a Kind cluster, installs Calico as the enforcing
+CNI, installs the chart with `e2e/k8s/values/network-policies.yaml`, and runs
+in-cluster probes that verify allowed API/controller traffic and denied
+unlabelled or managed-job egress traffic.
+
+</Tab>
+
+<Tab title="Python SDK">
+
+The Python SDK does not create Kind clusters, install Helm charts, or run
+Kubernetes NetworkPolicy probes. After the CLI smoke test passes, use the SDK
+only for a post-smoke API check if you expose the API with `kubectl
+port-forward`:
+
+```sh
+kubectl -n "$KUBE_NAMESPACE" port-forward svc/nemo-platform-api 8080:8080
+```
+
+```python
+from nemo_platform import NeMoPlatform
+
+client = NeMoPlatform(base_url="http://localhost:8080")
+for workspace in client.workspaces.list().data:
+    print(workspace.name)
+```
+
+</Tab>
+
+</Tabs>
+
+<Accordion title="Registry and private image options">
+
+Set `CALICO_IMAGE_REGISTRY` to override the Calico registry used by the Kind
+setup script. The default is `docker.io/calico`.
+
+When testing source changes, set `NMP_E2E_REGISTRY` and `NMP_E2E_TAG` to a
+branch-built `nmp-api` image. CI supplies these from the CPU smoke image build.
+If the image is in private GHCR, export `GITHUB_TOKEN` so the setup script can
+create the pull secret.
+
+</Accordion>
+
+## Next Steps
+
+- Review the [Helm chart reference](/documentation/self-managed-deployment/helm/helm-reference) for the generated `networkPolicies` values.
+- Continue with [Install](/documentation/self-managed-deployment/setup/helm/install) for production chart installation.
+- Review [Security](/documentation/self-managed-deployment/setup/security) for broader deployment hardening.

--- a/e2e/k8s/chainsaw/network-policies/chainsaw-test.yaml
+++ b/e2e/k8s/chainsaw/network-policies/chainsaw-test.yaml
@@ -1,0 +1,307 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: network-policies
+spec:
+  timeouts:
+    apply: 30s
+    assert: 2m
+    cleanup: 2m
+    delete: 2m
+  steps:
+    - name: assert network policies rendered
+      try:
+        - assert:
+            resource:
+              apiVersion: networking.k8s.io/v1
+              kind: NetworkPolicy
+              metadata:
+                name: nemo-platform-api-ingress
+              spec:
+                policyTypes:
+                  - Ingress
+        - assert:
+            resource:
+              apiVersion: networking.k8s.io/v1
+              kind: NetworkPolicy
+              metadata:
+                name: nemo-platform-core-controller-ingress
+              spec:
+                policyTypes:
+                  - Ingress
+        - assert:
+            resource:
+              apiVersion: networking.k8s.io/v1
+              kind: NetworkPolicy
+              metadata:
+                name: nemo-platform-jobs-egress
+              spec:
+                policyTypes:
+                  - Egress
+
+    - name: create open in-cluster target
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Service
+              metadata:
+                name: nmp-np-open-http
+              spec:
+                selector:
+                  app: nmp-network-policy-open-target
+                ports:
+                  - name: http
+                    port: 8080
+                    targetPort: http
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: nmp-np-open-http
+                labels:
+                  app: nmp-network-policy-open-target
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: http
+                    image: docker.io/library/python:3.12-alpine
+                    ports:
+                      - name: http
+                        containerPort: 8080
+                    command:
+                      - python
+                      - -m
+                      - http.server
+                      - "8080"
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: nmp-np-open-http
+            for:
+              condition:
+                name: Ready
+                value: "True"
+            timeout: 2m
+
+    - name: assert allowed traffic
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: nmp-np-release-api
+                labels:
+                  app.kubernetes.io/name: nemo-platform
+                  app.kubernetes.io/instance: nemo-platform
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:8.11.1
+                    command:
+                      - curl
+                      - -fsS
+                      - --connect-timeout
+                      - "8"
+                      - --max-time
+                      - "8"
+                      - http://nemo-platform-api:8080/health/ready
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: nmp-np-release-api
+            for:
+              jsonPath:
+                path: "{.status.phase}"
+                value: Succeeded
+            timeout: 2m
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: nmp-np-managed-job-api
+                labels:
+                  app: nemo-job
+                  nmp.nvidia.com/managed_by: jobs-controller
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:8.11.1
+                    command:
+                      - curl
+                      - -fsS
+                      - --connect-timeout
+                      - "8"
+                      - --max-time
+                      - "8"
+                      - http://nemo-platform-api:8080/health/ready
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: nmp-np-managed-job-api
+            for:
+              jsonPath:
+                path: "{.status.phase}"
+                value: Succeeded
+            timeout: 2m
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: nmp-np-release-controller
+                labels:
+                  app.kubernetes.io/name: nemo-platform
+                  app.kubernetes.io/instance: nemo-platform
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:8.11.1
+                    command:
+                      - curl
+                      - -fsS
+                      - --connect-timeout
+                      - "8"
+                      - --max-time
+                      - "8"
+                      - http://nemo-platform-core-controller:8080/health/ready
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: nmp-np-release-controller
+            for:
+              jsonPath:
+                path: "{.status.phase}"
+                value: Succeeded
+            timeout: 2m
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: nmp-np-release-open-http
+                labels:
+                  app.kubernetes.io/name: nemo-platform
+                  app.kubernetes.io/instance: nemo-platform
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:8.11.1
+                    command:
+                      - curl
+                      - -fsS
+                      - --connect-timeout
+                      - "8"
+                      - --max-time
+                      - "8"
+                      - http://nmp-np-open-http:8080/
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: nmp-np-release-open-http
+            for:
+              jsonPath:
+                path: "{.status.phase}"
+                value: Succeeded
+            timeout: 2m
+
+    - name: assert denied traffic
+      try:
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: nmp-np-managed-job-open-http
+                labels:
+                  app: nemo-job
+                  nmp.nvidia.com/managed_by: jobs-controller
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:8.11.1
+                    command:
+                      - curl
+                      - -fsS
+                      - --connect-timeout
+                      - "8"
+                      - --max-time
+                      - "8"
+                      - http://nmp-np-open-http:8080/
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: nmp-np-managed-job-open-http
+            for:
+              jsonPath:
+                path: "{.status.phase}"
+                value: Failed
+            timeout: 2m
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: nmp-np-denied-api
+                labels:
+                  app: nmp-network-policy-probe
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:8.11.1
+                    command:
+                      - curl
+                      - -fsS
+                      - --connect-timeout
+                      - "8"
+                      - --max-time
+                      - "8"
+                      - http://nemo-platform-api:8080/health/ready
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: nmp-np-denied-api
+            for:
+              jsonPath:
+                path: "{.status.phase}"
+                value: Failed
+            timeout: 2m
+        - apply:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: nmp-np-denied-controller
+                labels:
+                  app: nmp-network-policy-probe
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: curl
+                    image: curlimages/curl:8.11.1
+                    command:
+                      - curl
+                      - -fsS
+                      - --connect-timeout
+                      - "8"
+                      - --max-time
+                      - "8"
+                      - http://nemo-platform-core-controller:8080/health/ready
+        - wait:
+            apiVersion: v1
+            kind: Pod
+            name: nmp-np-denied-controller
+            for:
+              jsonPath:
+                path: "{.status.phase}"
+                value: Failed
+            timeout: 2m

--- a/e2e/k8s/chainsaw/network-policies/chainsaw-test.yaml
+++ b/e2e/k8s/chainsaw/network-policies/chainsaw-test.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:

--- a/e2e/k8s/scripts/install_helm_e2e.sh
+++ b/e2e/k8s/scripts/install_helm_e2e.sh
@@ -260,11 +260,7 @@ fi
 
 add_nvidia_helm_repo
 helm repo update nvidia 2>/dev/null || true
-if grep -Eq '^[[:space:]]*dependencies:' "${HELM_CHART}/Chart.yaml"; then
-    helm dependency build "${HELM_CHART}"
-else
-    log_info "Skipping Helm dependency build; chart declares no dependencies"
-fi
+helm dependency build "${HELM_CHART}"
 
 if ! helm upgrade -i "${HELM_ARGS[@]}"; then
     log_error "Helm install/upgrade failed"

--- a/e2e/k8s/scripts/install_helm_e2e.sh
+++ b/e2e/k8s/scripts/install_helm_e2e.sh
@@ -260,7 +260,11 @@ fi
 
 add_nvidia_helm_repo
 helm repo update nvidia 2>/dev/null || true
-helm dependency build "${HELM_CHART}"
+if grep -Eq '^[[:space:]]*dependencies:' "${HELM_CHART}/Chart.yaml"; then
+    helm dependency build "${HELM_CHART}"
+else
+    log_info "Skipping Helm dependency build; chart declares no dependencies"
+fi
 
 if ! helm upgrade -i "${HELM_ARGS[@]}"; then
     log_error "Helm install/upgrade failed"

--- a/e2e/k8s/scripts/run_network_policy_e2e.sh
+++ b/e2e/k8s/scripts/run_network_policy_e2e.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Local end-to-end path for Helm NetworkPolicy enforcement.
 

--- a/e2e/k8s/scripts/run_network_policy_e2e.sh
+++ b/e2e/k8s/scripts/run_network_policy_e2e.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Local end-to-end path for Helm NetworkPolicy enforcement.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel)"
+source "${SCRIPT_DIR}/lib.sh"
+
+export KIND_ENABLE_NETWORK_POLICIES="${KIND_ENABLE_NETWORK_POLICIES:-true}"
+export KIND_ENABLE_GATEWAY="${KIND_ENABLE_GATEWAY:-false}"
+export NAMESPACE="${NAMESPACE:-${KUBE_NAMESPACE:-default}}"
+export HELM_VALUES="${HELM_VALUES:-${REPO_ROOT}/e2e/k8s/values/kind.yaml}"
+
+if [ -z "${NMP_E2E_REGISTRY:-}" ] || [ -z "${NMP_E2E_TAG:-}" ]; then
+    log_warn "NMP_E2E_REGISTRY/NMP_E2E_TAG not set; Helm will use chart default images. For source checkouts, set them to a branch-built nmp-api image."
+fi
+
+network_policy_values="${REPO_ROOT}/e2e/k8s/values/network-policies.yaml"
+if [ -n "${HELM_EXTRA_ARGS:-}" ]; then
+    export HELM_EXTRA_ARGS="${HELM_EXTRA_ARGS} -f ${network_policy_values}"
+else
+    export HELM_EXTRA_ARGS="-f ${network_policy_values}"
+fi
+
+log_info "Setting up kind with Calico NetworkPolicy enforcement"
+"${SCRIPT_DIR}/setup_local_kind_cpu.sh"
+
+log_info "Installing Helm chart with NetworkPolicy values"
+"${SCRIPT_DIR}/install_helm_e2e.sh"
+
+log_info "Running NetworkPolicy smoke test"
+"${SCRIPT_DIR}/test_network_policies.sh"

--- a/e2e/k8s/scripts/setup_local_kind_cpu.sh
+++ b/e2e/k8s/scripts/setup_local_kind_cpu.sh
@@ -16,7 +16,16 @@ KUBE_NAMESPACE="${KUBE_NAMESPACE:-default}"
 KUBE_GATEWAY_NAME="${KUBE_GATEWAY_NAME:-nmp-e2e-gateway}"
 CLOUD_PROVIDER_KIND_VERSION="${CLOUD_PROVIDER_KIND_VERSION:-v0.10.0}"
 GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.4.1}"
+GATEWAY_API_STANDARD_CRD_BASE_URL="${GATEWAY_API_STANDARD_CRD_BASE_URL:-https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/${GATEWAY_API_VERSION}/config/crd/standard}"
 CLOUD_PROVIDER_KIND_CONTAINER="cloud-provider-kind-${KIND_CLUSTER_NAME}"
+CLOUD_PROVIDER_KIND_IMAGE="registry.k8s.io/cloud-provider-kind/cloud-controller-manager:${CLOUD_PROVIDER_KIND_VERSION}"
+KIND_ENABLE_GATEWAY="${KIND_ENABLE_GATEWAY:-true}"
+KIND_ENABLE_NETWORK_POLICIES="${KIND_ENABLE_NETWORK_POLICIES:-false}"
+CALICO_VERSION="${CALICO_VERSION:-v3.32.1}"
+CALICO_MANIFEST_URL="${CALICO_MANIFEST_URL:-https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/calico.yaml}"
+CALICO_IMAGE_REGISTRY="${CALICO_IMAGE_REGISTRY:-docker.io/calico}"
+CALICO_PRELOAD_IMAGES="${CALICO_PRELOAD_IMAGES:-false}"
+KIND_NETWORK_POLICY_POD_SUBNET="${KIND_NETWORK_POLICY_POD_SUBNET:-192.168.0.0/16}"
 
 for tool in kind docker kubectl helm; do
     if ! command -v "$tool" >/dev/null 2>&1; then
@@ -30,49 +39,128 @@ if [ -z "${NGC_API_KEY:-}" ]; then
     exit 1
 fi
 
+retry_command() {
+    local max_attempts=5
+    local delay_seconds=5
+    local attempt
+
+    for attempt in $(seq 1 "${max_attempts}"); do
+        if "$@"; then
+            return 0
+        fi
+        if [ "${attempt}" -eq "${max_attempts}" ]; then
+            return 1
+        fi
+        log_warn "Command failed; retrying in ${delay_seconds}s (${attempt}/${max_attempts}): $*"
+        sleep "${delay_seconds}"
+    done
+}
+
+install_network_policy_provider() {
+    local calico_manifest
+    local calico_image
+    local rewritten_calico_manifest
+
+    log_info "Installing Calico ${CALICO_VERSION} for NetworkPolicy enforcement..."
+
+    if [ "${CALICO_PRELOAD_IMAGES}" = "true" ]; then
+        for image in cni node kube-controllers; do
+            calico_image="${CALICO_IMAGE_REGISTRY}/${image}:${CALICO_VERSION}"
+            retry_command docker pull "${calico_image}"
+            kind load docker-image --name "${KIND_CLUSTER_NAME}" "${calico_image}"
+        done
+    fi
+
+    calico_manifest="$(mktemp)"
+    rewritten_calico_manifest="$(mktemp)"
+    retry_command curl -fsSLo "${calico_manifest}" "${CALICO_MANIFEST_URL}"
+    sed "s#quay.io/calico#${CALICO_IMAGE_REGISTRY}#g" "${calico_manifest}" > "${rewritten_calico_manifest}"
+    retry_command kubectl apply -f "${rewritten_calico_manifest}"
+    rm "${calico_manifest}" "${rewritten_calico_manifest}"
+
+    kubectl -n kube-system rollout status daemonset/calico-node --timeout=5m
+    kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=5m
+    kubectl -n kube-system wait --for=condition=ready pod -l k8s-app=kube-dns --timeout=5m
+}
+
 if ! kind get clusters 2>/dev/null | grep -Fxq "${KIND_CLUSTER_NAME}"; then
     log_info "Creating kind cluster ${KIND_CLUSTER_NAME}..."
-    kind create cluster --name "${KIND_CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}"
+    if [ "${KIND_ENABLE_NETWORK_POLICIES}" = "true" ]; then
+        kind_config="$(mktemp)"
+        trap 'rm -f "${kind_config}"' EXIT
+        cat > "${kind_config}" <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: ${KIND_NETWORK_POLICY_POD_SUBNET}
+nodes:
+  - role: control-plane
+    image: ${KIND_NODE_IMAGE}
+EOF
+        kind create cluster --name "${KIND_CLUSTER_NAME}" --config "${kind_config}"
+        install_network_policy_provider
+    else
+        kind create cluster --name "${KIND_CLUSTER_NAME}" --image "${KIND_NODE_IMAGE}"
+    fi
 else
     log_info "kind cluster ${KIND_CLUSTER_NAME} already exists"
     kubectl config use-context "kind-${KIND_CLUSTER_NAME}" >/dev/null
-fi
-
-log_info "Allowing LoadBalancer traffic to control-plane nodes..."
-kubectl label nodes --all node.kubernetes.io/exclude-from-external-load-balancers- >/dev/null 2>&1 || true
-
-if ! kubectl api-resources --api-group=networking.k8s.io | awk '{print $1}' | grep -Fxq "servicecidrs"; then
-    log_error "Kubernetes ServiceCIDR API is not available. cloud-provider-kind ${CLOUD_PROVIDER_KIND_VERSION} requires a kind node image with Kubernetes 1.33 or newer."
-    log_error "Current node image setting: ${KIND_NODE_IMAGE}"
-    exit 1
-fi
-
-log_info "Installing Gateway API CRDs (${GATEWAY_API_VERSION})..."
-kubectl apply --server-side -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
-
-log_info "Starting cloud-provider-kind (${CLOUD_PROVIDER_KIND_VERSION})..."
-docker rm -f "${CLOUD_PROVIDER_KIND_CONTAINER}" >/dev/null 2>&1 || true
-docker run -d --name "${CLOUD_PROVIDER_KIND_CONTAINER}" --rm \
-    --network host \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    "registry.k8s.io/cloud-provider-kind/cloud-controller-manager:${CLOUD_PROVIDER_KIND_VERSION}" \
-    --gateway-channel standard >/dev/null
-
-log_info "Waiting for Gateway API CRDs and GatewayClass..."
-kubectl wait --for=condition=Established crd/gateways.gateway.networking.k8s.io --timeout=2m
-kubectl wait --for=condition=Established crd/httproutes.gateway.networking.k8s.io --timeout=2m
-
-for attempt in $(seq 1 60); do
-    if kubectl get gatewayclass cloud-provider-kind >/dev/null 2>&1; then
-        break
-    fi
-    if [ "${attempt}" -eq 60 ]; then
-        log_error "Timed out waiting for GatewayClass cloud-provider-kind"
-        docker logs "${CLOUD_PROVIDER_KIND_CONTAINER}" || true
+    if [ "${KIND_ENABLE_NETWORK_POLICIES}" = "true" ] && ! kubectl -n kube-system get daemonset calico-node >/dev/null 2>&1; then
+        if kubectl -n kube-system get daemonset kindnet >/dev/null 2>&1; then
+            log_error "KIND_ENABLE_NETWORK_POLICIES=true requires a cluster created without Kind's default CNI. Delete ${KIND_CLUSTER_NAME} or use a new KIND_CLUSTER_NAME."
+            exit 1
+        fi
+        log_error "KIND_ENABLE_NETWORK_POLICIES=true requires a cluster created with Calico. Delete ${KIND_CLUSTER_NAME} or use a new KIND_CLUSTER_NAME."
         exit 1
     fi
-    sleep 2
-done
+    if [ "${KIND_ENABLE_NETWORK_POLICIES}" = "true" ]; then
+        kubectl -n kube-system rollout status daemonset/calico-node --timeout=5m
+        kubectl -n kube-system rollout status deployment/calico-kube-controllers --timeout=5m
+        kubectl -n kube-system wait --for=condition=ready pod -l k8s-app=kube-dns --timeout=5m
+    fi
+fi
+
+if [ "${KIND_ENABLE_GATEWAY}" = "true" ]; then
+    log_info "Allowing LoadBalancer traffic to control-plane nodes..."
+    kubectl label nodes --all node.kubernetes.io/exclude-from-external-load-balancers- >/dev/null 2>&1 || true
+
+    if ! kubectl api-resources --api-group=networking.k8s.io | awk '{print $1}' | grep -Fxq "servicecidrs"; then
+        log_error "Kubernetes ServiceCIDR API is not available. cloud-provider-kind ${CLOUD_PROVIDER_KIND_VERSION} requires a kind node image with Kubernetes 1.33 or newer."
+        log_error "Current node image setting: ${KIND_NODE_IMAGE}"
+        exit 1
+    fi
+
+    log_info "Installing Gateway API CRDs (${GATEWAY_API_VERSION})..."
+    for crd in gatewayclasses gateways httproutes grpcroutes referencegrants; do
+        retry_command kubectl apply --server-side -f "${GATEWAY_API_STANDARD_CRD_BASE_URL}/gateway.networking.k8s.io_${crd}.yaml"
+    done
+
+    log_info "Starting cloud-provider-kind (${CLOUD_PROVIDER_KIND_VERSION})..."
+    docker rm -f "${CLOUD_PROVIDER_KIND_CONTAINER}" >/dev/null 2>&1 || true
+    retry_command docker pull "${CLOUD_PROVIDER_KIND_IMAGE}"
+    docker run -d --name "${CLOUD_PROVIDER_KIND_CONTAINER}" --rm \
+        --network host \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        "${CLOUD_PROVIDER_KIND_IMAGE}" \
+        --gateway-channel standard >/dev/null
+
+    log_info "Waiting for Gateway API CRDs and GatewayClass..."
+    kubectl wait --for=condition=Established crd/gateways.gateway.networking.k8s.io --timeout=2m
+    kubectl wait --for=condition=Established crd/httproutes.gateway.networking.k8s.io --timeout=2m
+
+    for attempt in $(seq 1 60); do
+        if kubectl get gatewayclass cloud-provider-kind >/dev/null 2>&1; then
+            break
+        fi
+        if [ "${attempt}" -eq 60 ]; then
+            log_error "Timed out waiting for GatewayClass cloud-provider-kind"
+            docker logs "${CLOUD_PROVIDER_KIND_CONTAINER}" || true
+            exit 1
+        fi
+        sleep 2
+    done
+fi
 
 if [ "${KUBE_NAMESPACE}" != "default" ]; then
     log_info "Creating namespace ${KUBE_NAMESPACE}..."
@@ -84,8 +172,9 @@ KUBECTL_NS=(kubectl -n "${KUBE_NAMESPACE}")
 log_info "Creating Kubernetes secrets in namespace ${KUBE_NAMESPACE}..."
 create_platform_secrets "${KUBE_NAMESPACE}"
 
-log_info "Creating Gateway ${KUBE_NAMESPACE}/${KUBE_GATEWAY_NAME}..."
-kubectl apply -f - <<EOF
+if [ "${KIND_ENABLE_GATEWAY}" = "true" ]; then
+    log_info "Creating Gateway ${KUBE_NAMESPACE}/${KUBE_GATEWAY_NAME}..."
+    kubectl apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -102,13 +191,16 @@ spec:
           from: Same
 EOF
 
-log_info "Gateway created; it will be programmed after the chart creates its HTTPRoute."
+    log_info "Gateway created; it will be programmed after the chart creates its HTTPRoute."
+fi
 
 if [ -n "${GITHUB_ENV:-}" ]; then
     {
         echo "KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME}"
-        echo "KUBE_GATEWAY_NAME=${KUBE_GATEWAY_NAME}"
-        echo "NMP_E2E_CLUSTER_URL="
+        if [ "${KIND_ENABLE_GATEWAY}" = "true" ]; then
+            echo "KUBE_GATEWAY_NAME=${KUBE_GATEWAY_NAME}"
+            echo "NMP_E2E_CLUSTER_URL="
+        fi
     } >> "${GITHUB_ENV}"
 fi
 
@@ -117,7 +209,11 @@ log_info "kind E2E cluster is ready"
 log_info "=========================================="
 log_info "Cluster: ${KIND_CLUSTER_NAME}"
 log_info "Namespace: ${KUBE_NAMESPACE}"
-log_info "Gateway: ${KUBE_GATEWAY_NAME}"
-log_info "Cluster URL: assigned after Helm install programs the Gateway"
-log_info "cloud-provider-kind container: ${CLOUD_PROVIDER_KIND_CONTAINER}"
+log_info "Gateway setup: ${KIND_ENABLE_GATEWAY}"
+if [ "${KIND_ENABLE_GATEWAY}" = "true" ]; then
+    log_info "Gateway: ${KUBE_GATEWAY_NAME}"
+    log_info "Cluster URL: assigned after Helm install programs the Gateway"
+    log_info "cloud-provider-kind container: ${CLOUD_PROVIDER_KIND_CONTAINER}"
+fi
+log_info "NetworkPolicy enforcement: ${KIND_ENABLE_NETWORK_POLICIES}"
 log_info "=========================================="

--- a/e2e/k8s/scripts/test_network_policies.sh
+++ b/e2e/k8s/scripts/test_network_policies.sh
@@ -73,6 +73,15 @@ run_chainsaw() {
         --no-color
 }
 
+flattened_kubeconfig=""
+
+cleanup() {
+    if [ -n "${flattened_kubeconfig}" ]; then
+        rm -f "${flattened_kubeconfig}"
+    fi
+}
+trap cleanup EXIT
+
 if command -v chainsaw >/dev/null 2>&1; then
     log_info "Running NetworkPolicy smoke test with local chainsaw"
     run_chainsaw "${CHAINSAW_TEST_DIR}" "${CHAINSAW_REPORT_PATH}"
@@ -85,18 +94,16 @@ if ! command -v docker >/dev/null 2>&1; then
     exit 1
 fi
 
-kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
-if [[ "${kubeconfig}" == *:* ]]; then
-    log_warn "KUBECONFIG contains multiple paths; using the first path for Docker-mounted Chainsaw"
-    kubeconfig="${kubeconfig%%:*}"
-fi
-
-if [ ! -f "${kubeconfig}" ]; then
-    log_error "Kubeconfig not found for Docker-mounted Chainsaw: ${kubeconfig}"
+flattened_kubeconfig="$(mktemp)"
+if ! kubectl config view --flatten --raw > "${flattened_kubeconfig}"; then
+    log_error "Failed to create flattened kubeconfig for Docker-mounted Chainsaw"
     exit 1
 fi
 
-kubeconfig="$(cd "$(dirname "${kubeconfig}")" && pwd -P)/$(basename "${kubeconfig}")"
+if [ ! -s "${flattened_kubeconfig}" ]; then
+    log_error "Flattened kubeconfig is empty for Docker-mounted Chainsaw"
+    exit 1
+fi
 
 case "${CHAINSAW_TEST_DIR}" in
     "${REPO_ROOT}"/*)
@@ -114,7 +121,7 @@ docker run --rm \
     --network="${CHAINSAW_DOCKER_NETWORK:-host}" \
     -v "${REPO_ROOT}:/repo:ro" \
     -v "${CHAINSAW_REPORT_PATH}:/chainsaw-report" \
-    -v "${kubeconfig}:/kubeconfig:ro" \
+    -v "${flattened_kubeconfig}:/kubeconfig:ro" \
     -e KUBECONFIG=/kubeconfig \
     "${CHAINSAW_IMAGE}" test "${chainsaw_test_dir_container}" \
         --namespace "${NAMESPACE}" \

--- a/e2e/k8s/scripts/test_network_policies.sh
+++ b/e2e/k8s/scripts/test_network_policies.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Smoke-test Helm NetworkPolicy enforcement from inside the Kubernetes cluster.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib.sh"
+
+NAMESPACE="${NAMESPACE:-${KUBE_NAMESPACE:-default}}"
+HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-nemo-platform}"
+PROBE_IMAGE="${NETWORK_POLICY_PROBE_IMAGE:-curlimages/curl:8.11.1}"
+DENY_NAMESPACE="${NETWORK_POLICY_DENY_NAMESPACE:-${NAMESPACE}-network-policy-deny}"
+TIMEOUT_SECONDS="${NETWORK_POLICY_PROBE_TIMEOUT_SECONDS:-8}"
+CHART_NAME_LABEL="${NETWORK_POLICY_CHART_NAME_LABEL:-nemo-platform}"
+
+KUBECTL_NS=(kubectl -n "${NAMESPACE}")
+
+cleanup() {
+    "${KUBECTL_NS[@]}" delete pod \
+        nmp-np-release-api \
+        nmp-np-managed-job-api \
+        nmp-np-release-controller \
+        nmp-np-denied-api \
+        nmp-np-denied-controller \
+        --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    kubectl -n "${DENY_NAMESPACE}" delete pod \
+        nmp-np-denied-cross-api \
+        --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    kubectl delete namespace "${DENY_NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+first_jsonpath() {
+    local resource="$1"
+    local selector="$2"
+    local jsonpath="$3"
+
+    kubectl -n "${NAMESPACE}" get "${resource}" -l "${selector}" -o "jsonpath={.items[0]${jsonpath}}"
+}
+
+run_probe() {
+    local namespace="$1"
+    local name="$2"
+    local labels="$3"
+    local url="$4"
+
+    kubectl -n "${namespace}" delete pod "${name}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
+    kubectl -n "${namespace}" run "${name}" \
+        --attach=true \
+        --restart=Never \
+        --image="${PROBE_IMAGE}" \
+        --pod-running-timeout=2m \
+        --labels="${labels}" \
+        --command -- curl -fsS --connect-timeout "${TIMEOUT_SECONDS}" --max-time "${TIMEOUT_SECONDS}" "${url}"
+}
+
+expect_allowed() {
+    local description="$1"
+    shift
+
+    log_info "Expect allowed: ${description}"
+    "$@"
+}
+
+expect_denied() {
+    local description="$1"
+    shift
+
+    log_info "Expect denied: ${description}"
+    if "$@"; then
+        log_error "Unexpectedly allowed: ${description}"
+        return 1
+    fi
+}
+
+require_policy() {
+    local selector="$1"
+    local expected="$2"
+    local count
+
+    count="$(kubectl -n "${NAMESPACE}" get networkpolicy -l "${selector}" -o jsonpath='{.items[*].metadata.name}' | wc -w | tr -d ' ')"
+    if [ "${count}" != "${expected}" ]; then
+        log_error "Expected ${expected} NetworkPolicy resource(s) for selector ${selector}, found ${count}"
+        kubectl -n "${NAMESPACE}" get networkpolicy -o wide || true
+        exit 1
+    fi
+}
+
+log_info "Validating NetworkPolicy resources in namespace ${NAMESPACE}"
+require_policy "app.kubernetes.io/component=nmp-api,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" 1
+require_policy "app.kubernetes.io/component=nmp-core-controller,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" 1
+require_policy "app.kubernetes.io/component=nmp-core-jobs,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" 1
+
+api_service="$(first_jsonpath svc "app.kubernetes.io/component=nmp-api,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" ".metadata.name")"
+api_port="$(first_jsonpath svc "app.kubernetes.io/component=nmp-api,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" ".spec.ports[0].port")"
+controller_service="$(first_jsonpath svc "app.kubernetes.io/component=nmp-core-controller,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" ".metadata.name")"
+controller_port="$(first_jsonpath svc "app.kubernetes.io/component=nmp-core-controller,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" ".spec.ports[0].port")"
+
+if [ -z "${api_service}" ] || [ -z "${api_port}" ] || [ -z "${controller_service}" ] || [ -z "${controller_port}" ]; then
+    log_error "Could not discover API/controller services for release ${HELM_RELEASE_NAME}"
+    kubectl -n "${NAMESPACE}" get svc -o wide || true
+    exit 1
+fi
+
+same_release_labels="app.kubernetes.io/name=${CHART_NAME_LABEL},app.kubernetes.io/instance=${HELM_RELEASE_NAME}"
+managed_job_labels="app=nemo-job,nmp.nvidia.com/managed_by=jobs-controller"
+untrusted_labels="app=nmp-network-policy-probe"
+api_url="http://${api_service}.${NAMESPACE}.svc.cluster.local:${api_port}/health/ready"
+controller_url="http://${controller_service}.${NAMESPACE}.svc.cluster.local:${controller_port}/health/ready"
+
+kubectl create namespace "${DENY_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+expect_allowed "same-release pod to Platform API" \
+    run_probe "${NAMESPACE}" nmp-np-release-api "${same_release_labels}" "${api_url}"
+expect_allowed "managed job pod to Platform API" \
+    run_probe "${NAMESPACE}" nmp-np-managed-job-api "${managed_job_labels}" "${api_url}"
+expect_allowed "same-release pod to core controller" \
+    run_probe "${NAMESPACE}" nmp-np-release-controller "${same_release_labels}" "${controller_url}"
+
+expect_denied "unlabelled same-namespace pod to Platform API" \
+    run_probe "${NAMESPACE}" nmp-np-denied-api "${untrusted_labels}" "${api_url}"
+expect_denied "unlabelled same-namespace pod to core controller" \
+    run_probe "${NAMESPACE}" nmp-np-denied-controller "${untrusted_labels}" "${controller_url}"
+expect_denied "cross-namespace pod to Platform API" \
+    run_probe "${DENY_NAMESPACE}" nmp-np-denied-cross-api "${untrusted_labels}" "${api_url}"
+
+log_info "NetworkPolicy smoke test passed"

--- a/e2e/k8s/scripts/test_network_policies.sh
+++ b/e2e/k8s/scripts/test_network_policies.sh
@@ -1,171 +1,127 @@
 #!/usr/bin/env bash
 #
-# Smoke-test Helm NetworkPolicy enforcement from inside the Kubernetes cluster.
+# Smoke-test Helm NetworkPolicy enforcement with Chainsaw.
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd -P)"
 source "${SCRIPT_DIR}/lib.sh"
+
+usage() {
+    cat <<EOF
+Usage: ${0##*/}
+
+Runs the Helm NetworkPolicy Chainsaw smoke test against the current Kubernetes context.
+
+Environment:
+  NAMESPACE | KUBE_NAMESPACE    Target namespace. Defaults to the current kube context namespace or default.
+  CHAINSAW_IMAGE                Docker image used when local chainsaw is unavailable.
+  CHAINSAW_REPORT_FORMAT        Report format. Defaults to nil. CI sets XML.
+  CHAINSAW_REPORT_NAME          Report file base name. Defaults to report-network-policy-smoke.
+  CHAINSAW_REPORT_PATH          Report output directory. Defaults to the repo root.
+EOF
+}
+
+case "${1:-}" in
+    "")
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        log_error "Unexpected argument: $1"
+        usage
+        exit 2
+        ;;
+esac
 
 KUBE_CONTEXT_NAMESPACE="$(kubectl config view --minify -o 'jsonpath={..namespace}' 2>/dev/null || true)"
 NAMESPACE="${NAMESPACE:-${KUBE_NAMESPACE:-${KUBE_CONTEXT_NAMESPACE:-default}}}"
 HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-nemo-platform}"
-PROBE_IMAGE="${NETWORK_POLICY_PROBE_IMAGE:-curlimages/curl:8.11.1}"
-OPEN_TARGET_IMAGE="${NETWORK_POLICY_OPEN_TARGET_IMAGE:-docker.io/library/python:3.12-alpine}"
-OPEN_TARGET_PORT="${NETWORK_POLICY_OPEN_TARGET_PORT:-8080}"
-DENY_NAMESPACE="${NETWORK_POLICY_DENY_NAMESPACE:-${NAMESPACE}-network-policy-deny}"
-TIMEOUT_SECONDS="${NETWORK_POLICY_PROBE_TIMEOUT_SECONDS:-8}"
-CHART_NAME_LABEL="${NETWORK_POLICY_CHART_NAME_LABEL:-nemo-platform}"
-deny_namespace_created=false
 
-KUBECTL_NS=(kubectl -n "${NAMESPACE}")
+CHAINSAW_IMAGE="${CHAINSAW_IMAGE:-ghcr.io/kyverno/chainsaw:v0.2.3}"
+CHAINSAW_TEST_DIR="${CHAINSAW_TEST_DIR:-${REPO_ROOT}/e2e/k8s/chainsaw/network-policies}"
+CHAINSAW_REPORT_FORMAT="${CHAINSAW_REPORT_FORMAT:-nil}"
+CHAINSAW_REPORT_NAME="${CHAINSAW_REPORT_NAME:-report-network-policy-smoke}"
+CHAINSAW_REPORT_PATH="${CHAINSAW_REPORT_PATH:-${REPO_ROOT}}"
 
-cleanup() {
-    "${KUBECTL_NS[@]}" delete pod \
-        nmp-np-open-http \
-        nmp-np-release-open-http \
-        nmp-np-release-api \
-        nmp-np-managed-job-api \
-        nmp-np-managed-job-open-http \
-        nmp-np-release-controller \
-        nmp-np-denied-api \
-        nmp-np-denied-controller \
-        --ignore-not-found --wait=false >/dev/null 2>&1 || true
-    kubectl -n "${DENY_NAMESPACE}" delete pod \
-        nmp-np-denied-cross-api \
-        --ignore-not-found --wait=false >/dev/null 2>&1 || true
-    if [ "${deny_namespace_created}" = true ]; then
-        kubectl delete namespace "${DENY_NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
-    fi
-}
-trap cleanup EXIT
-
-first_jsonpath() {
-    local resource="$1"
-    local selector="$2"
-    local jsonpath="$3"
-
-    kubectl -n "${NAMESPACE}" get "${resource}" -l "${selector}" -o "jsonpath={.items[0]${jsonpath}}"
-}
-
-run_probe() {
-    local namespace="$1"
-    local name="$2"
-    local labels="$3"
-    local url="$4"
-
-    kubectl -n "${namespace}" delete pod "${name}" --ignore-not-found --wait=true >/dev/null 2>&1 || true
-    kubectl -n "${namespace}" run "${name}" \
-        --attach=true \
-        --restart=Never \
-        --image="${PROBE_IMAGE}" \
-        --pod-running-timeout=2m \
-        --labels="${labels}" \
-        --command -- curl -fsS --connect-timeout "${TIMEOUT_SECONDS}" --max-time "${TIMEOUT_SECONDS}" "${url}"
-}
-
-start_open_http_target() {
-    local labels="$1"
-    local pod_ip
-
-    "${KUBECTL_NS[@]}" delete pod nmp-np-open-http --ignore-not-found --wait=true >/dev/null 2>&1 || true
-    "${KUBECTL_NS[@]}" run nmp-np-open-http \
-        --restart=Never \
-        --image="${OPEN_TARGET_IMAGE}" \
-        --pod-running-timeout=2m \
-        --labels="${labels}" \
-        --port="${OPEN_TARGET_PORT}" \
-        --command -- python -m http.server "${OPEN_TARGET_PORT}" >/dev/null
-    "${KUBECTL_NS[@]}" wait --for=condition=ready pod/nmp-np-open-http --timeout=2m >/dev/null
-
-    pod_ip="$("${KUBECTL_NS[@]}" get pod nmp-np-open-http -o jsonpath='{.status.podIP}')"
-    if [ -z "${pod_ip}" ]; then
-        log_error "Could not discover open HTTP target pod IP"
-        "${KUBECTL_NS[@]}" describe pod nmp-np-open-http || true
-        exit 1
-    fi
-    printf 'http://%s:%s/' "${pod_ip}" "${OPEN_TARGET_PORT}"
-}
-
-expect_allowed() {
-    local description="$1"
-    shift
-
-    log_info "Expect allowed: ${description}"
-    "$@"
-}
-
-expect_denied() {
-    local description="$1"
-    shift
-
-    log_info "Expect denied: ${description}"
-    if "$@"; then
-        log_error "Unexpectedly allowed: ${description}"
-        return 1
-    fi
-}
-
-require_policy() {
-    local selector="$1"
-    local expected="$2"
-    local count
-
-    count="$(kubectl -n "${NAMESPACE}" get networkpolicy -l "${selector}" -o jsonpath='{.items[*].metadata.name}' | wc -w | tr -d ' ')"
-    if [ "${count}" != "${expected}" ]; then
-        log_error "Expected ${expected} NetworkPolicy resource(s) for selector ${selector}, found ${count}"
-        kubectl -n "${NAMESPACE}" get networkpolicy -o wide || true
-        exit 1
-    fi
-}
-
-log_info "Validating NetworkPolicy resources in namespace ${NAMESPACE}"
-require_policy "app.kubernetes.io/component=nmp-api,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" 1
-require_policy "app.kubernetes.io/component=nmp-core-controller,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" 1
-require_policy "app.kubernetes.io/component=nmp-core-jobs,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" 1
-
-api_service="$(first_jsonpath svc "app.kubernetes.io/component=nmp-api,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" ".metadata.name")"
-api_port="$(first_jsonpath svc "app.kubernetes.io/component=nmp-api,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" ".spec.ports[0].port")"
-controller_service="$(first_jsonpath svc "app.kubernetes.io/component=nmp-core-controller,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" ".metadata.name")"
-controller_port="$(first_jsonpath svc "app.kubernetes.io/component=nmp-core-controller,app.kubernetes.io/instance=${HELM_RELEASE_NAME}" ".spec.ports[0].port")"
-
-if [ -z "${api_service}" ] || [ -z "${api_port}" ] || [ -z "${controller_service}" ] || [ -z "${controller_port}" ]; then
-    log_error "Could not discover API/controller services for release ${HELM_RELEASE_NAME}"
-    kubectl -n "${NAMESPACE}" get svc -o wide || true
+if [ "${HELM_RELEASE_NAME}" != "nemo-platform" ]; then
+    log_error "NetworkPolicy Chainsaw smoke test expects HELM_RELEASE_NAME=nemo-platform"
     exit 1
 fi
 
-same_release_labels="app.kubernetes.io/name=${CHART_NAME_LABEL},app.kubernetes.io/instance=${HELM_RELEASE_NAME}"
-managed_job_labels="app=nemo-job,nmp.nvidia.com/managed_by=jobs-controller"
-untrusted_labels="app=nmp-network-policy-probe"
-open_target_labels="app=nmp-network-policy-open-target"
-api_url="http://${api_service}.${NAMESPACE}.svc.cluster.local:${api_port}/health/ready"
-controller_url="http://${controller_service}.${NAMESPACE}.svc.cluster.local:${controller_port}/health/ready"
-open_target_url="$(start_open_http_target "${open_target_labels}")"
-
-if kubectl get namespace "${DENY_NAMESPACE}" >/dev/null 2>&1; then
-    log_info "Using existing deny namespace ${DENY_NAMESPACE}; cleanup will leave it in place"
-else
-    kubectl create namespace "${DENY_NAMESPACE}"
-    deny_namespace_created=true
+if [ ! -d "${CHAINSAW_TEST_DIR}" ]; then
+    log_error "Chainsaw test directory not found: ${CHAINSAW_TEST_DIR}"
+    exit 1
 fi
 
-expect_allowed "same-release pod to Platform API" \
-    run_probe "${NAMESPACE}" nmp-np-release-api "${same_release_labels}" "${api_url}"
-expect_allowed "managed job pod to Platform API" \
-    run_probe "${NAMESPACE}" nmp-np-managed-job-api "${managed_job_labels}" "${api_url}"
-expect_allowed "same-release pod to core controller" \
-    run_probe "${NAMESPACE}" nmp-np-release-controller "${same_release_labels}" "${controller_url}"
-expect_allowed "same-release pod to open in-cluster HTTP target" \
-    run_probe "${NAMESPACE}" nmp-np-release-open-http "${same_release_labels}" "${open_target_url}"
-expect_denied "managed job pod to open in-cluster HTTP target" \
-    run_probe "${NAMESPACE}" nmp-np-managed-job-open-http "${managed_job_labels}" "${open_target_url}"
+mkdir -p "${CHAINSAW_REPORT_PATH}"
+CHAINSAW_REPORT_PATH="$(cd "${CHAINSAW_REPORT_PATH}" && pwd -P)"
 
-expect_denied "unlabelled same-namespace pod to Platform API" \
-    run_probe "${NAMESPACE}" nmp-np-denied-api "${untrusted_labels}" "${api_url}"
-expect_denied "unlabelled same-namespace pod to core controller" \
-    run_probe "${NAMESPACE}" nmp-np-denied-controller "${untrusted_labels}" "${controller_url}"
-expect_denied "cross-namespace pod to Platform API" \
-    run_probe "${DENY_NAMESPACE}" nmp-np-denied-cross-api "${untrusted_labels}" "${api_url}"
+run_chainsaw() {
+    local test_dir="$1"
+    local report_path="$2"
 
-log_info "NetworkPolicy smoke test passed"
+    chainsaw test "${test_dir}" \
+        --namespace "${NAMESPACE}" \
+        --report-format "${CHAINSAW_REPORT_FORMAT}" \
+        --report-name "${CHAINSAW_REPORT_NAME}" \
+        --report-path "${report_path}" \
+        --fail-fast \
+        --no-color
+}
+
+if command -v chainsaw >/dev/null 2>&1; then
+    log_info "Running NetworkPolicy smoke test with local chainsaw"
+    run_chainsaw "${CHAINSAW_TEST_DIR}" "${CHAINSAW_REPORT_PATH}"
+    log_info "NetworkPolicy Chainsaw smoke test passed"
+    exit 0
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    log_error "chainsaw is not installed and docker is unavailable"
+    exit 1
+fi
+
+kubeconfig="${KUBECONFIG:-${HOME}/.kube/config}"
+if [[ "${kubeconfig}" == *:* ]]; then
+    log_warn "KUBECONFIG contains multiple paths; using the first path for Docker-mounted Chainsaw"
+    kubeconfig="${kubeconfig%%:*}"
+fi
+
+if [ ! -f "${kubeconfig}" ]; then
+    log_error "Kubeconfig not found for Docker-mounted Chainsaw: ${kubeconfig}"
+    exit 1
+fi
+
+kubeconfig="$(cd "$(dirname "${kubeconfig}")" && pwd -P)/$(basename "${kubeconfig}")"
+
+case "${CHAINSAW_TEST_DIR}" in
+    "${REPO_ROOT}"/*)
+        chainsaw_test_dir_container="/repo/${CHAINSAW_TEST_DIR#"${REPO_ROOT}/"}"
+        ;;
+    *)
+        log_error "Docker-mounted Chainsaw requires CHAINSAW_TEST_DIR to be under ${REPO_ROOT}"
+        exit 1
+        ;;
+esac
+
+log_info "Running NetworkPolicy smoke test with ${CHAINSAW_IMAGE}"
+docker run --rm \
+    --user "$(id -u):$(id -g)" \
+    --network="${CHAINSAW_DOCKER_NETWORK:-host}" \
+    -v "${REPO_ROOT}:/repo:ro" \
+    -v "${CHAINSAW_REPORT_PATH}:/chainsaw-report" \
+    -v "${kubeconfig}:/kubeconfig:ro" \
+    -e KUBECONFIG=/kubeconfig \
+    "${CHAINSAW_IMAGE}" test "${chainsaw_test_dir_container}" \
+        --namespace "${NAMESPACE}" \
+        --report-format "${CHAINSAW_REPORT_FORMAT}" \
+        --report-name "${CHAINSAW_REPORT_NAME}" \
+        --report-path /chainsaw-report \
+        --fail-fast \
+        --no-color
+
+log_info "NetworkPolicy Chainsaw smoke test passed"

--- a/e2e/k8s/scripts/test_network_policies.sh
+++ b/e2e/k8s/scripts/test_network_policies.sh
@@ -7,19 +7,26 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/lib.sh"
 
-NAMESPACE="${NAMESPACE:-${KUBE_NAMESPACE:-default}}"
+KUBE_CONTEXT_NAMESPACE="$(kubectl config view --minify -o 'jsonpath={..namespace}' 2>/dev/null || true)"
+NAMESPACE="${NAMESPACE:-${KUBE_NAMESPACE:-${KUBE_CONTEXT_NAMESPACE:-default}}}"
 HELM_RELEASE_NAME="${HELM_RELEASE_NAME:-nemo-platform}"
 PROBE_IMAGE="${NETWORK_POLICY_PROBE_IMAGE:-curlimages/curl:8.11.1}"
+OPEN_TARGET_IMAGE="${NETWORK_POLICY_OPEN_TARGET_IMAGE:-docker.io/library/python:3.12-alpine}"
+OPEN_TARGET_PORT="${NETWORK_POLICY_OPEN_TARGET_PORT:-8080}"
 DENY_NAMESPACE="${NETWORK_POLICY_DENY_NAMESPACE:-${NAMESPACE}-network-policy-deny}"
 TIMEOUT_SECONDS="${NETWORK_POLICY_PROBE_TIMEOUT_SECONDS:-8}"
 CHART_NAME_LABEL="${NETWORK_POLICY_CHART_NAME_LABEL:-nemo-platform}"
+deny_namespace_created=false
 
 KUBECTL_NS=(kubectl -n "${NAMESPACE}")
 
 cleanup() {
     "${KUBECTL_NS[@]}" delete pod \
+        nmp-np-open-http \
+        nmp-np-release-open-http \
         nmp-np-release-api \
         nmp-np-managed-job-api \
+        nmp-np-managed-job-open-http \
         nmp-np-release-controller \
         nmp-np-denied-api \
         nmp-np-denied-controller \
@@ -27,7 +34,9 @@ cleanup() {
     kubectl -n "${DENY_NAMESPACE}" delete pod \
         nmp-np-denied-cross-api \
         --ignore-not-found --wait=false >/dev/null 2>&1 || true
-    kubectl delete namespace "${DENY_NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    if [ "${deny_namespace_created}" = true ]; then
+        kubectl delete namespace "${DENY_NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    fi
 }
 trap cleanup EXIT
 
@@ -53,6 +62,29 @@ run_probe() {
         --pod-running-timeout=2m \
         --labels="${labels}" \
         --command -- curl -fsS --connect-timeout "${TIMEOUT_SECONDS}" --max-time "${TIMEOUT_SECONDS}" "${url}"
+}
+
+start_open_http_target() {
+    local labels="$1"
+    local pod_ip
+
+    "${KUBECTL_NS[@]}" delete pod nmp-np-open-http --ignore-not-found --wait=true >/dev/null 2>&1 || true
+    "${KUBECTL_NS[@]}" run nmp-np-open-http \
+        --restart=Never \
+        --image="${OPEN_TARGET_IMAGE}" \
+        --pod-running-timeout=2m \
+        --labels="${labels}" \
+        --port="${OPEN_TARGET_PORT}" \
+        --command -- python -m http.server "${OPEN_TARGET_PORT}" >/dev/null
+    "${KUBECTL_NS[@]}" wait --for=condition=ready pod/nmp-np-open-http --timeout=2m >/dev/null
+
+    pod_ip="$("${KUBECTL_NS[@]}" get pod nmp-np-open-http -o jsonpath='{.status.podIP}')"
+    if [ -z "${pod_ip}" ]; then
+        log_error "Could not discover open HTTP target pod IP"
+        "${KUBECTL_NS[@]}" describe pod nmp-np-open-http || true
+        exit 1
+    fi
+    printf 'http://%s:%s/' "${pod_ip}" "${OPEN_TARGET_PORT}"
 }
 
 expect_allowed() {
@@ -106,10 +138,17 @@ fi
 same_release_labels="app.kubernetes.io/name=${CHART_NAME_LABEL},app.kubernetes.io/instance=${HELM_RELEASE_NAME}"
 managed_job_labels="app=nemo-job,nmp.nvidia.com/managed_by=jobs-controller"
 untrusted_labels="app=nmp-network-policy-probe"
+open_target_labels="app=nmp-network-policy-open-target"
 api_url="http://${api_service}.${NAMESPACE}.svc.cluster.local:${api_port}/health/ready"
 controller_url="http://${controller_service}.${NAMESPACE}.svc.cluster.local:${controller_port}/health/ready"
+open_target_url="$(start_open_http_target "${open_target_labels}")"
 
-kubectl create namespace "${DENY_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+if kubectl get namespace "${DENY_NAMESPACE}" >/dev/null 2>&1; then
+    log_info "Using existing deny namespace ${DENY_NAMESPACE}; cleanup will leave it in place"
+else
+    kubectl create namespace "${DENY_NAMESPACE}"
+    deny_namespace_created=true
+fi
 
 expect_allowed "same-release pod to Platform API" \
     run_probe "${NAMESPACE}" nmp-np-release-api "${same_release_labels}" "${api_url}"
@@ -117,6 +156,10 @@ expect_allowed "managed job pod to Platform API" \
     run_probe "${NAMESPACE}" nmp-np-managed-job-api "${managed_job_labels}" "${api_url}"
 expect_allowed "same-release pod to core controller" \
     run_probe "${NAMESPACE}" nmp-np-release-controller "${same_release_labels}" "${controller_url}"
+expect_allowed "same-release pod to open in-cluster HTTP target" \
+    run_probe "${NAMESPACE}" nmp-np-release-open-http "${same_release_labels}" "${open_target_url}"
+expect_denied "managed job pod to open in-cluster HTTP target" \
+    run_probe "${NAMESPACE}" nmp-np-managed-job-open-http "${managed_job_labels}" "${open_target_url}"
 
 expect_denied "unlabelled same-namespace pod to Platform API" \
     run_probe "${NAMESPACE}" nmp-np-denied-api "${untrusted_labels}" "${api_url}"

--- a/e2e/k8s/scripts/test_network_policies.sh
+++ b/e2e/k8s/scripts/test_network_policies.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Smoke-test Helm NetworkPolicy enforcement with Chainsaw.
 

--- a/e2e/k8s/values/network-policies.yaml
+++ b/e2e/k8s/values/network-policies.yaml
@@ -1,0 +1,11 @@
+# Enables optional NetworkPolicy resources for local and CI enforcement smoke tests.
+httpRoute:
+  enabled: false
+
+networkPolicies:
+  api:
+    enabled: true
+  controller:
+    enabled: true
+  jobs:
+    enabled: true

--- a/e2e/k8s/values/network-policies.yaml
+++ b/e2e/k8s/values/network-policies.yaml
@@ -1,11 +1,6 @@
-# Enables optional NetworkPolicy resources for local and CI enforcement smoke tests.
+# Enables NetworkPolicy resources for local and CI enforcement smoke tests.
 httpRoute:
   enabled: false
 
 networkPolicies:
-  api:
-    enabled: true
-  controller:
-    enabled: true
-  jobs:
-    enabled: true
+  enabled: true

--- a/e2e/k8s/values/network-policies.yaml
+++ b/e2e/k8s/values/network-policies.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Enables NetworkPolicy resources for local and CI enforcement smoke tests.
 httpRoute:
   enabled: false

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -399,6 +399,23 @@ For the complete default values, see [values.yaml](values.yaml).
 | ncclTest.iterations | int | `3` | How many times to run the full multinode NCCL test (orchestrator loop; env NCCL_TEST_ITERATIONS). Increase the test timeout on helm test if increasing this variable |
 | ncclTest.validation.minBandwidthMBpsAt1024MB | int | `8000` | Minimum allreduce bandwidth (MB/s) at 1024MB message size; 0 disables the floor check in nccl_test.py. |
 | ncclTest.waitTimeoutSeconds | int | `900` | Max seconds to wait for each worker pod to complete. |
+| networkPolicies | object | This object has the following default values for optional NetworkPolicy resources. | NetworkPolicy configuration. |
+| networkPolicies.jobs | object | This object has the following default values for managed job pod egress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration for pods created by the jobs controller. |
+| networkPolicies.jobs.dns | object | `{"enabled":true,"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"kube-system"}},"podSelector":{"matchLabels":{"k8s-app":"kube-dns"}},"ports":[{"port":53,"protocol":"UDP"},{"port":53,"protocol":"TCP"}]}` | Allow DNS lookup from managed job pods. |
+| networkPolicies.jobs.dns.enabled | bool | `true` | Enable egress to DNS pods. |
+| networkPolicies.jobs.dns.namespaceSelector | object | `{"matchLabels":{"kubernetes.io/metadata.name":"kube-system"}}` | Namespace selector for DNS pods. |
+| networkPolicies.jobs.dns.podSelector | object | `{"matchLabels":{"k8s-app":"kube-dns"}}` | Pod selector for DNS pods. |
+| networkPolicies.jobs.dns.ports | list | `[{"port":53,"protocol":"UDP"},{"port":53,"protocol":"TCP"}]` | DNS ports to allow. |
+| networkPolicies.jobs.enabled | bool | `false` | Create NetworkPolicy resources that isolate managed job pod egress. |
+| networkPolicies.jobs.externalEgress | object | `{"enabled":true,"ipBlocks":[{"cidr":"0.0.0.0/0","except":["10.0.0.0/8","100.64.0.0/10","127.0.0.0/8","169.254.0.0/16","172.16.0.0/12","192.168.0.0/16"]}],"ports":[]}` | Allow egress to external CIDR blocks. The default excludes common private, loopback, and link-local ranges so enabling the policy does not allow direct access to typical in-cluster service and pod networks. |
+| networkPolicies.jobs.externalEgress.enabled | bool | `true` | Enable egress to external CIDR blocks. |
+| networkPolicies.jobs.externalEgress.ipBlocks | list | `[{"cidr":"0.0.0.0/0","except":["10.0.0.0/8","100.64.0.0/10","127.0.0.0/8","169.254.0.0/16","172.16.0.0/12","192.168.0.0/16"]}]` | External destination CIDR blocks for managed job pods. |
+| networkPolicies.jobs.externalEgress.ports | list | `[]` | Optional list of ports for external egress. Empty allows all ports to the configured ipBlocks. |
+| networkPolicies.jobs.extraEgress | list | `[]` | Extra NetworkPolicy egress rules appended to the managed job policy, for cluster-specific dependencies or additional allowed CIDRs. |
+| networkPolicies.jobs.platformApi | object | `{"enabled":true,"port":""}` | Allow managed job pods to reach the in-namespace NeMo Platform API pods. |
+| networkPolicies.jobs.platformApi.enabled | bool | `true` | Enable egress to the platform API pods. |
+| networkPolicies.jobs.platformApi.port | string | `""` | Optional NetworkPolicy port for the platform API. Empty uses api.service.port. |
+| networkPolicies.jobs.podSelector | object | `{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}` | Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller. |
 | ngcAPIKey | string | `"YOUR-NGC-API-KEY"` | Your NVIDIA GPU Cloud (NGC) API key authenticates API calls to NGC services, such as model downloads. The existing secret overrides this key if you provide one to the `existingSecret` key. |
 | openshiftRoute | object | [See values.yaml](values.yaml#L587) | OpenShift Route (route.openshift.io/v1). Use on OpenShift to expose the API via a Route instead of Ingress. |
 | openshiftRoute.annotations | object | `{}` | Annotations for the route resource. |

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -123,12 +123,13 @@ and
 
 ## NetworkPolicies
 
-The chart can render optional NetworkPolicy resources for the Platform API, core
-controller, and managed job pods. They are disabled by default so chart upgrades
-do not change cluster connectivity unless you explicitly enable them.
+The chart can render NetworkPolicy resources for the Platform API, core
+controller, and managed job pods. A top-level switch enables all default
+policies, and each subpolicy can be disabled independently for cluster-specific
+exceptions.
 
 For a Calico-backed Kind smoke test that verifies allowed and denied in-cluster
-traffic, see
+traffic with Chainsaw, see
 [NetworkPolicy Smoke Test](https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test).
 The generated `networkPolicies` values reference remains in the table below.
 
@@ -410,9 +411,9 @@ For the complete default values, see [values.yaml](values.yaml).
 | ncclTest.iterations | int | `3` | How many times to run the full multinode NCCL test (orchestrator loop; env NCCL_TEST_ITERATIONS). Increase the test timeout on helm test if increasing this variable |
 | ncclTest.validation.minBandwidthMBpsAt1024MB | int | `8000` | Minimum allreduce bandwidth (MB/s) at 1024MB message size; 0 disables the floor check in nccl_test.py. |
 | ncclTest.waitTimeoutSeconds | int | `900` | Max seconds to wait for each worker pod to complete. |
-| networkPolicies | object | This object has the following default values for optional NetworkPolicy resources. | NetworkPolicy configuration. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test. |
-| networkPolicies.api | object | This object has the following default values for API pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration for the Platform API pods. |
-| networkPolicies.api.enabled | bool | `false` | Create NetworkPolicy resources that isolate Platform API pod ingress. |
+| networkPolicies | object | This object has the following default values. The top-level switch is disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration. Enable the top-level switch to render all default policies, then disable individual policies only for cluster-specific exceptions. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test. |
+| networkPolicies.api | object | This object has the following default values for API pod ingress isolation. | NetworkPolicy configuration for the Platform API pods. |
+| networkPolicies.api.enabled | bool | `true` | Create NetworkPolicy resources that isolate Platform API pod ingress. |
 | networkPolicies.api.extraIngress | list | `[]` | Extra NetworkPolicy ingress rules appended to the API policy, for cluster-specific ingress controllers, gateways, monitoring, or debugging pods. |
 | networkPolicies.api.managedJobs | object | `{"enabled":true,"podSelector":{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}}` | Allow managed job pods to reach the Platform API pods. |
 | networkPolicies.api.managedJobs.enabled | bool | `true` | Enable ingress from managed job pods. |
@@ -420,19 +421,20 @@ For the complete default values, see [values.yaml](values.yaml).
 | networkPolicies.api.port | string | `""` | Optional NetworkPolicy port for the Platform API. Empty uses api.service.port. |
 | networkPolicies.api.sameReleasePods | object | `{"enabled":true}` | Allow pods from the same Helm release namespace that carry the chart selector labels to reach the Platform API pods. |
 | networkPolicies.api.sameReleasePods.enabled | bool | `true` | Enable ingress from same-release pods. |
-| networkPolicies.controller | object | This object has the following default values for core controller pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration for the core controller pods. |
-| networkPolicies.controller.enabled | bool | `false` | Create NetworkPolicy resources that isolate core controller pod ingress. |
+| networkPolicies.controller | object | This object has the following default values for core controller pod ingress isolation. | NetworkPolicy configuration for the core controller pods. |
+| networkPolicies.controller.enabled | bool | `true` | Create NetworkPolicy resources that isolate core controller pod ingress. |
 | networkPolicies.controller.extraIngress | list | `[]` | Extra NetworkPolicy ingress rules appended to the core controller policy, for cluster-specific monitoring or debugging pods. |
 | networkPolicies.controller.port | string | `""` | Optional NetworkPolicy port for the core controller. Empty uses core.controller.service.port. |
 | networkPolicies.controller.sameReleasePods | object | `{"enabled":true}` | Allow pods from the same Helm release namespace that carry the chart selector labels to reach the core controller pods. |
 | networkPolicies.controller.sameReleasePods.enabled | bool | `true` | Enable ingress from same-release pods. |
-| networkPolicies.jobs | object | This object has the following default values for managed job pod egress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration for pods created by the jobs controller. |
+| networkPolicies.enabled | bool | `false` | Create NetworkPolicy resources for enabled subpolicies. |
+| networkPolicies.jobs | object | This object has the following default values for managed job pod egress isolation. | NetworkPolicy configuration for pods created by the jobs controller. |
 | networkPolicies.jobs.dns | object | `{"enabled":true,"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"kube-system"}},"podSelector":{"matchLabels":{"k8s-app":"kube-dns"}},"ports":[{"port":53,"protocol":"UDP"},{"port":53,"protocol":"TCP"}]}` | Allow DNS lookup from managed job pods. |
 | networkPolicies.jobs.dns.enabled | bool | `true` | Enable egress to DNS pods. |
 | networkPolicies.jobs.dns.namespaceSelector | object | `{"matchLabels":{"kubernetes.io/metadata.name":"kube-system"}}` | Namespace selector for DNS pods. |
 | networkPolicies.jobs.dns.podSelector | object | `{"matchLabels":{"k8s-app":"kube-dns"}}` | Pod selector for DNS pods. |
 | networkPolicies.jobs.dns.ports | list | `[{"port":53,"protocol":"UDP"},{"port":53,"protocol":"TCP"}]` | DNS ports to allow. |
-| networkPolicies.jobs.enabled | bool | `false` | Create NetworkPolicy resources that isolate managed job pod egress. |
+| networkPolicies.jobs.enabled | bool | `true` | Create NetworkPolicy resources that isolate managed job pod egress. |
 | networkPolicies.jobs.externalEgress | object | `{"enabled":true,"ipBlocks":[{"cidr":"0.0.0.0/0","except":["10.0.0.0/8","100.64.0.0/10","127.0.0.0/8","169.254.0.0/16","172.16.0.0/12","192.168.0.0/16"]}],"ports":[]}` | Allow egress to external CIDR blocks. The default excludes common private, loopback, and link-local ranges so enabling the policy does not allow direct access to typical in-cluster service and pod networks. |
 | networkPolicies.jobs.externalEgress.enabled | bool | `true` | Enable egress to external CIDR blocks. |
 | networkPolicies.jobs.externalEgress.ipBlocks | list | `[{"cidr":"0.0.0.0/0","except":["10.0.0.0/8","100.64.0.0/10","127.0.0.0/8","169.254.0.0/16","172.16.0.0/12","192.168.0.0/16"]}]` | External destination CIDR blocks for managed job pods. |

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -121,6 +121,29 @@ See the upstream
 and
 [OSS operational recommendations](https://clickhouse.com/docs/guides/oss/best-practices/tips).
 
+## NetworkPolicy Smoke Test
+
+The chart can render optional NetworkPolicy resources for the Platform API, core
+controller, and managed job pods. They are disabled by default.
+
+For a local Kind run that installs Calico as the enforcing CNI, enables the
+optional policies, installs the chart, and verifies allowed and denied
+in-cluster traffic:
+
+```shell
+export NGC_API_KEY=<your-ngc-api-key>
+e2e/k8s/scripts/run_network_policy_e2e.sh
+```
+
+Set `CALICO_IMAGE_REGISTRY` to override the Calico image registry used by the
+local Kind setup script. The default is `docker.io/calico`.
+
+When running from a source checkout, set `NMP_E2E_REGISTRY` and `NMP_E2E_TAG`
+to a branch-built `nmp-api` image. CI supplies these from the CPU smoke image
+build job.
+If that image is in private GHCR, export `GITHUB_TOKEN` so the setup script can
+create the pull secret.
+
 ## Values
 
 For the complete default values, see [values.yaml](values.yaml).
@@ -400,6 +423,21 @@ For the complete default values, see [values.yaml](values.yaml).
 | ncclTest.validation.minBandwidthMBpsAt1024MB | int | `8000` | Minimum allreduce bandwidth (MB/s) at 1024MB message size; 0 disables the floor check in nccl_test.py. |
 | ncclTest.waitTimeoutSeconds | int | `900` | Max seconds to wait for each worker pod to complete. |
 | networkPolicies | object | This object has the following default values for optional NetworkPolicy resources. | NetworkPolicy configuration. |
+| networkPolicies.api | object | This object has the following default values for API pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration for the Platform API pods. |
+| networkPolicies.api.enabled | bool | `false` | Create NetworkPolicy resources that isolate Platform API pod ingress. |
+| networkPolicies.api.extraIngress | list | `[]` | Extra NetworkPolicy ingress rules appended to the API policy, for cluster-specific ingress controllers, gateways, monitoring, or debugging pods. |
+| networkPolicies.api.managedJobs | object | `{"enabled":true,"podSelector":{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}}` | Allow managed job pods to reach the Platform API pods. |
+| networkPolicies.api.managedJobs.enabled | bool | `true` | Enable ingress from managed job pods. |
+| networkPolicies.api.managedJobs.podSelector | object | `{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}` | Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller. |
+| networkPolicies.api.port | string | `""` | Optional NetworkPolicy port for the Platform API. Empty uses api.service.port. |
+| networkPolicies.api.sameReleasePods | object | `{"enabled":true}` | Allow pods from the same Helm release namespace that carry the chart selector labels to reach the Platform API pods. |
+| networkPolicies.api.sameReleasePods.enabled | bool | `true` | Enable ingress from same-release pods. |
+| networkPolicies.controller | object | This object has the following default values for core controller pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration for the core controller pods. |
+| networkPolicies.controller.enabled | bool | `false` | Create NetworkPolicy resources that isolate core controller pod ingress. |
+| networkPolicies.controller.extraIngress | list | `[]` | Extra NetworkPolicy ingress rules appended to the core controller policy, for cluster-specific monitoring or debugging pods. |
+| networkPolicies.controller.port | string | `""` | Optional NetworkPolicy port for the core controller. Empty uses core.controller.service.port. |
+| networkPolicies.controller.sameReleasePods | object | `{"enabled":true}` | Allow pods from the same Helm release namespace that carry the chart selector labels to reach the core controller pods. |
+| networkPolicies.controller.sameReleasePods.enabled | bool | `true` | Enable ingress from same-release pods. |
 | networkPolicies.jobs | object | This object has the following default values for managed job pod egress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration for pods created by the jobs controller. |
 | networkPolicies.jobs.dns | object | `{"enabled":true,"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"kube-system"}},"podSelector":{"matchLabels":{"k8s-app":"kube-dns"}},"ports":[{"port":53,"protocol":"UDP"},{"port":53,"protocol":"TCP"}]}` | Allow DNS lookup from managed job pods. |
 | networkPolicies.jobs.dns.enabled | bool | `true` | Enable egress to DNS pods. |
@@ -412,7 +450,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | networkPolicies.jobs.externalEgress.ipBlocks | list | `[{"cidr":"0.0.0.0/0","except":["10.0.0.0/8","100.64.0.0/10","127.0.0.0/8","169.254.0.0/16","172.16.0.0/12","192.168.0.0/16"]}]` | External destination CIDR blocks for managed job pods. |
 | networkPolicies.jobs.externalEgress.ports | list | `[]` | Optional list of ports for external egress. Empty allows all ports to the configured ipBlocks. |
 | networkPolicies.jobs.extraEgress | list | `[]` | Extra NetworkPolicy egress rules appended to the managed job policy, for cluster-specific dependencies or additional allowed CIDRs. |
-| networkPolicies.jobs.platformApi | object | `{"enabled":true,"port":""}` | Allow managed job pods to reach the in-namespace NeMo Platform API pods. |
+| networkPolicies.jobs.platformApi | object | `{"enabled":true,"port":""}` | Allow managed job pods to reach the in-namespace Platform API pods. |
 | networkPolicies.jobs.platformApi.enabled | bool | `true` | Enable egress to the platform API pods. |
 | networkPolicies.jobs.platformApi.port | string | `""` | Optional NetworkPolicy port for the platform API. Empty uses api.service.port. |
 | networkPolicies.jobs.podSelector | object | `{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}` | Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller. |

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -439,7 +439,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | networkPolicies.jobs.externalEgress.ports | list | `[]` | Optional list of ports for external egress. Empty allows all ports to the configured ipBlocks. |
 | networkPolicies.jobs.extraEgress | list | `[]` | Extra NetworkPolicy egress rules appended to the managed job policy, for cluster-specific dependencies or additional allowed CIDRs. |
 | networkPolicies.jobs.platformApi | object | `{"enabled":true,"port":""}` | Allow managed job pods to reach the in-namespace Platform API pods. |
-| networkPolicies.jobs.platformApi.enabled | bool | `true` | Enable egress to the platform API pods. |
+| networkPolicies.jobs.platformApi.enabled | bool | `true` | Enable the default egress exception to the platform API pods. Disable only when managed job pods should not call the in-namespace API, or when API access is supplied through cluster-specific extraEgress rules. |
 | networkPolicies.jobs.platformApi.port | string | `""` | Optional NetworkPolicy port for the platform API. Empty uses api.service.port. |
 | networkPolicies.jobs.podSelector | object | `{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}` | Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller. |
 | ngcAPIKey | string | `"YOUR-NGC-API-KEY"` | Your NVIDIA GPU Cloud (NGC) API key authenticates API calls to NGC services, such as model downloads. The existing secret overrides this key if you provide one to the `existingSecret` key. |

--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -121,28 +121,16 @@ See the upstream
 and
 [OSS operational recommendations](https://clickhouse.com/docs/guides/oss/best-practices/tips).
 
-## NetworkPolicy Smoke Test
+## NetworkPolicies
 
 The chart can render optional NetworkPolicy resources for the Platform API, core
-controller, and managed job pods. They are disabled by default.
+controller, and managed job pods. They are disabled by default so chart upgrades
+do not change cluster connectivity unless you explicitly enable them.
 
-For a local Kind run that installs Calico as the enforcing CNI, enables the
-optional policies, installs the chart, and verifies allowed and denied
-in-cluster traffic:
-
-```shell
-export NGC_API_KEY=<your-ngc-api-key>
-e2e/k8s/scripts/run_network_policy_e2e.sh
-```
-
-Set `CALICO_IMAGE_REGISTRY` to override the Calico image registry used by the
-local Kind setup script. The default is `docker.io/calico`.
-
-When running from a source checkout, set `NMP_E2E_REGISTRY` and `NMP_E2E_TAG`
-to a branch-built `nmp-api` image. CI supplies these from the CPU smoke image
-build job.
-If that image is in private GHCR, export `GITHUB_TOKEN` so the setup script can
-create the pull secret.
+For a Calico-backed Kind smoke test that verifies allowed and denied in-cluster
+traffic, see
+[NetworkPolicy Smoke Test](https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test).
+The generated `networkPolicies` values reference remains in the table below.
 
 ## Values
 
@@ -422,7 +410,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | ncclTest.iterations | int | `3` | How many times to run the full multinode NCCL test (orchestrator loop; env NCCL_TEST_ITERATIONS). Increase the test timeout on helm test if increasing this variable |
 | ncclTest.validation.minBandwidthMBpsAt1024MB | int | `8000` | Minimum allreduce bandwidth (MB/s) at 1024MB message size; 0 disables the floor check in nccl_test.py. |
 | ncclTest.waitTimeoutSeconds | int | `900` | Max seconds to wait for each worker pod to complete. |
-| networkPolicies | object | This object has the following default values for optional NetworkPolicy resources. | NetworkPolicy configuration. |
+| networkPolicies | object | This object has the following default values for optional NetworkPolicy resources. | NetworkPolicy configuration. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test. |
 | networkPolicies.api | object | This object has the following default values for API pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration for the Platform API pods. |
 | networkPolicies.api.enabled | bool | `false` | Create NetworkPolicy resources that isolate Platform API pod ingress. |
 | networkPolicies.api.extraIngress | list | `[]` | Extra NetworkPolicy ingress rules appended to the API policy, for cluster-specific ingress controllers, gateways, monitoring, or debugging pods. |

--- a/k8s/helm/ci/23-enable-network-policies.yaml
+++ b/k8s/helm/ci/23-enable-network-policies.yaml
@@ -1,8 +1,3 @@
 # CI validates by running: helm template nemo-platform . -f ci/23-enable-network-policies.yaml
 networkPolicies:
-  api:
-    enabled: true
-  controller:
-    enabled: true
-  jobs:
-    enabled: true
+  enabled: true

--- a/k8s/helm/ci/23-enable-network-policies.yaml
+++ b/k8s/helm/ci/23-enable-network-policies.yaml
@@ -1,4 +1,8 @@
 # CI validates by running: helm template nemo-platform . -f ci/23-enable-network-policies.yaml
 networkPolicies:
+  api:
+    enabled: true
+  controller:
+    enabled: true
   jobs:
     enabled: true

--- a/k8s/helm/ci/23-enable-network-policies.yaml
+++ b/k8s/helm/ci/23-enable-network-policies.yaml
@@ -1,0 +1,4 @@
+# CI validates by running: helm template nemo-platform . -f ci/23-enable-network-policies.yaml
+networkPolicies:
+  jobs:
+    enabled: true

--- a/k8s/helm/ci/23-enable-network-policies.yaml
+++ b/k8s/helm/ci/23-enable-network-policies.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 # CI validates by running: helm template nemo-platform . -f ci/23-enable-network-policies.yaml
 networkPolicies:
   enabled: true

--- a/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
+++ b/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
@@ -122,6 +122,13 @@ See the upstream
 and
 [OSS operational recommendations](https://clickhouse.com/docs/guides/oss/best-practices/tips).
 
+## NetworkPolicies
+
+The chart can render NetworkPolicy resources for the Platform API, core
+controller, and managed job pods. A top-level switch enables all default
+policies, and each subpolicy can be disabled independently for cluster-specific
+exceptions.
+
 {{ define "nemo.valueDescriptionColumnRenderMd" -}}
 {{- if .Description -}}
 {{- .Description | replace "\n" " " | replace "|" "\\|" -}}

--- a/k8s/helm/templates/networking/api-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/api-networkpolicy.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.api.enabled .Values.networkPolicies.api.enabled }}
+{{- $api := .Values.networkPolicies.api -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-api-ingress" (include "nemo-platform.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    app.kubernetes.io/component: nmp-api
+    {{- include "nemo-platform.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: nmp-api
+      {{- include "nemo-platform.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  {{- if or $api.sameReleasePods.enabled $api.managedJobs.enabled $api.extraIngress }}
+  ingress:
+    {{- if $api.sameReleasePods.enabled }}
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "nemo-platform.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ default .Values.api.service.port $api.port }}
+    {{- end }}
+    {{- if $api.managedJobs.enabled }}
+    - from:
+        - podSelector:
+            {{- toYaml $api.managedJobs.podSelector | nindent 12 }}
+      ports:
+        - protocol: TCP
+          port: {{ default .Values.api.service.port $api.port }}
+    {{- end }}
+    {{- with $api.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/k8s/helm/templates/networking/api-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/api-networkpolicy.yaml
@@ -1,3 +1,8 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
 {{- if and .Values.api.enabled .Values.networkPolicies.enabled .Values.networkPolicies.api.enabled }}
 {{- $api := .Values.networkPolicies.api -}}
 apiVersion: networking.k8s.io/v1

--- a/k8s/helm/templates/networking/api-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/api-networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.api.enabled .Values.networkPolicies.api.enabled }}
+{{- if and .Values.api.enabled .Values.networkPolicies.enabled .Values.networkPolicies.api.enabled }}
 {{- $api := .Values.networkPolicies.api -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/k8s/helm/templates/networking/controller-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/controller-networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.core.enabled .Values.networkPolicies.controller.enabled }}
+{{- if and .Values.core.enabled .Values.networkPolicies.enabled .Values.networkPolicies.controller.enabled }}
 {{- $controller := .Values.networkPolicies.controller -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/k8s/helm/templates/networking/controller-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/controller-networkpolicy.yaml
@@ -1,3 +1,8 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
 {{- if and .Values.core.enabled .Values.networkPolicies.enabled .Values.networkPolicies.controller.enabled }}
 {{- $controller := .Values.networkPolicies.controller -}}
 apiVersion: networking.k8s.io/v1

--- a/k8s/helm/templates/networking/controller-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/controller-networkpolicy.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.core.enabled .Values.networkPolicies.controller.enabled }}
+{{- $controller := .Values.networkPolicies.controller -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-core-controller-ingress" (include "nemo-platform.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    app.kubernetes.io/component: nmp-core-controller
+    {{- include "nemo-platform.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: nmp-core-controller
+      {{- include "nemo-platform.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  {{- if or $controller.sameReleasePods.enabled $controller.extraIngress }}
+  ingress:
+    {{- if $controller.sameReleasePods.enabled }}
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "nemo-platform.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ default .Values.core.controller.service.port $controller.port }}
+    {{- end }}
+    {{- with $controller.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/k8s/helm/templates/networking/jobs-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/jobs-networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicies.jobs.enabled }}
+{{- if and .Values.networkPolicies.enabled .Values.networkPolicies.jobs.enabled }}
 {{- $jobs := .Values.networkPolicies.jobs -}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/k8s/helm/templates/networking/jobs-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/jobs-networkpolicy.yaml
@@ -1,3 +1,8 @@
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
 {{- if and .Values.networkPolicies.enabled .Values.networkPolicies.jobs.enabled }}
 {{- $jobs := .Values.networkPolicies.jobs -}}
 apiVersion: networking.k8s.io/v1

--- a/k8s/helm/templates/networking/jobs-networkpolicy.yaml
+++ b/k8s/helm/templates/networking/jobs-networkpolicy.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.networkPolicies.jobs.enabled }}
+{{- $jobs := .Values.networkPolicies.jobs -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-jobs-egress" (include "nemo-platform.fullname" .) | trunc 63 | trimSuffix "-" }}
+  labels:
+    app.kubernetes.io/component: nmp-core-jobs
+    {{- include "nemo-platform.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    {{- toYaml $jobs.podSelector | nindent 4 }}
+  policyTypes:
+    - Egress
+  {{- if or $jobs.dns.enabled $jobs.platformApi.enabled (and $jobs.externalEgress.enabled $jobs.externalEgress.ipBlocks) $jobs.extraEgress }}
+  egress:
+    {{- if $jobs.dns.enabled }}
+    - to:
+        - namespaceSelector:
+            {{- toYaml $jobs.dns.namespaceSelector | nindent 12 }}
+          podSelector:
+            {{- toYaml $jobs.dns.podSelector | nindent 12 }}
+      ports:
+        {{- toYaml $jobs.dns.ports | nindent 8 }}
+    {{- end }}
+    {{- if $jobs.platformApi.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/component: nmp-api
+              {{- include "nemo-platform.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ default .Values.api.service.port $jobs.platformApi.port }}
+    {{- end }}
+    {{- if and $jobs.externalEgress.enabled $jobs.externalEgress.ipBlocks }}
+    - to:
+        {{- range $block := $jobs.externalEgress.ipBlocks }}
+        - ipBlock:
+            cidr: {{ $block.cidr | quote }}
+            {{- with $block.except }}
+            except:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+        {{- end }}
+      {{- with $jobs.externalEgress.ports }}
+      ports:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
+    {{- with $jobs.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -172,7 +172,7 @@ networkPolicies:
         nmp.nvidia.com/managed_by: jobs-controller
     # -- Allow managed job pods to reach the in-namespace Platform API pods.
     platformApi:
-      # -- Enable egress to the platform API pods.
+      # -- Enable the default egress exception to the platform API pods. Disable only when managed job pods should not call the in-namespace API, or when API access is supplied through cluster-specific extraEgress rules.
       enabled: true
       # -- Optional NetworkPolicy port for the platform API. Empty uses api.service.port.
       port: ""

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -120,7 +120,7 @@ multinodeNetworking:
     # -- Number of RDMA devices (mlnxnics) to request per GPU
     rdmaDevicesPerGPU: 8
 
-# -- NetworkPolicy configuration.
+# -- NetworkPolicy configuration. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test.
 # @default -- This object has the following default values for optional NetworkPolicy resources.
 networkPolicies:
   # -- NetworkPolicy configuration for the Platform API pods.

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -120,6 +120,62 @@ multinodeNetworking:
     # -- Number of RDMA devices (mlnxnics) to request per GPU
     rdmaDevicesPerGPU: 8
 
+# -- NetworkPolicy configuration.
+# @default -- This object has the following default values for optional NetworkPolicy resources.
+networkPolicies:
+  # -- NetworkPolicy configuration for pods created by the jobs controller.
+  # @default -- This object has the following default values for managed job pod egress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
+  jobs:
+    # -- Create NetworkPolicy resources that isolate managed job pod egress.
+    enabled: false
+    # -- Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller.
+    podSelector:
+      matchLabels:
+        app: nemo-job
+        nmp.nvidia.com/managed_by: jobs-controller
+    # -- Allow managed job pods to reach the in-namespace NeMo Platform API pods.
+    platformApi:
+      # -- Enable egress to the platform API pods.
+      enabled: true
+      # -- Optional NetworkPolicy port for the platform API. Empty uses api.service.port.
+      port: ""
+    # -- Allow DNS lookup from managed job pods.
+    dns:
+      # -- Enable egress to DNS pods.
+      enabled: true
+      # -- Namespace selector for DNS pods.
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      # -- Pod selector for DNS pods.
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+      # -- DNS ports to allow.
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # -- Allow egress to external CIDR blocks. The default excludes common private, loopback, and link-local ranges so enabling the policy does not allow direct access to typical in-cluster service and pod networks.
+    externalEgress:
+      # -- Enable egress to external CIDR blocks.
+      enabled: true
+      # -- External destination CIDR blocks for managed job pods.
+      ipBlocks:
+        - cidr: 0.0.0.0/0
+          except:
+            - 10.0.0.0/8
+            - 100.64.0.0/10
+            - 127.0.0.0/8
+            - 169.254.0.0/16
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+      # -- Optional list of ports for external egress. Empty allows all ports to the configured ipBlocks.
+      ports: []
+    # -- Extra NetworkPolicy egress rules appended to the managed job policy, for cluster-specific dependencies or additional allowed CIDRs.
+    extraEgress: []
+
 # -- NCCL chart test (`helm test`): multi-node allreduce check. Templates use helm.sh/hook: test — they are not created on install/upgrade, only when you run helm test.
 # Requires nodes labeled with gpuNodeLabelKey/gpuNodeLabelValue (default NFD / GPU operator style).
 # See https://helm.sh/docs/topics/chart_tests/

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -123,6 +123,43 @@ multinodeNetworking:
 # -- NetworkPolicy configuration.
 # @default -- This object has the following default values for optional NetworkPolicy resources.
 networkPolicies:
+  # -- NetworkPolicy configuration for the Platform API pods.
+  # @default -- This object has the following default values for API pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
+  api:
+    # -- Create NetworkPolicy resources that isolate Platform API pod ingress.
+    enabled: false
+    # -- Optional NetworkPolicy port for the Platform API. Empty uses api.service.port.
+    port: ""
+    # -- Allow pods from the same Helm release namespace that carry the chart selector labels to reach the Platform API pods.
+    sameReleasePods:
+      # -- Enable ingress from same-release pods.
+      enabled: true
+    # -- Allow managed job pods to reach the Platform API pods.
+    managedJobs:
+      # -- Enable ingress from managed job pods.
+      enabled: true
+      # -- Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller.
+      podSelector:
+        matchLabels:
+          app: nemo-job
+          nmp.nvidia.com/managed_by: jobs-controller
+    # -- Extra NetworkPolicy ingress rules appended to the API policy, for cluster-specific ingress controllers, gateways, monitoring, or debugging pods.
+    extraIngress: []
+
+  # -- NetworkPolicy configuration for the core controller pods.
+  # @default -- This object has the following default values for core controller pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
+  controller:
+    # -- Create NetworkPolicy resources that isolate core controller pod ingress.
+    enabled: false
+    # -- Optional NetworkPolicy port for the core controller. Empty uses core.controller.service.port.
+    port: ""
+    # -- Allow pods from the same Helm release namespace that carry the chart selector labels to reach the core controller pods.
+    sameReleasePods:
+      # -- Enable ingress from same-release pods.
+      enabled: true
+    # -- Extra NetworkPolicy ingress rules appended to the core controller policy, for cluster-specific monitoring or debugging pods.
+    extraIngress: []
+
   # -- NetworkPolicy configuration for pods created by the jobs controller.
   # @default -- This object has the following default values for managed job pod egress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
   jobs:
@@ -133,7 +170,7 @@ networkPolicies:
       matchLabels:
         app: nemo-job
         nmp.nvidia.com/managed_by: jobs-controller
-    # -- Allow managed job pods to reach the in-namespace NeMo Platform API pods.
+    # -- Allow managed job pods to reach the in-namespace Platform API pods.
     platformApi:
       # -- Enable egress to the platform API pods.
       enabled: true

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -120,14 +120,16 @@ multinodeNetworking:
     # -- Number of RDMA devices (mlnxnics) to request per GPU
     rdmaDevicesPerGPU: 8
 
-# -- NetworkPolicy configuration. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test.
-# @default -- This object has the following default values for optional NetworkPolicy resources.
+# -- NetworkPolicy configuration. Enable the top-level switch to render all default policies, then disable individual policies only for cluster-specific exceptions. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test.
+# @default -- This object has the following default values. The top-level switch is disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
 networkPolicies:
+  # -- Create NetworkPolicy resources for enabled subpolicies.
+  enabled: false
   # -- NetworkPolicy configuration for the Platform API pods.
-  # @default -- This object has the following default values for API pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
+  # @default -- This object has the following default values for API pod ingress isolation.
   api:
     # -- Create NetworkPolicy resources that isolate Platform API pod ingress.
-    enabled: false
+    enabled: true
     # -- Optional NetworkPolicy port for the Platform API. Empty uses api.service.port.
     port: ""
     # -- Allow pods from the same Helm release namespace that carry the chart selector labels to reach the Platform API pods.
@@ -147,10 +149,10 @@ networkPolicies:
     extraIngress: []
 
   # -- NetworkPolicy configuration for the core controller pods.
-  # @default -- This object has the following default values for core controller pod ingress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
+  # @default -- This object has the following default values for core controller pod ingress isolation.
   controller:
     # -- Create NetworkPolicy resources that isolate core controller pod ingress.
-    enabled: false
+    enabled: true
     # -- Optional NetworkPolicy port for the core controller. Empty uses core.controller.service.port.
     port: ""
     # -- Allow pods from the same Helm release namespace that carry the chart selector labels to reach the core controller pods.
@@ -161,10 +163,10 @@ networkPolicies:
     extraIngress: []
 
   # -- NetworkPolicy configuration for pods created by the jobs controller.
-  # @default -- This object has the following default values for managed job pod egress isolation. Disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled.
+  # @default -- This object has the following default values for managed job pod egress isolation.
   jobs:
     # -- Create NetworkPolicy resources that isolate managed job pod egress.
-    enabled: false
+    enabled: true
     # -- Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller.
     podSelector:
       matchLabels:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Adds Helm NetworkPolicies for the Platform API, core controller, and managed job pods. The policies are controlled by a top-level `networkPolicies.enabled` switch with per-policy break-glass toggles, and the enforcement smoke test now uses Chainsaw instead of hand-rolled Kubernetes probe orchestration.

## Changes
- Added API ingress, core-controller ingress, and managed-job egress NetworkPolicy templates and values.
- Added a top-level `networkPolicies.enabled` switch while leaving API, controller, and jobs subpolicies enabled by default when the switch is on.
- Added Calico-enabled Kind setup and a local/CI NetworkPolicy smoke path.
- Replaced the custom bash probe logic with a Chainsaw 0.2.3 test suite plus a thin runner script.
- Updated CI to run the Chainsaw smoke test and keep producing the JUnit report artifact expected by the finalizer.
- Moved smoke-test instructions into a dedicated Fern how-to and regenerated the Helm README values reference.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [x] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- PASS: DCO audit for `origin/main..HEAD`
- PASS: current-main copyright checker for the five files reported by CI (`docs/set-up/helm/network-policy-smoke-test.mdx`, `k8s/helm/ci/23-enable-network-policies.yaml`, and the three NetworkPolicy Helm templates).
- PASS: `git diff --check`
- PASS: `bash -n e2e/k8s/scripts/test_network_policies.sh`
- PASS: Docker fallback kubeconfig flattening check: `kubectl config view --flatten --raw` produced a non-empty kubeconfig for the current context.
- PASS: `docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/repo:ro" -w /repo ghcr.io/kyverno/chainsaw:v0.2.3 lint test -f e2e/k8s/chainsaw/network-policies/chainsaw-test.yaml`
- PASS: `helm template nemo-platform k8s/helm -f e2e/k8s/values/kind.yaml -f e2e/k8s/values/network-policies.yaml --show-only templates/networking/api-networkpolicy.yaml --show-only templates/networking/controller-networkpolicy.yaml --show-only templates/networking/jobs-networkpolicy.yaml | docker run --rm -i ghcr.io/yannh/kubeconform:v0.6.7 -summary -output json` (`valid: 3`, `invalid: 0`)
- PASS: Helm render checks verified API, controller, and jobs NetworkPolicies do not render when `networkPolicies.enabled=false` or their individual subpolicy is disabled.
- PASS: `helm lint --strict` against a clean temp copy of `k8s/helm` excluding ignored local `charts/` and `Chart.lock` artifacts.
- PASS: `docker run --rm --user "$(id -u):$(id -g)" -v "$PWD:/repo" -w /repo jnorwood/helm-docs:v1.14.2 --chart-search-root=k8s/helm/ --template-files=k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl`
- PASS: `node docs/fern/scripts/sync-helm-docs.mjs`
- PASS: `make docs-check`
- PASS: `make docs-broken-links`
- PASS: `flox activate -d tools/actionlint -- actionlint .github/workflows/ci.yaml` (FloxHub login warning only)
- BLOCKED: `uv run pre-commit run -a` could not initialize the external `https://github.com/norwoodj/helm-docs` hook because GitHub returned HTTP 503. Helm docs were regenerated with the equivalent pinned `jnorwood/helm-docs:v1.14.2` container.
- BLOCKED: `make docs-check-python-snippets DOCS_PATH=docs/set-up/helm/network-policy-smoke-test.mdx` could not build the local Python environment because `nemo-fabric-runtime` requires Rust edition 2024 support and the local Cargo is 1.75.0.
- BLOCKED: full `tools/lint/lint-helm.sh` reached `helm lint --strict` successfully against a clean chart copy, then failed in local Envoy Docker validation because rootless Docker could not read the script-created temp-mounted `envoy.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional NetworkPolicies for API, controller, and managed-job workloads.
  * Added configurable ingress and egress controls, including DNS, platform API, CIDR, port, selector, and custom-rule settings.
  * Added a NetworkPolicy smoke-test workflow for local Kind clusters with Calico enforcement.

* **Documentation**
  * Added Helm configuration guidance and a dedicated NetworkPolicy smoke-test guide.

* **Tests**
  * Added end-to-end coverage verifying permitted traffic succeeds and restricted traffic is blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

