### PR TITLE
fix(helm): validate autoscaling resource requests

### DIFF
--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -36,12 +36,13 @@ secrets will not decrypt with a new key.
 | api | object | This object has the following default values for the API configuration. | API configuration settings for the api deployment |
 | api.affinity | object | `{}` | Affinity configuration for the API service. |
 | api.annotations | object | `{}` | Annotations to add to the API service deployment. |
-| api.autoscaling | object | `{"annotations":{},"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | Specifies autoscaling configurations for the deployment. |
+| api.autoscaling | object | `{"annotations":{},"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null}` | Specifies autoscaling configurations for the deployment. |
 | api.autoscaling.annotations | object | `{}` | Annotations for the HorizontalPodAutoscaler. |
 | api.autoscaling.enabled | bool | `false` | Whether to enable horizontal pod autoscaler. |
 | api.autoscaling.maxReplicas | int | `10` | The maximum number of replicas for the deployment. |
 | api.autoscaling.minReplicas | int | `1` | The minimum number of replicas for the deployment. |
-| api.autoscaling.targetCPUUtilizationPercentage | int | `80` | The target CPU utilization percentage. |
+| api.autoscaling.targetCPUUtilizationPercentage | int | `80` | The target CPU utilization percentage. Requires api.resources.requests.cpu. |
+| api.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | The target memory utilization percentage. Requires api.resources.requests.memory. |
 | api.enabled | bool | `true` | Specifies whether to enable the api deployment. |
 | api.extraArgs | list | `[]` | Additional arguments to pass to the Platform API service |
 | api.extraVolumeMounts | list | `[]` | Additional volume mounts to add to the Platform API container. |
@@ -70,7 +71,7 @@ secrets will not decrypt with a new key.
 | api.readinessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the readiness probe. |
 | api.readinessProbe.timeoutSeconds | int | `5` | The timeout in seconds for the readiness probe. |
 | api.replicaCount | int | `1` | Number of replicas for the API service. |
-| api.resources | object | `{}` | Kubernetes deployment resources configuration for the API service. |
+| api.resources | object | `{}` | Kubernetes deployment resources configuration for the API service. Utilization-based autoscaling requires a matching resource request. |
 | api.securityContext | object | `{}` | Container-level security context settings for the API service. |
 | api.service | object | This object has the following default values for the service configuration. | Service configuration for the API service. |
 | api.service.annotations | object | `{}` | Annotations for the API service. |
@@ -162,12 +163,13 @@ secrets will not decrypt with a new key.
 | envoyProxy.adminPort | int | `9901` | Envoy Admin port |
 | envoyProxy.affinity | object | `{}` | Affinity configuration for the Envoy pods. |
 | envoyProxy.annotations | object | `{}` | Annotations to add to the Envoy service deployment. |
-| envoyProxy.autoscaling | object | `{"annotations":{},"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80}` | Specifies autoscaling configurations for the deployment. |
+| envoyProxy.autoscaling | object | `{"annotations":{},"enabled":false,"maxReplicas":10,"minReplicas":1,"targetCPUUtilizationPercentage":80,"targetMemoryUtilizationPercentage":null}` | Specifies autoscaling configurations for the deployment. |
 | envoyProxy.autoscaling.annotations | object | `{}` | Annotations for the HorizontalPodAutoscaler. |
 | envoyProxy.autoscaling.enabled | bool | `false` | Whether to enable horizontal pod autoscaler. |
 | envoyProxy.autoscaling.maxReplicas | int | `10` | The maximum number of replicas for the deployment. |
 | envoyProxy.autoscaling.minReplicas | int | `1` | The minimum number of replicas for the deployment. |
-| envoyProxy.autoscaling.targetCPUUtilizationPercentage | int | `80` | The target CPU utilization percentage. |
+| envoyProxy.autoscaling.targetCPUUtilizationPercentage | int | `80` | The target CPU utilization percentage. Requires envoyProxy.resources.requests.cpu. |
+| envoyProxy.autoscaling.targetMemoryUtilizationPercentage | string | `nil` | The target memory utilization percentage. Requires envoyProxy.resources.requests.memory. |
 | envoyProxy.configOverride | string | `""` | Full Envoy config override. When set, this replaces the chart's default passthrough Envoy config. |
 | envoyProxy.enabled | bool | `true` | Specifies whether to enable the Envoy proxy deployment. Rendered only when platform config has auth.enabled: true. |
 | envoyProxy.extraArgs | list | `[]` | Extra arguments to append to the envoy container command. Useful for passing server flags such as concurrency. Example: ["--concurrency", "4"] |
@@ -185,7 +187,7 @@ secrets will not decrypt with a new key.
 | envoyProxy.podSecurityContext | object | This object has the following default values for the pod security context. | Pod-level security context settings for the Envoy service. |
 | envoyProxy.podSecurityContext.fsGroup | int | `1000` | The file system group ID to use for all containers. |
 | envoyProxy.readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/ready","port":"admin"},"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe for the Envoy container (admin interface /ready). |
-| envoyProxy.resources | object | `{}` | Kubernetes deployment resources configuration for the Envoy service. |
+| envoyProxy.resources | object | `{}` | Kubernetes deployment resources configuration for the Envoy service. Utilization-based autoscaling requires a matching resource request. |
 | envoyProxy.securityContext | object | `{}` | Container-level security context settings for the Envoy service. |
 | envoyProxy.service | object | This object has the following default values for the service configuration. | Service configuration for the Envoy service. |
 | envoyProxy.service.annotations | object | `{}` | Annotations for the Envoy service. |

--- a/k8s/helm/templates/api/api-hpa.yaml
+++ b/k8s/helm/templates/api/api-hpa.yaml
@@ -1,5 +1,12 @@
 {{- if .Values.api.enabled }}
 {{- if .Values.api.autoscaling.enabled }}
+{{- $requests := .Values.api.resources.requests | default dict }}
+{{- if and .Values.api.autoscaling.targetCPUUtilizationPercentage (not $requests.cpu) }}
+{{- fail "api.resources.requests.cpu is required when API CPU autoscaling is enabled" }}
+{{- end }}
+{{- if and .Values.api.autoscaling.targetMemoryUtilizationPercentage (not $requests.memory) }}
+{{- fail "api.resources.requests.memory is required when API memory autoscaling is enabled" }}
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/k8s/helm/templates/proxy/envoy-hpa.yaml
+++ b/k8s/helm/templates/proxy/envoy-hpa.yaml
@@ -1,5 +1,12 @@
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- if .Values.envoyProxy.autoscaling.enabled }}
+{{- $requests := .Values.envoyProxy.resources.requests | default dict }}
+{{- if and .Values.envoyProxy.autoscaling.targetCPUUtilizationPercentage (not $requests.cpu) }}
+{{- fail "envoyProxy.resources.requests.cpu is required when Envoy CPU autoscaling is enabled" }}
+{{- end }}
+{{- if and .Values.envoyProxy.autoscaling.targetMemoryUtilizationPercentage (not $requests.memory) }}
+{{- fail "envoyProxy.resources.requests.memory is required when Envoy memory autoscaling is enabled" }}
+{{- end }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -562,7 +562,7 @@ api:
     port: 8080
     # -- Annotations for the API service.
     annotations: {}
-  # -- Kubernetes deployment resources configuration for the API service.
+  # -- Kubernetes deployment resources configuration for the API service. Utilization-based autoscaling requires a matching resource request.
   resources: {}
 
   # -- Startup probe configuration for the api service.
@@ -631,9 +631,10 @@ api:
     minReplicas: 1
     # -- The maximum number of replicas for the deployment.
     maxReplicas: 10
-    # -- The target CPU utilization percentage.
+    # -- The target CPU utilization percentage. Requires api.resources.requests.cpu.
     targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
+    # -- The target memory utilization percentage. Requires api.resources.requests.memory.
+    targetMemoryUtilizationPercentage: null
     # -- Annotations for the HorizontalPodAutoscaler.
     annotations: {}
 
@@ -929,7 +930,7 @@ envoyProxy:
     # -- Cluster connect timeout (time to establish connection to backend).
     connect: "30s"
 
-  # -- Kubernetes deployment resources configuration for the Envoy service.
+  # -- Kubernetes deployment resources configuration for the Envoy service. Utilization-based autoscaling requires a matching resource request.
   resources: {}
 
   # -- Liveness probe for the Envoy container (admin interface /ready).
@@ -979,9 +980,10 @@ envoyProxy:
     minReplicas: 1
     # -- The maximum number of replicas for the deployment.
     maxReplicas: 10
-    # -- The target CPU utilization percentage.
+    # -- The target CPU utilization percentage. Requires envoyProxy.resources.requests.cpu.
     targetCPUUtilizationPercentage: 80
-    # targetMemoryUtilizationPercentage: 80
+    # -- The target memory utilization percentage. Requires envoyProxy.resources.requests.memory.
+    targetMemoryUtilizationPercentage: null
     # -- Annotations for the HorizontalPodAutoscaler.
     annotations: {}
 

--- a/tools/lint/lint-helm.sh
+++ b/tools/lint/lint-helm.sh
@@ -18,6 +18,19 @@ helm dependency update "${HELM_FOLDER}"
 # Lint the Helm chart
 helm lint --strict "${HELM_FOLDER}"
 
+# Utilization-based autoscaling must reject missing CPU requests.
+helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
+  --set api.autoscaling.enabled=true >/dev/null 2>&1 && {
+  echo "API autoscaling accepted a missing CPU request" >&2
+  exit 1
+}
+helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
+  --set platformConfig.auth.enabled=true \
+  --set envoyProxy.autoscaling.enabled=true >/dev/null 2>&1 && {
+  echo "Envoy autoscaling accepted a missing CPU request" >&2
+  exit 1
+}
+
 # Validate the Helm chart by rendering templates with all values files in ci/ directory
 shopt -s nullglob
 for value_file in "${HELM_FOLDER}"/ci/*.yaml; do

--- a/tools/lint/lint-helm.sh
+++ b/tools/lint/lint-helm.sh
@@ -19,17 +19,22 @@ helm dependency update "${HELM_FOLDER}"
 helm lint --strict "${HELM_FOLDER}"
 
 # Utilization-based autoscaling must reject missing CPU requests.
-helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
-  --set api.autoscaling.enabled=true >/dev/null 2>&1 && {
+api_autoscaling_output=$(helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
+  --set api.autoscaling.enabled=true 2>&1) && {
   echo "API autoscaling accepted a missing CPU request" >&2
   exit 1
 }
-helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
+grep -Fq "api.resources.requests.cpu is required when API CPU autoscaling is enabled" \
+  <<<"${api_autoscaling_output}"
+
+envoy_autoscaling_output=$(helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
   --set platformConfig.auth.enabled=true \
-  --set envoyProxy.autoscaling.enabled=true >/dev/null 2>&1 && {
+  --set envoyProxy.autoscaling.enabled=true 2>&1) && {
   echo "Envoy autoscaling accepted a missing CPU request" >&2
   exit 1
 }
+grep -Fq "envoyProxy.resources.requests.cpu is required when Envoy CPU autoscaling is enabled" \
+  <<<"${envoy_autoscaling_output}"
 
 # Validate the Helm chart by rendering templates with all values files in ci/ directory
 shopt -s nullglob


### PR DESCRIPTION
## Summary

CPU and memory utilization-based HPAs require matching resource requests. Without one, the HPA cannot calculate utilization and reports:

```text
failed to get cpu utilization: missing request for cpu in container <container-name>
```

This makes the Helm chart fail early with a clear error when API or Envoy autoscaling is enabled without the matching request. It also documents the requirement and adds small lint checks.

## Testing

- `helm lint --strict k8s/helm`
- Rendered all Helm CI values
- Verified missing requests fail and configured requests render successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable memory utilization targets for API and Envoy proxy autoscaling.
  * Updated Helm values to support `targetMemoryUtilizationPercentage` (defaulting to disabled).
* **Bug Fixes**
  * Prevented Helm chart rendering when autoscaling is enabled without the required CPU/memory resource requests for API and Envoy.
* **Documentation**
  * Updated Helm documentation to include memory autoscaling options and clarify the requirement for matching resource requests.
* **Tests / Chores**
  * Strengthened Helm linting by adding validations that confirm misconfigured autoscaling fails as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->