### PR TITLE
chore: attempt to fix fern docs comment failures

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yaml
+++ b/.github/workflows/fern-docs-preview-build.yaml
@@ -42,6 +42,14 @@ jobs:
           echo "$HEAD_REF" > preview-metadata/head_ref
           git diff --name-only "origin/${BASE_REF}...HEAD" -- '*.mdx' > preview-metadata/changed_mdx_files 2>/dev/null || true
 
+      - name: Prepare preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          npm --prefix docs/fern run prepare
+
       - name: Upload fern sources and metadata
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/fern-docs-preview-comment.yaml
+++ b/.github/workflows/fern-docs-preview-comment.yaml
@@ -17,6 +17,20 @@ on:
   workflow_run:
     workflows: ["Preview Fern Docs: Build"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "Run ID of a successful Preview Fern Docs: Build run"
+        required: true
+        type: string
+      pr_number:
+        description: "PR number to validate and comment on"
+        required: true
+        type: string
+      head_ref:
+        description: "Original PR branch name"
+        required: true
+        type: string
 
 permissions:
   pull-requests: write
@@ -25,21 +39,21 @@ permissions:
 jobs:
   preview:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Download fern sources and metadata
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: fern-preview
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ github.event_name == 'workflow_dispatch' && inputs.source_run_id || github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Read PR metadata
         id: metadata
         env:
           # head_ref comes from the trusted workflow_run event, not the artifact.
-          WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          TRUSTED_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          WORKFLOW_HEAD_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.head_ref || github.event.workflow_run.head_branch }}
+          TRUSTED_PR_NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event.workflow_run.pull_requests[0].number }}
         run: |
           # Use the PR association from workflow_run. The artifact comes from the
           # untrusted PR build, so it is only a consistency check.
@@ -90,7 +104,7 @@ jobs:
           PREVIEW_ID: ${{ steps.metadata.outputs.preview_id }}
         working-directory: ./docs/fern
         run: |
-          node scripts/filter-public-openapi.mjs
+          npm --prefix docs/fern run prepare
           set +e
           OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$PREVIEW_ID" 2>&1)
           STATUS=$?

--- a/.github/workflows/fern-docs-preview-comment.yaml
+++ b/.github/workflows/fern-docs-preview-comment.yaml
@@ -39,16 +39,44 @@ jobs:
         env:
           # head_ref comes from the trusted workflow_run event, not the artifact.
           WORKFLOW_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          TRUSTED_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
-          echo "head_ref=$WORKFLOW_HEAD_BRANCH" >> "$GITHUB_OUTPUT"
-          # pr_number originates from the (untrusted) PR-build artifact; validate
-          # it is a plain integer before using it in any privileged context.
-          PR_NUMBER=$(cat preview-metadata/pr_number)
+          # Use the PR association from workflow_run. The artifact comes from the
+          # untrusted PR build, so it is only a consistency check.
+          PR_NUMBER="$TRUSTED_PR_NUMBER"
           if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid PR number in artifact metadata: '$PR_NUMBER'"
+            echo "::error::Missing or invalid trusted PR number from workflow_run: '$PR_NUMBER'"
             exit 1
           fi
-          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          if [ -f preview-metadata/pr_number ]; then
+            ARTIFACT_PR_NUMBER=$(cat preview-metadata/pr_number)
+            if ! [[ "$ARTIFACT_PR_NUMBER" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid PR number in artifact metadata: '$ARTIFACT_PR_NUMBER'"
+              exit 1
+            fi
+            if [ "$ARTIFACT_PR_NUMBER" != "$PR_NUMBER" ]; then
+              echo "::error::Artifact PR number '$ARTIFACT_PR_NUMBER' does not match workflow_run PR '$PR_NUMBER'"
+              exit 1
+            fi
+          fi
+
+          SAFE_HEAD_REF=$(printf '%s' "$WORKFLOW_HEAD_BRANCH" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g' \
+            | cut -c1-48 \
+            | sed -E 's/-+$//')
+          if [ -n "$SAFE_HEAD_REF" ]; then
+            PREVIEW_ID="pr-${PR_NUMBER}-${SAFE_HEAD_REF}"
+          else
+            PREVIEW_ID="pr-${PR_NUMBER}"
+          fi
+
+          {
+            echo "head_ref=$WORKFLOW_HEAD_BRANCH"
+            echo "pr_number=$PR_NUMBER"
+            echo "preview_id=$PREVIEW_ID"
+          } >> "$GITHUB_OUTPUT"
+          echo "Using Fern preview id: $PREVIEW_ID"
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -59,13 +87,20 @@ jobs:
         id: generate-docs
         env:
           FERN_TOKEN: ${{ secrets.DOCS_FERN_TOKEN }}
-          HEAD_REF: ${{ steps.metadata.outputs.head_ref }}
+          PREVIEW_ID: ${{ steps.metadata.outputs.preview_id }}
         working-directory: ./docs/fern
         run: |
           node scripts/filter-public-openapi.mjs
-          OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$HEAD_REF" 2>&1)
+          set +e
+          OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$PREVIEW_ID" 2>&1)
+          STATUS=$?
+          set -e
           echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()')
+          if [ "$STATUS" -ne 0 ]; then
+            echo "::error::Fern preview generation failed for preview id '$PREVIEW_ID'."
+            exit "$STATUS"
+          fi
+          URL=$(echo "$OUTPUT" | grep -oP 'Published docs to \K.*(?= \()' | tail -1 || true)
           if [ -z "$URL" ]; then
             echo "::error::Failed to generate preview URL. See fern output above."
             exit 1

--- a/.github/workflows/fern-docs-preview-comment.yaml
+++ b/.github/workflows/fern-docs-preview-comment.yaml
@@ -104,7 +104,6 @@ jobs:
           PREVIEW_ID: ${{ steps.metadata.outputs.preview_id }}
         working-directory: ./docs/fern
         run: |
-          npm --prefix docs/fern run prepare
           set +e
           OUTPUT=$(npx -y fern-api@latest generate --docs --preview --id "$PREVIEW_ID" 2>&1)
           STATUS=$?

--- a/docs/fern/scripts/materialize-release-versions.mjs
+++ b/docs/fern/scripts/materialize-release-versions.mjs
@@ -257,7 +257,6 @@ function updateDocsYml(releases, previousGeneratedVersionPaths) {
       "display-name": release.displayName,
       path: versionPath(release),
       slug: release.slug,
-      availability: "stable",
     }));
     const generatedNode = doc.createNode(generatedVersions);
     if (!isSeq(generatedNode)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation preview generation with more reliable identifiers, safer branch handling, and stronger validation of preview metadata.
  * Enhanced failure handling and more resilient extraction of the published documentation URL to reduce avoidable pipeline errors.
* **New Features**
  * Added manual triggering for the documentation preview workflow with configurable inputs (source run ID, PR number, and head reference).
* **Documentation**
  * Updated generated `docs.yml` release entries to omit the `availability: "stable"` field, keeping only `display-name`, `path`, and `slug`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->