### PR TITLE
fix(intake): performance improvements for trace list

### DIFF
--- a/services/intake/src/nmp/intake/repository/clickhouse/trace.py
+++ b/services/intake/src/nmp/intake/repository/clickhouse/trace.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -26,6 +27,8 @@ from nmp.intake.spans.storage import (
     text_query_parameters,
     text_select_for_mode,
 )
+
+logger = logging.getLogger(__name__)
 
 TRACE_SORT_COLUMNS = {
     "started_at": "started_at",
@@ -163,6 +166,17 @@ class ClickHouseTraceRepository(TraceRepository):
                     },
                 )
             )
+            rows, dropped_refs = _reconcile_hydrated_page(page_refs, rows)
+            if dropped_refs:
+                logger.warning(
+                    "Trace page hydration omitted refs returned by the page query",
+                    extra={
+                        "workspace": filters.workspace,
+                        "page": page,
+                        "dropped_trace_refs": [ref.trace_key for ref in dropped_refs],
+                    },
+                )
+                total_results = max(offset + len(rows), total_results - len(dropped_refs))
         traces = [_row_to_trace(row) for row in rows]
         return PaginatedResult(
             data=traces,
@@ -240,6 +254,8 @@ class ClickHouseTraceRepository(TraceRepository):
 
 
 def _trace_page_sql(*, trace_index_sql: str, sort: str) -> str:
+    """Build the first-phase query that selects lightweight trace roots for one page."""
+
     return f"""
         SELECT
             {_trace_select_columns(include_aggregates=False)}
@@ -250,23 +266,14 @@ def _trace_page_sql(*, trace_index_sql: str, sort: str) -> str:
 
 
 def _trace_hydration_sql(*, trace_index_table: str, spans_table: str, mode: TraceMode) -> tuple[str, dict[str, Any]]:
-    trace_columns, trace_parameters = _trace_index_select_columns(mode=mode)
+    """Build the second-phase query that hydrates page roots and span aggregates."""
+
+    trace_roots_sql, trace_parameters = _page_trace_roots_sql(trace_index_table=trace_index_table, mode=mode)
     aggregates_sql, aggregate_parameters = _trace_aggregates_sql(spans_table)
     query = f"""
         WITH
         traces AS (
-            SELECT
-                {trace_columns}
-            FROM {trace_index_table} AS trace_roots FINAL
-            WHERE trace_roots.workspace = %(workspace)s
-                AND trace_roots.is_deleted = 0
-                AND trace_roots.trace_id IN %(page_trace_ids)s
-                AND (
-                    trace_roots.source_format,
-                    trace_roots.trace_id
-                ) IN %(page_trace_keys)s
-            ORDER BY trace_roots.root_started_at ASC, trace_roots.root_span_id ASC
-            LIMIT 1 BY trace_roots.workspace, trace_roots.source_format, trace_roots.trace_id
+            {trace_roots_sql}
         ),
         rollups AS (
             {aggregates_sql}
@@ -278,9 +285,27 @@ def _trace_hydration_sql(*, trace_index_table: str, spans_table: str, mode: Trac
             ON traces.workspace = rollups.workspace
             AND traces.source_format = rollups.source_format
             AND traces.id = rollups.trace_id
-        ORDER BY indexOf(%(page_trace_keys)s, (traces.source_format, traces.id)) ASC
     """
     return query, {**trace_parameters, **aggregate_parameters}
+
+
+def _page_trace_roots_sql(*, trace_index_table: str, mode: TraceMode) -> tuple[str, dict[str, Any]]:
+    trace_columns, parameters = _trace_index_select_columns(mode=mode)
+    query = f"""
+        SELECT
+            {trace_columns}
+        FROM {trace_index_table} AS trace_roots FINAL
+        WHERE trace_roots.workspace = %(workspace)s
+            AND trace_roots.is_deleted = 0
+            AND trace_roots.trace_id IN %(page_trace_ids)s
+            AND (
+                trace_roots.source_format,
+                trace_roots.trace_id
+            ) IN %(page_trace_keys)s
+        ORDER BY trace_roots.root_started_at ASC, trace_roots.root_span_id ASC
+        LIMIT 1 BY trace_roots.workspace, trace_roots.source_format, trace_roots.trace_id
+    """
+    return query, parameters
 
 
 def _trace_select_columns(*, include_aggregates: bool) -> str:
@@ -361,13 +386,7 @@ def _trace_index_select_columns(*, mode: TraceMode) -> tuple[str, dict[str, Any]
 
 def _trace_aggregates_sql(table: str) -> tuple[str, dict[str, Any]]:
     source_alias = "trace_spans"
-    metric_columns, parameters = metric_aggregate_columns(source_alias)
-
-    model_spec = spec_for_field(SpanAttributeField.MODEL)
-    provider_spec = spec_for_field(SpanAttributeField.PROVIDER)
-    parameters["model_key"] = model_spec.bag_key
-    parameters["provider_key"] = provider_spec.bag_key
-
+    select_columns, parameters = _trace_aggregate_select_columns(source_alias)
     current_spans = current_spans_sql(
         table,
         extra_where_sql=(
@@ -378,22 +397,7 @@ def _trace_aggregates_sql(table: str) -> tuple[str, dict[str, Any]]:
     )
     query = f"""
         SELECT
-            {source_alias}.workspace AS workspace,
-            {source_alias}.source_format AS source_format,
-            {source_alias}.trace_id AS trace_id,
-            {metric_columns},
-            arraySort(groupUniqArrayIf(
-                {source_alias}.attributes_string[%(model_key)s],
-                has(mapKeys({source_alias}.attributes_string), %(model_key)s)
-                    AND {source_alias}.attributes_string[%(model_key)s] != ''
-            )) AS models,
-            arraySort(groupUniqArrayIf(
-                {source_alias}.attributes_string[%(provider_key)s],
-                has(mapKeys({source_alias}.attributes_string), %(provider_key)s)
-                    AND {source_alias}.attributes_string[%(provider_key)s] != ''
-            )) AS providers,
-            count() AS span_count,
-            countIf({source_alias}.status = 'error') AS error_count
+            {select_columns}
         FROM {current_spans} AS {source_alias}
         WHERE {source_alias}.is_deleted = 0
         GROUP BY {source_alias}.workspace, {source_alias}.source_format, {source_alias}.trace_id
@@ -401,11 +405,49 @@ def _trace_aggregates_sql(table: str) -> tuple[str, dict[str, Any]]:
     return query, parameters
 
 
+def _trace_aggregate_select_columns(source_alias: str) -> tuple[str, dict[str, Any]]:
+    metric_columns, parameters = metric_aggregate_columns(source_alias)
+    parameters.update(
+        model_key=spec_for_field(SpanAttributeField.MODEL).bag_key,
+        provider_key=spec_for_field(SpanAttributeField.PROVIDER).bag_key,
+    )
+    columns = (
+        f"{source_alias}.workspace AS workspace",
+        f"{source_alias}.source_format AS source_format",
+        f"{source_alias}.trace_id AS trace_id",
+        metric_columns,
+        _unique_string_attribute_aggregate(source_alias, parameter="model_key", alias="models"),
+        _unique_string_attribute_aggregate(source_alias, parameter="provider_key", alias="providers"),
+        "count() AS span_count",
+        f"countIf({source_alias}.status = 'error') AS error_count",
+    )
+    return ",\n            ".join(columns), parameters
+
+
+def _unique_string_attribute_aggregate(source_alias: str, *, parameter: str, alias: str) -> str:
+    attribute = f"{source_alias}.attributes_string[%({parameter})s]"
+    return f"""arraySort(groupUniqArrayIf(
+                {attribute},
+                has(mapKeys({source_alias}.attributes_string), %({parameter})s)
+                    AND {attribute} != ''
+            )) AS {alias}"""
+
+
 def _trace_page_parameters(refs: Sequence[_TracePageRef]) -> dict[str, object]:
     return {
         "page_trace_ids": [ref.trace_id for ref in refs],
         "page_trace_keys": [ref.trace_key for ref in refs],
     }
+
+
+def _reconcile_hydrated_page(
+    page_refs: Sequence[_TracePageRef],
+    hydrated_rows: Sequence[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[_TracePageRef]]:
+    rows_by_ref = {_TracePageRef.from_row(row): row for row in hydrated_rows}
+    rows = [rows_by_ref[ref] for ref in page_refs if ref in rows_by_ref]
+    dropped_refs = [ref for ref in page_refs if ref not in rows_by_ref]
+    return rows, dropped_refs
 
 
 # Maps API/filter field names to their physical trace_index columns.

--- a/services/intake/src/nmp/intake/repository/clickhouse/trace.py
+++ b/services/intake/src/nmp/intake/repository/clickhouse/trace.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -77,6 +79,23 @@ _CURRENT_SPAN_VALUE_COLUMNS = (
 _ZERO_DATETIME = datetime.fromtimestamp(0, tz=timezone.utc)
 
 
+@dataclass(frozen=True)
+class _TracePageRef:
+    source_format: str
+    trace_id: str
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, Any]) -> _TracePageRef:
+        return cls(
+            source_format=str(row["source_format"]),
+            trace_id=str(row["id"]),
+        )
+
+    @property
+    def trace_key(self) -> tuple[str, str]:
+        return self.source_format, self.trace_id
+
+
 class ClickHouseTraceRepository(TraceRepository):
     def __init__(self, executor: ClickHouseExecutor) -> None:
         self._executor = executor
@@ -113,29 +132,37 @@ class ClickHouseTraceRepository(TraceRepository):
         )
 
         offset = (page - 1) * page_size
-        trace_index_sql, row_parameters = _trace_index_sql(
-            trace_index_table,
-            filters,
-            mode=mode,
-        )
-        rows_sql, rows_parameters = _trace_rows_sql(
-            trace_index_sql=trace_index_sql,
-            spans_table=spans_table,
-            mode=mode,
-            sort=sort,
-        )
-        rows = await self._executor.fetch_all(
+        page_sql = _trace_page_sql(trace_index_sql=count_trace_index_sql, sort=sort)
+        page_rows = await self._executor.fetch_all(
             ClickHouseQuery(
-                name="traces.list.rows",
-                statement=rows_sql,
+                name="traces.list.page",
+                statement=page_sql,
                 parameters={
-                    **row_parameters,
-                    **rows_parameters,
+                    **parameters,
                     "limit": page_size,
                     "offset": offset,
                 },
             )
         )
+        rows = page_rows
+        if mode != "summary" and page_rows:
+            page_refs = [_TracePageRef.from_row(row) for row in page_rows]
+            hydration_sql, hydration_parameters = _trace_hydration_sql(
+                trace_index_table=trace_index_table,
+                spans_table=spans_table,
+                mode=mode,
+            )
+            rows = await self._executor.fetch_all(
+                ClickHouseQuery(
+                    name="traces.list.hydrate",
+                    statement=hydration_sql,
+                    parameters={
+                        "workspace": filters.workspace,
+                        **hydration_parameters,
+                        **_trace_page_parameters(page_refs),
+                    },
+                )
+            )
         traces = [_row_to_trace(row) for row in rows]
         return PaginatedResult(
             data=traces,
@@ -212,47 +239,48 @@ class ClickHouseTraceRepository(TraceRepository):
         return {str(row["group_id"]): row["started_at"] for row in rows}
 
 
-def _trace_rows_sql(
-    *, trace_index_sql: str, spans_table: str, mode: TraceMode, sort: str
-) -> tuple[str, dict[str, Any]]:
-    if mode == "summary":
-        query = f"""
-            WITH page_traces AS (
-                SELECT *
-                FROM ({trace_index_sql}) AS traces
-                ORDER BY {_order_by(sort)}
-                LIMIT %(limit)s OFFSET %(offset)s
-            )
+def _trace_page_sql(*, trace_index_sql: str, sort: str) -> str:
+    return f"""
+        SELECT
+            {_trace_select_columns(include_aggregates=False)}
+        FROM ({trace_index_sql}) AS traces
+        ORDER BY {_order_by(sort, table_alias="traces")}
+        LIMIT %(limit)s OFFSET %(offset)s
+    """
+
+
+def _trace_hydration_sql(*, trace_index_table: str, spans_table: str, mode: TraceMode) -> tuple[str, dict[str, Any]]:
+    trace_columns, trace_parameters = _trace_index_select_columns(mode=mode)
+    aggregates_sql, aggregate_parameters = _trace_aggregates_sql(spans_table)
+    query = f"""
+        WITH
+        traces AS (
             SELECT
-                {_trace_select_columns(include_aggregates=False)}
-            FROM page_traces AS traces
-            ORDER BY {_order_by(sort, table_alias="traces")}
-        """
-        return query, {}
-    if mode in {"preview", "detailed"}:
-        aggregates_sql, parameters = _trace_aggregates_sql(spans_table)
-        query = f"""
-            WITH
-            page_traces AS (
-                SELECT *
-                FROM ({trace_index_sql}) AS traces
-                ORDER BY {_order_by(sort)}
-                LIMIT %(limit)s OFFSET %(offset)s
-            ),
-            rollups AS (
-                {aggregates_sql}
-            )
-            SELECT
-                {_trace_select_columns(include_aggregates=True)}
-            FROM page_traces AS traces
-            LEFT JOIN rollups
-                ON traces.workspace = rollups.workspace
-                AND traces.source_format = rollups.source_format
-                AND traces.id = rollups.trace_id
-            ORDER BY {_order_by(sort, table_alias="traces")}
-        """
-        return query, parameters
-    raise ValueError(f"Unsupported trace mode: {mode}")
+                {trace_columns}
+            FROM {trace_index_table} AS trace_roots FINAL
+            WHERE trace_roots.workspace = %(workspace)s
+                AND trace_roots.is_deleted = 0
+                AND trace_roots.trace_id IN %(page_trace_ids)s
+                AND (
+                    trace_roots.source_format,
+                    trace_roots.trace_id
+                ) IN %(page_trace_keys)s
+            ORDER BY trace_roots.root_started_at ASC, trace_roots.root_span_id ASC
+            LIMIT 1 BY trace_roots.workspace, trace_roots.source_format, trace_roots.trace_id
+        ),
+        rollups AS (
+            {aggregates_sql}
+        )
+        SELECT
+            {_trace_select_columns(include_aggregates=True)}
+        FROM traces
+        LEFT JOIN rollups
+            ON traces.workspace = rollups.workspace
+            AND traces.source_format = rollups.source_format
+            AND traces.id = rollups.trace_id
+        ORDER BY indexOf(%(page_trace_keys)s, (traces.source_format, traces.id)) ASC
+    """
+    return query, {**trace_parameters, **aggregate_parameters}
 
 
 def _trace_select_columns(*, include_aggregates: bool) -> str:
@@ -294,35 +322,41 @@ def _trace_index_sql(
     mode: TraceMode,
 ) -> tuple[str, dict[str, Any]]:
     where_sql, parameters = _trace_index_where(filters, qualifier="trace_roots")
-    parameters.update(text_query_parameters(mode))
-    payload_columns = ",\n            ".join(
-        (
-            text_select_for_mode("trace_roots.root_input", alias="input", mode=mode),
-            text_select_for_mode("trace_roots.root_output", alias="output", mode=mode),
-        )
-    )
+    select_columns, select_parameters = _trace_index_select_columns(mode=mode)
+    parameters.update(select_parameters)
     query = f"""
         SELECT
-            trace_roots.trace_id AS id,
-            trace_roots.workspace AS workspace,
-            trace_roots.session_id AS session_id,
-            trace_roots.source_format AS source_format,
-            nullIf(trace_roots.root_span_id, '') AS root_span_id,
-            nullIf(trace_roots.root_name, '') AS name,
-            {payload_columns},
-            nullIf(trace_roots.project, '') AS project,
-            nullIf(trace_roots.evaluation_id, '') AS evaluation_id,
-            nullIf(trace_roots.test_case_id, '') AS test_case_id,
-            trace_roots.root_started_at AS started_at,
-            trace_roots.root_ended_at AS ended_at,
-            trace_roots.root_status AS status,
-            trace_roots.event_ts AS ingested_at
+            {select_columns}
         FROM {table} AS trace_roots FINAL
         WHERE {where_sql}
         ORDER BY trace_roots.root_started_at ASC, trace_roots.root_span_id ASC
         LIMIT 1 BY trace_roots.workspace, trace_roots.source_format, trace_roots.trace_id
     """
     return query, parameters
+
+
+def _trace_index_select_columns(*, mode: TraceMode) -> tuple[str, dict[str, Any]]:
+    payload_columns = (
+        text_select_for_mode("trace_roots.root_input", alias="input", mode=mode),
+        text_select_for_mode("trace_roots.root_output", alias="output", mode=mode),
+    )
+    columns = (
+        "trace_roots.trace_id AS id",
+        "trace_roots.workspace AS workspace",
+        "trace_roots.session_id AS session_id",
+        "trace_roots.source_format AS source_format",
+        "nullIf(trace_roots.root_span_id, '') AS root_span_id",
+        "nullIf(trace_roots.root_name, '') AS name",
+        *payload_columns,
+        "nullIf(trace_roots.project, '') AS project",
+        "nullIf(trace_roots.evaluation_id, '') AS evaluation_id",
+        "nullIf(trace_roots.test_case_id, '') AS test_case_id",
+        "trace_roots.root_started_at AS started_at",
+        "trace_roots.root_ended_at AS ended_at",
+        "trace_roots.root_status AS status",
+        "trace_roots.event_ts AS ingested_at",
+    )
+    return ",\n            ".join(columns), text_query_parameters(mode)
 
 
 def _trace_aggregates_sql(table: str) -> tuple[str, dict[str, Any]]:
@@ -334,6 +368,14 @@ def _trace_aggregates_sql(table: str) -> tuple[str, dict[str, Any]]:
     parameters["model_key"] = model_spec.bag_key
     parameters["provider_key"] = provider_spec.bag_key
 
+    current_spans = current_spans_sql(
+        table,
+        extra_where_sql=(
+            "span_versions.trace_id IN %(page_trace_ids)s\n"
+            "                AND (span_versions.source_format, span_versions.trace_id) "
+            "IN %(page_trace_keys)s"
+        ),
+    )
     query = f"""
         SELECT
             {source_alias}.workspace AS workspace,
@@ -352,19 +394,18 @@ def _trace_aggregates_sql(table: str) -> tuple[str, dict[str, Any]]:
             )) AS providers,
             count() AS span_count,
             countIf({source_alias}.status = 'error') AS error_count
-        FROM {
-        current_spans_sql(
-            table,
-            extra_where_sql=(
-                "(span_versions.workspace, span_versions.source_format, span_versions.trace_id) IN "
-                "(SELECT workspace, source_format, id FROM page_traces)"
-            ),
-        )
-    } AS {source_alias}
+        FROM {current_spans} AS {source_alias}
         WHERE {source_alias}.is_deleted = 0
         GROUP BY {source_alias}.workspace, {source_alias}.source_format, {source_alias}.trace_id
     """
     return query, parameters
+
+
+def _trace_page_parameters(refs: Sequence[_TracePageRef]) -> dict[str, object]:
+    return {
+        "page_trace_ids": [ref.trace_id for ref in refs],
+        "page_trace_keys": [ref.trace_key for ref in refs],
+    }
 
 
 # Maps API/filter field names to their physical trace_index columns.

--- a/services/intake/tests/test_traces_clickhouse_repository.py
+++ b/services/intake/tests/test_traces_clickhouse_repository.py
@@ -122,7 +122,14 @@ async def test_latest_trace_started_at_by_group_aggregates_all_references_in_one
 
 @pytest.mark.asyncio
 async def test_preview_mode_bounds_payloads_and_adds_trace_aggregate_block():
-    client = _Client()
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    page_row = _trace_row(started_at=started_at, ended_at=None, ingested_at=started_at, detailed=False)
+    client = _Client(
+        query_results=[
+            _QueryResult([(1,)]),
+            _QueryResult([page_row], TRACE_COLUMNS),
+        ]
+    )
     repository = _repository(client)
 
     await repository.list_traces(
@@ -133,16 +140,37 @@ async def test_preview_mode_bounds_payloads_and_adds_trace_aggregate_block():
         mode="preview",
     )
 
-    assert "substringUTF8(trace_roots.root_input, 1, %(payload_char_limit)s)" in client.queries[1]
-    assert "substringUTF8(trace_roots.root_output, 1, %(payload_char_limit)s)" in client.queries[1]
-    assert client.parameters[1]["payload_char_limit"] == 300
-    assert "sumIf" in client.queries[1]
-    assert "count() AS span_count" in client.queries[1]
+    assert len(client.queries) == 3
+    assert "trace_roots.root_input" not in client.queries[1]
+    assert "trace_roots.root_output" not in client.queries[1]
+    assert "LIMIT %(limit)s OFFSET %(offset)s" in client.queries[1]
+    assert "substringUTF8(trace_roots.root_input, 1, %(payload_char_limit)s)" in client.queries[2]
+    assert "substringUTF8(trace_roots.root_output, 1, %(payload_char_limit)s)" in client.queries[2]
+    assert client.parameters[2]["payload_char_limit"] == 300
+    assert "sumIf" in client.queries[2]
+    assert "count() AS span_count" in client.queries[2]
+    assert "page_traces" not in client.queries[2]
+    assert "trace_page_refs" not in client.queries[2]
+    assert "IN %(page_trace_keys)s" in client.queries[2]
+    assert "trace_id IN %(page_trace_ids)s" in client.queries[2]
+    assert "LIMIT 1 BY trace_roots.workspace, trace_roots.source_format, trace_roots.trace_id" in client.queries[2]
+    assert "ORDER BY indexOf(%(page_trace_keys)s" in client.queries[2]
+    assert client.external_data[2] is None
+    assert client.parameters[2]["page_trace_ids"] == ["trace-a"]
+    assert client.parameters[2]["page_trace_keys"] == [("otel", "trace-a")]
+    assert "page_root_keys" not in client.parameters[2]
 
 
 @pytest.mark.asyncio
 async def test_detailed_mode_adds_trace_aggregate_block():
-    client = _Client()
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    page_row = _trace_row(started_at=started_at, ended_at=None, ingested_at=started_at, detailed=False)
+    client = _Client(
+        query_results=[
+            _QueryResult([(1,)]),
+            _QueryResult([page_row], TRACE_COLUMNS),
+        ]
+    )
     repository = _repository(client)
 
     await repository.list_traces(
@@ -155,21 +183,22 @@ async def test_detailed_mode_adds_trace_aggregate_block():
 
     assert "FROM trace_index AS trace_roots FINAL" in client.queries[0]
     assert "span_versions" not in client.queries[0]
-    assert "page_traces AS" in client.queries[1]
-    assert "AS trace_spans" in client.queries[1]
-    assert "(span_versions.workspace, span_versions.source_format, span_versions.trace_id) IN" in client.queries[1]
-    assert "SELECT workspace, source_format, id FROM page_traces" in client.queries[1]
-    assert "argMax(span_versions.input," not in client.queries[1]
-    assert "argMax(span_versions.output," not in client.queries[1]
-    assert "argMax(span_versions.attributes_string," in client.queries[1]
-    assert "argMax(span_versions.attributes_number," in client.queries[1]
-    assert "sumIf" in client.queries[1]
-    assert "groupUniqArrayIf" in client.queries[1]
-    assert "count() AS span_count" in client.queries[1]
-    assert "trace_roots.root_input AS input" in client.queries[1]
-    assert "trace_roots.root_output AS output" in client.queries[1]
-    assert "substringUTF8(trace_roots.root_input" not in client.queries[1]
-    assert "payload_char_limit" not in client.parameters[1]
+    assert "trace_roots.root_input" not in client.queries[1]
+    assert "trace_roots.root_output" not in client.queries[1]
+    assert "AS trace_spans" in client.queries[2]
+    assert "span_versions.trace_id IN %(page_trace_ids)s" in client.queries[2]
+    assert "(span_versions.source_format, span_versions.trace_id) IN %(page_trace_keys)s" in client.queries[2]
+    assert "argMax(span_versions.input," not in client.queries[2]
+    assert "argMax(span_versions.output," not in client.queries[2]
+    assert "argMax(span_versions.attributes_string," in client.queries[2]
+    assert "argMax(span_versions.attributes_number," in client.queries[2]
+    assert "sumIf" in client.queries[2]
+    assert "groupUniqArrayIf" in client.queries[2]
+    assert "count() AS span_count" in client.queries[2]
+    assert "trace_roots.root_input AS input" in client.queries[2]
+    assert "trace_roots.root_output AS output" in client.queries[2]
+    assert "substringUTF8(trace_roots.root_input" not in client.queries[2]
+    assert "payload_char_limit" not in client.parameters[2]
 
 
 @pytest.mark.asyncio
@@ -178,7 +207,14 @@ async def test_list_traces_maps_detailed_row():
     ended_at = started_at + timedelta(milliseconds=2500)
     ingested_at = started_at + timedelta(seconds=3)
     row = _trace_row(started_at=started_at, ended_at=ended_at, ingested_at=ingested_at)
-    client = _Client(query_results=[_QueryResult([(1,)]), _QueryResult([row], TRACE_COLUMNS)])
+    page_row = _trace_row(started_at=started_at, ended_at=ended_at, ingested_at=ingested_at, detailed=False)
+    client = _Client(
+        query_results=[
+            _QueryResult([(1,)]),
+            _QueryResult([page_row], TRACE_COLUMNS),
+            _QueryResult([row], TRACE_COLUMNS),
+        ]
+    )
     repository = _repository(client)
 
     result = await repository.list_traces(
@@ -211,6 +247,24 @@ async def test_list_traces_maps_detailed_row():
     assert trace.providers == ["openai"]
     assert trace.span_count == 3
     assert trace.error_count == 1
+
+
+@pytest.mark.asyncio
+async def test_non_summary_empty_page_skips_hydration_query():
+    client = _Client(query_results=[_QueryResult([(0,)])])
+    repository = _repository(client)
+
+    result = await repository.list_traces(
+        filters=TraceListFilter(workspace="workspace-a"),
+        page=1,
+        page_size=10,
+        sort="-started_at",
+        mode="preview",
+    )
+
+    assert result.data == []
+    assert len(client.queries) == 2
+    assert all(external_data is None for external_data in client.external_data)
 
 
 @pytest.mark.asyncio

--- a/services/intake/tests/test_traces_clickhouse_repository.py
+++ b/services/intake/tests/test_traces_clickhouse_repository.py
@@ -4,6 +4,7 @@
 """Trace repository tests."""
 
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -154,7 +155,7 @@ async def test_preview_mode_bounds_payloads_and_adds_trace_aggregate_block():
     assert "IN %(page_trace_keys)s" in client.queries[2]
     assert "trace_id IN %(page_trace_ids)s" in client.queries[2]
     assert "LIMIT 1 BY trace_roots.workspace, trace_roots.source_format, trace_roots.trace_id" in client.queries[2]
-    assert "ORDER BY indexOf(%(page_trace_keys)s" in client.queries[2]
+    assert "indexOf(%(page_trace_keys)s" not in client.queries[2]
     assert client.external_data[2] is None
     assert client.parameters[2]["page_trace_ids"] == ["trace-a"]
     assert client.parameters[2]["page_trace_keys"] == [("otel", "trace-a")]
@@ -268,6 +269,50 @@ async def test_non_summary_empty_page_skips_hydration_query():
 
 
 @pytest.mark.asyncio
+async def test_non_summary_reconciles_hydration_misses_and_restores_page_order(caplog: pytest.LogCaptureFixture):
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    page_rows = [
+        _trace_row(
+            trace_id=trace_id,
+            started_at=started_at,
+            ended_at=None,
+            ingested_at=started_at,
+            detailed=False,
+        )
+        for trace_id in ("trace-a", "trace-b", "trace-c")
+    ]
+    hydrated_rows = [
+        _trace_row(trace_id=trace_id, started_at=started_at, ended_at=None, ingested_at=started_at)
+        for trace_id in ("trace-c", "trace-a")
+    ]
+    client = _Client(
+        query_results=[
+            _QueryResult([(3,)]),
+            _QueryResult(page_rows, TRACE_COLUMNS),
+            _QueryResult(hydrated_rows, TRACE_COLUMNS),
+        ]
+    )
+    repository = _repository(client)
+
+    with caplog.at_level(logging.WARNING):
+        result = await repository.list_traces(
+            filters=TraceListFilter(workspace="workspace-a"),
+            page=1,
+            page_size=10,
+            sort="-started_at",
+            mode="preview",
+        )
+
+    assert [trace.id for trace in result.data] == ["trace-a", "trace-c"]
+    assert result.pagination.current_page_size == 2
+    assert result.pagination.total_results == 2
+    assert result.pagination.total_pages == 1
+    record = caplog.records[-1]
+    assert record.message == "Trace page hydration omitted refs returned by the page query"
+    assert getattr(record, "dropped_trace_refs") == [("otel", "trace-b")]
+
+
+@pytest.mark.asyncio
 async def test_summary_mode_maps_no_aggregate_fields():
     started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     row = _trace_row(started_at=started_at, ended_at=None, ingested_at=started_at, detailed=False)
@@ -336,13 +381,14 @@ async def test_root_filters_use_trace_index_columns():
 
 def _trace_row(
     *,
+    trace_id: str = "trace-a",
     started_at: datetime,
     ended_at: datetime | None,
     ingested_at: datetime,
     detailed: bool = True,
 ) -> tuple[object, ...]:
     values: dict[str, object | None] = {
-        "id": "trace-a",
+        "id": trace_id,
         "workspace": "workspace-a",
         "session_id": "session-a",
         "source_format": "otel",


### PR DESCRIPTION
Use a two phase query to hydrate the trace list view instead of the current single query approach, which requires reading _all_ input/output data across spans.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace listing pagination and multi-step loading to keep results consistent across modes.
  * Added reconciliation when hydration omits items, including warning logs and corrected total counts.
  * Refined preview payload handling to ensure proper truncation without impacting detailed views.
  * Empty preview pages now avoid unnecessary follow-up loading.

* **Tests**
  * Expanded assertions for preview and detailed query behavior, including aggregation expressions and payload formatting.
  * Added cases for empty pages and reconciliation when hydrated results miss requested refs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->