### PR TITLE
fix(deployments): tolerate containers removed during port enumeration

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/backend.py
@@ -31,7 +31,7 @@ from nemo_deployments_plugin.backends.docker.containers import (
     restart_policy_kwargs,
 )
 from nemo_deployments_plugin.backends.docker.gpu import GPUAllocationError, get_shared_gpu_pool
-from nemo_deployments_plugin.backends.docker.ports import find_available_port
+from nemo_deployments_plugin.backends.docker.ports import PortEnumerationError, find_available_port
 from nemo_deployments_plugin.backends.docker.probes import check_readiness_probe, host_url_for_port
 from nemo_deployments_plugin.backends.docker.status import (
     LOG_MAX_CHARS,
@@ -204,7 +204,13 @@ class DockerDeploymentBackend(DeploymentBackend):
             except GPUAllocationError as exc:
                 return BackendStatusUpdate(status="FAILED", status_message=str(exc))
 
-        host_ports = await self._allocate_host_ports(container_spec)
+        try:
+            host_ports = await self._allocate_host_ports(container_spec)
+        except PortEnumerationError as exc:
+            # Could not determine what is in use — report that, rather than blaming the port range.
+            if gpu_ids and gpu_pool is not None:
+                gpu_pool.release_gpu(dep_key)
+            return BackendStatusUpdate(status="FAILED", status_message=f"Could not determine host ports in use: {exc}")
         if host_ports is None:
             if gpu_ids and gpu_pool is not None:
                 gpu_pool.release_gpu(dep_key)
@@ -334,7 +340,9 @@ class DockerDeploymentBackend(DeploymentBackend):
     ) -> dict[int, int] | None:
         """Map each published container port to a free host port.
 
-        Returns None when the configured range holds no more free ports.
+        Returns None when the configured range holds no more free ports. Propagates
+        :class:`PortEnumerationError` when the ports in use could not be determined at all — that is
+        a different (usually transient) condition and must not be reported as an exhausted range.
         """
         excluded = set(exclude_ports or ())
         host_ports: dict[int, int] = {}
@@ -411,7 +419,10 @@ class DockerDeploymentBackend(DeploymentBackend):
                 # containers.run() creates then starts, so a failed start leaves the
                 # created container holding the name and blocking the retry.
                 await self._remove_container_by_name(name)
-                reallocated = await self._allocate_host_ports(container_spec, exclude_ports=rejected_ports)
+                try:
+                    reallocated = await self._allocate_host_ports(container_spec, exclude_ports=rejected_ports)
+                except PortEnumerationError as port_exc:
+                    return None, host_ports, f"Could not determine host ports in use: {port_exc}"
                 if reallocated is None:
                     return None, host_ports, "No host ports available in configured range"
                 host_ports = reallocated

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/ports.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/docker/ports.py
@@ -19,6 +19,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class PortEnumerationError(RuntimeError):
+    """Raised when the set of ports currently in use could not be determined.
+
+    Distinct from an exhausted range: here we don't know what is free, so the caller must not
+    report the range as full (the previous behaviour, which sent operators looking at
+    ``port_range_*`` config for what is usually a transient daemon-query failure).
+    """
+
+
 def is_remote_docker_host() -> bool:
     docker_host = os.environ.get("DOCKER_HOST", "")
     return docker_host.startswith("tcp://")
@@ -65,10 +74,15 @@ async def find_available_port(
         # Every container on the daemon competes for host ports, not just the ones
         # this platform manages. ``resource_scope`` scopes ownership and cleanup;
         # port safety has to consider foreign containers too.
-        containers = await asyncio.to_thread(client.containers.list, all=True)
-    except Exception:
-        logger.exception("Failed to list containers for port allocation")
-        return None
+        #
+        # ignore_removed=True is load-bearing: docker-py enumerates containers and then inspects
+        # each one individually, so a container removed between those two calls makes the inspect
+        # 404 and aborts the entire listing. That is routine whenever containers are being torn
+        # down concurrently, and a container that no longer exists holds no host ports.
+        containers = await asyncio.to_thread(client.containers.list, all=True, ignore_removed=True)
+    except Exception as exc:
+        # We do not know which ports are in use, so we cannot claim the range is full.
+        raise PortEnumerationError(f"could not list containers to determine ports in use: {exc}") from exc
 
     used_ports = collect_used_host_ports(containers)
     if exclude_ports:

--- a/plugins/nemo-deployments/tests/unit/backends/docker/test_ports.py
+++ b/plugins/nemo-deployments/tests/unit/backends/docker/test_ports.py
@@ -102,7 +102,56 @@ async def test_find_available_port_skips_unmanaged_containers(
     port = await find_available_port(mock_docker_client, 9000, 9002)
 
     assert port == 9001
-    assert mock_docker_client.containers.list.call_args.kwargs == {"all": True}
+    # No label filter: foreign containers hold host ports too, so they must be enumerated as well.
+    assert mock_docker_client.containers.list.call_args.kwargs == {"all": True, "ignore_removed": True}
+
+
+@pytest.mark.asyncio
+async def test_find_available_port_tolerates_containers_removed_mid_enumeration(
+    mock_docker_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """docker-py inspects each container individually after enumerating them.
+
+    A container removed between those two calls makes the inspect 404, which aborts the whole
+    ``list``. Under a teardown-heavy workload that is routine, not exceptional, so the listing must
+    opt in to skipping vanished containers -- one that no longer exists holds no host ports.
+    """
+    from nemo_deployments_plugin.backends.docker import ports as ports_mod
+    from nemo_deployments_plugin.backends.docker.ports import find_available_port
+
+    mock_docker_client.containers.list.return_value = []
+    monkeypatch.setattr(ports_mod, "is_port_free", lambda port: True)
+
+    assert await find_available_port(mock_docker_client, 9000, 9002) == 9000
+    assert mock_docker_client.containers.list.call_args.kwargs["ignore_removed"] is True
+
+
+@pytest.mark.asyncio
+async def test_find_available_port_raises_when_enumeration_fails(mock_docker_client: MagicMock) -> None:
+    """A failure to enumerate is not the same as a full port range.
+
+    Returning None for both made the caller report "No host ports available in configured range"
+    whenever the daemon query failed, which misdirects anyone debugging it -- the range was empty.
+    """
+    from nemo_deployments_plugin.backends.docker.ports import PortEnumerationError, find_available_port
+
+    mock_docker_client.containers.list.side_effect = RuntimeError("daemon says no")
+
+    with pytest.raises(PortEnumerationError):
+        await find_available_port(mock_docker_client, 9000, 9002)
+
+
+@pytest.mark.asyncio
+async def test_find_available_port_returns_none_only_when_range_is_full(
+    mock_docker_client: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from nemo_deployments_plugin.backends.docker import ports as ports_mod
+    from nemo_deployments_plugin.backends.docker.ports import find_available_port
+
+    mock_docker_client.containers.list.return_value = []
+    monkeypatch.setattr(ports_mod, "is_port_free", lambda port: False)  # every port taken
+
+    assert await find_available_port(mock_docker_client, 9000, 9002) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes an intermittent `Python integration tests` failure caused by a race in Docker host-port allocation.

## The bug

`find_available_port` enumerated containers with `client.containers.list(all=True)`. docker-py implements that as **two** API calls — enumerate, then inspect each container individually — and `ignore_removed` defaults to `False`. Its own source says so:

```python
for r in resp:
    try:
        containers.append(self.get(r['Id']))
    # a container may have been removed while iterating
    except NotFound:
        if not ignore_removed:   # <- defaults to False
            raise
```

So a container removed between the enumerate and its inspect 404s and aborts the whole listing:

```
requests.exceptions.HTTPError: 404 Client Error: Not Found for url:
http+docker://localhost/v1.48/containers/<id>/json
```

Under a teardown-heavy workload that is routine, not exceptional.

The exception was swallowed into a `None` return, which the caller reported as **"No host ports available in configured range"** — misleading twice over: the range was not full, and it sends the reader to `port_range_*` config for what is a transient daemon-query race.

## Observed impact

Recent `main` failures in `Python integration tests`, all in the Docker deployment path:

- `test_igw_cache_removes_deleted_deployment_provider` — `Deployment not READY: ERROR`, preceded by `Failed to list containers for port allocation` + the 404 above
- `test_deployments_plugin_docker_lifecycle` — `Container not running: created`

## The fix

1. **`ignore_removed=True`.** A container that no longer exists holds no host ports, so skipping it is the semantically correct answer rather than a workaround.
2. **Separate "cannot determine" from "range is full".** `find_available_port` now raises `PortEnumerationError` when enumeration fails, and reserves `None` for genuine exhaustion. Both docker-backend call sites map it to an accurate status message. This mirrors the existing `GPUAllocationError` handling a few lines above.

The second call site is the port-conflict retry loop, where `_allocate_host_ports` sits inside an exception handler — without explicit handling the new exception would have escaped uncaught instead of becoming a graceful `FAILED` status.

## Deliberately not fixed here

`is_port_free` binds and releases a probe socket, so two concurrent allocations can still pick the same port. That is a real but separate race, already mitigated by the existing `_PORT_CONFLICT_ATTEMPTS` retry loop. Left alone to keep this change scoped to the enumeration bug — happy to file it separately.

## Testing

Three new unit tests: the removal race (asserts `ignore_removed=True` is passed), enumeration failure raising `PortEnumerationError`, and `None` returned only on true exhaustion. One existing test updated — it pinned the exact `containers.list` kwargs; its original intent (no label filter, so foreign containers are counted) is preserved and now commented.

`375 passed, 17 skipped` in `plugins/nemo-deployments/tests/unit/`. Ruff clean; `ty` reports only pre-existing diagnostics in `openshell/backend.py`.

Note the integration tests that motivated this need a Docker daemon, so the fix is verified by unit tests plus CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker deployment port-allocation error handling.
  * Distinguishes fully occupied port ranges from failures while checking port availability.
  * Provides clearer deployment failure messages and properly releases allocated resources when port checks fail.
  * Tolerates containers removed during port enumeration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->