### PR TITLE
ci: cache the pinned OPA binary and retry its download

### DIFF
--- a/.github/actions/build-policy-wasm/action.yaml
+++ b/.github/actions/build-policy-wasm/action.yaml
@@ -8,6 +8,33 @@ description: >
 runs:
   using: composite
   steps:
+    # build_policy_wasm.sh already prefers a cached binary at .cache/opa/<version>/ before reaching
+    # out to openpolicyagent.org, but nothing ever populated that directory in CI, so every run
+    # depended on that download — and it has repeatedly failed, taking a required job down with it.
+    # Restoring the cache means the fetch is only needed the first time a pinned version is seen.
+    - name: Resolve pinned OPA version
+      id: opa
+      shell: bash
+      env:
+        REPO_ROOT: ${{ github.action_path }}/../../..
+      run: |
+        # Parse rather than source: the script builds the WASM on execution, so sourcing it here
+        # would do the work twice (and before the cache is restored).
+        version="$(sed -n 's/^OPA_VERSION="\${OPA_VERSION:-\([^}]*\)}"/\1/p' "${REPO_ROOT}/script/build_policy_wasm.sh" | head -1)"
+        if [ -z "${version}" ]; then
+          echo "Could not parse the pinned OPA version from script/build_policy_wasm.sh" >&2
+          echo "If the OPA_VERSION line moved, update this step — a wrong cache key silently disables caching." >&2
+          exit 1
+        fi
+        echo "version=${version}" >> "${GITHUB_OUTPUT}"
+        echo "Pinned OPA version: ${version}"
+
+    - name: Cache the pinned OPA binary
+      uses: actions/cache@v4
+      with:
+        path: .cache/opa
+        key: opa-${{ runner.os }}-${{ runner.arch }}-${{ steps.opa.outputs.version }}
+
     - name: Build policy WASM
       shell: bash
       env:

--- a/script/build_policy_wasm.sh
+++ b/script/build_policy_wasm.sh
@@ -112,12 +112,16 @@ download_opa() {
   url="${OPA_DOWNLOAD_BASE_URL}/${OPA_VERSION}/${asset}"
   sha_url="${url}.sha256"
   echo "Downloading OPA ${OPA_VERSION} from ${url}..." >&2
-  if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "${url}" -o "${tmp_bin}"; then
+  # Bound each attempt: without --max-time a stalled connection consumes the whole job and the
+  # retries never get a turn. 120s is ~25x headroom for a ~23 MB binary on a CI runner.
+  if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+      --connect-timeout 15 --max-time 120 "${url}" -o "${tmp_bin}"; then
     echo "Failed to download OPA binary from ${url}." >&2
     print_opa_help "${asset}"
     exit 1
   fi
-  if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "${sha_url}" -o "${tmp_sha}"; then
+  if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
+      --connect-timeout 15 --max-time 60 "${sha_url}" -o "${tmp_sha}"; then
     echo "Failed to download OPA checksum from ${sha_url}." >&2
     print_opa_help "${asset}"
     exit 1

--- a/script/build_policy_wasm.sh
+++ b/script/build_policy_wasm.sh
@@ -112,16 +112,20 @@ download_opa() {
   url="${OPA_DOWNLOAD_BASE_URL}/${OPA_VERSION}/${asset}"
   sha_url="${url}.sha256"
   echo "Downloading OPA ${OPA_VERSION} from ${url}..." >&2
-  # Bound each attempt: without --max-time a stalled connection consumes the whole job and the
-  # retries never get a turn. 120s is ~25x headroom for a ~23 MB binary on a CI runner.
+  # Bound both a single attempt (--max-time) and the whole retry window (--retry-max-time).
+  # --max-time RESETS on each retry, so without --retry-max-time the aggregate is unbounded: 4
+  # attempts could run for minutes. That matters because callers impose their own ceiling —
+  # embedded_pdp/policy_wasm.py runs this script with DEFAULT_BUILD_TIMEOUT_SECONDS=120 — and would
+  # kill the build mid-retry. Budget: <=45s aggregate + <=30s final attempt here, <=15s + <=10s for
+  # the checksum, leaving headroom for the `opa build` itself inside 120s.
   if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
-      --connect-timeout 15 --max-time 120 "${url}" -o "${tmp_bin}"; then
+      --connect-timeout 10 --max-time 30 --retry-max-time 45 "${url}" -o "${tmp_bin}"; then
     echo "Failed to download OPA binary from ${url}." >&2
     print_opa_help "${asset}"
     exit 1
   fi
   if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors \
-      --connect-timeout 15 --max-time 60 "${sha_url}" -o "${tmp_sha}"; then
+      --connect-timeout 10 --max-time 10 --retry-max-time 15 "${sha_url}" -o "${tmp_sha}"; then
     echo "Failed to download OPA checksum from ${sha_url}." >&2
     print_opa_help "${asset}"
     exit 1

--- a/script/build_policy_wasm.sh
+++ b/script/build_policy_wasm.sh
@@ -112,12 +112,12 @@ download_opa() {
   url="${OPA_DOWNLOAD_BASE_URL}/${OPA_VERSION}/${asset}"
   sha_url="${url}.sha256"
   echo "Downloading OPA ${OPA_VERSION} from ${url}..." >&2
-  if ! curl -fsSL "${url}" -o "${tmp_bin}"; then
+  if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "${url}" -o "${tmp_bin}"; then
     echo "Failed to download OPA binary from ${url}." >&2
     print_opa_help "${asset}"
     exit 1
   fi
-  if ! curl -fsSL "${sha_url}" -o "${tmp_sha}"; then
+  if ! curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors "${sha_url}" -o "${tmp_sha}"; then
     echo "Failed to download OPA checksum from ${sha_url}." >&2
     print_opa_help "${asset}"
     exit 1


### PR DESCRIPTION
## Summary

`Build OPA policy WASM` is a **required** job, and it has been failing on an unretried download from `openpolicyagent.org` — twice in three attempts on a single PR (#844), each time also taking down `Python e2e tests`, which needs its artifact:

```
Downloading OPA v1.8.0 from https://openpolicyagent.org/downloads/v1.8.0/opa_linux_amd64_static...
Failed to download OPA binary from ...
Unable to prepare OPA v1.8.0.
```

Two independent gaps, both one-liners.

## 1. The cache existed but CI never used it

`script/build_policy_wasm.sh` already prefers a cached binary at `.cache/opa/<version>/` before downloading — but nothing in CI ever populated that directory, so **every run depended on the network**. The composite action now restores and saves it, keyed on the pinned version, so the download is only needed the first time a given version is seen.

The version is parsed out of the script rather than duplicated, so the cache key cannot drift from the pin. It parses rather than sources, because executing the script would build the WASM a second time — and before the cache is restored.

## 2. The download had no retry

Both `curl` calls now use `--retry 3 --retry-delay 2 --retry-all-errors`. `--retry-all-errors` is the important part: the observed failures were connection-level, which plain `--retry` does not cover.

## Verification

- **Cold cache** — downloads and populates `.cache/opa/v1.8.0/opa_darwin_arm64_static`
- **Warm cache** — second run builds `policy.wasm` with **no download at all**
- **Retry flags** — checked against an unreachable endpoint: 4 attempts (initial + 3) with backoff between
- Regenerating `policy.wasm` leaves the tree clean, so output stays reproducible

## Scope

Deliberately standalone rather than folded into #844, where I hit this — it is CI infrastructure unrelated to that change, and it benefits every PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of OPA downloads by retrying transient network failures and enforcing connect/overall time limits for both the binary and its checksum.

* **Chores**
  * Added CI caching for the pinned OPA binary to reduce repeated downloads and speed up policy WASM builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->