### PR TITLE
fix(nemo-agents): Support Studio multi-turn transcript replay for Fabric agents

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -76,7 +76,7 @@ def _to_fabric_invocation_request(
 ) -> FabricInvocationRequest:
     """Translate the chat transcript into a Platform-owned Fabric request."""
     messages = request.messages
-    # AIRCORE-969: Interim behavior to get multi-turn in Studio chat.
+    # Interim behavior to get multi-turn in Studio chat.
     input_text = (
         messages[0].content
         if len(messages) == 1

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -74,9 +74,16 @@ def _to_fabric_invocation_request(
     *,
     session_id: str,
 ) -> FabricInvocationRequest:
-    """Translate the current chat turn into a Platform-owned Fabric request."""
+    """Translate the chat transcript into a Platform-owned Fabric request."""
+    messages = request.messages
+    # AIRCORE-969: Interim behavior to get multi-turn in Studio chat.
+    input_text = (
+        messages[0].content
+        if len(messages) == 1
+        else "\n\n".join(f"{message.role}: {message.content}" for message in messages)
+    )
     return FabricInvocationRequest(
-        input=request.messages[-1].content,
+        input=input_text,
         caller_context={"session_id": session_id},
     )
 

--- a/plugins/nemo-agents/tests/unit/test_fabric_server.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_server.py
@@ -570,7 +570,22 @@ def test_chat_completion_maps_failed_run_result(
     assert response.json() == {"detail": "adapter failed"}
 
 
-def test_chat_completion_request_translates_final_user_turn() -> None:
+def test_chat_completion_request_preserves_single_user_turn() -> None:
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Say hello."}],
+            "model": "test-model",
+            "stream": False,
+        }
+    )
+
+    invocation_request = server._to_fabric_invocation_request(request, session_id="session-1")
+
+    assert invocation_request.input == "Say hello."
+    assert invocation_request.caller_context == {"session_id": "session-1"}
+
+
+def test_chat_completion_request_serializes_full_transcript() -> None:
     request = ChatCompletionRequest.model_validate(
         {
             "messages": [
@@ -585,7 +600,9 @@ def test_chat_completion_request_translates_final_user_turn() -> None:
 
     invocation_request = server._to_fabric_invocation_request(request, session_id="session-1")
 
-    assert invocation_request.input == "Say hello."
+    assert invocation_request.input == (
+        "system: Be concise.\n\nassistant: How can I help?\n\nuser: Say hello."
+    )
     assert invocation_request.caller_context == {"session_id": "session-1"}
 
 

--- a/plugins/nemo-agents/tests/unit/test_fabric_server.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_server.py
@@ -600,9 +600,7 @@ def test_chat_completion_request_serializes_full_transcript() -> None:
 
     invocation_request = server._to_fabric_invocation_request(request, session_id="session-1")
 
-    assert invocation_request.input == (
-        "system: Be concise.\n\nassistant: How can I help?\n\nuser: Say hello."
-    )
+    assert invocation_request.input == ("system: Be concise.\n\nassistant: How can I help?\n\nuser: Say hello.")
     assert invocation_request.caller_context == {"session_id": "session-1"}
 
 


### PR DESCRIPTION
## Summary

- Serialize the complete OpenAI chat transcript into Fabric invocation input for multi-message requests.
- Preserve the existing input exactly for single-message, one-shot requests.
- Retain message roles and ordering so Studio can provide conversational context without managing Fabric session IDs.

Studio already provides multi-turn chat for NAT-backed agents by retaining the conversation client-side and resending the full OpenAI `messages` transcript on every turn. NAT-backed serving uses that replayed transcript as context rather than relying on a platform-managed session.

This change gives Fabric-backed agents parity with that existing Studio behavior. The Fabric shim translates the replayed transcript into a role-aware input string, while each request remains an independent invocation. Native Fabric session management and session-ID wiring remain separate follow-up work.

## Testing

- Added coverage for unchanged single-message input.
- Added coverage for role-aware serialization of system, assistant, and user messages.
- Verified the Fabric server unit suite: `25 passed`.
- Verified Ruff and `git diff --check` pass.

Studio Before:
<img width="1615" height="686" alt="Screenshot 2026-07-31 at 1 04 45 PM" src="https://github.com/user-attachments/assets/33b66e7c-db57-422d-98ed-947fd40ade6f" />


Studio After:
<img width="1617" height="1343" alt="Screenshot 2026-07-31 at 1 15 38 PM" src="https://github.com/user-attachments/assets/feb4b8ae-347e-45be-a243-bcb18d6f0b79" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat interactions by preserving the full conversation history when sending requests.
  * System, assistant, and user messages are now included in the proper order, providing better context for responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->