### PR TITLE
fix(api): declare the entity-store name pattern on create DTOs [ASTD-349]

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1100,7 +1100,7 @@ nemo files filesets create [OPTIONS] [NAME]
 
 **Arguments:**
 
-* `<NAME>`: The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen).
+* `<NAME>`: The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
 
 **Options:**
 
@@ -3144,7 +3144,7 @@ nemo inference providers create [OPTIONS] [NAME]
 
 **Arguments:**
 
-* `<NAME>`: Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen).
+* `<NAME>`: Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
 
 **Options:**
 
@@ -5066,7 +5066,7 @@ nemo workspaces create [OPTIONS] [NAME]
 
 **Arguments:**
 
-* `<NAME>`: Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen).
+* `<NAME>`: Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
 
 **Options:**
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1100,7 +1100,7 @@ nemo files filesets create [OPTIONS] [NAME]
 
 **Arguments:**
 
-* `<NAME>`: The name of the fileset. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots.
+* `<NAME>`: The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen).
 
 **Options:**
 
@@ -3144,7 +3144,7 @@ nemo inference providers create [OPTIONS] [NAME]
 
 **Arguments:**
 
-* `<NAME>`: Name of the model provider. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots.
+* `<NAME>`: Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen).
 
 **Options:**
 
@@ -5066,7 +5066,7 @@ nemo workspaces create [OPTIONS] [NAME]
 
 **Arguments:**
 
-* `<NAME>`: Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+* `<NAME>`: Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen).
 
 **Options:**
 

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -9420,8 +9420,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the fileset. Name must start with a lowercase letter,
-            be 2-63 characters, and contain only lowercase letters, digits, hyphens,
-            and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            be 2-63 characters, and use lowercase letters, digits, hyphens, and dots
+            (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9691,8 +9691,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Name of the model provider. Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -10440,9 +10440,9 @@ components:
         name:
           title: Name
           description: Entity name (optional - auto-generated if not provided). Name
-            must start with a lowercase letter, be 2-63 characters, and contain only
-            lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -10477,8 +10477,8 @@ components:
         new_name:
           title: New Name
           description: Updated entity name (optional). Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -16005,9 +16005,9 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
-            Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16055,9 +16055,9 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
-            Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16486,8 +16486,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the secret to create. Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key
@@ -16687,9 +16687,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Project name (unique within workspace). Name must start with
-            a lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
-            a hyphen).
+            a lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+            hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - ml-project
           - nlp-research
@@ -19725,9 +19724,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Workspace name (unique identifier). Name must start with a
-            lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
-            a hyphen).
+            lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+            hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - ml-team
           - research

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -9416,11 +9416,12 @@ components:
       properties:
         name:
           type: string
-          maxLength: 255
-          pattern: ^[\w\-.]+$
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'The name of the fileset. Allowed characters: letters (a-z,
-            A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: The name of the fileset. Name must start with a lowercase letter,
+            be 2-63 characters, and contain only lowercase letters, digits, and hyphens
+            (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9686,11 +9687,12 @@ components:
       properties:
         name:
           type: string
-          maxLength: 255
-          pattern: ^[\w\-.]+$
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'Name of the model provider. Allowed characters: letters (a-z,
-            A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: Name of the model provider. Name must start with a lowercase
+            letter, be 2-63 characters, and contain only lowercase letters, digits,
+            and hyphens (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -16480,9 +16482,12 @@ components:
       properties:
         name:
           type: string
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'The name of the secret to create. Allowed characters: letters
-            (a-z, A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: The name of the secret to create. Name must start with a lowercase
+            letter, be 2-63 characters, and contain only lowercase letters, digits,
+            and hyphens (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -9420,8 +9420,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the fileset. Name must start with a lowercase letter,
-            be 2-63 characters, and contain only lowercase letters, digits, and hyphens
-            (no consecutive hyphens, cannot end with a hyphen).
+            be 2-63 characters, and contain only lowercase letters, digits, hyphens,
+            and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9692,7 +9692,7 @@ components:
           title: Name
           description: Name of the model provider. Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -10441,8 +10441,8 @@ components:
           title: Name
           description: Entity name (optional - auto-generated if not provided). Name
             must start with a lowercase letter, be 2-63 characters, and contain only
-            lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -10478,7 +10478,7 @@ components:
           title: New Name
           description: Updated entity name (optional). Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -16006,8 +16006,8 @@ components:
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
             Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16056,8 +16056,8 @@ components:
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
             Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16487,7 +16487,7 @@ components:
           title: Name
           description: The name of the secret to create. Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key
@@ -16688,7 +16688,8 @@ components:
           title: Name
           description: Project name (unique within workspace). Name must start with
             a lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
+            a hyphen).
           examples:
           - ml-project
           - nlp-research
@@ -19725,7 +19726,8 @@ components:
           title: Name
           description: Workspace name (unique identifier). Name must start with a
             lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
+            a hyphen).
           examples:
           - ml-team
           - research

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -9420,8 +9420,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the fileset. Name must start with a lowercase letter,
-            be 2-63 characters, and contain only lowercase letters, digits, hyphens,
-            and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            be 2-63 characters, and use lowercase letters, digits, hyphens, and dots
+            (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9691,8 +9691,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Name of the model provider. Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -10440,9 +10440,9 @@ components:
         name:
           title: Name
           description: Entity name (optional - auto-generated if not provided). Name
-            must start with a lowercase letter, be 2-63 characters, and contain only
-            lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -10477,8 +10477,8 @@ components:
         new_name:
           title: New Name
           description: Updated entity name (optional). Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -16005,9 +16005,9 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
-            Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16055,9 +16055,9 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
-            Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16486,8 +16486,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the secret to create. Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key
@@ -16687,9 +16687,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Project name (unique within workspace). Name must start with
-            a lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
-            a hyphen).
+            a lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+            hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - ml-project
           - nlp-research
@@ -19725,9 +19724,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Workspace name (unique identifier). Name must start with a
-            lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
-            a hyphen).
+            lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+            hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - ml-team
           - research

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -9416,11 +9416,12 @@ components:
       properties:
         name:
           type: string
-          maxLength: 255
-          pattern: ^[\w\-.]+$
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'The name of the fileset. Allowed characters: letters (a-z,
-            A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: The name of the fileset. Name must start with a lowercase letter,
+            be 2-63 characters, and contain only lowercase letters, digits, and hyphens
+            (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9686,11 +9687,12 @@ components:
       properties:
         name:
           type: string
-          maxLength: 255
-          pattern: ^[\w\-.]+$
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'Name of the model provider. Allowed characters: letters (a-z,
-            A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: Name of the model provider. Name must start with a lowercase
+            letter, be 2-63 characters, and contain only lowercase letters, digits,
+            and hyphens (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -16480,9 +16482,12 @@ components:
       properties:
         name:
           type: string
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'The name of the secret to create. Allowed characters: letters
-            (a-z, A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: The name of the secret to create. Name must start with a lowercase
+            letter, be 2-63 characters, and contain only lowercase letters, digits,
+            and hyphens (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -9420,8 +9420,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the fileset. Name must start with a lowercase letter,
-            be 2-63 characters, and contain only lowercase letters, digits, and hyphens
-            (no consecutive hyphens, cannot end with a hyphen).
+            be 2-63 characters, and contain only lowercase letters, digits, hyphens,
+            and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9692,7 +9692,7 @@ components:
           title: Name
           description: Name of the model provider. Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -10441,8 +10441,8 @@ components:
           title: Name
           description: Entity name (optional - auto-generated if not provided). Name
             must start with a lowercase letter, be 2-63 characters, and contain only
-            lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -10478,7 +10478,7 @@ components:
           title: New Name
           description: Updated entity name (optional). Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -16006,8 +16006,8 @@ components:
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
             Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16056,8 +16056,8 @@ components:
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
             Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16487,7 +16487,7 @@ components:
           title: Name
           description: The name of the secret to create. Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key
@@ -16688,7 +16688,8 @@ components:
           title: Name
           description: Project name (unique within workspace). Name must start with
             a lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
+            a hyphen).
           examples:
           - ml-project
           - nlp-research
@@ -19725,7 +19726,8 @@ components:
           title: Name
           description: Workspace name (unique identifier). Name must start with a
             lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
+            a hyphen).
           examples:
           - ml-team
           - research

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -9420,8 +9420,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the fileset. Name must start with a lowercase letter,
-            be 2-63 characters, and contain only lowercase letters, digits, hyphens,
-            and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            be 2-63 characters, and use lowercase letters, digits, hyphens, and dots
+            (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9691,8 +9691,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Name of the model provider. Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -10440,9 +10440,9 @@ components:
         name:
           title: Name
           description: Entity name (optional - auto-generated if not provided). Name
-            must start with a lowercase letter, be 2-63 characters, and contain only
-            lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -10477,8 +10477,8 @@ components:
         new_name:
           title: New Name
           description: Updated entity name (optional). Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -16005,9 +16005,9 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
-            Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16055,9 +16055,9 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
-            Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16486,8 +16486,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the secret to create. Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key
@@ -16687,9 +16687,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Project name (unique within workspace). Name must start with
-            a lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
-            a hyphen).
+            a lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+            hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - ml-project
           - nlp-research
@@ -19725,9 +19724,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Workspace name (unique identifier). Name must start with a
-            lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
-            a hyphen).
+            lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+            hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - ml-team
           - research

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -9416,11 +9416,12 @@ components:
       properties:
         name:
           type: string
-          maxLength: 255
-          pattern: ^[\w\-.]+$
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'The name of the fileset. Allowed characters: letters (a-z,
-            A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: The name of the fileset. Name must start with a lowercase letter,
+            be 2-63 characters, and contain only lowercase letters, digits, and hyphens
+            (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9686,11 +9687,12 @@ components:
       properties:
         name:
           type: string
-          maxLength: 255
-          pattern: ^[\w\-.]+$
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'Name of the model provider. Allowed characters: letters (a-z,
-            A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: Name of the model provider. Name must start with a lowercase
+            letter, be 2-63 characters, and contain only lowercase letters, digits,
+            and hyphens (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -16480,9 +16482,12 @@ components:
       properties:
         name:
           type: string
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'The name of the secret to create. Allowed characters: letters
-            (a-z, A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: The name of the secret to create. Name must start with a lowercase
+            letter, be 2-63 characters, and contain only lowercase letters, digits,
+            and hyphens (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -9420,8 +9420,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the fileset. Name must start with a lowercase letter,
-            be 2-63 characters, and contain only lowercase letters, digits, and hyphens
-            (no consecutive hyphens, cannot end with a hyphen).
+            be 2-63 characters, and contain only lowercase letters, digits, hyphens,
+            and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9692,7 +9692,7 @@ components:
           title: Name
           description: Name of the model provider. Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -10441,8 +10441,8 @@ components:
           title: Name
           description: Entity name (optional - auto-generated if not provided). Name
             must start with a lowercase letter, be 2-63 characters, and contain only
-            lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -10478,7 +10478,7 @@ components:
           title: New Name
           description: Updated entity name (optional). Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -16006,8 +16006,8 @@ components:
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
             Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16056,8 +16056,8 @@ components:
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
             Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16487,7 +16487,7 @@ components:
           title: Name
           description: The name of the secret to create. Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key
@@ -16688,7 +16688,8 @@ components:
           title: Name
           description: Project name (unique within workspace). Name must start with
             a lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
+            a hyphen).
           examples:
           - ml-project
           - nlp-research
@@ -19725,7 +19726,8 @@ components:
           title: Name
           description: Workspace name (unique identifier). Name must start with a
             lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
+            a hyphen).
           examples:
           - ml-team
           - research

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/filesets.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/filesets.py
@@ -34,7 +34,7 @@ def create_filesets(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="The name of the fileset. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots. (required)"
+            help="The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -127,7 +127,7 @@ def create_filesets(
         ["name"],
         "files filesets create",
         {
-            "name": "The name of the fileset. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots. (required)",
+            "name": "The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/filesets.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/filesets.py
@@ -34,7 +34,7 @@ def create_filesets(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -127,7 +127,7 @@ def create_filesets(
         ["name"],
         "files filesets create",
         {
-            "name": "The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/providers.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/providers.py
@@ -34,7 +34,7 @@ def create_providers(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -179,7 +179,7 @@ def create_providers(
         "inference providers create",
         {
             "host_url": "The network endpoint URL for the model provider (required)",
-            "name": "Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/providers.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/providers.py
@@ -34,7 +34,7 @@ def create_providers(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Name of the model provider. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots. (required)"
+            help="Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -179,7 +179,7 @@ def create_providers(
         "inference providers create",
         {
             "host_url": "The network endpoint URL for the model provider (required)",
-            "name": "Name of the model provider. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots. (required)",
+            "name": "Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/projects.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/projects.py
@@ -34,7 +34,7 @@ def create_projects(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -95,7 +95,7 @@ def create_projects(
         ["name"],
         "projects create",
         {
-            "name": "Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/projects.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/projects.py
@@ -34,7 +34,7 @@ def create_projects(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -95,7 +95,7 @@ def create_projects(
         ["name"],
         "projects create",
         {
-            "name": "Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/workspaces/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/workspaces/__init__.py
@@ -41,7 +41,7 @@ def create_workspaces(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     wait_role_propagation: Annotated[
@@ -112,7 +112,7 @@ def create_workspaces(
         ["name"],
         "workspaces create",
         {
-            "name": "Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/workspaces/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/workspaces/__init__.py
@@ -41,7 +41,7 @@ def create_workspaces(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     wait_role_propagation: Annotated[
@@ -112,7 +112,7 @@ def create_workspaces(
         ["name"],
         "workspaces create",
         {
-            "name": "Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/entity_naming.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/entity_naming.py
@@ -20,6 +20,6 @@ NAME_MAX_LENGTH = 63
 
 NAME_PATTERN_DESCRIPTION = (
     "Name must start with a lowercase letter, be 2-63 characters, "
-    "and contain only lowercase letters, digits, and hyphens "
+    "and contain only lowercase letters, digits, hyphens, and @ . + _ "
     "(no consecutive hyphens, cannot end with a hyphen)."
 )

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/entity_naming.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/entity_naming.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The single definition of the entity name rule.
+
+This lives in ``nemo_platform_plugin`` rather than ``nmp_common`` because the
+dependency runs that way — ``nmp_common`` depends on this package, so anything
+here is importable from both sides. ``nmp.common.entities.constants`` re-exports
+these names.
+
+Imports nothing, so modules that need to stay leaf nodes can still use it.
+
+Any Pydantic model declaring ``pattern=NAME_PATTERN`` must also set
+``model_config = ConfigDict(regex_engine="python-re")``; the pattern uses
+lookaround, which Pydantic's default Rust engine rejects.
+"""
+
+# RFC 1035 compliant pattern with temporary support for special characters.
+# Allows lowercase letters, digits, hyphens, and temporarily: @, ., +, _
+# - Must start with a lowercase letter [a-z]
+# - Length: 2-63 characters
+# - No consecutive hyphens (--)
+# - Must not end with a hyphen
+# TODO(#3530): Remove @, ., +, _ once versioning is implemented and predefined target names (e.g., llama-3.2-3b-instruct@v1.0.0+A100) are updated.
+NAME_PATTERN = r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$"
+
+NAME_MAX_LENGTH = 63
+
+NAME_PATTERN_DESCRIPTION = (
+    "Name must start with a lowercase letter, be 2-63 characters, "
+    "and contain only lowercase letters, digits, and hyphens "
+    "(no consecutive hyphens, cannot end with a hyphen)."
+)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/entity_naming.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/entity_naming.py
@@ -20,6 +20,6 @@ NAME_MAX_LENGTH = 63
 
 NAME_PATTERN_DESCRIPTION = (
     "Name must start with a lowercase letter, be 2-63 characters, "
-    "and contain only lowercase letters, digits, hyphens, and @ . + _ "
+    "and use lowercase letters, digits, hyphens, and dots "
     "(no consecutive hyphens, cannot end with a hyphen)."
 )

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/entity_naming.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/entity_naming.py
@@ -1,18 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""The single definition of the entity name rule.
+"""Single definition of the entity name rule; ``nmp.common`` re-exports it.
 
-This lives in ``nemo_platform_plugin`` rather than ``nmp_common`` because the
-dependency runs that way — ``nmp_common`` depends on this package, so anything
-here is importable from both sides. ``nmp.common.entities.constants`` re-exports
-these names.
-
-Imports nothing, so modules that need to stay leaf nodes can still use it.
-
-Any Pydantic model declaring ``pattern=NAME_PATTERN`` must also set
-``model_config = ConfigDict(regex_engine="python-re")``; the pattern uses
-lookaround, which Pydantic's default Rust engine rejects.
+Lives here because ``nmp_common`` depends on this package, not the reverse.
+Models using ``pattern=NAME_PATTERN`` need ``regex_engine="python-re"``.
 """
 
 # RFC 1035 compliant pattern with temporary support for special characters.

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/types.py
@@ -16,7 +16,7 @@ from typing import Any, NotRequired, TypedDict
 from nemo_platform_plugin.files.metadata import FilesetMetadata
 from nemo_platform_plugin.files.storage_config import StorageConfig
 from nemo_platform_plugin.schema import Page
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class FilesetPurpose(StrEnum):
@@ -74,18 +74,25 @@ FilesetPage = Page[FilesetOutput]
 # Request types
 # ---------------------------------------------------------------------------
 
-# Mirrors ``nmp.common.entities.constants.REGEX_WORD_CHARACTER_DOT_DASH`` (and its
-# description / MAX_LENGTH_255) — inlined so this module stays a dependency-free leaf
-# node. Reuse these constants for any fileset-name check rather than restating them.
-NAME_PATTERN = r"^[\w\-.]+$"
-NAME_PATTERN_DESCRIPTION = "Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots."
+# Mirrors ``nmp.common.entities.constants.NAME_PATTERN`` — the rule the entity
+# store enforces downstream. Inlined rather than imported so this package stays
+# free of an ``nmp_common`` dependency.
+NAME_PATTERN = r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$"
+NAME_PATTERN_DESCRIPTION = (
+    "Name must start with a lowercase letter, be 2-63 characters, "
+    "and contain only lowercase letters, digits, and hyphens "
+    "(no consecutive hyphens, cannot end with a hyphen)."
+)
+NAME_MAX_LENGTH = 63
 MAX_LENGTH = 255
 
 
 class CreateFilesetRequest(BaseModel):
+    model_config = ConfigDict(regex_engine="python-re")
+
     name: str = Field(
         description=f"The name of the fileset. {NAME_PATTERN_DESCRIPTION}",
-        max_length=MAX_LENGTH,
+        max_length=NAME_MAX_LENGTH,
         pattern=NAME_PATTERN,
         examples=["training-data-v1", "llama-checkpoint"],
     )

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/types.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Any, NotRequired, TypedDict
 
+from nemo_platform_plugin.entity_naming import NAME_MAX_LENGTH, NAME_PATTERN, NAME_PATTERN_DESCRIPTION
 from nemo_platform_plugin.files.metadata import FilesetMetadata
 from nemo_platform_plugin.files.storage_config import StorageConfig
 from nemo_platform_plugin.schema import Page
@@ -74,16 +75,6 @@ FilesetPage = Page[FilesetOutput]
 # Request types
 # ---------------------------------------------------------------------------
 
-# Mirrors ``nmp.common.entities.constants.NAME_PATTERN`` — the rule the entity
-# store enforces downstream. Inlined rather than imported so this package stays
-# free of an ``nmp_common`` dependency.
-NAME_PATTERN = r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$"
-NAME_PATTERN_DESCRIPTION = (
-    "Name must start with a lowercase letter, be 2-63 characters, "
-    "and contain only lowercase letters, digits, and hyphens "
-    "(no consecutive hyphens, cannot end with a hyphen)."
-)
-NAME_MAX_LENGTH = 63
 MAX_LENGTH = 255
 
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/spec.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/spec.py
@@ -17,20 +17,10 @@ from __future__ import annotations
 
 from typing import Optional, Self
 
+from nemo_platform_plugin.entity_naming import NAME_PATTERN, NAME_PATTERN_DESCRIPTION
 from nemo_platform_plugin.jobs.constants import PERSISTENT_JOB_STORAGE_PATH_ENVVAR
 from nemo_platform_plugin.jobs.providers import Provider
 from pydantic import BaseModel, ConfigDict, Field, model_validator
-
-# RFC 1035 compliant pattern with temporary support for special characters.
-# Mirrors ``nmp.common.entities.constants.NAME_PATTERN`` — inlined so this
-# module stays a dependency-free leaf node (see files/types.py for the same
-# pattern of inlining name constraints into the plugin).
-NAME_PATTERN = r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$"
-NAME_PATTERN_DESCRIPTION = (
-    "Name must start with a lowercase letter, be 2-63 characters, "
-    "and contain only lowercase letters, digits, and hyphens "
-    "(no consecutive hyphens, cannot end with a hyphen)."
-)
 
 
 class PlatformJobSecretEnvironmentVariableRef(BaseModel):

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/secrets/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/secrets/types.py
@@ -11,17 +11,22 @@ Stainless-generated duplicates.
 
 from __future__ import annotations
 
-import re
 from datetime import datetime
 from typing import NotRequired, Self, TypedDict
 
-from pydantic import BaseModel, Field, SecretStr, field_serializer, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_serializer, model_validator
 
-# Mirrors ``nmp.common.entities.constants.REGEX_WORD_CHARACTER_DOT_DASH``. Inlined
-# rather than imported so this package stays free of an ``nmp_common`` dependency
-# (matching the ``files.types`` boundary — plugin types own their own contract).
-_NAME_REGEX = r"^[\w\-.]+$"
-_NAME_RE: re.Pattern[str] = re.compile(_NAME_REGEX)
+# Mirrors ``nmp.common.entities.constants.NAME_PATTERN`` — the rule the entity
+# store enforces downstream. Inlined rather than imported so this package stays
+# free of an ``nmp_common`` dependency (matching the ``files.types`` boundary —
+# plugin types own their own contract).
+_NAME_REGEX = r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$"
+_NAME_DESCRIPTION = (
+    "Name must start with a lowercase letter, be 2-63 characters, "
+    "and contain only lowercase letters, digits, and hyphens "
+    "(no consecutive hyphens, cannot end with a hyphen)."
+)
+_NAME_MAX_LENGTH = 63
 
 # ---------------------------------------------------------------------------
 # Response types
@@ -67,25 +72,16 @@ class PlatformSecretCreateRequest(BaseModel):
     # server would store the mask instead of the secret. (Keep this as a comment,
     # not the class docstring, so it does not leak into the OpenAPI schema.)
 
+    model_config = ConfigDict(regex_engine="python-re")
+
     name: str = Field(
-        description=(
-            "The name of the secret to create. Allowed characters: letters (a-z, A-Z), "
-            "digits (0-9), underscores, hyphens, and dots."
-        ),
+        description=f"The name of the secret to create. {_NAME_DESCRIPTION}",
+        max_length=_NAME_MAX_LENGTH,
+        pattern=_NAME_REGEX,
         examples=["hf-token", "wandb-api-key"],
     )
     description: str | None = Field(default=None, description="An optional description of the secret")
     value: SecretStr = Field(description="The payload of the secret")
-
-    @field_validator("name")
-    @classmethod
-    def _validate_name(cls, v: str) -> str:
-        if not _NAME_RE.match(v):
-            raise ValueError(
-                f"Invalid secret name '{v}'. Allowed characters: letters, digits, underscores, "
-                "hyphens, and dots. Example: my-api-key"
-            )
-        return v
 
     @field_serializer("value", when_used="json")
     def _serialize_value(self, value: SecretStr) -> str:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/secrets/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/secrets/types.py
@@ -14,19 +14,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import NotRequired, Self, TypedDict
 
+from nemo_platform_plugin.entity_naming import NAME_MAX_LENGTH, NAME_PATTERN, NAME_PATTERN_DESCRIPTION
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_serializer, model_validator
-
-# Mirrors ``nmp.common.entities.constants.NAME_PATTERN`` — the rule the entity
-# store enforces downstream. Inlined rather than imported so this package stays
-# free of an ``nmp_common`` dependency (matching the ``files.types`` boundary —
-# plugin types own their own contract).
-_NAME_REGEX = r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$"
-_NAME_DESCRIPTION = (
-    "Name must start with a lowercase letter, be 2-63 characters, "
-    "and contain only lowercase letters, digits, and hyphens "
-    "(no consecutive hyphens, cannot end with a hyphen)."
-)
-_NAME_MAX_LENGTH = 63
 
 # ---------------------------------------------------------------------------
 # Response types
@@ -75,9 +64,9 @@ class PlatformSecretCreateRequest(BaseModel):
     model_config = ConfigDict(regex_engine="python-re")
 
     name: str = Field(
-        description=f"The name of the secret to create. {_NAME_DESCRIPTION}",
-        max_length=_NAME_MAX_LENGTH,
-        pattern=_NAME_REGEX,
+        description=f"The name of the secret to create. {NAME_PATTERN_DESCRIPTION}",
+        max_length=NAME_MAX_LENGTH,
+        pattern=NAME_PATTERN,
         examples=["hf-token", "wandb-api-key"],
     )
     description: str | None = Field(default=None, description="An optional description of the secret")

--- a/packages/nmp_common/src/nmp/common/entities/constants.py
+++ b/packages/nmp_common/src/nmp/common/entities/constants.py
@@ -12,6 +12,8 @@
 # TODO(#3530): Remove @, ., +, _ once versioning is implemented and predefined target names (e.g., llama-3.2-3b-instruct@v1.0.0+A100) are updated.
 NAME_PATTERN = r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$"
 
+NAME_MAX_LENGTH = 63
+
 NAME_PATTERN_DESCRIPTION = (
     "Name must start with a lowercase letter, be 2-63 characters, "
     "and contain only lowercase letters, digits, and hyphens "

--- a/packages/nmp_common/src/nmp/common/entities/constants.py
+++ b/packages/nmp_common/src/nmp/common/entities/constants.py
@@ -3,21 +3,16 @@
 
 """Constants for entity validation."""
 
-# RFC 1035 compliant pattern with temporary support for special characters.
-# Allows lowercase letters, digits, hyphens, and temporarily: @, ., +, _
-# - Must start with a lowercase letter [a-z]
-# - Length: 2-63 characters
-# - No consecutive hyphens (--)
-# - Must not end with a hyphen
-# TODO(#3530): Remove @, ., +, _ once versioning is implemented and predefined target names (e.g., llama-3.2-3b-instruct@v1.0.0+A100) are updated.
-NAME_PATTERN = r"^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$"
-
-NAME_MAX_LENGTH = 63
-
-NAME_PATTERN_DESCRIPTION = (
-    "Name must start with a lowercase letter, be 2-63 characters, "
-    "and contain only lowercase letters, digits, and hyphens "
-    "(no consecutive hyphens, cannot end with a hyphen)."
+# Defined in nemo_platform_plugin so plugins can reach it without depending on
+# nmp_common, which would be circular. Re-exported here for existing callers.
+from nemo_platform_plugin.entity_naming import (
+    NAME_MAX_LENGTH as NAME_MAX_LENGTH,
+)
+from nemo_platform_plugin.entity_naming import (
+    NAME_PATTERN as NAME_PATTERN,
+)
+from nemo_platform_plugin.entity_naming import (
+    NAME_PATTERN_DESCRIPTION as NAME_PATTERN_DESCRIPTION,
 )
 
 # Field length constraints

--- a/packages/nmp_common/src/nmp/common/entities/constants.py
+++ b/packages/nmp_common/src/nmp/common/entities/constants.py
@@ -3,8 +3,6 @@
 
 """Constants for entity validation."""
 
-# Defined in nemo_platform_plugin so plugins can reach it without depending on
-# nmp_common, which would be circular. Re-exported here for existing callers.
 from nemo_platform_plugin.entity_naming import (
     NAME_MAX_LENGTH as NAME_MAX_LENGTH,
 )

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -9420,8 +9420,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the fileset. Name must start with a lowercase letter,
-            be 2-63 characters, and contain only lowercase letters, digits, hyphens,
-            and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            be 2-63 characters, and use lowercase letters, digits, hyphens, and dots
+            (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9691,8 +9691,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Name of the model provider. Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -10440,9 +10440,9 @@ components:
         name:
           title: Name
           description: Entity name (optional - auto-generated if not provided). Name
-            must start with a lowercase letter, be 2-63 characters, and contain only
-            lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -10477,8 +10477,8 @@ components:
         new_name:
           title: New Name
           description: Updated entity name (optional). Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -16005,9 +16005,9 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
-            Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16055,9 +16055,9 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
-            Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
-            cannot end with a hyphen).
+            Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+            letters, digits, hyphens, and dots (no consecutive hyphens, cannot end
+            with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16486,8 +16486,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: The name of the secret to create. Name must start with a lowercase
-            letter, be 2-63 characters, and contain only lowercase letters, digits,
-            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
+            letter, be 2-63 characters, and use lowercase letters, digits, hyphens,
+            and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key
@@ -16687,9 +16687,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Project name (unique within workspace). Name must start with
-            a lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
-            a hyphen).
+            a lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+            hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - ml-project
           - nlp-research
@@ -19725,9 +19724,8 @@ components:
           pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
           description: Workspace name (unique identifier). Name must start with a
-            lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
-            a hyphen).
+            lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+            hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - ml-team
           - research

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -9416,11 +9416,12 @@ components:
       properties:
         name:
           type: string
-          maxLength: 255
-          pattern: ^[\w\-.]+$
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'The name of the fileset. Allowed characters: letters (a-z,
-            A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: The name of the fileset. Name must start with a lowercase letter,
+            be 2-63 characters, and contain only lowercase letters, digits, hyphens,
+            and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - training-data-v1
           - llama-checkpoint
@@ -9686,11 +9687,12 @@ components:
       properties:
         name:
           type: string
-          maxLength: 255
-          pattern: ^[\w\-.]+$
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'Name of the model provider. Allowed characters: letters (a-z,
-            A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: Name of the model provider. Name must start with a lowercase
+            letter, be 2-63 characters, and contain only lowercase letters, digits,
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-nim-provider
           - openai-endpoint
@@ -10439,8 +10441,8 @@ components:
           title: Name
           description: Entity name (optional - auto-generated if not provided). Name
             must start with a lowercase letter, be 2-63 characters, and contain only
-            lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -10476,7 +10478,7 @@ components:
           title: New Name
           description: Updated entity name (optional). Name must start with a lowercase
             letter, be 2-63 characters, and contain only lowercase letters, digits,
-            and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - my-config
           - baseline-model-v1
@@ -16004,8 +16006,8 @@ components:
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
             Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16054,8 +16056,8 @@ components:
           title: Name
           description: The name of the step. Must be unique for all steps in a job.
             Name must start with a lowercase letter, be 2-63 characters, and contain
-            only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot
-            end with a hyphen).
+            only lowercase letters, digits, hyphens, and @ . + _ (no consecutive hyphens,
+            cannot end with a hyphen).
           examples:
           - preprocess
           - train-model
@@ -16480,9 +16482,12 @@ components:
       properties:
         name:
           type: string
+          maxLength: 63
+          pattern: ^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
           title: Name
-          description: 'The name of the secret to create. Allowed characters: letters
-            (a-z, A-Z), digits (0-9), underscores, hyphens, and dots.'
+          description: The name of the secret to create. Name must start with a lowercase
+            letter, be 2-63 characters, and contain only lowercase letters, digits,
+            hyphens, and @ . + _ (no consecutive hyphens, cannot end with a hyphen).
           examples:
           - hf-token
           - wandb-api-key
@@ -16683,7 +16688,8 @@ components:
           title: Name
           description: Project name (unique within workspace). Name must start with
             a lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
+            a hyphen).
           examples:
           - ml-project
           - nlp-research
@@ -19720,7 +19726,8 @@ components:
           title: Name
           description: Workspace name (unique identifier). Name must start with a
             lowercase letter, be 2-63 characters, and contain only lowercase letters,
-            digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+            digits, hyphens, and @ . + _ (no consecutive hyphens, cannot end with
+            a hyphen).
           examples:
           - ml-team
           - research

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/filesets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/filesets.py
@@ -34,7 +34,7 @@ def create_filesets(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="The name of the fileset. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots. (required)"
+            help="The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -127,7 +127,7 @@ def create_filesets(
         ["name"],
         "files filesets create",
         {
-            "name": "The name of the fileset. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots. (required)",
+            "name": "The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/filesets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/filesets.py
@@ -34,7 +34,7 @@ def create_filesets(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -127,7 +127,7 @@ def create_filesets(
         ["name"],
         "files filesets create",
         {
-            "name": "The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "The name of the fileset. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/providers.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/providers.py
@@ -34,7 +34,7 @@ def create_providers(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -179,7 +179,7 @@ def create_providers(
         "inference providers create",
         {
             "host_url": "The network endpoint URL for the model provider (required)",
-            "name": "Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/providers.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/inference/providers.py
@@ -34,7 +34,7 @@ def create_providers(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Name of the model provider. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots. (required)"
+            help="Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -179,7 +179,7 @@ def create_providers(
         "inference providers create",
         {
             "host_url": "The network endpoint URL for the model provider (required)",
-            "name": "Name of the model provider. Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and dots. (required)",
+            "name": "Name of the model provider. Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/projects.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/projects.py
@@ -34,7 +34,7 @@ def create_projects(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -95,7 +95,7 @@ def create_projects(
         ["name"],
         "projects create",
         {
-            "name": "Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/projects.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/projects.py
@@ -34,7 +34,7 @@ def create_projects(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     workspace: Annotated[str | None, typer.Option("--workspace")] = None,
@@ -95,7 +95,7 @@ def create_projects(
         ["name"],
         "projects create",
         {
-            "name": "Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Project name (unique within workspace). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/workspaces/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/workspaces/__init__.py
@@ -41,7 +41,7 @@ def create_workspaces(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     wait_role_propagation: Annotated[
@@ -112,7 +112,7 @@ def create_workspaces(
         ["name"],
         "workspaces create",
         {
-            "name": "Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/workspaces/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/workspaces/__init__.py
@@ -41,7 +41,7 @@ def create_workspaces(
     name: Annotated[
         str | None,
         typer.Argument(
-            help="Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen). (required)"
+            help="Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a hyphen). (required)"
         ),
     ] = None,
     wait_role_propagation: Annotated[
@@ -112,7 +112,7 @@ def create_workspaces(
         ["name"],
         "workspaces create",
         {
-            "name": "Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with a hyphen). (required)",
+            "name": "Workspace name (unique identifier). Name must start with a lowercase letter, be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . + \__ (no consecutive hyphens, cannot end with a hyphen). (required)",
         },
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/entities/entities.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/entities/entities.py
@@ -98,9 +98,8 @@ class EntitiesResource(SyncAPIResource):
           data: Entity-specific data (schema is opaque to entity store, validated by client SDK)
 
           name: Entity name (optional - auto-generated if not provided). Name must start with a
-              lowercase letter, be 2-63 characters, and contain only lowercase letters,
-              digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a
-              hyphen).
+              lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+              hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
 
           parent: Parent entity ID for nested entities
 
@@ -444,8 +443,8 @@ class EntitiesResource(SyncAPIResource):
               current version matches.
 
           new_name: Updated entity name (optional). Name must start with a lowercase letter, be 2-63
-              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
-              (no consecutive hyphens, cannot end with a hyphen).
+              characters, and use lowercase letters, digits, hyphens, and dots (no consecutive
+              hyphens, cannot end with a hyphen).
 
           project: The name of the project associated with this entity
 
@@ -546,9 +545,8 @@ class AsyncEntitiesResource(AsyncAPIResource):
           data: Entity-specific data (schema is opaque to entity store, validated by client SDK)
 
           name: Entity name (optional - auto-generated if not provided). Name must start with a
-              lowercase letter, be 2-63 characters, and contain only lowercase letters,
-              digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a
-              hyphen).
+              lowercase letter, be 2-63 characters, and use lowercase letters, digits,
+              hyphens, and dots (no consecutive hyphens, cannot end with a hyphen).
 
           parent: Parent entity ID for nested entities
 
@@ -894,8 +892,8 @@ class AsyncEntitiesResource(AsyncAPIResource):
               current version matches.
 
           new_name: Updated entity name (optional). Name must start with a lowercase letter, be 2-63
-              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
-              (no consecutive hyphens, cannot end with a hyphen).
+              characters, and use lowercase letters, digits, hyphens, and dots (no consecutive
+              hyphens, cannot end with a hyphen).
 
           project: The name of the project associated with this entity
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/entities/entities.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/entities/entities.py
@@ -99,7 +99,8 @@ class EntitiesResource(SyncAPIResource):
 
           name: Entity name (optional - auto-generated if not provided). Name must start with a
               lowercase letter, be 2-63 characters, and contain only lowercase letters,
-              digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+              digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a
+              hyphen).
 
           parent: Parent entity ID for nested entities
 
@@ -443,8 +444,8 @@ class EntitiesResource(SyncAPIResource):
               current version matches.
 
           new_name: Updated entity name (optional). Name must start with a lowercase letter, be 2-63
-              characters, and contain only lowercase letters, digits, and hyphens (no
-              consecutive hyphens, cannot end with a hyphen).
+              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
+              (no consecutive hyphens, cannot end with a hyphen).
 
           project: The name of the project associated with this entity
 
@@ -546,7 +547,8 @@ class AsyncEntitiesResource(AsyncAPIResource):
 
           name: Entity name (optional - auto-generated if not provided). Name must start with a
               lowercase letter, be 2-63 characters, and contain only lowercase letters,
-              digits, and hyphens (no consecutive hyphens, cannot end with a hyphen).
+              digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot end with a
+              hyphen).
 
           parent: Parent entity ID for nested entities
 
@@ -892,8 +894,8 @@ class AsyncEntitiesResource(AsyncAPIResource):
               current version matches.
 
           new_name: Updated entity name (optional). Name must start with a lowercase letter, be 2-63
-              characters, and contain only lowercase letters, digits, and hyphens (no
-              consecutive hyphens, cannot end with a hyphen).
+              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
+              (no consecutive hyphens, cannot end with a hyphen).
 
           project: The name of the project associated with this entity
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
@@ -96,8 +96,9 @@ class FilesetsResource(SyncAPIResource):
         used.
 
         Args:
-          name: The name of the fileset. Allowed characters: letters (a-z, A-Z), digits (0-9),
-              underscores, hyphens, and dots.
+          name: The name of the fileset. Name must start with a lowercase letter, be 2-63
+              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
+              (no consecutive hyphens, cannot end with a hyphen).
 
           cache: Cache all files after creation. Only applies to external storage.
 
@@ -421,8 +422,9 @@ class AsyncFilesetsResource(AsyncAPIResource):
         used.
 
         Args:
-          name: The name of the fileset. Allowed characters: letters (a-z, A-Z), digits (0-9),
-              underscores, hyphens, and dots.
+          name: The name of the fileset. Name must start with a lowercase letter, be 2-63
+              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
+              (no consecutive hyphens, cannot end with a hyphen).
 
           cache: Cache all files after creation. Only applies to external storage.
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/files/filesets.py
@@ -97,8 +97,8 @@ class FilesetsResource(SyncAPIResource):
 
         Args:
           name: The name of the fileset. Name must start with a lowercase letter, be 2-63
-              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
-              (no consecutive hyphens, cannot end with a hyphen).
+              characters, and use lowercase letters, digits, hyphens, and dots (no consecutive
+              hyphens, cannot end with a hyphen).
 
           cache: Cache all files after creation. Only applies to external storage.
 
@@ -423,8 +423,8 @@ class AsyncFilesetsResource(AsyncAPIResource):
 
         Args:
           name: The name of the fileset. Name must start with a lowercase letter, be 2-63
-              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
-              (no consecutive hyphens, cannot end with a hyphen).
+              characters, and use lowercase letters, digits, hyphens, and dots (no consecutive
+              hyphens, cannot end with a hyphen).
 
           cache: Cache all files after creation. Only applies to external storage.
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/inference/providers.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/inference/providers.py
@@ -103,8 +103,9 @@ class ProvidersResource(SyncAPIResource):
         Args:
           host_url: The network endpoint URL for the model provider
 
-          name: Name of the model provider. Allowed characters: letters (a-z, A-Z), digits
-              (0-9), underscores, hyphens, and dots.
+          name: Name of the model provider. Name must start with a lowercase letter, be 2-63
+              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
+              (no consecutive hyphens, cannot end with a hyphen).
 
           api_key_secret_name: Reference to an API key secret stored in the Secrets service. Create the secret
               first via secrets API, then pass the secret name here.
@@ -554,8 +555,9 @@ class AsyncProvidersResource(AsyncAPIResource):
         Args:
           host_url: The network endpoint URL for the model provider
 
-          name: Name of the model provider. Allowed characters: letters (a-z, A-Z), digits
-              (0-9), underscores, hyphens, and dots.
+          name: Name of the model provider. Name must start with a lowercase letter, be 2-63
+              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
+              (no consecutive hyphens, cannot end with a hyphen).
 
           api_key_secret_name: Reference to an API key secret stored in the Secrets service. Create the secret
               first via secrets API, then pass the secret name here.

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/inference/providers.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/inference/providers.py
@@ -104,8 +104,8 @@ class ProvidersResource(SyncAPIResource):
           host_url: The network endpoint URL for the model provider
 
           name: Name of the model provider. Name must start with a lowercase letter, be 2-63
-              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
-              (no consecutive hyphens, cannot end with a hyphen).
+              characters, and use lowercase letters, digits, hyphens, and dots (no consecutive
+              hyphens, cannot end with a hyphen).
 
           api_key_secret_name: Reference to an API key secret stored in the Secrets service. Create the secret
               first via secrets API, then pass the secret name here.
@@ -556,8 +556,8 @@ class AsyncProvidersResource(AsyncAPIResource):
           host_url: The network endpoint URL for the model provider
 
           name: Name of the model provider. Name must start with a lowercase letter, be 2-63
-              characters, and contain only lowercase letters, digits, hyphens, and @ . + \\__
-              (no consecutive hyphens, cannot end with a hyphen).
+              characters, and use lowercase letters, digits, hyphens, and dots (no consecutive
+              hyphens, cannot end with a hyphen).
 
           api_key_secret_name: Reference to an API key secret stored in the Secrets service. Create the secret
               first via secrets API, then pass the secret name here.

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/inference/virtual_models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/inference/virtual_models.py
@@ -32,7 +32,6 @@ from ..._response import (
     async_to_streamed_response_wrapper,
 )
 from ...pagination import SyncDefaultPagination, AsyncDefaultPagination
-from ..._exceptions import ConflictError
 from ..._base_client import AsyncPaginator, make_request_options
 from ...types.inference import (
     virtual_model_list_params,
@@ -44,6 +43,7 @@ from ...types.inference.virtual_model import VirtualModel
 from ...types.inference.middleware_call_param import MiddlewareCallParam
 from ...types.inference.virtual_model_filter_param import VirtualModelFilterParam
 from ...types.inference.virtual_model_inference_config_param import VirtualModelInferenceConfigParam
+from ..._exceptions import ConflictError
 
 __all__ = ["VirtualModelsResource", "AsyncVirtualModelsResource"]
 
@@ -166,7 +166,7 @@ class VirtualModelsResource(SyncAPIResource):
         except ConflictError:
             if not exist_ok:
                 raise
-            return self.retrieve(name=name, workspace=workspace)
+            return self.retrieve(name = name, workspace = workspace)
 
     def retrieve(
         self,
@@ -546,7 +546,7 @@ class AsyncVirtualModelsResource(AsyncAPIResource):
         except ConflictError:
             if not exist_ok:
                 raise
-            return await self.retrieve(name=name, workspace=workspace)
+            return await self.retrieve(name = name, workspace = workspace)
 
     async def retrieve(
         self,

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/projects/projects.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/projects/projects.py
@@ -86,8 +86,8 @@ class ProjectsResource(SyncAPIResource):
 
         Args:
           name: Project name (unique within workspace). Name must start with a lowercase letter,
-              be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no
-              consecutive hyphens, cannot end with a hyphen).
+              be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @
+              . + \\__ (no consecutive hyphens, cannot end with a hyphen).
 
           description: Optional description of the project
 
@@ -392,8 +392,8 @@ class AsyncProjectsResource(AsyncAPIResource):
 
         Args:
           name: Project name (unique within workspace). Name must start with a lowercase letter,
-              be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no
-              consecutive hyphens, cannot end with a hyphen).
+              be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @
+              . + \\__ (no consecutive hyphens, cannot end with a hyphen).
 
           description: Optional description of the project
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/projects/projects.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/projects/projects.py
@@ -86,8 +86,8 @@ class ProjectsResource(SyncAPIResource):
 
         Args:
           name: Project name (unique within workspace). Name must start with a lowercase letter,
-              be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @
-              . + \\__ (no consecutive hyphens, cannot end with a hyphen).
+              be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no
+              consecutive hyphens, cannot end with a hyphen).
 
           description: Optional description of the project
 
@@ -392,8 +392,8 @@ class AsyncProjectsResource(AsyncAPIResource):
 
         Args:
           name: Project name (unique within workspace). Name must start with a lowercase letter,
-              be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @
-              . + \\__ (no consecutive hyphens, cannot end with a hyphen).
+              be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no
+              consecutive hyphens, cannot end with a hyphen).
 
           description: Optional description of the project
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/secrets/secrets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/secrets/secrets.py
@@ -89,8 +89,9 @@ class SecretsResource(SyncAPIResource):
         Args:
           name: The name of the secret to create.
 
-        Allowed characters: letters (a-z, A-Z), digits
-              (0-9), underscores, hyphens, and dots.
+        Name must start with a lowercase letter, be
+              2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . +
+              \\__ (no consecutive hyphens, cannot end with a hyphen).
 
           value: The payload of the secret
 
@@ -388,8 +389,9 @@ class AsyncSecretsResource(AsyncAPIResource):
         Args:
           name: The name of the secret to create.
 
-        Allowed characters: letters (a-z, A-Z), digits
-              (0-9), underscores, hyphens, and dots.
+        Name must start with a lowercase letter, be
+              2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . +
+              \\__ (no consecutive hyphens, cannot end with a hyphen).
 
           value: The payload of the secret
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/secrets/secrets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/secrets/secrets.py
@@ -90,8 +90,8 @@ class SecretsResource(SyncAPIResource):
           name: The name of the secret to create.
 
         Name must start with a lowercase letter, be
-              2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . +
-              \\__ (no consecutive hyphens, cannot end with a hyphen).
+              2-63 characters, and use lowercase letters, digits, hyphens, and dots (no
+              consecutive hyphens, cannot end with a hyphen).
 
           value: The payload of the secret
 
@@ -390,8 +390,8 @@ class AsyncSecretsResource(AsyncAPIResource):
           name: The name of the secret to create.
 
         Name must start with a lowercase letter, be
-              2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . +
-              \\__ (no consecutive hyphens, cannot end with a hyphen).
+              2-63 characters, and use lowercase letters, digits, hyphens, and dots (no
+              consecutive hyphens, cannot end with a hyphen).
 
           value: The payload of the secret
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/workspaces/workspaces.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/workspaces/workspaces.py
@@ -102,8 +102,8 @@ class WorkspacesResource(SyncAPIResource):
 
         Args:
           name: Workspace name (unique identifier). Name must start with a lowercase letter, be
-              2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . +
-              \\__ (no consecutive hyphens, cannot end with a hyphen).
+              2-63 characters, and use lowercase letters, digits, hyphens, and dots (no
+              consecutive hyphens, cannot end with a hyphen).
 
           wait_role_propagation: If true, wait for Admin role to propagate before returning (default: true). Set
               to false for bulk operations.
@@ -410,8 +410,8 @@ class AsyncWorkspacesResource(AsyncAPIResource):
 
         Args:
           name: Workspace name (unique identifier). Name must start with a lowercase letter, be
-              2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . +
-              \\__ (no consecutive hyphens, cannot end with a hyphen).
+              2-63 characters, and use lowercase letters, digits, hyphens, and dots (no
+              consecutive hyphens, cannot end with a hyphen).
 
           wait_role_propagation: If true, wait for Admin role to propagate before returning (default: true). Set
               to false for bulk operations.

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/workspaces/workspaces.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/workspaces/workspaces.py
@@ -102,8 +102,8 @@ class WorkspacesResource(SyncAPIResource):
 
         Args:
           name: Workspace name (unique identifier). Name must start with a lowercase letter, be
-              2-63 characters, and contain only lowercase letters, digits, and hyphens (no
-              consecutive hyphens, cannot end with a hyphen).
+              2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . +
+              \\__ (no consecutive hyphens, cannot end with a hyphen).
 
           wait_role_propagation: If true, wait for Admin role to propagate before returning (default: true). Set
               to false for bulk operations.
@@ -410,8 +410,8 @@ class AsyncWorkspacesResource(AsyncAPIResource):
 
         Args:
           name: Workspace name (unique identifier). Name must start with a lowercase letter, be
-              2-63 characters, and contain only lowercase letters, digits, and hyphens (no
-              consecutive hyphens, cannot end with a hyphen).
+              2-63 characters, and contain only lowercase letters, digits, hyphens, and @ . +
+              \\__ (no consecutive hyphens, cannot end with a hyphen).
 
           wait_role_propagation: If true, wait for Admin role to propagate before returning (default: true). Set
               to false for bulk operations.

--- a/sdk/python/nemo-platform/src/nemo_platform/types/entities/entity_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/entities/entity_create_params.py
@@ -35,8 +35,8 @@ class EntityCreateParams(TypedDict, total=False):
     """Entity name (optional - auto-generated if not provided).
 
     Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with
-    a hyphen).
+    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
+    end with a hyphen).
     """
 
     parent: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/entities/entity_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/entities/entity_create_params.py
@@ -34,9 +34,9 @@ class EntityCreateParams(TypedDict, total=False):
     name: str
     """Entity name (optional - auto-generated if not provided).
 
-    Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
-    end with a hyphen).
+    Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+    letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a
+    hyphen).
     """
 
     parent: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/entities/entity_update_entity_by_name_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/entities/entity_update_entity_by_name_params.py
@@ -43,9 +43,9 @@ class EntityUpdateEntityByNameParams(TypedDict, total=False):
     new_name: str
     """Updated entity name (optional).
 
-    Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
-    end with a hyphen).
+    Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+    letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a
+    hyphen).
     """
 
     project: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/entities/entity_update_entity_by_name_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/entities/entity_update_entity_by_name_params.py
@@ -44,8 +44,8 @@ class EntityUpdateEntityByNameParams(TypedDict, total=False):
     """Updated entity name (optional).
 
     Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with
-    a hyphen).
+    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
+    end with a hyphen).
     """
 
     project: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/files/fileset_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/files/fileset_create_params.py
@@ -36,9 +36,9 @@ class FilesetCreateParams(TypedDict, total=False):
     name: Required[str]
     """The name of the fileset.
 
-    Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
-    end with a hyphen).
+    Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+    letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a
+    hyphen).
     """
 
     cache: bool

--- a/sdk/python/nemo-platform/src/nemo_platform/types/files/fileset_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/files/fileset_create_params.py
@@ -36,8 +36,9 @@ class FilesetCreateParams(TypedDict, total=False):
     name: Required[str]
     """The name of the fileset.
 
-    Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and
-    dots.
+    Name must start with a lowercase letter, be 2-63 characters, and contain only
+    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
+    end with a hyphen).
     """
 
     cache: bool

--- a/sdk/python/nemo-platform/src/nemo_platform/types/inference/provider_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/inference/provider_create_params.py
@@ -35,8 +35,9 @@ class ProviderCreateParams(TypedDict, total=False):
     name: Required[str]
     """Name of the model provider.
 
-    Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and
-    dots.
+    Name must start with a lowercase letter, be 2-63 characters, and contain only
+    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
+    end with a hyphen).
     """
 
     api_key_secret_name: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/inference/provider_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/inference/provider_create_params.py
@@ -35,9 +35,9 @@ class ProviderCreateParams(TypedDict, total=False):
     name: Required[str]
     """Name of the model provider.
 
-    Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
-    end with a hyphen).
+    Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+    letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a
+    hyphen).
     """
 
     api_key_secret_name: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_step_spec.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_step_spec.py
@@ -45,8 +45,8 @@ class PlatformJobStepSpec(BaseModel):
     """The name of the step.
 
     Must be unique for all steps in a job. Name must start with a lowercase letter,
-    be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @
-    . + \\__ (no consecutive hyphens, cannot end with a hyphen).
+    be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no
+    consecutive hyphens, cannot end with a hyphen).
     """
 
     config: Optional[Dict[str, object]] = None

--- a/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_step_spec.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_step_spec.py
@@ -45,8 +45,8 @@ class PlatformJobStepSpec(BaseModel):
     """The name of the step.
 
     Must be unique for all steps in a job. Name must start with a lowercase letter,
-    be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no
-    consecutive hyphens, cannot end with a hyphen).
+    be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @
+    . + \\__ (no consecutive hyphens, cannot end with a hyphen).
     """
 
     config: Optional[Dict[str, object]] = None

--- a/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_step_spec_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_step_spec_param.py
@@ -47,8 +47,8 @@ class PlatformJobStepSpecParam(TypedDict, total=False):
     """The name of the step.
 
     Must be unique for all steps in a job. Name must start with a lowercase letter,
-    be 2-63 characters, and contain only lowercase letters, digits, and hyphens (no
-    consecutive hyphens, cannot end with a hyphen).
+    be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @
+    . + \\__ (no consecutive hyphens, cannot end with a hyphen).
     """
 
     config: Dict[str, object]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_step_spec_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_step_spec_param.py
@@ -47,8 +47,8 @@ class PlatformJobStepSpecParam(TypedDict, total=False):
     """The name of the step.
 
     Must be unique for all steps in a job. Name must start with a lowercase letter,
-    be 2-63 characters, and contain only lowercase letters, digits, hyphens, and @
-    . + \\__ (no consecutive hyphens, cannot end with a hyphen).
+    be 2-63 characters, and use lowercase letters, digits, hyphens, and dots (no
+    consecutive hyphens, cannot end with a hyphen).
     """
 
     config: Dict[str, object]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/projects/project_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/projects/project_create_params.py
@@ -29,8 +29,8 @@ class ProjectCreateParams(TypedDict, total=False):
     """Project name (unique within workspace).
 
     Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with
-    a hyphen).
+    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
+    end with a hyphen).
     """
 
     description: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/projects/project_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/projects/project_create_params.py
@@ -28,9 +28,9 @@ class ProjectCreateParams(TypedDict, total=False):
     name: Required[str]
     """Project name (unique within workspace).
 
-    Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
-    end with a hyphen).
+    Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+    letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a
+    hyphen).
     """
 
     description: str

--- a/sdk/python/nemo-platform/src/nemo_platform/types/secrets/secret_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/secrets/secret_create_params.py
@@ -28,9 +28,9 @@ class SecretCreateParams(TypedDict, total=False):
     name: Required[str]
     """The name of the secret to create.
 
-    Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
-    end with a hyphen).
+    Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+    letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a
+    hyphen).
     """
 
     value: Required[str]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/secrets/secret_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/secrets/secret_create_params.py
@@ -28,8 +28,9 @@ class SecretCreateParams(TypedDict, total=False):
     name: Required[str]
     """The name of the secret to create.
 
-    Allowed characters: letters (a-z, A-Z), digits (0-9), underscores, hyphens, and
-    dots.
+    Name must start with a lowercase letter, be 2-63 characters, and contain only
+    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
+    end with a hyphen).
     """
 
     value: Required[str]

--- a/sdk/python/nemo-platform/src/nemo_platform/types/workspaces/workspace_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/workspaces/workspace_create_params.py
@@ -27,8 +27,8 @@ class WorkspaceCreateParams(TypedDict, total=False):
     """Workspace name (unique identifier).
 
     Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, and hyphens (no consecutive hyphens, cannot end with
-    a hyphen).
+    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
+    end with a hyphen).
     """
 
     wait_role_propagation: bool

--- a/sdk/python/nemo-platform/src/nemo_platform/types/workspaces/workspace_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/workspaces/workspace_create_params.py
@@ -26,9 +26,9 @@ class WorkspaceCreateParams(TypedDict, total=False):
     name: Required[str]
     """Workspace name (unique identifier).
 
-    Name must start with a lowercase letter, be 2-63 characters, and contain only
-    lowercase letters, digits, hyphens, and @ . + \\__ (no consecutive hyphens, cannot
-    end with a hyphen).
+    Name must start with a lowercase letter, be 2-63 characters, and use lowercase
+    letters, digits, hyphens, and dots (no consecutive hyphens, cannot end with a
+    hyphen).
     """
 
     wait_role_propagation: bool

--- a/services/core/models/src/nmp/core/models/schemas.py
+++ b/services/core/models/src/nmp/core/models/schemas.py
@@ -19,7 +19,7 @@ from nmp.core.models.constants import (
     MODEL_REF_PATTERN_DESCRIPTION,
     is_valid_model_ref,
 )
-from pydantic import AnyUrl, BaseModel, Field, field_validator
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, field_validator
 
 
 def get_model_id(prefix: str) -> str:
@@ -473,10 +473,12 @@ class ModelProviderSort(StrEnum):
 class CreateModelProviderRequest(BaseModel):
     """Request model for creating a ModelProvider."""
 
+    model_config = ConfigDict(regex_engine="python-re")
+
     name: str = Field(
-        description=f"Name of the model provider. {constants.REGEX_WORD_CHARACTER_DOT_DASH_DESCRIPTION}",
-        max_length=constants.MAX_LENGTH_255,
-        pattern=constants.REGEX_WORD_CHARACTER_DOT_DASH,
+        description=f"Name of the model provider. {constants.NAME_PATTERN_DESCRIPTION}",
+        max_length=constants.NAME_MAX_LENGTH,
+        pattern=constants.NAME_PATTERN,
         examples=["my-nim-provider", "openai-endpoint"],
     )
     project: Optional[str] = Field(

--- a/services/core/secrets/tests/integration/test_secrets_with_auth.py
+++ b/services/core/secrets/tests/integration/test_secrets_with_auth.py
@@ -34,7 +34,7 @@ from nmp.testing import (
     short_unique_name,
     unique_email,
 )
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 # Service principals have elevated access (like platform admin)
 SERVICE_PRINCIPAL = "service:integration-test"
@@ -997,9 +997,17 @@ class TestSecretNameValidation:
         # Name with uppercase letter - violates DNS-compliant naming rules
         invalid_name = "test-secret-123-Test"
 
+        with pytest.raises(ValidationError) as local_exc:
+            PlatformSecretCreateRequest(name=invalid_name, value=SecretStr("test-value"))
+        assert "should match pattern" in str(local_exc.value).lower()
+
+        # model_construct skips validation so the bad name still reaches the server,
+        # which is where the 500-vs-422 regression lived.
         with pytest.raises(ClientUnprocessableEntityError) as exc_info:
             admin_secrets.create_secret(
-                body=PlatformSecretCreateRequest(name=invalid_name, value=SecretStr("test-value")),
+                body=PlatformSecretCreateRequest.model_construct(
+                    name=invalid_name, value=SecretStr("test-value"), description=None
+                ),
                 workspace="default",
             )
 
@@ -1016,9 +1024,15 @@ class TestSecretNameValidation:
         admin_secrets = client_from_platform(admin_sdk, SecretsClient)
         invalid_name = "TEST-SECRET"
 
+        with pytest.raises(ValidationError) as local_exc:
+            PlatformSecretCreateRequest(name=invalid_name, value=SecretStr("test-value"))
+        assert "should match pattern" in str(local_exc.value).lower()
+
         with pytest.raises(ClientUnprocessableEntityError) as exc_info:
             admin_secrets.create_secret(
-                body=PlatformSecretCreateRequest(name=invalid_name, value=SecretStr("test-value")),
+                body=PlatformSecretCreateRequest.model_construct(
+                    name=invalid_name, value=SecretStr("test-value"), description=None
+                ),
                 workspace="default",
             )
 

--- a/services/core/secrets/tests/integration/test_secrets_with_auth.py
+++ b/services/core/secrets/tests/integration/test_secrets_with_auth.py
@@ -1001,8 +1001,7 @@ class TestSecretNameValidation:
             PlatformSecretCreateRequest(name=invalid_name, value=SecretStr("test-value"))
         assert "should match pattern" in str(local_exc.value).lower()
 
-        # model_construct skips validation so the bad name still reaches the server,
-        # which is where the 500-vs-422 regression lived.
+        # model_construct skips validation so the name still reaches the server.
         with pytest.raises(ClientUnprocessableEntityError) as exc_info:
             admin_secrets.create_secret(
                 body=PlatformSecretCreateRequest.model_construct(

--- a/services/core/secrets/tests/test_secrets.py
+++ b/services/core/secrets/tests/test_secrets.py
@@ -65,18 +65,26 @@ async def test_create_secret_with_empty_value(test_client):
     assert response.status_code == 422
 
 
-@pytest.mark.parametrize("invalid_name", ["bad name", "bad/name", "no!way", "a@b"])
-async def test_create_secret_with_invalid_name_returns_friendly_error(test_client, invalid_name):
-    """Verify that names with disallowed characters return a 422 with a readable message."""
+@pytest.mark.parametrize(
+    "invalid_name",
+    ["bad name", "bad/name", "no!way", "MySecret", "1secret", "my--secret", "secret-", "a" * 64],
+)
+async def test_create_secret_with_invalid_name_is_rejected(test_client, invalid_name):
+    """Names the entity store would reject must fail at the API boundary, not downstream."""
     response = test_client.post(
         "/apis/secrets/v2/workspaces/default/secrets",
         json={"name": invalid_name, "value": "x"},
     )
     assert response.status_code == 422
-    detail = response.json()["detail"]
-    msg = detail[0]["msg"]
-    assert "Invalid secret name" in msg
-    assert invalid_name in msg
+
+
+@pytest.mark.parametrize("valid_name", ["hf-token", "a@b", "model.v1", "svc_key", "ab"])
+async def test_create_secret_accepts_entity_store_names(test_client, valid_name):
+    response = test_client.post(
+        "/apis/secrets/v2/workspaces/default/secrets",
+        json={"name": valid_name, "value": "x"},
+    )
+    assert response.status_code == 201
 
 
 async def test_create_and_delete_secret(test_client):


### PR DESCRIPTION
## Problem

The OpenAPI spec advertises a name pattern the platform does not accept.

Create-request DTOs declare `^[\w\-.]+$` (max 255), but the entity store enforces the stricter RFC-1035-ish `NAME_PATTERN` downstream:

```
^[a-z](?!.*--)[a-z0-9\-@.+_]{1,62}(?<!-)$
```

So `Sparl` or `My_Provider` validates against the published spec, passes any generated client's validation, and then fails with a 422. That hits every SDK consumer, not just Studio.

Raised by @steramae-nvidia on #919:

> Is this a problem for the openapi schema? Anyone relying on the openapi schema should expect that the regex pattern in the spec should be valid.

#919 works around this on the frontend with a hand-mirrored copy of `NAME_PATTERN`. That mirror exists only because the spec is wrong.

## Change

Two commits.

### 1. Declare the real pattern on the create DTOs

| DTO | Before | After |
|---|---|---|
| `CreateModelProviderRequest.name` | `^[\w\-.]+$`, max 255 | `NAME_PATTERN`, max 63 |
| `CreateFilesetRequest.name` | `^[\w\-.]+$`, max 255 | `NAME_PATTERN`, max 63 |
| `PlatformSecretCreateRequest.name` | `field_validator` only — no pattern in the spec at all | `pattern=`, max 63 |

Three things worth calling out:

**`regex_engine="python-re"` is required.** `NAME_PATTERN` uses lookahead and lookbehind; Pydantic's default Rust engine rejects them outright. The entity-store schemas already set this — without it the models don't build.

**`max_length` 255 → 63.** The regex caps at 63 by construction (`^[a-z]` + `{1,62}`), so the old pair contradicted itself.

**`@` is legal under `NAME_PATTERN`.** Secrets previously rejected `a@b` via its own validator; it now accepts it, matching what the entity store always allowed. A loosening in one direction alongside the tightening.

### 2. Collapse the mirrored constants

The first commit made an existing problem worse, so the second one fixes it. `NAME_PATTERN` was copy-pasted verbatim in **four** Python modules: `nmp_common`, plus `files/types.py`, `secrets/types.py`, and `jobs/spec.py` inside `nemo_platform_plugin`. Each carried a comment explaining it was inlined to avoid an `nmp_common` dependency, and `jobs/spec.py` cited `files/types.py` as the precedent — the duplication was self-propagating.

The dependency only runs one way: `nmp_common/pyproject.toml` depends on `nemo-platform-plugin`, and `nmp_common/entities/client.py` imports `EntityBase` from it. So the plugin cannot import `nmp_common` without a cycle, which makes the plugin the correct home — as the `no-nmp-common-in-plugins` pre-commit hook's own comment prescribes.

New leaf module `nemo_platform_plugin/entity_naming.py` holds the single definition and imports nothing, so modules that need to stay leaf nodes still can. `nmp_common` re-exports it, leaving every existing `constants.NAME_PATTERN` call site untouched.

Regenerating the OpenAPI spec after this commit produces **no diff** — it's a pure refactor.

## Testing

- All three DTOs verified directly: `Sparl`, `my--provider`, `myprovider-`, `1provider`, 64-char, `My_Provider` rejected; `ok-name`, `a@b` accepted
- **4895 Python tests pass** after the refactor — plugin, secrets, files, models, entities, jobs, nmp_common. A wider sweep including evaluator, data-designer, and ext also passes, aside from 8 pre-existing failures in `nemo_platform_ext` daemonize/socket tests plus 2 evaluator errors, all confirmed identical on a clean tree
- Re-export identity asserted: `nmp.common.entities.constants.NAME_PATTERN is nemo_platform_plugin.entity_naming.NAME_PATTERN`
- 44 Studio tests pass on the three name-entry forms
- `ruff`, `ruff format`, `ty` clean on changed files
- Web SDK regenerated: `filesCreateFilesetBodyNameMax = 63` and the new regex. That output is gitignored, so nothing to commit

Two secrets tests changed. `test_create_secret_with_invalid_name_returns_friendly_error` asserted a message that no longer exists and listed `a@b` as invalid — replaced with a reject-list plus an accept-list. The two uppercase regression tests in `test_secrets_with_auth.py` were failing because the shared request model now rejects locally before the HTTP call; they use `model_construct` to bypass it so the original 500-vs-422 server-side coverage stays intact.

## Known remaining drift (not fixed here)

`packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/models.py:31` carries a hand-rewritten lookaround-free variant commented "Keep this aligned with `nmp.common.entities.constants.NAME_PATTERN`". It has drifted:

| input | entity store | evaluator SDK |
|---|---|---|
| `a-b-b-…` (81 chars) | reject | **accept** |
| `a-b-b-…` (125 chars) | reject | **accept** |

Each hyphen branch consumes two characters per repetition, so `{1,62}` admits up to 125 characters instead of 63. `nemo_evaluator_sdk` has no dependency on `nemo_platform_plugin`, so fixing it needs either a new dependency or a test asserting equivalence — out of scope here, happy to file it.

On the frontend, `main` today has two copies (`filesetName.ts` and `CreateSecretModal/constants.ts`). #919 collapses both into one — `entityName.ts` — so once that merges there is a single frontend copy left. It can drop its hand-written regex in favour of the generated `filesCreateFilesetBodyNameRegExp` once this PR lands; the per-rule error messages and the sanitizer's character classes have no generated equivalent and stay.

## Follow-up

`web/packages/common/src/utils/entityName.ts` (added in #919) can be reduced to the generated schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Validation Improvements**
  * Tightened `name` validation across filesets, model providers, platform secrets, and related entity inputs.
  * Enforced max length of **63**, with **lowercase-first** names, approved characters including **`@ . + _`**, plus existing constraints: **no consecutive hyphens** and **no trailing hyphen**.
  * Updated OpenAPI and CLI/help text to reflect the stricter, consistent rules.
* **Tests**
  * Expanded API boundary tests for broader invalid-name rejection.
  * Added/strengthened checks to ensure validation behavior results in consistent **HTTP 422** responses for invalid inputs, while allowing valid entity-store-style names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
