### PR TITLE
fix(ci): make stable GitHub releases idempotent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,11 +60,6 @@ on:
         required: false
         type: boolean
         default: false
-      create-github-release:
-        description: "Create the Git tag and GitHub Release for a custom stable release. Stable all releases do this automatically."
-        required: false
-        type: boolean
-        default: false
       helm-version:
         description: "Optional exact Helm chart version override for stable Helm-only releases."
         required: false
@@ -164,7 +159,6 @@ jobs:
       helm_version_override: ${{ steps.plan.outputs.helm_version_override }}
       update_ngc_metadata: ${{ steps.plan.outputs.update_ngc_metadata }}
       send_notifications: ${{ steps.plan.outputs.send_notifications }}
-      create_github_release: ${{ steps.plan.outputs.create_github_release }}
       dry_run: ${{ steps.plan.outputs.dry_run }}
     steps:
       # This job is intentionally the first gate. It resolves the user's
@@ -195,9 +189,6 @@ jobs:
             const releaseScope = isManual ? (inputs["release-scope"] || "all") : "all";
             const updateNgcMetadata = isManual && inputs["update-ngc-metadata"] === "true";
             const sendNotifications = inputs["send-notifications"] !== "false";
-            const createGitHubReleaseRequested = (
-              isManual && inputs["create-github-release"] === "true"
-            );
             const dryRun = isManual && inputs["dry-run"] === "true";
             const helmVersionOverride = isManual ? (inputs["helm-version"] ?? "").trim() : "";
 
@@ -226,14 +217,6 @@ jobs:
                 sourceSha = commit.sha;
               }
             }
-
-            const createGitHubRelease = (
-              releaseType === "stable"
-              && (
-                releaseScope === "all"
-                || (releaseScope === "custom" && createGitHubReleaseRequested)
-              )
-            );
 
             sourceSha = sourceSha.toLowerCase();
 
@@ -343,7 +326,6 @@ jobs:
             core.setOutput("helm_version_override", helmVersionOverride);
             core.setOutput("update_ngc_metadata", String(updateNgcMetadata));
             core.setOutput("send_notifications", String(sendNotifications));
-            core.setOutput("create_github_release", String(createGitHubRelease));
             core.setOutput("dry_run", String(dryRun));
 
             core.info(
@@ -1118,7 +1100,6 @@ jobs:
     needs: [plan-release, poll-final-release]
     if: >-
       needs.plan-release.outputs.release_type == 'stable' &&
-      needs.plan-release.outputs.create_github_release == 'true' &&
       needs.plan-release.outputs.dry_run != 'true' &&
       needs.poll-final-release.result == 'success'
     runs-on: ubuntu-latest
@@ -1141,6 +1122,17 @@ jobs:
           SOURCE_SHA: ${{ needs.plan-release.outputs.source_sha }}
         run: |
           set -euo pipefail
+
+          tag_sha="$(git rev-parse --verify --quiet "refs/tags/${RELEASE_TAG}^{commit}" || true)"
+          if [[ -n "${tag_sha}" && "${tag_sha}" != "${SOURCE_SHA}" ]]; then
+            echo "Tag ${RELEASE_TAG} already points to ${tag_sha}, not requested ${SOURCE_SHA}." >&2
+            exit 1
+          fi
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "GitHub Release ${RELEASE_TAG} already exists; nothing to do."
+            exit 0
+          fi
 
           notes_start_tag="$(
             {

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,11 @@ on:
         required: false
         type: boolean
         default: false
+      create-github-release:
+        description: "Create the Git tag and GitHub Release for a custom stable release. Stable all releases do this automatically."
+        required: false
+        type: boolean
+        default: false
       helm-version:
         description: "Optional exact Helm chart version override for stable Helm-only releases."
         required: false
@@ -159,6 +164,7 @@ jobs:
       helm_version_override: ${{ steps.plan.outputs.helm_version_override }}
       update_ngc_metadata: ${{ steps.plan.outputs.update_ngc_metadata }}
       send_notifications: ${{ steps.plan.outputs.send_notifications }}
+      create_github_release: ${{ steps.plan.outputs.create_github_release }}
       dry_run: ${{ steps.plan.outputs.dry_run }}
     steps:
       # This job is intentionally the first gate. It resolves the user's
@@ -189,6 +195,9 @@ jobs:
             const releaseScope = isManual ? (inputs["release-scope"] || "all") : "all";
             const updateNgcMetadata = isManual && inputs["update-ngc-metadata"] === "true";
             const sendNotifications = inputs["send-notifications"] !== "false";
+            const createGitHubReleaseRequested = (
+              isManual && inputs["create-github-release"] === "true"
+            );
             const dryRun = isManual && inputs["dry-run"] === "true";
             const helmVersionOverride = isManual ? (inputs["helm-version"] ?? "").trim() : "";
 
@@ -217,6 +226,14 @@ jobs:
                 sourceSha = commit.sha;
               }
             }
+
+            const createGitHubRelease = (
+              releaseType === "stable"
+              && (
+                releaseScope === "all"
+                || (releaseScope === "custom" && createGitHubReleaseRequested)
+              )
+            );
 
             sourceSha = sourceSha.toLowerCase();
 
@@ -326,6 +343,7 @@ jobs:
             core.setOutput("helm_version_override", helmVersionOverride);
             core.setOutput("update_ngc_metadata", String(updateNgcMetadata));
             core.setOutput("send_notifications", String(sendNotifications));
+            core.setOutput("create_github_release", String(createGitHubRelease));
             core.setOutput("dry_run", String(dryRun));
 
             core.info(
@@ -1100,7 +1118,7 @@ jobs:
     needs: [plan-release, poll-final-release]
     if: >-
       needs.plan-release.outputs.release_type == 'stable' &&
-      needs.plan-release.outputs.release_scope == 'all' &&
+      needs.plan-release.outputs.create_github_release == 'true' &&
       needs.plan-release.outputs.dry_run != 'true' &&
       needs.poll-final-release.result == 'success'
     runs-on: ubuntu-latest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -56,6 +56,7 @@ and select **Run workflow**. The form shows the allowed custom artifact IDs.
 | `release-scope` | `all` by default. Select `wheels`, `containers`, `helm`, or `custom` for a subset. |
 | `wheel-ids`, `container-ids` | Comma-separated IDs used only with `release-scope: custom`. Each ID must be in the catalog above; duplicates and empty entries fail validation. |
 | `include-helm` | Includes the Helm chart in a custom release. |
+| `create-github-release` | Creates the Git tag and GitHub Release after a custom stable release succeeds. Stable releases with `release-scope: all` do this automatically. |
 | `helm-version` | Optional exact SemVer Helm chart version for stable Helm-only releases. The stable release label still comes from `version`. |
 | `update-ngc-metadata` | Also runs the reusable NGC metadata workflow for `nemo-platform` and `nemo-platform-dev`. It checks out the workflow ref, normally `main`. |
 | `send-notifications` | Sends Slack start and final-status notifications. Defaults to `true`. |
@@ -67,6 +68,7 @@ Examples:
 | --- | --- |
 | Scheduled-style nightly | Leave `release-type` as `nightly` and use the default `all` scope. |
 | Stable full release | `release-type: stable`, `source-sha: <40-character SHA>`, `version: <MAJOR.MINOR.PATCH>`, `release-scope: all`. |
+| Stable custom release with tag | Select the custom artifacts, then set `release-type: stable` and `create-github-release: true`. |
 | One container | `release-scope: custom`, `container-ids: nmp-customizer-tasks`. |
 | Helm-only validation | `release-scope: helm`, `dry-run: true`. |
 | Stable Helm-only chart override | `release-type: stable`, `source-sha: <40-character SHA>`, `version: 0.1.0`, `release-scope: helm`, `helm-version: 0.1.0+helmfix1`. |
@@ -95,10 +97,11 @@ America/Los_Angeles.
    available before continuing. Nightly wheels are staged but not published, so
    they are not polled. The polling job times out after four hours and sends
    a Slack alert after two hours if it is still waiting.
-7. For a non-dry-run stable release with `release-scope: all`, creates the
-   GitHub release and tag at the selected SHA. GitHub generates the release
-   notes from the previous numeric SemVer tag. Subset releases do not create a
-   GitHub release or tag.
+7. For a non-dry-run stable release with `release-scope: all`, or a custom
+   stable release with `create-github-release: true`, creates the GitHub release
+   and tag at the selected SHA. GitHub generates the release notes from the
+   previous numeric SemVer tag. Other subset releases do not create a GitHub
+   release or tag.
 8. After polling succeeds, releases that include the Helm chart dispatch a
    deployment signal to the configured internal release repository. The
    downstream workflow creates a pending GitHub Deployment, and the deployment

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -50,13 +50,12 @@ and select **Run workflow**. The form shows the allowed custom artifact IDs.
 
 | Input | Use |
 | --- | --- |
-| `release-type` | `nightly` by default. Select `stable` for a full release. |
+| `release-type` | `nightly` by default. Select `stable` for a versioned release. Every successful non-dry-run stable release creates or confirms its Git tag and GitHub Release. |
 | `source-sha` | Required for stable releases. Optional for nightlies; a normal nightly with no SHA uses the current default-branch head. A dry-run nightly with no SHA uses the workflow commit so a branch can be validated. |
 | `version` | Required for stable releases. Enter the `MAJOR.MINOR.PATCH` release version. |
-| `release-scope` | `all` by default. Select `wheels`, `containers`, `helm`, or `custom` for a subset. |
+| `release-scope` | `all` by default. Select `wheels`, `containers`, `helm`, or `custom` for a subset. Scope controls which artifacts are released, not whether a stable tag and GitHub Release are created. |
 | `wheel-ids`, `container-ids` | Comma-separated IDs used only with `release-scope: custom`. Each ID must be in the catalog above; duplicates and empty entries fail validation. |
 | `include-helm` | Includes the Helm chart in a custom release. |
-| `create-github-release` | Creates the Git tag and GitHub Release after a custom stable release succeeds. Stable releases with `release-scope: all` do this automatically. |
 | `helm-version` | Optional exact SemVer Helm chart version for stable Helm-only releases. The stable release label still comes from `version`. |
 | `update-ngc-metadata` | Also runs the reusable NGC metadata workflow for `nemo-platform` and `nemo-platform-dev`. It checks out the workflow ref, normally `main`. |
 | `send-notifications` | Sends Slack start and final-status notifications. Defaults to `true`. |
@@ -68,8 +67,8 @@ Examples:
 | --- | --- |
 | Scheduled-style nightly | Leave `release-type` as `nightly` and use the default `all` scope. |
 | Stable full release | `release-type: stable`, `source-sha: <40-character SHA>`, `version: <MAJOR.MINOR.PATCH>`, `release-scope: all`. |
-| Stable custom release with tag | Select the custom artifacts, then set `release-type: stable` and `create-github-release: true`. |
-| One container | `release-scope: custom`, `container-ids: nmp-customizer-tasks`. |
+| Stable one-container release or retry | `release-type: stable`, `source-sha: <40-character SHA>`, `version: <MAJOR.MINOR.PATCH>`, `release-scope: custom`, `container-ids: nmp-customizer-tasks`. |
+| Stable one-wheel release or retry | `release-type: stable`, `source-sha: <40-character SHA>`, `version: <MAJOR.MINOR.PATCH>`, `release-scope: custom`, `wheel-ids: nemo-platform`. |
 | Helm-only validation | `release-scope: helm`, `dry-run: true`. |
 | Stable Helm-only chart override | `release-type: stable`, `source-sha: <40-character SHA>`, `version: 0.1.0`, `release-scope: helm`, `helm-version: 0.1.0+helmfix1`. |
 
@@ -97,11 +96,13 @@ America/Los_Angeles.
    available before continuing. Nightly wheels are staged but not published, so
    they are not polled. The polling job times out after four hours and sends
    a Slack alert after two hours if it is still waiting.
-7. For a non-dry-run stable release with `release-scope: all`, or a custom
-   stable release with `create-github-release: true`, creates the GitHub release
-   and tag at the selected SHA. GitHub generates the release notes from the
-   previous numeric SemVer tag. Other subset releases do not create a GitHub
-   release or tag.
+7. For every non-dry-run stable release, creates the GitHub release and tag at
+   the selected SHA after the selected artifacts become available. This is
+   independent of release scope, so stable subset and custom runs can release or
+   retry individual artifacts. A rerun reuses a matching tag and release,
+   creates a missing release for an existing matching tag, and fails if the
+   version tag points to a different SHA. GitHub generates the release notes
+   from the previous numeric SemVer tag.
 8. After polling succeeds, releases that include the Helm chart dispatch a
    deployment signal to the configured internal release repository. The
    downstream workflow creates a pending GitHub Deployment, and the deployment


### PR DESCRIPTION
Stable subset and custom runs are also used to finish or retry individual artifacts. The workflow previously keyed GitHub tag/release creation to `release-scope: all`, so the successful 0.3.0 custom run skipped its tag and GitHub Release.

This makes `stable` the release intent: every successful non-dry-run stable run converges on its version tag and GitHub Release, regardless of artifact scope. Retries are idempotent:

- A version tag that points to another SHA fails clearly.
- An existing GitHub Release succeeds as a no-op.
- A matching tag without a GitHub Release creates the missing release.

The extra `create-github-release` checkbox and its planner wiring are removed.

Incident: https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/30477833073/job/90703676069

## Human attention needed

- **Decision:** Treat every stable run as an instruction to create or confirm the version tag and GitHub Release.
- **Read carefully:** Stable subset and custom runs now create the tag/release for a new version; retries of an existing version are safe no-ops.
- **Safe to skim:** Documentation.
- **Proof:** `actionlint .github/workflows/release.yaml` and `git diff --check` pass.
- **Biggest risk:** Selecting `stable` for a subset with a brand-new version now cuts the version tag/release. This is intentional; `release-scope` controls artifacts only.

## Validation

- `actionlint .github/workflows/release.yaml`
- `git diff --check`
- Verified stable `all`, `wheels`, `containers`, `helm`, and `custom` scopes share the same release gate.
- Verified nightly, dry-run, and failed polling skip GitHub Release creation.
- Verified the release step no-ops for an existing release, repairs a matching tag-only state, and rejects a tag/SHA mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * GitHub Release creation is now consistently handled for all successful non-dry-run stable releases, regardless of release scope.
  * The “Create GitHub Release” step is more guarded: it checks that the existing tag points to the expected commit and avoids recreating a release if one already exists.

* **Documentation**
  * Updated release documentation to reflect the always-on stable release tag/GitHub Release behavior.
  * Removed guidance about the prior explicit GitHub release setting and added updated stable one-container/one-wheel examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->