### PR TITLE
feat(nemo-agents): serve Fabric agents via Docker and Kubernetes deployments

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/config.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/config.py
@@ -72,7 +72,7 @@ class DeploymentsRunnerConfig(BaseModel):
     )
     container_port: int = Field(
         default=8000,
-        description="Container port the NAT server listens on (and readiness probe target).",
+        description="Container port the agent server listens on (and readiness probe target).",
     )
     gateway_url_override: str | None = Field(
         default=None,
@@ -100,10 +100,11 @@ class DeploymentsRunnerConfig(BaseModel):
     config_mount_path: str = Field(
         default="/workspace/config.yaml",
         description=(
-            "Path inside the container where the NAT workflow config is placed. Must sit under "
+            "Path inside the container where the NAT workflow config is placed for nat-workflow-v1 "
+            "deployments. Fabric deployments use agent.yaml in the same directory. Must sit under "
             "the image's writable WORKDIR (/workspace) so docker mode, which materializes the "
             "config as the non-root container user, can write it; k8s mounts it read-only there "
-            "via a ConfigMap subPath. Matches the image's NAT_CONFIG_FILE convention."
+            "via a ConfigMap subPath."
         ),
     )
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
+import shlex
 import time
 from pathlib import PurePosixPath
 from typing import Any
@@ -59,6 +60,7 @@ _HTTP_PORT_NAME = "http"
 _PLUGIN_WHEELS_VOLUME = "plugin-wheels"
 _PLUGIN_WHEELS_MOUNT = "/opt/nemo/plugin-wheels"
 _NAT_CONFIG_ENV = "NAT_CONFIG_PATH"
+_NAT_CONFIG_YAML_ENV = "NAT_CONFIG_YAML"
 _AGENT_CONFIG_YAML_ENV = "AGENT_CONFIG_YAML"
 _AGENT_CONFIG_PATH_ENV = "AGENT_CONFIG_PATH"
 _FABRIC_SERVER_MODULE = "nemo_agents_plugin.fabric.server"
@@ -224,6 +226,17 @@ def _fabric_server_cli_args(*, config_path: str, port: int) -> list[str]:
     ]
 
 
+def _materialize_config_and_exec(*, config_path: str, yaml_env: str, argv: list[str]) -> list[str]:
+    """Return ``sh -c`` args that write the config from *yaml_env*, then exec *argv*.
+
+    Docker mode needs this because the docker backend does not mount ``config_files``.
+    Paths and argv are shell-escaped so spaces/metacharacters cannot break the script.
+    """
+    quoted_path = shlex.quote(config_path)
+    quoted_argv = " ".join(shlex.quote(arg) for arg in argv)
+    return [f'mkdir -p "$(dirname {quoted_path})" && printf "%s" "${yaml_env}" > {quoted_path} && exec {quoted_argv}']
+
+
 def executor_for_mode(config: DeploymentsRunnerConfig, mode: DeploymentMode) -> str | None:
     """Resolve the named deployments-plugin executor for *mode*."""
     if mode == "docker":
@@ -264,7 +277,7 @@ def build_deployment_config(
     workspace: str,
     image: str,
     port: int,
-    nat_config: dict[str, Any],
+    agent_config: dict[str, Any],
     platform_base_url: str,
     config_mount_path: str,
     mode: DeploymentMode,
@@ -274,8 +287,9 @@ def build_deployment_config(
 ) -> DeploymentConfig:
     """Compile an agent into a long-running ``DeploymentConfig`` (Always).
 
+    *agent_config* is either a NAT workflow config or a Platform-owned Fabric spec.
     NAT workflow configs start ``nat start fastapi`` with workflow YAML at
-    *config_mount_path*. Platform-owned Fabric configs start
+    *config_mount_path*. Fabric configs start
     ``python -m nemo_agents_plugin.fabric.server`` with ``agent.yaml`` beside the
     NAT config directory. Docker mode materializes config from env because the
     docker backend ignores ``config_files``; k8s mounts ``config_files`` via
@@ -283,15 +297,15 @@ def build_deployment_config(
     readiness probe on ``/health``.
 
     The caller is responsible for rebasing inference ``base_url`` values in
-    *nat_config* to a container-reachable gateway before calling this helper.
+    *agent_config* to a container-reachable gateway before calling this helper.
 
     ``platform_base_url`` is the container-reachable platform origin used to
     build the Inference Gateway URL. It is also exported as ``NMP_BASE_URL`` so
     SDK calls from inside the agent use the same platform instead of falling
     back to a baked or host CLI context.
     """
-    is_fabric = _is_fabric_agent_config(nat_config)
-    config_yaml = yaml.safe_dump(nat_config, sort_keys=False)
+    is_fabric = _is_fabric_agent_config(agent_config)
+    config_yaml = yaml.safe_dump(agent_config, sort_keys=False)
     config_path = _fabric_config_mount_path(config_mount_path) if is_fabric else config_mount_path
     env = [
         EnvVar(name="NMP_WORKSPACE", value=workspace),
@@ -330,49 +344,33 @@ def build_deployment_config(
         env.append(EnvVar(name="PYTHONPATH", value=_PLUGIN_WHEELS_MOUNT))
 
     if is_fabric:
-        fabric_args = ["python", *_fabric_server_cli_args(config_path=config_path, port=port)]
-        if mode == "docker":
-            env.append(EnvVar(name=_AGENT_CONFIG_YAML_ENV, value=config_yaml))
-            command = ["sh", "-c"]
-            args = [
-                f'mkdir -p "$(dirname "{config_path}")" '
-                f'&& printf "%s" "$AGENT_CONFIG_YAML" > "{config_path}" '
-                f"&& exec {' '.join(fabric_args)}"
-            ]
-        else:
-            command = ["python"]
-            args = _fabric_server_cli_args(config_path=config_path, port=port)
+        config_yaml_env = _AGENT_CONFIG_YAML_ENV
+        server_command = ["python"]
+        server_args = _fabric_server_cli_args(config_path=config_path, port=port)
     else:
-        nat_args = [
-            "nat",
-            "start",
-            "fastapi",
+        config_yaml_env = _NAT_CONFIG_YAML_ENV
+        server_command = ["nat", "start", "fastapi"]
+        server_args = [
             "--config_file",
-            config_mount_path,
+            config_path,
             "--host",
             "0.0.0.0",
             "--port",
             str(port),
         ]
-        if mode == "docker":
-            # Docker backend does not mount config_files; materialize the YAML from env.
-            env.append(EnvVar(name="NAT_CONFIG_YAML", value=config_yaml))
-            command = ["sh", "-c"]
-            args = [
-                f'mkdir -p "$(dirname "{config_mount_path}")" '
-                f'&& printf "%s" "$NAT_CONFIG_YAML" > "{config_mount_path}" '
-                f"&& exec {' '.join(nat_args)}"
-            ]
-        else:
-            command = ["nat", "start", "fastapi"]
-            args = [
-                "--config_file",
-                config_mount_path,
-                "--host",
-                "0.0.0.0",
-                "--port",
-                str(port),
-            ]
+
+    if mode == "docker":
+        # Docker backend does not mount config_files; materialize the YAML from env.
+        env.append(EnvVar(name=config_yaml_env, value=config_yaml))
+        command = ["sh", "-c"]
+        args = _materialize_config_and_exec(
+            config_path=config_path,
+            yaml_env=config_yaml_env,
+            argv=[*server_command, *server_args],
+        )
+    else:
+        command = server_command
+        args = server_args
 
     container = Container(
         name=_CONTAINER_NAME,
@@ -499,7 +497,7 @@ class DeploymentsRunnerBackend(RunnerBackend):
             workspace=workspace,
             image=resolved_image,
             port=self._config.container_port,
-            nat_config=config,
+            agent_config=config,
             platform_base_url=gateway,
             config_mount_path=self._config.config_mount_path,
             mode=deployment_mode,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -17,13 +17,16 @@ import asyncio
 import copy
 import logging
 import time
+from pathlib import PurePosixPath
 from typing import Any
 from urllib.parse import urlsplit
 
 import yaml
 from nemo_agents_plugin.config import AgentsConfig, DeploymentsRunnerConfig
 from nemo_agents_plugin.entities import (
+    AGENT_CONFIG_FILENAME,
     CONTAINER_DEPLOYMENT_MODES,
+    NEMO_AGENTS_SPEC_CONFIG_FORMAT,
     DeploymentMode,
     DeploymentStatus,
     Endpoint,
@@ -56,6 +59,9 @@ _HTTP_PORT_NAME = "http"
 _PLUGIN_WHEELS_VOLUME = "plugin-wheels"
 _PLUGIN_WHEELS_MOUNT = "/opt/nemo/plugin-wheels"
 _NAT_CONFIG_ENV = "NAT_CONFIG_PATH"
+_AGENT_CONFIG_YAML_ENV = "AGENT_CONFIG_YAML"
+_AGENT_CONFIG_PATH_ENV = "AGENT_CONFIG_PATH"
+_FABRIC_SERVER_MODULE = "nemo_agents_plugin.fabric.server"
 _AUTH_PROXY_IDENTITY = "agents"
 
 
@@ -159,6 +165,65 @@ def rewrite_config_base_urls(nat_config: dict[str, Any], gateway_url: str) -> di
     return config
 
 
+def rewrite_fabric_config_base_urls(agent_config: dict[str, Any], gateway_url: str) -> dict[str, Any]:
+    """Return a copy of *agent_config* with Fabric model IGW base_urls rebased onto *gateway_url*.
+
+    Rewrites ``models.*.settings.base_url`` and harness ``model.settings.base_url`` when the
+    URL points at the Inference Gateway. Third-party base URLs are left unchanged.
+    """
+    reachable = urlsplit(gateway_url.rstrip("/"))
+    reachable_origin = f"{reachable.scheme}://{reachable.netloc}"
+    config = copy.deepcopy(agent_config)
+    model_configs: list[Any] = []
+
+    models = config.get("models")
+    if isinstance(models, dict):
+        model_configs.extend(models.values())
+
+    harnesses = config.get("harnesses")
+    if isinstance(harnesses, dict):
+        for harness in harnesses.values():
+            if isinstance(harness, dict) and "model" in harness:
+                model_configs.append(harness["model"])
+
+    for model_config in model_configs:
+        if not isinstance(model_config, dict):
+            continue
+        settings = model_config.get("settings")
+        if not isinstance(settings, dict):
+            continue
+        current = settings.get("base_url")
+        if not isinstance(current, str) or "/apis/inference-gateway/" not in current:
+            continue
+        parts = urlsplit(current)
+        settings["base_url"] = f"{reachable_origin}{parts.path}"
+    return config
+
+
+def _is_fabric_agent_config(agent_config: dict[str, Any]) -> bool:
+    return agent_config.get("config_format") == NEMO_AGENTS_SPEC_CONFIG_FORMAT
+
+
+def _fabric_config_mount_path(config_mount_path: str) -> str:
+    parent = str(PurePosixPath(config_mount_path).parent)
+    if parent in ("", "."):
+        return f"/{AGENT_CONFIG_FILENAME}"
+    return f"{parent}/{AGENT_CONFIG_FILENAME}"
+
+
+def _fabric_server_cli_args(*, config_path: str, port: int) -> list[str]:
+    return [
+        "-m",
+        _FABRIC_SERVER_MODULE,
+        "--agent-config",
+        config_path,
+        "--host",
+        "0.0.0.0",
+        "--port",
+        str(port),
+    ]
+
+
 def executor_for_mode(config: DeploymentsRunnerConfig, mode: DeploymentMode) -> str | None:
     """Resolve the named deployments-plugin executor for *mode*."""
     if mode == "docker":
@@ -209,24 +274,34 @@ def build_deployment_config(
 ) -> DeploymentConfig:
     """Compile an agent into a long-running ``DeploymentConfig`` (Always).
 
-    NAT workflow YAML is always embedded in ``config_files`` (k8s mounts them).
-    Docker v1 ignores ``config_files``, so docker mode also injects the YAML via
-    ``NAT_CONFIG_YAML`` and a shell preamble that writes the file before ``nat``
-    starts. The main container binds ``0.0.0.0`` and exposes a readiness probe on
-    ``/health``.
+    NAT workflow configs start ``nat start fastapi`` with workflow YAML at
+    *config_mount_path*. Platform-owned Fabric configs start
+    ``python -m nemo_agents_plugin.fabric.server`` with ``agent.yaml`` beside the
+    NAT config directory. Docker mode materializes config from env because the
+    docker backend ignores ``config_files``; k8s mounts ``config_files`` via
+    ConfigMap subPath. The main container binds ``0.0.0.0`` and exposes a
+    readiness probe on ``/health``.
+
+    The caller is responsible for rebasing inference ``base_url`` values in
+    *nat_config* to a container-reachable gateway before calling this helper.
 
     ``platform_base_url`` is the container-reachable platform origin used to
     build the Inference Gateway URL. It is also exported as ``NMP_BASE_URL`` so
     SDK calls from inside the agent use the same platform instead of falling
     back to a baked or host CLI context.
     """
-    nat_yaml = yaml.safe_dump(nat_config, sort_keys=False)
+    is_fabric = _is_fabric_agent_config(nat_config)
+    config_yaml = yaml.safe_dump(nat_config, sort_keys=False)
+    config_path = _fabric_config_mount_path(config_mount_path) if is_fabric else config_mount_path
     env = [
         EnvVar(name="NMP_WORKSPACE", value=workspace),
         EnvVar(name="NMP_AGENT_NAME", value=name),
         EnvVar(name="NMP_BASE_URL", value=platform_base_url.rstrip("/")),
-        EnvVar(name=_NAT_CONFIG_ENV, value=config_mount_path),
     ]
+    if is_fabric:
+        env.append(EnvVar(name=_AGENT_CONFIG_PATH_ENV, value=config_path))
+    else:
+        env.append(EnvVar(name=_NAT_CONFIG_ENV, value=config_mount_path))
     volume_mounts: list[VolumeMount] = []
     init_containers: list[Container] = []
 
@@ -254,29 +329,24 @@ def build_deployment_config(
         )
         env.append(EnvVar(name="PYTHONPATH", value=_PLUGIN_WHEELS_MOUNT))
 
-    nat_args = [
-        "nat",
-        "start",
-        "fastapi",
-        "--config_file",
-        config_mount_path,
-        "--host",
-        "0.0.0.0",
-        "--port",
-        str(port),
-    ]
-    if mode == "docker":
-        # Docker backend does not mount config_files; materialize the YAML from env.
-        env.append(EnvVar(name="NAT_CONFIG_YAML", value=nat_yaml))
-        command = ["sh", "-c"]
-        args = [
-            f'mkdir -p "$(dirname "{config_mount_path}")" '
-            f'&& printf "%s" "$NAT_CONFIG_YAML" > "{config_mount_path}" '
-            f"&& exec {' '.join(nat_args)}"
-        ]
+    if is_fabric:
+        fabric_args = ["python", *_fabric_server_cli_args(config_path=config_path, port=port)]
+        if mode == "docker":
+            env.append(EnvVar(name=_AGENT_CONFIG_YAML_ENV, value=config_yaml))
+            command = ["sh", "-c"]
+            args = [
+                f'mkdir -p "$(dirname "{config_path}")" '
+                f'&& printf "%s" "$AGENT_CONFIG_YAML" > "{config_path}" '
+                f"&& exec {' '.join(fabric_args)}"
+            ]
+        else:
+            command = ["python"]
+            args = _fabric_server_cli_args(config_path=config_path, port=port)
     else:
-        command = ["nat", "start", "fastapi"]
-        args = [
+        nat_args = [
+            "nat",
+            "start",
+            "fastapi",
             "--config_file",
             config_mount_path,
             "--host",
@@ -284,6 +354,25 @@ def build_deployment_config(
             "--port",
             str(port),
         ]
+        if mode == "docker":
+            # Docker backend does not mount config_files; materialize the YAML from env.
+            env.append(EnvVar(name="NAT_CONFIG_YAML", value=config_yaml))
+            command = ["sh", "-c"]
+            args = [
+                f'mkdir -p "$(dirname "{config_mount_path}")" '
+                f'&& printf "%s" "$NAT_CONFIG_YAML" > "{config_mount_path}" '
+                f"&& exec {' '.join(nat_args)}"
+            ]
+        else:
+            command = ["nat", "start", "fastapi"]
+            args = [
+                "--config_file",
+                config_mount_path,
+                "--host",
+                "0.0.0.0",
+                "--port",
+                str(port),
+            ]
 
     container = Container(
         name=_CONTAINER_NAME,
@@ -315,7 +404,7 @@ def build_deployment_config(
         update={
             "init_containers": init_containers,
             "config_files": [
-                ConfigFile(path=config_mount_path, content=nat_yaml),
+                ConfigFile(path=config_path, content=config_yaml),
             ],
             "restart_policy": "Always",
             "auth_proxy_sidecar": auth_proxy_identity is not None,
@@ -386,11 +475,24 @@ class DeploymentsRunnerBackend(RunnerBackend):
         # agent targets the sidecar on localhost; the sidecar forwards to the
         # platform with a service-principal identity header.
         auth_proxy_identity: str | None = None
+        is_fabric = _is_fabric_agent_config(config)
         if platform_auth_enabled():
             auth_proxy_identity = _AUTH_PROXY_IDENTITY
-            config = rewrite_config_base_urls(config, f"http://127.0.0.1:{auth_proxy_port()}")
+            rewrite_target = f"http://127.0.0.1:{auth_proxy_port()}"
         else:
-            config = rewrite_config_base_urls(config, gateway)
+            rewrite_target = gateway
+
+        if is_fabric:
+            config = rewrite_fabric_config_base_urls(config, rewrite_target)
+        else:
+            config = rewrite_config_base_urls(config, rewrite_target)
+
+        deployment_labels = {
+            "nemo.agents/deployment": name,
+            "nemo.agents/mode": deployment_mode,
+        }
+        if is_fabric:
+            deployment_labels["nemo.agents/runtime"] = "fabric"
 
         deployment_config = build_deployment_config(
             name=name,
@@ -402,10 +504,7 @@ class DeploymentsRunnerBackend(RunnerBackend):
             config_mount_path=self._config.config_mount_path,
             mode=deployment_mode,
             plugin_wheels_init_image=self._config.plugin_wheels_init_image,
-            labels={
-                "nemo.agents/deployment": name,
-                "nemo.agents/mode": deployment_mode,
-            },
+            labels=deployment_labels,
             auth_proxy_identity=auth_proxy_identity,
         )
         await entities.create(deployment_config)

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -20,6 +20,7 @@ from nemo_agents_plugin.runner.deployments_backend import (
     map_status,
     resolve_agent_gateway_url,
     rewrite_config_base_urls,
+    rewrite_fabric_config_base_urls,
 )
 from nemo_deployments_plugin.entities import Deployment, DeploymentConfig
 from nemo_deployments_plugin.types import Endpoint as PluginEndpoint
@@ -112,6 +113,51 @@ def test_rewrite_config_base_urls_leaves_third_party_base_url() -> None:
     assert result["llms"]["llm"]["base_url"] == "https://api.openai.com/v1"
 
 
+def test_rewrite_fabric_config_base_urls_rebases_igw_host() -> None:
+    config = {
+        "config_format": "nemo-agents-spec-v1",
+        "models": {
+            "default": {
+                "provider": "openai",
+                "model": "test-model",
+                "settings": {
+                    "base_url": "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1",
+                },
+            }
+        },
+        "harnesses": {
+            "main": {
+                "model": {
+                    "provider": "openai",
+                    "model": "test-model",
+                    "settings": {
+                        "base_url": "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1",
+                    },
+                }
+            }
+        },
+    }
+    result = rewrite_fabric_config_base_urls(config, "http://nmp-api:8080")
+    expected = "http://nmp-api:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1"
+    assert result["models"]["default"]["settings"]["base_url"] == expected
+    assert result["harnesses"]["main"]["model"]["settings"]["base_url"] == expected
+    assert "localhost" in config["models"]["default"]["settings"]["base_url"]
+
+
+def test_rewrite_fabric_config_base_urls_leaves_third_party_base_url() -> None:
+    config = {
+        "models": {
+            "default": {
+                "provider": "openai",
+                "model": "test-model",
+                "settings": {"base_url": "https://api.openai.com/v1"},
+            }
+        }
+    }
+    result = rewrite_fabric_config_base_urls(config, "http://nmp-api:8080")
+    assert result["models"]["default"]["settings"]["base_url"] == "https://api.openai.com/v1"
+
+
 def test_executor_for_mode_prefers_mode_specific() -> None:
     cfg = DeploymentsRunnerConfig(
         default_executor="default-exec",
@@ -202,6 +248,64 @@ def test_build_deployment_config_docker_never_emits_init_containers() -> None:
         plugin_wheels_init_image="busybox:1.36",
     )
     assert cfg.init_containers == []
+
+
+_FABRIC_AGENT_CONFIG = {
+    "config_format": "nemo-agents-spec-v1",
+    "name": "fabric-agent",
+    "default_harness": "main",
+    "harnesses": {
+        "main": {
+            "provider": "codex",
+            "model": {"provider": "openai", "model": "test-model", "settings": {}},
+        }
+    },
+}
+
+
+def test_build_deployment_config_fabric_docker_uses_fabric_server() -> None:
+    cfg = build_deployment_config(
+        name="fabric-dep",
+        workspace="default",
+        image="fabric-runtime:latest",
+        port=8000,
+        nat_config=_FABRIC_AGENT_CONFIG,
+        platform_base_url="http://host.docker.internal:8080",
+        config_mount_path="/workspace/config.yaml",
+        mode="docker",
+    )
+    container = cfg.containers[0]
+    assert container.command == ["sh", "-c"]
+    assert any(e.name == "AGENT_CONFIG_YAML" for e in container.env)
+    assert not any(e.name == "NAT_CONFIG_YAML" for e in container.env)
+    assert any(e.name == "AGENT_CONFIG_PATH" and e.value == "/workspace/agent.yaml" for e in container.env)
+    assert "nemo_agents_plugin.fabric.server" in container.args[0]
+    assert container.readiness_probe is not None
+    assert container.readiness_probe.http_get is not None
+    assert container.readiness_probe.http_get.path == "/health"
+    assert cfg.config_files[0].path == "/workspace/agent.yaml"
+
+
+def test_build_deployment_config_fabric_k8s_uses_fabric_entrypoint() -> None:
+    cfg = build_deployment_config(
+        name="fabric-dep",
+        workspace="default",
+        image="fabric-runtime:latest",
+        port=8000,
+        nat_config=_FABRIC_AGENT_CONFIG,
+        platform_base_url="http://host.docker.internal:8080",
+        config_mount_path="/workspace/config.yaml",
+        mode="k8s",
+    )
+    container = cfg.containers[0]
+    assert container.command == ["python"]
+    assert container.args[0] == "-m"
+    assert container.args[1] == "nemo_agents_plugin.fabric.server"
+    assert "--agent-config" in container.args
+    assert "/workspace/agent.yaml" in container.args
+    assert "--host" in container.args and "0.0.0.0" in container.args
+    assert not any(e.name == "NAT_CONFIG_YAML" for e in container.env)
+    assert cfg.config_files[0].path == "/workspace/agent.yaml"
 
 
 def _backend(**deployments_kwargs: Any) -> DeploymentsRunnerBackend:
@@ -415,6 +519,124 @@ async def test_create_deployment_k8s_auth_off_no_sidecar() -> None:
     # Auth off: agent talks directly to the internal Service DNS (PR #899 behavior).
     assert baked["llms"]["llm"]["base_url"] == (
         "http://nmp-api:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_fabric_docker_rewrites_model_base_url() -> None:
+    backend = _backend(default_image="fabric:latest", default_executor="local-docker")
+    entities = AsyncMock()
+    backend._entities = entities
+    config = {
+        "config_format": "nemo-agents-spec-v1",
+        "name": "fabric-agent",
+        "default_harness": "main",
+        "harnesses": {
+            "main": {
+                "provider": "codex",
+                "model": {
+                    "provider": "openai",
+                    "model": "test-model",
+                    "settings": {
+                        "base_url": "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1",
+                    },
+                },
+            }
+        },
+    }
+    with patch("nemo_agents_plugin.runner.deployments_backend.get_base_url", return_value="http://localhost:8080"):
+        info = await backend.create_deployment(
+            workspace="default", name="fabric-dep", config=config, port=0, deployment_mode="docker"
+        )
+    assert info.status == "starting"
+    created_config = entities.create.await_args_list[0].args[0]
+    baked = yaml.safe_load(created_config.config_files[0].content)
+    assert baked["harnesses"]["main"]["model"]["settings"]["base_url"] == (
+        "http://host.docker.internal:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1"
+    )
+    assert created_config.labels["nemo.agents/runtime"] == "fabric"
+    assert "nemo_agents_plugin.fabric.server" in created_config.containers[0].args[0]
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_fabric_k8s_rewrites_model_base_url() -> None:
+    backend = _backend(
+        default_image="fabric:latest",
+        default_executor="k8s",
+        k8s_internal_base_url="http://nmp-api:8080",
+    )
+    entities = AsyncMock()
+    backend._entities = entities
+    config = {
+        "config_format": "nemo-agents-spec-v1",
+        "name": "fabric-agent",
+        "default_harness": "main",
+        "harnesses": {
+            "main": {
+                "provider": "codex",
+                "model": {
+                    "provider": "openai",
+                    "model": "test-model",
+                    "settings": {
+                        "base_url": "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1",
+                    },
+                },
+            }
+        },
+    }
+    with patch("nemo_agents_plugin.runner.deployments_backend.get_base_url", return_value="http://localhost:8080"):
+        info = await backend.create_deployment(
+            workspace="default", name="fabric-dep", config=config, port=0, deployment_mode="k8s"
+        )
+    assert info.status == "starting"
+    created_config = entities.create.await_args_list[0].args[0]
+    baked = yaml.safe_load(created_config.config_files[0].content)
+    assert baked["harnesses"]["main"]["model"]["settings"]["base_url"] == (
+        "http://nmp-api:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1"
+    )
+    assert created_config.containers[0].command == ["python"]
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_fabric_k8s_auth_on_rewrites_to_auth_proxy() -> None:
+    backend = _backend(
+        default_image="fabric:latest",
+        default_executor="k8s",
+        k8s_internal_base_url="http://nmp-api:8080",
+    )
+    entities = AsyncMock()
+    backend._entities = entities
+    config = {
+        "config_format": "nemo-agents-spec-v1",
+        "name": "fabric-agent",
+        "default_harness": "main",
+        "harnesses": {
+            "main": {
+                "provider": "codex",
+                "model": {
+                    "provider": "openai",
+                    "model": "test-model",
+                    "settings": {
+                        "base_url": "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1",
+                    },
+                },
+            }
+        },
+    }
+    with (
+        patch("nemo_agents_plugin.runner.deployments_backend.get_base_url", return_value="http://localhost:8080"),
+        patch("nemo_agents_plugin.runner.deployments_backend.platform_auth_enabled", return_value=True),
+        patch("nemo_agents_plugin.runner.deployments_backend.auth_proxy_port", return_value=8090),
+    ):
+        info = await backend.create_deployment(
+            workspace="default", name="fabric-dep", config=config, port=0, deployment_mode="k8s"
+        )
+    assert info.status == "starting"
+    created_config = entities.create.await_args_list[0].args[0]
+    assert created_config.auth_proxy_sidecar is True
+    baked = yaml.safe_load(created_config.config_files[0].content)
+    assert baked["harnesses"]["main"]["model"]["settings"]["base_url"] == (
+        "http://127.0.0.1:8090/apis/inference-gateway/v2/workspaces/default/openai/-/v1"
     )
 
 

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -181,7 +181,7 @@ def test_build_deployment_config_always_single_container() -> None:
         workspace="default",
         image="nat-runtime:latest",
         port=8000,
-        nat_config={"llms": {"nim": {"_type": "nim"}}},
+        agent_config={"llms": {"nim": {"_type": "nim"}}},
         platform_base_url="http://host.docker.internal:8080",
         config_mount_path="/workspace/config.yaml",
         mode="docker",
@@ -208,7 +208,7 @@ def test_build_deployment_config_k8s_uses_nat_entrypoint() -> None:
         workspace="default",
         image="nat-runtime:latest",
         port=8000,
-        nat_config={},
+        agent_config={},
         platform_base_url="http://nmp-api:8080",
         config_mount_path="/workspace/config.yaml",
         mode="k8s",
@@ -224,7 +224,7 @@ def test_build_deployment_config_k8s_option_b_when_image_set() -> None:
         workspace="default",
         image="nat-runtime:latest",
         port=8000,
-        nat_config={},
+        agent_config={},
         platform_base_url="http://nmp-api:8080",
         config_mount_path="/workspace/config.yaml",
         mode="k8s",
@@ -241,7 +241,7 @@ def test_build_deployment_config_docker_never_emits_init_containers() -> None:
         workspace="default",
         image="nat-runtime:latest",
         port=8000,
-        nat_config={},
+        agent_config={},
         platform_base_url="http://host.docker.internal:8080",
         config_mount_path="/workspace/config.yaml",
         mode="docker",
@@ -263,13 +263,29 @@ _FABRIC_AGENT_CONFIG = {
 }
 
 
+def test_build_deployment_config_docker_shell_escapes_config_path() -> None:
+    cfg = build_deployment_config(
+        name="spaced-dep",
+        workspace="default",
+        image="nat-runtime:latest",
+        port=8000,
+        agent_config={"llms": {"nim": {"_type": "nim"}}},
+        platform_base_url="http://host.docker.internal:8080",
+        config_mount_path="/workspace/my config/config.yaml",
+        mode="docker",
+    )
+    script = cfg.containers[0].args[0]
+    assert "'/workspace/my config/config.yaml'" in script
+    assert 'printf "%s" "$NAT_CONFIG_YAML"' in script
+
+
 def test_build_deployment_config_fabric_docker_uses_fabric_server() -> None:
     cfg = build_deployment_config(
         name="fabric-dep",
         workspace="default",
         image="fabric-runtime:latest",
         port=8000,
-        nat_config=_FABRIC_AGENT_CONFIG,
+        agent_config=_FABRIC_AGENT_CONFIG,
         platform_base_url="http://host.docker.internal:8080",
         config_mount_path="/workspace/config.yaml",
         mode="docker",
@@ -279,6 +295,7 @@ def test_build_deployment_config_fabric_docker_uses_fabric_server() -> None:
     assert any(e.name == "AGENT_CONFIG_YAML" for e in container.env)
     assert not any(e.name == "NAT_CONFIG_YAML" for e in container.env)
     assert any(e.name == "AGENT_CONFIG_PATH" and e.value == "/workspace/agent.yaml" for e in container.env)
+    assert next(e.value for e in container.env if e.name == "NMP_BASE_URL") == "http://host.docker.internal:8080"
     assert "nemo_agents_plugin.fabric.server" in container.args[0]
     assert container.readiness_probe is not None
     assert container.readiness_probe.http_get is not None
@@ -292,7 +309,7 @@ def test_build_deployment_config_fabric_k8s_uses_fabric_entrypoint() -> None:
         workspace="default",
         image="fabric-runtime:latest",
         port=8000,
-        nat_config=_FABRIC_AGENT_CONFIG,
+        agent_config=_FABRIC_AGENT_CONFIG,
         platform_base_url="http://host.docker.internal:8080",
         config_mount_path="/workspace/config.yaml",
         mode="k8s",


### PR DESCRIPTION
## Summary
- Extend `DeploymentsRunnerBackend` so `nemo-agents-spec-v1` agents compile to the Platform Fabric FastAPI shim (`python -m nemo_agents_plugin.fabric.server`) for Docker and Kubernetes, with `agent.yaml` injection/mount and `/health` readiness.
- Add `rewrite_fabric_config_base_urls()` so Fabric model/harness IGW URLs are rebased for container reachability (including auth-proxy), parallel to the existing NAT rewriter.
- Leave NAT `nat start fastapi` container behavior unchanged; add unit coverage for Fabric docker/k8s compile, rewrite, create, and auth-proxy paths.

Closes AIRCORE-947.

## Test plan
- [x] `uv run --frozen pytest plugins/nemo-agents/tests/unit/test_runner_deployments.py -v` (44 passed)
- [x] Gateway unit tests still green with deployment suite
- [x] `ty check` / pre-commit hooks on commit
- [x] CI on this PR
- [ ] Live Fabric container deploy once AIRCORE-902 ships Fabric in the default image (full matrix: AIRCORE-960)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for deploying Fabric agent configurations in Docker and Kubernetes.
  * Fabric deployments now start with the correct Fabric server entrypoint and configuration wiring for the target platform.
  * Automatically rebases Fabric model and harness `base_url` values to the inference gateway host when applicable.
  * When enabled, Fabric deployments can route `base_url` rewriting through an auth proxy.
* **Bug Fixes**
  * Clarified deployment configuration descriptions for the agent server listen port and the configuration mount path behavior for Fabric vs workflow deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->