### PR TITLE
fix(docs): Fix Agent Details docs in Studio

### DIFF
--- a/docs/studio/agents.mdx
+++ b/docs/studio/agents.mdx
@@ -6,25 +6,35 @@ Use **Agents** in the NeMo Studio workspace sidebar to review and operate agent 
 
 ## Agent List
 
-The Agents table shows the agents in the selected workspace, including their deployment state and creation time. Select a row to open the agent side panel.
+The Agents table shows the agents in the selected workspace, including description, model, deployment health, and creation time. Select a row to open the agent details page.
 
 | Action | Where | Result |
 |--------|-------|--------|
-| Review details | Select an agent row | Opens the agent side panel with name, workspace, description, and config format. |
+| Review details | Select an agent row | Opens the agent details page for that agent. |
+| Create an example agent | Page header > **Create Example Agent** | Creates a ready-made example agent in the workspace. |
 | Deploy an agent | Row actions > **Deploy** | Creates a deployment for the selected agent. |
 | Test models | Row actions > **Test models** | Opens the model playground for the agent's configured model. |
 | Clone an agent | Row actions > **Clone** | Creates a copy of the agent definition with a new name. |
-| Chat with a deployment | Agent side panel > **Chat Playground** tab | Opens the chat playground for a running deployment. |
-| Delete a deployment | Agent side panel > **Details** > **Deployments** > **Delete** | Removes that deployment. |
-| Delete an agent | Row actions > **Delete** | Removes the stored agent definition from the workspace. |
+| Delete an agent | Row actions > **Delete** | Removes the stored agent definition and all its deployments. |
+| Delete several agents | Select rows > **Delete** | Removes the selected agent definitions and their deployments. |
 
 ## Agent Details
 
-The agent side panel has three tabs:
+The agent details page opens at `Agents > <agent name>`. The header shows the agent name, deployment status, model, and description, along with these actions:
 
-- **Details** shows the stored agent metadata and config format. It includes a **Deployments** section listing active and historical deployments for the agent (endpoint and status), plus recent evaluations.
-- **Chat Playground** opens an interactive chat with a running deployment.
-- **Logs** shows deployment logs.
+- **Open traces** goes to the agent Monitor view for telemetry.
+- **Run evaluation** submits an evaluation job for the agent.
+- **Deploy** creates a new deployment.
+
+The page has five tabs:
+
+- **Deployments** (default) lists the agent's deployments with status and endpoint, plus per-deployment **Chat**, **Logs**, and **Delete** actions.
+- **Logs** shows logs for a selected deployment.
+- **Chat** opens an interactive chat with a running deployment.
+- **Evaluations** lists recent evaluation jobs for the agent and links through to each run.
+- **Details** shows the stored agent metadata and the full config, grouped into Workflow, Models, and Tools panels.
+
+The selected tab is reflected in the URL's `tab` query parameter, so you can link directly to a tab.
 
 Agents are created and updated through the `nemo agents` CLI or Agents API. NeMo Studio reflects the current workspace state after the platform services refresh.
 

--- a/docs/studio/index.mdx
+++ b/docs/studio/index.mdx
@@ -27,12 +27,6 @@ Use the Studio Agents area to review platform-managed NeMo Agent Toolkit workflo
 
 For the full workflow, see [Studio Agents](/documentation/studio/agents).
 
-### Suggestions
-
-Use **Agents \> Suggestions** to review optimizer suggestions for deployed agents. Studio groups suggestions by workspace or agent and lets you filter by type, priority, scope, and agent.
-
-For the full workflow, see [Studio Suggestions](/documentation/studio/suggestions).
-
 ### Monitor
 
 Use **Agents \> Monitor** to inspect agent telemetry stored by the platform, including recent inference logs and token usage summaries.
@@ -71,27 +65,27 @@ Keep models and data organized in dedicated workspaces.
 
 Use **Filesets** to organize files by **purpose**, which determines which metadata fields are available. Purpose is chosen at creation time and can't be changed afterward.
 
-| Purpose | Use for |
-| ------- | ------- |
-| Generic | Default. Files that don't fit the Dataset or Model categories. Doesn't add purpose-specific metadata fields. |
+| Purpose | Use for                                                                                                                                                                                      |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Generic | Default. Files that don't fit the Dataset or Model categories. Doesn't add purpose-specific metadata fields.                                                                                 |
 | Dataset | Training and evaluation data. Enables dataset-specific metadata, including schema information. Use built-in tools to transform data schemas with LLM assistance or create train/test splits. |
-| Model | Model weights and checkpoints. Enables model-specific metadata, including tool-calling and model configuration fields. |
+| Model   | Model weights and checkpoints. Enables model-specific metadata, including tool-calling and model configuration fields.                                                                       |
 
 **Supported file formats:** JSON (`.json`), JSONL (`.jsonl`), CSV (`.csv`), and Parquet (`.parquet`). PDF, image, and other binary formats are not currently supported.
 
 You can upload any file type into a fileset. However, each service supports specific input file types:
 
-| Service | Supported File Types |
-| --------------------------------------------------- | ------------------------------------- |
+| Service                                               | Supported File Types                  |
+| ----------------------------------------------------- | ------------------------------------- |
 | [Data Designer](/documentation/design-synthetic-data) | `.json`, `.jsonl`, `.csv`, `.parquet` |
 
 ### Evaluations
 
 **Evaluations** appears in two separate sidebar groups because it covers two distinct scopes:
 
-| Location | What it shows |
-| -------- | ------------- |
-| **Agents \> Evaluations** | Evaluation runs scoped to a specific agent — results tied to agent deployments and versions. |
+| Location                    | What it shows                                                                                  |
+| --------------------------- | ---------------------------------------------------------------------------------------------- |
+| **Agents \> Evaluations**   | Evaluation runs scoped to a specific agent — results tied to agent deployments and versions.   |
 | **Evaluate \> Evaluations** | All evaluation results across the workspace, regardless of which agent or model was evaluated. |
 
 Use **Agents \> Evaluations** when reviewing how a specific agent performed. Use **Evaluate \> Evaluations** for a broader view of evaluation history across the workspace.
@@ -106,18 +100,18 @@ Navigate to **Jobs** in the workspace sidebar to see all jobs in the current wor
 
 **Status tracking** — Each job displays its current status:
 
-| Status | Description |
-| ------ | ----------- |
-| Created | Job has been created but not yet scheduled |
-| Pending | Job is queued and waiting for resources |
-| Active | Job is currently running |
-| Completed | Job finished successfully |
-| Error | Job encountered an error |
-| Cancelled | Job was cancelled by a user |
-| Cancelling | Cancellation is in progress |
-| Paused | Job execution is paused |
-| Pausing | Job is transitioning to paused |
-| Resuming | Paused job is restarting |
+| Status     | Description                                |
+| ---------- | ------------------------------------------ |
+| Created    | Job has been created but not yet scheduled |
+| Pending    | Job is queued and waiting for resources    |
+| Active     | Job is currently running                   |
+| Completed  | Job finished successfully                  |
+| Error      | Job encountered an error                   |
+| Cancelled  | Job was cancelled by a user                |
+| Cancelling | Cancellation is in progress                |
+| Paused     | Job execution is paused                    |
+| Pausing    | Job is transitioning to paused             |
+| Resuming   | Paused job is restarting                   |
 
 **Service routing** — Clicking a job navigates to its service-specific detail view when one exists. Jobs from services that aren't enabled fall back to the generic job detail view.
 


### PR DESCRIPTION
https://nvbugspro.nvidia.com/bug/6537170

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Agents documentation to cover the table-based agent list, expanded details pages, creation and bulk deletion actions, deployment controls, and persistent tabs.
  * Clarified that deleting agents also removes associated deployments.
  * Removed outdated guidance for side panels, chat playgrounds, and deployment deletion.
  * Removed Studio Suggestions documentation.
  * Expanded and reformatted Filesets, Evaluations, and Jobs documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->