### PR TITLE
fix(insights): preflight service before analysis

### DIFF
--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
@@ -9,19 +9,20 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import httpx
 from nemo_insights_plugin.analyst.agent import (
     KICKOFF,
     MAX_REQUESTS,
     build_analyst_agent,
 )
-from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
+from nemo_insights_plugin.analyst.analyst_backend import AnalystBackend, make_analyst_backend
 from nemo_insights_plugin.analyst.deps import AnalystDeps
 from nemo_insights_plugin.analyst.observability import (
     ANALYST_OBSERVABILITY_ENV,
     setup_analyst_observability,
 )
 from nemo_insights_plugin.analyst.result import AnalystResult
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatformError
 from pydantic_ai import Agent, UsageLimits
 from pydantic_ai.messages import TextPart, ToolCallPart, ToolReturnPart
 
@@ -32,6 +33,10 @@ _VERBOSE_TRUNCATE = 2000
 
 class ClientConstructionError(Exception):
     """The analyst's NeMo Platform client could not be constructed."""
+
+
+class InsightsServiceUnavailableError(Exception):
+    """The remote Insights API failed its pre-generation availability check."""
 
 
 async def run_analyst(
@@ -69,6 +74,12 @@ async def run_analyst(
             client=client,
             insights_output=insights_output_path,
         )
+        if insights_output_path is None:
+            await _preflight_insights_service(
+                backend,
+                workspace=workspace,
+                agent=agent,
+            )
         deps = AnalystDeps(
             agent=agent,
             workspace=workspace,
@@ -97,6 +108,29 @@ async def run_analyst(
                 observability.shutdown()
         finally:
             await client.close()
+
+
+async def _preflight_insights_service(
+    backend: AnalystBackend,
+    *,
+    workspace: str,
+    agent: str,
+) -> None:
+    """Verify the remote Insight sink before any Intake reads or model work."""
+    try:
+        await backend.list_insights(
+            workspace=workspace,
+            page=1,
+            page_size=1,
+            agent=agent,
+            status=None,
+        )
+    except (NeMoPlatformError, httpx.HTTPError) as exc:
+        detail = " ".join(str(exc).splitlines()).strip() or type(exc).__name__
+        raise InsightsServiceUnavailableError(
+            f"Insights service preflight failed for workspace {workspace!r}: {detail}. "
+            "Start the Insights service and retry."
+        ) from exc
 
 
 def _analyst_observability_enabled() -> bool:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -13,7 +13,11 @@ from typing import ClassVar
 
 import httpx
 import typer
-from nemo_insights_plugin.analyst.run import ClientConstructionError, run_analyst
+from nemo_insights_plugin.analyst.run import (
+    ClientConstructionError,
+    InsightsServiceUnavailableError,
+    run_analyst,
+)
 from nemo_insights_plugin.client import make_client
 from nemo_insights_plugin.contracts.checks import CheckResult, advisories, format_report, required_failures
 from nemo_insights_plugin.contracts.insights import InsightsFileError, validate_insights_file
@@ -165,6 +169,9 @@ async def _run_analysis(analysis: _ResolvedAnalysis, *, verbose: bool) -> str:
             insights_output=analysis.insights_output,
             verbose=verbose,
         )
+    except InsightsServiceUnavailableError as exc:
+        typer.echo(f"Error: {_one_line_error(exc)}", err=True)
+        raise typer.Exit(1) from None
     except AgentRunError as exc:
         detail = _one_line_error(exc).rstrip(".")
         typer.echo(

--- a/plugins/nemo-insights/tests/test_analyst_run.py
+++ b/plugins/nemo-insights/tests/test_analyst_run.py
@@ -3,6 +3,9 @@
 
 """The ``run_analyst`` client injection contract."""
 
+from pathlib import Path
+
+import httpx
 import pytest
 from nemo_insights_plugin.analyst import run as run_module
 
@@ -16,6 +19,12 @@ class FakeClient:
 
 
 class FakeBackend:
+    def __init__(self, seen: dict[str, object]) -> None:
+        self.seen = seen
+
+    async def list_insights(self, **kwargs: object) -> None:
+        self.seen["preflight"] = kwargs
+
     async def persist_result(self, *, workspace: str, agent: str, result: object) -> str:
         return "REPORT"
 
@@ -23,9 +32,10 @@ class FakeBackend:
 def _stub_pipeline(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> None:
     def fake_make_backend(*, client: FakeClient, insights_output: str | None) -> FakeBackend:
         seen["backend_client"] = client
-        return FakeBackend()
+        return FakeBackend(seen)
 
     async def fake_run_agent(analyst: object, deps: object, *, verbose: bool) -> object:
+        seen["agent_saw_preflight"] = "preflight" in seen
         return object()
 
     monkeypatch.setattr(run_module, "make_analyst_backend", fake_make_backend)
@@ -48,6 +58,14 @@ async def test_injected_client_is_used_and_closed(monkeypatch: pytest.MonkeyPatc
 
     assert report == "REPORT"
     assert seen["backend_client"] is client
+    assert seen["preflight"] == {
+        "workspace": "workspace",
+        "page": 1,
+        "page_size": 1,
+        "agent": "agent",
+        "status": None,
+    }
+    assert seen["agent_saw_preflight"] is True
     assert client.closed
 
 
@@ -68,6 +86,72 @@ async def test_client_closed_when_backend_construction_raises(monkeypatch: pytes
             client=client,  # type: ignore[arg-type]
         )
 
+    assert client.closed
+
+
+async def test_insights_service_failure_stops_before_generation_and_closes_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeClient()
+    agent_called = False
+
+    class UnavailableBackend(FakeBackend):
+        async def list_insights(self, **kwargs: object) -> None:
+            request = httpx.Request(
+                "GET",
+                "https://platform/apis/insights/v2/workspaces/workspace/insights",
+            )
+            raise httpx.ConnectError("connection refused", request=request)
+
+    monkeypatch.setattr(
+        run_module,
+        "make_analyst_backend",
+        lambda **kwargs: UnavailableBackend({}),
+    )
+
+    async def record_agent_call(analyst: object, deps: object, *, verbose: bool) -> object:
+        nonlocal agent_called
+        agent_called = True
+        return object()
+
+    monkeypatch.setattr(run_module, "_run_agent", record_agent_call)
+
+    with pytest.raises(
+        run_module.InsightsServiceUnavailableError,
+        match="Start the Insights service and retry",
+    ):
+        await run_module.run_analyst(
+            agent="agent",
+            agent_spec=None,
+            workspace="workspace",
+            base_url="https://platform",
+            client=client,  # type: ignore[arg-type]
+        )
+
+    assert agent_called is False
+    assert client.closed
+
+
+async def test_local_insights_output_skips_remote_service_preflight(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    client = FakeClient()
+    seen: dict[str, object] = {}
+    _stub_pipeline(monkeypatch, seen)
+
+    report = await run_module.run_analyst(
+        agent="agent",
+        agent_spec=None,
+        workspace="workspace",
+        base_url="https://platform",
+        client=client,  # type: ignore[arg-type]
+        insights_output=tmp_path / "insights.yaml",
+    )
+
+    assert report == "REPORT"
+    assert "preflight" not in seen
+    assert seen["agent_saw_preflight"] is False
     assert client.closed
 
 

--- a/plugins/nemo-insights/tests/test_cli_profile.py
+++ b/plugins/nemo-insights/tests/test_cli_profile.py
@@ -506,6 +506,31 @@ def test_analyze_renders_agent_run_error_with_model_and_usage_guidance(
     assert "Traceback" not in result.output
 
 
+def test_analyze_renders_insights_service_preflight_failure_with_start_guidance(
+    app: typer.Typer,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_analysis(**kwargs: object) -> str:
+        raise cli.InsightsServiceUnavailableError(
+            "Insights service preflight failed for workspace 'default': connection refused. "
+            "Start the Insights service and retry."
+        )
+
+    monkeypatch.setattr(cli, "run_analyst", fail_analysis)
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["analyze"])
+
+    assert result.exit_code == 1
+    assert result.stderr.splitlines()[-1] == (
+        "Error: Insights service preflight failed for workspace 'default': connection refused. "
+        "Start the Insights service and retry."
+    )
+    assert "Intake availability" not in result.stderr
+    assert "Traceback" not in result.output
+
+
 @pytest.mark.parametrize("error_type", [RuntimeError, ValueError])
 def test_analyze_constructor_failure_warns_then_exits_cleanly(
     app: typer.Typer,


### PR DESCRIPTION
## Summary

- probe the remote Insights API before the analyst can read Intake traces or invoke the model
- fail fast with actionable startup guidance when the Insights service is unavailable
- preserve local-file insight output behavior

## Validation

- 137 non-testbed Insights tests passed
- Ruff lint and format checks passed
- ty checks passed
- applicable pre-commit hooks passed

Linear: https://linear.app/nvidia/issue/ASE-770/preflight-insights-service-before-generating-insights

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added an Insights service availability check before running remote analyses.
  - Prevented analysis from starting when the Insights service cannot be reached.
  - Added clear command-line error messages with guidance for resolving service startup issues.
  - Local-output analyses continue without requiring a remote Insights service.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->