### PR TITLE
docs: add Experimentalist PR walkthrough

### DIFF
--- a/docs/get-started/example-agent.mdx
+++ b/docs/get-started/example-agent.mdx
@@ -64,6 +64,10 @@ Finally, we'll run our agent using the dataset tasks and record the data to NeMo
 uv run --frozen plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
 ```
 
+To run more tasks concurrently, add an explicit value such as `--concurrency 10`.
+Each task starts Docker containers, so choose a value appropriate for your
+available CPU and memory.
+
 At this point you can navigate to the [traces tab](http://localhost:8080/studio/workspaces/tau3-airline/intake/traces) and see the traces from the agent.
 
 
@@ -101,13 +105,73 @@ uv run --frozen nemo workspaces create canonical-tau3-airline \
   --exist-ok
 ```
 
-Run the experimentalist in a Docker Sandbox so that both the optimization
-process and Harbor's task containers use the sandbox's microVM and private
-Docker daemon. Clone mode gives the experimentalist a private writable clone
-instead of write access to the host checkout. The host checkout remains
-available read-only at `/run/sandbox/source`; the prepared evaluation dataset
-is read from there. The sandbox uses `host.docker.internal` to reach the NeMo
-Platform services running on the host:
+The Experimentalist generates a draft pull request (PR) or merge request (MR)
+when it receives a GitHub or GitLab agent source. It creates a branch only when
+a changed candidate wins validation.
+
+To optimize the example agent, create a private GitHub repository with the
+[GitHub CLI](https://cli.github.com/) and populate it with the example source.
+Replace `your-github-user-or-org` with the GitHub account or organization that
+will own the repository. `rsync` excludes `.env`, so your API key is not copied
+into the repository.
+
+```bash
+gh auth login
+export GITHUB_OWNER="your-github-user-or-org"
+mkdir -p "$HOME/src"
+cd "$HOME/src"
+gh repo create "$GITHUB_OWNER/tau3-nooa-agent" --private --clone
+export EXAMPLE_AGENT_REPO="$PWD/tau3-nooa-agent"
+cd -
+rsync -a --exclude='.env' plugins/nemo-experimentalist/examples/tau3-nooa-agent/ "$EXAMPLE_AGENT_REPO/"
+git -C "$EXAMPLE_AGENT_REPO" checkout -b main
+git -C "$EXAMPLE_AGENT_REPO" add .
+git -C "$EXAMPLE_AGENT_REPO" commit -m "Add the tau3 NOOA example agent"
+git -C "$EXAMPLE_AGENT_REPO" push -u origin main
+export AGENT_REPO_URL="$(git -C "$EXAMPLE_AGENT_REPO" remote get-url origin)"
+```
+
+Run the Experimentalist against the Git repository. The `@main` suffix selects
+the source ref to optimize. It clones that baseline, pushes a validated winner
+to a new branch, and opens a draft PR or MR against `main`. To use a different
+target branch, set `storage.pr_base_branch` in the configuration.
+
+```bash
+uv run --frozen nemo agents experimentalist run \
+  --no-insight \
+  --agent "${AGENT_REPO_URL}@main" \
+  --agent-spec "$EXAMPLE_AGENT_REPO/AGENT-SPEC.md" \
+  --train-dataset plugins/nemo-experimentalist/tmp/tau3-airline/experimentalist/train \
+  --validation-dataset plugins/nemo-experimentalist/tmp/tau3-airline/experimentalist/validation \
+  --workspace canonical-tau3-airline \
+  --framework-skills plugins/nemo-experimentalist/framework-skills/nooa \
+  --config "$EXAMPLE_AGENT_REPO/experimentalist-smoke.yaml" \
+  --experiment-dir plugins/nemo-experimentalist/tmp/tau3-airline-experimentalist \
+  --base-url "$NMP_BASE_URL"
+```
+
+This setup enables `storage.archive_candidates`, which pushes every generated
+candidate branch; the default pushes only the winner. After the run, inspect a
+non-winning candidate with `git fetch origin`,
+`git -C "$EXAMPLE_AGENT_REPO" branch -r --list 'origin/optimizer/*'`, and
+`git diff main...origin/optimizer/<run-id>/<candidate>`.
+
+GitLab is supported too: use a GitLab repository URL and authenticate with
+`glab auth login`. The Experimentalist opens a draft PR/MR only when it finds a
+changed winning candidate.
+
+The trace records include the Experimentalist evaluation ID and Tau3 task ID.
+After the run completes, inspect
+`plugins/nemo-experimentalist/tmp/tau3-airline-experimentalist/eval-and-optimize/run.json`
+for the selected winner and compare the `agent-0` and `agent-1` directories to
+review the code change that was evaluated.
+
+### Optional: run locally without creating a PR or MR
+
+Use this alternative if you do not want to create or push to a repository. It
+changes only a private sandbox clone and never creates a PR/MR. The sandbox
+uses `host.docker.internal` to reach the NeMo Platform services running on the
+host:
 
 ```bash
 repo="$(git rev-parse --show-toplevel)"
@@ -140,7 +204,6 @@ sbx exec --workdir "$repo" \
   --experiment-dir plugins/nemo-experimentalist/tmp/tau3-airline-experimentalist \
   --base-url http://host.docker.internal:8080
 ```
-
 The sandbox needs outbound access to the package, model, registry, Harbor
 dataset, and NeMo Platform endpoints used by the run. `host.docker.internal`
 is translated to the host's loopback interface so the sandbox can reach the

--- a/docs/get-started/example-agent.mdx
+++ b/docs/get-started/example-agent.mdx
@@ -117,6 +117,7 @@ into the repository.
 
 ```bash
 gh auth login
+# Choose SSH when prompted for the preferred Git protocol.
 export GITHUB_OWNER="your-github-user-or-org"
 mkdir -p "$HOME/src"
 cd "$HOME/src"
@@ -128,7 +129,8 @@ git -C "$EXAMPLE_AGENT_REPO" checkout -b main
 git -C "$EXAMPLE_AGENT_REPO" add .
 git -C "$EXAMPLE_AGENT_REPO" commit -m "Add the tau3 NOOA example agent"
 git -C "$EXAMPLE_AGENT_REPO" push -u origin main
-export AGENT_REPO_URL="$(gh repo view "$GITHUB_OWNER/tau3-nooa-agent" --json url --jq .url)"
+export AGENT_REPO_URL="$(git -C "$EXAMPLE_AGENT_REPO" remote get-url origin)"
+export AGENT_REPO_HTTPS_URL="$(gh repo view "$GITHUB_OWNER/tau3-nooa-agent" --json url --jq .url)"
 ```
 
 Run the Experimentalist against the Git repository inside a Docker Sandbox. The
@@ -145,7 +147,7 @@ gh auth token | sbx exec -i --workdir "$repo" nemo-experimentalist-git \
   gh auth login --with-token
 sbx exec --workdir "$repo" nemo-experimentalist-git gh auth setup-git
 sbx exec --workdir "$repo" nemo-experimentalist-git \
-  git clone "$AGENT_REPO_URL" /tmp/tau3-nooa-agent
+  git clone "$AGENT_REPO_HTTPS_URL" /tmp/tau3-nooa-agent
 sbx exec --workdir "$repo" \
   --env UV_PROJECT_ENVIRONMENT=/home/agent/.venvs/nemo-platform \
   --env INFERENCE_API_KEY \

--- a/docs/get-started/example-agent.mdx
+++ b/docs/get-started/example-agent.mdx
@@ -117,7 +117,7 @@ into the repository.
 
 ```bash
 gh auth login
-# Choose SSH when prompted for the preferred Git protocol.
+# Choose HTTPS when prompted for the preferred Git protocol.
 export GITHUB_OWNER="your-github-user-or-org"
 mkdir -p "$HOME/src"
 cd "$HOME/src"
@@ -129,8 +129,7 @@ git -C "$EXAMPLE_AGENT_REPO" checkout -b main
 git -C "$EXAMPLE_AGENT_REPO" add .
 git -C "$EXAMPLE_AGENT_REPO" commit -m "Add the tau3 NOOA example agent"
 git -C "$EXAMPLE_AGENT_REPO" push -u origin main
-export AGENT_REPO_URL="$(git -C "$EXAMPLE_AGENT_REPO" remote get-url origin)"
-export AGENT_REPO_HTTPS_URL="$(gh repo view "$GITHUB_OWNER/tau3-nooa-agent" --json url --jq .url)"
+export AGENT_REPO_URL="https://github.com/$GITHUB_OWNER/tau3-nooa-agent.git"
 ```
 
 Run the Experimentalist against the Git repository inside a Docker Sandbox. The
@@ -147,7 +146,7 @@ gh auth token | sbx exec -i --workdir "$repo" nemo-experimentalist-git \
   gh auth login --with-token
 sbx exec --workdir "$repo" nemo-experimentalist-git gh auth setup-git
 sbx exec --workdir "$repo" nemo-experimentalist-git \
-  git clone "$AGENT_REPO_HTTPS_URL" /tmp/tau3-nooa-agent
+  git clone "$AGENT_REPO_URL" /tmp/tau3-nooa-agent
 sbx exec --workdir "$repo" \
   --env UV_PROJECT_ENVIRONMENT=/home/agent/.venvs/nemo-platform \
   --env INFERENCE_API_KEY \

--- a/docs/get-started/example-agent.mdx
+++ b/docs/get-started/example-agent.mdx
@@ -128,26 +128,51 @@ git -C "$EXAMPLE_AGENT_REPO" checkout -b main
 git -C "$EXAMPLE_AGENT_REPO" add .
 git -C "$EXAMPLE_AGENT_REPO" commit -m "Add the tau3 NOOA example agent"
 git -C "$EXAMPLE_AGENT_REPO" push -u origin main
-export AGENT_REPO_URL="$(git -C "$EXAMPLE_AGENT_REPO" remote get-url origin)"
+export AGENT_REPO_URL="$(gh repo view "$GITHUB_OWNER/tau3-nooa-agent" --json url --jq .url)"
 ```
 
-Run the Experimentalist against the Git repository. The `@main` suffix selects
-the source ref to optimize. It clones that baseline, pushes a validated winner
-to a new branch, and opens a draft PR or MR against `main`. To use a different
-target branch, set `storage.pr_base_branch` in the configuration.
+Run the Experimentalist against the Git repository inside a Docker Sandbox. The
+`@main` suffix selects the source ref to optimize. It clones that baseline,
+pushes a validated winner to a new branch, and opens a draft PR or MR against
+`main`. To use a different target branch, set `storage.pr_base_branch` in the
+configuration. Authenticate GitHub inside the sandbox so it can clone and push
+the private repository.
 
 ```bash
-uv run --frozen nemo agents experimentalist run \
+repo="$(git rev-parse --show-toplevel)"
+sbx create --clone --name nemo-experimentalist-git shell "$repo"
+gh auth token | sbx exec -i --workdir "$repo" nemo-experimentalist-git \
+  gh auth login --with-token
+sbx exec --workdir "$repo" nemo-experimentalist-git gh auth setup-git
+sbx exec --workdir "$repo" nemo-experimentalist-git \
+  git clone "$AGENT_REPO_URL" /tmp/tau3-nooa-agent
+sbx exec --workdir "$repo" \
+  --env UV_PROJECT_ENVIRONMENT=/home/agent/.venvs/nemo-platform \
+  --env INFERENCE_API_KEY \
+  --env INFERENCE_API_BASE \
+  --env OPENAI_API_KEY \
+  --env OPENAI_BASE_URL \
+  --env NEMO_EXPERIMENTALIST_API_KEY \
+  --env NEMO_EXPERIMENTALIST_API_BASE \
+  --env NEMO_EXPERIMENTALIST_MODELS_SMART \
+  --env NEMO_EXPERIMENTALIST_MODELS_MID \
+  --env NEMO_EXPERIMENTALIST_MODELS_FAST \
+  --env TAU2_USER_MODEL \
+  --env TAU2_NL_ASSERTIONS_MODEL \
+  --env AUT_MODEL_NAME \
+  nemo-experimentalist-git \
+  uv run --frozen --python 3.13 --package nemo-experimentalist-plugin --with ./plugins/nemo-agents \
+  nemo agents experimentalist run \
   --no-insight \
   --agent "${AGENT_REPO_URL}@main" \
-  --agent-spec "$EXAMPLE_AGENT_REPO/AGENT-SPEC.md" \
-  --train-dataset plugins/nemo-experimentalist/tmp/tau3-airline/experimentalist/train \
-  --validation-dataset plugins/nemo-experimentalist/tmp/tau3-airline/experimentalist/validation \
+  --agent-spec /tmp/tau3-nooa-agent/AGENT-SPEC.md \
+  --train-dataset /run/sandbox/source/plugins/nemo-experimentalist/tmp/tau3-airline/experimentalist/train \
+  --validation-dataset /run/sandbox/source/plugins/nemo-experimentalist/tmp/tau3-airline/experimentalist/validation \
   --workspace canonical-tau3-airline \
   --framework-skills plugins/nemo-experimentalist/framework-skills/nooa \
-  --config "$EXAMPLE_AGENT_REPO/experimentalist-smoke.yaml" \
+  --config /tmp/tau3-nooa-agent/experimentalist-smoke.yaml \
   --experiment-dir plugins/nemo-experimentalist/tmp/tau3-airline-experimentalist \
-  --base-url "$NMP_BASE_URL"
+  --base-url http://host.docker.internal:8080
 ```
 
 This setup enables `storage.archive_candidates`, which pushes every generated
@@ -161,7 +186,7 @@ GitLab is supported too: use a GitLab repository URL and authenticate with
 changed winning candidate.
 
 The trace records include the Experimentalist evaluation ID and Tau3 task ID.
-After the run completes, inspect
+After the run completes, inspect the sandbox's
 `plugins/nemo-experimentalist/tmp/tau3-airline-experimentalist/eval-and-optimize/run.json`
 for the selected winner and compare the `agent-0` and `agent-1` directories to
 review the code change that was evaluated.
@@ -191,7 +216,7 @@ sbx exec --workdir "$repo" \
   --env TAU2_NL_ASSERTIONS_MODEL \
   --env AUT_MODEL_NAME \
   nemo-experimentalist \
-  uv run --frozen --python 3.13 --package nemo-experimentalist-plugin \
+  uv run --frozen --python 3.13 --package nemo-experimentalist-plugin --with ./plugins/nemo-agents \
   nemo agents experimentalist run \
   --no-insight \
   --agent plugins/nemo-experimentalist/examples/tau3-nooa-agent \

--- a/docs/get-started/example-agent.mdx
+++ b/docs/get-started/example-agent.mdx
@@ -109,6 +109,9 @@ The Experimentalist generates a draft pull request (PR) or merge request (MR)
 when it receives a GitHub or GitLab agent source. It creates a branch only when
 a changed candidate wins validation.
 
+Git integration is optional. To run the optimization without creating a
+repository or PR/MR, [jump to the local-only alternative](#optional-run-locally-without-creating-a-pr-or-mr).
+
 To optimize the example agent, create a private GitHub repository with the
 [GitHub CLI](https://cli.github.com/) and populate it with the example source.
 Replace `your-github-user-or-org` with the GitHub account or organization that

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/result_manager.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/result_manager.py
@@ -263,9 +263,9 @@ def result_manager_factory(
         job_name=job_name,
         workspace=workspace,
         attempt_id=attempt_id,
-        file_manager_cls=file_manager_cls,  # type: ignore
-        files_sdk=files_sdk,  # type: ignore
-        jobs_sdk=jobs_sdk,  # type: ignore
+        file_manager_cls=file_manager_cls,
+        files_sdk=files_sdk,
+        jobs_sdk=jobs_sdk,
     )
 
 

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -81,7 +81,7 @@ sbx exec --workdir "$repo" \
   --env NEMO_EXPERIMENTALIST_MODELS_MID \
   --env NEMO_EXPERIMENTALIST_MODELS_FAST \
   nemo-experimentalist \
-  uv run --frozen --python 3.13 --package nemo-experimentalist-plugin \
+  uv run --frozen --python 3.13 --package nemo-experimentalist-plugin --with ./plugins/nemo-agents \
   nemo agents experimentalist run
 ```
 

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/.gitignore
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/.gitignore
@@ -1,2 +1,6 @@
 # Local inference credentials
 .env
+
+# Generated runtime artifacts
+metadata.json
+__pycache__/

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/.gitignore
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/.gitignore
@@ -1,0 +1,2 @@
+# Local inference credentials
+.env

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/.gitignore
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/.gitignore
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 # Local inference credentials
 .env
 

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/experimentalist-smoke.yaml
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/experimentalist-smoke.yaml
@@ -5,8 +5,8 @@ max_rounds: 1
 min_rounds_before_stopping: 1
 max_survivors: 1
 max_candidates: 1
-max_trajectory_tasks: 3
-max_train_batch_tasks: 6
+max_trajectory_tasks: 2
+max_train_batch_tasks: 4
 train_batch_seed: 20260727
 disable_trajectory_scoring: true
 disable_convergence_check: true

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/experimentalist-smoke.yaml
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/experimentalist-smoke.yaml
@@ -5,14 +5,15 @@ max_rounds: 1
 min_rounds_before_stopping: 1
 max_survivors: 1
 max_candidates: 1
-max_trajectory_tasks: 2
-max_train_batch_tasks: 4
+max_trajectory_tasks: 3
+max_train_batch_tasks: 6
 train_batch_seed: 20260727
 disable_trajectory_scoring: true
 disable_convergence_check: true
+storage:
+  archive_candidates: true
 evaluator:
   n_attempts: 1
-  n_concurrent_trials: 1
   quiet: true
   agent_setup_timeout_multiplier: 2.0
   environment_build_timeout_multiplier: 3.0

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/prepare-airline-datasets.sh
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/prepare-airline-datasets.sh
@@ -40,11 +40,16 @@ INSIGHTS_TASKS=(
 )
 EXPERIMENTALIST_TRAIN_TASKS=(
   "tau3-bench__tau3-airline-0"
+  "tau3-bench__tau3-airline-4"
+  "tau3-bench__tau3-airline-10"
   "tau3-bench__tau3-airline-20"
+  "tau3-bench__tau3-airline-34"
   "tau3-bench__tau3-airline-39"
 )
 EXPERIMENTALIST_VALIDATION_TASKS=(
   "tau3-bench__tau3-airline-3"
+  "tau3-bench__tau3-airline-12"
+  "tau3-bench__tau3-airline-27"
   "tau3-bench__tau3-airline-36"
 )
 

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/prepare-airline-datasets.sh
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/prepare-airline-datasets.sh
@@ -40,16 +40,11 @@ INSIGHTS_TASKS=(
 )
 EXPERIMENTALIST_TRAIN_TASKS=(
   "tau3-bench__tau3-airline-0"
-  "tau3-bench__tau3-airline-4"
-  "tau3-bench__tau3-airline-10"
   "tau3-bench__tau3-airline-20"
-  "tau3-bench__tau3-airline-34"
   "tau3-bench__tau3-airline-39"
 )
 EXPERIMENTALIST_VALIDATION_TASKS=(
   "tau3-bench__tau3-airline-3"
-  "tau3-bench__tau3-airline-12"
-  "tau3-bench__tau3-airline-27"
   "tau3-bench__tau3-airline-36"
 )
 

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
@@ -73,15 +73,18 @@ def _resolve_harbor_output_dir(path: Path) -> tuple[Path, Path]:
         run_dir = candidate.parent.parent if candidate.parent.name == "results" else candidate
     else:
         jobs_dir = candidate / "results"
-        job_dirs = [
-            child
-            for child in jobs_dir.iterdir()
-            if child.is_dir() and any(trial.is_dir() and (trial / "result.json").is_file() for trial in child.iterdir())
-        ] if jobs_dir.is_dir() else []
+        job_dirs = (
+            [
+                child
+                for child in jobs_dir.iterdir()
+                if child.is_dir()
+                and any(trial.is_dir() and (trial / "result.json").is_file() for trial in child.iterdir())
+            ]
+            if jobs_dir.is_dir()
+            else []
+        )
         if len(job_dirs) != 1:
-            raise ValueError(
-                f"{candidate} is not a Harbor output directory with exactly one job under results/"
-            )
+            raise ValueError(f"{candidate} is not a Harbor output directory with exactly one job under results/")
         job_dir = job_dirs[0]
         run_dir = candidate
 

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
@@ -58,6 +58,69 @@ def _configure_models(*, model: str, user_model: str, api_base: str) -> None:
     os.environ["TAU2_NL_ASSERTIONS_MODEL"] = user_model
 
 
+def _resolve_harbor_output_dir(path: Path) -> tuple[Path, Path]:
+    """Return the Harbor job directory and its enclosing run directory."""
+    candidate = path.expanduser().resolve()
+    if not candidate.is_dir():
+        raise FileNotFoundError(f"Harbor output directory not found: {candidate}")
+
+    if any(child.is_dir() and (child / "result.json").is_file() for child in candidate.iterdir()):
+        job_dir = candidate
+        run_dir = candidate.parent.parent if candidate.parent.name == "results" else candidate
+    else:
+        jobs_dir = candidate / "results"
+        job_dirs = [
+            child
+            for child in jobs_dir.iterdir()
+            if child.is_dir() and any(trial.is_dir() and (trial / "result.json").is_file() for trial in child.iterdir())
+        ] if jobs_dir.is_dir() else []
+        if len(job_dirs) != 1:
+            raise ValueError(
+                f"{candidate} is not a Harbor output directory with exactly one job under results/"
+            )
+        job_dir = job_dirs[0]
+        run_dir = candidate
+
+    if not any(child.is_dir() and (child / "result.json").is_file() for child in job_dir.iterdir()):
+        raise ValueError(f"Harbor job directory contains no trial result files: {job_dir}")
+    return job_dir, run_dir
+
+
+def _write_upload_summary(
+    run_dir: Path,
+    *,
+    experiment_id: str,
+    workspace: str,
+    agent_name: str,
+    agent_version: str,
+    model: str,
+    trials: list[TrialResult],
+    trace_ids: dict[str, str],
+) -> Path:
+    summary_path = run_dir / "uploaded-traces.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "experiment_id": experiment_id,
+                "workspace": workspace,
+                "agent_name": agent_name,
+                "agent_version": agent_version,
+                "model": model,
+                "trace_count": len(trace_ids),
+                "traces": [
+                    {"trial_id": trial.id, "task_id": trial.task_id, "trace_id": trace_ids[trial.id]}
+                    for trial in trials
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return summary_path
+
+
 async def _upload_trials(
     client: AsyncNeMoPlatform,
     trials: list[TrialResult],
@@ -137,10 +200,53 @@ async def run(args: argparse.Namespace) -> Path:
     dataset = HarborDataset.from_path(dataset_path)
     if args.task_ids:
         dataset = dataset.subset(args.task_ids)
-    if len(dataset.tasks) != args.expected_task_count:
+    if args.upload_dir is None and len(dataset.tasks) != args.expected_task_count:
         raise RuntimeError(
             f"Expected {args.expected_task_count} Tau3 tasks in {dataset_path}, found {len(dataset.tasks)}"
         )
+
+    if args.upload_dir is not None:
+        job_dir, run_dir = _resolve_harbor_output_dir(args.upload_dir)
+        evaluator = HarborEvaluator(experiment_dir=run_dir)
+        trials = list(await evaluator._trials_from_dir(job_dir, dataset.tasks))
+        uploadable_trials = [trial for trial in trials if trial.status == "completed" and trial.trace is not None]
+        if not uploadable_trials:
+            raise RuntimeError(f"No completed Harbor trials with trace artifacts found in {job_dir}")
+
+        experiment_id = args.experiment_id or run_dir.name
+        client = make_client(args.base_url)
+        try:
+            await client.workspaces.create(
+                name=args.workspace,
+                description="Tau3 Airline agent traces for Insights",
+                exist_ok=True,
+            )
+            trace_ids = await _upload_trials(
+                client,
+                uploadable_trials,
+                workspace=args.workspace,
+                experiment_id=experiment_id,
+                agent_name=args.agent_name,
+                agent_version=args.agent_version,
+                model=args.model,
+            )
+            await _wait_for_traces(client, set(trace_ids.values()), workspace=args.workspace)
+        finally:
+            await client.close()
+
+        summary_path = _write_upload_summary(
+            run_dir,
+            experiment_id=experiment_id,
+            workspace=args.workspace,
+            agent_name=args.agent_name,
+            agent_version=args.agent_version,
+            model=args.model,
+            trials=uploadable_trials,
+            trace_ids=trace_ids,
+        )
+        print(f"Uploaded and verified {len(trace_ids)} agent traces in workspace {args.workspace!r}.")
+        print(summary_path)
+        return summary_path
 
     experiment_id = args.experiment_id or _experiment_id()
     run_dir = args.output.expanduser().resolve() / experiment_id
@@ -190,30 +296,15 @@ async def run(args: argparse.Namespace) -> Path:
     finally:
         await client.close()
 
-    summary_path = run_dir / "uploaded-traces.json"
-    summary_path.write_text(
-        json.dumps(
-            {
-                "experiment_id": experiment_id,
-                "workspace": args.workspace,
-                "agent_name": args.agent_name,
-                "agent_version": args.agent_version,
-                "model": args.model,
-                "trace_count": len(trace_ids),
-                "traces": [
-                    {
-                        "trial_id": trial.id,
-                        "task_id": trial.task_id,
-                        "trace_id": trace_ids[trial.id],
-                    }
-                    for trial in trials
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
+    summary_path = _write_upload_summary(
+        run_dir,
+        experiment_id=experiment_id,
+        workspace=args.workspace,
+        agent_name=args.agent_name,
+        agent_version=args.agent_version,
+        model=args.model,
+        trials=trials,
+        trace_ids=trace_ids,
     )
     print(f"Uploaded and verified {len(trace_ids)} agent traces in workspace {args.workspace!r}.")
     print(summary_path)
@@ -226,6 +317,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--agent", type=Path, default=SCRIPT_DIR)
     parser.add_argument("--workspace", default=DEFAULT_WORKSPACE)
     parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument(
+        "--upload-dir",
+        type=Path,
+        help="Existing Harbor run directory or Harbor job-results directory to upload without rerunning trials.",
+    )
     parser.add_argument("--base-url", default=os.environ.get("NMP_BASE_URL", "http://localhost:8080"))
     parser.add_argument(
         "--api-base",

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
@@ -2,7 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Run the Tau3 Airline agent and upload only its execution traces to Intake."""
+"""Example setup helper: run Tau3 Airline and upload its traces to Intake.
+
+This script supplies trace data for the walkthrough; Experimentalist does not require
+agent repositories to include it.
+"""
 
 import argparse
 import asyncio

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/cli.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/cli.py
@@ -274,7 +274,7 @@ class ExperimentalistCLI(NemoCLI):
                         profile,
                         task_template=plan.task_template,
                         agent_source=plan.agent,
-                        storage=plan.config.storage.model_dump(),
+                        storage=plan.config.storage.model_dump(exclude_unset=True),
                         require_template=plan.insight is not None,
                         probes=_PREFLIGHT_PROBES,
                     )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/config.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/config.py
@@ -43,7 +43,7 @@ class CandidateStorageConfig(BaseModel):
 
     archive_candidates: bool = False
     candidate_branch_prefix: str = "optimizer"
-    publish_winner: bool = False
+    publish_winner: bool = True
     pr_draft: bool = True
     pr_base_branch: str | None = None
     pr_title: str | None = None

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/repository.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/repository.py
@@ -101,21 +101,9 @@ def split_agent_spec(spec: str) -> tuple[str, str]:
     return core, _validated_agent_path(agent_path)
 
 
-# Glob patterns for files never copied into the published branch: generated/run-local
-# files, VCS/tool dirs, and build artifacts. Matched with fnmatch against each name.
-_EXCLUDE_GLOBS = (
-    "metadata.json",
-    "harbor_wrapper.py",
-    "dind_environment.py",
-    "architecture.md",
-    ".git",
-    "__pycache__",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".ruff_cache",
-    "*.pyc",
-    "*.pyo",
-)
+# Candidate files are staged with ``git add -A``, so the repository's .gitignore
+# determines what is committed. Never copy a nested Git repository from a candidate.
+_EXCLUDE_GLOBS = (".git",)
 
 
 class AgentSource(BaseModel):
@@ -290,11 +278,7 @@ class PRPublisher:
 
     @staticmethod
     def _overlay(winner_dir: Path, dest: Path) -> None:
-        """Copy the winner's agent files over *dest*, excluding files matching ``_EXCLUDE_GLOBS``.
-
-        Exclusions apply at the top level and recursively (via ``shutil.ignore_patterns``),
-        so nested ``__pycache__``/``*.pyc`` and the like never reach the published branch.
-        """
+        """Copy candidate files over *dest*; Git decides what is staged via .gitignore."""
         dest.mkdir(parents=True, exist_ok=True)
         ignore = shutil.ignore_patterns(*_EXCLUDE_GLOBS)
         for item in winner_dir.iterdir():
@@ -327,16 +311,17 @@ class PRPublisher:
         """Replace the ``agent_path`` subtree with *src_dir*'s files (deletions captured).
 
         ``git rm`` the existing subtree first so files the candidate removed don't linger,
-        using literal pathspec semantics, then overlay the candidate's files. ``agent_path``
+        using literal pathspec semantics, then overlay the candidate's files. ``git add -A``
+        applies the repository's .gitignore when staging the resulting delta. ``agent_path``
         ``"."`` targets the whole repo.
         """
         self._validated_subtree(agent_path)
         self._run(["git", "--literal-pathspecs", "rm", "-r", "-q", "-f", "--ignore-unmatch", "--", agent_path])
         subtree = self._validated_subtree(agent_path)
-        stale_items = (
-            (item for item in subtree.iterdir() if item.name.casefold() != ".git") if agent_path == "." else (subtree,)
-        )
-        for item in stale_items:
+        subtree.mkdir(parents=True, exist_ok=True)
+        for item in subtree.iterdir():
+            if item.name.casefold() == ".git":
+                continue
             if item.is_dir() and not item.is_symlink():
                 shutil.rmtree(item)
             else:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/repository.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/repository.py
@@ -42,6 +42,19 @@ def _redact_url(url: str) -> str:
     return _CREDENTIAL_RE.sub("://***@", url)
 
 
+def _provenance_url(url: str) -> str:
+    """Return an HTTP(S) URL suitable for an Experiment ``source_link``."""
+    if url.startswith("git@"):
+        host, separator, path = url.removeprefix("git@").partition(":")
+        if host and separator and path:
+            return f"https://{host}/{path}"
+    parsed = urlsplit(url)
+    if parsed.scheme in {"ssh", "git"} and parsed.hostname:
+        port = f":{parsed.port}" if parsed.port is not None else ""
+        return f"https://{parsed.hostname}{port}/{parsed.path.lstrip('/')}"
+    return _redact_url(url)
+
+
 def _validated_agent_path(agent_path: str) -> str:
     """Return a safe relative POSIX agent path or raise a controlled error."""
     agent_path = agent_path.removesuffix("/").removeprefix("./")
@@ -207,9 +220,8 @@ def clone_agent_repo(spec: str, dest: Path, *, clone_depth: int | None = None) -
             ["git", "-C", str(dest), "rev-parse", "--abbrev-ref", "HEAD"],
             "git rev-parse",
         ).stdout.strip()
-    # repo_url is provenance (it becomes the candidate's source_link), so keep it
-    # credential-free; the conventional ssh ``git`` user is not a secret.
-    repo_url = url if url.startswith("ssh://git@") or "://" not in url else _redact_url(url)
+    # repo_url becomes an Experiment source_link, which accepts HTTP(S) URLs only.
+    repo_url = _provenance_url(url)
     return AgentSource(repo_url=repo_url, ref=ref, agent_path=agent_path)
 
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experiment_mirror.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experiment_mirror.py
@@ -53,7 +53,7 @@ def experiment_name(gname: str, label: str, split: str) -> str:
 
 
 def pseudo_source_link(gname: str, label: str) -> str:
-    """Fallback HTTP URL, stable per candidate across its splits (OQ-4)."""
+    """Fallback HTTP URL, stable per candidate across its splits."""
     return f"https://nemo.local/optimizations/{gname}/candidate/{label}"
 
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experiment_mirror.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experiment_mirror.py
@@ -53,8 +53,8 @@ def experiment_name(gname: str, label: str, split: str) -> str:
 
 
 def pseudo_source_link(gname: str, label: str) -> str:
-    """Fallback grouping-key URI, stable per candidate across its splits (OQ-4)."""
-    return f"opt://{gname}/candidate/{label}"
+    """Fallback HTTP URL, stable per candidate across its splits (OQ-4)."""
+    return f"https://nemo.local/optimizations/{gname}/candidate/{label}"
 
 
 def experiment_status(candidate: Candidate) -> str:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/resolve.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/resolve.py
@@ -491,7 +491,7 @@ async def resolve_experiment_inputs(
 
 def profile_storage_flags(profile: AgentProfile) -> dict:
     """Return validated, explicitly configured storage flags for Doctor."""
-    return _resolve_config(None, profile).storage.model_dump(exclude_defaults=True)
+    return _resolve_config(None, profile).storage.model_dump(exclude_unset=True)
 
 
 def pick_agent_spec(profile: AgentProfile) -> str | None:

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_repository.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_repository.py
@@ -466,7 +466,7 @@ def test_clone_agent_repo_parses_fragment_and_depth(tmp_path: Path, monkeypatch:
 
     monkeypatch.setattr(repo.subprocess, "run", fake_run)
     src = clone_agent_repo("ssh://git@h/g/r.git@main#pkg/agent", tmp_path / "dest", clone_depth=2)
-    assert src == AgentSource(repo_url="ssh://git@h/g/r.git", ref="main", agent_path="pkg/agent")
+    assert src == AgentSource(repo_url="https://h/g/r.git", ref="main", agent_path="pkg/agent")
     clone, clone_kwargs = next(call for call in calls if call[0][:2] == ["git", "clone"])
     assert "--depth" in clone and clone[clone.index("--depth") + 1] == "2"
     # the #fragment is stripped from the clone URL (only repo+ref reach git clone)
@@ -533,6 +533,18 @@ def test_clone_agent_repo_redacts_credentials_in_repo_url(tmp_path: Path, monkey
 
     source = clone_agent_repo("https://oauth2:token@gitlab.com/org/repo.git", tmp_path / "dest")  # trufflehog:ignore
     assert source.repo_url == "https://***@gitlab.com/org/repo.git"
+
+
+def test_clone_agent_repo_converts_scp_style_provenance_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        repo.subprocess,
+        "run",
+        lambda *_args, **_kwargs: repo.subprocess.CompletedProcess(args=[], returncode=0, stdout="main\n"),
+    )
+
+    source = clone_agent_repo("git@github.com:org/repo.git@main", tmp_path / "dest")
+
+    assert source.repo_url == "https://github.com/org/repo.git"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_repository.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_repository.py
@@ -160,7 +160,7 @@ def _winner(tmp_path: Path) -> Path:
     w = tmp_path / "winner"
     w.mkdir()
     (w / "main.py").write_text("print('improved')\n")
-    (w / "metadata.json").write_text("{}")  # must be skipped
+    (w / "metadata.json").write_text("{}")
     return w
 
 
@@ -197,8 +197,7 @@ def test_publish_gitlab_opens_draft_mr(tmp_path: Path) -> None:
     assert ["git", "fetch", "origin", "main"] in pub.calls
     assert ["git", "push", "--force-with-lease", "-u", "origin", "optimizer/run-1-agent-2"] in pub.calls
     assert ["git", "ls-remote", "--heads", "origin", "main"] in pub.calls
-    # Generated file was not committed (overlay skipped it).
-    assert not (agent_dir / "metadata.json").exists()
+    assert (agent_dir / "metadata.json").exists()
     assert (agent_dir / "main.py").read_text() == "print('improved')\n"
 
 
@@ -222,10 +221,10 @@ def test_publish_github_opens_draft_pr(tmp_path: Path) -> None:
     assert gh[:3] == ["gh", "pr", "create"] and "--draft" in gh
 
 
-def test_publish_skips_build_artifacts(tmp_path: Path) -> None:
+def test_publish_copies_all_candidate_files(tmp_path: Path) -> None:
     agent_dir = tmp_path / "clone"
     agent_dir.mkdir()
-    # Winner dir with top-level and NESTED build artifacts that must not be committed.
+    # Candidate files are copied; .gitignore determines what Git ultimately stages.
     winner = tmp_path / "winner"
     (winner / "pkg" / "__pycache__").mkdir(parents=True)
     (winner / "main.py").write_text("print('improved')\n")
@@ -242,12 +241,12 @@ def test_publish_skips_build_artifacts(tmp_path: Path) -> None:
     )
     pub.publish(winner_dir=winner, branch="b", base_ref="main", title="t", body="b")
 
-    # Real source copied; build artifacts (top-level + nested) excluded.
+    # All candidate files are copied into the Git worktree.
     assert (agent_dir / "main.py").exists()
     assert (agent_dir / "pkg" / "mod.py").exists()
-    assert not (agent_dir / "__pycache__").exists()
-    assert not (agent_dir / "stray.pyc").exists()
-    assert not (agent_dir / "pkg" / "__pycache__").exists()
+    assert (agent_dir / "__pycache__").exists()
+    assert (agent_dir / "stray.pyc").exists()
+    assert (agent_dir / "pkg" / "__pycache__").exists()
 
 
 def test_publish_tag_source_targets_default_branch(tmp_path: Path) -> None:
@@ -580,7 +579,7 @@ def test_push_branch_archives_candidate(tmp_path: Path) -> None:
         "pkg/agent",
     ] in pub.calls
     assert (agent_dir / "pkg" / "agent" / "main.py").read_text() == "print('improved')\n"
-    assert not (agent_dir / "pkg" / "agent" / "metadata.json").exists()  # generated file excluded
+    assert (agent_dir / "pkg" / "agent" / "metadata.json").exists()
 
 
 def test_snapshot_subtree_recreates_removed_nested_destination_with_real_git(tmp_path: Path) -> None:
@@ -600,9 +599,40 @@ def test_snapshot_subtree_recreates_removed_nested_destination_with_real_git(tmp
 
     assert not old_file.exists()
     assert not stale.exists()
-    assert not (checkout / "pkg" / "agent" / "metadata.json").exists()
+    assert (checkout / "pkg" / "agent" / "metadata.json").exists()
     assert (checkout / "pkg" / "agent" / "main.py").read_text(encoding="utf-8") == "print('improved')\n"
-    assert _git(checkout, "ls-files") == ["pkg/agent/main.py"]
+    assert _git(checkout, "ls-files") == ["pkg/agent/main.py", "pkg/agent/metadata.json"]
+
+
+def test_snapshot_subtree_includes_candidate_runtime_support_files(tmp_path: Path) -> None:
+    checkout = tmp_path / "repo"
+    checkout.mkdir()
+    _git(checkout, "init", "-q")
+
+    winner = _winner(tmp_path)
+    (winner / "harbor_wrapper.py").write_text("# candidate runtime wrapper\n", encoding="utf-8")
+
+    PRPublisher(agent_dir=checkout)._snapshot_subtree(winner, ".")
+
+    assert (checkout / "harbor_wrapper.py").read_text(encoding="utf-8") == "# candidate runtime wrapper\n"
+    assert _git(checkout, "ls-files") == ["harbor_wrapper.py", "main.py", "metadata.json"]
+
+
+def test_snapshot_subtree_respects_gitignore(tmp_path: Path) -> None:
+    checkout = tmp_path / "repo"
+    checkout.mkdir()
+    _git(checkout, "init", "-q")
+    (checkout / ".gitignore").write_text(".env\n", encoding="utf-8")
+    _git(checkout, "add", ".gitignore")
+
+    winner = _winner(tmp_path)
+    (winner / ".gitignore").write_text(".env\n", encoding="utf-8")
+    (winner / ".env").write_text("INFERENCE_API_KEY=secret\n", encoding="utf-8")
+
+    PRPublisher(agent_dir=checkout)._snapshot_subtree(winner, ".")
+
+    assert (checkout / ".env").exists()
+    assert ".env" not in _git(checkout, "ls-files")
 
 
 def test_snapshot_subtree_rejects_symlink_ancestor_before_commands_or_overlay(
@@ -699,6 +729,7 @@ def test_push_branch_scopes_snapshot_status_and_commit_to_agent_path(
     assert pushed is True
     assert _git(checkout, "diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD") == [
         "pkg/agent/main.py",
+        "pkg/agent/metadata.json",
         "pkg/agent/old.py",
     ]
     assert _git(checkout, "diff", "--cached", "--name-only") == ["unrelated.txt"]

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_repository.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_repository.py
@@ -622,17 +622,20 @@ def test_snapshot_subtree_respects_gitignore(tmp_path: Path) -> None:
     checkout = tmp_path / "repo"
     checkout.mkdir()
     _git(checkout, "init", "-q")
-    (checkout / ".gitignore").write_text(".env\n", encoding="utf-8")
+    gitignore = ".env\nmetadata.json\n__pycache__/\n"
+    (checkout / ".gitignore").write_text(gitignore, encoding="utf-8")
     _git(checkout, "add", ".gitignore")
 
     winner = _winner(tmp_path)
-    (winner / ".gitignore").write_text(".env\n", encoding="utf-8")
+    (winner / ".gitignore").write_text(gitignore, encoding="utf-8")
     (winner / ".env").write_text("INFERENCE_API_KEY=secret\n", encoding="utf-8")
+    (winner / "__pycache__" / "agent.pyc").parent.mkdir()
+    (winner / "__pycache__" / "agent.pyc").write_bytes(b"cache")
 
     PRPublisher(agent_dir=checkout)._snapshot_subtree(winner, ".")
 
     assert (checkout / ".env").exists()
-    assert ".env" not in _git(checkout, "ls-files")
+    assert not {".env", "metadata.json", "__pycache__/agent.pyc"} & set(_git(checkout, "ls-files"))
 
 
 def test_snapshot_subtree_rejects_symlink_ancestor_before_commands_or_overlay(

--- a/plugins/nemo-experimentalist/tests/test_experiment_mirror_mapping.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_mirror_mapping.py
@@ -70,4 +70,4 @@ def test_experiment_metadata_is_identity_only():
 
 
 def test_pseudo_source_link_is_a_url():
-    assert m.pseudo_source_link("opt-run-1", "agent-0") == "opt://opt-run-1/candidate/agent-0"
+    assert m.pseudo_source_link("opt-run-1", "agent-0") == "https://nemo.local/optimizations/opt-run-1/candidate/agent-0"

--- a/plugins/nemo-experimentalist/tests/test_experiment_mirror_mapping.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_mirror_mapping.py
@@ -70,4 +70,6 @@ def test_experiment_metadata_is_identity_only():
 
 
 def test_pseudo_source_link_is_a_url():
-    assert m.pseudo_source_link("opt-run-1", "agent-0") == "https://nemo.local/optimizations/opt-run-1/candidate/agent-0"
+    assert (
+        m.pseudo_source_link("opt-run-1", "agent-0") == "https://nemo.local/optimizations/opt-run-1/candidate/agent-0"
+    )

--- a/plugins/nemo-experimentalist/tests/test_resolve.py
+++ b/plugins/nemo-experimentalist/tests/test_resolve.py
@@ -657,8 +657,7 @@ def make_profile_tree(tmp_path: Path) -> Path:
     (tmp_path / "optimizer.yaml").write_text(
         "agent: flight-planner\n"
         "task_template: ./evals/task_template\n"
-        "datasets:\n  train: ./evals/train\n  validation: ./evals/val\n"
-        "experiment_config:\n  storage:\n    publish_winner: true\n",
+        "datasets:\n  train: ./evals/train\n  validation: ./evals/val\n",
         encoding="utf-8",
     )
     return tmp_path / "optimizer.yaml"
@@ -806,7 +805,7 @@ def test_config_unknown_top_level_key_is_tolerated(tmp_path: Path) -> None:
         )
     )
     assert inputs.config.max_rounds == 2
-    assert inputs.config.storage.publish_winner is False
+    assert inputs.config.storage.publish_winner is True
 
 
 @pytest.mark.parametrize(
@@ -889,8 +888,8 @@ def test_profile_agent_spec_must_be_readable_utf8(tmp_path: Path) -> None:
 
 
 def test_profile_storage_flags_reads_inline_and_path_forms(tmp_path: Path) -> None:
-    profile = load_profile(make_profile_tree(tmp_path))  # inline dict with publish_winner: true
-    assert profile_storage_flags(profile) == {"publish_winner": True}
+    profile = load_profile(make_profile_tree(tmp_path))
+    assert profile_storage_flags(profile) == {}
 
     (tmp_path / "exp.yaml").write_text("storage:\n  archive_candidates: true\n", encoding="utf-8")
     (tmp_path / "optimizer.yaml").write_text(


### PR DESCRIPTION
## Summary
- document creating a private standalone Git repository for the Tau3 example agent
- show GitHub/GitLab CLI authentication and draft PR/MR publication for a validated winner
- explain optional candidate-branch archival and how to list and compare non-winning candidates after a run
- normalize Git SSH provenance to HTTPS so Experiment mirror projection accepts source links
- publish every candidate file except agent-repository ignores; the example ignores `.env`, generated `metadata.json`, and `__pycache__/`

## Validation
- `uv run --frozen pytest plugins/nemo-experimentalist/tests/test_resolve.py -q` (65 passed)
- `uv run --frozen pytest plugins/nemo-experimentalist/tests/experimentalist/test_repository.py -q` (73 passed)
- focused Experiment mirror tests

Linear: https://linear.app/nvidia/issue/ASE-772/enable-example-agent-walk-trough-with-pr-creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added concurrent task execution and repository-backed experimental workflows.
  * Winning candidates are now published as draft pull or merge requests by default.
  * Added trace uploads from existing Harbor runs without rerunning trials.
  * Added optional candidate archiving.

* **Documentation**
  * Expanded guidance for repository setup, authentication, optimization, review, and local execution.

* **Bug Fixes**
  * Improved repository and candidate links with consistent HTTPS URLs and safer credential handling.
  * Preserved required metadata and runtime files in candidate snapshots.
  * Prevented local credentials and generated artifacts from being committed.
  * Improved storage configuration handling and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->