### PR TITLE
feat(auth): enforce cross-workspace export permissions

### DIFF
--- a/docs/auth/authorization/permissions-reference.mdx
+++ b/docs/auth/authorization/permissions-reference.mdx
@@ -16,106 +16,123 @@ PlatformAdmin is omitted — it bypasses permission checks entirely at the polic
 </Note>
 ## Entities API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>entities.(read &#124; create &#124; update &#124; delete)</code> | Read, create, update, delete entities |  |  |  |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| `entities.export` | Reference entities from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| <code>entities.(read &#124; create &#124; update &#124; delete)</code> | Read, create, update, delete entities |  |  |  |  |  |
 
 ## Files API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>filesets.(read &#124; list)</code> | Read, list files | ✓ | ✓ | ✓ |  |
-| <code>filesets.(create &#124; update &#124; delete)</code> | Create, update, delete files |  | ✓ | ✓ |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| <code>filesets.(read &#124; list)</code> | Read, list files | ✓ | ✓ | ✓ | ✓ |  |
+| <code>filesets.(create &#124; update &#124; delete)</code> | Create, update, delete files |  | ✓ |  | ✓ |  |
+| `filesets.export` | Reference filesets from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
 
 ## Guardrails API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| `guardrails.checks.exec` | Execute guardrail checks |  | ✓ | ✓ |  |
-| <code>guardrails.configs.(read &#124; list)</code> | Read, list guardrails configs | ✓ | ✓ | ✓ |  |
-| <code>guardrails.configs.(create &#124; update &#124; delete)</code> | Create, update, delete guardrails configs |  | ✓ | ✓ |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| `guardrails.checks.exec` | Execute guardrail checks |  | ✓ |  | ✓ |  |
+| <code>guardrails.configs.(read &#124; list)</code> | Read, list guardrails configs | ✓ | ✓ | ✓ | ✓ |  |
+| <code>guardrails.configs.(create &#124; update &#124; delete)</code> | Create, update, delete guardrails configs |  | ✓ |  | ✓ |  |
+| `guardrails.configs.export` | Reference guardrail configurations from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
 
 ## IAM API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>iam.(read &#124; list &#124; create &#124; delete)</code> | Read, list, create, delete iam |  |  | ✓ |  |
-| `iam.bundle.read` | Download OPA authorization bundle (external OPA / advanced ops) |  |  |  |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| <code>iam.(read &#124; list &#124; create &#124; delete)</code> | Read, list, create, delete iam |  |  |  | ✓ |  |
+| `iam.bundle.read` | Download OPA authorization bundle (external OPA / advanced ops) |  |  |  |  |  |
 
 ## Inference API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>inference.deployment-configs.(read &#124; list)</code> | Read, list inference deployment-configs | ✓ | ✓ | ✓ |  |
-| <code>inference.deployment-configs.(create &#124; delete)</code> | Create, delete inference deployment-configs |  | ✓ | ✓ |  |
-| <code>inference.deployments.(read &#124; list)</code> | Read, list inference deployments | ✓ | ✓ | ✓ |  |
-| <code>inference.deployments.(create &#124; update &#124; delete)</code> | Create, update, delete inference deployments |  | ✓ | ✓ |  |
-| `inference.gateway.model.exec` | Execute model gateway inference | ✓ | ✓ | ✓ |  |
-| `inference.gateway.openai.exec` | Execute OpenAI-compatible gateway inference | ✓ | ✓ | ✓ |  |
-| `inference.gateway.provider.exec` | Execute provider gateway inference | ✓ | ✓ | ✓ |  |
-| <code>inference.providers.(read &#124; list)</code> | Read, list inference providers | ✓ | ✓ | ✓ |  |
-| <code>inference.providers.(create &#124; update &#124; delete)</code> | Create, update, delete inference providers |  | ✓ | ✓ |  |
-| <code>inference.virtual-models.(read &#124; list)</code> | Read, list inference virtual-models | ✓ | ✓ | ✓ |  |
-| <code>inference.virtual-models.(create &#124; update &#124; delete)</code> | Create, update, delete inference virtual-models |  | ✓ | ✓ |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| <code>inference.deployment-configs.(read &#124; list)</code> | Read, list inference deployment-configs | ✓ | ✓ | ✓ | ✓ |  |
+| <code>inference.deployment-configs.(create &#124; delete)</code> | Create, delete inference deployment-configs |  | ✓ |  | ✓ |  |
+| `inference.deployment-configs.export` | Reference inference deployment configurations from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| <code>inference.deployments.(read &#124; list)</code> | Read, list inference deployments | ✓ | ✓ | ✓ | ✓ |  |
+| <code>inference.deployments.(create &#124; update &#124; delete)</code> | Create, update, delete inference deployments |  | ✓ |  | ✓ |  |
+| `inference.deployments.export` | Reference inference deployments from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| `inference.gateway.model.exec` | Execute model gateway inference | ✓ | ✓ | ✓ | ✓ |  |
+| `inference.gateway.openai.exec` | Execute OpenAI-compatible gateway inference | ✓ | ✓ | ✓ | ✓ |  |
+| `inference.gateway.provider.exec` | Execute provider gateway inference | ✓ | ✓ | ✓ | ✓ |  |
+| <code>inference.providers.(read &#124; list)</code> | Read, list inference providers | ✓ | ✓ | ✓ | ✓ |  |
+| <code>inference.providers.(create &#124; update &#124; delete)</code> | Create, update, delete inference providers |  | ✓ |  | ✓ |  |
+| `inference.providers.export` | Reference inference providers from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| <code>inference.virtual-models.(read &#124; list)</code> | Read, list inference virtual-models | ✓ | ✓ | ✓ | ✓ |  |
+| <code>inference.virtual-models.(create &#124; update &#124; delete)</code> | Create, update, delete inference virtual-models |  | ✓ |  | ✓ |  |
+| `inference.virtual-models.export` | Reference virtual models from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
 
 ## Jobs API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>jobs.(read &#124; list)</code> | Read, list jobs | ✓ | ✓ | ✓ |  |
-| <code>jobs.(create &#124; update &#124; delete &#124; cancel)</code> | Create, update, delete, cancel jobs |  | ✓ | ✓ |  |
-| `jobs.logs.create` | Upload job logs |  |  |  | ✓ |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| <code>jobs.(read &#124; list)</code> | Read, list jobs | ✓ | ✓ | ✓ | ✓ |  |
+| <code>jobs.(create &#124; update &#124; delete &#124; cancel)</code> | Create, update, delete, cancel jobs |  | ✓ |  | ✓ |  |
+| `jobs.export` | Reference jobs from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| `jobs.logs.create` | Upload job logs |  |  |  |  | ✓ |
 
 ## Models API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>models.(read &#124; list)</code> | Read, list models | ✓ | ✓ | ✓ |  |
-| <code>models.(create &#124; update &#124; delete)</code> | Create, update, delete models |  | ✓ | ✓ |  |
-| <code>models.adapters.(read &#124; list)</code> | Read, list models adapters | ✓ | ✓ | ✓ |  |
-| <code>models.adapters.(create &#124; update &#124; delete)</code> | Create, update, delete models adapters |  | ✓ | ✓ |  |
-| `models.prompts.read` | Read model prompts | ✓ | ✓ | ✓ |  |
-| <code>models.prompts.(create &#124; update &#124; delete)</code> | Create, update, delete models prompts |  | ✓ | ✓ |  |
-| `models.prompts.list` | List model prompts |  |  |  |  |
-| `models.tool-call-plugin.set` | Whether this user can set tool_call_plugin on Models or Deployment Configs *(policy-enforced)* |  |  | ✓ |  |
-| `models.trust-remote-code.set` | Whether this user can set trust_remote_code on Models *(policy-enforced)* |  |  | ✓ |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| <code>models.(read &#124; list)</code> | Read, list models | ✓ | ✓ | ✓ | ✓ |  |
+| <code>models.(create &#124; update &#124; delete)</code> | Create, update, delete models |  | ✓ |  | ✓ |  |
+| `models.export` | Reference models from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| <code>models.adapters.(read &#124; list)</code> | Read, list models adapters | ✓ | ✓ | ✓ | ✓ |  |
+| <code>models.adapters.(create &#124; update &#124; delete)</code> | Create, update, delete models adapters |  | ✓ |  | ✓ |  |
+| `models.adapters.export` | Reference model adapters from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| `models.prompts.read` | Read model prompts | ✓ | ✓ | ✓ | ✓ |  |
+| <code>models.prompts.(create &#124; update &#124; delete)</code> | Create, update, delete models prompts |  | ✓ |  | ✓ |  |
+| `models.prompts.export` | Reference model prompts from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| `models.prompts.list` | List model prompts |  |  |  |  |  |
+| `models.tool-call-plugin.set` | Whether this user can set tool_call_plugin on Models or Deployment Configs *(policy-enforced)* |  |  |  | ✓ |  |
+| `models.trust-remote-code.set` | Whether this user can set trust_remote_code on Models *(policy-enforced)* |  |  |  | ✓ |  |
 
 ## Platform
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| `platform.admin` | Platform-wide administrative bypass *(policy-enforced)* |  |  |  |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| `platform.admin` | Platform-wide administrative bypass *(policy-enforced)* |  |  |  |  |  |
 
 ## Projects API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>projects.(read &#124; list)</code> | Read, list projects | ✓ | ✓ | ✓ |  |
-| <code>projects.(create &#124; update &#124; delete)</code> | Create, update, delete projects |  | ✓ | ✓ |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| <code>projects.(read &#124; list)</code> | Read, list projects | ✓ | ✓ | ✓ | ✓ |  |
+| <code>projects.(create &#124; update &#124; delete)</code> | Create, update, delete projects |  | ✓ |  | ✓ |  |
+| `projects.export` | Reference projects from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
 
 ## Safe Synthesizer API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>safe-synthesizer.jobs.(read &#124; list &#124; create &#124; delete &#124; cancel)</code> | Read, list, create, delete, cancel safe synthesizer jobs |  |  |  |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| `safe-synthesizer.jobs.export` | Reference safe synthesizer jobs from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| <code>safe-synthesizer.jobs.(read &#124; list &#124; create &#124; delete &#124; cancel)</code> | Read, list, create, delete, cancel safe synthesizer jobs |  |  |  |  |  |
 
 ## Secrets API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>secrets.(read &#124; list)</code> | Read, list secrets | ✓ | ✓ | ✓ |  |
-| <code>secrets.(create &#124; update &#124; delete)</code> | Create, update, delete secrets |  | ✓ | ✓ |  |
-| <code>secrets.(access &#124; rotate)</code> | Access, rotate secrets |  |  |  |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| <code>secrets.(read &#124; list)</code> | Read and list secret metadata | ✓ | ✓ | ✓ | ✓ |  |
+| `secrets.access` | Allow a service to retrieve secret values on the principal's behalf |  | ✓ | ✓ | ✓ |  |
+| <code>secrets.(create &#124; update &#124; delete)</code> | Create, update, delete secrets |  | ✓ |  | ✓ |  |
+| `secrets.export` | Reference secrets from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| `secrets.rotate` | Rotate encryption keys |  |  |  |  |  |
 
 ## Workspaces API
 
-| Permission | Description | Viewer | Editor | Admin | JobRunner |
-| ------------ | ------------- | :------: | :------: | :------: | :------: |
-| <code>workspaces.(read &#124; list)</code> | Read, list workspaces | ✓ | ✓ | ✓ |  |
-| <code>workspaces.(update &#124; delete)</code> | Update, delete workspaces |  | ✓ | ✓ |  |
-| `workspaces.create` | Create workspaces |  |  |  |  |
-| <code>workspaces.members.(list &#124; create &#124; update &#124; delete)</code> | List, create, update, delete workspaces members |  |  | ✓ |  |
-| `workspaces.members.read` | Read workspace member details |  |  |  |  |
+| Permission | Description | Viewer | Editor | Exporter | Admin | JobRunner |
+| ------------ | ------------- | :------: | :------: | :------: | :------: | :------: |
+| <code>workspaces.(read &#124; list)</code> | Read, list workspaces | ✓ | ✓ | ✓ | ✓ |  |
+| <code>workspaces.(update &#124; delete)</code> | Update, delete workspaces |  | ✓ |  | ✓ |  |
+| `workspaces.export` | Reference workspaces from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| `workspaces.create` | Create workspaces |  |  |  |  |  |
+| `workspaces.members.export` | Reference workspace member details from another workspace *(policy-enforced)* |  |  | ✓ | ✓ |  |
+| <code>workspaces.members.(list &#124; create &#124; update &#124; delete)</code> | List, create, update, delete workspaces members |  |  |  | ✓ |  |
+| `workspaces.members.read` | Read workspace member details |  |  |  |  |  |
 
 ## Related
 

--- a/docs/auth/authorization/plugin-authorization.mdx
+++ b/docs/auth/authorization/plugin-authorization.mdx
@@ -182,9 +182,12 @@ The derivation grants each catalog permission to roles by a suffix heuristic:
 | Permission id ends with | Granted to |
 |-------------------------|------------|
 | `.list` or `.read` | Viewer + Editor |
+| `.export` | Exporter |
 | everything else | Editor only |
 
 Use `extra_role_permissions` when that heuristic is wrong — e.g. an agent gateway's `.invoke` permission that a Viewer must hold to call a deployed agent even though its suffix isn't `read`. Grants are **unioned** with the suffix defaults (never subtractive), every granted permission must live in this service's own namespace (or the whole plugin fails closed), and a permission granted here is registered in the catalog automatically, so it need not also appear in `extra_permissions`.
+
+Cross-workspace export is always opt-in. Declaring a `.read`, `.list`, or `.access` permission does not synthesize a sibling `.export` permission. A plugin that supports cross-workspace references must explicitly declare that `.export` permission through `extra_permissions()`; the suffix heuristic then grants it to the Exporter role.
 
 ## When a Plugin's Authz Is Invalid
 

--- a/docs/auth/authorization/roles-and-permissions.mdx
+++ b/docs/auth/authorization/roles-and-permissions.mdx
@@ -22,9 +22,22 @@ NeMo Platform provides human-facing roles for interactive users and a separate w
 - Run customization jobs, evaluations, and data design tasks
 - Cannot manage workspace members or settings
 
+**Exporter** — For users and shared-library bindings that may expose workspace resources to other workspaces.
+
+- All Viewer permissions
+- Reference resources from this workspace in deployments, jobs, and other workspace-scoped operations
+- Allow services to retrieve secret values on the user's behalf for exported secret references
+- Cannot create, update, or delete resources
+
+<Note>
+
+Durable jobs and deployments do not persist identity-provider group claims, because replaying a group snapshot would retain access after group removal. Give the creating principal a direct workspace role binding when a background runtime must continue resolving cross-workspace resources.
+
+</Note>
+
 **Admin** — For workspace owners who manage their team's access.
 
-- All Editor permissions
+- All Editor and Exporter permissions
 - Add and remove workspace members
 - Change member roles
 - Grant wildcard access (`*`) to the workspace
@@ -60,13 +73,18 @@ flowchart BT
 +cancel"]
     Admin["Admin
 +manage members
++export
 +change visibility"]
+    Exporter["Exporter
++export"]
     PlatformAdmin["PlatformAdmin
 all workspaces
 all operations"]
 
     Viewer --> Editor
+    Viewer --> Exporter
     Editor --> Admin
+    Exporter --> Admin
     Admin --> PlatformAdmin
 ```
 
@@ -76,13 +94,13 @@ Rows are operations; columns are human-facing roles. Read the hierarchy above fi
 
 ### Workspace Operations
 
-| Operation | Viewer | Editor | Admin | PlatformAdmin |
-|-----------|:------:|:------:|:-----:|:-------------:|
-| List workspaces (visible to user) | ✓ | ✓ | ✓ | ✓ |
-| Delete workspace | | | ✓ | ✓ |
-| List workspace members | ✓ | ✓ | ✓ | ✓ |
-| Add / remove members | | | ✓ | ✓ |
-| Change workspace visibility | | | ✓ | ✓ |
+| Operation | Viewer | Editor | Exporter | Admin | PlatformAdmin |
+|-----------|:------:|:------:|:--------:|:-----:|:-------------:|
+| List workspaces (visible to user) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Delete workspace | | | | ✓ | ✓ |
+| List workspace members | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Add / remove members | | | | ✓ | ✓ |
+| Change workspace visibility | | | | ✓ | ✓ |
 
 <Note>
 
@@ -91,23 +109,25 @@ Workspace creation is controlled by the `WorkspaceCreator` permission in the `sy
 </Note>
 ### Resource Operations (Models, Datasets, Projects)
 
-| Operation | Viewer | Editor | Admin | PlatformAdmin |
-|-----------|:------:|:------:|:-----:|:-------------:|
-| List resources | ✓ | ✓ | ✓ | ✓ |
-| View / read resource | ✓ | ✓ | ✓ | ✓ |
-| Create resource | | ✓ | ✓ | ✓ |
-| Update resource | | ✓ | ✓ | ✓ |
-| Delete resource | | ✓ | ✓ | ✓ |
+| Operation | Viewer | Editor | Exporter | Admin | PlatformAdmin |
+|-----------|:------:|:------:|:--------:|:-----:|:-------------:|
+| List resources | ✓ | ✓ | ✓ | ✓ | ✓ |
+| View / read resource | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Reference resource from another workspace | | | ✓ | ✓ | ✓ |
+| Create resource | | ✓ | | ✓ | ✓ |
+| Update resource | | ✓ | | ✓ | ✓ |
+| Delete resource | | ✓ | | ✓ | ✓ |
 
 ### Jobs (Customization, Evaluation, Data Design)
 
-| Operation | Viewer | Editor | Admin | PlatformAdmin |
-|-----------|:------:|:------:|:-----:|:-------------:|
-| List jobs | ✓ | ✓ | ✓ | ✓ |
-| View job / logs | ✓ | ✓ | ✓ | ✓ |
-| Create / run job | | ✓ | ✓ | ✓ |
-| Cancel job | | ✓ | ✓ | ✓ |
-| Delete job | | ✓ | ✓ | ✓ |
+| Operation | Viewer | Editor | Exporter | Admin | PlatformAdmin |
+|-----------|:------:|:------:|:--------:|:-----:|:-------------:|
+| List jobs | ✓ | ✓ | ✓ | ✓ | ✓ |
+| View job / logs | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Reference job from another workspace | | | ✓ | ✓ | ✓ |
+| Create / run job | | ✓ | | ✓ | ✓ |
+| Cancel job | | ✓ | | ✓ | ✓ |
+| Delete job | | ✓ | | ✓ | ✓ |
 
 <Note>
 
@@ -117,23 +137,24 @@ JobRunner can upload logs from workload containers but does not grant job creati
 
 ### Inference
 
-| Operation | Viewer | Editor | Admin | PlatformAdmin |
-|-----------|:------:|:------:|:-----:|:-------------:|
-| Run inference (chat completions, completions, embeddings) | ✓ | ✓ | ✓ | ✓ |
+| Operation | Viewer | Editor | Exporter | Admin | PlatformAdmin |
+|-----------|:------:|:------:|:--------:|:-----:|:-------------:|
+| Run inference (chat completions, completions, embeddings) | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 ### Deployment
 
-| Operation | Viewer | Editor | Admin | PlatformAdmin |
-|-----------|:------:|:------:|:-----:|:-------------:|
-| List deployments | ✓ | ✓ | ✓ | ✓ |
-| View deployment | ✓ | ✓ | ✓ | ✓ |
-| Create deployment | | ✓ | ✓ | ✓ |
-| Update deployment | | ✓ | ✓ | ✓ |
-| Delete deployment | | ✓ | ✓ | ✓ |
+| Operation | Viewer | Editor | Exporter | Admin | PlatformAdmin |
+|-----------|:------:|:------:|:--------:|:-----:|:-------------:|
+| List deployments | ✓ | ✓ | ✓ | ✓ | ✓ |
+| View deployment | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Reference deployment from another workspace | | | ✓ | ✓ | ✓ |
+| Create deployment | | ✓ | | ✓ | ✓ |
+| Update deployment | | ✓ | | ✓ | ✓ |
+| Delete deployment | | ✓ | | ✓ | ✓ |
 
 ## Wildcard Principal Behavior
 
-The wildcard principal `*` grants a role to **all authenticated users**. When both a wildcard binding and an explicit binding exist for a user in the same workspace, the highest role wins.
+The wildcard principal `*` grants a role to **all authenticated users**. Wildcard and explicit bindings are combined, so a principal receives the union of all granted role permissions.
 
 Example:
 

--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -119,7 +119,7 @@ auth:
     workload_token_ttl_seconds: 300
     # JWT key id advertised by the NeMo auth service workload identity JWKS endpoint. | default: 'nemo-workload-exchange'
     workload_token_key_id: nemo-workload-exchange
-    # Path to a PEM-encoded RSA private key used by the NeMo auth service to sign workload identity access tokens. Intended for mounted shared secrets.
+    # Path to a PEM-encoded RSA private key used by the NeMo auth service to sign workload identity access tokens and by API services to authenticate Files HF runtime downloads. Required for model downloads when authorization is enabled; intended for mounted shared secrets.
     workload_token_private_key_file:
     # Additional RFC 8693 audience values accepted by the NeMo auth service workload token exchange endpoint. The configured workload_audience is always accepted.
     workload_allowed_audiences: []

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -8605,6 +8605,11 @@ components:
           title: Principal On Behalf Of Email
           description: The on-behalf-of principal's email address
           type: string
+        origin_workspace:
+          title: Origin Workspace
+          description: Workspace that initiated the operation captured by this auth
+            context
+          type: string
       type: object
       required:
       - principal_id

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -8605,6 +8605,11 @@ components:
           title: Principal On Behalf Of Email
           description: The on-behalf-of principal's email address
           type: string
+        origin_workspace:
+          title: Origin Workspace
+          description: Workspace that initiated the operation captured by this auth
+            context
+          type: string
       type: object
       required:
       - principal_id

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -8605,6 +8605,11 @@ components:
           title: Principal On Behalf Of Email
           description: The on-behalf-of principal's email address
           type: string
+        origin_workspace:
+          title: Origin Workspace
+          description: Workspace that initiated the operation captured by this auth
+            context
+          type: string
       type: object
       required:
       - principal_id

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/authz_merge.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/authz_merge.py
@@ -58,6 +58,8 @@ def _default_roles_for_permission(permission_id: str) -> list[str]:
     suffix = permission_id.rsplit(".", 1)[-1]
     if suffix in {"list", "read"}:
         return ["Viewer", "Editor"]
+    if suffix == "export":
+        return ["Exporter"]
     return ["Editor"]
 
 
@@ -71,8 +73,9 @@ def merge_authz_contributions(
 
     - ``permissions``: flat ``permission_id -> description`` for the registry
     - ``endpoints``: ``path -> {method: {permissions, scopes?}}``
-    - ``role_permissions``: optional ``role -> [permission_id, ...]`` extra grants
-      (defaults: ``.list``/``.read`` → Viewer+Editor, else Editor only)
+    - ``role_permissions``: optional ``role -> [permission_id, ...]`` extra grants.
+      Export permissions must be declared explicitly and granted to ``Exporter``;
+      readable resources never become cross-workspace exportable implicitly.
 
     Later contributions override endpoint methods for the same path+method.
     """

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/entities/base.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/entities/base.py
@@ -249,7 +249,6 @@ class EntityDeleteClientProtocol(EntityGetterProtocol[EntityT], Protocol[EntityT
         page: int = 1,
         page_size: int = 100,
     ) -> ListResponse[EntityT]: ...
-
     async def delete(
         self,
         entity_type: Type[EntityT],
@@ -264,6 +263,13 @@ class EntityClientProtocol(EntityDeleteClientProtocol[EntityT], Protocol[EntityT
     """Protocol for the common entity CRUD operations used by plugins."""
 
     async def create(self, entity: EntityT) -> EntityT: ...
+    async def get_by_id(
+        self,
+        entity_type: Type[EntityT],
+        entity_id: str,
+        *,
+        workspace: Optional[str] = None,
+    ) -> EntityT: ...
 
 
 class AnyEntityGetterProtocol(Protocol):
@@ -661,12 +667,18 @@ class EntityClient:
         self,
         entity_type: EntityTypeLike,
         entity_id: str,
+        *,
+        workspace: Optional[str] = None,
     ) -> EntityT:
         """Get entity by ID (for debugging/internal use).
 
         Args:
             entity_type: The entity class to return
             entity_id: Entity UUID
+            workspace: When provided, constrain the lookup to this workspace.
+                This uses the workspace-qualified list endpoint so delegated
+                callers do not need to use the fail-closed workspace-less
+                entity-by-ID endpoint.
 
         Returns:
             Entity with the given ID
@@ -674,6 +686,9 @@ class EntityClient:
         Raises:
             EntityNotFoundError: Entity not found
         """
+        if workspace is not None:
+            return await self.get_by_field(entity_type, workspace=workspace, id=entity_id)
+
         try:
             response = await self._client.get_entity_by_id(entity_id=entity_id)
             return self._convert_api_entity_to_model(response.data(), entity_type)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/execution_profiles.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/execution_profiles.py
@@ -62,6 +62,7 @@ RESERVED_JOB_ENVIRONMENT_VARIABLE_NAMES: frozenset[str] = frozenset(
         PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
         TASK_CONFIG_ENVVAR,
         # Auth
+        "NMP_ORIGIN_WORKSPACE",
         "NMP_PRINCIPAL",
         WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR,
         # Platform launcher logs

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/types.py
@@ -100,6 +100,10 @@ class AuthContext(BaseModel):
     principal_on_behalf_of_email: Optional[str] = Field(
         default=None, description="The on-behalf-of principal's email address"
     )
+    origin_workspace: Optional[str] = Field(
+        default=None,
+        description="Workspace that initiated the operation captured by this auth context",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk_provider.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/sdk_provider.py
@@ -18,8 +18,9 @@ Lookup order for the provider
    When ``nmp-common`` is installed in the image (platform deployment), its
    provider is picked up automatically.
 3. **Built-in default** — :class:`DefaultSDKProvider`, an env-var-based
-   implementation that reads ``NMP_BASE_URL`` and ``NMP_PRINCIPAL``.  Works
-   for local development and gateway-routed task containers.
+   implementation that reads ``NMP_BASE_URL``, ``NMP_PRINCIPAL``, and
+   ``NMP_ORIGIN_WORKSPACE``. Works for local development and gateway-routed
+   task containers.
 
 Usage from a plugin ``__main__.py``::
 
@@ -51,6 +52,8 @@ _INTERNAL_REQUEST_HEADER = "X-NMP-Internal"
 # Environment variable the jobs backend writes with the job creator's
 # principal (JSON-serialised).
 _NMP_PRINCIPAL_ENVVAR = "NMP_PRINCIPAL"
+_NMP_ORIGIN_WORKSPACE_ENVVAR = "NMP_ORIGIN_WORKSPACE"
+_NMP_ORIGIN_WORKSPACE_HEADER = "X-NMP-Origin-Workspace"
 
 
 # ---------------------------------------------------------------------------
@@ -158,8 +161,15 @@ def _on_behalf_of_headers(principal: dict[str, Any]) -> dict[str, str]:
     return headers
 
 
+def _task_origin_headers() -> dict[str, str]:
+    origin_workspace = os.environ.get(_NMP_ORIGIN_WORKSPACE_ENVVAR)
+    return {_NMP_ORIGIN_WORKSPACE_HEADER: origin_workspace} if origin_workspace else {}
+
+
 def _workload_identity_headers(*, internal: bool) -> dict[str, str]:
-    return {_INTERNAL_REQUEST_HEADER: "true"} if internal else {}
+    headers = {_INTERNAL_REQUEST_HEADER: "true"} if internal else {}
+    headers.update(_task_origin_headers())
+    return headers
 
 
 class DefaultSDKProvider:
@@ -181,6 +191,7 @@ class DefaultSDKProvider:
             "X-NMP-Principal-Id": f"service:{service_name}",
             _INTERNAL_REQUEST_HEADER: "true",
         }
+        headers.update(_task_origin_headers())
 
         principal = _read_principal_from_env()
         if principal is not None:
@@ -210,6 +221,7 @@ class DefaultSDKProvider:
             "X-NMP-Principal-Id": f"service:{service_name}",
             _INTERNAL_REQUEST_HEADER: "true",
         }
+        headers.update(_task_origin_headers())
 
         principal = _read_principal_from_env()
         if principal is not None:

--- a/packages/nemo_platform_plugin/tests/test_entity_client.py
+++ b/packages/nemo_platform_plugin/tests/test_entity_client.py
@@ -115,3 +115,22 @@ async def test_count_by_rejects_non_direct_field() -> None:
 
     with pytest.raises(ValueError, match="direct entity data field"):
         await client.count_by(ExperimentGroup, "data.insight_id")
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_with_workspace_uses_qualified_lookup() -> None:
+    mock_api = Mock()
+    mock_api.get_entity_by_id = AsyncMock()
+    client = EntityClient(mock_api)
+    expected = Mock()
+    client.get_by_field = AsyncMock(return_value=expected)  # type: ignore[method-assign]
+
+    result = await client.get_by_id(ExperimentGroup, "entity-id", workspace="workspace-a")
+
+    assert result is expected
+    client.get_by_field.assert_awaited_once_with(  # type: ignore[attr-defined]
+        ExperimentGroup,
+        workspace="workspace-a",
+        id="entity-id",
+    )
+    mock_api.get_entity_by_id.assert_not_awaited()

--- a/packages/nemo_platform_plugin/tests/test_sdk_provider.py
+++ b/packages/nemo_platform_plugin/tests/test_sdk_provider.py
@@ -96,6 +96,7 @@ class TestOnBehalfOfHeaders:
 class TestDefaultSDKProvider:
     def test_get_task_sdk_with_principal(self, monkeypatch):
         monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")
+        monkeypatch.setenv("NMP_ORIGIN_WORKSPACE", "workspace-a")
         monkeypatch.setenv(
             "NMP_PRINCIPAL",
             json.dumps({"id": "creator@ex.com", "email": "creator@ex.com", "groups": ["team"]}),
@@ -109,6 +110,7 @@ class TestDefaultSDKProvider:
         assert sdk.default_headers["X-NMP-Principal-Id"] == "service:evaluator"
         assert sdk.default_headers["X-NMP-Internal"] == "true"
         assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "creator@ex.com"
+        assert sdk.default_headers["X-NMP-Origin-Workspace"] == "workspace-a"
 
     def test_get_task_sdk_without_principal(self, monkeypatch):
         monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")
@@ -132,6 +134,7 @@ class TestDefaultSDKProvider:
         subject_token_file = tmp_path / "workload-token"
         subject_token_file.write_text("subject-token-from-file\n", encoding="utf-8")
         monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")
+        monkeypatch.setenv("NMP_ORIGIN_WORKSPACE", "workspace-a")
         monkeypatch.setenv(WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR, str(subject_token_file))
         monkeypatch.setenv(
             "NMP_PRINCIPAL",
@@ -142,6 +145,7 @@ class TestDefaultSDKProvider:
         sdk = provider.get_task_sdk("evaluator")
         try:
             assert sdk.default_headers["X-NMP-Internal"] == "true"
+            assert sdk.default_headers["X-NMP-Origin-Workspace"] == "workspace-a"
             assert "X-NMP-Principal-Id" not in sdk.default_headers
             assert "X-NMP-Principal-On-Behalf-Of" not in sdk.default_headers
         finally:
@@ -175,6 +179,7 @@ class TestDefaultSDKProvider:
 class TestAsyncTaskSdk:
     def test_async_task_sdk_with_principal(self, monkeypatch):
         monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")
+        monkeypatch.setenv("NMP_ORIGIN_WORKSPACE", "workspace-a")
         monkeypatch.setenv(
             "NMP_PRINCIPAL",
             json.dumps({"id": "creator@ex.com", "email": "creator@ex.com", "groups": ["team"]}),
@@ -187,6 +192,7 @@ class TestAsyncTaskSdk:
         assert sdk.default_headers["X-NMP-Principal-Id"] == "service:evaluator"
         assert sdk.default_headers["X-NMP-Internal"] == "true"
         assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "creator@ex.com"
+        assert sdk.default_headers["X-NMP-Origin-Workspace"] == "workspace-a"
 
     def test_async_task_sdk_without_principal(self, monkeypatch):
         monkeypatch.setenv("NMP_BASE_URL", "http://test:9090")

--- a/packages/nmp_common/src/nmp/common/auth/__init__.py
+++ b/packages/nmp_common/src/nmp/common/auth/__init__.py
@@ -9,13 +9,20 @@ from .client import AuthClient, AuthorizationResult
 from .dependencies import (
     auth_as_service,
     auth_client_context,
+    build_service_principal_bearer_token,
     build_service_principal_headers,
     get_auth_client,
     get_principal_auth_headers,
 )
 from .exceptions import AuthorizationError, InvalidPermissionFormatError, InvalidScopeFormatError
 from .middleware import AuthorizationMiddleware
-from .models import NMP_PRINCIPAL_ENVVAR, AuthContext, Principal
+from .models import (
+    NMP_ORIGIN_WORKSPACE_ENVVAR,
+    NMP_ORIGIN_WORKSPACE_HEADER,
+    NMP_PRINCIPAL_ENVVAR,
+    AuthContext,
+    Principal,
+)
 from .permissions import ALL_WORKSPACES, compute_accessible_workspaces
 from .tasks import principal_from_env
 
@@ -32,10 +39,13 @@ __all__ = [
     "InvalidScopeFormatError",
     "AuthorizationMiddleware",
     "AuthorizationResult",
+    "NMP_ORIGIN_WORKSPACE_ENVVAR",
+    "NMP_ORIGIN_WORKSPACE_HEADER",
     "NMP_PRINCIPAL_ENVVAR",
     "Principal",
     "auth_as_service",
     "auth_client_context",
+    "build_service_principal_bearer_token",
     "build_service_principal_headers",
     "principal_from_env",
     "compute_accessible_workspaces",

--- a/packages/nmp_common/src/nmp/common/auth/client.py
+++ b/packages/nmp_common/src/nmp/common/auth/client.py
@@ -57,6 +57,14 @@ class AuthClient(BaseModel):
         default=None,
         description="Name of the calling service. Used to build service principal headers for PDP requests.",
     )
+    origin_workspace: Optional[str] = Field(
+        default=None,
+        description="Workspace that initiated this service-to-service request, if supplied by the caller.",
+    )
+    request_workspace: Optional[str] = Field(
+        default=None,
+        description="Workspace addressed by the current request, used for downstream origin propagation.",
+    )
 
     model_config = {"arbitrary_types_allowed": True, "validate_assignment": False}
 
@@ -69,6 +77,11 @@ class AuthClient(BaseModel):
     def policy_decision_point_base_url(self) -> Optional[str]:
         """Policy Decision Point (PDP) base URL for permission checks."""
         return self.config.policy_decision_point_base_url
+
+    @property
+    def outbound_origin_workspace(self) -> Optional[str]:
+        """Origin workspace to preserve on downstream calls."""
+        return self.origin_workspace or self.request_workspace
 
     def _new_pdp_http_client(self) -> httpx.AsyncClient:
         endpoint = parse_platform_endpoint(self.config.policy_decision_point_base_url)
@@ -95,6 +108,7 @@ class AuthClient(BaseModel):
         path: str,
         scopes: Optional[List[str]] = None,
         http_client: Optional[httpx.AsyncClient] = None,
+        origin_workspace: Optional[str] = None,
     ) -> AuthorizationResult:
         """Check if the current principal is authorized to make a request.
 
@@ -146,6 +160,8 @@ class AuthClient(BaseModel):
             auth_input["on_behalf_of_principal_id"] = self.principal.on_behalf_of
         if scopes:
             auth_input["scopes"] = scopes
+        if origin_workspace:
+            auth_input["origin_workspace"] = origin_workspace
 
         auth_url = self.config.get_pdp_url("allow")
 

--- a/packages/nmp_common/src/nmp/common/auth/dependencies.py
+++ b/packages/nmp_common/src/nmp/common/auth/dependencies.py
@@ -3,14 +3,28 @@
 
 """FastAPI dependencies and utilities for authentication."""
 
+import re
+import time
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Dict, Generator, Optional
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
 
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import HTTPException, Request
+from nmp.common.config import get_auth_config
 
 if TYPE_CHECKING:
     from .client import AuthClient
+
+from .models import NMP_ORIGIN_WORKSPACE_HEADER, Principal
+
+_SERVICE_BEARER_TOKEN_PREFIX = "nmp-service-v2."
+_SERVICE_BEARER_TOKEN_AUDIENCE = "nmp-files-hf"
+_SERVICE_NAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62})$")
 
 # Context variable to store the current auth client (set by middleware or tasks runtime)
 auth_client_context: ContextVar[Optional["AuthClient"]] = ContextVar("auth_client_context", default=None)
@@ -97,7 +111,10 @@ def get_principal_auth_headers() -> Dict[str, str]:
     """
     auth_client = auth_client_context.get()
     if auth_client and auth_client.principal:
-        return auth_client.principal.get_headers()
+        headers = auth_client.principal.get_headers()
+        if auth_client.outbound_origin_workspace:
+            headers[NMP_ORIGIN_WORKSPACE_HEADER] = auth_client.outbound_origin_workspace
+        return headers
     return {}
 
 
@@ -124,6 +141,9 @@ def build_service_principal_headers(service_name: str) -> Dict[str, str]:
     if auth_client is None or not auth_client.principal or not auth_client.principal.id:
         return headers
 
+    if auth_client.outbound_origin_workspace:
+        headers[NMP_ORIGIN_WORKSPACE_HEADER] = auth_client.outbound_origin_workspace
+
     effective = auth_client.principal.effective_principal
     if effective.id.startswith("service:"):
         return headers
@@ -133,7 +153,159 @@ def build_service_principal_headers(service_name: str) -> Dict[str, str]:
         headers["X-NMP-Principal-On-Behalf-Of-Email"] = effective.email
     if effective.groups:
         headers["X-NMP-Principal-On-Behalf-Of-Groups"] = ",".join(effective.groups)
+    return headers
 
+
+def build_service_principal_bearer_token(
+    service_name: str,
+    *,
+    on_behalf_of: Principal,
+    origin_workspace: str,
+    source_workspace: str,
+) -> str:
+    """Sign delegated service context for clients limited to a Bearer token.
+
+    The Hugging Face client used by model pullers cannot send the platform's
+    ``X-NMP-*`` headers. Its token therefore carries signed service/delegate
+    context, scoped to the Files HF API and one source workspace.
+    """
+    if not _SERVICE_NAME_RE.fullmatch(service_name):
+        raise ValueError(f"Invalid service name: {service_name!r}")
+    if not origin_workspace:
+        raise ValueError("origin_workspace is required for delegated service bearer tokens")
+    if not source_workspace:
+        raise ValueError("source_workspace is required for delegated service bearer tokens")
+
+    effective = on_behalf_of.effective_principal
+    payload: dict[str, Any] = {
+        "aud": _SERVICE_BEARER_TOKEN_AUDIENCE,
+        "iat": int(time.time()),
+        "iss": _service_bearer_token_issuer(),
+        "sub": effective.id,
+        "service": service_name,
+        "principal_id": effective.id,
+        "origin_workspace": origin_workspace,
+        "source_workspace": source_workspace,
+    }
+    if effective.email:
+        payload["principal_email"] = effective.email
+    # Group claims are intentionally not persisted into durable runtime
+    # credentials. Replaying a creation-time group snapshot would retain access
+    # after the user is removed from that identity-provider group.
+    private_key, key_id = _service_bearer_signing_key()
+    encoded = jwt.encode(
+        payload,
+        private_key,
+        algorithm="RS256",
+        headers={"kid": key_id},
+    )
+    token = f"{_SERVICE_BEARER_TOKEN_PREFIX}{encoded}"
+    if len(token) > 16_384:
+        raise ValueError("Delegated service bearer token exceeds the maximum supported size")
+    return token
+
+
+def _service_bearer_token_issuer() -> str:
+    config = get_auth_config()
+    return config.oidc.workload_token_issuer or "nmp-internal-service"
+
+
+def _service_bearer_signing_key() -> tuple[bytes, str]:
+    config = get_auth_config()
+    key_file = config.oidc.workload_token_private_key_file
+    if not key_file:
+        raise ValueError("auth.oidc.workload_token_private_key_file is required for Files runtime tokens")
+    try:
+        key_path = Path(key_file)
+        stat = key_path.stat()
+        private_key_pem, _ = _load_service_bearer_key(key_file, stat.st_mtime_ns, stat.st_size)
+        return private_key_pem, config.oidc.workload_token_key_id
+    except OSError as exc:
+        raise ValueError(f"Could not read Files runtime token signing key: {key_file}") from exc
+
+
+@lru_cache(maxsize=4)
+def _load_service_bearer_key(
+    key_file: str,
+    _mtime_ns: int,
+    _size: int,
+) -> tuple[bytes, rsa.RSAPublicKey]:
+    private_key_pem = Path(key_file).read_bytes()
+    private_key = serialization.load_pem_private_key(private_key_pem, password=None)
+    if not isinstance(private_key, rsa.RSAPrivateKey):
+        raise ValueError("Files runtime token signing key must be an RSA private key")
+    return private_key_pem, private_key.public_key()
+
+
+def _service_bearer_verification_key() -> tuple[rsa.RSAPublicKey, str]:
+    config = get_auth_config()
+    key_file = config.oidc.workload_token_private_key_file
+    if not key_file:
+        raise ValueError("auth.oidc.workload_token_private_key_file is required for Files runtime tokens")
+    try:
+        key_path = Path(key_file)
+        stat = key_path.stat()
+        _, public_key = _load_service_bearer_key(key_file, stat.st_mtime_ns, stat.st_size)
+        return public_key, config.oidc.workload_token_key_id
+    except OSError as exc:
+        raise ValueError(f"Could not read Files runtime token signing key: {key_file}") from exc
+
+
+def parse_service_principal_bearer_token(
+    token: str,
+    *,
+    expected_source_workspace: str,
+) -> Dict[str, str] | None:
+    """Validate an internal Files runtime token into normalized principal headers."""
+    if token.startswith("service:") and not get_auth_config().enabled:
+        return {"x-nmp-principal-id": token}
+    if not token.startswith(_SERVICE_BEARER_TOKEN_PREFIX):
+        return None
+
+    encoded = token.removeprefix(_SERVICE_BEARER_TOKEN_PREFIX)
+    if not encoded or len(encoded) > 16_384:
+        return None
+    try:
+        signing_key, key_id = _service_bearer_verification_key()
+        header = jwt.get_unverified_header(encoded)
+        if header.get("kid") != key_id:
+            return None
+        payload = jwt.decode(
+            encoded,
+            signing_key,
+            algorithms=["RS256"],
+            audience=_SERVICE_BEARER_TOKEN_AUDIENCE,
+            issuer=_service_bearer_token_issuer(),
+            options={"require": ["aud", "iat", "iss", "sub"]},
+        )
+    except (ValueError, TypeError, jwt.PyJWTError):
+        return None
+
+    service_name = payload.get("service")
+    principal_id = payload.get("principal_id")
+    origin_workspace = payload.get("origin_workspace")
+    source_workspace = payload.get("source_workspace")
+    principal_email = payload.get("principal_email")
+    if (
+        not isinstance(service_name, str)
+        or not _SERVICE_NAME_RE.fullmatch(service_name)
+        or not isinstance(principal_id, str)
+        or not principal_id
+        or payload.get("sub") != principal_id
+        or not isinstance(origin_workspace, str)
+        or not origin_workspace
+        or source_workspace != expected_source_workspace
+        or (principal_email is not None and not isinstance(principal_email, str))
+    ):
+        return None
+
+    headers = {
+        "x-nmp-principal-id": f"service:{service_name}",
+        "x-nmp-principal-on-behalf-of": principal_id,
+        "x-nmp-origin-workspace": origin_workspace,
+    }
+    if principal_email:
+        headers["x-nmp-principal-on-behalf-of-email"] = principal_email
     return headers
 
 

--- a/packages/nmp_common/src/nmp/common/auth/middleware.py
+++ b/packages/nmp_common/src/nmp/common/auth/middleware.py
@@ -4,7 +4,9 @@
 """Authorization middleware for NeMo Platform services."""
 
 import logging
+import re
 from typing import Any, Callable, Optional
+from urllib.parse import unquote
 
 import httpx
 from fastapi import Request, Response
@@ -16,11 +18,13 @@ from starlette.responses import JSONResponse
 from starlette.types import ASGIApp
 
 from .client import AuthClient
-from .dependencies import auth_client_context
+from .dependencies import auth_client_context, parse_service_principal_bearer_token
 from .exceptions import InvalidPrincipalHeader, InvalidScopeFormatError
-from .models import Principal
+from .models import NMP_ORIGIN_WORKSPACE_HEADER, Principal
 
 logger = logging.getLogger(__name__)
+_WORKSPACE_RE = re.compile(r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$")
+_ROUTE_WORKSPACE_RE = re.compile(r"/v\d+/workspaces/([^/]+)(?:/|$)")
 
 
 class PrincipalExtractionError(RuntimeError):
@@ -32,6 +36,28 @@ def _require_principal(principal: Principal | None) -> Principal:
     if principal is None:
         raise PrincipalExtractionError("principal extraction succeeded without returning a principal")
     return principal
+
+
+def _request_workspace(path: str) -> str | None:
+    """Extract a concrete workspace from the conventional platform URL shape."""
+    match = _ROUTE_WORKSPACE_RE.search(path)
+    workspace = unquote(match.group(1)) if match else None
+    if workspace is None or workspace == "-" or not _WORKSPACE_RE.fullmatch(workspace):
+        return None
+    return workspace
+
+
+def _hf_request_workspace(path: str) -> str | None:
+    """Extract the source workspace from supported Files HF-compatible paths."""
+    prefix = "/apis/files/v2/hf/"
+    if not path.startswith(prefix):
+        return None
+    parts = [unquote(part) for part in path.removeprefix(prefix).split("/") if part]
+    if parts[:2] == ["api", "models"]:
+        workspace = parts[2] if len(parts) > 2 else None
+    else:
+        workspace = parts[0] if parts else None
+    return workspace if workspace and _WORKSPACE_RE.fullmatch(workspace) else None
 
 
 def _describe_pdp_failure(exc: BaseException) -> str:
@@ -142,6 +168,18 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
         except InvalidPrincipalHeader as e:
             logger.warning("Invalid principal header: %s", e)
             return None, JSONResponse(status_code=400, content={"detail": str(e)})
+        raw_origin = headers_dict.get(NMP_ORIGIN_WORKSPACE_HEADER.lower())
+        if principal.id.startswith("service:"):
+            if raw_origin and not _WORKSPACE_RE.fullmatch(raw_origin):
+                return None, JSONResponse(
+                    status_code=400,
+                    content={"detail": f"Invalid {NMP_ORIGIN_WORKSPACE_HEADER} header"},
+                )
+            if principal.is_delegated and not raw_origin:
+                return None, JSONResponse(
+                    status_code=400,
+                    content={"detail": f"{NMP_ORIGIN_WORKSPACE_HEADER} is required for delegated service requests"},
+                )
         return principal, None
 
     def _get_jwt_validator(self) -> Optional[Any]:
@@ -170,6 +208,28 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
             endpoint = parse_platform_endpoint(self.config.policy_decision_point_base_url)
             self._client = endpoint.async_http_client(timeout=self.config.policy_decision_point_request_timeout_seconds)
         return self._client
+
+    def _make_auth_client(
+        self,
+        principal: Principal,
+        request: Request,
+        *,
+        headers_dict: dict[str, str] | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> AuthClient:
+        headers = headers_dict if headers_dict is not None else dict(request.headers)
+        raw_origin = headers.get(NMP_ORIGIN_WORKSPACE_HEADER.lower())
+        origin_workspace = None
+        if principal.id.startswith("service:") and raw_origin:
+            origin_workspace = raw_origin
+        return AuthClient(
+            principal=principal,
+            config=self.config,
+            http_client=http_client,
+            service_name=self.service_name,
+            origin_workspace=origin_workspace,
+            request_workspace=_request_workspace(request.url.path),
+        )
 
     def _update_auth_context(self, principal: Principal) -> None:
         """Update the observability AuthContext with principal info.
@@ -276,10 +336,9 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         """Handle requests to HuggingFace-compatible endpoints.
 
-        These endpoints are restricted to service principals only. Auth is provided
-        via Bearer token (HF_TOKEN) containing a service principal identifier like
-        "service:nim". This allows huggingface-hub clients to authenticate by setting
-        HF_TOKEN=service:<name>.
+        These endpoints are restricted to signed, source-workspace-bound runtime
+        tokens when authorization is enabled. Auth-disabled development retains
+        the legacy ``HF_TOKEN=service:<name>`` compatibility path.
 
         Args:
             request: The incoming HTTP request
@@ -292,8 +351,15 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
         auth_header = headers_dict.get("authorization", "")
         if auth_header.lower().startswith("bearer "):
             token = auth_header[7:]
-            if token.startswith("service:"):
-                headers_dict["x-nmp-principal-id"] = token
+            source_workspace = _hf_request_workspace(request.url.path)
+            if source_workspace is None:
+                return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
+            service_headers = parse_service_principal_bearer_token(
+                token,
+                expected_source_workspace=source_workspace,
+            )
+            if service_headers is not None:
+                headers_dict.update(service_headers)
                 return await self._handle_principal_headers_request(request, call_next, headers_dict)
 
         return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
@@ -325,8 +391,11 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
         if error_response is not None:
             return error_response
         principal = _require_principal(principal)
-        auth_client = AuthClient(
-            principal=principal, config=self.config, http_client=self._client, service_name=self.service_name
+        auth_client = self._make_auth_client(
+            principal,
+            request,
+            headers_dict=headers_dict,
+            http_client=self._client,
         )
         return await self._call_next_with_auth_client(request, call_next, auth_client)
 
@@ -354,8 +423,11 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
 
         if not self.config.enabled:
             # Auth disabled - just extract principal and proceed
-            auth_client = AuthClient(
-                principal=principal, config=self.config, http_client=self._client, service_name=self.service_name
+            auth_client = self._make_auth_client(
+                principal,
+                request,
+                headers_dict=headers_dict,
+                http_client=self._client,
             )
             return await self._call_next_with_auth_client(request, call_next, auth_client)
 
@@ -425,18 +497,11 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
 
         # If auth is disabled, just proceed with the principal
         if not self.config.enabled:
-            auth_client = AuthClient(
-                principal=principal, config=self.config, http_client=self._client, service_name=self.service_name
-            )
+            auth_client = self._make_auth_client(principal, request, http_client=self._client)
             return await self._call_next_with_auth_client(request, call_next, auth_client)
 
         # Perform authorization check with PDP
-        auth_client = AuthClient(
-            principal=principal,
-            config=self.config,
-            http_client=self._get_client(request),
-            service_name=self.service_name,
-        )
+        auth_client = self._make_auth_client(principal, request, http_client=self._get_client(request))
 
         # Extract scopes from token claims
         scopes = claims.scopes if claims.scopes else None
@@ -447,6 +512,7 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
                 path=request.url.path,
                 scopes=scopes,
                 http_client=auth_client.http_client,
+                origin_workspace=auth_client.origin_workspace,
             )
         except httpx.ConnectError as e:
             logger.error(
@@ -548,9 +614,7 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
             principal.groups,
         )
 
-        auth_client = AuthClient(
-            principal=principal, config=self.config, http_client=self._client, service_name=self.service_name
-        )
+        auth_client = self._make_auth_client(principal, request, http_client=self._client)
         return await self._call_next_with_auth_client(request, call_next, auth_client)
 
     async def _handle_auth_check(
@@ -591,11 +655,11 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
 
         # Create AuthClient for the authorization check
         # Pass http_client for ASGI transport in tests - see architecture/docs/http-client-injection.md
-        auth_client = AuthClient(
-            principal=principal,
-            config=self.config,
+        auth_client = self._make_auth_client(
+            principal,
+            request,
+            headers_dict=headers_dict,
             http_client=self._get_client(request),
-            service_name=self.service_name,
         )
 
         # Perform authorization check - only catch errors from the PDP call itself.
@@ -606,6 +670,7 @@ class AuthorizationMiddleware(BaseHTTPMiddleware):
                 path=request.url.path,
                 scopes=scopes,
                 http_client=auth_client.http_client,
+                origin_workspace=auth_client.origin_workspace,
             )
         except httpx.ConnectError as e:
             logger.error(

--- a/packages/nmp_common/src/nmp/common/auth/models.py
+++ b/packages/nmp_common/src/nmp/common/auth/models.py
@@ -19,6 +19,8 @@ from .exceptions import InvalidPrincipalHeader
 logger = logging.getLogger(__name__)
 
 NMP_PRINCIPAL_ENVVAR = "NMP_PRINCIPAL"
+NMP_ORIGIN_WORKSPACE_ENVVAR = "NMP_ORIGIN_WORKSPACE"
+NMP_ORIGIN_WORKSPACE_HEADER = "X-NMP-Origin-Workspace"
 
 MAX_PRINCIPAL_ID_LENGTH = 256
 MAX_EMAIL_LENGTH = 320
@@ -317,26 +319,41 @@ class AuthContext(BaseModel):
     principal_on_behalf_of_email: Optional[str] = Field(
         default=None, description="The on-behalf-of principal's email address"
     )
+    origin_workspace: Optional[str] = Field(
+        default=None,
+        description="Workspace that initiated the operation captured by this auth context",
+    )
 
     @classmethod
-    def from_principal(cls, principal: Principal) -> Self:
-        """Create from a runtime Principal."""
+    def from_principal(cls, principal: Principal, *, origin_workspace: str | None = None) -> Self:
+        """Create a durable context without replayable identity-provider group claims."""
         return cls(
             principal_id=principal.id,
             principal_email=principal.email,
-            principal_groups=principal.groups,
+            principal_groups=[],
             principal_on_behalf_of=principal.on_behalf_of,
-            principal_on_behalf_of_groups=principal.on_behalf_of_groups,
+            principal_on_behalf_of_groups=None,
             principal_on_behalf_of_email=principal.on_behalf_of_email,
+            # Some callers use protocol-like or mocked AuthClient objects whose
+            # optional origin attribute is not a real string. Treat that the
+            # same as an absent origin instead of leaking it into persistence.
+            origin_workspace=origin_workspace if isinstance(origin_workspace, str) else None,
         )
 
     def to_principal(self) -> Principal:
-        """Convert back to a Principal for SDK calls."""
+        """Convert back without trusting group snapshots from stored resources."""
         return Principal(
             id=self.principal_id,
             email=self.principal_email,
-            groups=self.principal_groups,
+            groups=[],
             on_behalf_of=self.principal_on_behalf_of,
-            on_behalf_of_groups=self.principal_on_behalf_of_groups,
+            on_behalf_of_groups=None,
             on_behalf_of_email=self.principal_on_behalf_of_email,
         )
+
+    def get_env_vars(self) -> Dict[str, str]:
+        """Serialize the stored identity and origin workspace for a task runtime."""
+        env = self.to_principal().get_env_var()
+        if self.origin_workspace:
+            env[NMP_ORIGIN_WORKSPACE_ENVVAR] = self.origin_workspace
+        return env

--- a/packages/nmp_common/src/nmp/common/config/base.py
+++ b/packages/nmp_common/src/nmp/common/config/base.py
@@ -193,7 +193,8 @@ class OIDCConfig(BaseSettings):
         default=None,
         description=(
             "Path to a PEM-encoded RSA private key used by the NeMo auth service to sign workload identity "
-            "access tokens. Intended for mounted shared secrets."
+            "access tokens and by API services to authenticate Files HF runtime downloads. "
+            "Required for model downloads when authorization is enabled; intended for mounted shared secrets."
         ),
     )
 

--- a/packages/nmp_common/src/nmp/common/sdk_factory.py
+++ b/packages/nmp_common/src/nmp/common/sdk_factory.py
@@ -4,13 +4,21 @@
 """SDK factory functions for creating NeMo Platform SDK instances."""
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, TypeVar, cast
 
 import httpx
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.client.constants import is_workload_identity_token_file_set
-from nmp.common.auth import Principal, get_principal_auth_headers, principal_from_env
+from nmp.common.auth import (
+    NMP_ORIGIN_WORKSPACE_ENVVAR,
+    NMP_ORIGIN_WORKSPACE_HEADER,
+    Principal,
+    build_service_principal_headers,
+    get_principal_auth_headers,
+    principal_from_env,
+)
 from nmp.common.config import Configuration, PlatformConfig
 from nmp.common.http_clients import shared_async_http_client, shared_sync_http_client
 from nmp.common.observability import MARK_INTERNAL_REQUEST_HEADERS
@@ -173,12 +181,18 @@ def _should_bootstrap_workload_identity(
     )
 
 
-def _workload_identity_extra_headers(*, internal: bool) -> dict[str, str]:
-    return MARK_INTERNAL_REQUEST_HEADERS.copy() if internal else {}
+def _workload_identity_extra_headers(*, internal: bool, origin_workspace: str | None = None) -> dict[str, str]:
+    headers = MARK_INTERNAL_REQUEST_HEADERS.copy() if internal else {}
+    if origin_workspace:
+        headers[NMP_ORIGIN_WORKSPACE_HEADER] = origin_workspace
+    return headers
 
 
 def _get_default_headers(
-    as_service: str | None = None, internal: bool = False, on_behalf_of: str | Principal | None = None
+    as_service: str | None = None,
+    internal: bool = False,
+    on_behalf_of: str | Principal | None = None,
+    origin_workspace: str | None = None,
 ) -> dict[str, str]:
     """Get default headers for SDK requests.
 
@@ -235,6 +249,9 @@ def _get_default_headers(
             else:
                 headers["X-NMP-Principal-On-Behalf-Of"] = on_behalf_of
 
+    if origin_workspace:
+        headers[NMP_ORIGIN_WORKSPACE_HEADER] = origin_workspace
+
     return headers
 
 
@@ -244,6 +261,7 @@ def get_platform_sdk(
     http_client: httpx.Client | None = None,
     on_behalf_of: str | Principal | None = None,
     base_url: str | None = None,
+    origin_workspace: str | None = None,
 ) -> NeMoPlatform:
     """
     Returns an instance of the NeMoPlatform SDK configured with the platform's base URL.
@@ -269,14 +287,14 @@ def get_platform_sdk(
         http_client=http_client,
         endpoint=endpoint,
     ):
-        headers = _workload_identity_extra_headers(internal=internal)
+        headers = _workload_identity_extra_headers(internal=internal, origin_workspace=origin_workspace)
         sdk = NeMoPlatform(
             base_url=base_url or endpoint.connect_base_url,
             default_headers=headers if headers else None,
         )
         return attach_platform_request_router(sdk)
 
-    headers = _get_default_headers(as_service, internal, on_behalf_of)
+    headers = _get_default_headers(as_service, internal, on_behalf_of, origin_workspace)
     sdk = NeMoPlatform(
         base_url=base_url or endpoint.connect_base_url,
         http_client=_sync_http_client_for_endpoint(endpoint, http_client),
@@ -300,7 +318,10 @@ def get_task_sdk(as_service: str, http_client: httpx.Client | None = None) -> Ne
         Configured NeMoPlatform SDK with internal + on-behalf-of headers.
     """
     if http_client is None and is_workload_identity_token_file_set():
-        return get_platform_sdk(internal=True)
+        return get_platform_sdk(
+            internal=True,
+            origin_workspace=os.environ.get(NMP_ORIGIN_WORKSPACE_ENVVAR),
+        )
 
     if http_client is None:
         http_client = resolve_platform_endpoint().sync_sdk_http_client()
@@ -316,6 +337,7 @@ def get_task_sdk(as_service: str, http_client: httpx.Client | None = None) -> Ne
         internal=True,
         http_client=http_client,
         on_behalf_of=principal.effective_principal if principal else None,
+        origin_workspace=os.environ.get(NMP_ORIGIN_WORKSPACE_ENVVAR),
     )
 
 
@@ -334,7 +356,10 @@ def get_async_task_sdk(as_service: str, http_client: Optional[httpx.AsyncClient]
         Configured AsyncNeMoPlatform SDK with internal + on-behalf-of headers.
     """
     if http_client is None and is_workload_identity_token_file_set():
-        return get_async_platform_sdk(internal=True)
+        return get_async_platform_sdk(
+            internal=True,
+            origin_workspace=os.environ.get(NMP_ORIGIN_WORKSPACE_ENVVAR),
+        )
 
     if http_client is None:
         http_client = resolve_platform_endpoint().async_sdk_http_client()
@@ -350,6 +375,7 @@ def get_async_task_sdk(as_service: str, http_client: Optional[httpx.AsyncClient]
         internal=True,
         http_client=http_client,
         on_behalf_of=principal.effective_principal if principal else None,
+        origin_workspace=os.environ.get(NMP_ORIGIN_WORKSPACE_ENVVAR),
     )
 
 
@@ -359,6 +385,7 @@ def get_async_platform_sdk(
     http_client: Optional[httpx.AsyncClient] = None,
     on_behalf_of: Optional[str | Principal] = None,
     base_url: str | None = None,
+    origin_workspace: str | None = None,
 ) -> AsyncNeMoPlatform:
     """
     Returns an instance of the AsyncNeMoPlatform SDK configured with the platform's base URL.
@@ -384,7 +411,7 @@ def get_async_platform_sdk(
         http_client=http_client,
         endpoint=endpoint,
     ):
-        headers = _workload_identity_extra_headers(internal=internal)
+        headers = _workload_identity_extra_headers(internal=internal, origin_workspace=origin_workspace)
         if _test_http_client is None:
             sdk = AsyncNeMoPlatform(
                 base_url=base_url or endpoint.connect_base_url,
@@ -398,7 +425,7 @@ def get_async_platform_sdk(
             )
         return attach_platform_request_router(sdk)
 
-    headers = _get_default_headers(as_service, internal, on_behalf_of)
+    headers = _get_default_headers(as_service, internal, on_behalf_of, origin_workspace)
 
     # Use explicitly provided http_client (from DependencyProvider) or fall back to
     # module-level _test_http_client for backward compatibility with direct callers.
@@ -414,16 +441,25 @@ def get_async_platform_sdk(
 
 def get_request_scoped_sdk(
     base_sdk: AsyncNeMoPlatform,
+    *,
+    as_service: str | None = None,
+    origin_workspace: str | None = None,
 ) -> AsyncNeMoPlatform:
     """Create a request-scoped SDK with current auth and observability headers.
 
     Takes a base SDK (with shared HTTP client) and returns a new SDK instance
-    with the current request's auth headers applied via .with_options().
+    with the current request's auth headers applied via .with_options(). When
+    ``as_service`` is provided, the request is authenticated as that service on
+    behalf of the current user, making its origin workspace a trusted
+    service-to-service signal.
 
     This is lightweight - the underlying HTTP client is reused.
 
     Args:
         base_sdk: The base SDK instance (typically cached by DependencyProvider)
+        as_service: Optional calling service name for delegated downstream requests.
+        origin_workspace: Trusted workspace from the current route, used when
+            middleware context cannot infer the mounted route's full path.
 
     Returns:
         SDK instance with auth + OTEL headers, or base_sdk if no headers to add.
@@ -433,9 +469,14 @@ def get_request_scoped_sdk(
         for FastAPI dependency injection.
     """
 
-    # Combine OTEL headers (tracing) + auth headers (user identity)
+    # Combine OTEL headers (tracing) + auth headers (direct user or delegated service).
     headers = get_otel_headers().copy()
-    headers.update(get_principal_auth_headers())
+    if as_service:
+        headers.update(build_service_principal_headers(as_service))
+        if origin_workspace:
+            headers[NMP_ORIGIN_WORKSPACE_HEADER] = origin_workspace
+    else:
+        headers.update(get_principal_auth_headers())
 
     # If we have headers to add, create a new SDK with them
     # This reuses the underlying HTTP client (lightweight operation)
@@ -446,9 +487,11 @@ def get_request_scoped_sdk(
 
 
 def get_sdk_on_behalf_of(
-    base_sdk: NeMoPlatform | AsyncNeMoPlatform,
+    base_sdk: PlatformSDKT,
     on_behalf_of: str | Principal,
-) -> NeMoPlatform | AsyncNeMoPlatform:
+    *,
+    origin_workspace: str | None = None,
+) -> PlatformSDKT:
     """Create an SDK with on-behalf-of headers for delegated access.
 
     Takes an existing SDK (typically created as a service principal) and returns
@@ -462,6 +505,7 @@ def get_sdk_on_behalf_of(
     Args:
         base_sdk: The base SDK instance (typically created with as_service)
         on_behalf_of: The principal ID to act on behalf of (e.g., user email)
+        origin_workspace: Workspace that initiated the delegated operation.
 
     Returns:
         SDK instance with on-behalf-of header added and all original headers preserved.
@@ -496,6 +540,8 @@ def get_sdk_on_behalf_of(
         merged_headers = {**headers, "X-NMP-Principal-On-Behalf-Of": on_behalf_of}
         merged_headers.pop("X-NMP-Principal-On-Behalf-Of-Groups", None)
         merged_headers.pop("X-NMP-Principal-On-Behalf-Of-Email", None)
+    if origin_workspace:
+        merged_headers[NMP_ORIGIN_WORKSPACE_HEADER] = origin_workspace
     return with_options_preserving_request_router(base_sdk, set_default_headers=merged_headers)
 
 

--- a/packages/nmp_common/src/nmp/common/service/base.py
+++ b/packages/nmp_common/src/nmp/common/service/base.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from typing import ClassVar, Dict, Generic, List, Optional, Self, Type, TypeVar, cast, get_args, get_origin
 
 import httpx
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 from nemo_platform import AsyncNeMoPlatform, DefaultAsyncHttpxClient
 from nmp.common.api.utils import register_query_param_schemas
@@ -84,6 +84,23 @@ class DependencyProvider:
             self._http_client = DefaultAsyncHttpxClient()
         return self._http_client
 
+    def _request_service_name(self) -> str:
+        """Resolve the service owning the current route in a merged platform app."""
+        from nmp.common.observability.context import get_app_ctx
+
+        app_ctx = get_app_ctx()
+        if app_ctx is not None and app_ctx.service_name:
+            return app_ctx.service_name
+        return self._service_name
+
+    @staticmethod
+    def _route_origin_workspace(request: Request) -> str | None:
+        """Return a concrete route workspace, excluding the all-workspaces sentinel."""
+        workspace = request.path_params.get("workspace")
+        if isinstance(workspace, str) and workspace != "-":
+            return workspace
+        return None
+
     def get_sdk_client(self, as_service: str | None = None) -> AsyncNeMoPlatform:
         """Return the async platform SDK client.
 
@@ -112,6 +129,11 @@ class DependencyProvider:
     def get_entity_client(self, as_service: str | None = None) -> Optional[EntityClient]:
         """Return the EntityClient.
 
+        For FastAPI request handling, use ``get_request_scoped_entity_client`` instead —
+        it is the active dependency override and correctly propagates the route workspace
+        as the ``X-NMP-Origin-Workspace`` header. This method is for background tasks,
+        controllers, and startup code that run outside a request context.
+
         Args:
             as_service: If provided, creates a NEW EntityClient backed by an SDK with
                        service principal credentials (not cached). Use this for startup
@@ -119,9 +141,9 @@ class DependencyProvider:
                        request context.
 
         Returns:
-            EntityClient - new instance with service principal + on-behalf-of SDK
-            for request handling, or new instance with explicit service credentials
-            if as_service is provided.
+            EntityClient with explicit service credentials when ``as_service`` is provided,
+            otherwise an EntityClient with service principal + on-behalf-of from the
+            current auth context (no origin workspace).
         """
         from nemo_platform_plugin.client.adapter import client_from_platform
         from nemo_platform_plugin.entities.client import AsyncEntitiesClient
@@ -139,7 +161,7 @@ class DependencyProvider:
         sdk = self._get_entity_sdk_on_behalf_of()
         return EntityClient(client_from_platform(sdk, AsyncEntitiesClient))
 
-    def _get_entity_sdk_on_behalf_of(self) -> AsyncNeMoPlatform:
+    def _get_entity_sdk_on_behalf_of(self, *, origin_workspace: str | None = None) -> AsyncNeMoPlatform:
         """Create a per-request SDK for entity operations using service principal + on-behalf-of.
 
         Uses the cached base SDK and applies per-request headers via .with_options()
@@ -149,9 +171,35 @@ class DependencyProvider:
         from nmp.common.service.headers import build_downstream_service_headers
 
         base_sdk = self.get_sdk_client()
-        headers = build_downstream_service_headers(self._service_name)
+        headers = build_downstream_service_headers(
+            self._service_name,
+            origin_workspace=origin_workspace,
+        )
 
         return with_options_preserving_request_router(base_sdk, set_default_headers=headers)
+
+    def get_request_scoped_entity_client(self, request: Request) -> EntityClient:
+        """Return an entity client scoped to the current route and principal."""
+        from nemo_platform_plugin.client.adapter import client_from_platform
+        from nemo_platform_plugin.entities.client import AsyncEntitiesClient
+        from nmp.common.entities.client import EntityClient
+        from nmp.common.sdk_factory import get_request_scoped_sdk, with_options_preserving_request_router
+        from nmp.common.service.headers import build_downstream_service_headers
+
+        workspace = self._route_origin_workspace(request)
+        if workspace is not None:
+            service_name = self._request_service_name()
+            base_sdk = self.get_sdk_client()
+            headers = build_downstream_service_headers(
+                service_name,
+                origin_workspace=workspace,
+            )
+            sdk = with_options_preserving_request_router(base_sdk, set_default_headers=headers)
+        else:
+            # A workspace-less route has no trusted delegation origin. Preserve
+            # the direct caller instead of manufacturing an unverifiable origin.
+            sdk = get_request_scoped_sdk(self.get_sdk_client())
+        return EntityClient(client_from_platform(sdk, AsyncEntitiesClient))
 
     def get_platform_config(self) -> PlatformConfig:
         """Return the PlatformConfig (lazily initialized)."""
@@ -159,7 +207,7 @@ class DependencyProvider:
             self._platform_config = Configuration.get_platform_config()
         return self._platform_config
 
-    def get_request_scoped_sdk(self) -> AsyncNeMoPlatform:
+    def get_request_scoped_sdk(self, request: Request) -> AsyncNeMoPlatform:
         """Return a request-scoped SDK with current auth and OTEL headers.
 
         This wraps the cached base SDK with per-request headers via .with_options().
@@ -168,7 +216,12 @@ class DependencyProvider:
         from nmp.common.sdk_factory import get_request_scoped_sdk
 
         base_sdk = self.get_sdk_client()  # Cached base SDK
-        return get_request_scoped_sdk(base_sdk)
+        workspace = self._route_origin_workspace(request)
+        return get_request_scoped_sdk(
+            base_sdk,
+            as_service=self._request_service_name() if workspace else None,
+            origin_workspace=workspace,
+        )
 
     def setup_dependencies(self, app: FastAPI, service: "Service") -> None:
         """Configure FastAPI dependency overrides."""
@@ -179,8 +232,9 @@ class DependencyProvider:
             get_service_config,
         )
 
+        self._service_name = service.name
         app.dependency_overrides[get_sdk_client] = self.get_request_scoped_sdk
-        app.dependency_overrides[get_entity_client] = self.get_entity_client
+        app.dependency_overrides[get_entity_client] = self.get_request_scoped_entity_client
         app.dependency_overrides[get_platform_config] = self.get_platform_config
         if service._service_config is not None:
             app.dependency_overrides[get_service_config] = lambda: service._service_config

--- a/packages/nmp_common/src/nmp/common/service/headers.py
+++ b/packages/nmp_common/src/nmp/common/service/headers.py
@@ -5,11 +5,15 @@
 
 from typing import Dict
 
-from nmp.common.auth import build_service_principal_headers
+from nmp.common.auth import NMP_ORIGIN_WORKSPACE_HEADER, build_service_principal_headers
 from nmp.common.observability.otel import get_otel_headers
 
 
-def build_downstream_service_headers(service_name: str) -> Dict[str, str]:
+def build_downstream_service_headers(
+    service_name: str,
+    *,
+    origin_workspace: str | None = None,
+) -> Dict[str, str]:
     """Build the full set of headers for HTTP requests to downstream NeMo Platform services.
 
     This is used when constructing the SDK client for entity operations
@@ -23,6 +27,8 @@ def build_downstream_service_headers(service_name: str) -> Dict[str, str]:
 
     Args:
         service_name: The calling service's name (e.g. ``"guardrails"``).
+        origin_workspace: Trusted workspace from the current route for delegated
+            downstream requests.
 
     Returns:
         Header dictionary ready to merge into an outbound request.
@@ -36,4 +42,7 @@ def build_downstream_service_headers(service_name: str) -> Dict[str, str]:
         #   "X-NMP-Principal-On-Behalf-Of": "<user-id>",   # if user in context
         # }
     """
-    return {**get_otel_headers(), **build_service_principal_headers(service_name)}
+    headers = {**get_otel_headers(), **build_service_principal_headers(service_name)}
+    if origin_workspace:
+        headers[NMP_ORIGIN_WORKSPACE_HEADER] = origin_workspace
+    return headers

--- a/packages/nmp_common/tests/auth/test_authz_merge.py
+++ b/packages/nmp_common/tests/auth/test_authz_merge.py
@@ -20,7 +20,9 @@ def test_merge_adds_endpoints_and_role_permissions() -> None:
             "permissions": {
                 "customization.automodel.jobs.create": "Create automodel jobs",
                 "customization.automodel.jobs.read": "Read automodel jobs",
+                "customization.automodel.jobs.export": "Export automodel jobs",
             },
+            "role_permissions": {"Exporter": ["customization.automodel.jobs.export"]},
             "endpoints": {
                 "/apis/customization/v2/workspaces/{workspace}/automodel/jobs": {
                     "post": {
@@ -39,3 +41,27 @@ def test_merge_adds_endpoints_and_role_permissions() -> None:
     assert "customization.automodel.jobs.create" in editor_perms
     viewer_perms = merged["authz"]["roles"]["Viewer"]["permissions"]
     assert "customization.automodel.jobs.read" in viewer_perms
+    export_permission = "customization.automodel.jobs.export"
+    assert export_permission in merged["authz"]["roles"]["Exporter"]["permissions"]
+    # Admin inherits export permissions from Exporter via includes[] at OPA eval time,
+    # so the merge does not need to add them directly to the Admin role.
+    assert "Admin" not in merged["authz"]["roles"]
+    assert export_permission not in editor_perms
+
+
+def test_merge_does_not_make_read_permissions_exportable_implicitly() -> None:
+    base = {
+        "authz": {
+            "permissions": {},
+            "roles": {"Editor": {"permissions": []}, "Viewer": {"permissions": []}},
+            "endpoints": {},
+        }
+    }
+
+    merged = merge_authz_contributions(
+        base,
+        [{"permissions": {"sensitive.records.read": "Read sensitive records"}}],
+    )
+
+    assert "Exporter" not in merged["authz"]["roles"]
+    assert "export" not in merged["authz"]["permissions"]["sensitive"]["records"]

--- a/packages/nmp_common/tests/auth/test_client.py
+++ b/packages/nmp_common/tests/auth/test_client.py
@@ -227,6 +227,30 @@ class TestAuthorizeRequestPdpPayloadWithDelegation:
         assert body["principal_groups"] == ["workspace-editors"]
         assert body["on_behalf_of_principal_id"] == "user@example.com"
 
+    @pytest.mark.asyncio
+    async def test_authorize_request_sends_origin_workspace(self, auth_config, principal_service_delegating):
+        mock_http_client = httpx.AsyncClient()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": {"allowed": True}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(mock_http_client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            auth_client = AuthClient(
+                principal=principal_service_delegating,
+                config=auth_config,
+                http_client=mock_http_client,
+            )
+            await auth_client.authorize_request(
+                "GET",
+                "/v2/workspaces/source/models",
+                http_client=mock_http_client,
+                origin_workspace="destination",
+            )
+
+        body = mock_post.call_args[1]["json"]["input"]
+        assert body["origin_workspace"] == "destination"
+
 
 class TestWaitRole:
     @pytest.mark.asyncio

--- a/packages/nmp_common/tests/auth/test_dependencies.py
+++ b/packages/nmp_common/tests/auth/test_dependencies.py
@@ -300,13 +300,20 @@ class TestBuildServicePrincipalHeadersDelegation:
             email="user@example.com",
             groups=["team-a", "team-b"],
         )
-        token = auth_client_context.set(AuthClient(principal=user, config=AuthConfig()))
+        token = auth_client_context.set(
+            AuthClient(
+                principal=user,
+                config=AuthConfig(),
+                request_workspace="workspace-a",
+            )
+        )
         try:
             h = build_service_principal_headers("guardrails")
             assert h["X-NMP-Principal-Id"] == "service:guardrails"
             assert h["X-NMP-Principal-On-Behalf-Of"] == "user@example.com"
             assert h["X-NMP-Principal-On-Behalf-Of-Email"] == "user@example.com"
             assert h["X-NMP-Principal-On-Behalf-Of-Groups"] == "team-a,team-b"
+            assert h["X-NMP-Origin-Workspace"] == "workspace-a"
         finally:
             auth_client_context.reset(token)
 

--- a/packages/nmp_common/tests/auth/test_middleware.py
+++ b/packages/nmp_common/tests/auth/test_middleware.py
@@ -8,11 +8,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import jwt
 import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nmp.common.auth.client import AuthClient
+from nmp.common.auth.dependencies import build_service_principal_bearer_token
 from nmp.common.auth.jwt import TokenClaims, UnsignedJWTRejectedError
-from nmp.common.auth.middleware import HEALTH_ENDPOINTS, PUBLIC_GET_PATHS, AuthorizationMiddleware
+from nmp.common.auth.middleware import HEALTH_ENDPOINTS, PUBLIC_GET_PATHS, AuthorizationMiddleware, _request_workspace
 from nmp.common.auth.models import Principal
 from nmp.common.config import AuthConfig, Configuration
 from nmp.common.config.base import OIDCConfig
@@ -26,12 +29,22 @@ def _cleanup_config_overrides():
 
 
 @pytest.fixture
-def oidc_config():
+def oidc_config(tmp_path):
     """Create an OIDC config for testing."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_key_file = tmp_path / "service-token.pem"
+    private_key_file.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
     return OIDCConfig(
         enabled=True,
         issuer="https://sso.example.com",
         client_id="test-client",
+        workload_token_private_key_file=str(private_key_file),
     )
 
 
@@ -123,6 +136,12 @@ def create_test_app_with_platform_routes(auth_config: AuthConfig) -> FastAPI:
         return {"data": []}
 
     return app
+
+
+def test_request_workspace_uses_canonical_versioned_workspace_segment() -> None:
+    path = "/apis/entities/v2/workspaces/source/entities/workspaces/resource-name"
+
+    assert _request_workspace(path) == "source"
 
 
 class TestHealthEndpointsBypass:
@@ -440,8 +459,9 @@ class TestCompatibilityAuth:
     @pytest.mark.parametrize(
         "token,expected_status",
         [
-            ("service:nim", 200),
-            ("service:customizer", 200),
+            ("service:nim", 401),
+            ("service:customizer", 401),
+            ("nmp-service-v2.not-a-jwt", 401),
             ("invalid-token", 401),
         ],
     )
@@ -462,8 +482,8 @@ class TestCompatibilityAuth:
             if expected_status == 200:
                 mock_authorize.assert_called_once()
 
-    def test_hf_endpoint_authorizes_as_bearer_service_principal(self, auth_config_enabled):
-        """The PDP receives the service principal synthesized from the HF Bearer token."""
+    def test_hf_endpoint_rejects_legacy_service_principal_token(self, auth_config_enabled):
+        """Raw service principals are not credentials for the HF endpoint."""
         app = create_test_app(auth_config_enabled)
         client = TestClient(app, raise_server_exceptions=False)
 
@@ -475,9 +495,78 @@ class TestCompatibilityAuth:
                 headers={"Authorization": "Bearer service:models"},
             )
 
+        assert response.status_code == 401
+        mock_authorize.assert_not_called()
+
+    def test_hf_endpoint_authorizes_with_delegated_service_token(self, auth_config_enabled):
+        """A puller token preserves the original user and source workspace context."""
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+        token = build_service_principal_bearer_token(
+            "models",
+            on_behalf_of=Principal(
+                id="user@example.com",
+                email="user@example.com",
+                groups=["model-exporters"],
+            ),
+            origin_workspace="destination-workspace",
+            source_workspace="source-workspace",
+        )
+
+        with patch.object(AuthClient, "authorize_request", autospec=True) as mock_authorize:
+            mock_authorize.return_value = MagicMock(allowed=True)
+            response = client.get(
+                "/apis/files/v2/hf/source-workspace/my-fileset/resolve/main/model.bin",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
         assert response.status_code == 200
         auth_client = mock_authorize.call_args.args[0]
         assert auth_client.principal.id == "service:models"
+        assert auth_client.principal.effective_id == "user@example.com"
+        assert auth_client.principal.effective_email == "user@example.com"
+        assert auth_client.principal.effective_groups == []
+        assert mock_authorize.call_args.kwargs["origin_workspace"] == "destination-workspace"
+
+    def test_hf_endpoint_rejects_token_for_different_source_workspace(self, auth_config_enabled):
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+        token = build_service_principal_bearer_token(
+            "models",
+            on_behalf_of=Principal(id="user@example.com"),
+            origin_workspace="destination-workspace",
+            source_workspace="different-source",
+        )
+
+        with patch.object(AuthClient, "authorize_request", autospec=True) as mock_authorize:
+            response = client.get(
+                "/apis/files/v2/hf/source-workspace/my-fileset/resolve/main/model.bin",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+        assert response.status_code == 401
+        mock_authorize.assert_not_called()
+
+    def test_hf_endpoint_rejects_tampered_delegation_token(self, auth_config_enabled):
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+        token = build_service_principal_bearer_token(
+            "models",
+            on_behalf_of=Principal(id="user@example.com"),
+            origin_workspace="destination-workspace",
+            source_workspace="source-workspace",
+        )
+        replacement = "a" if token[-1] != "a" else "b"
+        tampered = f"{token[:-1]}{replacement}"
+
+        with patch.object(AuthClient, "authorize_request", autospec=True) as mock_authorize:
+            response = client.get(
+                "/apis/files/v2/hf/source-workspace/my-fileset/resolve/main/model.bin",
+                headers={"Authorization": f"Bearer {tampered}"},
+            )
+
+        assert response.status_code == 401
+        mock_authorize.assert_not_called()
 
     def test_files_otlp_logs_upload_accepts_service_principal_header(self, auth_config_enabled):
         """Job log uploads accept the launcher fallback service principal header."""
@@ -615,6 +704,7 @@ class TestServicePrincipalDelegationMiddleware:
                     "x-nmp-principal-on-behalf-of": "user@example.com",
                     "x-nmp-principal-on-behalf-of-groups": "ws-editors",
                     "x-nmp-principal-on-behalf-of-email": "user@example.com",
+                    "x-nmp-origin-workspace": "test-workspace",
                 },
             )
 
@@ -639,7 +729,77 @@ class TestServicePrincipalDelegationMiddleware:
                     "x-nmp-principal-id": "service:worker",
                     "x-nmp-principal-on-behalf-of": "user@example.com",
                     "x-nmp-principal-on-behalf-of-groups": "no-access",
+                    "x-nmp-origin-workspace": "test-workspace",
                 },
             )
 
         assert response.status_code == 403
+
+    def test_service_origin_workspace_is_sent_to_pdp(self, auth_config_enabled):
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch.object(AuthClient, "authorize_request", new_callable=AsyncMock) as mock_authorize:
+            mock_authorize.return_value = MagicMock(allowed=True)
+            response = client.post(
+                "/apis/files/v2/workspaces/workspace-b/filesets/logs/otlp/v1/logs",
+                headers={
+                    "x-nmp-principal-id": "service:worker",
+                    "x-nmp-principal-on-behalf-of": "user@example.com",
+                    "x-nmp-origin-workspace": "workspace-a",
+                },
+            )
+
+        assert response.status_code == 200
+        assert mock_authorize.call_args.kwargs["origin_workspace"] == "workspace-a"
+
+    def test_user_cannot_spoof_origin_workspace(self, auth_config_enabled):
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch.object(AuthClient, "authorize_request", new_callable=AsyncMock) as mock_authorize:
+            mock_authorize.return_value = MagicMock(allowed=True)
+            response = client.post(
+                "/apis/files/v2/workspaces/workspace-b/filesets/logs/otlp/v1/logs",
+                headers={
+                    "x-nmp-principal-id": "user@example.com",
+                    "x-nmp-origin-workspace": "workspace-b",
+                },
+            )
+
+        assert response.status_code == 200
+        assert mock_authorize.call_args.kwargs["origin_workspace"] is None
+
+    def test_service_delegation_requires_origin_workspace(self, auth_config_enabled):
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch.object(AuthClient, "authorize_request", new_callable=AsyncMock) as mock_authorize:
+            response = client.post(
+                "/apis/files/v2/workspaces/workspace-b/filesets/logs/otlp/v1/logs",
+                headers={
+                    "x-nmp-principal-id": "service:worker",
+                    "x-nmp-principal-on-behalf-of": "user@example.com",
+                },
+            )
+
+        assert response.status_code == 400
+        mock_authorize.assert_not_awaited()
+
+    def test_service_malformed_origin_workspace_is_rejected(self, auth_config_enabled):
+        app = create_test_app(auth_config_enabled)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        with patch.object(AuthClient, "authorize_request", new_callable=AsyncMock) as mock_authorize:
+            mock_authorize.return_value = MagicMock(allowed=True)
+            response = client.post(
+                "/apis/files/v2/workspaces/workspace-b/filesets/logs/otlp/v1/logs",
+                headers={
+                    "x-nmp-principal-id": "service:worker",
+                    "x-nmp-principal-on-behalf-of": "user@example.com",
+                    "x-nmp-origin-workspace": "invalid!!header",
+                },
+            )
+
+        assert response.status_code == 400
+        mock_authorize.assert_not_awaited()

--- a/packages/nmp_common/tests/auth/test_models.py
+++ b/packages/nmp_common/tests/auth/test_models.py
@@ -383,7 +383,7 @@ class TestPrincipalFromEnvVar:
 
 
 class TestAuthContextPrincipalRoundTrip:
-    """AuthContext should preserve delegation fields for persistence and SDK rehydration."""
+    """AuthContext preserves identity but drops durable group snapshots."""
 
     def test_from_principal_and_to_principal_round_trip(self):
         p = Principal(
@@ -394,16 +394,30 @@ class TestAuthContextPrincipalRoundTrip:
             on_behalf_of_email="user@example.com",
             on_behalf_of_groups=["g-user"],
         )
-        ctx = AuthContext.from_principal(p)
+        ctx = AuthContext.from_principal(p, origin_workspace="workspace-a")
         assert ctx.principal_id == "service:x"
         assert ctx.principal_email == "svc@example.com"
-        assert ctx.principal_groups == ["g-svc"]
+        assert ctx.principal_groups == []
         assert ctx.principal_on_behalf_of == "user@example.com"
         assert ctx.principal_on_behalf_of_email == "user@example.com"
-        assert ctx.principal_on_behalf_of_groups == ["g-user"]
+        assert ctx.principal_on_behalf_of_groups is None
+        assert ctx.origin_workspace == "workspace-a"
 
         restored = ctx.to_principal()
-        assert restored.model_dump() == p.model_dump()
+        assert restored.id == p.id
+        assert restored.email == p.email
+        assert restored.groups == []
+        assert restored.on_behalf_of == p.on_behalf_of
+        assert restored.on_behalf_of_email == p.on_behalf_of_email
+        assert restored.on_behalf_of_groups is None
+
+        env = ctx.get_env_vars()
+        assert env["NMP_ORIGIN_WORKSPACE"] == "workspace-a"
+
+    def test_from_principal_ignores_non_string_origin(self):
+        ctx = AuthContext.from_principal(Principal(id="service:x"), origin_workspace=object())  # type: ignore[arg-type]
+
+        assert ctx.origin_workspace is None
 
 
 class TestPrincipalGetOtlpHeadersValue:

--- a/packages/nmp_common/tests/nmp_common/test_dependency_provider.py
+++ b/packages/nmp_common/tests/nmp_common/test_dependency_provider.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nmp.common.service import DependencyProvider
 from nmp.common.service.dependencies import get_entity_client, get_platform_config, get_sdk_client
+from starlette.requests import Request
 
 
 def test_get_http_client_caches_default_client() -> None:
@@ -47,13 +48,159 @@ def test_setup_dependencies_registers_fastapi_overrides() -> None:
     provider = DependencyProvider()
     app = FastAPI()
     service = MagicMock()
+    service.name = "data-designer"
     service._service_config = None
 
     provider.setup_dependencies(app, service)
 
+    assert provider._service_name == "data-designer"
     assert app.dependency_overrides[get_sdk_client] == provider.get_request_scoped_sdk
-    assert app.dependency_overrides[get_entity_client] == provider.get_entity_client
+    assert app.dependency_overrides[get_entity_client] == provider.get_request_scoped_entity_client
     assert app.dependency_overrides[get_platform_config] == provider.get_platform_config
+
+
+def test_request_scoped_sdk_uses_service_name_and_workspace_path() -> None:
+    provider = DependencyProvider()
+    provider._service_name = "data-designer"
+    base_sdk = MagicMock(name="base_sdk")
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v2/workspaces/workspace-a/preview",
+            "headers": [],
+            "path_params": {"workspace": "workspace-a"},
+        }
+    )
+
+    with (
+        patch.object(provider, "get_sdk_client", return_value=base_sdk),
+        patch("nmp.common.sdk_factory.get_request_scoped_sdk", return_value=MagicMock()) as scoped,
+    ):
+        provider.get_request_scoped_sdk(request)
+
+    scoped.assert_called_once_with(
+        base_sdk,
+        as_service="data-designer",
+        origin_workspace="workspace-a",
+    )
+
+
+def test_request_scoped_sdk_preserves_direct_principal_without_workspace() -> None:
+    provider = DependencyProvider()
+    provider._service_name = "auth"
+    base_sdk = MagicMock(name="base_sdk")
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/v2/iam/opa-bundle.tar.gz",
+            "headers": [],
+            "path_params": {},
+        }
+    )
+
+    with (
+        patch.object(provider, "get_sdk_client", return_value=base_sdk),
+        patch("nmp.common.sdk_factory.get_request_scoped_sdk", return_value=MagicMock()) as scoped,
+    ):
+        provider.get_request_scoped_sdk(request)
+
+    scoped.assert_called_once_with(
+        base_sdk,
+        as_service=None,
+        origin_workspace=None,
+    )
+
+
+def test_request_scoped_sdk_preserves_direct_principal_for_all_workspaces() -> None:
+    provider = DependencyProvider()
+    base_sdk = MagicMock(name="base_sdk")
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/v2/workspaces/-/jobs",
+            "headers": [],
+            "path_params": {"workspace": "-"},
+        }
+    )
+
+    with (
+        patch.object(provider, "get_sdk_client", return_value=base_sdk),
+        patch("nmp.common.sdk_factory.get_request_scoped_sdk", return_value=MagicMock()) as scoped,
+    ):
+        provider.get_request_scoped_sdk(request)
+
+    scoped.assert_called_once_with(
+        base_sdk,
+        as_service=None,
+        origin_workspace=None,
+    )
+
+
+def test_request_scoped_entity_client_delegates_with_route_workspace() -> None:
+    provider = DependencyProvider()
+    provider._service_name = "data-designer"
+    base_sdk = MagicMock(name="base_sdk")
+    sdk = MagicMock(name="scoped_sdk")
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v2/workspaces/workspace-a/entities",
+            "headers": [],
+            "path_params": {"workspace": "workspace-a"},
+        }
+    )
+
+    with (
+        patch.object(provider, "get_sdk_client", return_value=base_sdk),
+        patch(
+            "nmp.common.service.headers.build_downstream_service_headers", return_value={"test": "header"}
+        ) as headers,
+        patch("nmp.common.sdk_factory.with_options_preserving_request_router", return_value=sdk) as scoped,
+        patch("nemo_platform_plugin.client.adapter.client_from_platform"),
+        patch("nmp.common.entities.client.EntityClient"),
+    ):
+        provider.get_request_scoped_entity_client(request)
+
+    headers.assert_called_once_with("data-designer", origin_workspace="workspace-a")
+    scoped.assert_called_once_with(base_sdk, set_default_headers={"test": "header"})
+
+
+def test_request_service_name_uses_merged_router_context() -> None:
+    provider = DependencyProvider()
+    provider._service_name = "last-registered-service"
+    app_ctx = MagicMock(service_name="files")
+
+    with patch("nmp.common.observability.context.get_app_ctx", return_value=app_ctx):
+        assert provider._request_service_name() == "files"
+
+
+def test_request_scoped_entity_client_preserves_direct_principal_without_workspace() -> None:
+    provider = DependencyProvider()
+    base_sdk = MagicMock(name="base_sdk")
+    scoped_sdk = MagicMock(name="scoped_sdk")
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/v2/iam/opa-bundle.tar.gz",
+            "headers": [],
+            "path_params": {},
+        }
+    )
+
+    with (
+        patch.object(provider, "get_sdk_client", return_value=base_sdk),
+        patch("nmp.common.sdk_factory.get_request_scoped_sdk", return_value=scoped_sdk) as scoped,
+        patch("nemo_platform_plugin.client.adapter.client_from_platform"),
+        patch("nmp.common.entities.client.EntityClient"),
+    ):
+        provider.get_request_scoped_entity_client(request)
+
+    scoped.assert_called_once_with(base_sdk)
 
 
 @pytest.mark.asyncio

--- a/packages/nmp_common/tests/sdk_factory/test_sdk.py
+++ b/packages/nmp_common/tests/sdk_factory/test_sdk.py
@@ -299,12 +299,14 @@ def test_get_task_sdk_with_principal(monkeypatch: pytest.MonkeyPatch):
         }
     )
     monkeypatch.setenv("NMP_PRINCIPAL", principal_json)
+    monkeypatch.setenv("NMP_ORIGIN_WORKSPACE", "training-workspace")
 
     sdk = get_task_sdk(as_service="customizer")
 
     assert sdk.default_headers["X-NMP-Principal-Id"] == "service:customizer"
     assert sdk.default_headers["X-NMP-Internal"] == "true"
     assert sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "real-user@example.com"
+    assert sdk.default_headers["X-NMP-Origin-Workspace"] == "training-workspace"
 
 
 def test_get_task_sdk_without_principal(monkeypatch: pytest.MonkeyPatch):
@@ -442,6 +444,54 @@ def test_get_request_scoped_sdk_merges_otel_and_auth_headers():
     assert scoped_sdk.default_headers["X-NMP-Principal-Groups"] == "group1,group2"
 
 
+def test_get_request_scoped_sdk_can_delegate_as_calling_service():
+    """Service request SDKs carry the trusted caller, delegated user, and origin."""
+    base_sdk = get_async_platform_sdk()
+    service_headers = {
+        "X-NMP-Principal-Id": "service:models",
+        "X-NMP-Principal-On-Behalf-Of": "user@example.com",
+        "X-NMP-Origin-Workspace": "workspace-a",
+    }
+
+    with (
+        patch("nmp.common.sdk_factory.get_otel_headers", return_value={}),
+        patch(
+            "nmp.common.sdk_factory.build_service_principal_headers",
+            return_value=service_headers,
+        ) as build_headers,
+    ):
+        scoped_sdk = get_request_scoped_sdk(base_sdk, as_service="models")
+
+    build_headers.assert_called_once_with("models")
+    assert scoped_sdk.default_headers["X-NMP-Principal-Id"] == "service:models"
+    assert scoped_sdk.default_headers["X-NMP-Principal-On-Behalf-Of"] == "user@example.com"
+    assert scoped_sdk.default_headers["X-NMP-Origin-Workspace"] == "workspace-a"
+
+
+def test_get_request_scoped_sdk_uses_trusted_route_workspace_as_origin():
+    """A mounted workspace route supplies origin even when middleware path inference cannot."""
+    base_sdk = get_async_platform_sdk()
+    service_headers = {
+        "X-NMP-Principal-Id": "service:data-designer",
+        "X-NMP-Principal-On-Behalf-Of": "user@example.com",
+    }
+
+    with (
+        patch("nmp.common.sdk_factory.get_otel_headers", return_value={}),
+        patch(
+            "nmp.common.sdk_factory.build_service_principal_headers",
+            return_value=service_headers,
+        ),
+    ):
+        scoped_sdk = get_request_scoped_sdk(
+            base_sdk,
+            as_service="data-designer",
+            origin_workspace="workspace-a",
+        )
+
+    assert scoped_sdk.default_headers["X-NMP-Origin-Workspace"] == "workspace-a"
+
+
 def test_get_request_scoped_sdk_preserves_request_router(monkeypatch: pytest.MonkeyPatch):
     """Derived request SDKs must keep the base SDK's path-aware platform request router."""
     monkeypatch.setenv("NMP_BASE_URL", "https://nemo-gateway:8080")
@@ -480,7 +530,7 @@ def test_get_sdk_on_behalf_of_preserves_request_router(monkeypatch: pytest.Monke
 
     try:
         base_sdk = get_async_platform_sdk(as_service="models", internal=True)
-        scoped_sdk = get_sdk_on_behalf_of(base_sdk, "user@example.com")
+        scoped_sdk = get_sdk_on_behalf_of(base_sdk, "user@example.com", origin_workspace="workspace-a")
 
         prepared = scoped_sdk._prepare_url("https://nemo-gateway:8080/apis/entities/v2/workspaces")
 
@@ -488,6 +538,7 @@ def test_get_sdk_on_behalf_of_preserves_request_router(monkeypatch: pytest.Monke
         assert prepared.host == "127.0.0.1"
         assert prepared.port == 8080
         assert prepared.path == "/apis/entities/v2/workspaces"
+        assert scoped_sdk.default_headers["X-NMP-Origin-Workspace"] == "workspace-a"
     finally:
         Configuration.clear_cache()
 

--- a/packages/nmp_platform_runner/tests/test_sidecars.py
+++ b/packages/nmp_platform_runner/tests/test_sidecars.py
@@ -187,7 +187,7 @@ def test_real_adapters_sidecar_entrypoint_starts_and_stops_with_required_env(
     monkeypatch.delenv("VLLM_ENDPOINT", raising=False)
 
     monkeypatch.setattr(adapters_main, "get_platform_config", lambda: MagicMock(base_url="http://platform.local"))
-    monkeypatch.setattr(adapters_main, "get_platform_sdk", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(adapters_main, "get_task_sdk", lambda *_args, **_kwargs: MagicMock())
     monkeypatch.setattr(adapters_main.asyncio, "new_event_loop", lambda: MagicMock())
     monkeypatch.setattr(adapters_main, "Loop", FakeLoop)
     monkeypatch.setattr(adapters_main, "TimedLoopWaiter", lambda *_args, **_kwargs: object())

--- a/packages/nmp_testing/src/nmp/testing/client.py
+++ b/packages/nmp_testing/src/nmp/testing/client.py
@@ -15,12 +15,14 @@ from pathlib import Path
 from typing import Callable, Generator, Mapping, Protocol, TypeVar
 
 import httpx
+from fastapi import Request
 from fastapi.testclient import TestClient
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform, NotGiven, not_given
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nmp.common.config.base import AuthConfig, Configuration, DatabaseConfig, PlatformConfig, ServiceConfig
 from nmp.common.entities.client import EntityClient
+from nmp.common.observability.context import get_app_ctx
 from nmp.common.service import Service
 from nmp.common.service.dependencies import get_entity_client, get_sdk_client
 from nmp.core.entities.config import EntitiesConfig
@@ -507,8 +509,18 @@ def create_test_client(
         if get_sdk_client not in all_overrides:
             from nmp.common.sdk_factory import get_request_scoped_sdk
 
-            def _get_request_scoped_test_sdk() -> AsyncNeMoPlatform:
-                return get_request_scoped_sdk(async_sdk)
+            def _get_request_scoped_test_sdk(request: Request) -> AsyncNeMoPlatform:
+                app_ctx = get_app_ctx()
+                service_name = app_ctx.service_name if app_ctx is not None and app_ctx.service_name else "platform"
+                workspace_param = request.path_params.get("workspace")
+                workspace_origin = (
+                    workspace_param if isinstance(workspace_param, str) and workspace_param != "-" else None
+                )
+                return get_request_scoped_sdk(
+                    async_sdk,
+                    as_service=service_name if workspace_origin else None,
+                    origin_workspace=workspace_origin,
+                )
 
             all_overrides[get_sdk_client] = _get_request_scoped_test_sdk
 
@@ -519,14 +531,23 @@ def create_test_client(
         # apps get service:<name> and on-behalf-of the same as real deployments;
         # routes without that context (e.g. /health) fall back to "platform".
         if get_entity_client not in all_overrides:
-            from nmp.common.observability.context import get_app_ctx
             from nmp.common.service.headers import build_downstream_service_headers
 
-            def _get_entity_client_on_behalf_of() -> EntityClient:
+            def _get_entity_client_on_behalf_of(request: Request) -> EntityClient:
                 app_ctx = get_app_ctx()
                 service_name = app_ctx.service_name if app_ctx is not None and app_ctx.service_name else "platform"
-                headers = build_downstream_service_headers(service_name)
-                sdk = async_sdk.with_options(set_default_headers=headers)
+                workspace_param = request.path_params.get("workspace")
+                workspace_origin = (
+                    workspace_param if isinstance(workspace_param, str) and workspace_param != "-" else None
+                )
+                if workspace_origin:
+                    headers = build_downstream_service_headers(
+                        service_name,
+                        origin_workspace=workspace_origin,
+                    )
+                    sdk = async_sdk.with_options(set_default_headers=headers)
+                else:
+                    sdk = get_request_scoped_sdk(async_sdk)
                 return EntityClient(client_from_platform(sdk, AsyncEntitiesClient))
 
             all_overrides[get_entity_client] = _get_entity_client_on_behalf_of

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/bridge.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/bridge.py
@@ -17,12 +17,12 @@ from nemo_platform_plugin.jobs.constants import (
     NEMO_JOB_WORKSPACE_ENVVAR,
     PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
 )
-from nemo_platform_plugin.sdk_provider import get_platform_sdk
+from nemo_platform_plugin.sdk_provider import get_task_sdk
 
 
 def run() -> int:
     step_config = _get_step_config()
-    sdk = get_platform_sdk(as_service="data-designer")
+    sdk = get_task_sdk("data-designer")
     ctx = _get_ctx(sdk)
 
     return run_step_config(

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -8605,6 +8605,11 @@ components:
           title: Principal On Behalf Of Email
           description: The on-behalf-of principal's email address
           type: string
+        origin_workspace:
+          title: Origin Workspace
+          description: Workspace that initiated the operation captured by this auth
+            context
+          type: string
       type: object
       required:
       - principal_id

--- a/sdk/python/nemo-platform/src/nemo_platform/types/shared/auth_context.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/shared/auth_context.py
@@ -32,6 +32,9 @@ class AuthContext(BaseModel):
     principal_id: str
     """The principal's unique identifier"""
 
+    origin_workspace: Optional[str] = None
+    """Workspace that initiated the operation captured by this auth context"""
+
     principal_email: Optional[str] = None
     """The principal's email address"""
 

--- a/services/core/auth/scripts/auth-tools.py
+++ b/services/core/auth/scripts/auth-tools.py
@@ -707,6 +707,7 @@ def update(
     - Remove orphaned endpoints found in auth config but not in OpenAPI
     - Add orphaned permissions to appropriate roles:
       - .read and .list permissions → Viewer role
+      - .export permissions → Exporter role
       - All other permissions → Editor role
     """
     # Use default paths if not provided
@@ -801,7 +802,7 @@ def update(
     no_role_permissions = get_no_role_permissions(auth_config)
     orphaned_permissions = endpoint_permissions_stripped - role_permissions - no_role_permissions
 
-    permissions_added_to_roles = {"Viewer": [], "Editor": []}
+    permissions_added_to_roles = {"Viewer": [], "Editor": [], "Exporter": []}
 
     if orphaned_permissions and not dry_run:
         # Ensure roles exist
@@ -810,9 +811,12 @@ def update(
 
         # Add orphaned permissions to appropriate roles
         for perm in orphaned_permissions:
-            # Heuristic: .read and .list go to Viewer, everything else to Editor
+            # Read/list permissions belong to Viewer, export permissions to Exporter,
+            # and mutating permissions to Editor.
             if perm.endswith(".read") or perm.endswith(".list"):
                 target_role = "Viewer"
+            elif perm.endswith(".export"):
+                target_role = "Exporter"
             else:
                 target_role = "Editor"
 
@@ -832,7 +836,7 @@ def update(
                 permissions_added_to_roles[target_role].append(perm)
 
         # Sort permissions in each role for consistency
-        for role in ["Viewer", "Editor"]:
+        for role in ["Viewer", "Editor", "Exporter"]:
             if role in auth_config["authz"]["roles"] and "permissions" in auth_config["authz"]["roles"][role]:
                 auth_config["authz"]["roles"][role]["permissions"].sort()
     elif orphaned_permissions and dry_run:
@@ -840,6 +844,8 @@ def update(
         for perm in orphaned_permissions:
             if perm.endswith(".read") or perm.endswith(".list"):
                 permissions_added_to_roles["Viewer"].append(perm)
+            elif perm.endswith(".export"):
+                permissions_added_to_roles["Exporter"].append(perm)
             else:
                 permissions_added_to_roles["Editor"].append(perm)
 
@@ -1215,7 +1221,7 @@ def _generate_permissions_reference(auth_config: Dict) -> str:
         role_perms_map[role_name] = extract_role_permissions_recursive(roles_data, role_name)
 
     area_groups = _build_docs_area_groups(registry)
-    ordered_roles = ["Viewer", "Editor", "Admin", "JobRunner"]
+    ordered_roles = ["Viewer", "Editor", "Exporter", "Admin", "JobRunner"]
 
     lines: List[str] = []
     lines.append("---")

--- a/services/core/auth/src/nmp/core/auth/api/v2/iam/endpoints.py
+++ b/services/core/auth/src/nmp/core/auth/api/v2/iam/endpoints.py
@@ -75,6 +75,7 @@ async def list_role_bindings(
     This endpoint requires Platform Admin permissions.
     """
     require_service_principal_for_iam_role_bindings(auth_client)
+    entities_client = entities_client.as_service("auth", internal=True)
 
     # Translate is_active filter to revoked_at EXISTS filter for database query
     is_active_value = parsed.remove("is_active")
@@ -133,6 +134,7 @@ async def create_role_binding(
     Use `wait_role_propagation=false` to skip waiting (useful for bulk operations).
     """
     require_service_principal_for_iam_role_bindings(auth_client)
+    entities_client = entities_client.as_service("auth", internal=True)
     # Get the principal ID of the user making the request
     granted_by = auth_client.principal.id if auth_client.principal.id else "system"
 
@@ -197,6 +199,7 @@ async def get_role_binding(
     This endpoint requires Platform Admin permissions.
     """
     require_service_principal_for_iam_role_bindings(auth_client)
+    entities_client = entities_client.as_service("auth", internal=True)
     obj = await entities_client.get(RoleBindingEntity, name=name)
     if obj is None:
         raise HTTPException(status_code=404, detail="Role binding not found")
@@ -227,6 +230,7 @@ async def revoke_role_binding(
     Use `wait_role_propagation=false` to skip waiting (useful for bulk operations).
     """
     require_service_principal_for_iam_role_bindings(auth_client)
+    entities_client = entities_client.as_service("auth", internal=True)
     obj = await entities_client.get(RoleBindingEntity, name=name)
     if obj is None:
         raise HTTPException(status_code=404, detail="Role binding not found")

--- a/services/core/auth/src/nmp/core/auth/app/policies/authz.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/authz.rego
@@ -5,10 +5,13 @@ import future.keywords.if
 import future.keywords.in
 
 import data.authz.extract_method
+import data.authz.extract_on_behalf_of_principal_id
+import data.authz.extract_origin_workspace
 import data.authz.extract_path
 import data.authz.scope_check_passed
 import data.common.endpoint_scan
 import data.common.get_applicable_principals
+import data.common.get_effective_applicable_principals
 import data.common.has_permissions
 import data.common.req_callers
 import data.common.req_deny
@@ -226,6 +229,111 @@ allow_request if {
 
 # Default allow (deny_request overrides allow_request when true)
 default deny_request := false
+
+# A downstream read from another workspace requires the sibling ``.export``
+# permission for every read/list permission declared by the endpoint.
+export_permission(permission) := export_perm if {
+	parts := split(permission, ".")
+	count(parts) >= 2
+	action := parts[count(parts) - 1]
+	action in ["read", "list", "access"]
+	prefix := array.slice(parts, 0, count(parts) - 1)
+	export_perm := concat(".", array.concat(prefix, ["export"]))
+}
+
+req_export_permissions := {export_perm |
+	some permission in req_permissions
+	export_perm := export_permission(permission)
+}
+
+default cross_workspace_export_required := false
+
+cross_workspace_export_required if {
+	method := extract_method
+	method in ["GET", "HEAD"]
+	origin_workspace := extract_origin_workspace
+	origin_workspace != ""
+	workspace_scan != ""
+	workspace_scan != "-"
+	origin_workspace != workspace_scan
+	count(req_export_permissions) > 0
+}
+
+default cross_workspace_export_allowed := false
+
+cross_workspace_export_allowed if {
+	applicable_principals := get_effective_applicable_principals
+	count(applicable_principals) > 0
+	some principal in applicable_principals
+	has_permissions(principal, workspace_scan, req_export_permissions)
+}
+
+deny_request if {
+	cross_workspace_export_required
+	not cross_workspace_export_allowed
+	not platform_admin_in_system
+}
+
+# A delegated service may use its own identity for private storage in the generic
+# Entities API, but reads from other service APIs must also be authorized for
+# the effective user. Otherwise ServiceSystem's wildcard would let a service
+# bypass same-workspace permissions such as secrets.read or filesets.read.
+delegated_read_permission_required if {
+	method := extract_method
+	method in ["GET", "HEAD"]
+	extract_on_behalf_of_principal_id != ""
+	count(req_permissions) > 0
+	base_path := split(extract_path, "?")[0]
+	not startswith(base_path, "/apis/entities/")
+}
+
+delegated_read_permission_allowed if {
+	applicable_principals := get_effective_applicable_principals
+	count(applicable_principals) > 0
+	some principal in applicable_principals
+	has_permissions(principal, workspace_scan, req_permissions)
+}
+
+deny_request if {
+	delegated_read_permission_required
+	not delegated_read_permission_allowed
+	not platform_admin_in_system
+}
+
+# A delegated read cannot safely use a wildcard or workspace-less resource path:
+# the PDP has no concrete source workspace against which to evaluate ``*.export``.
+# Callers must issue one request per source workspace instead.
+deny_request if {
+	method := extract_method
+	method in ["GET", "HEAD"]
+	extract_origin_workspace != ""
+	workspace_scan in ["", "-"]
+	count(req_export_permissions) > 0
+	not delegated_entities_list
+	not platform_admin_in_system
+}
+
+# The generic Entities list endpoint applies its own per-workspace filtering:
+# origin workspace access is preserved and every other workspace requires
+# ``entities.export`` for the effective user. Keep all other wildcard and
+# workspace-less delegated reads fail-closed.
+delegated_entities_list if {
+	principal_id := extract_principal_id
+	startswith(principal_id, "service:")
+	base_path := split(extract_path, "?")[0]
+	startswith(base_path, "/apis/entities/v2/workspaces/-/entities/")
+}
+
+# Delegated service reads must always identify their origin. Otherwise the
+# request is indistinguishable from a direct read and would skip export checks.
+deny_request if {
+	method := extract_method
+	method in ["GET", "HEAD"]
+	extract_on_behalf_of_principal_id != ""
+	extract_origin_workspace == ""
+	count(req_export_permissions) > 0
+	not platform_admin_in_system
+}
 
 # Explicit deny marker (data.authz.endpoints[...].deny == true) — the fail-closed signal for
 # unruled or invalid plugin routes. As a deny_request it overrides every allow rule, including

--- a/services/core/auth/src/nmp/core/auth/app/policies/authz_has_permissions.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/authz_has_permissions.rego
@@ -23,7 +23,7 @@ import data.common
 # }
 has_permissions := result if {
 	# Platform admin bypass - has access to everything
-	applicable_principals := common.get_applicable_principals
+	applicable_principals := common.get_effective_applicable_principals
 	count(applicable_principals) > 0
 
 	# Check if any principal is a platform admin
@@ -36,7 +36,7 @@ has_permissions := result if {
 	required_permissions := input.permissions
 
 	# Get all applicable principals
-	applicable_principals := common.get_applicable_principals
+	applicable_principals := common.get_effective_applicable_principals
 	count(applicable_principals) > 0
 
 	# Check if any principal has all required permissions in the workspace

--- a/services/core/auth/src/nmp/core/auth/app/policies/common.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/common.rego
@@ -6,6 +6,7 @@ import data.authz.extract_method
 import data.authz.extract_path
 import data.authz.extract_principal_email
 import data.authz.extract_principal_groups
+import data.authz.extract_effective_principal_id
 import data.authz.extract_principal_id
 
 # PERMISSIONS HELPERS
@@ -175,8 +176,9 @@ get_all_roles_in_chain(role_name) := all_roles if {
 	all_roles := (((level_0 | level_1) | level_2) | level_3) | level_4
 }
 
-# Get all applicable principals (id, email, groups)
-# Returns a set of all principal identifiers that should be checked
+# Get all applicable principals (authenticated id, effective email, effective groups).
+# The authenticated service identity remains applicable to ordinary downstream
+# authorization; delegated read boundaries are enforced in authz.rego.
 get_applicable_principals := principals if {
 	# Start with empty set
 	base := set()
@@ -202,6 +204,32 @@ get_applicable_principals := principals if {
 	principals := ((base | id_set) | email_set) | groups_set
 
 	# Ensure we have at least one principal
+	count(principals) > 0
+} else := set()
+
+# Get only the effective user identifiers for delegated authorization boundaries.
+# This intentionally excludes the authenticated service identity so its
+# ServiceSystem wildcard cannot satisfy an export permission for the user.
+# Structurally identical to get_applicable_principals but resolves the effective
+# (delegated) principal ID instead of the authenticated caller ID.
+get_effective_applicable_principals := principals if {
+	base := set()
+
+	principal_id := extract_effective_principal_id
+	id_set := {principal_id | principal_id != ""}
+
+	email_set := {email |
+		email := extract_principal_email
+		email != ""
+	}
+
+	groups_set := {g |
+		groups := extract_principal_groups
+		g := groups[_]
+		g != ""
+	}
+
+	principals := ((base | id_set) | email_set) | groups_set
 	count(principals) > 0
 } else := set()
 

--- a/services/core/auth/src/nmp/core/auth/app/policies/extract.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policies/extract.rego
@@ -87,11 +87,52 @@ extract_principal_id := principal_id if {
 	principal_id := input.attributes.request.http.headers["X-NMP-Principal-Id"]
 }
 
+# Extract the delegated principal ID while retaining extract_principal_id as the
+# authenticated caller identity for caller-kind checks.
+extract_on_behalf_of_principal_id := principal_id if {
+	input.on_behalf_of_principal_id
+	principal_id := input.on_behalf_of_principal_id
+} else := principal_id if {
+	input.attributes.request.http.headers["x-nmp-principal-on-behalf-of"]
+	principal_id := input.attributes.request.http.headers["x-nmp-principal-on-behalf-of"]
+} else := principal_id if {
+	input.attributes.request.http.headers["X-NMP-Principal-On-Behalf-Of"]
+	principal_id := input.attributes.request.http.headers["X-NMP-Principal-On-Behalf-Of"]
+} else := ""
+
+# The effective principal is the original user for delegated service calls.
+extract_effective_principal_id := principal_id if {
+	principal_id := extract_on_behalf_of_principal_id
+	principal_id != ""
+} else := principal_id if {
+	principal_id := extract_principal_id
+}
+
+# Workspace from which a service operation originated. Direct user requests omit
+# this value, so ordinary UI/API browsing does not require export permission.
+extract_origin_workspace := workspace if {
+	input.origin_workspace
+	workspace := input.origin_workspace
+} else := workspace if {
+	input.attributes.request.http.headers["x-nmp-origin-workspace"]
+	workspace := input.attributes.request.http.headers["x-nmp-origin-workspace"]
+} else := workspace if {
+	input.attributes.request.http.headers["X-NMP-Origin-Workspace"]
+	workspace := input.attributes.request.http.headers["X-NMP-Origin-Workspace"]
+} else := ""
+
 # Extract principal_email from either format
 extract_principal_email := email if {
 	# Direct format
 	input.principal_email
 	email := input.principal_email
+} else := email if {
+	# Envoy delegated format - prefer the effective user's email
+	input.attributes.request.http.headers["x-nmp-principal-on-behalf-of-email"]
+	email := input.attributes.request.http.headers["x-nmp-principal-on-behalf-of-email"]
+} else := email if {
+	input.attributes.request.http.headers["X-NMP-Principal-On-Behalf-Of-Email"]
+	email := input.attributes.request.http.headers["X-NMP-Principal-On-Behalf-Of-Email"]
 } else := email if {
 	# Envoy format - try x-nmp-principal-email header
 	input.attributes.request.http.headers["x-nmp-principal-email"]
@@ -107,6 +148,13 @@ extract_principal_groups := groups if {
 	# Direct format
 	input.principal_groups
 	groups := input.principal_groups
+} else := groups if {
+	# Envoy delegated format - prefer the effective user's groups
+	input.attributes.request.http.headers["x-nmp-principal-on-behalf-of-groups"]
+	groups := split(input.attributes.request.http.headers["x-nmp-principal-on-behalf-of-groups"], ",")
+} else := groups if {
+	input.attributes.request.http.headers["X-NMP-Principal-On-Behalf-Of-Groups"]
+	groups := split(input.attributes.request.http.headers["X-NMP-Principal-On-Behalf-Of-Groups"], ",")
 } else := groups if {
 	# Envoy format - try x-nmp-principal-groups header (comma-separated)
 	input.attributes.request.http.headers["x-nmp-principal-groups"]

--- a/services/core/auth/src/nmp/core/auth/app/policy_tests/export_permission_test.rego
+++ b/services/core/auth/src/nmp/core/auth/app/policy_tests/export_permission_test.rego
@@ -1,0 +1,253 @@
+package authz_export_test
+
+import data.authz
+import future.keywords.if
+
+export_roles := {
+	"Viewer": {
+		"permissions": ["models.read", "models.list"],
+	},
+	"Exporter": {
+		"includes": ["Viewer"],
+		"permissions": ["models.export"],
+	},
+	"ServiceSystem": {
+		"permissions": ["*"],
+	},
+}
+
+export_endpoints := {
+	"/apis/models/v2/workspaces/{workspace}/models/{name}": {
+		"get": {"permissions": ["models.read"]},
+	},
+}
+
+export_principals := {
+	"viewer@example.com": {
+		"workspaces": {"source-workspace": ["Viewer"]},
+	},
+	"exporter@example.com": {
+		"workspaces": {"source-workspace": ["Exporter"]},
+	},
+}
+
+test_direct_user_read_does_not_require_export if {
+	result := authz.allow
+		with input as {
+			"principal_id": "viewer@example.com",
+			"method": "GET",
+			"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as export_principals
+
+	result.allowed == true
+}
+
+test_same_workspace_service_read_does_not_require_export if {
+	result := authz.allow
+		with input as {
+			"principal_id": "service:models",
+			"on_behalf_of_principal_id": "viewer@example.com",
+			"method": "GET",
+			"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+			"origin_workspace": "source-workspace",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as export_principals
+
+	result.allowed == true
+}
+
+test_same_workspace_service_read_cannot_bypass_delegate_permissions if {
+	result := authz.allow
+		with input as {
+			"principal_id": "service:models",
+			"on_behalf_of_principal_id": "unbound@example.com",
+			"method": "GET",
+			"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+			"origin_workspace": "source-workspace",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as export_principals
+
+	result.allowed == false
+}
+
+test_delegated_service_read_without_origin_is_denied if {
+	result := authz.allow
+		with input as {
+			"principal_id": "service:models",
+			"on_behalf_of_principal_id": "exporter@example.com",
+			"method": "GET",
+			"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as export_principals
+
+	result.allowed == false
+}
+
+test_cross_workspace_service_read_denied_without_export if {
+	result := authz.allow
+		with input as {
+			"principal_id": "service:models",
+			"on_behalf_of_principal_id": "viewer@example.com",
+			"method": "GET",
+			"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+			"origin_workspace": "destination-workspace",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as export_principals
+
+	result.allowed == false
+}
+
+test_cross_workspace_service_read_allowed_with_export if {
+	result := authz.allow
+		with input as {
+			"principal_id": "service:models",
+			"on_behalf_of_principal_id": "exporter@example.com",
+			"method": "GET",
+			"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+			"origin_workspace": "destination-workspace",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as export_principals
+
+	result.allowed == true
+}
+
+test_shared_workspace_wildcard_export if {
+	shared_principals := object.union(
+		export_principals,
+		{"*": {"workspaces": {"source-workspace": ["Exporter"]}}},
+	)
+	result := authz.allow
+		with input as {
+			"principal_id": "service:models",
+			"on_behalf_of_principal_id": "unbound@example.com",
+			"method": "GET",
+			"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+			"origin_workspace": "destination-workspace",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as shared_principals
+
+	result.allowed == true
+}
+
+test_delegated_wildcard_workspace_read_is_denied if {
+	result := authz.allow
+		with input as {
+			"principal_id": "service:models",
+			"on_behalf_of_principal_id": "exporter@example.com",
+			"method": "GET",
+			"path": "/apis/models/v2/workspaces/-/models/model-a",
+			"origin_workspace": "destination-workspace",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as export_principals
+
+	result.allowed == false
+}
+
+# The entities list endpoint with wildcard workspace is exempted from the
+# wildcard-workspace deny rule so that cross-workspace entity queries work.
+# The application layer enforces per-workspace access on the results.
+test_delegated_entities_list_wildcard_allowed if {
+	entity_endpoints := object.union(export_endpoints, {
+		"/apis/entities/v2/workspaces/{workspace}/entities/{entity_type}": {
+			"get": {"permissions": ["entities.read"]},
+		},
+	})
+	result := authz.allow
+		with input as {
+			"principal_id": "service:entities",
+			"on_behalf_of_principal_id": "viewer@example.com",
+			"method": "GET",
+			"path": "/apis/entities/v2/workspaces/-/entities/customization_config",
+			"origin_workspace": "destination-workspace",
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as entity_endpoints
+		with data.authz.principals as export_principals
+
+	result.allowed == true
+}
+
+test_envoy_delegated_groups_use_on_behalf_of_identity if {
+	group_principals := object.union(
+		export_principals,
+		{
+			"delegate-exporters": {
+				"workspaces": {"source-workspace": ["Exporter"]},
+			},
+		},
+	)
+	result := authz.allow
+		with input as {
+			"attributes": {
+				"request": {
+					"http": {
+						"method": "GET",
+						"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+						"headers": {
+							"x-nmp-principal-id": "service:models",
+							"x-nmp-principal-groups": "service-group",
+							"x-nmp-principal-on-behalf-of": "viewer@example.com",
+							"x-nmp-principal-on-behalf-of-groups": "delegate-exporters",
+							"x-nmp-origin-workspace": "destination-workspace",
+						},
+					},
+				},
+			},
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as group_principals
+
+	result.allowed == true
+}
+
+test_envoy_service_groups_cannot_authorize_delegate if {
+	group_principals := object.union(
+		export_principals,
+		{
+			"service-exporters": {
+				"workspaces": {"source-workspace": ["Exporter"]},
+			},
+		},
+	)
+	result := authz.allow
+		with input as {
+			"attributes": {
+				"request": {
+					"http": {
+						"method": "GET",
+						"path": "/apis/models/v2/workspaces/source-workspace/models/model-a",
+						"headers": {
+							"x-nmp-principal-id": "service:models",
+							"x-nmp-principal-groups": "service-exporters",
+							"x-nmp-principal-on-behalf-of": "viewer@example.com",
+							"x-nmp-principal-on-behalf-of-groups": "no-access",
+							"x-nmp-origin-workspace": "destination-workspace",
+						},
+					},
+				},
+			},
+		}
+		with data.authz.roles as export_roles
+		with data.authz.endpoints as export_endpoints
+		with data.authz.principals as group_principals
+
+	result.allowed == false
+}

--- a/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
+++ b/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
@@ -14,6 +14,9 @@ authz:
       delete:
         description: "Delete entities"
         has_role: false
+      export:
+        description: "Reference entities from another workspace"
+        has_endpoint: false
       read:
         description: "Read entities"
         has_role: false
@@ -25,6 +28,9 @@ authz:
         description: "Create filesets"
       delete:
         description: "Delete filesets"
+      export:
+        description: "Reference filesets from another workspace"
+        has_endpoint: false
       list:
         description: "List filesets"
       read:
@@ -40,6 +46,9 @@ authz:
           description: "Create guardrail configurations"
         delete:
           description: "Delete guardrail configurations"
+        export:
+          description: "Reference guardrail configurations from another workspace"
+          has_endpoint: false
         list:
           description: "List guardrail configurations"
         read:
@@ -64,6 +73,9 @@ authz:
           description: "Create inference deployment configurations"
         delete:
           description: "Delete inference deployment configurations"
+        export:
+          description: "Reference inference deployment configurations from another workspace"
+          has_endpoint: false
         list:
           description: "List inference deployment configurations"
         read:
@@ -73,6 +85,9 @@ authz:
           description: "Create inference deployments"
         delete:
           description: "Delete inference deployments"
+        export:
+          description: "Reference inference deployments from another workspace"
+          has_endpoint: false
         list:
           description: "List inference deployments"
         read:
@@ -94,6 +109,9 @@ authz:
           description: "Create inference providers"
         delete:
           description: "Delete inference providers"
+        export:
+          description: "Reference inference providers from another workspace"
+          has_endpoint: false
         list:
           description: "List inference providers"
         read:
@@ -105,6 +123,9 @@ authz:
           description: "Create virtual models"
         delete:
           description: "Delete virtual models"
+        export:
+          description: "Reference virtual models from another workspace"
+          has_endpoint: false
         list:
           description: "List virtual models"
         read:
@@ -115,6 +136,9 @@ authz:
       evaluator-results:
         create:
           description: "Create intake evaluator results"
+        export:
+          description: "Reference intake evaluator results from another workspace"
+          has_endpoint: false
         list:
           description: "List intake evaluator results"
         read:
@@ -122,6 +146,9 @@ authz:
       annotations:
         create:
           description: "Create intake annotations"
+        export:
+          description: "Reference intake annotations from another workspace"
+          has_endpoint: false
         list:
           description: "List intake annotations"
         read:
@@ -133,6 +160,9 @@ authz:
           description: "Create intake experiments"
         delete:
           description: "Delete intake experiments"
+        export:
+          description: "Reference intake experiments from another workspace"
+          has_endpoint: false
         read:
           description: "Read intake experiments"
         update:
@@ -142,6 +172,9 @@ authz:
           description: "Create intake evaluations"
         delete:
           description: "Delete intake evaluations"
+        export:
+          description: "Reference intake evaluations from another workspace"
+          has_endpoint: false
         read:
           description: "Read intake evaluations"
         update:
@@ -150,14 +183,23 @@ authz:
         create:
           description: "Ingest traces into intake"
       sessions:
+        export:
+          description: "Reference intake sessions from another workspace"
+          has_endpoint: false
         read:
           description: "Read intake sessions"
       spans:
+        export:
+          description: "Reference intake spans from another workspace"
+          has_endpoint: false
         list:
           description: "List intake spans"
         read:
           description: "Read intake spans"
       traces:
+        export:
+          description: "Reference intake traces from another workspace"
+          has_endpoint: false
         read:
           description: "Read intake traces"
     jobs:
@@ -167,6 +209,9 @@ authz:
         description: "Create jobs"
       delete:
         description: "Delete jobs"
+      export:
+        description: "Reference jobs from another workspace"
+        has_endpoint: false
       list:
         description: "List jobs"
       logs:
@@ -182,6 +227,9 @@ authz:
           description: "Read model adapters"
         list:
           description: "List model adapters"
+        export:
+          description: "Reference model adapters from another workspace"
+          has_endpoint: false
         create:
           description: "Create model adapters"
         update:
@@ -193,6 +241,9 @@ authz:
           description: "Read model prompts"
         list:
           description: "List model prompts"
+        export:
+          description: "Reference model prompts from another workspace"
+          has_endpoint: false
         create:
           description: "Create model prompts"
         update:
@@ -203,6 +254,9 @@ authz:
         description: "Create models"
       delete:
         description: "Delete models"
+      export:
+        description: "Reference models from another workspace"
+        has_endpoint: false
       list:
         description: "List models"
       read:
@@ -226,6 +280,9 @@ authz:
         description: "Create projects"
       delete:
         description: "Delete projects"
+      export:
+        description: "Reference projects from another workspace"
+        has_endpoint: false
       list:
         description: "List projects"
       read:
@@ -240,6 +297,9 @@ authz:
           description: "Create safe synthesizer jobs"
         delete:
           description: "Delete safe synthesizer jobs"
+        export:
+          description: "Reference safe synthesizer jobs from another workspace"
+          has_endpoint: false
         list:
           description: "List safe synthesizer jobs"
         read:
@@ -252,6 +312,9 @@ authz:
         description: "Create secrets"
       delete:
         description: "Delete secrets"
+      export:
+        description: "Reference secrets from another workspace"
+        has_endpoint: false
       list:
         description: "List secrets"
       read:
@@ -272,6 +335,9 @@ authz:
           description: "Read workspace member details"
         list:
           description: "List workspace members"
+        export:
+          description: "Reference workspace member details from another workspace"
+          has_endpoint: false
         create:
           description: "Add workspace members"
         update:
@@ -280,6 +346,9 @@ authz:
           description: "Remove workspace members"
       read:
         description: "Read workspaces"
+      export:
+        description: "Reference workspaces from another workspace"
+        has_endpoint: false
       update:
         description: "Update workspaces"
 
@@ -377,14 +446,43 @@ authz:
       - projects.create
       - projects.delete
       - projects.update
+      - secrets.access
       - secrets.create
       - secrets.delete
       - secrets.update
       - workspaces.delete
       - workspaces.update
+    Exporter:
+      description: "Read resources and reference them from other workspaces"
+      includes: ["Viewer"]
+      permissions:
+      - entities.export
+      - filesets.export
+      - guardrails.configs.export
+      - inference.deployment-configs.export
+      - inference.deployments.export
+      - inference.providers.export
+      - inference.virtual-models.export
+      - intake.annotations.export
+      - intake.evaluations.export
+      - intake.evaluator-results.export
+      - intake.experiments.export
+      - intake.sessions.export
+      - intake.spans.export
+      - intake.traces.export
+      - jobs.export
+      - models.adapters.export
+      - models.export
+      - models.prompts.export
+      - projects.export
+      - safe-synthesizer.jobs.export
+      - secrets.access
+      - secrets.export
+      - workspaces.export
+      - workspaces.members.export
     Admin:
       description: "Full workspace management capabilities"
-      includes: ["Editor"]
+      includes: ["Editor", "Exporter"]
       permissions:
       - iam.create
       - iam.read

--- a/services/core/auth/tests/test_embedded_pdp.py
+++ b/services/core/auth/tests/test_embedded_pdp.py
@@ -682,6 +682,48 @@ class TestGenericEntitiesApiBlocked:
         result = evaluate("allow", {"principal_id": "service:evaluator", "method": method, "path": path})
         assert result["allowed"] is True, f"Service principal should be allowed {method} {path}"
 
+    def test_same_workspace_delegated_service_principal_allowed(self, static_authz_data):
+        static_authz_data["authz"]["principals"] = {
+            "editor@test.com": {"workspaces": {"my-ws": ["Editor"]}},
+        }
+        set_policy_data(static_authz_data)
+
+        result = evaluate(
+            "allow",
+            {
+                "principal_id": "service:models",
+                "principal_email": "editor@test.com",
+                "on_behalf_of_principal_id": "editor@test.com",
+                "origin_workspace": "my-ws",
+                "method": "GET",
+                "path": "/apis/entities/v2/workspaces/my-ws/entities/model/model-a",
+                "scopes": ["entities:read", "platform:read"],
+            },
+        )
+
+        assert result["allowed"] is True
+
+    def test_delegated_entities_wildcard_list_allowed_for_endpoint_filtering(self, static_authz_data):
+        static_authz_data["authz"]["principals"] = {
+            "editor@test.com": {"workspaces": {"my-ws": ["Editor"]}},
+        }
+        set_policy_data(static_authz_data)
+
+        result = evaluate(
+            "allow",
+            {
+                "principal_id": "service:models",
+                "principal_email": "editor@test.com",
+                "on_behalf_of_principal_id": "editor@test.com",
+                "origin_workspace": "my-ws",
+                "method": "GET",
+                "path": "/apis/entities/v2/workspaces/-/entities/adapter",
+                "scopes": ["entities:read", "platform:read"],
+            },
+        )
+
+        assert result["allowed"] is True
+
     def test_viewer_can_still_list_workspaces(self, static_authz_data):
         """Non-entity endpoints under /apis/entities/ are unaffected."""
         # Listing workspaces is a no-{workspace} GET, so its permission is checked in the

--- a/services/core/entities/src/nmp/core/entities/api/v2/entities/endpoints.py
+++ b/services/core/entities/src/nmp/core/entities/api/v2/entities/endpoints.py
@@ -88,6 +88,8 @@ async def _validate_parent_access(
     accessible: set[str] | None,
     repository: EntityRepository,
     parent_id: str,
+    workspace: str,
+    auth_client: AuthClient,
 ) -> None:
     """Ensure the parent exists and the caller may reference it (parent may live in another workspace).
 
@@ -102,6 +104,15 @@ async def _validate_parent_access(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Parent entity '{parent_id}' not found or not in accessible workspaces",
+        )
+    if parent.workspace == workspace:
+        return
+
+    can_export = await auth_client.has_permissions(parent.workspace, ["entities.export"])
+    if not can_export:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Parent entity '{parent_id}' not found or not exportable to workspace '{workspace}'",
         )
 
 
@@ -225,7 +236,7 @@ async def create_entity(
     )
 
     if entity.parent is not None:
-        await _validate_parent_access(accessible, repository, entity.parent)
+        await _validate_parent_access(accessible, repository, entity.parent, workspace, auth_client)
     try:
         new_entity = await repository.create_entity(
             workspace=workspace,

--- a/services/core/entities/src/nmp/core/entities/api/v2/utils.py
+++ b/services/core/entities/src/nmp/core/entities/api/v2/utils.py
@@ -26,6 +26,7 @@ ROLE_BINDING_ENTITY_TYPE = "role_binding"
 
 # Wildcard principal that grants access to all authenticated users
 WILDCARD_PRINCIPAL = "*"
+MAX_EXPORT_PERMISSION_CHECK_CONCURRENCY = 20
 
 # In-process LRU + TTL cache for _fetch_bindings_for_principal.
 # Configure with NMP_ENTITIES_PRINCIPAL_BINDINGS_CACHE_{ENABLED,TTL_SEC,MAX_SIZE} (see EntitiesConfig).
@@ -243,6 +244,27 @@ async def get_accessible_workspaces(
 
     if accessible == ALL_WORKSPACES:
         return None  # No filtering needed
+
+    # Delegated wildcard reads may include the operation's origin workspace,
+    # but data from any other workspace must be explicitly exportable by the
+    # effective user. The auth service's has-permissions entrypoint evaluates
+    # delegated requests using only that effective identity, not ServiceSystem.
+    if principal.is_delegated and auth_client.origin_workspace:
+        origin_workspace = auth_client.origin_workspace
+        candidate_exports = [workspace for workspace in accessible if workspace != origin_workspace]
+        semaphore = asyncio.Semaphore(MAX_EXPORT_PERMISSION_CHECK_CONCURRENCY)
+
+        async def can_export(workspace: str) -> bool:
+            async with semaphore:
+                return await auth_client.has_permissions(workspace, ["entities.export"])
+
+        export_checks = await asyncio.gather(*(can_export(workspace) for workspace in candidate_exports))
+        exportable_workspaces = {
+            workspace for workspace, allowed in zip(candidate_exports, export_checks, strict=True) if allowed
+        }
+        if origin_workspace in accessible:
+            exportable_workspaces.add(origin_workspace)
+        return exportable_workspaces
 
     return accessible
 

--- a/services/core/entities/tests/integration/test_entity_create_parent_auth.py
+++ b/services/core/entities/tests/integration/test_entity_create_parent_auth.py
@@ -4,9 +4,11 @@
 """Integration tests: create entity must allow access to path workspace and parent workspace (when set)."""
 
 from datetime import datetime, timezone
+from unittest.mock import AsyncMock
 
 import pytest
 from httpx import AsyncClient
+from nmp.common.auth import AuthClient
 from nmp.core.entities.api.v2.utils import ROLE_BINDING_ENTITY_TYPE
 from nmp.core.entities.app.repository import (
     EntityRepositoryInterface,
@@ -30,6 +32,7 @@ async def _seed_workspaces(
     workspace_repo: WorkspaceRepositoryInterface,
     entity_repo: EntityRepositoryInterface,
     member_of: set[str] | None = None,
+    role: str = "Editor",
 ) -> None:
     """Create the two test workspaces, then optionally one Editor role_binding per name in *member_of*."""
     for name, desc in _WS_SEED:
@@ -46,7 +49,7 @@ async def _seed_workspaces(
             data={
                 "principal": TEST_USER_EMAIL,
                 "workspace": ws,
-                "role": "Editor",
+                "role": role,
                 "granted_by": TEST_USER_EMAIL,
                 "granted_at": granted,
                 "revoked_at": None,
@@ -106,10 +109,17 @@ class TestCreateEntityParentWorkspaceAuth:
         )
         assert r.status_code == 403, r.text
 
-    async def test_201_create_cross_ws_when_user_has_both(self, client_with_auth: AsyncClient, repos) -> None:
-        """With Editor in both workspaces, a cross-workspace child linked to a model in the default path returns 201."""
+    async def test_422_cross_ws_parent_requires_export_permission(
+        self,
+        client_with_auth: AsyncClient,
+        repos,
+        monkeypatch,
+    ) -> None:
+        """Workspace membership alone cannot authorize a cross-workspace parent reference."""
         wr: WorkspaceRepositoryInterface = repos["workspace"]
         await _seed_workspaces(wr, repos["entity"], member_of={_DEFAULT_WS, _OTHER_WS})
+        has_permissions = AsyncMock(return_value=False)
+        monkeypatch.setattr(AuthClient, "has_permissions", has_permissions)
         mresp = await client_with_auth.post(
             f"/apis/entities/v2/workspaces/{_DEFAULT_WS}/entities/model",
             json={"name": "m-both", "data": {}},
@@ -120,6 +130,36 @@ class TestCreateEntityParentWorkspaceAuth:
             f"/apis/entities/v2/workspaces/{_OTHER_WS}/entities/adapter",
             json={"name": "a-both", "parent": model_id, "data": {"finetuning_type": "LoRA"}},
         )
+        assert r.status_code == 422, r.text
+        has_permissions.assert_awaited_once_with(_DEFAULT_WS, ["entities.export"])
+
+    async def test_201_create_cross_ws_with_export_permission(
+        self,
+        client_with_auth: AsyncClient,
+        repos,
+        monkeypatch,
+    ) -> None:
+        """An Admin/Exporter authorization permits the external parent reference."""
+        wr: WorkspaceRepositoryInterface = repos["workspace"]
+        await _seed_workspaces(
+            wr,
+            repos["entity"],
+            member_of={_DEFAULT_WS, _OTHER_WS},
+            role="Admin",
+        )
+        has_permissions = AsyncMock(return_value=True)
+        monkeypatch.setattr(AuthClient, "has_permissions", has_permissions)
+        mresp = await client_with_auth.post(
+            f"/apis/entities/v2/workspaces/{_DEFAULT_WS}/entities/model",
+            json={"name": "m-exportable", "data": {}},
+        )
+        assert mresp.status_code == 201, mresp.text
+        model_id = mresp.json()["id"]
+        r = await client_with_auth.post(
+            f"/apis/entities/v2/workspaces/{_OTHER_WS}/entities/adapter",
+            json={"name": "a-exported", "parent": model_id, "data": {"finetuning_type": "LoRA"}},
+        )
         assert r.status_code == 201, r.text
         assert r.json()["parent"] == model_id
         assert r.json()["workspace"] == _OTHER_WS
+        has_permissions.assert_awaited_once_with(_DEFAULT_WS, ["entities.export"])

--- a/services/core/entities/tests/integration/test_entity_filter_relationship_auth.py
+++ b/services/core/entities/tests/integration/test_entity_filter_relationship_auth.py
@@ -96,6 +96,10 @@ class TestRelationshipFilterWithAuth:
         Same graph as the excluded case: model in default, adapter in other, but
         `get_accessible_workspaces` includes the other workspace so
         `relationship_child_workspaces` no longer filters out the child.
+
+        The adapter is seeded via the repo to bypass the API-level entities.export
+        permission check (tested separately in test_entity_create_parent_auth.py);
+        this test covers only the EXISTS filter scoping logic.
         """
         wr: WorkspaceRepositoryInterface = repos["workspace"]
         er: EntityRepositoryInterface = repos["entity"]
@@ -107,11 +111,14 @@ class TestRelationshipFilterWithAuth:
         )
         assert mresp.status_code == 201, mresp.text
         model_id = mresp.json()["id"]
-        aresp = await client_with_auth.post(
-            f"/apis/entities/v2/workspaces/{_OTHER_WS}/entities/adapter",
-            json={"name": "a-remote-now-readable", "parent": model_id, "data": {}},
+        await er.create_entity(
+            workspace=_OTHER_WS,
+            entity_type="adapter",
+            name="a-remote-now-readable",
+            data={},
+            parent=model_id,
+            created_by=TEST_USER_EMAIL,
         )
-        assert aresp.status_code == 201, aresp.text
 
         fresp = await client_with_auth.get(
             f"/apis/entities/v2/workspaces/{_DEFAULT_WS}/entities/model",
@@ -225,6 +232,15 @@ class TestRelationshipFilterWithServiceOnBehalfOf:
     async def test_on_behalf_of_matches_both_workspaces_like_direct_user(
         self, client_with_auth_service_on_behalf_of: AsyncClient, repos
     ) -> None:
+        """Service on-behalf-of sees adapters in any workspace accessible to the effective user.
+
+        The adapter is seeded via the repo to bypass the API-level entities.export
+        permission check (tested separately in test_entity_create_parent_auth.py);
+        this test covers only the EXISTS filter scoping logic.
+
+        See also TestRelationshipFilterWithAuth.test_with_auth_on_adapter_in_other_ws_does_not_satisfy_exists
+        for the excluded-workspace counterpart.
+        """
         wr: WorkspaceRepositoryInterface = repos["workspace"]
         er: EntityRepositoryInterface = repos["entity"]
         await _seed_workspaces(wr, er, member_of={_DEFAULT_WS, _OTHER_WS})
@@ -234,11 +250,14 @@ class TestRelationshipFilterWithServiceOnBehalfOf:
         )
         assert mresp.status_code == 201, mresp.text
         model_id = mresp.json()["id"]
-        aresp = await client_with_auth_service_on_behalf_of.post(
-            f"/apis/entities/v2/workspaces/{_OTHER_WS}/entities/adapter",
-            json={"name": "a-remote-obo-ok", "parent": model_id, "data": {}},
+        await er.create_entity(
+            workspace=_OTHER_WS,
+            entity_type="adapter",
+            name="a-remote-obo-ok",
+            data={},
+            parent=model_id,
+            created_by=TEST_USER_EMAIL,
         )
-        assert aresp.status_code == 201, aresp.text
 
         fresp = await client_with_auth_service_on_behalf_of.get(
             f"/apis/entities/v2/workspaces/{_DEFAULT_WS}/entities/model",

--- a/services/core/entities/tests/test_accessible_workspaces_utils.py
+++ b/services/core/entities/tests/test_accessible_workspaces_utils.py
@@ -3,7 +3,13 @@
 
 """Unit tests for workspace access helpers in api/v2/utils.py."""
 
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from nmp.common.auth.dependencies import auth_client_context
 from nmp.common.auth.models import Principal
+from nmp.core.entities.api.v2 import utils
 from nmp.core.entities.api.v2.utils import _applicable_principal_strings
 
 
@@ -42,3 +48,85 @@ def test_applicable_principal_strings_includes_groups() -> None:
 def test_applicable_principal_strings_group_dedupes_against_id() -> None:
     p = Principal(id="dup", email=None, groups=["dup", "other"])
     assert _applicable_principal_strings(p) == ["dup", "other"]
+
+
+@pytest.mark.asyncio
+async def test_delegated_accessible_workspaces_require_export_outside_origin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    principal = Principal(
+        id="service:models",
+        on_behalf_of="editor@example.com",
+        on_behalf_of_email="editor@example.com",
+    )
+    auth_client = MagicMock(
+        auth_enabled=True,
+        principal=principal,
+        origin_workspace="origin-ws",
+    )
+    auth_client.has_permissions = AsyncMock(side_effect=lambda workspace, _permissions: workspace == "exported-ws")
+
+    bindings = []
+    for index, workspace in enumerate(("origin-ws", "exported-ws", "viewer-only-ws")):
+        binding = MagicMock(
+            id=f"binding-{index}",
+            workspace=workspace,
+            data={"workspace": workspace, "role": "Viewer"},
+        )
+        bindings.append(binding)
+
+    async def fetch_bindings(_repository: object, principal_id: str):
+        return bindings if principal_id == "editor@example.com" else []
+
+    monkeypatch.setattr(utils, "_fetch_bindings_for_principal", fetch_bindings)
+    token = auth_client_context.set(auth_client)
+    try:
+        accessible = await utils.get_accessible_workspaces(MagicMock())
+    finally:
+        auth_client_context.reset(token)
+
+    assert accessible == {"origin-ws", "exported-ws"}
+    assert {call.args[0] for call in auth_client.has_permissions.await_args_list} == {
+        "exported-ws",
+        "viewer-only-ws",
+    }
+    for call in auth_client.has_permissions.await_args_list:
+        assert call.args[1] == ["entities.export"]
+
+
+@pytest.mark.asyncio
+async def test_delegated_export_checks_use_bounded_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
+    principal = Principal(id="service:models", on_behalf_of="editor@example.com")
+    auth_client = MagicMock(auth_enabled=True, principal=principal, origin_workspace="origin-ws")
+    active = 0
+    peak = 0
+
+    async def has_permissions(_workspace: str, _permissions: list[str]) -> bool:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return True
+
+    auth_client.has_permissions = AsyncMock(side_effect=has_permissions)
+    bindings = [
+        MagicMock(
+            id=f"binding-{index}",
+            workspace=workspace,
+            data={"workspace": workspace, "role": "Viewer"},
+        )
+        for index, workspace in enumerate(["origin-ws", *(f"workspace-{index}" for index in range(50))])
+    ]
+
+    async def fetch_bindings(_repository: object, principal_id: str):
+        return bindings if principal_id == "editor@example.com" else []
+
+    monkeypatch.setattr(utils, "_fetch_bindings_for_principal", fetch_bindings)
+    token = auth_client_context.set(auth_client)
+    try:
+        await utils.get_accessible_workspaces(MagicMock())
+    finally:
+        auth_client_context.reset(token)
+
+    assert peak <= utils.MAX_EXPORT_PERMISSION_CHECK_CONCURRENCY

--- a/services/core/files/src/nmp/core/files/api/endpoint_helpers.py
+++ b/services/core/files/src/nmp/core/files/api/endpoint_helpers.py
@@ -19,7 +19,7 @@ from nemo_platform_plugin.secrets.client import AsyncSecretsClient
 from nmp.common.auth import AuthClient
 from nmp.common.entities.client import EntityClient, EntityNotFoundError
 from nmp.common.entities.utils import parse_entity_ref
-from nmp.common.sdk_factory import get_async_platform_sdk
+from nmp.common.sdk_factory import get_sdk_on_behalf_of
 from nmp.common.secrets.exceptions import SecretAccessDeniedError, SecretNotFoundError
 from nmp.core.files.app.backends import FileInfo, StorageConfig
 from nmp.core.files.app.backends.base import ByteRange, StorageImpl
@@ -302,7 +302,11 @@ async def resolve_storage_secrets_for_user(
     auth_client: AuthClient,
 ) -> dict[str, str]:
     """Resolve storage secrets using delegated headers on request-scoped SDK."""
-    service_sdk = get_async_platform_sdk(as_service="files", internal=True, on_behalf_of=auth_client.principal.id)
+    service_sdk = get_sdk_on_behalf_of(
+        sdk,
+        auth_client.principal,
+        origin_workspace=auth_client.outbound_origin_workspace or workspace,
+    )
     return await resolve_storage_secrets(storage, workspace, service_sdk)
 
 

--- a/services/core/inference-gateway/tests/integration/test_igw_with_auth.py
+++ b/services/core/inference-gateway/tests/integration/test_igw_with_auth.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 
 import pytest
 from nemo_platform import NeMoPlatform
+from nmp.common.auth import NMP_ORIGIN_WORKSPACE_HEADER
 from nmp.core.auth.app.bundle import build_authorization_data as _real_build_authorization_data
 from nmp.core.inference_gateway.service import InferenceGatewayService
 from nmp.core.models.service import ModelsService
@@ -785,11 +786,12 @@ class TestIGWDelegatedServicePrincipalAccess:
     SERVICE_PRINCIPAL_AGENTS = "service:agents"
 
     @staticmethod
-    def _delegated_headers(on_behalf_of: str) -> dict[str, str]:
+    def _delegated_headers(on_behalf_of: str, origin_workspace: str) -> dict[str, str]:
         return {
             "X-NMP-Principal-Id": TestIGWDelegatedServicePrincipalAccess.SERVICE_PRINCIPAL_AGENTS,
             "X-NMP-Principal-On-Behalf-Of": on_behalf_of,
             "X-NMP-Principal-On-Behalf-Of-Email": on_behalf_of,
+            NMP_ORIGIN_WORKSPACE_HEADER: origin_workspace,
         }
 
     def test_delegated_denied_when_obo_user_lacks_role(self, sdk: NeMoPlatform):
@@ -808,7 +810,7 @@ class TestIGWDelegatedServicePrincipalAccess:
 
         response = sdk._client.get(
             f"/apis/inference-gateway/v2/workspaces/{workspace}/openai/-/v1/models",
-            headers=self._delegated_headers(obo_email),
+            headers=self._delegated_headers(obo_email, workspace),
         )
         assert response.status_code == 403
 
@@ -823,7 +825,7 @@ class TestIGWDelegatedServicePrincipalAccess:
 
         response = sdk._client.get(
             f"/apis/inference-gateway/v2/workspaces/{workspace}/openai/-/v1/models",
-            headers=self._delegated_headers(obo_email),
+            headers=self._delegated_headers(obo_email, workspace),
         )
         assert response.status_code == 200
 
@@ -844,7 +846,7 @@ class TestIGWDelegatedServicePrincipalAccess:
         response = sdk._client.post(
             f"/apis/inference-gateway/v2/workspaces/{workspace}/openai/-/v1/chat/completions",
             json={"model": f"{workspace}/{model_name}", "messages": [{"role": "user", "content": "hi"}]},
-            headers=self._delegated_headers(obo_email),
+            headers=self._delegated_headers(obo_email, workspace),
         )
         assert response.status_code == 403
 
@@ -866,6 +868,6 @@ class TestIGWDelegatedServicePrincipalAccess:
         response = sdk._client.post(
             f"/apis/inference-gateway/v2/workspaces/{workspace}/openai/-/v1/chat/completions",
             json={"model": f"{workspace}/{model_name}", "messages": [{"role": "user", "content": "hi"}]},
-            headers=self._delegated_headers(obo_email),
+            headers=self._delegated_headers(obo_email, workspace),
         )
         assert response.status_code == 200

--- a/services/core/jobs/src/nmp/core/jobs/api/v2/jobs/endpoints.py
+++ b/services/core/jobs/src/nmp/core/jobs/api/v2/jobs/endpoints.py
@@ -267,7 +267,10 @@ async def create_job(
         return await dispatcher.create_job(
             request,
             workspace,
-            auth_context=AuthContext.from_principal(auth_client.principal),
+            auth_context=AuthContext.from_principal(
+                auth_client.principal,
+                origin_workspace=auth_client.outbound_origin_workspace,
+            ),
             sdk=sdk,
         )
     except JobOutputLocationError as exc:

--- a/services/core/jobs/src/nmp/core/jobs/app/dispatcher.py
+++ b/services/core/jobs/src/nmp/core/jobs/app/dispatcher.py
@@ -359,7 +359,11 @@ class JobDispatcher:
         except EntityNotFoundError:
             return None
         try:
-            attempt = await self.store.get_by_id(PlatformJobAttempt, job_entity.current_attempt_id)  # type: ignore
+            attempt = await self.store.get_by_id(
+                PlatformJobAttempt,
+                job_entity.current_attempt_id,  # type: ignore[arg-type]
+                workspace=workspace,
+            )
         except EntityNotFoundError:
             return None
         return create_platform_job_response(job_entity, attempt)
@@ -406,7 +410,11 @@ class JobDispatcher:
                 continue
 
             try:
-                attempt = await self.store.get_by_id(PlatformJobAttempt, job.current_attempt_id)
+                attempt = await self.store.get_by_id(
+                    PlatformJobAttempt,
+                    job.current_attempt_id,
+                    workspace=workspace,
+                )
             except EntityNotFoundError:
                 logger.warning(f"Attempt {job.current_attempt_id} not found for job {job.id}")
                 continue
@@ -538,36 +546,46 @@ class JobDispatcher:
             "Created first step for job", extra={"job": job.name, "workspace": job.workspace, "step": first_step.name}
         )
 
-    async def get_attempt(self, attempt_id: str) -> Optional[PlatformJobAttempt]:
+    async def get_attempt(self, attempt_id: str, *, workspace: str | None = None) -> Optional[PlatformJobAttempt]:
         """Get an attempt by ID."""
         try:
-            return await self.store.get_by_id(PlatformJobAttempt, attempt_id)
+            return await self.store.get_by_id(PlatformJobAttempt, attempt_id, workspace=workspace)
         except EntityNotFoundError:
             return None
 
-    async def _get_job_by_id_optional(self, job_id: str) -> Optional[PlatformJob]:
+    async def _get_job_by_id_optional(self, job_id: str, *, workspace: str | None = None) -> Optional[PlatformJob]:
         """Get a job by ID, returning None if not found."""
         try:
-            return await self.store.get_by_id(PlatformJob, job_id)
+            return await self.store.get_by_id(PlatformJob, job_id, workspace=workspace)
         except EntityNotFoundError:
             return None
 
-    async def _gather_attempts(self, attempt_ids: set[str]) -> list[Optional[PlatformJobAttempt]]:
+    async def _gather_attempts(
+        self,
+        attempt_ids: set[str],
+        *,
+        workspace: str | None = None,
+    ) -> list[Optional[PlatformJobAttempt]]:
         """Fetch all attempts by ID concurrently using TaskGroup."""
         if not attempt_ids:
             return []
         aid_list = list(attempt_ids)
         async with asyncio.TaskGroup() as tg:
-            tasks = [tg.create_task(self.get_attempt(aid)) for aid in aid_list]
+            tasks = [tg.create_task(self.get_attempt(aid, workspace=workspace)) for aid in aid_list]
         return [t.result() for t in tasks]
 
-    async def _gather_jobs(self, job_ids: set[str]) -> list[Optional[PlatformJob]]:
+    async def _gather_jobs(
+        self,
+        job_ids: set[str],
+        *,
+        workspace: str | None = None,
+    ) -> list[Optional[PlatformJob]]:
         """Fetch all jobs by ID concurrently using TaskGroup."""
         if not job_ids:
             return []
         jid_list = list(job_ids)
         async with asyncio.TaskGroup() as tg:
-            tasks = [tg.create_task(self._get_job_by_id_optional(jid)) for jid in jid_list]
+            tasks = [tg.create_task(self._get_job_by_id_optional(jid, workspace=workspace)) for jid in jid_list]
         return [t.result() for t in tasks]
 
     async def get_current_attempt(self, job_name: str, workspace: str) -> Optional[PlatformJobAttempt]:
@@ -697,10 +715,10 @@ class JobDispatcher:
             return [], total_count if use_store_pagination else 0
 
         attempt_ids = {s.attempt_id for s in all_steps}
-        attempt_results = await self._gather_attempts(attempt_ids)
+        attempt_results = await self._gather_attempts(attempt_ids, workspace=workspace)
         attempt_by_id = {aid: a for aid, a in zip(attempt_ids, attempt_results) if a is not None}
         job_ids = {a.job for a in attempt_by_id.values()}
-        job_results = await self._gather_jobs(job_ids)
+        job_results = await self._gather_jobs(job_ids, workspace=workspace)
         job_by_id = {jid: j for jid, j in zip(job_ids, job_results) if j is not None}
 
         result = []
@@ -877,7 +895,11 @@ class JobDispatcher:
                 if attempt == 0:
                     # Refetch step and retry once if transition still valid
                     try:
-                        refetched = await self.store.get_by_id(PlatformJobStep, step_to_save.id)
+                        refetched = await self.store.get_by_id(
+                            PlatformJobStep,
+                            step_to_save.id,
+                            workspace=step_to_save.workspace,
+                        )
                     except EntityNotFoundError:
                         raise e from e
                     if refetched.status.can_transition_to(status):
@@ -889,7 +911,7 @@ class JobDispatcher:
             raise RuntimeError("update_job_status_from_step did not produce a saved step")
 
         # Update job / attempt status from step
-        attempt = await self.get_attempt(saved_step.attempt_id)
+        attempt = await self.get_attempt(saved_step.attempt_id, workspace=saved_step.workspace)
         if attempt is None:
             raise Exception(f"Attempt does not exist: {saved_step.attempt_id}")
 

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/base.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/base.py
@@ -20,7 +20,7 @@ from nemo_platform_plugin.jobs import execution_profiles as _execution_profiles
 from nemo_platform_plugin.jobs.client import JobsClient
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nemo_platform_plugin.jobs.types import PlatformJobStepResponse, PlatformJobStepWithContext
-from nmp.common.auth.models import NMP_PRINCIPAL_ENVVAR
+from nmp.common.auth.models import NMP_ORIGIN_WORKSPACE_ENVVAR, NMP_PRINCIPAL_ENVVAR
 from nmp.common.config.base import (
     LOOPBACK_ADDRESSES,
     NMP_CONFIG_WARNINGS_DISABLED_ENV_VAR,
@@ -98,6 +98,7 @@ RESERVED_JOB_ENVIRONMENT_VARIABLE_NAMES: frozenset[str] = (
             PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
             TASK_CONFIG_ENVVAR,
             # Auth
+            NMP_ORIGIN_WORKSPACE_ENVVAR,
             NMP_PRINCIPAL_ENVVAR,
             # Platform launcher logs
             JOB_LOGS_ENDPOINT_ENVVAR,

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -968,8 +968,7 @@ chmod -R 777 {job_vol}/{storage_subpath}
         if step.auth_context:
             sdk_auth_context = step.auth_context
             auth_context = AuthContext.model_validate(sdk_auth_context.model_dump(mode="python", exclude_none=True))
-            principal = auth_context.to_principal()
-            env_var_dict = principal.get_env_var()
+            env_var_dict = auth_context.get_env_vars()
             for name, value in env_var_dict.items():
                 env[name] = value
 

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/kubernetes/common.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/kubernetes/common.py
@@ -1018,8 +1018,7 @@ def create_pod_template_spec(
     if step.auth_context:
         sdk_auth_context = step.auth_context
         auth_context = AuthContext.model_validate(sdk_auth_context.model_dump(mode="python", exclude_none=True))
-        principal = auth_context.to_principal()
-        env_var_dict = principal.get_env_var()
+        env_var_dict = auth_context.get_env_vars()
         for name, value in env_var_dict.items():
             env.append(client.V1EnvVar(name=name, value=value))
 

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess.py
@@ -477,8 +477,7 @@ class SubprocessJobBackend(JobBackend[SubprocessExecutionProvider, SubprocessJob
 
         if step.auth_context:
             auth_context = AuthContext.model_validate(step.auth_context.model_dump(mode="python", exclude_none=True))
-            principal = auth_context.to_principal()
-            env.update(principal.get_env_var())
+            env.update(auth_context.get_env_vars())
 
         inject_secret_env_vars(env)
         return env, task_id, work_dir, log_path, persistent_dir

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/subprocess_runtime.py
@@ -20,7 +20,12 @@ import httpx
 import requests
 from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
 from nemo_platform_plugin.client.oidc_factory import resolve_workload_exchange_provider
-from nmp.common.auth.models import NMP_PRINCIPAL_ENVVAR, Principal
+from nmp.common.auth.models import (
+    NMP_ORIGIN_WORKSPACE_ENVVAR,
+    NMP_ORIGIN_WORKSPACE_HEADER,
+    NMP_PRINCIPAL_ENVVAR,
+    Principal,
+)
 from nmp.common.jobs.constants import NEMO_JOB_SECRETS_ENVVAR
 from opentelemetry._logs import Logger
 from opentelemetry._logs.severity import SeverityNumber
@@ -177,10 +182,12 @@ def inject_secret_env_vars(env: dict[str, str], *, secrets_url: str | None = Non
     _validate_http_url(api_base_url, "NMP_SECRETS_URL")
 
     principal = _principal_from_env(env)
+    origin_workspace = env.get(NMP_ORIGIN_WORKSPACE_ENVVAR)
     for reference in references:
         env[reference.env_var_name] = _fetch_secret(
             api_base_url=api_base_url,
             principal=principal,
+            origin_workspace=origin_workspace,
             workspace=reference.workspace,
             secret_name=reference.secret_name,
         )
@@ -301,13 +308,22 @@ def _principal_from_env(env: dict[str, str]) -> Principal | None:
         return None
 
 
-def _fetch_secret(*, api_base_url: str, principal: Principal | None, workspace: str, secret_name: str) -> str:
+def _fetch_secret(
+    *,
+    api_base_url: str,
+    principal: Principal | None,
+    origin_workspace: str | None,
+    workspace: str,
+    secret_name: str,
+) -> str:
     request = Request(
         url=f"{api_base_url}/apis/secrets/v2/workspaces/{quote(workspace, safe='')}/secrets/{quote(secret_name, safe='')}/access",
         method="GET",
     )
     for name, value in _secret_request_headers(principal).items():
         request.add_header(name, value)
+    if origin_workspace:
+        request.add_header(NMP_ORIGIN_WORKSPACE_HEADER, origin_workspace)
 
     try:
         with urlopen(request, timeout=10) as response:

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -2466,6 +2466,7 @@ def test_job_step_with_auth_context():
             principal_id="creator@example.com",
             principal_email="creator@example.com",
             principal_groups=["engineering", "ml-team"],
+            origin_workspace="default",
         ),
     )
 
@@ -2501,8 +2502,9 @@ def test_docker_job_schedule_with_auth_context(docker_job, docker_client_mock, t
     assert principal_data == {
         "id": "creator@example.com",
         "email": "creator@example.com",
-        "groups": ["engineering", "ml-team"],
+        "groups": [],
     }
+    assert env["NMP_ORIGIN_WORKSPACE"] == "default"
 
     # Verify launcher application log auth is not configured through env headers.
     assert "NMP_JOB_LAUNCHER_OTLP_LOGS_HEADERS" not in env

--- a/services/core/jobs/tests/controllers/test_kubernetes_backend.py
+++ b/services/core/jobs/tests/controllers/test_kubernetes_backend.py
@@ -2138,6 +2138,7 @@ def test_step_pending_with_auth_context() -> PlatformJobStepWithContext:
             principal_id="creator@example.com",
             principal_email="creator@example.com",
             principal_groups=["engineering", "ml-team"],
+            origin_workspace="default",
         ),
     )
 
@@ -2153,7 +2154,7 @@ def test_kubernetes_job_schedule_with_auth_context(
     """
     import json
 
-    from nmp.common.auth.models import NMP_PRINCIPAL_ENVVAR
+    from nmp.common.auth.models import NMP_ORIGIN_WORKSPACE_ENVVAR, NMP_PRINCIPAL_ENVVAR
 
     # Mock successful job creation
     kubernetes_job._batch_v1.create_namespaced_job.return_value = MagicMock()
@@ -2180,8 +2181,9 @@ def test_kubernetes_job_schedule_with_auth_context(
     assert principal_data == {
         "id": "creator@example.com",
         "email": "creator@example.com",
-        "groups": ["engineering", "ml-team"],
+        "groups": [],
     }
+    assert env_vars[NMP_ORIGIN_WORKSPACE_ENVVAR] == "default"
 
     # Verify launcher application log auth is not configured through env headers.
     assert "NMP_JOB_LAUNCHER_OTLP_LOGS_HEADERS" not in env_var_names

--- a/services/core/jobs/tests/controllers/test_subprocess_runtime.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_runtime.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
 from nmp.common.auth import Principal
-from nmp.common.auth.models import NMP_PRINCIPAL_ENVVAR
+from nmp.common.auth.models import NMP_ORIGIN_WORKSPACE_ENVVAR, NMP_PRINCIPAL_ENVVAR
 from nmp.common.jobs.constants import NEMO_JOB_SECRETS_ENVVAR
 from nmp.core.jobs.controllers.backends.subprocess_runtime import (
     NMP_JOB_LAUNCHER_OTLP_LOGS_SOCKET_PATH_ENVVAR,
@@ -47,6 +47,7 @@ def test_inject_secret_env_vars():
     principal = Principal(id="creator@example.com")
     env = {
         NEMO_JOB_SECRETS_ENVVAR: "HF_TOKEN=default/hf-token",
+        NMP_ORIGIN_WORKSPACE_ENVVAR: "training-workspace",
         NMP_PRINCIPAL_ENVVAR: principal.model_dump_json(exclude_none=True),
         "NMP_SECRETS_URL": "http://secrets.example",
     }
@@ -64,6 +65,7 @@ def test_inject_secret_env_vars():
     assert request.full_url == "http://secrets.example/apis/secrets/v2/workspaces/default/secrets/hf-token/access"
     assert request.get_header("X-nmp-principal-id") == "service:jobs"
     assert request.get_header("X-nmp-principal-on-behalf-of") == "creator@example.com"
+    assert request.get_header("X-nmp-origin-workspace") == "training-workspace"
 
 
 def test_inject_secret_env_vars_rejects_missing_value_field():

--- a/services/core/jobs/tests/integration/test_jobs_auth_propagation.py
+++ b/services/core/jobs/tests/integration/test_jobs_auth_propagation.py
@@ -118,4 +118,4 @@ class TestJobCreationWithAuth:
         assert step.auth_context is not None, "Service principal should see auth_context"
         assert step.auth_context.principal_id == creator_email
         assert step.auth_context.principal_email == creator_email
-        assert step.auth_context.principal_groups == creator_groups
+        assert step.auth_context.principal_groups == []

--- a/services/core/jobs/tests/integration/test_task_auth_runtime.py
+++ b/services/core/jobs/tests/integration/test_task_auth_runtime.py
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Integration tests for task-side auth propagation via ``NMP_PRINCIPAL``.
+"""Integration tests for task-side auth propagation via task auth environment variables.
 
 These tests cover the runtime half of the jobs auth propagation story:
 
 - the task receives ``NMP_PRINCIPAL``
+- the task receives ``NMP_ORIGIN_WORKSPACE``
 - ``get_task_sdk(as_service=...)`` converts that into service + on-behalf-of headers
 - downstream services authorize based on the delegated user's permissions
 """
@@ -90,6 +91,7 @@ class TestTaskRuntimeAuthPropagation:
             ):
                 monkeypatch.setenv("NEMO_JOB_WORKSPACE", workspace)
                 monkeypatch.setenv("NEMO_TEST_SECRET_NAME", secret_name)
+                monkeypatch.setenv("NMP_ORIGIN_WORKSPACE", workspace)
                 monkeypatch.setenv(
                     "NMP_PRINCIPAL",
                     json.dumps(
@@ -136,6 +138,7 @@ class TestTaskRuntimeAuthPropagation:
             ):
                 monkeypatch.setenv("NEMO_JOB_WORKSPACE", workspace)
                 monkeypatch.setenv("NEMO_TEST_SECRET_NAME", secret_name)
+                monkeypatch.setenv("NMP_ORIGIN_WORKSPACE", workspace)
                 monkeypatch.setenv(
                     "NMP_PRINCIPAL",
                     json.dumps(

--- a/services/core/jobs/tests/test_dispatcher.py
+++ b/services/core/jobs/tests/test_dispatcher.py
@@ -119,6 +119,24 @@ async def create_test_job_data(
     return saved_job.id, saved_job.name, saved_attempt.id, saved_step.id, saved_task.id, saved_result.id
 
 
+@pytest.mark.asyncio
+async def test_get_job_uses_workspace_qualified_attempt_lookup(
+    mock_dispatcher: JobDispatcher,
+    mock_store: EntityClient,
+):
+    _, job_name, attempt_id, _, _, _ = await create_test_job_data(mock_store, "qualified-get-job")
+
+    with patch.object(mock_store, "get_by_id", wraps=mock_store.get_by_id) as get_by_id:
+        job = await mock_dispatcher.get_job(job_name, DEFAULT_WORKSPACE)
+
+    assert job is not None
+    get_by_id.assert_awaited_once_with(
+        PlatformJobAttempt,
+        attempt_id,
+        workspace=DEFAULT_WORKSPACE,
+    )
+
+
 async def verify_job_data_exists(store: EntityClient, job_id: str, should_exist: bool = True) -> None:
     """Verify that job data exists or does not exist."""
     if should_exist:

--- a/services/core/models/src/nmp/core/models/api/permissions.py
+++ b/services/core/models/src/nmp/core/models/api/permissions.py
@@ -23,6 +23,21 @@ from nmp.common.auth import AuthClient
 from nmp.common.entities.utils import parse_entity_ref
 
 
+async def _has_reference_permissions(
+    auth_client: AuthClient,
+    *,
+    source_workspace: str,
+    destination_workspace: str,
+    read_permission: str,
+    export_permission: str,
+) -> bool:
+    """Require read access, plus export access when a reference crosses workspaces."""
+    permissions = [read_permission]
+    if source_workspace != destination_workspace:
+        permissions.append(export_permission)
+    return await auth_client.has_permissions(source_workspace, permissions)
+
+
 async def check_secret_access(nmp_sdk: AsyncNeMoPlatform, secret_name: str, workspace: str) -> None:
     """Check that the current user can access the referenced secret.
 
@@ -68,7 +83,13 @@ async def check_deployment_access(auth_client: AuthClient, deployment_id: str, w
         PermissionError: If the user cannot access the deployment's workspace.
     """
     deploy_workspace = parse_entity_ref(deployment_id, default_workspace=workspace).workspace
-    if not await auth_client.has_permissions(deploy_workspace, ["inference.deployments.read"]):
+    if not await _has_reference_permissions(
+        auth_client,
+        source_workspace=deploy_workspace,
+        destination_workspace=workspace,
+        read_permission="inference.deployments.read",
+        export_permission="inference.deployments.export",
+    ):
         raise PermissionError(f"Access denied to deployment '{deployment_id}'")
 
 
@@ -78,7 +99,14 @@ async def check_deployment_config_access(auth_client: AuthClient, config_name: s
     Raises:
         PermissionError: If the user cannot access the config's workspace.
     """
-    if not await auth_client.has_permissions(workspace, ["inference.deployment-configs.read"]):
+    config_workspace = parse_entity_ref(config_name, default_workspace=workspace).workspace
+    if not await _has_reference_permissions(
+        auth_client,
+        source_workspace=config_workspace,
+        destination_workspace=workspace,
+        read_permission="inference.deployment-configs.read",
+        export_permission="inference.deployment-configs.export",
+    ):
         raise PermissionError(f"Access denied to deployment config '{config_name}' in workspace '{workspace}'")
 
 
@@ -91,7 +119,13 @@ async def check_model_entity_access(auth_client: AuthClient, model_entity_id: st
         PermissionError: If the user cannot access the model entity's workspace.
     """
     entity_workspace = parse_entity_ref(model_entity_id, default_workspace=workspace).workspace
-    if not await auth_client.has_permissions(entity_workspace, ["models.read"]):
+    if not await _has_reference_permissions(
+        auth_client,
+        source_workspace=entity_workspace,
+        destination_workspace=workspace,
+        read_permission="models.read",
+        export_permission="models.export",
+    ):
         raise PermissionError(f"Access denied to model entity '{model_entity_id}'")
 
 

--- a/services/core/models/src/nmp/core/models/api/service/model_deployment_config_service.py
+++ b/services/core/models/src/nmp/core/models/api/service/model_deployment_config_service.py
@@ -6,7 +6,7 @@
 import json
 import logging
 
-from nemo_platform import PermissionDeniedError
+from nemo_platform_plugin.client.errors import PermissionDeniedError
 from nmp.common.api.common import Page, PaginationData
 from nmp.common.api.filter import FilterOperation
 from nmp.common.entities.client import EntityClient, EntityConflictError, EntityNotFoundError

--- a/services/core/models/src/nmp/core/models/api/service/model_deployment_service.py
+++ b/services/core/models/src/nmp/core/models/api/service/model_deployment_service.py
@@ -13,6 +13,7 @@ from nmp.common.api.common import Page, PaginationData
 from nmp.common.api.filter import FilterOperation
 from nmp.common.auth import AuthContext
 from nmp.common.entities.client import EntityClient, EntityConflictError, EntityNotFoundError
+from nmp.common.entities.utils import parse_entity_ref
 from nmp.core.models.entities import ModelDeployment as ModelDeploymentEntity
 from nmp.core.models.entities import ModelDeploymentConfig as ModelDeploymentConfigEntity
 from nmp.core.models.schemas import (
@@ -177,18 +178,19 @@ class ModelDeploymentService:
             raise ValueError(f"Deployment with workspace '{workspace}' and name '{request.name}' already exists")
 
         # If config_version not specified, get the latest version
+        config_ref = parse_entity_ref(request.config, default_workspace=workspace)
         config_version = request.config_version
         if not config_version:
-            config_version = await self._get_config_latest_version(workspace, request.config)
+            config_version = await self._get_config_latest_version(config_ref.workspace, config_ref.name)
             if not config_version:
-                raise ValueError(f"Deployment config '{workspace}/{request.config}' does not exist")
+                raise ValueError(f"Deployment config '{config_ref.workspace}/{config_ref.name}' does not exist")
             logger.debug(f"Using latest config version: {config_version}")
 
         # Verify the deployment config exists
-        config = await self._get_config_by_version(workspace, request.config, config_version)
+        config = await self._get_config_by_version(config_ref.workspace, config_ref.name, config_version)
         if not config:
             raise ValueError(
-                f"Deployment config '{workspace}/{request.config}' version '{config_version}' does not exist"
+                f"Deployment config '{config_ref.workspace}/{config_ref.name}' version '{config_version}' does not exist"
             )
 
         # Create the entity with versioned name
@@ -356,18 +358,19 @@ class ModelDeploymentService:
             raise ValueError(f"Deployment with workspace '{workspace}' and name '{name}' does not exist")
 
         # Determine config_version: use from request or preserve current
+        config_ref = parse_entity_ref(request.config, default_workspace=workspace)
         config_version = request.config_version
         if not config_version:
-            config_version = await self._get_config_latest_version(workspace, request.config)
+            config_version = await self._get_config_latest_version(config_ref.workspace, config_ref.name)
             if not config_version:
-                raise ValueError(f"Deployment config '{workspace}/{request.config}' does not exist")
+                raise ValueError(f"Deployment config '{config_ref.workspace}/{config_ref.name}' does not exist")
             logger.debug(f"Using latest config version: {config_version}")
 
         # Verify the deployment config exists
-        config = await self._get_config_by_version(workspace, request.config, config_version)
+        config = await self._get_config_by_version(config_ref.workspace, config_ref.name, config_version)
         if not config:
             raise ValueError(
-                f"Deployment config '{workspace}/{request.config}' version '{config_version}' does not exist"
+                f"Deployment config '{config_ref.workspace}/{config_ref.name}' version '{config_version}' does not exist"
             )
 
         new_version = current.entity_version + 1

--- a/services/core/models/src/nmp/core/models/api/v2/deployments.py
+++ b/services/core/models/src/nmp/core/models/api/v2/deployments.py
@@ -102,7 +102,10 @@ async def create_deployment(
 
     logger.debug(f"Creating deployment: {workspace}/{deployment_input.name}")
 
-    auth_context = AuthContext.from_principal(auth_client.principal)
+    auth_context = AuthContext.from_principal(
+        auth_client.principal,
+        origin_workspace=auth_client.outbound_origin_workspace,
+    )
     try:
         await check_deployment_config_access(auth_client, deployment_input.config, workspace)
 
@@ -298,7 +301,13 @@ async def update_deployment(
         await check_deployment_config_access(auth_client, deployment_input.config, workspace)
 
         deployment = await service.update_deployment(
-            workspace, deployment_name, deployment_input, auth_context=AuthContext.from_principal(auth_client.principal)
+            workspace,
+            deployment_name,
+            deployment_input,
+            auth_context=AuthContext.from_principal(
+                auth_client.principal,
+                origin_workspace=auth_client.outbound_origin_workspace,
+            ),
         )
         return deployment
     except PermissionError as e:

--- a/services/core/models/src/nmp/core/models/api/v2/providers.py
+++ b/services/core/models/src/nmp/core/models/api/v2/providers.py
@@ -92,7 +92,10 @@ async def create_provider(
     Create a new model provider.
     """
     logger.info(f"Creating model provider: {workspace}/{request.name}")
-    auth_context = AuthContext.from_principal(auth_client.principal)
+    auth_context = AuthContext.from_principal(
+        auth_client.principal,
+        origin_workspace=auth_client.outbound_origin_workspace,
+    )
 
     try:
         if request.api_key_secret_name:
@@ -145,7 +148,10 @@ async def upsert_provider(
     Create or update a model provider.
     """
     logger.debug(f"Upserting model provider: {workspace}/{name}")
-    auth_context = AuthContext.from_principal(auth_client.principal)
+    auth_context = AuthContext.from_principal(
+        auth_client.principal,
+        origin_workspace=auth_client.outbound_origin_workspace,
+    )
 
     try:
         if request.api_key_secret_name:

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/compiler.py
@@ -7,6 +7,7 @@ Parity ports from ``k8s_nim_operator/nimservice_compiler.py`` — please review
 mapping of ``k8s_nim_operator_config`` → plugin ``K8sDeploymentConfig``.
 """
 
+import json
 from dataclasses import dataclass
 
 from nemo_deployments_plugin.entities import (
@@ -26,6 +27,7 @@ from nemo_deployments_plugin.entities import (
 from nemo_deployments_plugin.secrets import platform_ngc_secret_ref
 from nemo_platform_plugin.config import get_platform_config
 from nemo_platform_plugin.jobs.image import get_qualified_image
+from nmp.common.auth import NMP_ORIGIN_WORKSPACE_ENVVAR, NMP_PRINCIPAL_ENVVAR
 from nmp.common.config import Runtime
 from nmp.core.models.app import ModelWeightsType
 from nmp.core.models.app.constants import MODEL_MANAGED_BY_LABEL, MODEL_MANAGED_BY_MODELS_CONTROLLER
@@ -41,6 +43,7 @@ from nmp.core.models.controllers.backends.deployments_plugin.nim_compiler import
     tool_call_plugin_install_path,
 )
 from nmp.core.models.controllers.backends.deployments_plugin.resolve import ResolvedPluginDeployment
+from nmp.core.models.controllers.backends.deployments_plugin.runtime_auth import files_service_bearer_token
 from nmp.core.models.controllers.backends.engine import (
     ENGINE_GENERIC,
     ENGINE_NIM,
@@ -173,6 +176,21 @@ def _lora_sidecar(
         "XDG_STATE_HOME": _LORA_SIDECAR_XDG_HOME,
         "XDG_DATA_HOME": _LORA_SIDECAR_XDG_HOME,
     }
+    auth_context = getattr(resolved.deployment, "auth_context", None)
+    if auth_context is not None:
+        sidecar_env[NMP_PRINCIPAL_ENVVAR] = json.dumps(
+            {
+                "id": auth_context.principal_id,
+                "email": auth_context.principal_email,
+                "groups": auth_context.principal_groups or [],
+                "on_behalf_of": auth_context.principal_on_behalf_of,
+                "on_behalf_of_email": auth_context.principal_on_behalf_of_email,
+                "on_behalf_of_groups": auth_context.principal_on_behalf_of_groups,
+            }
+        )
+        sidecar_env[NMP_ORIGIN_WORKSPACE_ENVVAR] = (
+            getattr(auth_context, "origin_workspace", None) or resolved.deployment.workspace
+        )
     if engine == ENGINE_VLLM:
         sidecar_env["VLLM_LORA_BASE_MODEL_OVERRIDE"] = MODEL_STORE_PATH
         # Native sidecar / pod-local network: talk to the sibling vLLM server.
@@ -237,7 +255,11 @@ def compile_model_deployment(
                 k8s=K8sVolumeConfig(storageClass=config.default_storage_class),
             ),
         )
-        puller_env = {"HF_ENDPOINT": resolved.files_hf_url, "HF_TOKEN": "service:models"}
+        assert resolved.model_namespace is not None
+        puller_env = {
+            "HF_ENDPOINT": resolved.files_hf_url,
+            "HF_TOKEN": files_service_bearer_token(resolved.deployment, resolved.model_namespace),
+        }
         puller_args = ["download", f"{resolved.model_namespace}/{resolved.model_name}", "--local-dir", _WEIGHTS_MOUNT]
         if resolved.model_revision:
             puller_args.extend(["--revision", resolved.model_revision])

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/nim_compiler.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/nim_compiler.py
@@ -30,10 +30,12 @@ from nemo_deployments_plugin.entities import (
 from nemo_platform.types.inference.k8s_nim_operator_config import K8sNIMOperatorConfig
 from nemo_platform.types.models.model_entity import ModelEntity
 from nmp.common.config import Runtime
+from nmp.common.entities.utils import parse_entity_ref
 from nmp.core.models.app import is_multi_llm_image, parse_model_name_revision
 from nmp.core.models.controllers.backends.common import DeploymentConfigView
 from nmp.core.models.controllers.backends.deployments_plugin.config import DeploymentsPluginConfig
 from nmp.core.models.controllers.backends.deployments_plugin.resolve import ResolvedPluginDeployment
+from nmp.core.models.controllers.backends.deployments_plugin.runtime_auth import files_service_bearer_token
 from nmp.core.models.controllers.backends.engine import ENGINE_GENERIC, ENGINE_NIM, ENGINE_VLLM
 
 _WEIGHTS_MOUNT = "/model-store"
@@ -123,6 +125,7 @@ def tool_call_plugin_init_containers(
     puller_parts = _puller_image_parts(resolved.huggingface_model_puller)
     if puller_parts is None:
         return None
+    plugin_workspace = parse_entity_ref(plugin_fileset, default_workspace=resolved.deployment.workspace).workspace
     puller_repo, puller_tag = puller_parts
     scratch_mount = VolumeMount(name=names_scratch, mountPath=_SCRATCH_MOUNT)
     weights_mount = VolumeMount(name=names_volume, mountPath=_WEIGHTS_MOUNT)
@@ -152,7 +155,10 @@ def tool_call_plugin_init_containers(
             command=["download", plugin_fileset, "--local-dir", _TOOL_CALL_PLUGIN_SCRATCH_DIR],
             env=[
                 EnvVar(name="HF_ENDPOINT", value=resolved.files_hf_url),
-                EnvVar(name="HF_TOKEN", value="service:models"),
+                EnvVar(
+                    name="HF_TOKEN",
+                    value=files_service_bearer_token(resolved.deployment, plugin_workspace),
+                ),
             ],
             volumeMounts=[scratch_mount],
         ),

--- a/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/runtime_auth.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/deployments_plugin/runtime_auth.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Delegated authorization for model files downloaded by runtime pullers."""
+
+from nemo_platform.types.inference.model_deployment import ModelDeployment
+from nmp.common.auth import Principal, build_service_principal_bearer_token
+from nmp.common.config import get_auth_config
+
+
+def files_service_bearer_token(deployment: ModelDeployment, source_workspace: str) -> str:
+    """Return an HF token that rechecks the deployment creator's current access."""
+    auth_context = getattr(deployment, "auth_context", None)
+    if auth_context is None:
+        if not get_auth_config().enabled:
+            return "service:models"
+        raise ValueError(
+            "Model downloads require a deployment auth context; "
+            f"cannot access {source_workspace!r} from {deployment.workspace!r}"
+        )
+
+    principal = Principal(
+        id=auth_context.principal_id,
+        email=getattr(auth_context, "principal_email", None),
+        # Durable runtime credentials must not replay creation-time group claims.
+        groups=[],
+        on_behalf_of=getattr(auth_context, "principal_on_behalf_of", None),
+        on_behalf_of_email=getattr(auth_context, "principal_on_behalf_of_email", None),
+        on_behalf_of_groups=None,
+    )
+    return build_service_principal_bearer_token(
+        "models",
+        on_behalf_of=principal,
+        origin_workspace=getattr(auth_context, "origin_workspace", None) or deployment.workspace,
+        source_workspace=source_workspace,
+    )

--- a/services/core/models/src/nmp/core/models/sidecars/adapters/main.py
+++ b/services/core/models/src/nmp/core/models/sidecars/adapters/main.py
@@ -25,7 +25,7 @@ from nmp.common.controller import (
     TimedLoopWaiter,
     TrackLastExecutionTime,
 )
-from nmp.common.sdk_factory import get_platform_sdk
+from nmp.common.sdk_factory import get_task_sdk
 
 stop_signal = threading.Event()
 
@@ -88,10 +88,7 @@ class AdaptersController(HeartbeatMixin, Controller):
 
         self.platform_config = get_platform_config()
 
-        self._sdk: NeMoPlatform = get_platform_sdk(
-            as_service="models",
-            internal=True,
-        )
+        self._sdk: NeMoPlatform = get_task_sdk("models")
 
     def download_fileset(self, dest_dir: str, workspace: str, name: str) -> bool:
         try:

--- a/services/core/models/tests/conftest.py
+++ b/services/core/models/tests/conftest.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from nmp.common.config import AuthConfig
+
+
+@pytest.fixture(scope="session")
+def _files_runtime_signing_key_file(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Generate one shared API signing key for model runtime-token tests."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key_file: Path = tmp_path_factory.mktemp("files-runtime-token") / "private-key.pem"
+    key_file.write_bytes(
+        private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+    )
+    return key_file
+
+
+@pytest.fixture(autouse=True)
+def _files_runtime_signing_key(
+    monkeypatch: pytest.MonkeyPatch,
+    _files_runtime_signing_key_file: Path,
+) -> None:
+    """Scope the runtime-token auth configuration to each model test."""
+    config = AuthConfig(enabled=True)
+    config.oidc.workload_token_private_key_file = str(_files_runtime_signing_key_file)
+
+    from nmp.common.auth import dependencies
+    from nmp.core.models.controllers.backends.deployments_plugin import runtime_auth
+
+    monkeypatch.setattr(dependencies, "get_auth_config", lambda: config)
+    monkeypatch.setattr(runtime_auth, "get_auth_config", lambda: config)

--- a/services/core/models/tests/integration/test_chat_template_tool_calling.py
+++ b/services/core/models/tests/integration/test_chat_template_tool_calling.py
@@ -188,6 +188,15 @@ def sample_deployment():
     dep.config = None
     dep.config_version = None
     dep.model_provider_id = None
+    dep.auth_context = SimpleNamespace(
+        principal_id="test-user@example.com",
+        principal_email="test-user@example.com",
+        principal_groups=[],
+        principal_on_behalf_of=None,
+        principal_on_behalf_of_email=None,
+        principal_on_behalf_of_groups=None,
+        origin_workspace=DEFAULT_WORKSPACE,
+    )
     return dep
 
 

--- a/services/core/models/tests/integration/test_models_auth_propagation.py
+++ b/services/core/models/tests/integration/test_models_auth_propagation.py
@@ -108,7 +108,7 @@ class TestDeploymentAuthPropagation:
         assert retrieved.auth_context is not None, "retrieve: service principal should see auth_context"
         assert retrieved.auth_context.principal_id == creator_email
         assert retrieved.auth_context.principal_email == creator_email
-        assert retrieved.auth_context.principal_groups == creator_groups
+        assert retrieved.auth_context.principal_groups == []
 
         # List response
         result = service_sdk.inference.deployments.list(workspace="default")
@@ -116,7 +116,7 @@ class TestDeploymentAuthPropagation:
         assert len(matching) == 1
         assert matching[0].auth_context is not None, "list: service principal should see auth_context"
         assert matching[0].auth_context.principal_id == creator_email
-        assert matching[0].auth_context.principal_groups == creator_groups
+        assert matching[0].auth_context.principal_groups == []
 
     def test_auth_context_persisted_across_users(self, sdk: NeMoPlatform):
         """Auth context persists the original creator's identity, invisible to other users."""
@@ -141,7 +141,7 @@ class TestDeploymentAuthPropagation:
         )
         assert retrieved_by_service.auth_context is not None
         assert retrieved_by_service.auth_context.principal_id == creator_email
-        assert retrieved_by_service.auth_context.principal_groups == creator_groups
+        assert retrieved_by_service.auth_context.principal_groups == []
 
 
 class TestProviderAuthPropagation:
@@ -170,7 +170,7 @@ class TestProviderAuthPropagation:
         assert retrieved.auth_context is not None, "Service principal should see auth_context"
         assert retrieved.auth_context.principal_id == creator_email
         assert retrieved.auth_context.principal_email == creator_email
-        assert retrieved.auth_context.principal_groups == creator_groups
+        assert retrieved.auth_context.principal_groups == []
 
     def test_auth_context_stripped_for_regular_user_on_list(self, sdk: NeMoPlatform):
         """Auth context should be stripped from list responses for regular users."""
@@ -214,7 +214,7 @@ class TestProviderAuthPropagation:
         )
         assert retrieved.auth_context is not None
         assert retrieved.auth_context.principal_id == creator_email
-        assert retrieved.auth_context.principal_groups == creator_groups
+        assert retrieved.auth_context.principal_groups == []
 
         # Upsert updates the existing provider
         updated = creator_sdk.inference.providers.update(
@@ -231,4 +231,4 @@ class TestProviderAuthPropagation:
         )
         assert retrieved_after_update.auth_context is not None, "Service principal should see auth_context after update"
         assert retrieved_after_update.auth_context.principal_id == creator_email
-        assert retrieved_after_update.auth_context.principal_groups == creator_groups
+        assert retrieved_after_update.auth_context.principal_groups == []

--- a/services/core/models/tests/integration/test_workspace_iam_models_isolation.py
+++ b/services/core/models/tests/integration/test_workspace_iam_models_isolation.py
@@ -10,9 +10,9 @@ HTTP to the same routes using a ``requests`` Session (see
 :class:`_TestClientToRequestsAdapter`) that forwards to the Starlette ``TestClient``,
 since CPython ``requests`` cannot open an in-process ASGI app directly.
 
-Per-workspace model entities exist in C and D. User A (group on C) may add an
-adapter in A whose fileset (LoRA / base data) is in C; a fileset in D while
-adapting a model in A must be denied (403) because the caller cannot read D.
+Per-workspace model entities exist in C and D. User A (group on C) may export a
+fileset from C for an adapter in A; a fileset in D while adapting a model in A
+must be denied (403) because the caller cannot export from D.
 """
 
 from __future__ import annotations
@@ -143,7 +143,7 @@ class TestWorkspaceIamIsolationSDK:
 
         grant_workspace_role(admin, workspace=ws_a, principal=user_a, roles=["Editor"])
         grant_workspace_role(admin, workspace=ws_b, principal=user_b, roles=["Editor"])
-        grant_workspace_role(admin, workspace=ws_c, principal=shared_group, roles=["Editor"])
+        grant_workspace_role(admin, workspace=ws_c, principal=shared_group, roles=["Editor", "Exporter"])
 
         model_a = short_unique_name("mdl-a")
         model_b = short_unique_name("mdl-b")
@@ -181,7 +181,7 @@ class TestWorkspaceIamIsolationSDK:
                 finetuning_type="lora",
             )
 
-        # Adapter in ws_a on local model, LoRA data in ws_c: allowed (user A can read C).
+        # Adapter in ws_a on local model, LoRA data in ws_c: allowed (user A can export from C).
         uac.models.adapters.create(
             model_a,
             workspace=ws_a,
@@ -288,7 +288,7 @@ class TestWorkspaceIamIsolationHttpRequests:
         assert (
             post(
                 f"{b}/apis/entities/v2/workspaces/{ws_c}/members?wait_role_propagation=true",
-                json={"principal": shared_group, "roles": ["Editor"]},
+                json={"principal": shared_group, "roles": ["Editor", "Exporter"]},
                 headers=h(TEST_ADMIN_EMAIL),
             ).status_code
             == 201

--- a/services/core/models/tests/unit/api/test_permissions.py
+++ b/services/core/models/tests/unit/api/test_permissions.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock
+
+import pytest
+from nmp.core.models.api.permissions import (
+    check_deployment_access,
+    check_deployment_config_access,
+    check_model_entity_access,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("check", "reference", "read_permission", "export_permission"),
+    [
+        (check_model_entity_access, "source/model-a", "models.read", "models.export"),
+        (
+            check_deployment_access,
+            "source/deployment-a",
+            "inference.deployments.read",
+            "inference.deployments.export",
+        ),
+        (
+            check_deployment_config_access,
+            "source/config-a",
+            "inference.deployment-configs.read",
+            "inference.deployment-configs.export",
+        ),
+    ],
+)
+async def test_cross_workspace_reference_requires_read_and_export(
+    check,
+    reference: str,
+    read_permission: str,
+    export_permission: str,
+) -> None:
+    auth_client = AsyncMock()
+    auth_client.has_permissions.return_value = True
+
+    await check(auth_client, reference, "destination")
+
+    auth_client.has_permissions.assert_awaited_once_with("source", [read_permission, export_permission])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("check", "reference", "read_permission"),
+    [
+        (check_model_entity_access, "model-a", "models.read"),
+        (check_deployment_access, "deployment-a", "inference.deployments.read"),
+        (check_deployment_config_access, "config-a", "inference.deployment-configs.read"),
+    ],
+)
+async def test_same_workspace_reference_requires_only_read(check, reference: str, read_permission: str) -> None:
+    auth_client = AsyncMock()
+    auth_client.has_permissions.return_value = True
+
+    await check(auth_client, reference, "destination")
+
+    auth_client.has_permissions.assert_awaited_once_with("destination", [read_permission])

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_backend.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_backend.py
@@ -18,9 +18,26 @@ from nmp.core.models.controllers.backends.deployments_plugin.config import Deplo
 from nmp.core.models.controllers.backends.deployments_plugin.resolve import ResolvedPluginDeployment
 
 
+def _auth_context() -> SimpleNamespace:
+    return SimpleNamespace(
+        principal_id="creator@example.com",
+        principal_email="creator@example.com",
+        principal_groups=["model-builders"],
+        principal_on_behalf_of=None,
+        principal_on_behalf_of_email=None,
+        principal_on_behalf_of_groups=None,
+        origin_workspace="default",
+    )
+
+
 def _ctx() -> SimpleNamespace:
     return SimpleNamespace(
-        model_deployment=SimpleNamespace(name="my-dep", workspace="default", status="CREATED"),
+        model_deployment=SimpleNamespace(
+            name="my-dep",
+            workspace="default",
+            status="CREATED",
+            auth_context=_auth_context(),
+        ),
         model_deployment_config=SimpleNamespace(engine="vllm"),
         model_entity=None,
     )
@@ -28,7 +45,7 @@ def _ctx() -> SimpleNamespace:
 
 def _resolved() -> ResolvedPluginDeployment:
     return ResolvedPluginDeployment(
-        deployment=SimpleNamespace(name="my-dep", workspace="default"),
+        deployment=SimpleNamespace(name="my-dep", workspace="default", auth_context=_auth_context()),
         config=SimpleNamespace(engine="vllm"),
         model_entity=None,
         view=DeploymentConfigView(model_namespace="org", model_name="model"),
@@ -131,7 +148,7 @@ async def test_create_order_volume_puller_server_with_prerequisite() -> None:
 
 def _resolved_docker_lora() -> ResolvedPluginDeployment:
     return ResolvedPluginDeployment(
-        deployment=SimpleNamespace(name="my-dep", workspace="default"),
+        deployment=SimpleNamespace(name="my-dep", workspace="default", auth_context=_auth_context()),
         config=SimpleNamespace(engine="vllm"),
         model_entity=None,
         view=DeploymentConfigView(model_namespace="org", model_name="model", lora_enabled=True, gpu=1),

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_compiler.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from nemo_deployments_plugin.entities import SecretRef
 from nemo_platform.types.inference.k8s_nim_operator_config import K8sNIMOperatorConfig
+from nmp.common.auth.dependencies import parse_service_principal_bearer_token
 from nmp.common.config import Runtime
 from nmp.core.models.app import ModelWeightsType
 from nmp.core.models.controllers.backends.common import DeploymentConfigView
@@ -18,7 +19,19 @@ from nmp.core.models.controllers.backends.vllm_compiler import MODEL_STORE_PATH
 
 def _resolved(engine: str, *, lora: bool = False, runtime: Runtime = Runtime.KUBERNETES) -> ResolvedPluginDeployment:
     return ResolvedPluginDeployment(
-        deployment=SimpleNamespace(name="my-dep", workspace="default"),
+        deployment=SimpleNamespace(
+            name="my-dep",
+            workspace="default",
+            auth_context=SimpleNamespace(
+                principal_id="creator@example.com",
+                principal_email="creator@example.com",
+                principal_groups=["model-builders"],
+                principal_on_behalf_of=None,
+                principal_on_behalf_of_email=None,
+                principal_on_behalf_of_groups=None,
+                origin_workspace="default",
+            ),
+        ),
         config=SimpleNamespace(engine=engine),
         model_entity=None,
         view=DeploymentConfigView(model_namespace="org", model_name="model", lora_enabled=lora),
@@ -88,7 +101,14 @@ def test_vllm_server_command_image_args_and_gpu() -> None:
     puller = compiled.puller_config.containers[0]
     puller_env = {item.name: item.value for item in puller.env}
     assert puller_env["HF_ENDPOINT"] == resolved.files_hf_url
-    assert puller_env["HF_TOKEN"] == "service:models"
+    token_headers = parse_service_principal_bearer_token(
+        puller_env["HF_TOKEN"],
+        expected_source_workspace="org",
+    )
+    assert token_headers is not None
+    assert token_headers["x-nmp-principal-id"] == "service:models"
+    assert token_headers["x-nmp-principal-on-behalf-of"] == "creator@example.com"
+    assert token_headers["x-nmp-origin-workspace"] == "default"
     assert puller.resources is not None
     assert puller.resources.limits["nvidia.com/gpu"] == "1"
 
@@ -225,7 +245,13 @@ def test_nim_tool_call_plugin_adds_init_containers_and_env() -> None:
     pull = compiled.server_config.init_containers[1]
     assert pull.command == ["download", "test-ws/my-plugin-fileset", "--local-dir", "/scratch/plugin"]
     pull_env = {item.name: item.value for item in pull.env}
-    assert pull_env["HF_TOKEN"] == "service:models"
+    token_headers = parse_service_principal_bearer_token(
+        pull_env["HF_TOKEN"],
+        expected_source_workspace="test-ws",
+    )
+    assert token_headers is not None
+    assert token_headers["x-nmp-principal-on-behalf-of"] == "creator@example.com"
+    assert token_headers["x-nmp-origin-workspace"] == "default"
     assert pull_env["HF_ENDPOINT"] == resolved.files_hf_url
     server_env = {item.name: item.value for item in compiled.server_config.containers[0].env}
     assert server_env["NIM_TOOL_PARSER_PLUGIN"] == "/model-store/plugin/plugin.py"
@@ -371,3 +397,33 @@ def test_lora_uses_native_sidecar_on_k8s_and_container_on_docker() -> None:
     assert env["NMP_BASE_URL"] == "http://platform.example:8080"
     assert env["VLLM_ENDPOINT"] == "http://127.0.0.1:8000"
     assert len(docker.server_config.containers) == 2
+
+
+def test_lora_sidecar_delegates_as_creator_from_deployment_workspace() -> None:
+    resolved = _resolved("vllm", lora=True)
+    resolved.deployment.auth_context = SimpleNamespace(
+        principal_id="creator@example.com",
+        principal_email="creator@example.com",
+        principal_groups=["model-builders"],
+        principal_on_behalf_of=None,
+        principal_on_behalf_of_email=None,
+        principal_on_behalf_of_groups=None,
+    )
+    platform = MagicMock(base_url="http://platform.example:8080")
+    with (
+        patch(
+            "nmp.core.models.controllers.backends.deployments_plugin.compiler.get_qualified_image",
+            return_value="registry/nmp-api:tag",
+        ),
+        patch(
+            "nmp.core.models.controllers.backends.deployments_plugin.compiler.get_platform_config",
+            return_value=platform,
+        ),
+    ):
+        compiled = compile_model_deployment(resolved, DeploymentsPluginConfig())
+
+    sidecar = compiled.server_config.init_containers[-1]
+    env = {item.name: item.value for item in sidecar.env}
+    assert env["NMP_ORIGIN_WORKSPACE"] == "default"
+    assert '"id": "creator@example.com"' in env["NMP_PRINCIPAL"]
+    assert '"model-builders"' in env["NMP_PRINCIPAL"]

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_nim_compiler.py
@@ -34,7 +34,19 @@ from nmp.core.models.controllers.backends.deployments_plugin.resolve import Reso
 
 def _resolved() -> ResolvedPluginDeployment:
     return ResolvedPluginDeployment(
-        deployment=SimpleNamespace(name="my-dep", workspace="default"),
+        deployment=SimpleNamespace(
+            name="my-dep",
+            workspace="default",
+            auth_context=SimpleNamespace(
+                principal_id="creator@example.com",
+                principal_email="creator@example.com",
+                principal_groups=[],
+                principal_on_behalf_of=None,
+                principal_on_behalf_of_email=None,
+                principal_on_behalf_of_groups=None,
+                origin_workspace="default",
+            ),
+        ),
         config=SimpleNamespace(engine="nim"),
         model_entity=None,
         view=DeploymentConfigView(model_namespace="org", model_name="model"),

--- a/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_runtime_auth.py
+++ b/services/core/models/tests/unit/controllers/backends/deployments_plugin/test_runtime_auth.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+from nmp.common.auth.dependencies import parse_service_principal_bearer_token
+from nmp.core.models.controllers.backends.deployments_plugin.runtime_auth import files_service_bearer_token
+
+
+def test_runtime_token_preserves_original_user_and_origin() -> None:
+    deployment = SimpleNamespace(
+        workspace="destination",
+        auth_context=SimpleNamespace(
+            principal_id="creator@example.com",
+            principal_email="creator@example.com",
+            principal_groups=["exporters"],
+            principal_on_behalf_of=None,
+            principal_on_behalf_of_email=None,
+            principal_on_behalf_of_groups=None,
+            origin_workspace="destination",
+        ),
+    )
+
+    token = files_service_bearer_token(deployment, "source")
+
+    headers = parse_service_principal_bearer_token(token, expected_source_workspace="source")
+    assert headers is not None
+    assert headers["x-nmp-principal-id"] == "service:models"
+    assert headers["x-nmp-principal-on-behalf-of"] == "creator@example.com"
+    assert "x-nmp-principal-on-behalf-of-groups" not in headers
+    assert headers["x-nmp-origin-workspace"] == "destination"
+
+
+def test_runtime_without_auth_context_fails_closed() -> None:
+    deployment = SimpleNamespace(workspace="destination", auth_context=None)
+
+    with pytest.raises(ValueError, match="require a deployment auth context"):
+        files_service_bearer_token(deployment, "source")
+
+
+def test_same_workspace_runtime_without_auth_context_fails_closed() -> None:
+    deployment = SimpleNamespace(workspace="source", auth_context=None)
+
+    with pytest.raises(ValueError, match="require a deployment auth context"):
+        files_service_bearer_token(deployment, "source")

--- a/services/core/models/tests/unit/test_model_deployment_service_unit.py
+++ b/services/core/models/tests/unit/test_model_deployment_service_unit.py
@@ -181,6 +181,35 @@ async def test_create_deployment_success(
 
 
 @pytest.mark.asyncio
+async def test_create_deployment_resolves_qualified_config_in_source_workspace(
+    deployment_service,
+    mock_entity_client,
+    sample_config_entity,
+    sample_deployment_entity,
+):
+    request = CreateModelDeploymentRequest(
+        name="test-deployment",
+        project="test-project",
+        config="source-workspace/test-config",
+    )
+    no_deployments = MagicMock(data=[])
+    source_configs = MagicMock(data=[sample_config_entity])
+    mock_entity_client.list.side_effect = [no_deployments, source_configs]
+    mock_entity_client.get.return_value = sample_config_entity
+    mock_entity_client.create.return_value = sample_deployment_entity
+
+    await deployment_service.create_deployment(request, "destination-workspace")
+
+    config_list_call = mock_entity_client.list.await_args_list[1]
+    assert config_list_call.kwargs["workspace"] == "source-workspace"
+    mock_entity_client.get.assert_awaited_once_with(
+        ModelDeploymentConfigEntity,
+        workspace="source-workspace",
+        name="test-config-v1",
+    )
+
+
+@pytest.mark.asyncio
 async def test_create_deployment_already_exists(
     deployment_service, mock_entity_client, sample_create_request, sample_deployment_entity
 ):

--- a/services/core/secrets/tests/integration/test_secrets_with_auth.py
+++ b/services/core/secrets/tests/integration/test_secrets_with_auth.py
@@ -717,11 +717,12 @@ class TestDelegatedSecretAccess:
     These tests verify that when a principal acts on behalf of another user,
     the delegated user's permissions are checked for secret access.
 
-    Note: Viewer role includes secrets.read permission (see static-authz.yaml).
+    Viewer can read secret metadata but cannot authorize retrieval of secret values.
+    Editor and Exporter explicitly include secrets.access for delegated retrieval.
     """
 
-    def test_service_principal_can_access_on_behalf_of_viewer(self, sdk: NeMoPlatform):
-        """Test service principal accessing secret on behalf of a Viewer who has secrets.read.
+    def test_service_principal_cannot_access_on_behalf_of_viewer(self, sdk: NeMoPlatform):
+        """Test service principal cannot access a secret value on behalf of a Viewer.
 
         Only service principals can call the /access endpoint. PlatformAdmin is denied
         direct access by OPA policy, so delegation must use a service principal as caller.
@@ -745,37 +746,34 @@ class TestDelegatedSecretAccess:
             workspace=workspace_name,
         ).data()
 
-        # Service principal accesses secret on behalf of viewer
-        # Viewer has secrets.read permission, so this should succeed
-        delegated_sdk = get_sdk_on_behalf_of(as_user(sdk, SERVICE_PRINCIPAL), viewer_email)
-        result = (
-            client_from_platform(delegated_sdk, SecretsClient)
-            .access_secret(name=secret_name, workspace=workspace_name)
-            .data()
+        # Viewer can read secret metadata but does not have secrets.access.
+        delegated_sdk = get_sdk_on_behalf_of(
+            as_user(sdk, SERVICE_PRINCIPAL), viewer_email, origin_workspace=workspace_name
         )
+        with pytest.raises(ClientPermissionDeniedError):
+            client_from_platform(delegated_sdk, SecretsClient).access_secret(name=secret_name, workspace=workspace_name)
 
-        assert result.name == secret_name
-        assert result.value == secret_value
-
-    def test_service_principal_can_access_on_behalf_of_group_bound_viewer(self, sdk: NeMoPlatform):
-        """Test delegated access succeeds when the delegated user's group has Viewer."""
-        workspace_name = short_unique_name("del-grp")
+    def test_service_principal_can_access_exported_secret_on_behalf_of_group_bound_exporter(self, sdk: NeMoPlatform):
+        """Test cross-workspace access when the delegated user's group has Exporter."""
+        source_workspace = short_unique_name("del-grp-src")
+        origin_workspace = short_unique_name("del-grp-dst")
         secret_name = short_unique_name("secret")
         secret_value = "delegated-group-secret"
-        delegated_email = unique_email("viewer")
-        delegated_group = f"group-{short_unique_name('vw')}"
+        delegated_email = unique_email("exporter")
+        delegated_group = f"group-{short_unique_name('exp')}"
 
         platform_admin_sdk = as_user(sdk, TEST_ADMIN_EMAIL)
-        platform_admin_sdk.workspaces.create(name=workspace_name)
+        platform_admin_sdk.workspaces.create(name=source_workspace)
+        platform_admin_sdk.workspaces.create(name=origin_workspace)
         grant_workspace_role(
             platform_admin_sdk,
-            workspace=workspace_name,
+            workspace=source_workspace,
             principal=delegated_group,
-            roles=["Viewer"],
+            roles=["Exporter"],
         )
         client_from_platform(platform_admin_sdk, SecretsClient).create_secret(
             body=PlatformSecretCreateRequest(name=secret_name, value=SecretStr(secret_value)),
-            workspace=workspace_name,
+            workspace=source_workspace,
         ).data()
 
         delegated_sdk = get_sdk_on_behalf_of(
@@ -785,11 +783,12 @@ class TestDelegatedSecretAccess:
                 email=delegated_email,
                 groups=[delegated_group],
             ),
+            origin_workspace=origin_workspace,
         )
 
         result = (
             client_from_platform(delegated_sdk, SecretsClient)
-            .access_secret(name=secret_name, workspace=workspace_name)
+            .access_secret(name=secret_name, workspace=source_workspace)
             .data()
         )
 
@@ -813,7 +812,9 @@ class TestDelegatedSecretAccess:
 
         # Platform admin accesses secret on behalf of non-member
         # Non-member doesn't have any role in workspace, so this should fail
-        delegated_sdk = get_sdk_on_behalf_of(as_user(sdk, TEST_ADMIN_EMAIL), non_member_email)
+        delegated_sdk = get_sdk_on_behalf_of(
+            as_user(sdk, TEST_ADMIN_EMAIL), non_member_email, origin_workspace=workspace_name
+        )
         with pytest.raises(ClientPermissionDeniedError):
             client_from_platform(delegated_sdk, SecretsClient).access_secret(name=secret_name, workspace=workspace_name)
 
@@ -845,6 +846,7 @@ class TestDelegatedSecretAccess:
                 email=delegated_email,
                 groups=[other_group],
             ),
+            origin_workspace=workspace_name,
         )
 
         with pytest.raises(ClientPermissionDeniedError):
@@ -871,9 +873,10 @@ class TestDelegatedSecretAccess:
             workspace=workspace_name,
         ).data()
 
-        # Service principal accesses secret on behalf of editor
-        # Editor has secrets.read permission (inherits from Viewer), so this should succeed
-        delegated_sdk = get_sdk_on_behalf_of(as_user(sdk, SERVICE_PRINCIPAL), editor_email)
+        # Editor explicitly has secrets.access, so delegated retrieval succeeds.
+        delegated_sdk = get_sdk_on_behalf_of(
+            as_user(sdk, SERVICE_PRINCIPAL), editor_email, origin_workspace=workspace_name
+        )
         result = (
             client_from_platform(delegated_sdk, SecretsClient)
             .access_secret(name=secret_name, workspace=workspace_name)
@@ -933,7 +936,9 @@ class TestDelegatedSecretAccess:
 
         # Service accesses secret on behalf of another service
         # Both services have elevated permissions, so this should succeed
-        delegated_sdk = get_sdk_on_behalf_of(as_user(sdk, SERVICE_PRINCIPAL), other_service)
+        delegated_sdk = get_sdk_on_behalf_of(
+            as_user(sdk, SERVICE_PRINCIPAL), other_service, origin_workspace=workspace_name
+        )
         result = (
             client_from_platform(delegated_sdk, SecretsClient)
             .access_secret(name=secret_name, workspace=workspace_name)
@@ -966,7 +971,9 @@ class TestDelegatedSecretAccess:
         ).data()
 
         # Editor tries to access secret on behalf of non-member
-        delegated_sdk = get_sdk_on_behalf_of(as_user(sdk, editor_email), non_member_email)
+        delegated_sdk = get_sdk_on_behalf_of(
+            as_user(sdk, editor_email), non_member_email, origin_workspace=workspace_name
+        )
         with pytest.raises(ClientPermissionDeniedError):
             client_from_platform(delegated_sdk, SecretsClient).access_secret(name=secret_name, workspace=workspace_name)
 

--- a/web/packages/studio/src/routes/WorkspaceMembersRoute/WorkspaceMemberModal.test.tsx
+++ b/web/packages/studio/src/routes/WorkspaceMembersRoute/WorkspaceMemberModal.test.tsx
@@ -56,7 +56,7 @@ vi.mock('@nemo/sdk/generated/platform/api', async (importOriginal) => {
 
 const mockMember = {
   principal: 'user@example.com',
-  roles: ['Viewer'] as ('Viewer' | 'Editor' | 'Admin')[],
+  roles: ['Viewer'] as ('Viewer' | 'Editor' | 'Exporter' | 'Admin')[],
   workspace: 'test-workspace',
 };
 

--- a/web/packages/studio/src/routes/WorkspaceMembersRoute/WorkspaceMemberModal.tsx
+++ b/web/packages/studio/src/routes/WorkspaceMembersRoute/WorkspaceMemberModal.tsx
@@ -50,7 +50,7 @@ function createWorkspaceMemberFormSchema(
   return z
     .object({
       principal: z.string(),
-      role: z.enum(['Viewer', 'Editor', 'Admin']),
+      role: z.enum(WORKSPACE_MEMBER_ROLES),
     })
     .superRefine((data, ctx) => {
       if (mode === 'add' && data.principal.trim() === '') {

--- a/web/packages/studio/src/routes/WorkspaceMembersRoute/workspaceMemberRoles.ts
+++ b/web/packages/studio/src/routes/WorkspaceMembersRoute/workspaceMemberRoles.ts
@@ -4,7 +4,7 @@
  */
 
 /** Workspace role binding names accepted by the Entities members API (see platform role bindings). */
-export const WORKSPACE_MEMBER_ROLES = ['Viewer', 'Editor', 'Admin'] as const;
+export const WORKSPACE_MEMBER_ROLES = ['Viewer', 'Editor', 'Exporter', 'Admin'] as const;
 
 export type WorkspaceMemberRole = (typeof WORKSPACE_MEMBER_ROLES)[number];
 
@@ -12,6 +12,7 @@ export type WorkspaceMemberRole = (typeof WORKSPACE_MEMBER_ROLES)[number];
 export const WORKSPACE_ROLE_DESCRIPTIONS: Record<WorkspaceMemberRole, string> = {
   Viewer: 'View all resources.',
   Editor: 'Create, modify, and delete resources.',
+  Exporter: 'View resources and reference them from other workspaces.',
   Admin: 'Full administrative access over resources, users, and access.',
 };
 


### PR DESCRIPTION
## Summary

Addresses AIRCORE-218 by preventing delegated services and background runtimes from using broad service permissions to reference resources across workspace boundaries.

Cross-workspace references now require the effective user to hold both:

1. The resource's normal read/list/access permission.
2. The corresponding `.export` permission in the source workspace.

## Why

Internal services use privileged service principals for service-to-service operations. When acting on behalf of a user, those privileges could previously satisfy downstream reads even when the user was not authorized to expose the resource outside its workspace.

This change separates permission to **read** a resource from permission to **export/reference** it from another workspace.

## Changes

### Export authorization

- Add `.export` permissions for shareable workspace resources.
- Add an `Exporter` workspace role:
  - includes Viewer permissions;
  - permits cross-workspace references;
  - does not permit resource mutation.
- Make `Admin` inherit both Editor and Exporter permissions.
- Require plugins to declare export permissions explicitly instead of deriving them automatically from read permissions.
- Evaluate delegated authorization using the effective user rather than the service principal's `ServiceSystem` wildcard.

### Origin-workspace propagation

- Introduce trusted `X-NMP-Origin-Workspace` propagation for delegated service calls.
- Derive the origin from the workspace-scoped route when creating request-scoped SDK and entity clients.
- Propagate the origin through:
  - service-to-service SDK calls;
  - entity operations;
  - jobs and task runtimes;
  - Docker, Kubernetes, and subprocess backends;
  - model providers and deployments;
  - secret resolution and model sidecars.
- Reject delegated requests without a valid origin when the source workspace cannot be evaluated safely.
- Keep wildcard Entities listing as a controlled exception with application-level per-workspace filtering and bounded PDP concurrency.

### Cross-workspace references

Enforce read and export permissions for:

- entity parent relationships;
- models and adapters;
- deployments and deployment configurations;
- providers and virtual models;
- filesets and runtime model downloads;
- secrets used by jobs and storage configurations;
- other plugin-declared exportable resources.

Qualified deployment configuration references are now resolved from their declared source workspace.

### Runtime credentials

- Replace forgeable raw Hugging Face service tokens with RS256-signed internal tokens when authorization is enabled.
- Scope runtime tokens to:
  - a fixed audience and issuer;
  - the delegated user;
  - the calling service;
  - the initiating workspace;
  - the exact source workspace.
- Validate the signature, key ID, audience, issuer, subject, and source workspace before accepting the token.
- Continue accepting legacy `service:<name>` tokens only when authorization is disabled.
- Require the configured workload-token RSA key for authenticated Files runtime downloads.

### Durable identity

- Preserve the initiating principal and origin workspace for background jobs and deployments.
- Do not persist identity-provider group claims in durable authorization contexts.
- This prevents a creation-time group snapshot from retaining access after the user is removed from that group.
- Background resources that require durable cross-workspace access should use a direct principal role binding.

### Studio and documentation

- Expose the `Exporter` role in Studio workspace-member management.
- Use the shared typed role list for form validation and role selection.
- Update authorization roles, permission references, plugin guidance, configuration documentation, OpenAPI specifications, and generated SDK types.

## Authorization behavior

| Scenario | Required authorization |
| --- | --- |
| Direct user read | Existing read/list/access permission |
| Same-workspace delegated reference | Existing read/list/access permission |
| Cross-workspace delegated reference | Read/list/access **and** matching `.export` permission |
| Delegated request without a trusted origin | Denied when export evaluation is required |
| Platform administrator | Existing platform-admin bypass |
| Auth-disabled runtime download | Legacy service token remains supported |
| Auth-enabled runtime download | Signed, source-scoped runtime token |

## Compatibility considerations

- Editors do not automatically gain cross-workspace export access.
- Admins retain export access through role inheritance.
- Same-workspace and direct-user behavior remains unchanged.
- Auth-enabled model downloads require `auth.oidc.workload_token_private_key_file`.
- Durable runtimes no longer retain permissions obtained only through a stored group snapshot.

## Test coverage

Added or updated coverage for:

- cross-workspace export allow and deny policy decisions;
- effective-user authorization for delegated services;
- missing-origin and wildcard-workspace rejection;
- bounded cross-workspace entity filtering;
- cross-workspace parent relationships;
- model, deployment, and deployment-config references;
- signed runtime-token creation, validation, and source scoping;
- job, secret, sidecar, and backend origin propagation;
- durable group-claim removal;
- plugin export-permission behavior;
- Studio `Exporter` role selection.

Latest focused verification:

- Ruff lint and format checks passed.
- OPA policy validation passed.
- Patch whitespace validation passed.
- Affected Files, model-runtime, and inference-gateway suites: **51 passed**.