### PR TITLE
feat(experimentalist): add the airline, retail, and telecom tau3 suites

### DIFF
--- a/plugins/nemo-experimentalist/benchmarks/README.md
+++ b/plugins/nemo-experimentalist/benchmarks/README.md
@@ -39,44 +39,54 @@ asserts that the quality partition covers all 89 canonical IDs exactly once.
 
 ## tau3 provenance
 
-Each tau3 suite scopes one domain of `sierra-research/tau3-bench@1` by task-ID prefix.
-All four share the package's 375 tasks, its content hash
-`sha256:a57304f682894ac061090769af771a3617664f3ff6e5417d4eadf8e30433e4d9`, and its
+Each tau3 suite scopes one domain of `sierra-research/tau3-bench@1` by task-ID prefix,
+so the four cover disjoint subsets of the package's 375 tasks. All share its content
+hash `sha256:a57304f682894ac061090769af771a3617664f3ff6e5417d4eadf8e30433e4d9` and its
 Harbor Hub record
 <https://hub.harborframework.com/datasets/sierra-research/tau3-bench/1>:
 
-| Suite | Task-ID prefix | Tasks | Quality split |
+| Suite | Task-ID prefix | Quality split | LLM judge scores it? |
 | --- | --- | --- | --- |
-| `tau3-banking.yaml` | `tau3-bench__tau3-banking_knowledge-` | 97 | 41/28/28 |
-| `tau3-airline.yaml` | `tau3-bench__tau3-airline-` | 50 | 20/10/20 |
-| `tau3-retail.yaml` | `tau3-bench__tau3-retail-` | 114 | 50/24/40 |
-| `tau3-telecom.yaml` | `tau3-bench__tau3-telecom-` | 114 | 50/24/40 |
+| `tau3-banking.yaml` | `tau3-bench__tau3-banking_knowledge-` | 41/28/28 | quality only |
+| `tau3-airline.yaml` | `tau3-bench__tau3-airline-` | 20/10/20 | no |
+| `tau3-retail.yaml` | `tau3-bench__tau3-retail-` | 50/24/40 | yes |
+| `tau3-telecom.yaml` | `tau3-bench__tau3-telecom-` | 50/24/40 | no |
 
 Banking's partition came from `optimization-datasets` `feat/tau2-other-domains`
 commit `025ecd2ef2b518ad81f6b22d3f3937af8906fb01`, whose
 `tau2-banking-knowledge-NNN` names map onto the canonical
-`tau3-bench__tau3-banking_knowledge-task-NNN` IDs. The other three take `test`
-from the domain's upstream `split_tasks.json` test list and carve `validation` out
-of its train list, every third entry in upstream order; that file's train and test
-lists partition the domain exactly, so the quality split needs nothing invented
-beyond the validation stride.
+`tau3-bench__tau3-banking_knowledge-task-NNN` IDs. The other three domains ship an
+upstream `split_tasks.json` whose train and test lists partition the domain exactly,
+so `test` is that file's test list verbatim and only `validation` is carved out, at
+train indices 2, 5, 8, and so on.
 
 A canonical ID is `tau3-bench__` plus the name Harbor's `adapters/tau3-bench` gives
-the task, `tau3-<domain>-<slugified upstream task ID>`. Re-deriving IDs from that
-adapter against a `tau2-bench` checkout reproduces the banking manifest exactly,
-which is how the other three manifests were built.
+the task, `tau3-<domain>-<slugified upstream task ID>`. Running that adapter's naming
+rule over a `tau2-bench` checkout reproduces the banking manifest exactly, and its
+`adapter_metadata.json` records the same per-domain counts this directory claims
+(`airline=50, retail=114, telecom=114, banking_knowledge=97`). Those two checks agree
+on every ID and count, but neither is the published package: only
+`run.py --validate-only` compares a manifest against the Hub, and banking is the one
+domain the adapter enumerates from a task directory rather than from
+`split_tasks.json`, so reproducing it does not exercise that selection path.
 
-Every fast partition is 6/3/3. Banking picks its tasks from a filtered subset; the
-other three sample each quality split at a fixed stride, so a smoke run spans the
-split instead of clustering at its start — telecom's task IDs sort by issue type, and
-the first twelve are all `mms_issue`.
+Every fast partition is 6/3/3. Banking picks from a filtered subset; the other three
+take `split[:: len(split) // n][:n]`, which spans each split instead of clustering at
+its start — telecom's IDs sort by issue type, and its first twelve are all
+`mms_issue`.
 
-A domain's `reward_basis` decides whether scoring needs an LLM judge. Banking's fast
-partition draws only from its 87 pure-database-state tasks. Airline scores on
-database state and a substring check of the agent's messages, and telecom on
-environment assertions and expected actions, so both are judge-free in either
-partition. 112 of retail's 114 tasks carry an `NL_ASSERTION`, so retail always
-scores through the judge.
+Whether scoring needs an LLM judge is per task, set by each task's `reward_basis`.
+Banking's fast partition draws only from its 87 pure-database-state tasks, so smoke
+runs skip the judge. Telecom scores on environment assertions and expected actions,
+and airline on database state plus a substring check of the agent's messages, so
+neither reaches the judge at all. Retail does: only its tasks 33 and 34 score on
+database state alone.
+
+Two caveats these domains inherit from the package. Airline's tasks all carry
+`nl_assertions` that its `reward_basis` omits, and only 6 of the 50 assert
+`communicate_info`, so 44 of them are scored on database state alone — a weaker bar
+than upstream tau2 airline. And airline is small enough that its quality split leaves
+the optimizer 20 train and 10 validation tasks, the least signal of any suite here.
 
 Each task also runs a `tau3-runtime` sidecar hosting the tau2 environment and user
 simulator. Tau-style suites set `models.user_simulator`, which makes the runner
@@ -140,8 +150,7 @@ uv run python benchmarks/run.py \
   --agent examples/tau3-nooa-agent
 ```
 
-The other tau3 domains change only `--suite`; the two tau3 configs and the agent are
-domain-independent.
+The other tau3 domains change only `--suite`.
 
 Both setup and agent execution require network access. Each AUT installs its own
 dependencies from its committed `uv.lock` inside the task container and does not

--- a/plugins/nemo-experimentalist/benchmarks/README.md
+++ b/plugins/nemo-experimentalist/benchmarks/README.md
@@ -64,10 +64,10 @@ A canonical ID is `tau3-bench__` plus the name Harbor's `adapters/tau3-bench` gi
 the task, `tau3-<domain>-<slugified upstream task ID>`. Running that adapter's naming
 rule over a `tau2-bench` checkout reproduces the banking manifest exactly, and its
 `adapter_metadata.json` records the same per-domain counts this directory claims
-(`airline=50, retail=114, telecom=114, banking_knowledge=97`). Those two checks agree
-on every ID and count, but neither is the published package: only
-`run.py --validate-only` compares a manifest against the Hub, and banking is the one
-domain the adapter enumerates from a task directory rather than from
+(`airline=50, retail=114, telecom=114, banking_knowledge=97`). The naming rule accounts
+for every ID and that metadata for every count, but neither is the published package:
+only `run.py --validate-only` compares a manifest against the Hub, and banking is the
+one domain the adapter enumerates from a task directory rather than from
 `split_tasks.json`, so reproducing it does not exercise that selection path.
 
 Every fast partition is 6/3/3. Banking picks from a filtered subset; the other three

--- a/plugins/nemo-experimentalist/benchmarks/README.md
+++ b/plugins/nemo-experimentalist/benchmarks/README.md
@@ -66,8 +66,13 @@ the task, `tau3-<domain>-<slugified upstream task ID>`. Re-deriving IDs from tha
 adapter against a `tau2-bench` checkout reproduces the banking manifest exactly,
 which is how the other three manifests were built.
 
-A domain's `reward_basis` decides whether scoring needs an LLM judge. Banking's 6/3/3
-fast partition draws only from its 87 pure-database-state tasks. Airline scores on
+Every fast partition is 6/3/3. Banking picks its tasks from a filtered subset; the
+other three sample each quality split at a fixed stride, so a smoke run spans the
+split instead of clustering at its start — telecom's task IDs sort by issue type, and
+the first twelve are all `mms_issue`.
+
+A domain's `reward_basis` decides whether scoring needs an LLM judge. Banking's fast
+partition draws only from its 87 pure-database-state tasks. Airline scores on
 database state and a substring check of the agent's messages, and telecom on
 environment assertions and expected actions, so both are judge-free in either
 partition. 112 of retail's 114 tasks carry an `NL_ASSERTION`, so retail always

--- a/plugins/nemo-experimentalist/benchmarks/README.md
+++ b/plugins/nemo-experimentalist/benchmarks/README.md
@@ -6,13 +6,19 @@
 These benchmarks measure M2 Experimentalist optimization on unmodified Harbor Hub
 packages. They do not cover M1 Insight → Eval Author behavior.
 
-Two suites ship today. Both store only task IDs and download task definitions into
+Five suites ship today. All store only task IDs and download task definitions into
 a local cache; no task content is vendored here.
 
 | Suite | Package | Tasks | Agent under test |
 | --- | --- | --- | --- |
 | `suites/terminal-bench-2.1.yaml` (default) | `terminal-bench/terminal-bench-2-1@6` | 89 | `examples/terminal-bench-agent` |
 | `suites/tau3-banking.yaml` | `sierra-research/tau3-bench@1`, banking scoped | 97 | `examples/tau3-nooa-agent` |
+| `suites/tau3-airline.yaml` | `sierra-research/tau3-bench@1`, airline scoped | 50 | `examples/tau3-nooa-agent` |
+| `suites/tau3-retail.yaml` | `sierra-research/tau3-bench@1`, retail scoped | 114 | `examples/tau3-nooa-agent` |
+| `suites/tau3-telecom.yaml` | `sierra-research/tau3-bench@1`, telecom scoped | 114 | `examples/tau3-nooa-agent` |
+
+The four tau3 suites share one agent: its `AGENT-SPEC.md` is domain-generic because
+the domain policy arrives at runtime in the task instruction.
 
 ## Terminal-Bench provenance
 
@@ -31,23 +37,41 @@ The 38/25/26 quality partition and 35/12/12 fast partition came from Gaia's
 the runner asks Harbor Hub for revision 6, verifies its content hash, and
 asserts that the quality partition covers all 89 canonical IDs exactly once.
 
-## tau3 banking provenance
+## tau3 provenance
 
-The suite scopes `sierra-research/tau3-bench@1` to its `banking_knowledge` domain:
+Each tau3 suite scopes one domain of `sierra-research/tau3-bench@1` by task-ID prefix.
+All four share the package's 375 tasks, its content hash
+`sha256:a57304f682894ac061090769af771a3617664f3ff6e5417d4eadf8e30433e4d9`, and its
+Harbor Hub record
+<https://hub.harborframework.com/datasets/sierra-research/tau3-bench/1>:
 
-- 97 of the package's 375 tasks, selected by the
-  `tau3-bench__tau3-banking_knowledge-` task-ID prefix
-- dataset content hash
-  `sha256:a57304f682894ac061090769af771a3617664f3ff6e5417d4eadf8e30433e4d9`
-- Harbor Hub record:
-  <https://hub.harborframework.com/datasets/sierra-research/tau3-bench/1>
+| Suite | Task-ID prefix | Tasks | Quality split |
+| --- | --- | --- | --- |
+| `tau3-banking.yaml` | `tau3-bench__tau3-banking_knowledge-` | 97 | 41/28/28 |
+| `tau3-airline.yaml` | `tau3-bench__tau3-airline-` | 50 | 20/10/20 |
+| `tau3-retail.yaml` | `tau3-bench__tau3-retail-` | 114 | 50/24/40 |
+| `tau3-telecom.yaml` | `tau3-bench__tau3-telecom-` | 114 | 50/24/40 |
 
-The 41/28/28 quality partition came from `optimization-datasets`
-`feat/tau2-other-domains` commit `025ecd2ef2b518ad81f6b22d3f3937af8906fb01`,
-whose `tau2-banking-knowledge-NNN` names map onto the canonical
-`tau3-bench__tau3-banking_knowledge-task-NNN` IDs. The 6/3/3 fast partition draws
-only from the 87 tasks whose `reward_basis` is pure database state, so smoke runs
-score deterministically without an LLM judge.
+Banking's partition came from `optimization-datasets` `feat/tau2-other-domains`
+commit `025ecd2ef2b518ad81f6b22d3f3937af8906fb01`, whose
+`tau2-banking-knowledge-NNN` names map onto the canonical
+`tau3-bench__tau3-banking_knowledge-task-NNN` IDs. The other three take `test`
+from the domain's upstream `split_tasks.json` test list and carve `validation` out
+of its train list, every third entry in upstream order; that file's train and test
+lists partition the domain exactly, so the quality split needs nothing invented
+beyond the validation stride.
+
+A canonical ID is `tau3-bench__` plus the name Harbor's `adapters/tau3-bench` gives
+the task, `tau3-<domain>-<slugified upstream task ID>`. Re-deriving IDs from that
+adapter against a `tau2-bench` checkout reproduces the banking manifest exactly,
+which is how the other three manifests were built.
+
+A domain's `reward_basis` decides whether scoring needs an LLM judge. Banking's 6/3/3
+fast partition draws only from its 87 pure-database-state tasks. Airline scores on
+database state and a substring check of the agent's messages, and telecom on
+environment assertions and expected actions, so both are judge-free in either
+partition. 112 of retail's 114 tasks carry an `NL_ASSERTION`, so retail always
+scores through the judge.
 
 Each task also runs a `tau3-runtime` sidecar hosting the tau2 environment and user
 simulator. Tau-style suites set `models.user_simulator`, which makes the runner
@@ -110,6 +134,9 @@ uv run python benchmarks/run.py \
   --config benchmarks/configs/tau3-smoke.yaml \
   --agent examples/tau3-nooa-agent
 ```
+
+The other tau3 domains change only `--suite`; the two tau3 configs and the agent are
+domain-independent.
 
 Both setup and agent execution require network access. Each AUT installs its own
 dependencies from its committed `uv.lock` inside the task container and does not

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-airline.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-airline.yaml
@@ -18,12 +18,11 @@ partitions:
     commit: 363133ada1936491fb5bcec33cd62c3518a99f65
     note: >-
       The commit above identifies the `tau2-bench` revision these splits were derived from.
-      `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
-      third entry of its train list, in upstream order, and `train` is the rest. Task IDs
-      only; no task content is copied here. The fast partition samples each quality split at a
-      fixed stride, 6/3/3, so a smoke run spans the split rather than clustering at its start.
-      Airline rewards score on database state and a substring check of the agent's messages,
-      so no LLM judge is involved.
+      `test` is this domain's upstream `split_tasks.json` test list, taken verbatim; its train
+      list supplies `validation` at indices 2, 5, 8, ... and `train` from the rest. The fast
+      partition takes `split[:: len(split) // n][:n]` for n of 6, 3, and 3, so a smoke run
+      spans each split rather than clustering at its start. Task IDs only; no task content is
+      copied here.
   quality:
     train: [
       "0", "1", "4", "5", "9", "10", "12", "14", "17", "20", "23", "27", "33", "34", "38", "39", "41",

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-airline.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-airline.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: 1
+dataset:
+  name: sierra-research/tau3-bench
+  ref: "1"
+  resolved_ref: sha256:a57304f682894ac061090769af771a3617664f3ff6e5417d4eadf8e30433e4d9
+  registry_url: https://hub.harborframework.com
+  source_url: https://hub.harborframework.com/datasets/sierra-research/tau3-bench/1
+  expected_task_count: 50
+  task_id_prefix: tau3-bench__tau3-airline-
+workspace: canonical-tau3-airline
+framework_skills:
+  - nooa
+partitions:
+  source:
+    commit: 363133ada1936491fb5bcec33cd62c3518a99f65
+    note: >-
+      The commit above identifies the `tau2-bench` revision these splits were derived from.
+      `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
+      third entry of its train list, in upstream order, and `train` is the rest. Task IDs
+      only; no task content is copied here. The fast partition is the first 6/3/3 of each
+      quality split. Airline rewards score on database state and a substring check of the
+      agent's messages, so no LLM judge is involved.
+  quality:
+    train: [
+      "0", "1", "4", "5", "9", "10", "12", "14", "17", "20", "23", "27", "33", "34", "38", "39", "41",
+      "42", "46", "47"
+    ]
+    validation: [
+      "3", "7", "11", "15", "21", "28", "36", "40", "43", "49"
+    ]
+    test: [
+      "2", "6", "8", "13", "16", "18", "19", "22", "24", "25", "26", "29", "30", "31", "32", "35", "37",
+      "44", "45", "48"
+    ]
+  fast:
+    train: [
+      "0", "1", "4", "5", "9", "10"
+    ]
+    validation: [
+      "3", "7", "11"
+    ]
+    test: [
+      "2", "6", "8"
+    ]

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-airline.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-airline.yaml
@@ -20,9 +20,10 @@ partitions:
       The commit above identifies the `tau2-bench` revision these splits were derived from.
       `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
       third entry of its train list, in upstream order, and `train` is the rest. Task IDs
-      only; no task content is copied here. The fast partition is the first 6/3/3 of each
-      quality split. Airline rewards score on database state and a substring check of the
-      agent's messages, so no LLM judge is involved.
+      only; no task content is copied here. The fast partition samples each quality split at a
+      fixed stride, 6/3/3, so a smoke run spans the split rather than clustering at its start.
+      Airline rewards score on database state and a substring check of the agent's messages,
+      so no LLM judge is involved.
   quality:
     train: [
       "0", "1", "4", "5", "9", "10", "12", "14", "17", "20", "23", "27", "33", "34", "38", "39", "41",
@@ -37,11 +38,11 @@ partitions:
     ]
   fast:
     train: [
-      "0", "1", "4", "5", "9", "10"
+      "0", "5", "12", "20", "33", "39"
     ]
     validation: [
-      "3", "7", "11"
+      "3", "15", "36"
     ]
     test: [
-      "2", "6", "8"
+      "2", "19", "30"
     ]

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-retail.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-retail.yaml
@@ -20,9 +20,10 @@ partitions:
       The commit above identifies the `tau2-bench` revision these splits were derived from.
       `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
       third entry of its train list, in upstream order, and `train` is the rest. Task IDs
-      only; no task content is copied here. The fast partition is the first 6/3/3 of each
-      quality split. 112 of the 114 retail tasks carry an `NL_ASSERTION` reward basis, so
-      retail scores through the LLM judge in both partitions.
+      only; no task content is copied here. The fast partition samples each quality split at a
+      fixed stride, 6/3/3, so a smoke run spans the split rather than clustering at its start.
+      112 of the 114 retail tasks carry an `NL_ASSERTION` reward basis, so retail scores
+      through the LLM judge in both partitions.
   quality:
     train: [
       "0", "1", "3", "4", "7", "8", "11", "13", "15", "16", "20", "21", "23", "24", "28", "29", "31",
@@ -41,11 +42,11 @@ partitions:
     ]
   fast:
     train: [
-      "0", "1", "3", "4", "7", "8"
+      "0", "15", "31", "54", "78", "93"
     ]
     validation: [
-      "2", "6", "10"
+      "2", "35", "81"
     ]
     test: [
-      "5", "9", "12"
+      "5", "42", "70"
     ]

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-retail.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-retail.yaml
@@ -18,12 +18,12 @@ partitions:
     commit: 363133ada1936491fb5bcec33cd62c3518a99f65
     note: >-
       The commit above identifies the `tau2-bench` revision these splits were derived from.
-      `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
-      third entry of its train list, in upstream order, and `train` is the rest. Task IDs
-      only; no task content is copied here. The fast partition samples each quality split at a
-      fixed stride, 6/3/3, so a smoke run spans the split rather than clustering at its start.
-      112 of the 114 retail tasks carry an `NL_ASSERTION` reward basis, so retail scores
-      through the LLM judge in both partitions.
+      `test` is this domain's upstream `split_tasks.json` test list, taken verbatim; its train
+      list supplies `validation` at indices 2, 5, 8, ... and `train` from the rest. The fast
+      partition takes `split[:: len(split) // n][:n]` for n of 6, 3, and 3, so a smoke run
+      spans each split rather than clustering at its start. Task IDs only; no task content is
+      copied here. Retail is the one tau3 domain whose fast partition cannot avoid the LLM
+      judge: only tasks 33 and 34 score on database state alone.
   quality:
     train: [
       "0", "1", "3", "4", "7", "8", "11", "13", "15", "16", "20", "21", "23", "24", "28", "29", "31",

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-retail.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-retail.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: 1
+dataset:
+  name: sierra-research/tau3-bench
+  ref: "1"
+  resolved_ref: sha256:a57304f682894ac061090769af771a3617664f3ff6e5417d4eadf8e30433e4d9
+  registry_url: https://hub.harborframework.com
+  source_url: https://hub.harborframework.com/datasets/sierra-research/tau3-bench/1
+  expected_task_count: 114
+  task_id_prefix: tau3-bench__tau3-retail-
+workspace: canonical-tau3-retail
+framework_skills:
+  - nooa
+partitions:
+  source:
+    commit: 363133ada1936491fb5bcec33cd62c3518a99f65
+    note: >-
+      The commit above identifies the `tau2-bench` revision these splits were derived from.
+      `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
+      third entry of its train list, in upstream order, and `train` is the rest. Task IDs
+      only; no task content is copied here. The fast partition is the first 6/3/3 of each
+      quality split. 112 of the 114 retail tasks carry an `NL_ASSERTION` reward basis, so
+      retail scores through the LLM judge in both partitions.
+  quality:
+    train: [
+      "0", "1", "3", "4", "7", "8", "11", "13", "15", "16", "20", "21", "23", "24", "28", "29", "31",
+      "34", "37", "41", "44", "46", "48", "50", "54", "57", "59", "63", "67", "69", "73", "75", "78",
+      "80", "82", "83", "85", "87", "89", "91", "93", "95", "98", "99", "104", "105", "107", "109", "112",
+      "113"
+    ]
+    validation: [
+      "2", "6", "10", "14", "19", "22", "25", "30", "35", "43", "47", "52", "58", "66", "72", "76", "81",
+      "84", "88", "92", "96", "103", "106", "110"
+    ]
+    test: [
+      "5", "9", "12", "17", "18", "26", "27", "32", "33", "36", "38", "39", "40", "42", "45", "49", "51",
+      "53", "55", "56", "60", "61", "62", "64", "65", "68", "70", "71", "74", "77", "79", "86", "90",
+      "94", "97", "100", "101", "102", "108", "111"
+    ]
+  fast:
+    train: [
+      "0", "1", "3", "4", "7", "8"
+    ]
+    validation: [
+      "2", "6", "10"
+    ]
+    test: [
+      "5", "9", "12"
+    ]

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-telecom.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-telecom.yaml
@@ -18,12 +18,11 @@ partitions:
     commit: 363133ada1936491fb5bcec33cd62c3518a99f65
     note: >-
       The commit above identifies the `tau2-bench` revision these splits were derived from.
-      `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
-      third entry of its train list, in upstream order, and `train` is the rest. Task IDs
-      only; no task content is copied here. The fast partition samples each quality split at a
-      fixed stride, 6/3/3, so a smoke run spans the split rather than clustering at its start.
-      Telecom rewards score on environment assertions and expected actions, so no LLM judge is
-      involved.
+      `test` is this domain's upstream `split_tasks.json` test list, taken verbatim; its train
+      list supplies `validation` at indices 2, 5, 8, ... and `train` from the rest. The fast
+      partition takes `split[:: len(split) // n][:n]` for n of 6, 3, and 3, so a smoke run
+      spans each split rather than clustering at its start. Task IDs only; no task content is
+      copied here.
   quality:
     train:
       - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-hard

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-telecom.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-telecom.yaml
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+schema_version: 1
+dataset:
+  name: sierra-research/tau3-bench
+  ref: "1"
+  resolved_ref: sha256:a57304f682894ac061090769af771a3617664f3ff6e5417d4eadf8e30433e4d9
+  registry_url: https://hub.harborframework.com
+  source_url: https://hub.harborframework.com/datasets/sierra-research/tau3-bench/1
+  expected_task_count: 114
+  task_id_prefix: tau3-bench__tau3-telecom-
+workspace: canonical-tau3-telecom
+framework_skills:
+  - nooa
+partitions:
+  source:
+    commit: 363133ada1936491fb5bcec33cd62c3518a99f65
+    note: >-
+      The commit above identifies the `tau2-bench` revision these splits were derived from.
+      `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
+      third entry of its train list, in upstream order, and `train` is the rest. Task IDs
+      only; no task content is copied here. The fast partition is the first 6/3/3 of each
+      quality split. Telecom rewards score on environment assertions and expected actions, so
+      no LLM judge is involved.
+  quality:
+    train:
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-none
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-enabled-off-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-user-abroad-roaming-enabled-off-persona-none
+      - mms-issue-airplane-mode-on-bad-network-preference-break-apn-mms-setting-data-mode-off-unseat-sim-card-user-abroad-roaming-disabled-off-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-break-apn-mms-setting-data-usage-exceeded-persona-hard
+      - mms-issue-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-persona-easy
+      - mms-issue-bad-network-preference-bad-wifi-calling-break-app-both-permissions-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-none
+      - mms-issue-bad-network-preference-bad-wifi-calling-break-app-sms-permission-data-mode-off-unseat-sim-card-user-abroad-roaming-enabled-off-persona-hard
+      - mms-issue-bad-network-preference-break-app-sms-permission-data-mode-off-data-usage-exceeded-user-abroad-roaming-enabled-off-persona-none
+      - mms-issue-bad-network-preference-user-abroad-roaming-disabled-on-persona-none
+      - mms-issue-bad-wifi-calling-break-apn-mms-setting-break-app-sms-permission-data-usage-exceeded-persona-hard
+      - mms-issue-bad-wifi-calling-break-apn-mms-setting-unseat-sim-card-user-abroad-roaming-enabled-off-persona-easy
+      - mms-issue-bad-wifi-calling-data-mode-off-data-usage-exceeded-persona-easy
+      - mms-issue-break-apn-mms-setting-data-mode-off-user-abroad-roaming-disabled-on-persona-hard
+      - mms-issue-break-app-both-permissions-data-usage-exceeded-persona-hard
+      - mms-issue-break-app-sms-permission-data-usage-exceeded-user-abroad-roaming-disabled-on-persona-none
+      - mms-issue-break-app-storage-permission-data-usage-exceeded-persona-easy
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-persona-hard
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-bad-vpn-data-mode-off-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-hard
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-bad-vpn-data-mode-off-data-saver-mode-on-user-abroad-roaming-disabled-off-persona-hard
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-bad-vpn-data-mode-off-data-usage-exceeded-user-abroad-roaming-enabled-off-persona-easy
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-bad-vpn-data-saver-mode-on-user-abroad-roaming-disabled-on-persona-easy
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-data-mode-off-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-disabled-on-persona-none
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-data-mode-off-user-abroad-roaming-disabled-on-persona-hard
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-none
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-user-abroad-roaming-enabled-off-persona-easy
+      - mobile-data-issue-airplane-mode-on-data-mode-off-persona-none
+      - mobile-data-issue-bad-network-preference-bad-vpn-data-mode-off-data-saver-mode-on-persona-none
+      - mobile-data-issue-bad-network-preference-bad-vpn-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-easy
+      - mobile-data-issue-bad-network-preference-bad-vpn-user-abroad-roaming-enabled-off-persona-easy
+      - mobile-data-issue-bad-network-preference-data-mode-off-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-easy
+      - mobile-data-issue-bad-network-preference-user-abroad-roaming-enabled-off-persona-hard
+      - mobile-data-issue-bad-vpn-data-saver-mode-on-user-abroad-roaming-disabled-on-persona-none
+      - mobile-data-issue-data-mode-off-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-hard
+      - mobile-data-issue-data-saver-mode-on-data-usage-exceeded-persona-easy
+      - service-issue-airplane-mode-on-break-apn-settings-persona-hard
+      - service-issue-airplane-mode-on-break-apn-settings-contract-end-suspension-unseat-sim-card-persona-easy
+      - service-issue-airplane-mode-on-break-apn-settings-lock-sim-card-pin-overdue-bill-suspension-unseat-sim-card-persona-none
+      - service-issue-airplane-mode-on-break-apn-settings-overdue-bill-suspension-unseat-sim-card-persona-none
+      - service-issue-airplane-mode-on-lock-sim-card-pin-overdue-bill-suspension-unseat-sim-card-persona-easy
+      - service-issue-airplane-mode-on-lock-sim-card-pin-unseat-sim-card-persona-hard
+      - service-issue-airplane-mode-on-unseat-sim-card-persona-none
+      - service-issue-break-apn-settings-lock-sim-card-pin-overdue-bill-suspension-unseat-sim-card-persona-easy
+      - service-issue-contract-end-suspension-lock-sim-card-pin-persona-hard
+      - service-issue-lock-sim-card-pin-overdue-bill-suspension-persona-easy
+    validation:
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-enabled-off-persona-none
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-storage-permission-unseat-sim-card-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-break-apn-mms-setting-break-app-storage-permission-persona-none
+      - mms-issue-airplane-mode-on-bad-network-preference-data-usage-exceeded-persona-none
+      - mms-issue-bad-network-preference-bad-wifi-calling-break-app-both-permissions-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-hard
+      - mms-issue-bad-network-preference-user-abroad-roaming-disabled-off-persona-none
+      - mms-issue-bad-wifi-calling-break-apn-mms-setting-data-mode-off-data-usage-exceeded-unseat-sim-card-persona-none
+      - mms-issue-break-apn-mms-setting-data-mode-off-data-usage-exceeded-user-abroad-roaming-disabled-on-persona-hard
+      - mms-issue-break-app-both-permissions-unseat-sim-card-user-abroad-roaming-disabled-on-persona-hard
+      - mms-issue-break-app-storage-permission-unseat-sim-card-user-abroad-roaming-disabled-on-persona-easy
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-bad-vpn-data-mode-off-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-disabled-on-persona-none
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-bad-vpn-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-enabled-off-persona-none
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-data-mode-off-data-usage-exceeded-user-abroad-roaming-disabled-on-persona-none
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-easy
+      - mobile-data-issue-airplane-mode-on-user-abroad-roaming-enabled-off-persona-none
+      - mobile-data-issue-bad-network-preference-bad-vpn-user-abroad-roaming-disabled-on-persona-none
+      - mobile-data-issue-bad-network-preference-data-saver-mode-on-data-usage-exceeded-persona-hard
+      - mobile-data-issue-data-mode-off-data-usage-exceeded-persona-none
+      - mobile-data-issue-data-usage-exceeded-user-abroad-roaming-enabled-off-persona-easy
+      - service-issue-airplane-mode-on-break-apn-settings-lock-sim-card-pin-persona-none
+      - service-issue-airplane-mode-on-break-apn-settings-unseat-sim-card-persona-none
+      - service-issue-airplane-mode-on-overdue-bill-suspension-unseat-sim-card-persona-easy
+      - service-issue-break-apn-settings-overdue-bill-suspension-unseat-sim-card-persona-hard
+    test:
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-unseat-sim-card-user-abroad-roaming-enabled-off-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-none
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-break-app-both-permissions-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-break-app-storage-permission-data-mode-off-user-abroad-roaming-enabled-off-persona-easy
+      - mms-issue-airplane-mode-on-bad-wifi-calling-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-enabled-off-persona-none
+      - mms-issue-airplane-mode-on-bad-wifi-calling-user-abroad-roaming-enabled-off-persona-easy
+      - mms-issue-airplane-mode-on-break-app-both-permissions-persona-hard
+      - mms-issue-airplane-mode-on-break-app-both-permissions-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-none
+      - mms-issue-bad-network-preference-bad-wifi-calling-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-enabled-off-persona-easy
+      - mms-issue-bad-network-preference-break-app-both-permissions-persona-easy
+      - mms-issue-bad-network-preference-break-app-sms-permission-user-abroad-roaming-disabled-on-persona-hard
+      - mms-issue-bad-network-preference-data-mode-off-user-abroad-roaming-disabled-on-persona-none
+      - mms-issue-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-none
+      - mms-issue-break-apn-mms-setting-user-abroad-roaming-enabled-off-persona-hard
+      - mms-issue-break-app-sms-permission-data-mode-off-persona-none
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-bad-vpn-data-mode-off-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-enabled-off-persona-easy
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-data-mode-off-data-saver-mode-on-persona-hard
+      - mobile-data-issue-airplane-mode-on-data-mode-off-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-enabled-off-persona-hard
+      - mobile-data-issue-airplane-mode-on-data-saver-mode-on-user-abroad-roaming-disabled-on-persona-none
+      - mobile-data-issue-bad-network-preference-bad-vpn-data-mode-off-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-enabled-off-persona-easy
+      - mobile-data-issue-bad-network-preference-bad-vpn-data-saver-mode-on-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-easy
+      - mobile-data-issue-bad-network-preference-bad-vpn-user-abroad-roaming-disabled-off-persona-hard
+      - mobile-data-issue-bad-vpn-data-mode-off-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-none
+      - mobile-data-issue-data-saver-mode-on-user-abroad-roaming-enabled-off-persona-easy
+      - service-issue-airplane-mode-on-break-apn-settings-contract-end-suspension-lock-sim-card-pin-persona-none
+      - service-issue-airplane-mode-on-break-apn-settings-contract-end-suspension-lock-sim-card-pin-unseat-sim-card-persona-easy
+      - service-issue-airplane-mode-on-break-apn-settings-lock-sim-card-pin-overdue-bill-suspension-persona-hard
+      - service-issue-airplane-mode-on-break-apn-settings-lock-sim-card-pin-unseat-sim-card-persona-none
+      - service-issue-airplane-mode-on-break-apn-settings-overdue-bill-suspension-persona-none
+      - service-issue-airplane-mode-on-contract-end-suspension-lock-sim-card-pin-unseat-sim-card-persona-hard
+      - service-issue-airplane-mode-on-lock-sim-card-pin-persona-easy
+      - service-issue-airplane-mode-on-lock-sim-card-pin-overdue-bill-suspension-persona-easy
+      - service-issue-airplane-mode-on-overdue-bill-suspension-persona-none
+      - service-issue-break-apn-settings-contract-end-suspension-lock-sim-card-pin-persona-hard
+      - service-issue-break-apn-settings-contract-end-suspension-lock-sim-card-pin-unseat-sim-card-persona-hard
+      - service-issue-break-apn-settings-lock-sim-card-pin-persona-none
+      - service-issue-break-apn-settings-lock-sim-card-pin-overdue-bill-suspension-persona-easy
+      - service-issue-contract-end-suspension-unseat-sim-card-persona-hard
+      - service-issue-overdue-bill-suspension-unseat-sim-card-persona-easy
+  fast:
+    train:
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-none
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-enabled-off-persona-hard
+    validation:
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-enabled-off-persona-none
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-easy
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-storage-permission-unseat-sim-card-persona-hard
+    test:
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-unseat-sim-card-user-abroad-roaming-enabled-off-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-none
+      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-easy

--- a/plugins/nemo-experimentalist/benchmarks/suites/tau3-telecom.yaml
+++ b/plugins/nemo-experimentalist/benchmarks/suites/tau3-telecom.yaml
@@ -20,9 +20,10 @@ partitions:
       The commit above identifies the `tau2-bench` revision these splits were derived from.
       `test` is this domain's upstream `split_tasks.json` test list; `validation` is every
       third entry of its train list, in upstream order, and `train` is the rest. Task IDs
-      only; no task content is copied here. The fast partition is the first 6/3/3 of each
-      quality split. Telecom rewards score on environment assertions and expected actions, so
-      no LLM judge is involved.
+      only; no task content is copied here. The fast partition samples each quality split at a
+      fixed stride, 6/3/3, so a smoke run spans the split rather than clustering at its start.
+      Telecom rewards score on environment assertions and expected actions, so no LLM judge is
+      involved.
   quality:
     train:
       - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-hard
@@ -144,16 +145,16 @@ partitions:
   fast:
     train:
       - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-hard
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-hard
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-persona-easy
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-easy
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-none
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-enabled-off-persona-hard
+      - mms-issue-airplane-mode-on-bad-network-preference-break-apn-mms-setting-data-mode-off-unseat-sim-card-user-abroad-roaming-disabled-off-persona-easy
+      - mms-issue-bad-wifi-calling-break-apn-mms-setting-unseat-sim-card-user-abroad-roaming-enabled-off-persona-easy
+      - mobile-data-issue-airplane-mode-on-bad-network-preference-bad-vpn-data-mode-off-data-saver-mode-on-user-abroad-roaming-disabled-off-persona-hard
+      - mobile-data-issue-bad-network-preference-bad-vpn-data-mode-off-data-saver-mode-on-persona-none
+      - service-issue-airplane-mode-on-break-apn-settings-persona-hard
     validation:
       - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-enabled-off-persona-none
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-off-persona-easy
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-app-storage-permission-unseat-sim-card-persona-hard
+      - mms-issue-break-apn-mms-setting-data-mode-off-data-usage-exceeded-user-abroad-roaming-disabled-on-persona-hard
+      - mobile-data-issue-bad-network-preference-bad-vpn-user-abroad-roaming-disabled-on-persona-none
     test:
       - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-unseat-sim-card-user-abroad-roaming-enabled-off-persona-hard
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-sms-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-none
-      - mms-issue-airplane-mode-on-bad-network-preference-bad-wifi-calling-break-apn-mms-setting-break-app-storage-permission-data-mode-off-data-usage-exceeded-unseat-sim-card-user-abroad-roaming-disabled-on-persona-easy
+      - mms-issue-bad-wifi-calling-break-apn-mms-setting-break-app-both-permissions-data-mode-off-data-usage-exceeded-user-abroad-roaming-disabled-off-persona-none
+      - service-issue-airplane-mode-on-break-apn-settings-contract-end-suspension-lock-sim-card-pin-unseat-sim-card-persona-easy

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_benchmark.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_benchmark.py
@@ -27,17 +27,29 @@ def _load_runner() -> ModuleType:
     return module
 
 
+# Quality and fast train/validation/test sizes, as documented in benchmarks/README.md.
+DOCUMENTED_SPLIT_SIZES = {
+    "terminal-bench-2.1": ((38, 25, 26), (35, 12, 12)),
+    "tau3-banking": ((41, 28, 28), (6, 3, 3)),
+    "tau3-airline": ((20, 10, 20), (6, 3, 3)),
+    "tau3-retail": ((50, 24, 40), (6, 3, 3)),
+    "tau3-telecom": ((50, 24, 40), (6, 3, 3)),
+}
+
+
 @pytest.mark.parametrize(
     "suite_path",
     sorted((BENCHMARK_ROOT / "suites").glob("*.yaml")),
     ids=lambda path: path.stem,
 )
 def test_shipped_suite_agrees_with_its_own_partitions(suite_path: Path) -> None:
-    """Check each manifest against the runner's canonical rules, minus the live Hub.
+    """Check each manifest for the mistakes that do not need the live Hub to detect.
 
-    Substituting the quality partition for the Hub's task list still catches an
-    ``expected_task_count`` that disagrees with the split, a fast entry outside the
-    domain, and overlapping splits — the ways a hand-written manifest goes wrong.
+    Substituting the quality partition for the Hub's task list leaves the ID-level
+    checks tautological, but still catches an ``expected_task_count`` that disagrees
+    with the split, a fast entry outside the quality partition, overlapping splits,
+    entries YAML read as something other than strings, and a framework skill that
+    resolves to no directory. Rebalancing a split stays caught by its recorded sizes.
     """
     runner = _load_runner()
     suite = runner.load_suite(suite_path)
@@ -49,6 +61,9 @@ def test_shipped_suite_agrees_with_its_own_partitions(suite_path: Path) -> None:
     )
 
     assert suite.framework_skills_dirs(PLUGIN_ROOT)
+    quality_sizes, fast_sizes = DOCUMENTED_SPLIT_SIZES[suite_path.stem]
+    for split, expected in ((suite.partitions.quality, quality_sizes), (suite.partitions.fast, fast_sizes)):
+        assert (len(split.train), len(split.validation), len(split.test)) == expected
 
 
 def test_terminal_bench_suite_corrects_the_upstream_task_id() -> None:

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_benchmark.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_benchmark.py
@@ -27,23 +27,36 @@ def _load_runner() -> ModuleType:
     return module
 
 
-def test_shipped_suite_covers_canonical_count_and_fast_subset() -> None:
+@pytest.mark.parametrize(
+    "suite_path",
+    sorted((BENCHMARK_ROOT / "suites").glob("*.yaml")),
+    ids=lambda path: path.stem,
+)
+def test_shipped_suite_agrees_with_its_own_partitions(suite_path: Path) -> None:
+    """Check each manifest against the runner's canonical rules, minus the live Hub.
+
+    Substituting the quality partition for the Hub's task list still catches an
+    ``expected_task_count`` that disagrees with the split, a fast entry outside the
+    domain, and overlapping splits — the ways a hand-written manifest goes wrong.
+    """
     runner = _load_runner()
-    suite = runner.load_suite(BENCHMARK_ROOT / "suites" / "terminal-bench-2.1.yaml")
-    canonical_ids = set(suite.partitions.quality.all_ids())
+    suite = runner.load_suite(suite_path)
 
     runner.validate_canonical_suite(
         suite,
-        canonical_task_ids=canonical_ids,
+        canonical_task_ids=set(suite.partitions.quality.all_ids()),
         resolved_ref=suite.dataset.resolved_ref,
     )
 
-    assert len(suite.partitions.quality.train) == 38
-    assert len(suite.partitions.quality.validation) == 25
-    assert len(suite.partitions.quality.test) == 26
-    assert len(suite.partitions.fast.train) == 35
-    assert len(suite.partitions.fast.validation) == 12
-    assert len(suite.partitions.fast.test) == 12
+    assert suite.framework_skills_dirs(PLUGIN_ROOT)
+
+
+def test_terminal_bench_suite_corrects_the_upstream_task_id() -> None:
+    runner = _load_runner()
+    suite = runner.load_suite(BENCHMARK_ROOT / "suites" / "terminal-bench-2.1.yaml")
+
+    canonical_ids = set(suite.partitions.quality.all_ids())
+
     assert "install-windows-3.11" in canonical_ids
     assert "install-windows-3-11" not in canonical_ids
 


### PR DESCRIPTION
Follow-up to #935, which added `banking_knowledge`. `sierra-research/tau3-bench@1` holds 375 tasks across four tau2 domains; this expresses the other three as suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TAU3 benchmark suites for airline, retail, and telecom domains.
  * Benchmark coverage now includes five suites: Terminal-Bench and four TAU3 domains.
  * Added quality and fast partitions for the new suites.
  * Users can switch between TAU3 domains by changing the `--suite` option.

* **Documentation**
  * Updated benchmark documentation with suite details, task identifiers, partitioning guidance, provenance, and domain-specific considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->