### PR TITLE
fix(insights): serialize experiment metadata

### DIFF
--- a/plugins/nemo-insights/testbed/ingest.py
+++ b/plugins/nemo-insights/testbed/ingest.py
@@ -4,7 +4,7 @@
 
 import os
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import datetime, timezone
 from typing import Any, Protocol
 from urllib.parse import urlparse
@@ -118,7 +118,7 @@ def create_experiment(
     experiment_group_id: str,
     dataset_name: str,
     dataset_version: str,
-    metadata: dict,
+    metadata: Mapping[str, object],
     client: httpx.Client | None = None,
 ) -> None:
     """Create the per-run Experiment under ``experiment_group_id``.
@@ -133,7 +133,7 @@ def create_experiment(
         "experiment_group_id": experiment_group_id,
         "dataset_name": dataset_name,
         "dataset_version": dataset_version,
-        "metadata": metadata,
+        "metadata": {key: str(value) for key, value in metadata.items()},
     }
     owns_client = client is None
     client = client or httpx.Client(timeout=30.0)

--- a/plugins/nemo-insights/tests/testbed/test_ingest.py
+++ b/plugins/nemo-insights/tests/testbed/test_ingest.py
@@ -191,7 +191,7 @@ def test_create_experiment_posts_full_body():
                 "experiment_group_id": "grp-1",
                 "dataset_name": "tau2:airline",
                 "dataset_version": "v1",
-                "metadata": {"seed": 300},
+                "metadata": {"seed": "300"},
             },
         )
     ]


### PR DESCRIPTION
## Summary

- serialize testbed Experiment metadata values before sending them to Intake
- accept typed testbed metadata through a `Mapping[str, object]` input
- update the request payload test for Intake’s `dict[str, str]` contract

## Why

Tau2 configuration values such as `seed`, `num_trials`, and `num_tasks` are integers. Intake now requires Experiment metadata values to be strings, so the completed benchmark run failed ingestion with HTTP 422.

## Testing

- `uv run --frozen --group insights pytest -q plugins/nemo-insights/tests/testbed/test_ingest.py` (15 passed)
- `uv run --frozen ruff check plugins/nemo-insights/testbed/ingest.py plugins/nemo-insights/tests/testbed/test_ingest.py`
- `uv run --frozen ruff format --check plugins/nemo-insights/testbed/ingest.py plugins/nemo-insights/tests/testbed/test_ingest.py`
- full 30-task Tau2 airline run previously verified through Intake ingestion and Insights analysis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Experiment metadata is now consistently converted to JSON-safe string values when submitted.
  * Metadata accepts a broader range of value types while preserving reliable request formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->