### PR TITLE
feat(studio): Anonymizer job detail page [ASTD-330]

### DIFF
--- a/web/packages/common/src/utils/file.test.ts
+++ b/web/packages/common/src/utils/file.test.ts
@@ -78,6 +78,16 @@ describe('triggerDownload', () => {
       expect(Blob).toHaveBeenCalledWith([testData]);
     });
 
+    it('should pass a Blob through untouched so its type survives', () => {
+      vi.unstubAllGlobals();
+      const blob = new Blob(['tar bytes'], { type: 'application/x-tar' });
+
+      triggerDownload(blob, 'artifacts');
+
+      expect(mockCreateObjectURL).toHaveBeenCalledWith(blob);
+      expect((mockCreateObjectURL.mock.calls[0][0] as Blob).type).toBe('application/x-tar');
+    });
+
     it('should create an object URL from the Blob', () => {
       const testData = 'test file content';
       const filename = 'test.txt';

--- a/web/packages/common/src/utils/file.ts
+++ b/web/packages/common/src/utils/file.ts
@@ -54,8 +54,8 @@ export function findMessagesArray(
  * @param filename - The name to give the downloaded file.
  */
 export const triggerDownload = (data: BlobPart, filename: string) => {
-  // Create a Blob from the data
-  const blob = new Blob([data]);
+  // Re-wrapping a Blob would drop its type, and the browser uses that to pick the extension.
+  const blob = data instanceof Blob ? data : new Blob([data]);
 
   // Create an object URL for the Blob
   const blobUrl = URL.createObjectURL(blob);

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ExpandedCellModal.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ExpandedCellModal.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TableExpandableCellState } from '@nemo/common/src/components/DataView/TableExpandableCell';
+import { Button, Flex, Modal, Text } from '@nvidia/foundations-react-core';
+import type { FC } from 'react';
+
+interface ExpandedCellModalProps {
+  readonly cell: TableExpandableCellState | null;
+  readonly onClose: () => void;
+}
+
+export const ExpandedCellModal: FC<ExpandedCellModalProps> = ({ cell, onClose }) => (
+  <Modal
+    open={cell !== null}
+    onOpenChange={(open) => {
+      if (!open) onClose();
+    }}
+    slotHeading={cell?.title ?? 'Cell Content'}
+    className="w-[90vw] max-w-[1000px]"
+    slotFooter={
+      <Flex justify="end" align="center" className="w-full">
+        <Button kind="tertiary" onClick={onClose}>
+          Close
+        </Button>
+      </Flex>
+    }
+  >
+    <div className="max-h-[70vh] overflow-auto">
+      <Text kind="body/regular/md" className="whitespace-pre-wrap">
+        {cell?.content}
+      </Text>
+    </div>
+  </Modal>
+);

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/FailedRecordsPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/FailedRecordsPanel.tsx
@@ -34,6 +34,9 @@ export const FailedRecordsPanel: FC<FailedRecordsPanelProps> = ({ workspace, art
     workspace,
     name: location?.fileset ?? '',
     path: `${location?.basePath}/failed_records.json`,
+    // Pretty-printed JSON array: the size-capped preview truncates mid-array and the parse
+    // below then silently yields zero records, hiding every failure.
+    fullContent: true,
     enabled: !!location,
   });
 
@@ -62,8 +65,8 @@ export const FailedRecordsPanel: FC<FailedRecordsPanelProps> = ({ workspace, art
           </TableRow>
         </TableHead>
         <TableBody>
-          {records.map((record) => (
-            <TableRow key={record.record_id}>
+          {records.map((record, index) => (
+            <TableRow key={record.record_id ?? index}>
               <TableDataCell>
                 <Text kind="body/regular/sm">{record.record_id ?? '—'}</Text>
               </TableDataCell>

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/FailedRecordsPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/FailedRecordsPanel.tsx
@@ -34,8 +34,7 @@ export const FailedRecordsPanel: FC<FailedRecordsPanelProps> = ({ workspace, art
     workspace,
     name: location?.fileset ?? '',
     path: `${location?.basePath}/failed_records.json`,
-    // Pretty-printed JSON array: the size-capped preview truncates mid-array and the parse
-    // below then silently yields zero records, hiding every failure.
+    // A truncated JSON array parses to nothing, hiding every failure.
     fullContent: true,
     enabled: !!location,
   });

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/FailedRecordsPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/FailedRecordsPanel.tsx
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Banner,
+  Panel,
+  TableBody,
+  TableDataCell,
+  TableHead,
+  TableHeaderCell,
+  TableRoot,
+  TableRow,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import { parseArtifactUrl } from '@studio/routes/AnonymizerJobDetailRoute/util';
+import { useMemo, type FC } from 'react';
+
+interface FailedRecordsPanelProps {
+  readonly workspace: string;
+  readonly artifactUrl: string | undefined;
+}
+
+interface FailedRecord {
+  readonly record_id?: string;
+  readonly step?: string;
+  readonly reason?: string;
+}
+
+export const FailedRecordsPanel: FC<FailedRecordsPanelProps> = ({ workspace, artifactUrl }) => {
+  const location = parseArtifactUrl(artifactUrl);
+
+  const { data, error } = useDatasetFileContent({
+    workspace,
+    name: location?.fileset ?? '',
+    path: `${location?.basePath}/failed_records.json`,
+    enabled: !!location,
+  });
+
+  const records = useMemo<FailedRecord[]>(() => {
+    try {
+      const parsed = JSON.parse(data ?? '[]');
+      return Array.isArray(parsed) ? (parsed as FailedRecord[]) : [];
+    } catch {
+      return [];
+    }
+  }, [data]);
+
+  if (error || !records.length) return null;
+
+  return (
+    <Panel slotHeading={`Failed Records (${records.length})`} elevation="high" density="compact">
+      <Banner kind="inline" status="warning">
+        These records were dropped during processing and are absent from the results.
+      </Banner>
+      <TableRoot className="bg-transparent w-full mt-density-md" align="left">
+        <TableHead>
+          <TableRow>
+            <TableHeaderCell>Record</TableHeaderCell>
+            <TableHeaderCell>Step</TableHeaderCell>
+            <TableHeaderCell>Reason</TableHeaderCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {records.map((record) => (
+            <TableRow key={record.record_id}>
+              <TableDataCell>
+                <Text kind="body/regular/sm">{record.record_id ?? '—'}</Text>
+              </TableDataCell>
+              <TableDataCell>{record.step ?? '—'}</TableDataCell>
+              <TableDataCell>{record.reason ?? '—'}</TableDataCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </TableRoot>
+    </Panel>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel.tsx
@@ -11,7 +11,7 @@ import { jobSource, jobStrategy } from '@studio/routes/AnonymizerJobDetailRoute/
 import type { FC } from 'react';
 
 interface JobSummaryPanelProps {
-  job: RunJob;
+  readonly job: RunJob;
 }
 
 export const JobSummaryPanel: FC<JobSummaryPanelProps> = ({ job }) => {

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel.tsx
@@ -26,11 +26,6 @@ export const JobSummaryPanel: FC<JobSummaryPanelProps> = ({ job }) => {
             value={job.status ? <StatusBadge status={job.status} /> : EMPTY_FIELD_VALUE}
           />
           <KVPair label="Strategy" value={jobStrategy(job) ?? EMPTY_FIELD_VALUE} />
-          <KVPair label="Source" value={jobSource(job) ?? EMPTY_FIELD_VALUE} />
-          <KVPair
-            label="Created by"
-            value={(job.ownership?.created_by as string | undefined) ?? EMPTY_FIELD_VALUE}
-          />
           <KVPair
             label="Created"
             value={job.created_at ? <RelativeTime datetime={job.created_at} /> : EMPTY_FIELD_VALUE}
@@ -39,7 +34,12 @@ export const JobSummaryPanel: FC<JobSummaryPanelProps> = ({ job }) => {
             label="Updated"
             value={job.updated_at ? <RelativeTime datetime={job.updated_at} /> : EMPTY_FIELD_VALUE}
           />
+          <KVPair
+            label="Created by"
+            value={(job.ownership?.created_by as string | undefined) ?? EMPTY_FIELD_VALUE}
+          />
         </Grid>
+        <KVPair label="Source" value={jobSource(job) ?? EMPTY_FIELD_VALUE} />
         {errorMessage && (
           <Banner kind="inline" status="error">
             {errorMessage}

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel.tsx
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { KVPair } from '@nemo/common/src/components/KVPair';
+import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
+import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
+import type { RunJob } from '@nemo/sdk/generated/anonymizer/schema';
+import { Banner, Grid, Panel, Stack } from '@nvidia/foundations-react-core';
+import { EMPTY_FIELD_VALUE } from '@studio/constants/constants';
+import { jobSource, jobStrategy } from '@studio/routes/AnonymizerJobDetailRoute/util';
+import type { FC } from 'react';
+
+interface JobSummaryPanelProps {
+  job: RunJob;
+}
+
+export const JobSummaryPanel: FC<JobSummaryPanelProps> = ({ job }) => {
+  const errorMessage = job.error_details?.message as string | undefined;
+
+  return (
+    <Panel slotHeading="Job Details" elevation="high" density="compact">
+      <Stack gap="density-xl">
+        <Grid cols={{ base: 1, md: 2 }} gap="density-lg">
+          <KVPair
+            label="Status"
+            value={job.status ? <StatusBadge status={job.status} /> : EMPTY_FIELD_VALUE}
+          />
+          <KVPair label="Strategy" value={jobStrategy(job) ?? EMPTY_FIELD_VALUE} />
+          <KVPair label="Source" value={jobSource(job) ?? EMPTY_FIELD_VALUE} />
+          <KVPair
+            label="Created by"
+            value={(job.ownership?.created_by as string | undefined) ?? EMPTY_FIELD_VALUE}
+          />
+          <KVPair
+            label="Created"
+            value={job.created_at ? <RelativeTime datetime={job.created_at} /> : EMPTY_FIELD_VALUE}
+          />
+          <KVPair
+            label="Updated"
+            value={job.updated_at ? <RelativeTime datetime={job.updated_at} /> : EMPTY_FIELD_VALUE}
+          />
+        </Grid>
+        {errorMessage && (
+          <Banner kind="inline" status="error">
+            {errorMessage}
+          </Banner>
+        )}
+      </Stack>
+    </Panel>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel.tsx
@@ -40,11 +40,11 @@ export const JobSummaryPanel: FC<JobSummaryPanelProps> = ({ job }) => {
           />
         </Grid>
         <KVPair label="Source" value={jobSource(job) ?? EMPTY_FIELD_VALUE} />
-        {errorMessage && (
+        {errorMessage ? (
           <Banner kind="inline" status="error">
             {errorMessage}
           </Banner>
-        )}
+        ) : null}
       </Stack>
     </Panel>
   );

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPanel.tsx
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { anonymizerDownloadRunJobResult } from '@nemo/sdk/generated/anonymizer/api';
+import type { PlatformJobResultResponse } from '@nemo/sdk/generated/anonymizer/schema';
+import { Banner, Button, Flex, Panel, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
+import { Download } from 'lucide-react';
+import { useState, type FC } from 'react';
+
+interface ResultsPanelProps {
+  workspace: string;
+  jobName: string;
+  results: PlatformJobResultResponse[];
+  isLoading: boolean;
+  isTerminal: boolean;
+}
+
+export const ResultsPanel: FC<ResultsPanelProps> = ({
+  workspace,
+  jobName,
+  results,
+  isLoading,
+  isTerminal,
+}) => {
+  const [downloading, setDownloading] = useState<string | null>(null);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  const download = async (name: string) => {
+    setDownloading(name);
+    setError(undefined);
+    try {
+      const blob = await anonymizerDownloadRunJobResult(workspace, jobName, name);
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = name;
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      setError(`Could not download ${name}`);
+    } finally {
+      setDownloading(null);
+    }
+  };
+
+  return (
+    <Panel slotHeading="Results" elevation="high" density="compact">
+      <Stack gap="density-md">
+        {error && (
+          <Banner kind="inline" status="error">
+            {error}
+          </Banner>
+        )}
+        {isLoading ? (
+          <Spinner aria-label="Loading results" />
+        ) : results.length ? (
+          results.map((result) => (
+            <Flex key={result.name} align="center" justify="between" gap="density-md">
+              <Text kind="body/regular/md">{result.name}</Text>
+              <Button
+                kind="tertiary"
+                size="small"
+                disabled={downloading === result.name}
+                onClick={() => download(result.name)}
+              >
+                <Download />
+                Download
+              </Button>
+            </Flex>
+          ))
+        ) : (
+          <Text kind="body/regular/md">
+            {isTerminal ? 'This job produced no results.' : 'Results appear once the job finishes.'}
+          </Text>
+        )}
+      </Stack>
+    </Panel>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPanel.tsx
@@ -44,11 +44,11 @@ export const ResultsPanel: FC<ResultsPanelProps> = ({
   return (
     <Panel slotHeading="Results" elevation="high" density="compact">
       <Stack gap="density-md">
-        {error && (
+        {error ? (
           <Banner kind="inline" status="error">
             {error}
           </Banner>
-        )}
+        ) : null}
         {loadError ? (
           <Banner kind="inline" status="error">
             Could not load results for this job.

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPanel.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { triggerDownload } from '@nemo/common/src/utils/file';
 import { anonymizerDownloadRunJobResult } from '@nemo/sdk/generated/anonymizer/api';
 import type { PlatformJobResultResponse } from '@nemo/sdk/generated/anonymizer/schema';
 import { Banner, Button, Flex, Panel, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
@@ -30,12 +31,7 @@ export const ResultsPanel: FC<ResultsPanelProps> = ({
     setError(undefined);
     try {
       const blob = await anonymizerDownloadRunJobResult(workspace, jobName, name);
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = name;
-      link.click();
-      URL.revokeObjectURL(url);
+      triggerDownload(blob, name);
     } catch {
       setError(`Could not download ${name}`);
     } finally {

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPanel.tsx
@@ -9,11 +9,12 @@ import { Download } from 'lucide-react';
 import { useState, type FC } from 'react';
 
 interface ResultsPanelProps {
-  workspace: string;
-  jobName: string;
-  results: PlatformJobResultResponse[];
-  isLoading: boolean;
-  isTerminal: boolean;
+  readonly workspace: string;
+  readonly jobName: string;
+  readonly results: readonly PlatformJobResultResponse[];
+  readonly isLoading: boolean;
+  readonly isTerminal: boolean;
+  readonly loadError: boolean;
 }
 
 export const ResultsPanel: FC<ResultsPanelProps> = ({
@@ -22,6 +23,7 @@ export const ResultsPanel: FC<ResultsPanelProps> = ({
   results,
   isLoading,
   isTerminal,
+  loadError,
 }) => {
   const [downloading, setDownloading] = useState<string | null>(null);
   const [error, setError] = useState<string | undefined>(undefined);
@@ -47,7 +49,11 @@ export const ResultsPanel: FC<ResultsPanelProps> = ({
             {error}
           </Banner>
         )}
-        {isLoading ? (
+        {loadError ? (
+          <Banner kind="inline" status="error">
+            Could not load results for this job.
+          </Banner>
+        ) : isLoading ? (
           <Spinner aria-label="Loading results" />
         ) : results.length ? (
           results.map((result) => (

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewPanel.tsx
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import type { TableExpandableCellState } from '@nemo/common/src/components/DataView/TableExpandableCell';
 import { Banner, Panel, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
+import { ExpandedCellModal } from '@studio/routes/AnonymizerJobDetailRoute/components/ExpandedCellModal';
 import { ResultsPreviewTable } from '@studio/routes/AnonymizerJobDetailRoute/components/ResultsPreviewTable';
 import { useResultPreview } from '@studio/routes/AnonymizerJobDetailRoute/useResultPreview';
-import type { FC } from 'react';
+import { useCallback, useState, type FC } from 'react';
 
 interface ResultsPreviewPanelProps {
   readonly workspace: string;
@@ -13,6 +15,8 @@ interface ResultsPreviewPanelProps {
 
 export const ResultsPreviewPanel: FC<ResultsPreviewPanelProps> = ({ workspace, artifactUrl }) => {
   const { rows, columns, isLoading, error } = useResultPreview(workspace, artifactUrl);
+  const [expandedCell, setExpandedCell] = useState<TableExpandableCellState | null>(null);
+  const closeExpandedCell = useCallback(() => setExpandedCell(null), []);
 
   return (
     <Panel slotHeading="Preview" elevation="high" density="compact">
@@ -24,7 +28,7 @@ export const ResultsPreviewPanel: FC<ResultsPreviewPanelProps> = ({ workspace, a
         <Spinner aria-label="Loading preview" />
       ) : rows.length ? (
         <Stack gap="density-md">
-          <ResultsPreviewTable rows={rows} columns={columns} />
+          <ResultsPreviewTable rows={rows} columns={columns} onExpand={setExpandedCell} />
           <Text kind="body/regular/sm">
             Showing the first {rows.length} records. Download the result for the full dataset.
           </Text>
@@ -32,6 +36,7 @@ export const ResultsPreviewPanel: FC<ResultsPreviewPanelProps> = ({ workspace, a
       ) : (
         <Text kind="body/regular/md">No preview available for this job.</Text>
       )}
+      <ExpandedCellModal cell={expandedCell} onClose={closeExpandedCell} />
     </Panel>
   );
 };

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewPanel.tsx
@@ -1,77 +1,18 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  Banner,
-  Panel,
-  Spinner,
-  Stack,
-  TableBody,
-  TableDataCell,
-  TableHead,
-  TableHeaderCell,
-  TableRoot,
-  TableRow,
-  Text,
-} from '@nvidia/foundations-react-core';
-import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
-import {
-  orderResultColumns,
-  parseArtifactUrl,
-  parseJsonLines,
-  RESULT_PREVIEW_ROWS,
-} from '@studio/routes/AnonymizerJobDetailRoute/util';
-import { useMemo, type FC } from 'react';
+import { Banner, Panel, Spinner, Stack, Text } from '@nvidia/foundations-react-core';
+import { ResultsPreviewTable } from '@studio/routes/AnonymizerJobDetailRoute/components/ResultsPreviewTable';
+import { useResultPreview } from '@studio/routes/AnonymizerJobDetailRoute/useResultPreview';
+import type { FC } from 'react';
 
 interface ResultsPreviewPanelProps {
   readonly workspace: string;
   readonly artifactUrl: string | undefined;
 }
 
-type ResultRow = Record<string, unknown>;
-
-const renderCell = (value: unknown): string => {
-  if (value == null) return '—';
-  if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
-};
-
 export const ResultsPreviewPanel: FC<ResultsPreviewPanelProps> = ({ workspace, artifactUrl }) => {
-  const location = parseArtifactUrl(artifactUrl);
-  const enabled = !!location;
-
-  const { data: metadata } = useDatasetFileContent({
-    workspace,
-    name: location?.fileset ?? '',
-    path: `${location?.basePath}/metadata.json`,
-    enabled,
-  });
-
-  const {
-    data: dataset,
-    isLoading,
-    error,
-  } = useDatasetFileContent({
-    workspace,
-    name: location?.fileset ?? '',
-    path: `${location?.basePath}/dataset.parquet`,
-    range: [0, RESULT_PREVIEW_ROWS],
-    enabled,
-  });
-
-  const rows = useMemo(() => parseJsonLines<ResultRow>(dataset), [dataset]);
-
-  const columns = useMemo(() => {
-    if (!rows.length) return [];
-    let textColumn: string | undefined;
-    try {
-      textColumn = (JSON.parse(metadata ?? '{}') as { original_text_column?: string })
-        .original_text_column;
-    } catch {
-      textColumn = undefined;
-    }
-    return orderResultColumns(Object.keys(rows[0]), textColumn);
-  }, [rows, metadata]);
+  const { rows, columns, isLoading, error } = useResultPreview(workspace, artifactUrl);
 
   return (
     <Panel slotHeading="Preview" elevation="high" density="compact">
@@ -83,30 +24,7 @@ export const ResultsPreviewPanel: FC<ResultsPreviewPanelProps> = ({ workspace, a
         <Spinner aria-label="Loading preview" />
       ) : rows.length ? (
         <Stack gap="density-md">
-          <div className="overflow-auto max-h-[28rem]">
-            <TableRoot className="bg-transparent w-full" align="left">
-              <TableHead>
-                <TableRow>
-                  {columns.map((column) => (
-                    <TableHeaderCell key={column}>{column}</TableHeaderCell>
-                  ))}
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {rows.map((row, index) => (
-                  <TableRow key={index}>
-                    {columns.map((column) => (
-                      <TableDataCell key={column} className="align-top max-w-md">
-                        <span className="line-clamp-6 whitespace-pre-wrap">
-                          {renderCell(row[column])}
-                        </span>
-                      </TableDataCell>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </TableRoot>
-          </div>
+          <ResultsPreviewTable rows={rows} columns={columns} />
           <Text kind="body/regular/sm">
             Showing the first {rows.length} records. Download the result for the full dataset.
           </Text>

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewPanel.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewPanel.tsx
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Banner,
+  Panel,
+  Spinner,
+  Stack,
+  TableBody,
+  TableDataCell,
+  TableHead,
+  TableHeaderCell,
+  TableRoot,
+  TableRow,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import {
+  orderResultColumns,
+  parseArtifactUrl,
+  parseJsonLines,
+  RESULT_PREVIEW_ROWS,
+} from '@studio/routes/AnonymizerJobDetailRoute/util';
+import { useMemo, type FC } from 'react';
+
+interface ResultsPreviewPanelProps {
+  readonly workspace: string;
+  readonly artifactUrl: string | undefined;
+}
+
+type ResultRow = Record<string, unknown>;
+
+const renderCell = (value: unknown): string => {
+  if (value == null) return '—';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+};
+
+export const ResultsPreviewPanel: FC<ResultsPreviewPanelProps> = ({ workspace, artifactUrl }) => {
+  const location = parseArtifactUrl(artifactUrl);
+  const enabled = !!location;
+
+  const { data: metadata } = useDatasetFileContent({
+    workspace,
+    name: location?.fileset ?? '',
+    path: `${location?.basePath}/metadata.json`,
+    enabled,
+  });
+
+  const {
+    data: dataset,
+    isLoading,
+    error,
+  } = useDatasetFileContent({
+    workspace,
+    name: location?.fileset ?? '',
+    path: `${location?.basePath}/dataset.parquet`,
+    range: [0, RESULT_PREVIEW_ROWS],
+    enabled,
+  });
+
+  const rows = useMemo(() => parseJsonLines<ResultRow>(dataset), [dataset]);
+
+  const columns = useMemo(() => {
+    if (!rows.length) return [];
+    let textColumn: string | undefined;
+    try {
+      textColumn = (JSON.parse(metadata ?? '{}') as { original_text_column?: string })
+        .original_text_column;
+    } catch {
+      textColumn = undefined;
+    }
+    return orderResultColumns(Object.keys(rows[0]), textColumn);
+  }, [rows, metadata]);
+
+  return (
+    <Panel slotHeading="Preview" elevation="high" density="compact">
+      {error ? (
+        <Banner kind="inline" status="error">
+          Could not load the result preview.
+        </Banner>
+      ) : isLoading ? (
+        <Spinner aria-label="Loading preview" />
+      ) : rows.length ? (
+        <Stack gap="density-md">
+          <div className="overflow-auto max-h-[28rem]">
+            <TableRoot className="bg-transparent w-full" align="left">
+              <TableHead>
+                <TableRow>
+                  {columns.map((column) => (
+                    <TableHeaderCell key={column}>{column}</TableHeaderCell>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {rows.map((row, index) => (
+                  <TableRow key={index}>
+                    {columns.map((column) => (
+                      <TableDataCell key={column} className="align-top max-w-md">
+                        <span className="line-clamp-6 whitespace-pre-wrap">
+                          {renderCell(row[column])}
+                        </span>
+                      </TableDataCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </TableRoot>
+          </div>
+          <Text kind="body/regular/sm">
+            Showing the first {rows.length} records. Download the result for the full dataset.
+          </Text>
+        </Stack>
+      ) : (
+        <Text kind="body/regular/md">No preview available for this job.</Text>
+      )}
+    </Panel>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewTable.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewTable.tsx
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
+import {
+  TableExpandableCell,
+  type TableExpandableCellState,
+} from '@nemo/common/src/components/DataView/TableExpandableCell';
+import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
+import { Text } from '@nvidia/foundations-react-core';
+import type { DataFileRow } from '@studio/components/FileRowEditor/types';
+import { ExpandedCellModal } from '@studio/routes/AnonymizerJobDetailRoute/components/ExpandedCellModal';
+import { RESULT_PREVIEW_ROWS } from '@studio/routes/AnonymizerJobDetailRoute/util';
+import { useCallback, useMemo, useState, type ComponentProps, type FC } from 'react';
+
+interface ResultsPreviewTableProps {
+  readonly rows: readonly DataFileRow[];
+  readonly columns: readonly string[];
+}
+
+const cellText = (value: unknown): string =>
+  typeof value === 'object' ? JSON.stringify(value) : String(value);
+
+export const ResultsPreviewTable: FC<ResultsPreviewTableProps> = ({ rows, columns }) => {
+  const [expandedCell, setExpandedCell] = useState<TableExpandableCellState | null>(null);
+  const dataViewState = useStudioDataViewState({ defaultPageSize: RESULT_PREVIEW_ROWS });
+
+  const { pageIndex, pageSize } = dataViewState.pagination.state;
+  const pageRows = useMemo(
+    () => rows.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
+    [rows, pageIndex, pageSize]
+  );
+
+  const makeColumns = useCallback<
+    ComponentProps<typeof StudioDataView<DataFileRow>>['makeColumns']
+  >(
+    (col) =>
+      columns.map((column) =>
+        col.display({
+          id: column,
+          header: column,
+          cell: ({ row }) => {
+            const value = row.original[column];
+            return value == null ? (
+              <Text kind="body/regular/sm" color="secondary">
+                —
+              </Text>
+            ) : (
+              <TableExpandableCell
+                content={cellText(value)}
+                title={column}
+                onExpand={setExpandedCell}
+              />
+            );
+          },
+        })
+      ),
+    [columns]
+  );
+
+  return (
+    <>
+      <div className="flex flex-col min-h-[400px] max-h-[640px]">
+        <StudioDataView<DataFileRow>
+          dataViewState={dataViewState}
+          makeColumns={makeColumns}
+          maxTwoLines={false}
+          attributes={{ DataViewRoot: { data: pageRows, totalCount: rows.length } }}
+        />
+      </div>
+      <ExpandedCellModal cell={expandedCell} onClose={() => setExpandedCell(null)} />
+    </>
+  );
+};

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewTable.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/components/ResultsPreviewTable.tsx
@@ -9,57 +9,53 @@ import {
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { Text } from '@nvidia/foundations-react-core';
 import type { DataFileRow } from '@studio/components/FileRowEditor/types';
-import { ExpandedCellModal } from '@studio/routes/AnonymizerJobDetailRoute/components/ExpandedCellModal';
 import { RESULT_PREVIEW_ROWS } from '@studio/routes/AnonymizerJobDetailRoute/util';
-import { useCallback, useMemo, useState, type ComponentProps, type FC } from 'react';
+import { memo, useCallback, useMemo, type ComponentProps, type FC } from 'react';
 
 interface ResultsPreviewTableProps {
   readonly rows: readonly DataFileRow[];
   readonly columns: readonly string[];
+  readonly onExpand: (cell: TableExpandableCellState) => void;
 }
 
 const cellText = (value: unknown): string =>
   typeof value === 'object' ? JSON.stringify(value) : String(value);
 
-export const ResultsPreviewTable: FC<ResultsPreviewTableProps> = ({ rows, columns }) => {
-  const [expandedCell, setExpandedCell] = useState<TableExpandableCellState | null>(null);
-  const dataViewState = useStudioDataViewState({ defaultPageSize: RESULT_PREVIEW_ROWS });
+/** Memoized so opening the expanded-cell modal does not re-render every cell. */
+export const ResultsPreviewTable: FC<ResultsPreviewTableProps> = memo(
+  ({ rows, columns, onExpand }) => {
+    const dataViewState = useStudioDataViewState({ defaultPageSize: RESULT_PREVIEW_ROWS });
 
-  const { pageIndex, pageSize } = dataViewState.pagination.state;
-  const pageRows = useMemo(
-    () => rows.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
-    [rows, pageIndex, pageSize]
-  );
+    const { pageIndex, pageSize } = dataViewState.pagination.state;
+    const pageRows = useMemo(
+      () => rows.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
+      [rows, pageIndex, pageSize]
+    );
 
-  const makeColumns = useCallback<
-    ComponentProps<typeof StudioDataView<DataFileRow>>['makeColumns']
-  >(
-    (col) =>
-      columns.map((column) =>
-        col.display({
-          id: column,
-          header: column,
-          cell: ({ row }) => {
-            const value = row.original[column];
-            return value == null ? (
-              <Text kind="body/regular/sm" color="secondary">
-                —
-              </Text>
-            ) : (
-              <TableExpandableCell
-                content={cellText(value)}
-                title={column}
-                onExpand={setExpandedCell}
-              />
-            );
-          },
-        })
-      ),
-    [columns]
-  );
+    const makeColumns = useCallback<
+      ComponentProps<typeof StudioDataView<DataFileRow>>['makeColumns']
+    >(
+      (col) =>
+        columns.map((column) =>
+          col.display({
+            id: column,
+            header: column,
+            cell: ({ row }) => {
+              const value = row.original[column];
+              return value == null ? (
+                <Text kind="body/regular/sm" color="secondary">
+                  —
+                </Text>
+              ) : (
+                <TableExpandableCell content={cellText(value)} title={column} onExpand={onExpand} />
+              );
+            },
+          })
+        ),
+      [columns, onExpand]
+    );
 
-  return (
-    <>
+    return (
       <div className="flex flex-col min-h-[400px] max-h-[640px]">
         <StudioDataView<DataFileRow>
           dataViewState={dataViewState}
@@ -68,7 +64,8 @@ export const ResultsPreviewTable: FC<ResultsPreviewTableProps> = ({ rows, column
           attributes={{ DataViewRoot: { data: pageRows, totalCount: rows.length } }}
         />
       </div>
-      <ExpandedCellModal cell={expandedCell} onClose={() => setExpandedCell(null)} />
-    </>
-  );
-};
+    );
+  }
+);
+
+ResultsPreviewTable.displayName = 'ResultsPreviewTable';

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
@@ -1,27 +1,108 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { PageHeader, Stack, Text } from '@nvidia/foundations-react-core';
+import { LogViewer } from '@nemo/common/src/components/LogViewer';
+import {
+  useAnonymizerGetRunJob,
+  useAnonymizerGetRunJobLogs,
+  useAnonymizerListRunJobResults,
+} from '@nemo/sdk/generated/anonymizer/api';
+import { Banner, Grid, PageHeader, Panel, Stack } from '@nvidia/foundations-react-core';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
+import { AnonymizerJobActionsMenu } from '@studio/components/AnonymizerJobActionsMenu';
 import { ANONYMIZER_ENABLED } from '@studio/constants/environment';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { JobSummaryPanel } from '@studio/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel';
+import { ResultsPanel } from '@studio/routes/AnonymizerJobDetailRoute/components/ResultsPanel';
+import { ANONYMIZER_POLLING_INTERVAL_MS } from '@studio/routes/AnonymizerJobDetailRoute/util';
+import { getWorkspaceAnonymizerRoute } from '@studio/routes/utils';
+import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
+import { isJobTerminated } from '@studio/util/safeSynthesizer';
 import type { FC } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 export const AnonymizerJobDetailRoute: FC | null = ANONYMIZER_ENABLED
   ? () => {
-      const { [ROUTE_PARAMS.anonymizerJobName]: jobName } = useParams();
+      const workspace = useWorkspaceFromPath();
+      const navigate = useNavigate();
+      const { anonymizerJobName } = useRequiredPathParams([ROUTE_PARAMS.anonymizerJobName]);
+
+      const {
+        data: job,
+        isLoading: isLoadingJob,
+        error,
+      } = useAnonymizerGetRunJob(workspace, anonymizerJobName, {
+        query: {
+          refetchInterval: (query) =>
+            isJobTerminated(query.state.data?.status) ? false : ANONYMIZER_POLLING_INTERVAL_MS,
+        },
+      });
+
+      const isTerminal = isJobTerminated(job?.status);
+
+      const { data: results, isLoading: isLoadingResults } = useAnonymizerListRunJobResults(
+        workspace,
+        anonymizerJobName,
+        { query: { enabled: isTerminal } }
+      );
+
+      const { data: logs, isLoading: isLoadingLogs } = useAnonymizerGetRunJobLogs(
+        workspace,
+        anonymizerJobName,
+        undefined,
+        { query: { refetchInterval: isTerminal ? false : ANONYMIZER_POLLING_INTERVAL_MS } }
+      );
 
       useBreadcrumbs({
-        items: [{ slotLabel: 'Anonymizer' }, { slotLabel: jobName ?? 'Job' }],
+        items: [
+          { href: getWorkspaceAnonymizerRoute(workspace), slotLabel: 'Anonymizer' },
+          { slotLabel: anonymizerJobName },
+        ],
       });
 
       return (
-        <AccessibleTitle title={jobName ?? 'Anonymizer Job'}>
-          <Stack className="h-full" gap="density-2xl" padding="density-2xl">
-            <PageHeader className="p-0" slotHeading={jobName ?? 'Anonymizer Job'} />
-            <Text kind="body/regular/md">Job details coming soon.</Text>
+        <AccessibleTitle title={`Anonymizer Job - ${anonymizerJobName}`}>
+          <Stack className="h-full w-full overflow-auto" gap="density-2xl" padding="density-2xl">
+            <PageHeader
+              className="p-0"
+              slotHeading={anonymizerJobName}
+              slotActions={
+                job ? (
+                  <AnonymizerJobActionsMenu
+                    job={job}
+                    onDeleted={() => navigate(getWorkspaceAnonymizerRoute(workspace))}
+                  />
+                ) : null
+              }
+            />
+
+            {error ? (
+              <Banner kind="inline" status="error">
+                Could not load this job.
+              </Banner>
+            ) : (
+              <Stack gap="density-2xl" className="w-full min-w-0">
+                <Grid cols={{ base: 1, xl: 2 }} gap="density-2xl">
+                  {job && !isLoadingJob ? <JobSummaryPanel job={job} /> : null}
+                  <ResultsPanel
+                    workspace={workspace}
+                    jobName={anonymizerJobName}
+                    results={results?.data ?? []}
+                    isLoading={isLoadingResults}
+                    isTerminal={isTerminal}
+                  />
+                </Grid>
+                <Panel slotHeading="Logs" elevation="high" density="compact">
+                  <LogViewer
+                    logs={logs?.data ?? []}
+                    isLoading={isLoadingLogs}
+                    downloadFilename={`anonymizer-${anonymizerJobName}-logs.txt`}
+                  />
+                </Panel>
+              </Stack>
+            )}
           </Stack>
         </AccessibleTitle>
       );

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
@@ -14,8 +14,10 @@ import { ANONYMIZER_ENABLED } from '@studio/constants/environment';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { FailedRecordsPanel } from '@studio/routes/AnonymizerJobDetailRoute/components/FailedRecordsPanel';
 import { JobSummaryPanel } from '@studio/routes/AnonymizerJobDetailRoute/components/JobSummaryPanel';
 import { ResultsPanel } from '@studio/routes/AnonymizerJobDetailRoute/components/ResultsPanel';
+import { ResultsPreviewPanel } from '@studio/routes/AnonymizerJobDetailRoute/components/ResultsPreviewPanel';
 import { ANONYMIZER_POLLING_INTERVAL_MS } from '@studio/routes/AnonymizerJobDetailRoute/util';
 import { getWorkspaceAnonymizerRoute } from '@studio/routes/utils';
 import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
@@ -58,6 +60,8 @@ export const AnonymizerJobDetailRoute: FC | null = ANONYMIZER_ENABLED
         query: { refetchInterval: isTerminal ? false : ANONYMIZER_POLLING_INTERVAL_MS },
       });
 
+      const artifactUrl = results?.data?.[0]?.artifact_url;
+
       useBreadcrumbs({
         items: [
           { href: getWorkspaceAnonymizerRoute(workspace), slotLabel: 'Anonymizer' },
@@ -98,6 +102,13 @@ export const AnonymizerJobDetailRoute: FC | null = ANONYMIZER_ENABLED
                     loadError={!!resultsError}
                   />
                 </Grid>
+                {isTerminal && artifactUrl ? (
+                  <>
+                    <ResultsPreviewPanel workspace={workspace} artifactUrl={artifactUrl} />
+                    <FailedRecordsPanel workspace={workspace} artifactUrl={artifactUrl} />
+                  </>
+                ) : null}
+
                 <Panel slotHeading="Logs" elevation="high" density="compact">
                   {logsError ? (
                     <Banner kind="inline" status="error">

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/index.tsx
@@ -42,18 +42,21 @@ export const AnonymizerJobDetailRoute: FC | null = ANONYMIZER_ENABLED
 
       const isTerminal = isJobTerminated(job?.status);
 
-      const { data: results, isLoading: isLoadingResults } = useAnonymizerListRunJobResults(
-        workspace,
-        anonymizerJobName,
-        { query: { enabled: isTerminal } }
-      );
+      const {
+        data: results,
+        isLoading: isLoadingResults,
+        error: resultsError,
+      } = useAnonymizerListRunJobResults(workspace, anonymizerJobName, {
+        query: { enabled: isTerminal },
+      });
 
-      const { data: logs, isLoading: isLoadingLogs } = useAnonymizerGetRunJobLogs(
-        workspace,
-        anonymizerJobName,
-        undefined,
-        { query: { refetchInterval: isTerminal ? false : ANONYMIZER_POLLING_INTERVAL_MS } }
-      );
+      const {
+        data: logs,
+        isLoading: isLoadingLogs,
+        error: logsError,
+      } = useAnonymizerGetRunJobLogs(workspace, anonymizerJobName, undefined, {
+        query: { refetchInterval: isTerminal ? false : ANONYMIZER_POLLING_INTERVAL_MS },
+      });
 
       useBreadcrumbs({
         items: [
@@ -92,14 +95,21 @@ export const AnonymizerJobDetailRoute: FC | null = ANONYMIZER_ENABLED
                     results={results?.data ?? []}
                     isLoading={isLoadingResults}
                     isTerminal={isTerminal}
+                    loadError={!!resultsError}
                   />
                 </Grid>
                 <Panel slotHeading="Logs" elevation="high" density="compact">
-                  <LogViewer
-                    logs={logs?.data ?? []}
-                    isLoading={isLoadingLogs}
-                    downloadFilename={`anonymizer-${anonymizerJobName}-logs.txt`}
-                  />
+                  {logsError ? (
+                    <Banner kind="inline" status="error">
+                      Could not load logs for this job.
+                    </Banner>
+                  ) : (
+                    <LogViewer
+                      logs={logs?.data ?? []}
+                      isLoading={isLoadingLogs}
+                      downloadFilename={`anonymizer-${anonymizerJobName}-logs.txt`}
+                    />
+                  )}
                 </Panel>
               </Stack>
             )}

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/useResultPreview.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/useResultPreview.ts
@@ -19,7 +19,6 @@ export interface ResultPreview {
   readonly error: Error | null;
 }
 
-/** Reads the first {@link RESULT_PREVIEW_ROWS} rows of a finished job's result fileset. */
 export const useResultPreview = (
   workspace: string,
   artifactUrl: string | undefined
@@ -48,7 +47,6 @@ export const useResultPreview = (
 
   const rows = useMemo<DataFileRow[]>(() => {
     if (!dataset) return [];
-    // parseDataFile throws on a malformed line; no route error boundary is wired.
     try {
       return parseDataFile(dataset, 'jsonl');
     } catch {

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/useResultPreview.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/useResultPreview.ts
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useDatasetFileContent } from '@studio/api/datasets/useDatasetFileContent';
+import { parseDataFile } from '@studio/components/FileRowEditor/parse';
+import type { DataFileRow } from '@studio/components/FileRowEditor/types';
+import {
+  metadataTextColumn,
+  orderResultColumns,
+  parseArtifactUrl,
+  RESULT_PREVIEW_ROWS,
+} from '@studio/routes/AnonymizerJobDetailRoute/util';
+import { useMemo } from 'react';
+
+export interface ResultPreview {
+  readonly rows: DataFileRow[];
+  readonly columns: string[];
+  readonly isLoading: boolean;
+  readonly error: Error | null;
+}
+
+/** Reads the first {@link RESULT_PREVIEW_ROWS} rows of a finished job's result fileset. */
+export const useResultPreview = (
+  workspace: string,
+  artifactUrl: string | undefined
+): ResultPreview => {
+  const location = parseArtifactUrl(artifactUrl);
+  const enabled = !!location;
+
+  const { data: metadata } = useDatasetFileContent({
+    workspace,
+    name: location?.fileset ?? '',
+    path: `${location?.basePath}/metadata.json`,
+    enabled,
+  });
+
+  const {
+    data: dataset,
+    isLoading,
+    error,
+  } = useDatasetFileContent({
+    workspace,
+    name: location?.fileset ?? '',
+    path: `${location?.basePath}/dataset.parquet`,
+    range: [0, RESULT_PREVIEW_ROWS],
+    enabled,
+  });
+
+  const rows = useMemo<DataFileRow[]>(() => {
+    if (!dataset) return [];
+    // parseDataFile throws on a malformed line; no route error boundary is wired.
+    try {
+      return parseDataFile(dataset, 'jsonl');
+    } catch {
+      return [];
+    }
+  }, [dataset]);
+
+  const columns = useMemo(
+    () =>
+      rows.length ? orderResultColumns(Object.keys(rows[0]), metadataTextColumn(metadata)) : [],
+    [rows, metadata]
+  );
+
+  return { rows, columns, isLoading, error };
+};

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.test.ts
@@ -5,9 +5,9 @@ import type { RunJob } from '@nemo/sdk/generated/anonymizer/schema';
 import {
   jobSource,
   jobStrategy,
+  metadataTextColumn,
   orderResultColumns,
   parseArtifactUrl,
-  parseJsonLines,
 } from '@studio/routes/AnonymizerJobDetailRoute/util';
 
 const job = (config: unknown, source?: string): RunJob =>
@@ -50,11 +50,12 @@ describe('parseArtifactUrl', () => {
   });
 });
 
-describe('parseJsonLines', () => {
-  it('reads one object per line and skips unparseable ones', () => {
-    expect(parseJsonLines<{ a: number }>('{"a":1}\n{"a":2}\n')).toEqual([{ a: 1 }, { a: 2 }]);
-    expect(parseJsonLines('{"a":1}\nnot json\n')).toEqual([{ a: 1 }]);
-    expect(parseJsonLines(undefined)).toEqual([]);
+describe('metadataTextColumn', () => {
+  it('reads the source column and tolerates missing or malformed metadata', () => {
+    expect(metadataTextColumn('{"original_text_column":"biography"}')).toBe('biography');
+    expect(metadataTextColumn('{}')).toBeUndefined();
+    expect(metadataTextColumn(undefined)).toBeUndefined();
+    expect(metadataTextColumn('not json')).toBeUndefined();
   });
 });
 

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.test.ts
@@ -2,7 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { RunJob } from '@nemo/sdk/generated/anonymizer/schema';
-import { jobSource, jobStrategy } from '@studio/routes/AnonymizerJobDetailRoute/util';
+import {
+  jobSource,
+  jobStrategy,
+  orderResultColumns,
+  parseArtifactUrl,
+  parseJsonLines,
+} from '@studio/routes/AnonymizerJobDetailRoute/util';
 
 const job = (config: unknown, source?: string): RunJob =>
   ({ name: 'job-1', spec: { request: { config, data: { source } } } }) as RunJob;
@@ -26,5 +32,50 @@ describe('jobSource', () => {
   it('reads the data source, and tolerates a missing spec', () => {
     expect(jobSource(job({ replace: { kind: 'hash' } }, 's3://x.csv'))).toBe('s3://x.csv');
     expect(jobSource({ name: 'job-1' } as RunJob)).toBeUndefined();
+  });
+});
+
+describe('parseArtifactUrl', () => {
+  it('splits the fileset reference from the path', () => {
+    expect(parseArtifactUrl('default/job-fileset-deer#results/attempt-1/artifacts')).toEqual({
+      fileset: 'job-fileset-deer',
+      basePath: 'results/attempt-1/artifacts',
+    });
+  });
+
+  it('is undefined without both halves', () => {
+    expect(parseArtifactUrl(undefined)).toBeUndefined();
+    expect(parseArtifactUrl('default/job-fileset-deer')).toBeUndefined();
+    expect(parseArtifactUrl('#results/artifacts')).toBeUndefined();
+  });
+});
+
+describe('parseJsonLines', () => {
+  it('reads one object per line and skips unparseable ones', () => {
+    expect(parseJsonLines<{ a: number }>('{"a":1}\n{"a":2}\n')).toEqual([{ a: 1 }, { a: 2 }]);
+    expect(parseJsonLines('{"a":1}\nnot json\n')).toEqual([{ a: 1 }]);
+    expect(parseJsonLines(undefined)).toEqual([]);
+  });
+});
+
+describe('orderResultColumns', () => {
+  it('puts the rewrite output next to its source column', () => {
+    expect(
+      orderResultColumns(['biography', 'biography_rewritten', 'utility_score'], 'biography')
+    ).toEqual(['biography', 'biography_rewritten', 'utility_score']);
+  });
+
+  it('prefers the replaced column over other same-prefix columns', () => {
+    expect(
+      orderResultColumns(
+        ['biography', 'biography_with_spans', 'final_entities', 'biography_replaced'],
+        'biography'
+      )
+    ).toEqual(['biography', 'biography_replaced', 'biography_with_spans', 'final_entities']);
+  });
+
+  it('leaves the order alone when the text column is unknown or absent', () => {
+    expect(orderResultColumns(['a', 'b'], undefined)).toEqual(['a', 'b']);
+    expect(orderResultColumns(['a', 'b'], 'missing')).toEqual(['a', 'b']);
   });
 });

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.test.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { RunJob } from '@nemo/sdk/generated/anonymizer/schema';
+import { jobSource, jobStrategy } from '@studio/routes/AnonymizerJobDetailRoute/util';
+
+const job = (config: unknown, source?: string): RunJob =>
+  ({ name: 'job-1', spec: { request: { config, data: { source } } } }) as RunJob;
+
+describe('jobStrategy', () => {
+  it('reads the replace kind', () => {
+    expect(jobStrategy(job({ replace: { kind: 'hash' } }))).toBe('hash');
+  });
+
+  it('reports rewrite jobs', () => {
+    expect(jobStrategy(job({ rewrite: { risk_tolerance: 'low' } }))).toBe('rewrite');
+  });
+
+  it('is undefined when the spec carries no config', () => {
+    expect(jobStrategy({ name: 'job-1' } as RunJob)).toBeUndefined();
+    expect(jobStrategy(job({}))).toBeUndefined();
+  });
+});
+
+describe('jobSource', () => {
+  it('reads the data source, and tolerates a missing spec', () => {
+    expect(jobSource(job({ replace: { kind: 'hash' } }, 's3://x.csv'))).toBe('s3://x.csv');
+    expect(jobSource({ name: 'job-1' } as RunJob)).toBeUndefined();
+  });
+});

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.test.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.test.ts
@@ -57,6 +57,14 @@ describe('metadataTextColumn', () => {
     expect(metadataTextColumn(undefined)).toBeUndefined();
     expect(metadataTextColumn('not json')).toBeUndefined();
   });
+
+  it('ignores a non-string column and non-object metadata', () => {
+    expect(metadataTextColumn('{"original_text_column":42}')).toBeUndefined();
+    expect(metadataTextColumn('{"original_text_column":null}')).toBeUndefined();
+    expect(metadataTextColumn('{"original_text_column":["biography"]}')).toBeUndefined();
+    expect(metadataTextColumn('null')).toBeUndefined();
+    expect(metadataTextColumn('7')).toBeUndefined();
+  });
 });
 
 describe('orderResultColumns', () => {

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
@@ -29,7 +29,6 @@ export const parseArtifactUrl = (artifactUrl: string | undefined): ArtifactLocat
   return fileset ? { fileset, basePath } : undefined;
 };
 
-/** `metadata.json` records the source column the run anonymized. */
 export const metadataTextColumn = (metadata: string | undefined): string | undefined => {
   try {
     return (JSON.parse(metadata ?? '{}') as { original_text_column?: string }).original_text_column;
@@ -41,10 +40,6 @@ export const metadataTextColumn = (metadata: string | undefined): string | undef
 /** Rewrite writes `<column>_rewritten`; the replace strategies write `<column>_replaced`. */
 const OUTPUT_SUFFIXES = ['_rewritten', '_replaced'];
 
-/**
- * Source column first, then its anonymized counterpart, then whatever else the run produced.
- * Matching the suffix exactly matters — replace runs also emit `<column>_with_spans`.
- */
 export const orderResultColumns = (columns: string[], textColumn: string | undefined): string[] => {
   if (!textColumn || !columns.includes(textColumn)) return columns;
   const output = OUTPUT_SUFFIXES.map((suffix) => `${textColumn}${suffix}`).find((column) =>

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { RunJob } from '@nemo/sdk/generated/anonymizer/schema';
+
+export const ANONYMIZER_POLLING_INTERVAL_MS = 5000;
+
+export const jobStrategy = (job: RunJob): string | undefined => {
+  const config = job.spec?.request?.config;
+  if (!config) return undefined;
+  if (config.rewrite) return 'rewrite';
+  return (config.replace as { kind?: string } | undefined)?.kind;
+};
+
+export const jobSource = (job: RunJob): string | undefined => job.spec?.request?.data?.source;

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
@@ -31,7 +31,9 @@ export const parseArtifactUrl = (artifactUrl: string | undefined): ArtifactLocat
 
 export const metadataTextColumn = (metadata: string | undefined): string | undefined => {
   try {
-    return (JSON.parse(metadata ?? '{}') as { original_text_column?: string }).original_text_column;
+    const parsed: unknown = JSON.parse(metadata ?? '{}');
+    const column = (parsed as { original_text_column?: unknown })?.original_text_column;
+    return typeof column === 'string' ? column : undefined;
   } catch {
     return undefined;
   }

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
@@ -29,17 +29,14 @@ export const parseArtifactUrl = (artifactUrl: string | undefined): ArtifactLocat
   return fileset ? { fileset, basePath } : undefined;
 };
 
-export const parseJsonLines = <T>(content: string | undefined): T[] =>
-  (content ?? '')
-    .split('\n')
-    .filter(Boolean)
-    .flatMap((line) => {
-      try {
-        return [JSON.parse(line) as T];
-      } catch {
-        return [];
-      }
-    });
+/** `metadata.json` records the source column the run anonymized. */
+export const metadataTextColumn = (metadata: string | undefined): string | undefined => {
+  try {
+    return (JSON.parse(metadata ?? '{}') as { original_text_column?: string }).original_text_column;
+  } catch {
+    return undefined;
+  }
+};
 
 /** Rewrite writes `<column>_rewritten`; the replace strategies write `<column>_replaced`. */
 const OUTPUT_SUFFIXES = ['_rewritten', '_replaced'];

--- a/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
+++ b/web/packages/studio/src/routes/AnonymizerJobDetailRoute/util.ts
@@ -13,3 +13,46 @@ export const jobStrategy = (job: RunJob): string | undefined => {
 };
 
 export const jobSource = (job: RunJob): string | undefined => job.spec?.request?.data?.source;
+
+export const RESULT_PREVIEW_ROWS = 20;
+
+export interface ArtifactLocation {
+  readonly fileset: string;
+  readonly basePath: string;
+}
+
+/** `default/job-fileset-x#results/attempt-1/artifacts` → fileset `job-fileset-x`, path `results/…`. */
+export const parseArtifactUrl = (artifactUrl: string | undefined): ArtifactLocation | undefined => {
+  const [reference, basePath] = artifactUrl?.split('#') ?? [];
+  if (!reference || !basePath) return undefined;
+  const fileset = reference.split('/').pop();
+  return fileset ? { fileset, basePath } : undefined;
+};
+
+export const parseJsonLines = <T>(content: string | undefined): T[] =>
+  (content ?? '')
+    .split('\n')
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as T];
+      } catch {
+        return [];
+      }
+    });
+
+/** Rewrite writes `<column>_rewritten`; the replace strategies write `<column>_replaced`. */
+const OUTPUT_SUFFIXES = ['_rewritten', '_replaced'];
+
+/**
+ * Source column first, then its anonymized counterpart, then whatever else the run produced.
+ * Matching the suffix exactly matters — replace runs also emit `<column>_with_spans`.
+ */
+export const orderResultColumns = (columns: string[], textColumn: string | undefined): string[] => {
+  if (!textColumn || !columns.includes(textColumn)) return columns;
+  const output = OUTPUT_SUFFIXES.map((suffix) => `${textColumn}${suffix}`).find((column) =>
+    columns.includes(column)
+  );
+  const lead = output ? [textColumn, output] : [textColumn];
+  return [...lead, ...columns.filter((column) => !lead.includes(column))];
+};


### PR DESCRIPTION
Closes [ASTD-330](https://linear.app/nvidia/issue/ASTD-330/studio-anonymizer-job-detail-page).

Replaces the "Job details coming soon." placeholder at `/anonymizer/:anonymizerJobName`, so list rows and the post-create redirect finally land somewhere real.

## What's here

- **Job Details** — status badge, strategy, source, created-by, created/updated, plus an error banner when the job carries `error_details`
- **Results** — lists artifacts with per-file download; distinguishes "produced no results" from "results appear once the job finishes"
- **Preview** — a `StudioDataView` of the first 20 output records, with long cells expandable into a modal, so you can eyeball what the job produced without downloading a tarball
- **Failed Records** — records dropped mid-pipeline, with the step and reason; hidden entirely when there are none
- **Logs** — `LogViewer` with download, same component Safe Synthesizer uses
- **Actions** — reuses the existing `AnonymizerJobActionsMenu` (cancel/delete); deleting returns to the list
- **Polling** — job and logs poll every 5s while the job is live and stop at terminal status; results are only fetched once terminal, since none exist before

## Notable

**The stored job shape is not the one you submit.** `RunJobRequest.spec` is an `AnonymizerRequest`, but `RunJob.spec` is an `AnonymizerStepConfig` that wraps it — so the strategy and source live at `job.spec.request.config` / `.data.source`, not `job.spec.config`. Easy to get wrong from the ticket alone; `jobStrategy` / `jobSource` isolate it and are unit-tested, including the missing-spec case.

**Results are a fileset, not an opaque tarball.** `PlatformJobResultResponse.artifact_url` looks like `default/job-fileset-deer#results/attempt-1/artifacts`, and every file under that path is individually addressable through the existing datasets API. That's what makes Preview and Failed Records possible with no new dependency and no new endpoint — `dataset.parquet` is read with a `[0, 20]` row range, and `metadata.json` / `failed_records.json` are read whole.

**`failed_records.json` has to bypass the preview cap.** It is a pretty-printed JSON array, so the 512 KB size-capped preview would truncate it mid-array; `JSON.parse` then throws into a `catch`, the record list comes back empty, and the panel hides itself — indistinguishable from a job with no failures. It is read with `fullContent` instead, which raises the ceiling to 8 MB. JSONL survives that truncation, which is why nothing else here needed the same treatment.

**Column ordering is strategy-aware.** Rewrite writes `<column>_rewritten`, the replace strategies write `<column>_replaced`. `orderResultColumns` pins the source column and its output side by side and leaves everything else alone. It matches the suffix exactly rather than by prefix, so a `biography_with_spans` column is not mistaken for the output of `biography` — there's a test pinning that.

**Parsing and the table are existing components, not new ones.** Per review, JSONL parsing goes through `parseDataFile(…, 'jsonl')` rather than a local helper, and the table is `StudioDataView` rather than a hand-rolled `TableRoot`, modelled on `AgentEvalTaskResultsPanel`. `parseDataFile` throws per line where the local helper swallowed, so the call is wrapped — no route error boundary is wired and a malformed line would otherwise throw during render. The panel is split accordingly: `useResultPreview` owns the fetches and parsing, `ResultsPreviewTable` owns the DataView, `ExpandedCellModal` owns the modal. The table is memoized so opening the modal doesn't re-render all 140 cells of a full page.

**The builder's live preview is still ASTD-332.** That panel streams unsaved records from `/preview` while you edit a config; this one reads a finished job's artifacts. Different data path, different component.

## Testing

Unit tests on the spec-reading and artifact-parsing helpers, typecheck, eslint, prettier clean.

Verified against **real jobs on a live platform**, not mocks — the workspace has jobs in every terminal state, and the two failure states were produced by intercepting the API and forcing a 500:

| Job | State | Result |
| --- | --- | --- |
| `ytterbic-aquamarine-deer` | completed (rewrite) | Completed badge, artifacts + Download, preview columns `biography` / `biography_rewritten` / `utility_score`, 3 failed records, 30 log lines |
| `obvious-apricot-crow` | completed (hash) | preview columns `biography` / `biography_replaced` / `biography_with_spans` — confirms the suffix match picks the right output column |
| `minor-black-lark` | error | Error badge, "Job exited with code 1", "This job produced no results.", traceback in logs, no preview |
| `lively-maroon-leopon` | cancelled | Cancelled badge, no results, no preview, logs render |
| `…deer` + forced 500 on `/results` | — | results error banner, page otherwise intact |
| `…deer` + forced 500 on `/logs` | — | logs error banner, preview and results still render |

No console errors in any of the six runs. Download was exercised end-to-end through the UI: clicking Download fetched **`artifacts.tar`, 457 KB**. The expandable cells were exercised too — 140 expand affordances on a full page (20 rows × 7 columns), clicking one opens a modal headed with the column name and the full untruncated value, and Close dismisses it.

Two bugs the real data caught, both fixed here:

- Fileset sources are long enough that `default/anonymizer-sample#NVIDIA_synthetic_biographies.csv` overlapped the neighbouring column in the two-up grid, so Source now gets its own full-width row.
- `triggerDownload` re-wrapped an existing `Blob`, dropping its MIME type — the browser then named the tarball `artifacts.txt`. Fixed in the shared helper, with a test.

## Screenshots

<img width="2880" height="2400" alt="01-completed-rewrite" src="https://github.com/user-attachments/assets/cfa98898-adcf-4f8a-a12a-81fe632d38e4" />
<img width="2880" height="2400" alt="02-completed-replace" src="https://github.com/user-attachments/assets/d8bdb053-984e-4153-aa4c-8fa4b1974976" />
<img width="2880" height="2400" alt="03-error" src="https://github.com/user-attachments/assets/caadac3d-2dd8-464f-9a9c-af871c6d1a2f" />
<img width="2880" height="2400" alt="04-cancelled" src="https://github.com/user-attachments/assets/ac5320e2-3c95-41fc-84a0-e6eed8fc8122" />
<img width="2880" height="2400" alt="05-results-unavailable" src="https://github.com/user-attachments/assets/7d0c4f75-de2f-43c4-9e12-47106d7de955" />
<img width="2880" height="2400" alt="06-logs-unavailable" src="https://github.com/user-attachments/assets/3c8a6728-8dec-4845-bee1-93290c9eecda" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a functional Anonymizer Job Details page with a job summary, results display, results preview, and logs.
  * Added a failed records panel and an expanded-cell preview modal for result values.
  * Added inline error messaging for job, results, and logs loading states, including a clearer results-load failure banner.
* **Bug Fixes**
  * Improved file downloads by preserving existing `Blob` MIME types.
* **Tests**
  * Added unit tests covering anonymizer utility parsing/ordering and `Blob` type preservation during downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

