### PR TITLE
fix(helm): keep PostgreSQL PVC template labels stable

### DIFF
--- a/k8s/helm/templates/postgres/postgres-statefulset.yaml
+++ b/k8s/helm/templates/postgres/postgres-statefulset.yaml
@@ -113,7 +113,6 @@ spec:
         name: data
         labels:
           app.kubernetes.io/component: postgres
-          {{- include "nemo-platform.labels" . | nindent 10 }}
       spec:
         accessModes:
           - ReadWriteOnce

--- a/tools/lint/lint-helm.sh
+++ b/tools/lint/lint-helm.sh
@@ -18,6 +18,24 @@ helm dependency update "${HELM_FOLDER}"
 # Lint the Helm chart
 helm lint --strict "${HELM_FOLDER}"
 
+# StatefulSet volumeClaimTemplates are immutable, so chart metadata must not change them.
+postgres_claim_tmp=$(mktemp -d)
+trap 'rm -rf "${postgres_claim_tmp}"' EXIT
+
+for version in 1 2; do
+  helm package "${HELM_FOLDER}" \
+    --version "0.0.0-claim-test.${version}" \
+    --app-version "claim-test-${version}" \
+    --destination "${postgres_claim_tmp}" >/dev/null
+  helm template "${HELM_RELEASE_NAME}" \
+    "${postgres_claim_tmp}/nemo-platform-0.0.0-claim-test.${version}.tgz" \
+    --show-only templates/postgres/postgres-statefulset.yaml \
+    | sed -n '/^  volumeClaimTemplates:/,$p' > "${postgres_claim_tmp}/claim-${version}.yaml"
+  test -s "${postgres_claim_tmp}/claim-${version}.yaml"
+done
+
+diff -u "${postgres_claim_tmp}/claim-1.yaml" "${postgres_claim_tmp}/claim-2.yaml"
+
 # Utilization-based autoscaling must reject missing CPU requests.
 api_autoscaling_output=$(helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
   --set api.autoscaling.enabled=true 2>&1) && {


### PR DESCRIPTION
PostgreSQL's `volumeClaimTemplates` included chart and app version labels. Those labels change between releases, but Kubernetes treats the entire field as immutable, so a normal Helm upgrade can fail while updating the StatefulSet.

This keeps only the stable PostgreSQL component label in the claim template. It also adds a regression that packages two chart versions and verifies their claim templates are identical.

[Kubernetes StatefulSet validation source](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/apps/validation/validation.go#L223-L242)

Existing StatefulSets with the old labels still require one-time recreation. This change prevents the mismatch for newly created StatefulSets.

## Testing

- `bash tools/lint/lint-helm.sh`
- `shellcheck tools/lint/lint-helm.sh`
- `uv run pre-commit run -a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PostgreSQL StatefulSet persistent volume claim labels to include only the PostgreSQL component label, improving label consistency.

* **Tests**
  * Enhanced Helm lint validation to ensure PostgreSQL StatefulSet `volumeClaimTemplates` output remains unchanged across chart/app version variations, preventing unintended template drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->