### PR TITLE
feat(studio): seed the Data Designer builder from a generated job config

### DIFF
--- a/web/packages/studio/src/components/NewDataDesignerJobForm/constants.ts
+++ b/web/packages/studio/src/components/NewDataDesignerJobForm/constants.ts
@@ -6,7 +6,7 @@ export const DATA_DESIGNER_JOB_GENERATOR_SYSTEM_PROMPT = `You are a Data Designe
 You must always call the tool exactly once with the "job_request" argument. The job_request must have:
 - spec (required): { num_records (positive integer), config (object) }
 - config must have "columns" (array with at least one column). Each column must have "name" (string) and "column_type" (string). Add type-specific fields per column_type (e.g. expression: expr, dtype; sampler: sampler_type, params; llm-text: prompt, model_alias).
-- If any column uses model_alias, include config.model_configs with matching alias, model, and provider (required). Set provider from the model identifier (e.g. "openai" for openai/gpt-3.5-turbo) or use "workspace/provider-name". Add optional inference_parameters (e.g. generation_type: "chat-completion", max_tokens).
+- If any column uses model_alias, include config.model_configs with matching alias, model, and provider (required). Add optional inference_parameters (e.g. generation_type: "chat-completion", max_tokens).
 - Optionally job_request.name (no spaces; use hyphens or underscores, e.g. "my-data-job"), description, project; optionally config.seed_config.
 
 Critical rules (these prevent silent 422s or runtime failures):

--- a/web/packages/studio/src/components/NewDataDesignerJobForm/tools.ts
+++ b/web/packages/studio/src/components/NewDataDesignerJobForm/tools.ts
@@ -19,7 +19,7 @@ export const generateDataDesignerJobRequestTool: ChatCompletionTool = {
   type: 'function',
   function: {
     name: 'generate_data_designer_job_request',
-    description: `Generate a Data Designer job request from the user's description. Call with job_request containing a valid spec: spec.num_records (positive integer) and spec.config (object with "columns" array, at least one column). Optional: job_request.name, job_request.description, job_request.project. ${COLUMN_TYPE_DESCRIPTION} If using LLM columns, include spec.config.model_configs: array of { "alias": string, "model": string, "provider": string (required), "inference_parameters"?: { "generation_type": "chat-completion", "max_tokens"?: number } }. Each model_config MUST have "provider": the model provider name (e.g. "openai" for openai/gpt-3.5-turbo, or "workspace/provider-name"). Keep config minimal and valid for preview.`,
+    description: `Generate a Data Designer job request from the user's description. Call with job_request containing a valid spec: spec.num_records (positive integer) and spec.config (object with "columns" array, at least one column). Optional: job_request.name, job_request.description, job_request.project. ${COLUMN_TYPE_DESCRIPTION} If using LLM columns, include spec.config.model_configs: array of { "alias": string, "model": string, "provider": string (required), "inference_parameters"?: { "generation_type": "chat-completion", "max_tokens"?: number } }. Each model_config MUST have "provider": the model provider name. Keep config minimal and valid for preview.`,
     parameters: {
       type: 'object',
       properties: {
@@ -152,12 +152,12 @@ export const generateDataDesignerJobRequestTool: ChatCompletionTool = {
                           alias: { type: 'string' },
                           model: {
                             type: 'string',
-                            description: 'Model identifier (e.g. openai/gpt-3.5-turbo).',
+                            description: 'Model identifier (e.g. workspace/model-name).',
                           },
                           provider: {
                             type: 'string',
                             description:
-                              'Model provider name. Required. Use the provider part of the model (e.g. "openai" for openai/gpt-3.5-turbo) or "workspace/provider-name" if workspace-scoped.',
+                              'Model provider name. Required. Use the provider part of the model or "workspace/provider-name" if workspace-scoped.',
                           },
                           inference_parameters: {
                             type: 'object',

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/aiSeed.test.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/aiSeed.test.ts
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
+import type {
+  CreateJobRequest as DataDesignerJobRequest,
+  DataDesignerConfig,
+} from '@nemo/sdk/generated/data-designer/schema';
+import {
+  ERROR_NO_COLUMNS,
+  ERROR_NO_LOADABLE_COLUMNS,
+  getGeneratedJobRequestFromState,
+  seedFromJobRequest,
+  validateGeneratedJobRequest,
+} from '@studio/routes/DataDesignerJobBuildRoute/aiSeed';
+
+const MODEL_GROUPS: ModelWorkspaceGroup[] = [
+  {
+    workspace: 'default',
+    models: [
+      {
+        id: 'default/llama-3.3',
+        workspace: 'default',
+        name: 'llama-3.3',
+        created_at: '',
+        updated_at: '',
+        model_providers: ['default/nim'],
+      },
+    ],
+  } as unknown as ModelWorkspaceGroup,
+];
+
+const config = (overrides: Partial<DataDesignerConfig> = {}): DataDesignerConfig =>
+  ({
+    columns: [
+      {
+        name: 'topic',
+        column_type: 'sampler',
+        sampler_type: 'category',
+        params: { values: ['science', 'history'] },
+      },
+      {
+        name: 'question',
+        column_type: 'llm-text',
+        prompt: 'Write a question about {{ topic }}.',
+        model_alias: 'gen',
+      },
+    ],
+    model_configs: [{ alias: 'gen', model: 'gpt-4o', provider: 'openai' }],
+    ...overrides,
+  }) as unknown as DataDesignerConfig;
+
+const jobRequest = (overrides: Partial<DataDesignerConfig> = {}): DataDesignerJobRequest => ({
+  name: 'qa-pairs',
+  spec: { num_records: 50, config: config(overrides) },
+});
+
+describe('validateGeneratedJobRequest', () => {
+  it('accepts a config the builder can load, resolving models against the workspace', () => {
+    const result = validateGeneratedJobRequest(jobRequest(), MODEL_GROUPS);
+
+    expect(result.status).toBe('valid');
+    if (result.status !== 'valid') return;
+    expect(result.seed.columns.map((column) => column.name)).toEqual(['topic', 'question']);
+    expect(result.seed.models).toEqual([
+      expect.objectContaining({
+        alias: 'gen',
+        model: 'default/llama-3.3',
+        provider: 'default/nim',
+      }),
+    ]);
+    expect(result.jobRequest.spec.config.model_configs?.[0]).toEqual(
+      expect.objectContaining({ model: 'default/llama-3.3', provider: 'default/nim' })
+    );
+    expect(result.warnings).toEqual([
+      '"gpt-4o" is not available in this workspace — alias "gen" now uses "default/llama-3.3".',
+    ]);
+  });
+
+  it('points every alias at the model that drafted the config', () => {
+    const result = validateGeneratedJobRequest(jobRequest(), MODEL_GROUPS, {
+      model: 'default/llama-3.3',
+      provider: 'default/nim',
+    });
+
+    expect(result.status).toBe('valid');
+    if (result.status !== 'valid') return;
+    expect(result.seed.models).toEqual([
+      expect.objectContaining({
+        alias: 'gen',
+        model: 'default/llama-3.3',
+        provider: 'default/nim',
+      }),
+    ]);
+    expect(result.warnings).toEqual([
+      'Alias "gen" now uses "default/llama-3.3" — the model you selected — instead of the drafted "gpt-4o".',
+    ]);
+  });
+
+  it('uses the generation model even when it is not in the loaded model list', () => {
+    // The picker's list is search-filtered, so the selected model may not appear in it.
+    const result = validateGeneratedJobRequest(jobRequest(), [], {
+      model: 'default/some-other-model',
+      provider: 'default/nim',
+    });
+
+    expect(result.status).toBe('valid');
+    if (result.status !== 'valid') return;
+    expect(result.seed.models[0]).toEqual(
+      expect.objectContaining({ model: 'default/some-other-model', provider: 'default/nim' })
+    );
+  });
+
+  it('says nothing when the draft already named the generation model', () => {
+    const result = validateGeneratedJobRequest(
+      jobRequest({
+        model_configs: [{ alias: 'gen', model: 'default/llama-3.3', provider: 'default/nim' }],
+      }),
+      MODEL_GROUPS,
+      { model: 'default/llama-3.3', provider: 'default/nim' }
+    );
+
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('leaves generated models untouched when the workspace model list is empty', () => {
+    const result = validateGeneratedJobRequest(jobRequest(), []);
+
+    expect(result.status).toBe('valid');
+    if (result.status !== 'valid') return;
+    expect(result.seed.models[0].model).toBe('gpt-4o');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('rejects a config with no columns', () => {
+    const result = validateGeneratedJobRequest(jobRequest({ columns: [] }), MODEL_GROUPS);
+
+    expect(result).toEqual({ status: 'invalid', errors: [ERROR_NO_COLUMNS], warnings: [] });
+  });
+
+  it('rejects a config whose columns are all unknown to the builder', () => {
+    const result = validateGeneratedJobRequest(
+      jobRequest({
+        columns: [{ name: 'mystery', column_type: 'not-a-column-type' }],
+        model_configs: [],
+      } as unknown as Partial<DataDesignerConfig>),
+      MODEL_GROUPS
+    );
+
+    expect(result.status).toBe('invalid');
+    if (result.status !== 'invalid') return;
+    expect(result.errors).toContain(ERROR_NO_LOADABLE_COLUMNS);
+  });
+
+  it('rejects an LLM column pointing at an alias no model config defines', () => {
+    const result = validateGeneratedJobRequest(
+      jobRequest({ model_configs: [{ alias: 'other', model: 'gpt-4o', provider: 'openai' }] }),
+      MODEL_GROUPS
+    );
+
+    expect(result.status).toBe('invalid');
+    if (result.status !== 'invalid') return;
+    expect(result.errors).toContain('question: no model is configured with alias "gen".');
+  });
+
+  it('rejects a column missing a required field', () => {
+    const result = validateGeneratedJobRequest(
+      jobRequest({
+        columns: [{ name: 'question', column_type: 'llm-text', model_alias: 'gen' }],
+      } as unknown as Partial<DataDesignerConfig>),
+      MODEL_GROUPS
+    );
+
+    expect(result.status).toBe('invalid');
+    if (result.status !== 'invalid') return;
+    expect(result.errors).toContain('question: Prompt is required.');
+  });
+
+  it('warns about columns it had to skip but still accepts the rest', () => {
+    const result = validateGeneratedJobRequest(
+      jobRequest({
+        columns: [...config().columns, { name: 'mystery', column_type: 'not-a-column-type' }],
+      } as unknown as Partial<DataDesignerConfig>),
+      MODEL_GROUPS
+    );
+
+    expect(result.status).toBe('valid');
+    expect(result.warnings).toContain(
+      "Skipped 1 column(s) the builder can't edit: mystery (not-a-column-type)."
+    );
+  });
+
+  it('defaults a non-positive record count and says so', () => {
+    const request = jobRequest();
+    request.spec.num_records = 0;
+
+    const result = validateGeneratedJobRequest(request, MODEL_GROUPS);
+
+    expect(result.status).toBe('valid');
+    if (result.status !== 'valid') return;
+    expect(result.seed.rows).toBe('100');
+    expect(result.warnings).toContain(
+      'Record count was not a positive whole number — defaulted to 100.'
+    );
+  });
+});
+
+describe('seedFromJobRequest', () => {
+  it('falls back to a default name when the request has none', () => {
+    const request = jobRequest();
+    delete request.name;
+
+    expect(seedFromJobRequest(request).name).toBe('untitled-dataset');
+  });
+});
+
+describe('getGeneratedJobRequestFromState', () => {
+  it('returns the request when the state carries one', () => {
+    const request = jobRequest();
+
+    expect(getGeneratedJobRequestFromState({ generatedJobRequest: request })).toBe(request);
+  });
+
+  it.each([[null], [undefined], [{}], [{ cloneJobRequest: {} }], [{ generatedJobRequest: {} }]])(
+    'returns null for unrelated state (%o)',
+    (state) => {
+      expect(getGeneratedJobRequestFromState(state)).toBeNull();
+    }
+  );
+});

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/aiSeed.ts
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/aiSeed.ts
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ModelWorkspaceGroup } from '@nemo/common/src/api/models/useModels';
+import type {
+  CreateJobRequest as DataDesignerJobRequest,
+  ModelConfig,
+} from '@nemo/sdk/generated/data-designer/schema';
+import {
+  buildColumnsFromConfig,
+  validateColumns,
+} from '@studio/routes/DataDesignerJobBuildRoute/columns';
+import {
+  buildModelsFromConfig,
+  resolveTemplateModel,
+  validateModels,
+} from '@studio/routes/DataDesignerJobBuildRoute/models';
+import type { JobBuilderSeed } from '@studio/routes/DataDesignerJobBuildRoute/useJobBuilder';
+
+/** Values key holding an LLM column's `model_alias` (see `MODEL_ALIAS_FIELD` in columns.ts). */
+const MODEL_ALIAS_KEY = 'model_alias';
+
+export const DEFAULT_GENERATED_NAME = 'untitled-dataset';
+export const DEFAULT_GENERATED_ROWS = 100;
+
+export const ERROR_NO_CONFIG = 'The model did not return a job config.';
+export const ERROR_NO_COLUMNS = 'The generated config has no columns.';
+export const ERROR_NO_LOADABLE_COLUMNS =
+  'None of the generated columns map to a column type the builder can edit.';
+
+/**
+ * Outcome of checking an LLM-generated job request against the build route's own rules.
+ * Only a `valid` result carries a `jobRequest` — that's what the create route hands to the
+ * builder, so an invalid draft can never be loaded.
+ */
+export type GeneratedConfigValidation =
+  | {
+      status: 'valid';
+      /** Normalized request: model configs resolved to real workspace models. */
+      jobRequest: DataDesignerJobRequest;
+      seed: JobBuilderSeed;
+      /** Non-blocking notes (substituted models, skipped columns). */
+      warnings: string[];
+    }
+  | { status: 'invalid'; errors: string[]; warnings: string[] };
+
+/** Router state key used to hand a generated job request to the build route. */
+export interface DataDesignerGeneratedState {
+  generatedJobRequest: DataDesignerJobRequest;
+}
+
+/**
+ * Narrow an unknown router location state to a generated job request, if present.
+ * Mirrors `getCloneJobRequestFromState` — the build route treats both the same way.
+ */
+export const getGeneratedJobRequestFromState = (state: unknown): DataDesignerJobRequest | null => {
+  if (!state || typeof state !== 'object' || !('generatedJobRequest' in state)) return null;
+  const request = (state as { generatedJobRequest: unknown }).generatedJobRequest;
+  if (!request || typeof request !== 'object' || !('spec' in request)) return null;
+  return request as DataDesignerJobRequest;
+};
+
+/**
+ * Turns a job request into builder state — the same conversion the clone path uses, so a
+ * generated config lands on the canvas fully editable rather than as opaque JSON.
+ */
+export const seedFromJobRequest = (jobRequest: DataDesignerJobRequest): JobBuilderSeed => ({
+  name: jobRequest.name?.trim() || DEFAULT_GENERATED_NAME,
+  rows: String(jobRequest.spec?.num_records ?? DEFAULT_GENERATED_ROWS),
+  columns: buildColumnsFromConfig(jobRequest.spec.config),
+  models: buildModelsFromConfig(jobRequest.spec.config.model_configs),
+});
+
+/** The model that drafted the config, carried through so the columns generate with it too. */
+export interface GenerationModel {
+  /** Model URN. */
+  model: string;
+  /** Resource ref of the model's provider; required by Data Designer on every model config. */
+  provider: string;
+}
+
+/**
+ * Points each generated model config at a model that actually exists in the workspace.
+ *
+ * The LLM writes plausible-looking identifiers (`gpt-4o`, `meta/llama-3`) for models the
+ * workspace has never heard of. When the panel knows which model drafted the config, every alias
+ * is pointed at that one — it is known to exist, the user picked it, and it makes the draft
+ * predictable no matter what the LLM invented. Without that (a bare config, e.g. from a test),
+ * we fall back to matching the platform list the way templates do.
+ *
+ * Left untouched while the model list is still empty and no generation model is known.
+ */
+const normalizeModelConfigs = (
+  configs: ModelConfig[],
+  modelGroups: ModelWorkspaceGroup[],
+  warnings: string[],
+  generationModel?: GenerationModel
+): ModelConfig[] => {
+  if (generationModel?.model) {
+    return configs.map((config) => {
+      if (config.model && config.model !== generationModel.model) {
+        warnings.push(
+          `Alias "${config.alias}" now uses "${generationModel.model}" — the model you selected — instead of the drafted "${config.model}".`
+        );
+      }
+      return {
+        ...config,
+        model: generationModel.model,
+        provider: generationModel.provider || config.provider,
+      };
+    });
+  }
+
+  if (modelGroups.length === 0) return configs;
+  return configs.map((config) => {
+    const resolved = resolveTemplateModel(modelGroups, config.model || undefined);
+    if (!resolved) return config;
+    if (config.model && config.model !== resolved.model) {
+      warnings.push(
+        `"${config.model}" is not available in this workspace — alias "${config.alias}" now uses "${resolved.model}".`
+      );
+    }
+    return { ...config, model: resolved.model, provider: resolved.provider };
+  });
+};
+
+/** Column names the builder dropped, e.g. an image column with no palette equivalent. */
+const skippedColumnLabels = (
+  jobRequest: DataDesignerJobRequest,
+  seed: JobBuilderSeed
+): string[] => {
+  const loaded = new Set(seed.columns.map((column) => column.name));
+  return jobRequest.spec.config.columns
+    .filter((column) => column.column_type !== 'seed-dataset' && !loaded.has(column.name))
+    .map((column) => `${column.name} (${column.column_type})`);
+};
+
+/** LLM columns pointing at a `model_alias` that no model config defines. */
+const danglingAliasErrors = (seed: JobBuilderSeed): string[] => {
+  const aliases = new Set(seed.models.map((model) => model.alias.trim()));
+  return seed.columns.flatMap((column) => {
+    const alias = column.values[MODEL_ALIAS_KEY]?.trim();
+    if (!alias || aliases.has(alias)) return [];
+    return [`${column.name}: no model is configured with alias "${alias}".`];
+  });
+};
+
+/**
+ * Decides whether an LLM-generated job request can be loaded into the build route, by running
+ * it through the exact conversion and validation the builder itself uses. Anything that would
+ * leave the canvas in a broken state is an error and blocks Continue; lossy-but-recoverable
+ * adjustments (a substituted model, a skipped column) are warnings.
+ */
+export const validateGeneratedJobRequest = (
+  jobRequest: DataDesignerJobRequest,
+  modelGroups: ModelWorkspaceGroup[],
+  generationModel?: GenerationModel
+): GeneratedConfigValidation => {
+  const warnings: string[] = [];
+  const config = jobRequest.spec?.config;
+  if (!config) return { status: 'invalid', errors: [ERROR_NO_CONFIG], warnings };
+  if (!config.columns?.length) return { status: 'invalid', errors: [ERROR_NO_COLUMNS], warnings };
+
+  const numRecords = jobRequest.spec.num_records;
+  const rows =
+    Number.isInteger(numRecords) && numRecords >= 1 ? numRecords : DEFAULT_GENERATED_ROWS;
+  if (rows !== numRecords) {
+    warnings.push(`Record count was not a positive whole number — defaulted to ${rows}.`);
+  }
+
+  const normalized: DataDesignerJobRequest = {
+    ...jobRequest,
+    spec: {
+      ...jobRequest.spec,
+      num_records: rows,
+      config: {
+        ...config,
+        model_configs: normalizeModelConfigs(
+          config.model_configs ?? [],
+          modelGroups,
+          warnings,
+          generationModel
+        ),
+      },
+    },
+  };
+
+  const seed = seedFromJobRequest(normalized);
+
+  const skipped = skippedColumnLabels(normalized, seed);
+  if (skipped.length > 0) {
+    warnings.push(
+      `Skipped ${skipped.length} column(s) the builder can't edit: ${skipped.join(', ')}.`
+    );
+  }
+
+  const errors =
+    seed.columns.length === 0
+      ? [ERROR_NO_LOADABLE_COLUMNS]
+      : [...validateColumns(seed.columns), ...danglingAliasErrors(seed)];
+  errors.push(...validateModels(seed.models));
+
+  if (errors.length > 0) return { status: 'invalid', errors, warnings };
+  return { status: 'valid', jobRequest: normalized, seed, warnings };
+};

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.test.tsx
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CreateJobRequest as DataDesignerJobRequest } from '@nemo/sdk/generated/data-designer/schema';
+import { ROUTES } from '@studio/constants/routes';
+import { DataDesignerJobBuildRoute } from '@studio/routes/DataDesignerJobBuildRoute';
+import type { DataDesignerGeneratedState } from '@studio/routes/DataDesignerJobBuildRoute/aiSeed';
+import { getDataDesignerJobBuildRoute } from '@studio/routes/utils';
+import { TestProviders } from '@studio/tests/util/TestProviders';
+import { render, screen } from '@testing-library/react';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+
+const BUILD_ROUTE = ROUTES.workspace.dataDesignerJobBuild;
+const BUILD_PATH = getDataDesignerJobBuildRoute('default');
+
+const generatedJobRequest: DataDesignerJobRequest = {
+  name: 'phishing-emails',
+  spec: {
+    num_records: 400,
+    config: {
+      columns: [
+        {
+          name: 'topic',
+          column_type: 'sampler',
+          sampler_type: 'category',
+          params: { values: ['invoice', 'password reset'] },
+        },
+        {
+          name: 'email_body',
+          column_type: 'llm-text',
+          prompt: 'Write an email about {{ topic }}.',
+          model_alias: 'gen',
+        },
+      ],
+      model_configs: [{ alias: 'gen', model: 'default/llama-3.3', provider: 'default/nim' }],
+    },
+  },
+} as unknown as DataDesignerJobRequest;
+
+const renderBuildRoute = (state?: DataDesignerGeneratedState) => {
+  const router = createMemoryRouter(
+    [{ path: BUILD_ROUTE, element: <DataDesignerJobBuildRoute /> }],
+    { initialEntries: [{ pathname: BUILD_PATH, state }] }
+  );
+  return render(
+    <TestProviders>
+      <RouterProvider router={router} />
+    </TestProviders>
+  );
+};
+
+describe('DataDesignerJobBuildRoute', () => {
+  it('loads a generated job request from router state into the builder', async () => {
+    renderBuildRoute({ generatedJobRequest });
+
+    expect(await screen.findByText('topic')).toBeInTheDocument();
+    expect(await screen.findByText('email_body')).toBeInTheDocument();
+  });
+
+  it('opens empty when there is no seed in router state', async () => {
+    renderBuildRoute();
+
+    expect(await screen.findByText(/No columns yet/i)).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
+++ b/web/packages/studio/src/routes/DataDesignerJobBuildRoute/index.tsx
@@ -12,6 +12,10 @@ import { usePreview } from '@studio/components/NewDataDesignerJobForm/usePreview
 import { getCloneJobRequestFromState } from '@studio/components/NewDataDesignerJobForm/utils';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import {
+  getGeneratedJobRequestFromState,
+  seedFromJobRequest,
+} from '@studio/routes/DataDesignerJobBuildRoute/aiSeed';
 import { BuilderCanvas } from '@studio/routes/DataDesignerJobBuildRoute/BuilderCanvas';
 import { BuilderConfigPane } from '@studio/routes/DataDesignerJobBuildRoute/BuilderConfigPane';
 import { BuilderDetailsPanel } from '@studio/routes/DataDesignerJobBuildRoute/BuilderDetailsPanel';
@@ -73,11 +77,18 @@ export const DataDesignerJobBuildRoute: FC = () => {
     };
   }, [locationState]);
 
+  const generatedSeed = useMemo<JobBuilderSeed | null>(() => {
+    const generatedRequest = getGeneratedJobRequestFromState(locationState);
+    return generatedRequest?.spec ? seedFromJobRequest(generatedRequest) : null;
+  }, [locationState]);
+
   const heading = cloneSeed
     ? `Clone of ${cloneSeed.name}`
-    : template
-      ? template.title
-      : 'Build from scratch';
+    : generatedSeed
+      ? 'Describe with AI'
+      : template
+        ? template.title
+        : 'Build from scratch';
 
   useBreadcrumbs({
     items: [
@@ -87,7 +98,7 @@ export const DataDesignerJobBuildRoute: FC = () => {
     ],
   });
 
-  const builder = useJobBuilder(template, workspace, cloneSeed);
+  const builder = useJobBuilder(template, workspace, cloneSeed ?? generatedSeed);
   const { data: providersPage } = useModelsListProviders(
     workspace,
     { page_size: DEFAULT_LARGE_PAGE_SIZE },


### PR DESCRIPTION
Adds aiSeed, which validates an LLM-generated Data Designer job request against the build route's own column and model rules and normalizes it into a JobBuilderSeed. A draft is only ever loadable when it validates, so the builder can't open on a config it cannot edit; skipped columns and substituted models come back as non-blocking warnings.

The build route now reads a `generatedJobRequest` off router state and seeds the builder from it, mirroring how clone already works.

Nothing produces that state yet — the "Describe with AI" entry point lands separately, so this is additive with no user-visible change.

Also drops the hardcoded openai/gpt-3.5-turbo examples from the job generator system prompt and tool schema; they biased the model toward a provider that isn't necessarily configured in the workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading AI-generated Data Designer job requests into the job builder.
  * AI-generated requests now populate columns and model settings automatically.
  * Added validation with clear errors and warnings for incomplete, unsupported, or invalid configurations.
  * Added sensible defaults for missing dataset names and non-positive record counts.
  * Updated job-building guidance for model providers and aliases.

* **Tests**
  * Added comprehensive coverage for AI-generated request validation, state handling, and builder rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->