### PR TITLE
feat(studio): support nemo-agents-spec-v1 configs in Create Example Agent

### DIFF
--- a/web/packages/studio/src/api/agents/loadSampleAgentConfig.test.ts
+++ b/web/packages/studio/src/api/agents/loadSampleAgentConfig.test.ts
@@ -96,6 +96,13 @@ describe('loadSampleAgentConfig', () => {
     );
   });
 
+  it('throws on an unsupported config_format instead of falling back to NAT', async () => {
+    mockFetchText('config_format: nemo-agents-spec-v2\nworkflow:\n  _type: react_agent\n');
+    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(
+      /unsupported config_format: nemo-agents-spec-v2/
+    );
+  });
+
   it('throws when the fetch fails', async () => {
     mockFetchText('', false);
     await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(

--- a/web/packages/studio/src/api/agents/loadSampleAgentConfig.test.ts
+++ b/web/packages/studio/src/api/agents/loadSampleAgentConfig.test.ts
@@ -17,6 +17,23 @@ workflow:
   tool_names: [email_phishing_analyzer]
 `;
 
+const FABRIC_AGENT_YAML = `config_format: nemo-agents-spec-v1
+name: email-phishing-fabric
+default_harness: deepagents
+harnesses:
+  deepagents:
+    kind: deepagents
+models:
+  default:
+    provider: openai
+    model: \${NEMO_DEFAULT_MODEL}
+mcp:
+  servers:
+    email-phishing-analyzer:
+      transport: stdio
+      url: /workspace/.venv/bin/email-phishing-analyzer-mcp
+`;
+
 const mockFetchText = (body: string, ok = true) =>
   vi.spyOn(globalThis, 'fetch').mockResolvedValue({
     ok,
@@ -53,6 +70,29 @@ describe('loadSampleAgentConfig', () => {
     mockFetchText('llms:\n  llm: some-string\n');
     await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(
       /missing llms\.llm/
+    );
+  });
+
+  it('injects the model into models.default for a Fabric config', async () => {
+    mockFetchText(FABRIC_AGENT_YAML);
+    const config = (await loadSampleAgentConfig('sample-agents/x/agent.yml', 'my-model')) as {
+      config_format: string;
+      default_harness: string;
+      models: { default: { model: string; provider: string } };
+      mcp: { servers: Record<string, { transport: string }> };
+    };
+    expect(config.models.default.model).toBe('my-model');
+    // The rest of the Fabric config is preserved and llms.llm is never required.
+    expect(config.config_format).toBe('nemo-agents-spec-v1');
+    expect(config.default_harness).toBe('deepagents');
+    expect(config.models.default.provider).toBe('openai');
+    expect(config.mcp.servers['email-phishing-analyzer'].transport).toBe('stdio');
+  });
+
+  it('throws when a Fabric config is missing models.default', async () => {
+    mockFetchText('config_format: nemo-agents-spec-v1\ndefault_harness: deepagents\n');
+    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(
+      /missing models\.default/
     );
   });
 

--- a/web/packages/studio/src/api/agents/loadSampleAgentConfig.ts
+++ b/web/packages/studio/src/api/agents/loadSampleAgentConfig.ts
@@ -23,13 +23,21 @@ export const loadSampleAgentConfig = async (
   const text = await fetchSampleText(agentConfigPath);
   const config = YAML.parse(text) as Record<string, unknown>;
 
-  if (config?.config_format === 'nemo-agents-spec-v1') {
+  const configFormat = config?.config_format;
+
+  if (configFormat === 'nemo-agents-spec-v1') {
     injectFabricModel(config, modelName, agentConfigPath);
     return config;
   }
 
-  injectNatModel(config, modelName, agentConfigPath);
-  return config;
+  if (configFormat === undefined || configFormat === 'nat-workflow-v1') {
+    injectNatModel(config, modelName, agentConfigPath);
+    return config;
+  }
+
+  throw new Error(
+    `Sample agent config ${agentConfigPath} has unsupported config_format: ${String(configFormat)}`
+  );
 };
 
 /** NAT workflow config: overwrite `llms.llm.model_name`. */

--- a/web/packages/studio/src/api/agents/loadSampleAgentConfig.ts
+++ b/web/packages/studio/src/api/agents/loadSampleAgentConfig.ts
@@ -5,10 +5,16 @@ import { fetchSampleText } from '@studio/api/agents/fetchSampleText';
 import YAML from 'yaml';
 
 /**
- * Loads a sample agent's NAT workflow config from a public static asset and
- * injects the selected model. Parse-then-set: the fetched YAML's model_name
- * literal is overwritten, so the asset can stay byte-identical to the plugin's
+ * Loads a sample agent's config from a public static asset and injects the
+ * selected model. Parse-then-set: the fetched YAML's model literal is
+ * overwritten, so the asset can stay byte-identical to the plugin's
  * ${NEMO_DEFAULT_MODEL} version (the platform service doesn't resolve that).
+ *
+ * Branches on the config's own `config_format`:
+ * - NAT (`nat-workflow-v1`, the default when absent): model lives at
+ *   `llms.llm.model_name`.
+ * - Fabric (`nemo-agents-spec-v1`): model lives at `models.default.model`; the
+ *   selected harness inherits it when it declares no model of its own.
  */
 export const loadSampleAgentConfig = async (
   agentConfigPath: string,
@@ -16,10 +22,39 @@ export const loadSampleAgentConfig = async (
 ): Promise<Record<string, unknown>> => {
   const text = await fetchSampleText(agentConfigPath);
   const config = YAML.parse(text) as Record<string, unknown>;
+
+  if (config?.config_format === 'nemo-agents-spec-v1') {
+    injectFabricModel(config, modelName, agentConfigPath);
+    return config;
+  }
+
+  injectNatModel(config, modelName, agentConfigPath);
+  return config;
+};
+
+/** NAT workflow config: overwrite `llms.llm.model_name`. */
+const injectNatModel = (
+  config: Record<string, unknown>,
+  modelName: string,
+  agentConfigPath: string
+): void => {
   const llm = (config?.llms as { llm?: unknown } | undefined)?.llm;
   if (!llm || typeof llm !== 'object' || Array.isArray(llm)) {
     throw new Error(`Sample agent config ${agentConfigPath} is missing llms.llm`);
   }
   (llm as Record<string, unknown>).model_name = modelName;
-  return config;
+};
+
+/** Fabric (nemo-agents-spec-v1) config: overwrite `models.default.model`. */
+const injectFabricModel = (
+  config: Record<string, unknown>,
+  modelName: string,
+  agentConfigPath: string
+): void => {
+  const models = config?.models as { default?: unknown } | undefined;
+  const defaultModel = models?.default;
+  if (!defaultModel || typeof defaultModel !== 'object' || Array.isArray(defaultModel)) {
+    throw new Error(`Sample agent config ${agentConfigPath} is missing models.default`);
+  }
+  (defaultModel as Record<string, unknown>).model = modelName;
 };

--- a/web/packages/studio/src/constants/sampleAgents.ts
+++ b/web/packages/studio/src/constants/sampleAgents.ts
@@ -26,6 +26,10 @@ export interface SampleAgent {
   /** Public path to a reusable nemo-evaluator eval-config.json. Samples without
    *  one remain available for agent creation but not evaluation seeding. */
   evalConfigPath?: string;
+  /** Config format identifier sent to the create API. Defaults to
+   *  `nat-workflow-v1` server-side when omitted; set to `nemo-agents-spec-v1`
+   *  for Fabric-backed samples so the API validates them as Fabric, not NAT. */
+  configFormat?: string;
 }
 
 export const SAMPLE_AGENTS: SampleAgent[] = [

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/CreateExampleAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/CreateExampleAgentModal/index.tsx
@@ -147,6 +147,9 @@ export const CreateExampleAgentModal: FC<CreateExampleAgentModalProps> = ({
           name: buildSampleAgentName(example.namePrefix),
           description: example.description,
           config,
+          // Omitted for NAT samples (API defaults to nat-workflow-v1); set for
+          // Fabric samples so the API validates the config as nemo-agents-spec-v1.
+          ...(example.configFormat ? { config_format: example.configFormat } : {}),
         },
       });
     } catch {


### PR DESCRIPTION
## What

Makes Studio's **Create Example Agent** flow config-format-aware so it can create Fabric (`nemo-agents-spec-v1`) agents, not just NAT (`nat-workflow-v1`) ones. The change is **harness-agnostic** — it supports any Fabric harness the platform translator handles (claude, codex, deepagents, hermes).

## Why

The flow assumed NAT workflow configs in two places:

1. `loadSampleAgentConfig` hard-threw on missing `llms.llm`, then wrote `llms.llm.model_name`. A Fabric config has no `llms.llm` — its model lives at `models.default.model`.
2. `CreateExampleAgentModal` sent the create POST without `config_format`, so the API defaulted to `nat-workflow-v1` and would validate a Fabric config as NAT (400).

Both are format-level, not harness-level, so this unblocks Fabric examples without committing to any specific example.

## Changes

- **`loadSampleAgentConfig.ts`** — branch on the parsed `config_format`:
  - NAT (default/absent) → inject `llms.llm.model_name` (unchanged behavior).
  - Fabric (`nemo-agents-spec-v1`) → inject `models.default.model`; the selected harness inherits it. No `llms.llm` requirement.
- **`sampleAgents.ts`** — add optional `configFormat` to the `SampleAgent` interface.
- **`CreateExampleAgentModal/index.tsx`** — thread `config_format` into the create POST when the registry entry sets it. The generated SDK's `CreateAgentRequest` already carries `config_format?: string`, so no SDK regen is needed.
- **`loadSampleAgentConfig.test.ts`** — add Fabric cases (model injected into `models.default.model`; missing `models.default` throws).

## Scope / follow-up

Format-level **plumbing only**. This PR does **not** add a Fabric sample-agent entry to `SAMPLE_AGENTS` or its static assets — that follows once the example's `agent.yml` shape (harness, MCP binding, credential path) is locked. After this merges, Studio silently accepts Fabric configs; the visible demo entry lands in a later PR.

## Verification

- `loadSampleAgentConfig` unit tests: **6/6 pass** (4 existing NAT + 2 new Fabric).
- Full `nemo-studio-ui` suite: **2689/2689 pass**.
- Lint clean; typecheck clean on all changed files.
  (Three pre-existing `db_version` typecheck errors in `guardrails.ts` / `VirtualModelDetailsSidePanel` are unrelated to this PR.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating sample agents using both NAT and Fabric configuration formats.
  * Fabric-based samples can now specify their configuration format and selected model correctly.
  * Existing NAT samples continue to use the default configuration behavior.

* **Bug Fixes**
  * Added validation and clear errors for unsupported formats or missing model settings when creating sample agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->