### PR TITLE
feat: Validate no custom columns in DD configs

### DIFF
--- a/packages/data_designer_nemo/src/data_designer_nemo/columns.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/columns.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+import data_designer.config as dd
+from data_designer_nemo.errors import NDDInvalidConfigError
+
+_CUSTOM_COLUMN_TYPE = "custom"
+CUSTOM_COLUMNS_UNSUPPORTED_MESSAGE = (
+    "Custom columns are not supported by the NeMo Platform Data Designer service. "
+    "Replace the custom column with a built-in column type before trying again."
+)
+
+
+def validate_no_custom_columns(data: Any) -> None:
+    """Raises if a raw Data Designer request contains a custom column.
+
+    This function is used from "before"-mode Pydantic validators on request models
+    carrying a ``config: dd.DataDesignerConfig`` field. At that point the payload
+    still has the raw ``column_type`` discriminator, so we can preempt Pydantic's
+    generic union/deserialization error with a platform-specific explanation.
+    """
+    if not _has_custom_column(data):
+        return
+
+    raise ValueError(CUSTOM_COLUMNS_UNSUPPORTED_MESSAGE)
+
+
+def validate_config_has_no_custom_columns(config: dd.DataDesignerConfig) -> None:
+    """Raises if a parsed Data Designer config contains a custom column."""
+    if any(column.column_type == _CUSTOM_COLUMN_TYPE for column in config.columns):
+        raise NDDInvalidConfigError(CUSTOM_COLUMNS_UNSUPPORTED_MESSAGE)
+
+
+def _has_custom_column(data: Any) -> bool:
+    try:
+        columns = data["config"]["columns"]
+    except Exception:
+        return False
+
+    if not isinstance(columns, list):
+        return False
+
+    return any(isinstance(column, dict) and column.get("column_type") == _CUSTOM_COLUMN_TYPE for column in columns)

--- a/packages/data_designer_nemo/src/data_designer_nemo/context.py
+++ b/packages/data_designer_nemo/src/data_designer_nemo/context.py
@@ -20,6 +20,7 @@ from data_designer.engine.secret_resolver import (
     PlaintextResolver,
     SecretResolver,
 )
+from data_designer_nemo.columns import validate_config_has_no_custom_columns
 from data_designer_nemo.errors import NDDError
 from data_designer_nemo.fileset_file_seed_reader import FilesetFileSeedReader
 from data_designer_nemo.fileset_filesystem_provider import (
@@ -78,6 +79,11 @@ class LocalDataDesignerContext:
     async def validate(self, config: dd.DataDesignerConfig) -> list[NDDError]:
         async_sdk = self._async_sdk()
         errors: list[NDDError] = []
+
+        try:
+            validate_config_has_no_custom_columns(config)
+        except NDDError as e:
+            errors.append(e)
 
         try:
             if validated_root := await validate_seed(config, self._workspace, async_sdk, is_local=True):
@@ -140,6 +146,11 @@ class RemoteDataDesignerContext:
     async def validate(self, config: dd.DataDesignerConfig) -> list[NDDError]:
         async_sdk = self._async_sdk()
         errors: list[NDDError] = []
+
+        try:
+            validate_config_has_no_custom_columns(config)
+        except NDDError as e:
+            errors.append(e)
 
         try:
             validate_no_tool_configs(config)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/_types.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/functions/_types.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any, Literal, TypeAlias
 import data_designer.config as dd
 from data_designer.config.analysis.dataset_profiler import DatasetProfilerResults
 from data_designer.config.dataset_metadata import DatasetMetadata
+from data_designer_nemo.columns import validate_no_custom_columns
 from data_designer_nemo.seed import validate_seed_source_for_execution_context
 from nemo_platform_plugin.functions.frames import Done, Error, Heartbeat
 from pydantic import BaseModel, Field, ValidationInfo, model_validator
@@ -21,7 +22,8 @@ class PreviewSpec(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_seed_source_scope(cls, data: Any, info: ValidationInfo) -> Any:
+    def validate_config_for_platform(cls, data: Any, info: ValidationInfo) -> Any:
+        validate_no_custom_columns(data)
         validate_seed_source_for_execution_context(data, is_local=_is_local_context(info))
         return data
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/spec.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/jobs/spec.py
@@ -4,6 +4,7 @@
 from typing import Any
 
 import data_designer.config as dd
+from data_designer_nemo.columns import validate_no_custom_columns
 from data_designer_nemo.seed import validate_seed_source_for_execution_context
 from pydantic import BaseModel, ValidationInfo, model_validator
 
@@ -19,7 +20,8 @@ class DataDesignerJobConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_seed_source_scope(cls, data: Any, info: ValidationInfo) -> Any:
+    def validate_config_for_platform(cls, data: Any, info: ValidationInfo) -> Any:
+        validate_no_custom_columns(data)
         validate_seed_source_for_execution_context(data, is_local=_is_local_context(info))
         return data
 

--- a/plugins/nemo-data-designer/tests/integration/test_remote_validation_errors.py
+++ b/plugins/nemo-data-designer/tests/integration/test_remote_validation_errors.py
@@ -118,6 +118,27 @@ def test_mcp_tools_not_allowed() -> None:
         _assert_error(dd_client, builder, ["Tool configs are not supported"])
 
 
+def test_custom_columns_not_supported() -> None:
+    @dd.custom_column_generator(required_columns=["school_subject"])
+    def append_custom_value(row: dict) -> dict:
+        row["custom_value"] = f"{row['school_subject']} custom"
+        return row
+
+    builder = dd.DataDesignerConfigBuilder(model_configs=[u.make_model_config()])
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="school_subject",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["math", "science", "history"]),
+        )
+    )
+    builder.add_column(column_config=dd.CustomColumnConfig(name="custom_value", generator_function=append_custom_value))
+
+    with u.make_mock_client_context() as client_context:
+        dd_client = u.make_dd_client(client_context)
+        _assert_error(dd_client, builder, ["Custom columns are not supported"])
+
+
 def test_seed_dataset_bad_token() -> None:
     bad_token_secret = "unrecognized-secret-ref"
     builder = dd.DataDesignerConfigBuilder(model_configs=[u.make_model_config()])

--- a/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
+++ b/plugins/nemo-data-designer/tests/integration/test_validate_sdk.py
@@ -222,6 +222,36 @@ async def test_sdk_validate_method_rejects_df_seed_for_local() -> None:
     assert any("Dataframe seed sources" in err.message for err in result.errors)
 
 
+async def test_sdk_validate_method_rejects_custom_columns() -> None:
+    @dd.custom_column_generator(required_columns=["foo"])
+    def append_custom_value(row: dict) -> dict:
+        row["custom_value"] = f"{row['foo']} custom"
+        return row
+
+    builder = dd.DataDesignerConfigBuilder(model_configs=[u.make_model_config(provider=u.OPEN_PROVIDER_NAME)])
+    builder.add_column(
+        column_config=dd.SamplerColumnConfig(
+            name="foo",
+            sampler_type=dd.SamplerType.CATEGORY,
+            params=dd.CategorySamplerParams(values=["a", "b"]),
+        )
+    )
+    builder.add_column(column_config=dd.CustomColumnConfig(name="custom_value", generator_function=append_custom_value))
+
+    with (
+        u.make_mock_client_context() as client_context,
+        u.setup_mock_providers(client_context),
+    ):
+        dd_client = AsyncDataDesignerResource(client_context.async_sdk)
+        report = await dd_client.validate(builder, execution_context="remote")
+
+    assert not report.ok
+    [result] = report.results
+    assert result.context == "remote"
+    messages = [err.message for err in result.errors]
+    assert any("Custom columns are not supported" in m for m in messages)
+
+
 async def test_validate_remote_only_rejects_unknown_provider() -> None:
     builder = _llm_builder(u.make_model_config(provider="some-unknown-provider"))
 


### PR DESCRIPTION
The upstream Data Designer library allows users define custom column types via a decorated Python function. These don't work in the platform plugin because we don't have the user-created implementation server-side, nor can we serialize the function and send it over the wire. Today if a user builds a config client-side with a custom column and submits that config to the service, they get a raw error message when Pydantic tries and fails to deserialize the config. This PR ensures we provide a clearer error message that custom columns are not supported here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject unsupported custom columns during configuration, preview, creation, and remote execution.
  * Validation reports now clearly indicate when custom columns are not supported, without interrupting other validation checks.

* **Tests**
  * Added coverage for custom-column rejection in preview, creation, and SDK validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->