### PR TITLE
fix: tighten 3.11 and 3.12 pinning for Python, fix links

### DIFF
--- a/.github/wheel-constraints/nemo-platform-plugin.txt
+++ b/.github/wheel-constraints/nemo-platform-plugin.txt
@@ -1,7 +1,6 @@
 # Partial dependency constraints for the CI wheel install-smoke-test.
 # Pins the DIRECT external deps of the built nemo-platform-plugin wheel to vetted versions for
-# reproducibility; deep transitives resolve normally (so they stay py3.14-compatible and
-# cannot self-conflict). litellm is capped <1.92 — its 1.92.0 native build has no py3.14 wheel.
+# reproducibility; deep transitives resolve normally and cannot self-conflict.
 # Regenerate with: script/compile-wheel-constraints.sh <dir-with-built-wheels>
 #
 anthropic==0.118.0
@@ -26,4 +25,3 @@ rich==15.0.0
 sniffio==1.3.1
 typer==0.25.1
 typing-extensions==4.16.0
-litellm<1.92  # 1.92.0 native build has no py3.14 wheel

--- a/.github/wheel-constraints/nemo-platform-services.txt
+++ b/.github/wheel-constraints/nemo-platform-services.txt
@@ -1,7 +1,6 @@
 # Partial dependency constraints for the CI wheel install-smoke-test.
 # Pins the DIRECT external deps of the built nemo-platform[services] wheel to vetted versions for
-# reproducibility; deep transitives resolve normally (so they stay py3.14-compatible and
-# cannot self-conflict). litellm is capped <1.92 — its 1.92.0 native build has no py3.14 wheel.
+# reproducibility; deep transitives resolve normally and cannot self-conflict.
 # Regenerate with: script/compile-wheel-constraints.sh <dir-with-built-wheels>
 #
 aioboto3==15.5.0
@@ -97,4 +96,3 @@ uvicorn==0.51.0
 wasmtime==47.0.1
 xdg-base-dirs==6.0.2
 yara-python==4.5.1
-litellm<1.92  # 1.92.0 native build has no py3.14 wheel

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1182,10 +1182,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [nemo-platform, nemo-platform-plugin]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-        exclude:
-          - package: nemo-platform
-            python-version: "3.11"
+        python-version: ["3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1229,10 +1226,7 @@ jobs:
       fail-fast: false
       matrix:
         package: [nemo-platform, nemo-platform-plugin]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
-        exclude:
-          - package: nemo-platform
-            python-version: "3.11"
+        python-version: ["3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -1266,17 +1260,9 @@ jobs:
             echo "::error::Expected exactly one wheel, found ${#wheels[@]}"
             exit 1
           fi
-          if [[ "${PYTHON_VERSION}" == "3.14" ]]; then
-            # litellm 1.92.0 builds its Rust bridge from source on Python 3.14.
-            # Its pinned PyO3 supports the stable ABI, but rejects 3.14 unless
-            # this forward-compatibility opt-in is present.
-            export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
-          fi
           WHEEL="${wheels[0]}"
           # Supply-chain: partial-pin the wheel's direct external deps to a committed constraints
-          # file (deep transitives resolve normally, so they stay py3.14-compatible and can't
-          # self-conflict), and cap the litellm transitive whose 1.92.0 native build has no py3.14
-          # wheel. Regenerate with script/compile-wheel-constraints.sh.
+          # file. Regenerate with script/compile-wheel-constraints.sh.
           VENV="${RUNNER_TEMP}/wheelcheck/.venv"
           uv venv "${VENV}" --python "${PYTHON_VERSION}"
           uv pip install --python "${VENV}/bin/python" \

--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ The demo agent uses `${NEMO_DEFAULT_MODEL}` for both execution and the judge LLM
 
 Full documentation: [NeMo Platform docs](https://docs.nvidia.com/nemo-platform)
 
-- [Setup](docs/get-started/setup.md): installation, providers, SDK.
-- [CLI reference](docs/cli/index.md): all commands.
-- [API reference](docs/api/index.md): REST endpoints.
+- [Setup](https://docs.nvidia.com/nemo-platform/documentation/get-started): installation, providers, SDK.
+- [CLI reference](https://docs.nvidia.com/nemo-platform/documentation/reference/cli-reference): all commands.
+- [API reference](https://docs.nvidia.com/nemo-platform/documentation/reference/api-reference): REST endpoints.
 
 ## Development
 

--- a/packages/nemo_platform/README.md
+++ b/packages/nemo_platform/README.md
@@ -82,8 +82,8 @@ http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1/c
 - **Source:** https://github.com/NVIDIA-NeMo/nemo-platform
 - **Documentation:** https://docs.nvidia.com/nemo-platform/
 - **Setup playbook:** https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/SETUP.md
-- **CLI reference:** https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/docs/cli/index.md
-- **API reference:** https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/docs/api/index.md
+- **CLI reference:** https://docs.nvidia.com/nemo-platform/documentation/reference/cli-reference
+- **API reference:** https://docs.nvidia.com/nemo-platform/documentation/reference/api-reference
 - **Issue tracker:** https://github.com/NVIDIA-NeMo/nemo-platform/issues
 
 ## License

--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -18,12 +18,11 @@ description = "Convenience wrapper distribution for NeMo Platform Python package
 readme = "README.md"
 authors = [{ name = "NVIDIA Corporation" }]
 license = "Apache-2.0"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<3.14"
 classifiers = [
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
   "Operating System :: POSIX",
   "Operating System :: MacOS",

--- a/packages/nemo_platform_plugin/pyproject.toml
+++ b/packages/nemo_platform_plugin/pyproject.toml
@@ -3,13 +3,11 @@ name = "nemo-platform-plugin"
 dynamic = ["version"]
 description = "Public plugin contract for the NeMo Platform - the only package plugin authors need."
 readme = "src/nemo_platform_plugin/README.md"
-requires-python = ">=3.11,<3.15"
+requires-python = ">=3.12,<3.14"
 classifiers = [
   "Intended Audience :: Developers",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Operating System :: OS Independent",
   "Operating System :: POSIX",
   "Operating System :: MacOS",

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/README.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/README.md
@@ -1,7 +1,7 @@
 # nemo-platform-plugin
 
 [![License](https://img.shields.io/badge/license-Apache_2.0-D22128?style=flat-square)](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE)
-[![Python](https://img.shields.io/badge/python-3.11--3.14-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/python-3.12--3.13-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![Docs](https://img.shields.io/static/v1?label=docs&message=docs.nvidia.com%2Fnemo-platform&color=76B900&style=flat-square&logo=readthedocs&logoColor=white)](https://docs.nvidia.com/nemo-platform)
 
 Build NeMo Platform plugins in Python.
@@ -40,7 +40,7 @@ A complete NeMo Platform plugin that contributes one HTTP route — a `pyproject
 [project]
 name = "nemo-my-plugin"
 version = "0.1.0"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = ["nemo-platform-plugin"]
 
 [project.entry-points."nemo.services"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the NeMo Platform README links to hosted Setup/Get Started, CLI reference, and API reference docs.
  - Refreshed the plugin README to reflect supported Python versions (3.12–3.13).

- **Compatibility**
  - Narrowed supported Python version ranges for the platform and plugin packages to Python 3.12–3.13.

- **Build & CI**
  - Updated CI wheel build/test coverage to run only on Python 3.12 and 3.13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->