### PR TITLE
feat(studio): DD AI config

### DIFF
--- a/web/packages/studio/src/components/CreateFilesetStart/DescribeWithAiPanel.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/DescribeWithAiPanel.tsx
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useModelSearch } from '@nemo/common/src/api/models/useModelSearch';
+import { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
+import { LoadingButton } from '@nemo/common/src/components/LoadingButton';
+import { ModelSelectV2 } from '@nemo/common/src/components/ModelSelectV2/ModelSelectV2';
+import type { ModelSelection } from '@nemo/common/src/components/ModelSelectV2/types';
+import { Flex, FormField, Stack } from '@nvidia/foundations-react-core';
+import { GeneratedConfigResult } from '@studio/components/CreateFilesetStart/GeneratedConfigResult';
+import type { DescribeWithAiPanelProps } from '@studio/components/CreateFilesetStart/types';
+import { useDescribeWithAi } from '@studio/components/CreateFilesetStart/useDescribeWithAi';
+import { providerForSelection } from '@studio/routes/DataDesignerJobBuildRoute/models';
+import type { FC } from 'react';
+import { useController } from 'react-hook-form';
+
+const PROMPT_PLACEHOLDER =
+  'e.g. 400 customer support emails, each labelled as phishing or legitimate, with a short reason for the label and the sender domain.';
+
+const MODEL_HELP =
+  'Needs tool-calling support. LLM columns in the draft are wired to a model from this workspace.';
+
+/**
+ * "Describe with AI" detail panel: pick the model that drafts the config, describe the fileset
+ * in plain language, and see whether the draft is loadable. The generated config never reaches
+ * the builder unvalidated — the parent gates Continue on `onValidConfig` returning a request.
+ */
+export const DescribeWithAiPanel: FC<DescribeWithAiPanelProps> = ({ workspace, onValidConfig }) => {
+  const modelSearch = useModelSearch({ workspace });
+  const { form, validation, requestError, rawOutput, pendingAction, generate, requestFix } =
+    useDescribeWithAi(workspace, onValidConfig, modelSearch.groups);
+  const isBusy = pendingAction !== null;
+
+  const { field: modelField, fieldState: modelState } = useController({
+    control: form.control,
+    name: 'model',
+  });
+  const modelValue: ModelSelection | null = modelField.value ? { model: modelField.value } : null;
+
+  return (
+    <form onSubmit={generate} noValidate>
+      <Flex gap="density-xl" className="w-full flex-wrap items-stretch">
+        <Stack gap="density-md" className="min-w-[320px] flex-1">
+          <FormField
+            slotLabel="Model"
+            slotHelp={MODEL_HELP}
+            slotError={modelState.error?.message}
+            status={modelState.error ? 'error' : undefined}
+            required
+          >
+            <ModelSelectV2
+              {...modelSearch}
+              value={modelValue}
+              onValueChange={(selection) => {
+                modelField.onChange(selection.model);
+                form.setValue('provider', providerForSelection(selection));
+              }}
+              onOpenChange={(isOpen) => {
+                if (!isOpen) modelField.onBlur();
+              }}
+              disabled={isBusy}
+              placeholder="Choose a model"
+              fullWidth
+              dropdownSide="bottom"
+              aria-label="Model that drafts the config"
+            />
+          </FormField>
+
+          <ControlledTextArea
+            label="What do you want to generate?"
+            required
+            rows={8}
+            className="w-full resize-y"
+            placeholder={PROMPT_PLACEHOLDER}
+            disabled={isBusy}
+            useControllerProps={{ name: 'prompt', control: form.control }}
+          />
+
+          <Flex justify="start">
+            <LoadingButton
+              type="submit"
+              kind="secondary"
+              loading={pendingAction === 'generate'}
+              disabled={isBusy}
+            >
+              {validation || requestError ? 'Regenerate' : 'Generate'}
+            </LoadingButton>
+          </Flex>
+        </Stack>
+
+        <Stack gap="density-md" className="min-w-[320px] flex-1">
+          <GeneratedConfigResult
+            validation={validation}
+            requestError={requestError}
+            rawOutput={rawOutput}
+            isGenerating={pendingAction === 'generate'}
+            isFixing={pendingAction === 'fix'}
+            onFix={() => void requestFix()}
+          />
+        </Stack>
+      </Flex>
+    </form>
+  );
+};

--- a/web/packages/studio/src/components/CreateFilesetStart/DescribeWithAiPanel.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/DescribeWithAiPanel.tsx
@@ -15,10 +15,9 @@ import type { FC } from 'react';
 import { useController } from 'react-hook-form';
 
 const PROMPT_PLACEHOLDER =
-  'e.g. 400 customer support emails, each labelled as phishing or legitimate, with a short reason for the label and the sender domain.';
+  '100 customer support emails, each labelled as phishing or legitimate, with a short reason for the label and the sender domain. Sampled across categories (billing, returns, tech support) with subcategories per category (billing: overcharge, failed payment; returns: damaged item, wrong size)';
 
-const MODEL_HELP =
-  'Needs tool-calling support. LLM columns in the draft are wired to a model from this workspace.';
+const MODEL_HELP = 'Needs tool-calling support. This model will be used in LLM columns.';
 
 /**
  * "Describe with AI" detail panel: pick the model that drafts the config, describe the fileset

--- a/web/packages/studio/src/components/CreateFilesetStart/GeneratedConfigPanel.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/GeneratedConfigPanel.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  CodeSnippet,
+  Flex,
+  SidePanelContent,
+  SidePanelDialog,
+  SidePanelHeading,
+  SidePanelRoot,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
+import type { GeneratedConfigPanelProps } from '@studio/components/CreateFilesetStart/types';
+import { FileJson } from 'lucide-react';
+import type { FC } from 'react';
+
+/**
+ * Read-only view of what the model actually returned, for checking a draft before loading it
+ * — or working out why one was rejected. Shows the tool-call arguments verbatim, so it can
+ * differ from the config that lands on the canvas when the builder substitutes a model.
+ */
+export const GeneratedConfigPanel: FC<GeneratedConfigPanelProps> = ({ open, config, onClose }) => (
+  <SidePanelRoot open={open} onOpenChange={onClose} modal>
+    <SidePanelDialog>
+      <SidePanelContent className="w-[720px]" bordered>
+        <SidePanelHeading>
+          <Flex gap="density-md" align="center">
+            <FileJson size={20} aria-hidden />
+            Generated config
+          </Flex>
+        </SidePanelHeading>
+        <Stack gap="density-md" padding="4" className="h-full min-h-0 overflow-y-auto">
+          <Text kind="body/regular/sm" className="text-secondary">
+            Raw output from the model. Any model the builder had to substitute is listed as a
+            warning next to the result.
+          </Text>
+          <CodeSnippet
+            value={config}
+            language="json"
+            kind="block"
+            attributes={{
+              CodeSnippetCode: {
+                className:
+                  'max-h-[calc(100vh-220px)] [&_code]:whitespace-pre-wrap [&_code]:break-words [&_pre]:whitespace-pre-wrap',
+              },
+            }}
+          />
+        </Stack>
+      </SidePanelContent>
+    </SidePanelDialog>
+  </SidePanelRoot>
+);

--- a/web/packages/studio/src/components/CreateFilesetStart/GeneratedConfigResult.test.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/GeneratedConfigResult.test.tsx
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { GeneratedConfigResult } from '@studio/components/CreateFilesetStart/GeneratedConfigResult';
+import type { GeneratedConfigValidation } from '@studio/routes/DataDesignerJobBuildRoute/aiSeed';
+import { render, screen } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
+
+const RAW_OUTPUT = '{\n  "job_request": {\n    "name": "qa-pairs"\n  }\n}';
+
+const INVALID: GeneratedConfigValidation = {
+  status: 'invalid',
+  errors: ['The generated config has no columns.'],
+  warnings: [],
+};
+
+const VALID_WITH_WARNING: GeneratedConfigValidation = {
+  status: 'valid',
+  jobRequest: { name: 'qa-pairs', spec: { num_records: 25, config: { columns: [] } } } as never,
+  seed: { name: 'qa-pairs', rows: '25', columns: [], models: [] },
+  warnings: ['Skipped 1 column(s) the builder can’t edit: thumbnail (image).'],
+};
+
+const renderResult = (props: Partial<Parameters<typeof GeneratedConfigResult>[0]> = {}) =>
+  render(
+    <GeneratedConfigResult
+      validation={INVALID}
+      requestError={null}
+      rawOutput={RAW_OUTPUT}
+      isGenerating={false}
+      isFixing={false}
+      {...props}
+    />
+  );
+
+describe('GeneratedConfigResult', () => {
+  it('opens the raw config in a side panel from View config', async () => {
+    const user = userEvent.setup();
+    renderResult();
+
+    expect(screen.queryByText(/"qa-pairs"/)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /view config/i }));
+
+    expect(await screen.findByText(/Generated config/)).toBeInTheDocument();
+    expect(screen.getByText(/"qa-pairs"/)).toBeInTheDocument();
+  });
+
+  it('offers View config for a rejected draft, alongside the errors', () => {
+    renderResult();
+
+    expect(screen.getByText('The generated config has no columns.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /view config/i })).toBeInTheDocument();
+  });
+
+  it('hides View config when there is no output to show', () => {
+    renderResult({ rawOutput: null });
+
+    expect(screen.queryByRole('button', { name: /view config/i })).not.toBeInTheDocument();
+  });
+
+  describe('fix', () => {
+    it('offers a fix for warnings on an otherwise loadable draft', async () => {
+      const user = userEvent.setup();
+      const onFix = vi.fn();
+      renderResult({ validation: VALID_WITH_WARNING, onFix });
+
+      await user.click(screen.getByRole('button', { name: /fix these warnings/i }));
+
+      expect(onFix).toHaveBeenCalledTimes(1);
+    });
+
+    it('offers a fix for the errors that block a rejected draft', async () => {
+      const user = userEvent.setup();
+      const onFix = vi.fn();
+      renderResult({ onFix });
+
+      await user.click(screen.getByRole('button', { name: /fix these errors/i }));
+
+      expect(onFix).toHaveBeenCalledTimes(1);
+      // An invalid draft sends its errors and warnings together, so no second button.
+      expect(screen.queryByRole('button', { name: /fix these warnings/i })).not.toBeInTheDocument();
+    });
+
+    it('hides the fix affordance when there is no draft to send back', () => {
+      renderResult({ validation: VALID_WITH_WARNING, rawOutput: null, onFix: vi.fn() });
+
+      expect(screen.queryByRole('button', { name: /fix these/i })).not.toBeInTheDocument();
+    });
+
+    it('replaces the result with progress copy while the model reworks the draft', () => {
+      renderResult({ isFixing: true, onFix: vi.fn() });
+
+      expect(screen.getByText('Working through the issues…')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /fix these/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/packages/studio/src/components/CreateFilesetStart/GeneratedConfigResult.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/GeneratedConfigResult.tsx
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Banner, Button, Flex, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
+import { GeneratedConfigPanel } from '@studio/components/CreateFilesetStart/GeneratedConfigPanel';
+import type { GeneratedConfigResultProps } from '@studio/components/CreateFilesetStart/types';
+import { FileJson, Sparkles, Wand2 } from 'lucide-react';
+import { type FC, useState } from 'react';
+
+const IssueList: FC<{ items: string[] }> = ({ items }) => (
+  <ul className="list-disc pl-density-lg">
+    {items.map((item) => (
+      <li key={item}>
+        <Text kind="body/regular/sm">{item}</Text>
+      </li>
+    ))}
+  </ul>
+);
+
+/** Hands the listed issues back to the model. Rendered inside the banner it belongs to. */
+const FixButton: FC<{ label: string; onFix: () => void }> = ({ label, onFix }) => (
+  <Flex justify="start" className="mt-density-sm">
+    <Button kind="secondary" size="small" onClick={onFix}>
+      <Wand2 size={14} aria-hidden />
+      {label}
+    </Button>
+  </Flex>
+);
+
+/**
+ * Verdict on the last generated draft: whether it can be loaded into the build canvas, plus
+ * what would be lost or had to be substituted. Rendered next to the prompt so a failed draft
+ * is read as "the model got it wrong, refine and regenerate" rather than a broken page.
+ */
+export const GeneratedConfigResult: FC<GeneratedConfigResultProps> = ({
+  validation,
+  requestError,
+  rawOutput,
+  isGenerating,
+  isFixing,
+  onFix,
+}) => {
+  const [isConfigOpen, setIsConfigOpen] = useState(false);
+
+  if (isGenerating || isFixing) {
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        gap="density-sm"
+        className="h-full min-h-[220px] rounded-md border border-base bg-surface-raised p-density-xl"
+      >
+        <Spinner size="small" aria-label={isFixing ? 'Fixing' : 'Generating'} />
+        <Text kind="body/regular/sm" className="text-secondary">
+          {isFixing ? 'Working through the issues…' : 'Drafting your columns…'}
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (requestError) {
+    return (
+      <Banner kind="inline" status="error">
+        {requestError}
+      </Banner>
+    );
+  }
+
+  if (!validation) {
+    return (
+      <Stack
+        gap="density-xs"
+        align="center"
+        className="h-full min-h-[220px] justify-center rounded-md border border-dashed border-base p-density-xl text-center"
+      >
+        <Sparkles size={18} className="text-secondary" aria-hidden />
+        <Text kind="body/semibold/sm" className="text-primary">
+          No draft yet
+        </Text>
+        <Text kind="body/regular/sm" className="text-secondary">
+          Describe the fileset you need, then generate. We check the result before it can be loaded
+          into the builder.
+        </Text>
+      </Stack>
+    );
+  }
+
+  const fixHandler = rawOutput !== null ? onFix : undefined;
+
+  return (
+    <Stack gap="density-md">
+      {rawOutput ? (
+        <>
+          <Flex justify="end">
+            <Button kind="tertiary" size="small" onClick={() => setIsConfigOpen(true)}>
+              <FileJson size={14} aria-hidden />
+              View config
+            </Button>
+          </Flex>
+          <GeneratedConfigPanel
+            open={isConfigOpen}
+            config={rawOutput}
+            onClose={() => setIsConfigOpen(false)}
+          />
+        </>
+      ) : null}
+
+      {validation.status === 'valid' ? (
+        <>
+          <Banner kind="inline" status="success">
+            Valid job config — ready to load into the builder.
+          </Banner>
+          <Stack gap="density-xs" className="rounded-md border border-base p-density-lg">
+            <Text kind="label/bold/sm" className="text-secondary">
+              {validation.seed.name} · {validation.seed.rows} records ·{' '}
+              {validation.seed.columns.length} column(s) · {validation.seed.models.length} model(s)
+            </Text>
+            <Stack gap="density-xxs">
+              {validation.seed.columns.map((column) => (
+                <Flex key={column.id} align="center" justify="between" gap="density-sm">
+                  <Text kind="body/regular/sm" className="text-primary">
+                    {column.name}
+                  </Text>
+                  <Text kind="body/regular/xs" className="text-secondary">
+                    {column.option.label}
+                  </Text>
+                </Flex>
+              ))}
+            </Stack>
+          </Stack>
+        </>
+      ) : (
+        <Banner kind="inline" status="error">
+          This draft can&apos;t be loaded into the builder yet:
+          <IssueList items={validation.errors} />
+          {fixHandler ? <FixButton label="Fix these errors" onFix={fixHandler} /> : null}
+        </Banner>
+      )}
+
+      {validation.warnings.length > 0 && (
+        <Banner kind="inline" status="warning">
+          <IssueList items={validation.warnings} />
+          {fixHandler && validation.status === 'valid' ? (
+            <FixButton label="Fix these warnings" onFix={fixHandler} />
+          ) : null}
+        </Banner>
+      )}
+    </Stack>
+  );
+};

--- a/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/StartOptionDetail.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Divider, Flex, Grid, Stack, Text } from '@nvidia/foundations-react-core';
+import { DescribeWithAiPanel } from '@studio/components/CreateFilesetStart/DescribeWithAiPanel';
 import { TemplateCard } from '@studio/components/CreateFilesetStart/TemplateCard';
 import { FILESET_TEMPLATES } from '@studio/components/CreateFilesetStart/templates';
 import type {
@@ -63,9 +64,12 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
   option,
   selectedTemplateId,
   onSelectTemplate,
+  workspace,
+  onValidConfig,
 }) => {
-  const content =
-    option.id === 'template' ? (
+  let content: ReactNode;
+  if (option.id === 'template') {
+    content = (
       <Grid colMinWidth="300px" gap="density-md">
         {FILESET_TEMPLATES.map((template) => (
           <TemplateCard
@@ -76,9 +80,12 @@ export const StartOptionDetail: FC<StartOptionDetailProps> = ({
           />
         ))}
       </Grid>
-    ) : (
-      DETAIL_CONTENT[option.id]
     );
+  } else if (option.id === 'ai') {
+    content = <DescribeWithAiPanel workspace={workspace} onValidConfig={onValidConfig} />;
+  } else {
+    content = DETAIL_CONTENT[option.id];
+  }
 
   if (!content) {
     return null;

--- a/web/packages/studio/src/components/CreateFilesetStart/constants.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/constants.ts
@@ -10,10 +10,6 @@ const RECIPE_COUNT_LABEL = `${FILESET_TEMPLATES.length} ${
   FILESET_TEMPLATES.length === 1 ? 'recipe' : 'recipes'
 }`;
 
-/**
- * The "How do you want to start?" tiles, in display order. Only "Build from scratch"
- * is enabled today; the others are placeholders for upcoming entry points.
- */
 export const START_OPTIONS: StartOption[] = [
   {
     id: 'ai',
@@ -21,7 +17,7 @@ export const START_OPTIONS: StartOption[] = [
     description:
       'Tell us what you need in plain language. AI drafts the columns and prompts — then you refine everything visually.',
     icon: Sparkles,
-    enabled: false,
+    enabled: true,
   },
   {
     id: 'template',

--- a/web/packages/studio/src/components/CreateFilesetStart/fixRequest.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/fixRequest.ts
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DATA_DESIGNER_JOB_GENERATOR_SYSTEM_PROMPT } from '@studio/components/NewDataDesignerJobForm/constants';
+import type { ChatCompletionMessageParam } from 'openai/resources/index.mjs';
+
+export interface FixRequestInput {
+  /** The description the user originally wrote, so the retry keeps the same intent. */
+  prompt: string;
+  /** The config the model produced last time, verbatim (its tool-call arguments). */
+  config: string;
+  /** Issues that block loading; empty when the draft was merely lossy. */
+  errors: string[];
+  /** Issues that don't block loading but lost something (skipped columns, substitutions). */
+  warnings: string[];
+}
+
+const bulletList = (items: string[]): string => items.map((item) => `- ${item}`).join('\n');
+
+/**
+ * Builds the follow-up conversation that asks the model to repair its own draft: the original
+ * request, the config it returned, and what the builder found wrong with it.
+ *
+ * The previous config is replayed as a plain assistant turn rather than a tool call — a
+ * `tool_calls` message would need a matching `tool` response, which providers enforce
+ * inconsistently, and the model only needs to see the JSON it wrote.
+ */
+export const buildFixMessages = ({
+  prompt,
+  config,
+  errors,
+  warnings,
+}: FixRequestInput): ChatCompletionMessageParam[] => {
+  const sections = [
+    errors.length > 0
+      ? `Errors — the builder cannot load this config until these are fixed:\n${bulletList(errors)}`
+      : '',
+    warnings.length > 0
+      ? `Warnings — the config loads, but something was lost or substituted:\n${bulletList(warnings)}`
+      : '',
+  ].filter(Boolean);
+
+  return [
+    { role: 'system', content: DATA_DESIGNER_JOB_GENERATOR_SYSTEM_PROMPT },
+    { role: 'user', content: prompt },
+    { role: 'assistant', content: config },
+    {
+      role: 'user',
+      content: [
+        'That config was checked against the visual builder and these issues came back:',
+        '',
+        sections.join('\n\n'),
+        '',
+        'Call the tool again with a corrected job config. Keep the intent, column names, and',
+        'anything already working unchanged — change only what is needed to resolve the issues',
+        'above. If a column type was skipped because the builder cannot edit it, replace it with',
+        'the closest supported column type rather than dropping the data it produced.',
+      ].join('\n'),
+    },
+  ];
+};

--- a/web/packages/studio/src/components/CreateFilesetStart/index.test.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/index.test.tsx
@@ -2,87 +2,108 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { CreateFilesetStart } from '@studio/components/CreateFilesetStart';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from '@studio/tests/util/render';
 import userEvent from '@testing-library/user-event';
 
+const renderStart = () => {
+  const onContinue = vi.fn();
+  render(<CreateFilesetStart workspace="default" onContinue={onContinue} />);
+  return { onContinue };
+};
+
 describe('CreateFilesetStart', () => {
-  it('renders all four start options', () => {
-    render(<CreateFilesetStart onContinue={vi.fn()} />);
+  it('renders all start options', () => {
+    renderStart();
 
     expect(screen.getByText('Describe with AI')).toBeInTheDocument();
     expect(screen.getByText('Start from a template')).toBeInTheDocument();
     expect(screen.getByText('Build from scratch')).toBeInTheDocument();
   });
 
-  it('shows no Continue footer until a selectable option is chosen', () => {
-    render(<CreateFilesetStart onContinue={vi.fn()} />);
+  it('shows no Continue footer until an option is chosen', () => {
+    renderStart();
 
     expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument();
-  });
-
-  it('does not select disabled options (they are no-ops)', async () => {
-    const user = userEvent.setup();
-    const onContinue = vi.fn();
-    render(<CreateFilesetStart onContinue={onContinue} />);
-
-    await user.click(screen.getByText('Describe with AI'));
-
-    expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument();
-    expect(onContinue).not.toHaveBeenCalled();
   });
 
   it('selecting Build from scratch reveals Continue and invokes onContinue with "scratch"', async () => {
     const user = userEvent.setup();
-    const onContinue = vi.fn();
-    render(<CreateFilesetStart onContinue={onContinue} />);
+    const { onContinue } = renderStart();
 
     await user.click(screen.getByText('Build from scratch'));
 
     const continueButton = screen.getByRole('button', { name: /continue/i });
-    expect(continueButton).toBeInTheDocument();
+    expect(continueButton).toBeEnabled();
 
     await user.click(continueButton);
     expect(onContinue).toHaveBeenCalledTimes(1);
-    expect(onContinue).toHaveBeenCalledWith('scratch');
+    expect(onContinue).toHaveBeenCalledWith({ optionId: 'scratch' });
   });
 
-  it('reveals template cards but no Continue until a template is chosen', async () => {
+  it('reveals template cards but keeps Continue disabled until a template is chosen', async () => {
     const user = userEvent.setup();
-    render(<CreateFilesetStart onContinue={vi.fn()} />);
+    renderStart();
 
     await user.click(screen.getByText('Start from a template'));
 
     expect(screen.getByText('Instruction fine-tuning (SFT)')).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
+    expect(screen.getByText('Pick a recipe to continue.')).toBeInTheDocument();
   });
 
-  it('choosing a template reveals Continue and invokes onContinue with the template id', async () => {
+  it('choosing a template enables Continue and invokes onContinue with the template id', async () => {
     const user = userEvent.setup();
-    const onContinue = vi.fn();
-    render(<CreateFilesetStart onContinue={onContinue} />);
+    const { onContinue } = renderStart();
 
     await user.click(screen.getByText('Start from a template'));
     await user.click(screen.getByText('Instruction fine-tuning (SFT)'));
 
-    const continueButton = screen.getByRole('button', { name: /continue/i });
-    await user.click(continueButton);
+    await user.click(screen.getByRole('button', { name: /continue/i }));
 
     expect(onContinue).toHaveBeenCalledTimes(1);
-    expect(onContinue).toHaveBeenCalledWith('template', 'sft-instruction');
+    expect(onContinue).toHaveBeenCalledWith({
+      optionId: 'template',
+      templateId: 'sft-instruction',
+    });
   });
 
   it('switching options clears a prior template selection', async () => {
     const user = userEvent.setup();
-    render(<CreateFilesetStart onContinue={vi.fn()} />);
+    renderStart();
 
     await user.click(screen.getByText('Start from a template'));
     await user.click(screen.getByText('Instruction fine-tuning (SFT)'));
-    expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue/i })).toBeEnabled();
 
     await user.click(screen.getByText('Build from scratch'));
     await user.click(screen.getByText('Start from a template'));
 
-    // Template selection was reset when the option changed, so Continue is gone again.
-    expect(screen.queryByRole('button', { name: /continue/i })).not.toBeInTheDocument();
+    // Template selection was reset when the option changed, so Continue is blocked again.
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
+  });
+
+  it('selecting Describe with AI keeps Continue disabled until a config is generated', async () => {
+    const user = userEvent.setup();
+    renderStart();
+
+    await user.click(screen.getByText('Describe with AI'));
+
+    expect(
+      screen.getByRole('textbox', { name: /what do you want to generate/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
+    expect(screen.getByText('Generate a valid config to continue.')).toBeInTheDocument();
+  });
+
+  it('blocks an empty generate with field errors instead of calling the model', async () => {
+    const user = userEvent.setup();
+    renderStart();
+
+    await user.click(screen.getByText('Describe with AI'));
+    await user.click(screen.getByRole('button', { name: /generate/i }));
+
+    expect(await screen.findByText('Choose a model to draft the config.')).toBeInTheDocument();
+    expect(screen.getByText('Describe the fileset you want.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
   });
 });

--- a/web/packages/studio/src/components/CreateFilesetStart/index.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/index.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { CreateJobRequest as DataDesignerJobRequest } from '@nemo/sdk/generated/data-designer/schema';
 import {
   Block,
   Button,
@@ -19,28 +20,50 @@ import type {
   StartOptionId,
 } from '@studio/components/CreateFilesetStart/types';
 import { ArrowRight } from 'lucide-react';
-import { useState, type FC } from 'react';
+import { useCallback, useState, type FC } from 'react';
 
-export const CreateFilesetStart: FC<CreateFilesetStartProps> = ({ onContinue }) => {
+/** Why Continue is unavailable, shown next to the disabled button. */
+const BLOCKED_HINT: Partial<Record<StartOptionId, string>> = {
+  template: 'Pick a recipe to continue.',
+  ai: 'Generate a valid config to continue.',
+};
+
+export const CreateFilesetStart: FC<CreateFilesetStartProps> = ({ workspace, onContinue }) => {
   const [selectedId, setSelectedId] = useState<StartOptionId | null>(null);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
+  // Set only once a generated draft passes validation, so Continue can never load a broken config.
+  const [generatedJobRequest, setGeneratedJobRequest] = useState<DataDesignerJobRequest | null>(
+    null
+  );
   const selectedOption = START_OPTIONS.find((option) => option.id === selectedId) ?? null;
 
   const selectOption = (optionId: StartOptionId) => {
     setSelectedId(optionId);
     setSelectedTemplateId(null);
+    setGeneratedJobRequest(null);
   };
 
-  // Ready to continue once a tile is chosen — and, for "template", a template card too.
+  // Identity-stable so it can be a dependency of the AI panel's generate callback.
+  const handleValidConfig = useCallback(
+    (jobRequest: DataDesignerJobRequest | null) => setGeneratedJobRequest(jobRequest),
+    []
+  );
+
+  // Ready to continue once a tile is chosen — plus that option's own payload: a template card
+  // for "template", a validated config for "ai".
   const canContinue =
-    selectedOption !== null && (selectedOption.id !== 'template' || selectedTemplateId !== null);
+    selectedOption !== null &&
+    (selectedOption.id !== 'template' || selectedTemplateId !== null) &&
+    (selectedOption.id !== 'ai' || generatedJobRequest !== null);
 
   const handleContinue = () => {
     if (!selectedOption) return;
     if (selectedOption.id === 'template' && selectedTemplateId) {
-      onContinue(selectedOption.id, selectedTemplateId);
-    } else {
-      onContinue(selectedOption.id);
+      onContinue({ optionId: 'template', templateId: selectedTemplateId });
+    } else if (selectedOption.id === 'ai' && generatedJobRequest) {
+      onContinue({ optionId: 'ai', jobRequest: generatedJobRequest });
+    } else if (selectedOption.id === 'scratch') {
+      onContinue({ optionId: 'scratch' });
     }
   };
 
@@ -75,18 +98,25 @@ export const CreateFilesetStart: FC<CreateFilesetStartProps> = ({ onContinue }) 
               option={selectedOption}
               selectedTemplateId={selectedTemplateId}
               onSelectTemplate={setSelectedTemplateId}
+              workspace={workspace}
+              onValidConfig={handleValidConfig}
             />
           ) : null}
         </Stack>
       </Block>
 
-      {canContinue ? (
+      {selectedOption ? (
         <Flex
           align="center"
           justify="end"
           className="shrink-0 gap-4 border-t border-base bg-surface-base px-10 py-4"
         >
-          <Button color="brand" kind="primary" onClick={handleContinue}>
+          {!canContinue && BLOCKED_HINT[selectedOption.id] ? (
+            <Text kind="body/regular/sm" className="text-secondary">
+              {BLOCKED_HINT[selectedOption.id]}
+            </Text>
+          ) : null}
+          <Button color="brand" kind="primary" onClick={handleContinue} disabled={!canContinue}>
             Continue
             <ArrowRight size={16} aria-hidden />
           </Button>

--- a/web/packages/studio/src/components/CreateFilesetStart/types.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/types.ts
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { CreateJobRequest as DataDesignerJobRequest } from '@nemo/sdk/generated/data-designer/schema';
 import type { InferenceParams } from '@nemo/sdk/generated/platform/schema';
 import type { BadgeProps } from '@nvidia/foundations-react-core';
 import type { AddColumnSelection } from '@studio/components/AddColumnPalette/types';
+import type { GeneratedConfigValidation } from '@studio/routes/DataDesignerJobBuildRoute/aiSeed';
 import type { LucideIcon } from 'lucide-react';
 
 export type StartOptionId = 'ai' | 'template' | 'clone' | 'scratch';
@@ -82,17 +84,56 @@ export interface DetailPoint {
   description: string;
 }
 
+export interface DescribeWithAiPanelProps {
+  /** Workspace whose models are offered, and against which the draft is validated. */
+  workspace: string;
+  /**
+   * Fired after every generation: the normalized job request when the draft can be loaded
+   * into the build route, null when it can't (so a failed retry clears an earlier success).
+   */
+  onValidConfig: (jobRequest: DataDesignerJobRequest | null) => void;
+}
+
+export interface GeneratedConfigResultProps {
+  /** Verdict on the last draft; null before the first generation. */
+  validation: GeneratedConfigValidation | null;
+  /** Set when the request failed outright (network, auth, model error). */
+  requestError: string | null;
+  /** Pretty-printed model output for the last draft; enables "View config" when present. */
+  rawOutput: string | null;
+  isGenerating: boolean;
+  /** True while the model is reworking the draft, so the result area says so. */
+  isFixing: boolean;
+  /** Asks the model to resolve the listed issues. Omit to hide the fix affordance. */
+  onFix?: () => void;
+}
+
+export interface GeneratedConfigPanelProps {
+  open: boolean;
+  /** Pretty-printed JSON shown in the snippet. */
+  config: string;
+  onClose: () => void;
+}
+
 export interface StartOptionDetailProps {
   option: StartOption;
   /** Id of the currently-chosen template, when {@link option} is "template". */
   selectedTemplateId: string | null;
   onSelectTemplate: (templateId: string) => void;
+  /** Workspace passed through to the "ai" option's panel. */
+  workspace: string;
+  onValidConfig: (jobRequest: DataDesignerJobRequest | null) => void;
 }
 
+/** What the user confirmed via the Continue footer, carrying that option's payload. */
+export type StartSelection =
+  | { optionId: 'scratch' }
+  | { optionId: 'template'; templateId: string }
+  | { optionId: 'ai'; jobRequest: DataDesignerJobRequest };
+
 export interface CreateFilesetStartProps {
-  /**
-   * Fired when the user confirms a selected start option via the Continue footer. For
-   * the "template" option, the chosen template id is passed as the second argument.
-   */
-  onContinue: (optionId: StartOptionId, templateId?: string) => void;
+  /** Workspace whose models the "Describe with AI" option draws from. */
+  workspace: string;
+  /** Fired when the user confirms a selected start option via the Continue footer. */
+  onContinue: (selection: StartSelection) => void;
 }

--- a/web/packages/studio/src/components/CreateFilesetStart/useDescribeWithAi.test.tsx
+++ b/web/packages/studio/src/components/CreateFilesetStart/useDescribeWithAi.test.tsx
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
+import {
+  ERROR_NO_TOOL_CALL,
+  ERROR_PARSE_RESPONSE,
+  useDescribeWithAi,
+} from '@studio/components/CreateFilesetStart/useDescribeWithAi';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+const mutateAsync = vi.fn();
+
+vi.mock('@nemo/common/src/hooks/useChatCompletion', () => ({
+  useChatCompletion: () => ({ mutateAsync, isPending: false }),
+}));
+
+/** Stands in for the panel's model search results, which the hook uses to resolve model configs. */
+const MODEL_GROUPS: ModelWorkspaceGroup[] = [
+  {
+    workspace: 'default',
+    models: [
+      {
+        id: 'default/llama-3.3',
+        workspace: 'default',
+        name: 'llama-3.3',
+        model_providers: ['default/nim'],
+      },
+    ],
+  } as unknown as ModelWorkspaceGroup,
+];
+
+const JOB_REQUEST = {
+  name: 'qa-pairs',
+  spec: {
+    num_records: 25,
+    config: {
+      columns: [
+        {
+          name: 'topic',
+          column_type: 'sampler',
+          sampler_type: 'category',
+          params: { values: ['science', 'history'] },
+        },
+      ],
+    },
+  },
+};
+
+const toolCallResponse = (args: unknown) => ({
+  choices: [
+    {
+      message: {
+        tool_calls: [{ function: { arguments: JSON.stringify(args) } }],
+      },
+    },
+  ],
+});
+
+const setUp = ({ fill = true }: { fill?: boolean } = {}) => {
+  const onValidConfig = vi.fn();
+  const { result } = renderHook(() => useDescribeWithAi('default', onValidConfig, MODEL_GROUPS));
+  if (fill) {
+    act(() => {
+      result.current.form.setValue('model', 'default/llama-3.3');
+      result.current.form.setValue('provider', 'default/nim');
+      result.current.form.setValue('prompt', '50 trivia questions by topic');
+    });
+  }
+  return { result, onValidConfig };
+};
+
+describe('useDescribeWithAi', () => {
+  beforeEach(() => {
+    mutateAsync.mockReset();
+  });
+
+  it('does not call the model until both fields are filled in', async () => {
+    const { result } = setUp({ fill: false });
+
+    // Submitting empty: the form's own rules (asserted in the panel) stop the request.
+    await act(() => result.current.generate());
+    expect(mutateAsync).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.form.setValue('model', 'default/llama-3.3');
+      result.current.form.setValue('prompt', '50 trivia questions by topic');
+    });
+    await act(() => result.current.generate());
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a loadable draft and hands the job request to the caller', async () => {
+    mutateAsync.mockResolvedValue(toolCallResponse({ job_request: JOB_REQUEST }));
+    const { result, onValidConfig } = setUp();
+
+    await act(() => result.current.generate());
+
+    await waitFor(() => expect(result.current.validation?.status).toBe('valid'));
+    expect(onValidConfig).toHaveBeenCalledWith(expect.objectContaining({ name: 'qa-pairs' }));
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ workspace: 'default', model: 'llama-3.3', tool_choice: 'required' })
+    );
+  });
+
+  it('rejects a reply with no tool call', async () => {
+    mutateAsync.mockResolvedValue({ choices: [{ message: { content: 'sure!' } }] });
+    const { result, onValidConfig } = setUp();
+
+    await act(() => result.current.generate());
+
+    expect(result.current.validation).toEqual({
+      status: 'invalid',
+      errors: [ERROR_NO_TOOL_CALL],
+      warnings: [],
+    });
+    expect(onValidConfig).toHaveBeenCalledWith(null);
+  });
+
+  it('rejects tool arguments that are not a job request', async () => {
+    mutateAsync.mockResolvedValue(toolCallResponse({ not: 'a job request' }));
+    const { result, onValidConfig } = setUp();
+
+    await act(() => result.current.generate());
+
+    expect(result.current.validation).toEqual({
+      status: 'invalid',
+      errors: [ERROR_PARSE_RESPONSE],
+      warnings: [],
+    });
+    expect(onValidConfig).toHaveBeenCalledWith(null);
+  });
+
+  it('keeps the raw model output for inspection, valid draft or not', async () => {
+    mutateAsync.mockResolvedValue(toolCallResponse({ not: 'a job request' }));
+    const { result } = setUp();
+
+    await act(() => result.current.generate());
+
+    // Pretty-printed, and kept even though the draft was rejected.
+    expect(result.current.rawOutput).toBe('{\n  "not": "a job request"\n}');
+  });
+
+  describe('requestFix', () => {
+    it('replays the draft and its issues, then settles on the reworked config', async () => {
+      // First run is rejected: an image column the builder can't load leaves it with no columns.
+      mutateAsync.mockResolvedValueOnce(
+        toolCallResponse({
+          job_request: {
+            name: 'qa-pairs',
+            spec: { num_records: 25, config: { columns: [{ name: 'art', column_type: 'image' }] } },
+          },
+        })
+      );
+      const { result, onValidConfig } = setUp();
+      await act(() => result.current.generate());
+      await waitFor(() => expect(result.current.validation?.status).toBe('invalid'));
+
+      mutateAsync.mockResolvedValueOnce(toolCallResponse({ job_request: JOB_REQUEST }));
+      await act(() => result.current.requestFix());
+
+      const [{ messages }] = mutateAsync.mock.calls[1] as [{ messages: { content: string }[] }];
+      // Original request, the config that failed, and what was wrong with it.
+      expect(messages[1].content).toBe('50 trivia questions by topic');
+      expect(messages[2].content).toContain('"art"');
+      expect(messages[3].content).toContain('Errors');
+
+      await waitFor(() => expect(result.current.validation?.status).toBe('valid'));
+      expect(onValidConfig).toHaveBeenLastCalledWith(expect.objectContaining({ name: 'qa-pairs' }));
+    });
+
+    it('does nothing before a draft exists', async () => {
+      const { result } = setUp();
+
+      await act(() => result.current.requestFix());
+
+      expect(mutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('reports which request is in flight', async () => {
+      mutateAsync.mockResolvedValue(toolCallResponse({ job_request: JOB_REQUEST }));
+      const { result } = setUp();
+
+      expect(result.current.pendingAction).toBeNull();
+      await act(() => result.current.generate());
+      expect(result.current.pendingAction).toBeNull();
+    });
+  });
+
+  it('clears a previously valid draft when a regeneration fails outright', async () => {
+    mutateAsync.mockResolvedValueOnce(toolCallResponse({ job_request: JOB_REQUEST }));
+    const { result, onValidConfig } = setUp();
+    await act(() => result.current.generate());
+    await waitFor(() => expect(result.current.validation?.status).toBe('valid'));
+
+    mutateAsync.mockRejectedValueOnce(new Error('model is offline'));
+    await act(() => result.current.generate());
+
+    expect(result.current.requestError).toBe('model is offline');
+    expect(result.current.validation).toBeNull();
+    expect(onValidConfig).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/web/packages/studio/src/components/CreateFilesetStart/useDescribeWithAi.ts
+++ b/web/packages/studio/src/components/CreateFilesetStart/useDescribeWithAi.ts
@@ -1,0 +1,223 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { type ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
+import { useChatCompletion } from '@nemo/common/src/hooks/useChatCompletion';
+import type { CreateJobRequest as DataDesignerJobRequest } from '@nemo/sdk/generated/data-designer/schema';
+import { buildFixMessages } from '@studio/components/CreateFilesetStart/fixRequest';
+import { DATA_DESIGNER_JOB_GENERATOR_SYSTEM_PROMPT } from '@studio/components/NewDataDesignerJobForm/constants';
+import { generateDataDesignerJobRequestTool } from '@studio/components/NewDataDesignerJobForm/tools';
+import {
+  getErrorMessage,
+  getWorkspaceAndModel,
+  parseToolResponseToJobRequest,
+  sanitizeJobRequestName,
+} from '@studio/components/NewDataDesignerJobForm/utils';
+import {
+  type GeneratedConfigValidation,
+  type GenerationModel,
+  validateGeneratedJobRequest,
+} from '@studio/routes/DataDesignerJobBuildRoute/aiSeed';
+import type { ChatCompletion, ChatCompletionMessageParam } from 'openai/resources/index.mjs';
+import { type FormEvent, useCallback, useState } from 'react';
+import { type UseFormReturn, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+export const ERROR_NO_TOOL_CALL =
+  'The model replied without calling the job-config tool. Try again, or pick a model with tool-calling support.';
+export const ERROR_PARSE_RESPONSE =
+  "The model's response could not be read as a Data Designer job config.";
+
+export const MODEL_REQUIRED_MESSAGE = 'Choose a model to draft the config.';
+export const PROMPT_REQUIRED_MESSAGE = 'Describe the fileset you want.';
+
+/**
+ * The panel's inputs, owned by React Hook Form. Rules live here rather than on the individual
+ * fields so a submit can never reach the model with an empty prompt, whatever renders the form.
+ */
+export const describeWithAiFormSchema = z.object({
+  /** URN of the model that drafts the config (e.g. `workspace/model-name`). */
+  model: z.string().min(1, MODEL_REQUIRED_MESSAGE),
+  /**
+   * Provider of the selected model, captured at selection time. Data Designer requires an
+   * explicit provider on every model config, and reading it back from a filtered search list
+   * later is unreliable — so the panel stores it alongside the model.
+   */
+  provider: z.string(),
+  prompt: z.string().trim().min(1, PROMPT_REQUIRED_MESSAGE),
+});
+
+export type DescribeWithAiFormValues = z.infer<typeof describeWithAiFormSchema>;
+
+export interface DescribeWithAiState {
+  form: UseFormReturn<DescribeWithAiFormValues>;
+  /** Result of the last generation, or null before the first run. */
+  validation: GeneratedConfigValidation | null;
+  /** Set when the request itself failed (network, auth, model error) rather than the output. */
+  requestError: string | null;
+  /**
+   * The model's tool-call arguments from the last run, pretty-printed. Kept whether or not the
+   * draft validated, so a rejected config can still be inspected.
+   */
+  rawOutput: string | null;
+  /** Which request is in flight, or null when idle. */
+  pendingAction: DescribeWithAiAction | null;
+  /** Submit handler: validates the form, then runs one generation. */
+  generate: (event?: FormEvent) => Promise<void>;
+  /**
+   * Sends the last draft back to the same model with the issues the builder found, and
+   * replaces the result with whatever comes back. No-op when there is nothing to fix.
+   */
+  requestFix: () => Promise<void>;
+}
+
+/** Distinguishes a first draft from a repair run; both hit the same model and tool. */
+export type DescribeWithAiAction = 'generate' | 'fix';
+
+/** Pretty-print the tool-call arguments, falling back to the raw string if they aren't JSON. */
+const formatRawOutput = (args: string): string => {
+  try {
+    return JSON.stringify(JSON.parse(args), null, 2);
+  } catch {
+    return args;
+  }
+};
+
+/**
+ * Drives the "Describe with AI" panel: pick a model, describe the fileset, and have the model
+ * draft a Data Designer job config via tool call. The draft is only accepted once it survives
+ * {@link validateGeneratedJobRequest}, so the caller can gate Continue on `onValidConfig`
+ * having produced a request.
+ *
+ * `onValidConfig` is called after every run — with the request when the draft is loadable, and
+ * with null otherwise — so a failed regeneration clears a previously-valid result.
+ */
+export const useDescribeWithAi = (
+  workspace: string,
+  onValidConfig: (jobRequest: DataDesignerJobRequest | null) => void,
+  modelGroups: ModelWorkspaceGroup[]
+): DescribeWithAiState => {
+  const form = useForm<DescribeWithAiFormValues>({
+    resolver: zodResolver(describeWithAiFormSchema),
+    defaultValues: { model: '', provider: '', prompt: '' },
+  });
+  const [validation, setValidation] = useState<GeneratedConfigValidation | null>(null);
+  const [requestError, setRequestError] = useState<string | null>(null);
+  const [rawOutput, setRawOutput] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<DescribeWithAiAction | null>(null);
+
+  const chatCompletion = useChatCompletion();
+
+  const settle = useCallback(
+    (result: GeneratedConfigValidation) => {
+      setValidation(result);
+      onValidConfig(result.status === 'valid' ? result.jobRequest : null);
+    },
+    [onValidConfig]
+  );
+
+  /**
+   * One round-trip to the model: send `messages`, then settle the panel on whatever comes back.
+   * Shared by the first draft and the repair run so both are validated identically.
+   */
+  const runCompletion = useCallback(
+    async (generationModel: GenerationModel, messages: ChatCompletionMessageParam[]) => {
+      const model = generationModel.model;
+      setRequestError(null);
+      setRawOutput(null);
+      const { workspace: chatWorkspace, name: modelName } = getWorkspaceAndModel(model, workspace);
+
+      try {
+        const response = (await chatCompletion.mutateAsync({
+          workspace: chatWorkspace,
+          model: modelName,
+          stream: false,
+          messages,
+          tools: [generateDataDesignerJobRequestTool],
+          tool_choice: 'required',
+        })) as ChatCompletion;
+
+        const toolCall = response.choices[0]?.message?.tool_calls?.[0];
+        if (!toolCall) {
+          settle({ status: 'invalid', errors: [ERROR_NO_TOOL_CALL], warnings: [] });
+          return;
+        }
+
+        setRawOutput(formatRawOutput(toolCall.function.arguments));
+
+        const jobRequest = parseToolResponseToJobRequest(toolCall.function.arguments);
+        if (!jobRequest?.spec?.config) {
+          settle({ status: 'invalid', errors: [ERROR_PARSE_RESPONSE], warnings: [] });
+          return;
+        }
+
+        settle(
+          validateGeneratedJobRequest(
+            sanitizeJobRequestName(jobRequest),
+            modelGroups,
+            generationModel
+          )
+        );
+      } catch (error) {
+        setRequestError(getErrorMessage(error, 'Generation failed.'));
+        setValidation(null);
+        onValidConfig(null);
+      }
+    },
+    [chatCompletion, modelGroups, onValidConfig, settle, workspace]
+  );
+
+  const run = useCallback(
+    async (
+      action: DescribeWithAiAction,
+      generationModel: GenerationModel,
+      messages: ChatCompletionMessageParam[]
+    ) => {
+      setPendingAction(action);
+      try {
+        await runCompletion(generationModel, messages);
+      } finally {
+        setPendingAction(null);
+      }
+    },
+    [runCompletion]
+  );
+
+  const runGeneration = useCallback(
+    ({ model, provider, prompt }: DescribeWithAiFormValues) =>
+      run('generate', { model, provider }, [
+        { role: 'system', content: DATA_DESIGNER_JOB_GENERATOR_SYSTEM_PROMPT },
+        { role: 'user', content: prompt },
+      ]),
+    [run]
+  );
+
+  const requestFix = useCallback(async () => {
+    // Nothing to repair without a draft to send back, and nothing to repair it against.
+    if (!rawOutput || !validation) return;
+    const { model, provider, prompt } = form.getValues();
+    if (!model) return;
+
+    await run(
+      'fix',
+      { model, provider },
+      buildFixMessages({
+        prompt,
+        config: rawOutput,
+        errors: validation.status === 'invalid' ? validation.errors : [],
+        warnings: validation.warnings,
+      })
+    );
+  }, [form, rawOutput, run, validation]);
+
+  return {
+    form,
+    validation,
+    requestError,
+    rawOutput,
+    pendingAction,
+    generate: form.handleSubmit(runGeneration),
+    requestFix,
+  };
+};

--- a/web/packages/studio/src/components/ModelConfigPanel/index.tsx
+++ b/web/packages/studio/src/components/ModelConfigPanel/index.tsx
@@ -32,7 +32,7 @@ export const ModelConfigPanel: FC<ModelConfigPanelProps> = ({
   onRemove,
   onClose,
 }) => {
-  const { control, getValues } = useFormContext<JobBuilderFormValues>();
+  const { control, getValues, setValue } = useFormContext<JobBuilderFormValues>();
   const modelIndex = getValues('models').findIndex((model) => model.id === modelId);
   const aliasPath = `models.${modelIndex}.alias` as const;
   const { field: modelField } = useController({ control, name: `models.${modelIndex}.model` });
@@ -56,9 +56,25 @@ export const ModelConfigPanel: FC<ModelConfigPanelProps> = ({
   );
   const modelValue: ModelSelection | null = modelField.value ? { model: modelField.value } : null;
 
+  const { field: aliasField } = useController({ control, name: aliasPath });
+
   const handleModelChange = (selection: ModelSelection) => {
+    const oldAlias = aliasField.value as string;
+    const newAlias = selection.model.split('/').pop()?.split('@')[0] ?? selection.model;
+
     modelField.onChange(selection.model);
     providerField.onChange(providerForSelection(selection));
+
+    if (newAlias && newAlias !== oldAlias) {
+      aliasField.onChange(newAlias);
+      const columns = getValues('columns');
+      const updated = columns.map((col) =>
+        col.values?.model_alias === oldAlias
+          ? { ...col, values: { ...col.values, model_alias: newAlias } }
+          : col
+      );
+      setValue('columns', updated);
+    }
   };
 
   return (

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderConfigPane.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderConfigPane.tsx
@@ -4,7 +4,7 @@
 import { Flex, Text } from '@nvidia/foundations-react-core';
 import { ColumnConfigPanel } from '@studio/components/ColumnConfigPanel';
 import { ModelConfigPanel } from '@studio/components/ModelConfigPanel';
-import type { FC } from 'react';
+import { type FC, memo } from 'react';
 
 export interface BuilderConfigPaneProps {
   selectedColumnId: string | null;
@@ -16,7 +16,7 @@ export interface BuilderConfigPaneProps {
   onModelClose: () => void;
 }
 
-export const BuilderConfigPane: FC<BuilderConfigPaneProps> = ({
+export const BuilderConfigPane: FC<BuilderConfigPaneProps> = memo(function BuilderConfigPane({
   selectedColumnId,
   selectedModelId,
   workspace,
@@ -24,27 +24,29 @@ export const BuilderConfigPane: FC<BuilderConfigPaneProps> = ({
   onColumnClose,
   onModelRemove,
   onModelClose,
-}) => (
-  <div className="w-[240px] shrink-0 border-l border-base bg-surface-base">
-    {selectedColumnId ? (
-      <ColumnConfigPanel
-        columnId={selectedColumnId}
-        onRemove={onColumnRemove}
-        onClose={onColumnClose}
-      />
-    ) : selectedModelId ? (
-      <ModelConfigPanel
-        modelId={selectedModelId}
-        workspace={workspace}
-        onRemove={onModelRemove}
-        onClose={onModelClose}
-      />
-    ) : (
-      <Flex align="center" justify="center" className="h-full p-density-lg">
-        <Text kind="body/regular/sm" className="text-secondary text-center">
-          Select a column or model to configure it, or add one from the left.
-        </Text>
-      </Flex>
-    )}
-  </div>
-);
+}) {
+  return (
+    <div className="w-[240px] shrink-0 border-l border-base bg-surface-base">
+      {selectedColumnId ? (
+        <ColumnConfigPanel
+          columnId={selectedColumnId}
+          onRemove={onColumnRemove}
+          onClose={onColumnClose}
+        />
+      ) : selectedModelId ? (
+        <ModelConfigPanel
+          modelId={selectedModelId}
+          workspace={workspace}
+          onRemove={onModelRemove}
+          onClose={onModelClose}
+        />
+      ) : (
+        <Flex align="center" justify="center" className="h-full p-density-lg">
+          <Text kind="body/regular/sm" className="text-secondary text-center">
+            Select a column or model to configure it, or add one from the left.
+          </Text>
+        </Flex>
+      )}
+    </div>
+  );
+});

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderDetailsPanel.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderDetailsPanel.tsx
@@ -5,7 +5,7 @@ import { useStickToBottom } from '@nemo/common/src/hooks/useStickToBottom';
 import { Banner, Button, CodeSnippet, Flex, Stack } from '@nvidia/foundations-react-core';
 import { formatPreviewLogsForDisplay } from '@studio/components/NewDataDesignerJobForm/previewApi';
 import { ChevronDown, ChevronRight } from 'lucide-react';
-import type { FC } from 'react';
+import { type FC, memo } from 'react';
 
 export interface BuilderDetailsPanelProps {
   validationErrors: string[];
@@ -14,13 +14,13 @@ export interface BuilderDetailsPanelProps {
   isOpen: boolean;
   onToggle: () => void;
 }
-export const BuilderDetailsPanel: FC<BuilderDetailsPanelProps> = ({
+export const BuilderDetailsPanel: FC<BuilderDetailsPanelProps> = memo(function BuilderDetailsPanel({
   validationErrors,
   submitError,
   previewLogs,
   isOpen,
   onToggle,
-}) => {
+}) {
   const { ref: logsScrollRef } = useStickToBottom<HTMLDivElement>({
     enabled: isOpen && !!previewLogs,
   });
@@ -80,4 +80,4 @@ export const BuilderDetailsPanel: FC<BuilderDetailsPanelProps> = ({
       )}
     </div>
   );
-};
+});

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderPalette.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderPalette.tsx
@@ -10,7 +10,7 @@ import type {
   JobBuilderFormValues,
   PaletteTab,
 } from '@studio/routes/DataDesignerJobBuildRoute/useJobBuilder';
-import type { FC } from 'react';
+import { type FC, memo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 export interface BuilderPaletteProps {
@@ -24,7 +24,7 @@ export interface BuilderPaletteProps {
 }
 
 // Tabs only swap what you're adding — column and model configs both open in the right pane.
-export const BuilderPalette: FC<BuilderPaletteProps> = ({
+export const BuilderPalette: FC<BuilderPaletteProps> = memo(function BuilderPalette({
   tab,
   onTabChange,
   selectedModelId,
@@ -32,7 +32,7 @@ export const BuilderPalette: FC<BuilderPaletteProps> = ({
   onAddColumn,
   onAddModel,
   onSelectModel,
-}) => {
+}) {
   const { control, getValues } = useFormContext<JobBuilderFormValues>();
   const models = useWatch({ control, name: 'models' });
   const hasSeedColumn = getValues('columns').some(
@@ -69,4 +69,4 @@ export const BuilderPalette: FC<BuilderPaletteProps> = ({
       </div>
     </aside>
   );
-};
+});

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderToolbar.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/BuilderToolbar.tsx
@@ -7,7 +7,7 @@ import { Button, Flex, SegmentedControl, Tag, Text } from '@nvidia/foundations-r
 import type { StartOptionTag } from '@studio/components/CreateFilesetStart/types';
 import type { JobBuilderFormValues } from '@studio/routes/DataDesignerJobBuildRoute/useJobBuilder';
 import { FileJson, ListTree, Pencil, SplinePointer } from 'lucide-react';
-import { type FC, useState } from 'react';
+import { type FC, memo, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
 /** Which renderer the center pane shows: the flat schema list or the DAG canvas. */
@@ -26,7 +26,7 @@ export interface BuilderToolbarProps {
   isSubmitting: boolean;
 }
 
-export const BuilderToolbar: FC<BuilderToolbarProps> = ({
+export const BuilderToolbar: FC<BuilderToolbarProps> = memo(function BuilderToolbar({
   templateTag,
   columnCount,
   viewMode,
@@ -35,7 +35,7 @@ export const BuilderToolbar: FC<BuilderToolbarProps> = ({
   isPreviewing,
   onSubmit,
   isSubmitting,
-}) => {
+}) {
   const [isEditingName, setIsEditingName] = useState(false);
   const { control } = useFormContext<JobBuilderFormValues>();
   const name = useWatch({ control, name: 'name' }) ?? '';
@@ -126,4 +126,4 @@ export const BuilderToolbar: FC<BuilderToolbarProps> = ({
       </Flex>
     </Flex>
   );
-};
+});

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/SchemaList.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/SchemaList.tsx
@@ -13,7 +13,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 
 export interface SchemaListProps {
   selectedId: string | null;
-  onSelect: (id: string | null) => void;
+  onSelect: (id: string) => void;
   onDelete: (id: string) => void;
 }
 
@@ -63,8 +63,8 @@ export const SchemaList: FC<SchemaListProps> = ({ selectedId, onSelect, onDelete
               column={column}
               references={referencesById.get(column.id) ?? []}
               selected={column.id === selectedId}
-              onSelect={() => onSelect(column.id)}
-              onDelete={() => onDelete(column.id)}
+              onSelect={onSelect}
+              onDelete={onDelete}
             />
           ))}
         </Stack>

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/SchemaRow.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/SchemaRow.tsx
@@ -6,7 +6,7 @@ import { CardIconBadge } from '@studio/components/common/SelectableCard';
 import type { BuilderColumn } from '@studio/routes/DataDesignerJobBuildRoute/columns';
 import { describeColumn } from '@studio/routes/DataDesignerJobBuildRoute/describeColumn';
 import { Box, Trash2 } from 'lucide-react';
-import type { FC } from 'react';
+import { type FC, memo } from 'react';
 
 /** Accent color → NVIDIA Foundations text token, matching the DAG node icon styling. */
 const ACCENT_ICON_CLASS: Record<string, string> = {
@@ -24,8 +24,8 @@ export interface SchemaRowProps {
   /** Names of columns this one references, shown inline as `{{ name }}` relationship tags. */
   references: string[];
   selected: boolean;
-  onSelect: () => void;
-  onDelete: () => void;
+  onSelect: (id: string) => void;
+  onDelete: (id: string) => void;
 }
 
 /**
@@ -33,13 +33,13 @@ export interface SchemaRowProps {
  * the column name, a type badge, a one-line summary, and its relationship tags. Selecting the
  * row opens the same config pane the DAG canvas uses; the trailing button deletes the column.
  */
-export const SchemaRow: FC<SchemaRowProps> = ({
+export const SchemaRow: FC<SchemaRowProps> = memo(function SchemaRow({
   column,
   references,
   selected,
   onSelect,
   onDelete,
-}) => {
+}) {
   const { option } = column;
   const { typeLabel, detail } = describeColumn(column);
   const Icon = option.icon ?? Box;
@@ -54,7 +54,7 @@ export const SchemaRow: FC<SchemaRowProps> = ({
       <button
         type="button"
         data-select=""
-        onClick={onSelect}
+        onClick={() => onSelect(column.id)}
         aria-pressed={selected}
         className="flex min-w-0 flex-1 items-center gap-density-md px-density-lg py-density-md text-left focus-visible:outline-none cursor-pointer"
       >
@@ -93,7 +93,7 @@ export const SchemaRow: FC<SchemaRowProps> = ({
           kind="tertiary"
           color="danger"
           size="tiny"
-          onClick={onDelete}
+          onClick={() => onDelete(column.id)}
           aria-label={`Delete ${column.name || option.label}`}
           className="h-full rounded-none opacity-0 transition-opacity focus-visible:opacity-100 group-hover:opacity-100"
         >
@@ -102,4 +102,4 @@ export const SchemaRow: FC<SchemaRowProps> = ({
       </Flex>
     </Flex>
   );
-};
+});

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/aiSeed.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/aiSeed.test.ts
@@ -92,9 +92,7 @@ describe('validateGeneratedJobRequest', () => {
         provider: 'default/nim',
       }),
     ]);
-    expect(result.warnings).toEqual([
-      'Alias "gen" now uses "default/llama-3.3" — the model you selected — instead of the drafted "gpt-4o".',
-    ]);
+    expect(result.warnings).toEqual([]);
   });
 
   it('uses the generation model even when it is not in the loaded model list', () => {

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/aiSeed.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/aiSeed.ts
@@ -97,18 +97,11 @@ const normalizeModelConfigs = (
   generationModel?: GenerationModel
 ): ModelConfig[] => {
   if (generationModel?.model) {
-    return configs.map((config) => {
-      if (config.model && config.model !== generationModel.model) {
-        warnings.push(
-          `Alias "${config.alias}" now uses "${generationModel.model}" — the model you selected — instead of the drafted "${config.model}".`
-        );
-      }
-      return {
-        ...config,
-        model: generationModel.model,
-        provider: generationModel.provider || config.provider,
-      };
-    });
+    return configs.map((config) => ({
+      ...config,
+      model: generationModel.model,
+      provider: generationModel.provider || config.provider,
+    }));
   }
 
   if (modelGroups.length === 0) return configs;

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
@@ -140,16 +140,16 @@ export const DataDesignerJobBuildRoute: FC = () => {
     getCurrentConfig,
   });
 
-  const handlePreview = () => {
+  const handlePreview = useCallback(() => {
     if (validateAndCollectErrors().length > 0) return;
     setIsDetailsOpen(true);
     void runPreview();
-  };
+  }, [validateAndCollectErrors, runPreview]);
 
   const createJob = useDataDesignerCreateJob();
   const submitError = createJob.error ? getErrorMessage(createJob.error) : null;
 
-  const handleSubmit = async () => {
+  const handleSubmit = useCallback(async () => {
     if (validateAndCollectErrors().length > 0) return;
     const { columns, models, name, rows } = builder.getBuilderValues();
 
@@ -173,7 +173,17 @@ export const DataDesignerJobBuildRoute: FC = () => {
       setIsDetailsOpen(true);
       // Error surfaced via createJob.error / submitError below.
     }
-  };
+  }, [validateAndCollectErrors, builder, createJob, workspace, servedModelNames, navigate]);
+
+  const toggleDetails = useCallback(() => setIsDetailsOpen((open) => !open), []);
+  const onColumnRemove = useCallback(() => {
+    if (builder.selectedColumnId) builder.removeColumn(builder.selectedColumnId);
+  }, [builder]);
+  const onColumnClose = useCallback(() => builder.selectColumn(null), [builder]);
+  const onModelRemove = useCallback(() => {
+    if (builder.selectedModelId) builder.removeModel(builder.selectedModelId);
+  }, [builder]);
+  const onModelClose = useCallback(() => builder.selectModel(null), [builder]);
 
   return (
     <AccessibleTitle title={heading}>
@@ -195,7 +205,7 @@ export const DataDesignerJobBuildRoute: FC = () => {
             submitError={submitError}
             previewLogs={previewLogs}
             isOpen={isDetailsOpen}
-            onToggle={() => setIsDetailsOpen((open) => !open)}
+            onToggle={toggleDetails}
           />
 
           <Flex className="min-h-0 border-t border-base h-full">
@@ -229,14 +239,10 @@ export const DataDesignerJobBuildRoute: FC = () => {
               selectedColumnId={builder.selectedColumnId}
               selectedModelId={builder.selectedModelId}
               workspace={workspace}
-              onColumnRemove={() =>
-                builder.selectedColumnId && builder.removeColumn(builder.selectedColumnId)
-              }
-              onColumnClose={() => builder.selectColumn(null)}
-              onModelRemove={() =>
-                builder.selectedModelId && builder.removeModel(builder.selectedModelId)
-              }
-              onModelClose={() => builder.selectModel(null)}
+              onColumnRemove={onColumnRemove}
+              onColumnClose={onColumnClose}
+              onModelRemove={onModelRemove}
+              onModelClose={onModelClose}
             />
           </Flex>
         </Stack>

--- a/web/packages/studio/src/routes/NewDataDesignerJobRoute/index.tsx
+++ b/web/packages/studio/src/routes/NewDataDesignerJobRoute/index.tsx
@@ -3,9 +3,10 @@
 
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { CreateFilesetStart } from '@studio/components/CreateFilesetStart';
-import type { StartOptionId } from '@studio/components/CreateFilesetStart/types';
+import type { StartSelection } from '@studio/components/CreateFilesetStart/types';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import type { DataDesignerGeneratedState } from '@studio/routes/DataDesignerJobBuildRoute/aiSeed';
 import { getDataDesignerJobBuildRoute, getDataDesignerJobListRoute } from '@studio/routes/utils';
 import type { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -21,17 +22,25 @@ export const NewDataDesignerJobRoute: FC = () => {
     ],
   });
 
-  const handleContinue = (optionId: StartOptionId, templateId?: string) => {
-    if (optionId === 'scratch') {
-      navigate(getDataDesignerJobBuildRoute(workspace));
-    } else if (optionId === 'template' && templateId) {
-      navigate(`${getDataDesignerJobBuildRoute(workspace)}?template=${templateId}`);
+  const handleContinue = (selection: StartSelection) => {
+    switch (selection.optionId) {
+      case 'scratch':
+        navigate(getDataDesignerJobBuildRoute(workspace));
+        break;
+      case 'template':
+        navigate(`${getDataDesignerJobBuildRoute(workspace)}?template=${selection.templateId}`);
+        break;
+      case 'ai': {
+        const state: DataDesignerGeneratedState = { generatedJobRequest: selection.jobRequest };
+        navigate(getDataDesignerJobBuildRoute(workspace), { state });
+        break;
+      }
     }
   };
 
   return (
     <AccessibleTitle title="Create a fileset">
-      <CreateFilesetStart onContinue={handleContinue} />
+      <CreateFilesetStart workspace={workspace} onContinue={handleContinue} />
     </AccessibleTitle>
   );
 };


### PR DESCRIPTION
This PR adds the ability to create a DD config and subsequent DD job with natural language 

Signed-off-by: Sean Teramae <steramae@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Describe with AI” as a new way to create data designer jobs.
  * Users can select an AI model, describe their dataset, and generate a job configuration.
  * Added validation feedback, warnings, raw configuration preview, and options to fix issues or regenerate.
  * Valid configurations now open directly in the job builder.
  * Continue remains disabled until required selections or a valid AI-generated configuration are available.

* **Bug Fixes**
  * Improved handling of model selection, configuration validation, missing columns, and invalid settings.
  * Added sensible defaults for missing dataset names and invalid row counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->