### PR TITLE
test(deployments): keep the image pull out of the observe-wait timing window

### DIFF
--- a/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/docker/test_docker_backend.py
@@ -93,7 +93,14 @@ def _docker_backend_with_observe_timeout(
     *,
     oneshot_observe_timeout_seconds: int,
 ) -> DockerDeploymentBackend:
-    return _build_docker_backend(oneshot_observe_timeout_seconds=oneshot_observe_timeout_seconds)
+    # `pull_images` is off so the caller can pre-pull and keep the registry
+    # round-trip out of any window it times. `create_deployment` pulls
+    # unconditionally, not just when the image is missing locally, so leaving
+    # this on would put ~2s of Docker Hub latency inside the measurement.
+    return _build_docker_backend(
+        oneshot_observe_timeout_seconds=oneshot_observe_timeout_seconds,
+        pull_images=False,
+    )
 
 
 def _always_http_config() -> DeploymentConfig:
@@ -169,8 +176,9 @@ async def test_never_deployment_outlives_observe_wait_then_succeeds() -> None:
     client = docker.from_env()
 
     try:
-        # Warm the image cache so the timed window below measures the observe wait
-        # rather than an uncached image pull.
+        # The backend is built with `pull_images=False`, so this pull is what puts
+        # the image on the host. Doing it here keeps it out of the timed window
+        # below, which is measuring the observe wait.
         await asyncio.to_thread(client.images.pull, ALPINE_IMAGE)
 
         started = time.monotonic()


### PR DESCRIPTION
## What

`test_never_deployment_outlives_observe_wait_then_succeeds` asserts that `create_deployment` returns within `observe_timeout + 2.0s`. It pre-pulls `alpine:3.20` with a comment saying this keeps an uncached pull out of the timed window — but that is not what happens.

The backend is built with `pull_images=True`, and [`create_deployment` pulls unconditionally](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py#L213) rather than only when the image is missing locally. The warm-up avoids re-downloading layers; it does nothing about the registry round-trip, which still lands inside the measurement.

## Why now

A fully cached `alpine:3.20` pull measures **~1.7s** locally. That puts the unfixed test at **2.85s against a 3.0s budget** on a fast machine with a warm cache — 0.15s of margin, all of it hostage to Docker Hub latency. CI has been tipping over it on `main` and on unrelated branches:

| run | branch | `create_elapsed` |
|---|---|---|
| [30554298719](https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/30554298719) | `main` | 4.39s |
| [30550043391](https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/30550043391) | `fix-stop-instance-lock-race/schapman` (#987) | 3.84s |
| [30549563915](https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/30549563915) | `feat/experimentalist-run-progress` | 3.42s |

There is no `@pytest.mark.flaky` on this test — reruns are opt-in per-test in this repo — so a single slow pull is a hard CI failure on whatever PR happens to be running.

## The fix

Build the backend with `pull_images=False` in `_docker_backend_with_observe_timeout`, so the test's own pre-pull is what puts the image on the host and the timed window covers container create, start, and the observe wait — what the assertion is actually about.

The helper is used only by this test; the other three tests in the file keep the default `pull_images=True`.

## Verification

Measured `create_elapsed` locally, 3 runs each:

| | run 1 | run 2 | run 3 | budget |
|---|---|---|---|---|
| before | 2.86s | 2.84s | 2.83s | 3.0s |
| after | 1.18s | 1.18s | 1.18s | 3.0s |

Full `test_docker_backend.py`: 4 passed. `ruff check` / `ruff format --check` clean; `tools/lint/lint-python-types.sh` exits 0 with this file unimplicated; `lint-copyright-headers`, `lint-merge-conflict`, `lint-no-nmp-common-in-plugins` pass.

## Out of scope

`pull_images` is described as *"Pull container images before run when missing locally"*, but the implementation pulls unconditionally. That mismatch is real and worth a look, but changing it alters production pull behaviour for mutable tags, so it does not belong in a test-flake fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Docker deployment timing measurements by pulling images before the timed observation period.
  * Measurements now focus on deployment observation time instead of image download latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->