### PR TITLE
fix: default to writing insights to platform

### DIFF
--- a/docs/agents/insight-driven-optimization.mdx
+++ b/docs/agents/insight-driven-optimization.mdx
@@ -540,7 +540,7 @@ Run the Analyst for one analysis of an agent's traces.
 | `--workspace` | no | profile `workspace`, else `default` | Workspace to operate in. |
 | `--base-url` | no | `NMP_BASE_URL`, else `http://localhost:8080` | Running platform instance the Analyst's tools call. |
 | `--profile` | no | discovered by walking up from the current working directory | Path to `optimizer.yaml`. |
-| `--insights-file-output` | no | `<profile-dir>/.nemo-optimizer/insights.yaml` when a profile is found, else the Insights API | Read and write Insights from a local YAML file. |
+| `--insights-file-output` | no | off — Insights go to the platform only | Additionally mirror the Insights the platform stored into a local YAML file, platform ids included. Each run merges into the file. |
 | `--verbose` / `-v` | no | off | Stream tool calls and reasoning to standard error. |
 
 ### `nemo insights analysis enable | disable | status`

--- a/plugins/nemo-experimentalist/AGENTS.md
+++ b/plugins/nemo-experimentalist/AGENTS.md
@@ -82,10 +82,10 @@ breaking rename with no compatibility aliases:
 Two names deliberately did **not** change. `optimizer.yaml` and the
 `.nemo-optimizer/` state directory are a shared contract with
 `nemo-insights-plugin`: `PROFILE_FILENAME` and `discover_profile()` live in
-`nemo_insights_plugin.contracts.profile`, and `nemo agents analyst run` writes
-`<profile-dir>/.nemo-optimizer/insights.yaml` under `--local-only` (or mirrors
-Platform rows into an explicit `--insights-file-output`), which this plugin
-reads as the default insight when the file exists. Rename them only in lockstep with a Platform change to that
+`nemo_insights_plugin.contracts.profile`, and `nemo agents analyst run` can
+mirror the Platform rows it wrote into `<profile-dir>/.nemo-optimizer/insights.yaml`
+via `--insights-file-output`, which this plugin reads as the default insight when
+the file exists. Rename them only in lockstep with a Platform change to that
 contract. `EvolutionaryOptimizer` and `EvolutionaryOptimizerConfig` also keep
 their names — they describe the optimization algorithm, not the product.
 

--- a/plugins/nemo-experimentalist/AGENTS.md
+++ b/plugins/nemo-experimentalist/AGENTS.md
@@ -83,8 +83,9 @@ Two names deliberately did **not** change. `optimizer.yaml` and the
 `.nemo-optimizer/` state directory are a shared contract with
 `nemo-insights-plugin`: `PROFILE_FILENAME` and `discover_profile()` live in
 `nemo_insights_plugin.contracts.profile`, and `nemo agents analyst run` writes
-`<profile-dir>/.nemo-optimizer/insights.yaml`, which this plugin reads as the
-default insight. Rename them only in lockstep with a Platform change to that
+`<profile-dir>/.nemo-optimizer/insights.yaml` under `--local-only` (or mirrors
+Platform rows into an explicit `--insights-file-output`), which this plugin
+reads as the default insight when the file exists. Rename them only in lockstep with a Platform change to that
 contract. `EvolutionaryOptimizer` and `EvolutionaryOptimizerConfig` also keep
 their names — they describe the optimization algorithm, not the product.
 

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -38,10 +38,12 @@ nemo agents analyst run → .nemo-optimizer/insights.yaml or Platform Insight ID
 ```
 
 Run `nemo agents analyst run` using the Platform Insights plugin and its
-documented trace, workspace, and output options. The producer may write the
-local profile default, `.nemo-optimizer/insights.yaml`, or persist an Insight
-on Platform and report its ID. The Experimentalist does not analyze traces,
-schedule analysis, or host an Insight API.
+documented trace, workspace, and output options. It persists an Insight on
+Platform by default and reports its ID; `--insights-file-output` additionally
+mirrors those rows into a local file, and `--local-only` writes the local
+profile default, `.nemo-optimizer/insights.yaml`, and nothing else. The
+Experimentalist does not analyze traces, schedule analysis, or host an Insight
+API.
 
 From an agent directory with an `optimizer.yaml` profile, validate the
 effective inputs:

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -38,12 +38,11 @@ nemo agents analyst run → .nemo-optimizer/insights.yaml or Platform Insight ID
 ```
 
 Run `nemo agents analyst run` using the Platform Insights plugin and its
-documented trace, workspace, and output options. It persists an Insight on
-Platform by default and reports its ID; `--insights-file-output` additionally
-mirrors those rows into a local file, and `--local-only` writes the local
-profile default, `.nemo-optimizer/insights.yaml`, and nothing else. The
-Experimentalist does not analyze traces, schedule analysis, or host an Insight
-API.
+documented trace, workspace, and output options. It always persists an Insight
+on Platform and reports its ID; `--insights-file-output` additionally mirrors
+those rows into a local file, which this plugin can consume in place of an ID.
+The Experimentalist does not analyze traces, schedule analysis, or host an
+Insight API.
 
 From an agent directory with an `optimizer.yaml` profile, validate the
 effective inputs:

--- a/plugins/nemo-insights/README.md
+++ b/plugins/nemo-insights/README.md
@@ -45,7 +45,8 @@ defaults. `--base-url` takes precedence over `NMP_BASE_URL`.
 
 ### Where insights are written
 
-Insights go to the platform by default, through the Insights plugin API.
+Insights always go to the platform, through the Insights plugin API. There is no
+mode that keeps them off it.
 
 Pass `--insights-file-output <path>` to also keep a local copy: the platform is
 written first and the file mirrors what it stored, platform ids included, so a
@@ -54,19 +55,9 @@ than overwriting it. Because the platform is the source of truth, a file that
 cannot be written is reported as a warning on the run report instead of failing
 the run.
 
-Pass `--local-only` to skip the platform entirely — for a deployment that hosts
-observability data but does not have the Insights plugin installed. It writes to
-`--insights-file-output` when given, otherwise to the shared profile default
-`.nemo-optimizer/insights.yaml` beside `optimizer.yaml`. With neither a profile
-nor an explicit path there is nowhere to write, and the command errors. Ids in a
-`--local-only` file are minted locally, so such a file is an independent store
-rather than a mirror of platform rows. Trace and feedback reads always hit
-`--base-url`.
-
 ```bash
 uv run nemo agents analyst run                                  # platform only
 uv run nemo agents analyst run --insights-file-output out.yaml  # platform + local mirror
-uv run nemo agents analyst run --local-only                     # local only
 ```
 
 ```bash

--- a/plugins/nemo-insights/README.md
+++ b/plugins/nemo-insights/README.md
@@ -43,9 +43,31 @@ explicit command-line flags, then profile values (for `agent`, `agent_spec`,
 and `workspace`) or `NMP_BASE_URL` (for the base URL), then the built-in
 defaults. `--base-url` takes precedence over `NMP_BASE_URL`.
 
-With a discovered profile, analysis reads and writes the shared local output at
-`.nemo-optimizer/insights.yaml` beside `optimizer.yaml`. Pass
-`--insights-file-output` to use a different file explicitly.
+### Where insights are written
+
+Insights go to the platform by default, through the Insights plugin API.
+
+Pass `--insights-file-output <path>` to also keep a local copy: the platform is
+written first and the file mirrors what it stored, platform ids included, so a
+later run's updates land in both stores. Each run merges into the file rather
+than overwriting it. Because the platform is the source of truth, a file that
+cannot be written is reported as a warning on the run report instead of failing
+the run.
+
+Pass `--local-only` to skip the platform entirely — for a deployment that hosts
+observability data but does not have the Insights plugin installed. It writes to
+`--insights-file-output` when given, otherwise to the shared profile default
+`.nemo-optimizer/insights.yaml` beside `optimizer.yaml`. With neither a profile
+nor an explicit path there is nowhere to write, and the command errors. Ids in a
+`--local-only` file are minted locally, so such a file is an independent store
+rather than a mirror of platform rows. Trace and feedback reads always hit
+`--base-url`.
+
+```bash
+uv run nemo agents analyst run                                  # platform only
+uv run nemo agents analyst run --insights-file-output out.yaml  # platform + local mirror
+uv run nemo agents analyst run --local-only                     # local only
+```
 
 ```bash
 uv run nemo agents analyst run \

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
@@ -17,11 +17,20 @@ Intake reads (spans, span groups, annotations, session count) always hit the
 live platform. Insight listing and result persistence vary by backend, because the
 target deployment may not have the Insights plugin installed.
 :class:`RemoteAnalystBackend` lists insights via the plugin API and persists the
-result as Insight rows via the plugin API.
-:class:`LocalAnalystBackend` lists from and persists to a local YAML file
-(``--insights-file-output``), merging each run's change-set into the file rather
-than overwriting it. :func:`make_analyst_backend` picks one. The client's
-lifecycle is owned by the caller (the CLI), so the backend never closes it.
+result as Insight rows via the plugin API. Given an
+:class:`InsightsFileStore`, it then mirrors what the platform stored — platform
+ids included — into a local YAML file (``--insights-file-output``), so the two
+stores speak the same identifiers and a later run's updates land in both.
+:class:`LocalAnalystBackend` (``--local-only``) never touches the plugin API: it
+lists from and persists to the file alone.
+
+The platform is the source of truth in mirror mode. Insights are written there
+first and the file follows; a file that cannot be written degrades to a warning
+on the run report rather than failing a run whose platform writes already
+succeeded.
+
+:func:`make_analyst_backend` picks one. The client's lifecycle is owned by the
+caller (the CLI), so the backend never closes it.
 """
 
 import uuid
@@ -317,13 +326,102 @@ class AnalystBackend(ABC):
         ...
 
 
+def _generate_local_insight_id() -> str:
+    """Mint a path-safe, unique insight id for offline mode.
+
+    Mirrors the remote store's ``insight-<suffix>`` shape so file records look
+    like what the platform would assign; the suffix is a uuid4 hex rather than
+    the store's base58 encoding (no extra dependency), which is still unique.
+    """
+    return f"insight-{uuid.uuid4().hex}"
+
+
+def _record_to_insight(record: dict) -> Insight:
+    """Rebuild an :class:`Insight` (id/timestamps included) from a file record.
+
+    A record is an :class:`Insight` JSON-able dump; any keys not on the entity
+    are ignored by Pydantic during validation.
+    """
+    insight = Insight.model_validate(record)
+    insight._id = record.get("id") or None
+    for attr, key in (("_created_at", "created_at"), ("_updated_at", "updated_at")):
+        raw = record.get(key)
+        setattr(insight, attr, datetime.fromisoformat(raw) if raw else None)
+    return insight
+
+
+def _insight_to_record(insight: Insight, *, workspace: str) -> dict:
+    """Flatten a stored :class:`Insight` into a file record.
+
+    Keeps the platform's id and timestamps rather than minting local ones: the
+    mirror is only useful if its records can be matched against the platform
+    rows they came from on the next run.
+    """
+    return {
+        "id": insight.id,
+        "workspace": workspace,
+        "name": insight.name,
+        "title": insight.title,
+        "agent": insight.agent,
+        "description": insight.description,
+        "status": insight.status.value,
+        "trace_refs": list(insight.trace_refs),
+        "created_at": insight.created_at.isoformat() if insight.created_at else None,
+        "updated_at": insight.updated_at.isoformat() if insight.updated_at else None,
+    }
+
+
+class InsightsFileStore:
+    """The local Insights YAML document: ``{"insights": [<record>, ...]}``.
+
+    Shared by the local backend (as its store) and the remote backend (as its
+    mirror). Writes preserve any other top-level keys the document carries, so
+    a hand-maintained file keeps its own metadata across analyst runs.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def read_records(self) -> list[dict]:
+        if not self.path.exists():
+            return []
+        raw = yaml.safe_load(self.path.read_text(encoding="utf-8")) or {}
+        return list(raw.get("insights", []))
+
+    def write_records(self, records: list[dict]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        document = yaml.safe_load(self.path.read_text(encoding="utf-8")) if self.path.exists() else None
+        if not isinstance(document, dict):
+            document = {}
+        document["insights"] = records
+        self.path.write_text(yaml.safe_dump(document, sort_keys=False, allow_unicode=True), encoding="utf-8")
+
+    def merge(self, records: list[dict]) -> None:
+        """Upsert *records* by ``(workspace, id)`` into the existing document."""
+        existing = self.read_records()
+        index = {(r.get("workspace"), r.get("id")): position for position, r in enumerate(existing)}
+        for record in records:
+            key = (record.get("workspace"), record.get("id"))
+            position = index.get(key)
+            if position is None:
+                index[key] = len(existing)
+                existing.append(record)
+            else:
+                existing[position] = record
+        self.write_records(existing)
+
+
 class RemoteAnalystBackend(AnalystBackend):
-    """Persist insights via the Insights plugin API.
+    """Persist insights via the Insights plugin API, optionally mirroring to a file.
 
     Translates the SDK's HTTP 404 on an update into the backend-neutral
     not-found error so the persistence logic doesn't depend on ``httpx``
     semantics.
     """
+
+    def __init__(self, client: AsyncNeMoPlatform, mirror: InsightsFileStore | None = None) -> None:
+        super().__init__(client)
+        self.mirror = mirror
 
     @property
     def _insights(self):
@@ -347,13 +445,15 @@ class RemoteAnalystBackend(AnalystBackend):
         )
 
     async def persist_result(self, *, workspace: str, agent: str, result: AnalystResult) -> str:
-        """Replay the change-set: insights into the DB.
+        """Replay the change-set: insights into the DB, then into the mirror.
 
         New insights are created with their evidence; the store auto-assigns a
         unique slug name and an id. Existing insights are referenced by id —
-        only trace refs are appended.
+        only trace refs are appended. Whatever the platform stored is then
+        mirrored to the local file, if one is configured.
         """
         lines: list[str] = []
+        stored: list[Insight] = []
 
         for new in result.new_insights:
             created = await self._create(
@@ -364,27 +464,47 @@ class RemoteAnalystBackend(AnalystBackend):
                 status=new.status,
                 trace_refs=new.trace_refs or None,
             )
+            stored.append(created)
             lines.append(f"- created: {new.title} [{created.id}] ({len(new.trace_refs)} trace refs)")
 
         for upd in result.updated_insights:
             try:
                 if upd.trace_refs:
-                    await self._add_trace_refs(
+                    updated = await self._add_trace_refs(
                         workspace=workspace,
                         insight_id=upd.id,
                         trace_refs=upd.trace_refs,
                     )
                 else:
-                    await self._get(workspace=workspace, insight_id=upd.id)
+                    updated = await self._get(workspace=workspace, insight_id=upd.id)
             except InsightNotFoundError:
                 lines.append(f"- skipped (insight not found): {upd.id}")
                 continue
+            stored.append(updated)
             lines.append(f"- updated: {upd.id} ({len(upd.trace_refs)} trace refs)")
 
         if not lines:
             lines.append("- no insights created or updated")
 
+        lines.extend(self._mirror(workspace=workspace, stored=stored))
         return f"{result.summary}\n\n" + "\n".join(lines)
+
+    def _mirror(self, *, workspace: str, stored: list[Insight]) -> list[str]:
+        """Write what the platform stored to the mirror file; report the outcome.
+
+        The platform writes have already landed by the time this runs, so a
+        file that cannot be written is reported as a warning instead of raising
+        — failing here would claim the whole run failed when the source of
+        truth is up to date.
+        """
+        if self.mirror is None:
+            return []
+        try:
+            self.mirror.merge([_insight_to_record(insight, workspace=workspace) for insight in stored])
+        except (OSError, UnicodeError, yaml.YAMLError) as exc:
+            detail = " ".join(str(exc).split())
+            return [f"- warning: platform updated, but mirror {self.mirror.path} could not be written: {detail}"]
+        return [f"- mirrored {len(stored)} insight(s) to {self.mirror.path}"]
 
     async def _create(
         self,
@@ -427,37 +547,17 @@ class RemoteAnalystBackend(AnalystBackend):
             raise
 
 
-def _generate_local_insight_id() -> str:
-    """Mint a path-safe, unique insight id for offline mode.
-
-    Mirrors the remote store's ``insight-<suffix>`` shape so file records look
-    like what the platform would assign; the suffix is a uuid4 hex rather than
-    the store's base58 encoding (no extra dependency), which is still unique.
-    """
-    return f"insight-{uuid.uuid4().hex}"
-
-
-def _record_to_insight(record: dict) -> Insight:
-    """Rebuild an :class:`Insight` (id/timestamps included) from a file record.
-
-    A record is an :class:`Insight` JSON-able dump; any keys not on the entity
-    are ignored by Pydantic during validation.
-    """
-    insight = Insight.model_validate(record)
-    insight._id = record.get("id") or None
-    for attr, key in (("_created_at", "created_at"), ("_updated_at", "updated_at")):
-        raw = record.get(key)
-        setattr(insight, attr, datetime.fromisoformat(raw) if raw else None)
-    return insight
-
-
 class LocalAnalystBackend(AnalystBackend):
-    """Persist the analyst's result to a local YAML file (offline mode).
+    """Persist the analyst's result to a local YAML file only (``--local-only``).
 
     For running against a deployment that hosts observability data but does not
     have the Insights plugin installed: reads of traces/spans/annotations still
     hit the live platform, but insights are both listed from and written to the
-    file. The file accumulates across runs — ``persist_result`` merges the new
+    file, and nothing is written to the platform. Ids are minted locally, so a
+    file written this way is an independent store rather than a mirror of
+    platform rows.
+
+    The file accumulates across runs — ``persist_result`` merges the new
     change-set into whatever the file already holds rather than overwriting it,
     so re-running the analyst against the same file folds new evidence into
     existing insights instead of dropping prior work.
@@ -468,24 +568,14 @@ class LocalAnalystBackend(AnalystBackend):
 
     def __init__(self, *, client: AsyncNeMoPlatform, path: Path) -> None:
         super().__init__(client)
-        self.path = path
+        self.store = InsightsFileStore(path)
 
-    def _read_records(self) -> list[dict]:
-        if not self.path.exists():
-            return []
-        raw = yaml.safe_load(self.path.read_text(encoding="utf-8")) or {}
-        return list(raw.get("insights", []))
-
-    def _write_records(self, records: list[dict]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        document = yaml.safe_load(self.path.read_text(encoding="utf-8")) if self.path.exists() else None
-        if not isinstance(document, dict):
-            document = {}
-        document["insights"] = records
-        self.path.write_text(yaml.safe_dump(document, sort_keys=False, allow_unicode=True), encoding="utf-8")
+    @property
+    def path(self) -> Path:
+        return self.store.path
 
     async def persist_result(self, *, workspace: str, agent: str, result: AnalystResult) -> str:
-        records = self._read_records()
+        records = self.store.read_records()
         by_id = {(r.get("workspace"), r.get("id")): r for r in records}
         now = datetime.now(timezone.utc).isoformat()
         lines: list[str] = []
@@ -519,7 +609,7 @@ class LocalAnalystBackend(AnalystBackend):
         if not lines:
             lines.append("- no insights created or updated")
 
-        self._write_records(records)
+        self.store.write_records(records)
         return f"{result.summary}\n\nWrote analyst result to {self.path}\n" + "\n".join(lines)
 
     async def list_insights(
@@ -531,7 +621,7 @@ class LocalAnalystBackend(AnalystBackend):
         agent: str | None,
         status: InsightStatus | None,
     ) -> InsightPage:
-        items = [_record_to_insight(r) for r in self._read_records() if r.get("workspace") == workspace]
+        items = [_record_to_insight(r) for r in self.store.read_records() if r.get("workspace") == workspace]
         if agent:
             items = [i for i in items if i.agent == agent]
         if status is not None:
@@ -552,13 +642,23 @@ class LocalAnalystBackend(AnalystBackend):
         return InsightPage(data=page_items, pagination=pagination)
 
 
-def make_analyst_backend(*, client: AsyncNeMoPlatform, insights_output: str | None) -> AnalystBackend:
-    """Select the analyst backend based on *insights_output*.
+def make_analyst_backend(
+    *,
+    client: AsyncNeMoPlatform,
+    insights_output: str | None,
+    local_only: bool = False,
+) -> AnalystBackend:
+    """Select the analyst backend.
 
-    When set, the analyst's result is written to that local YAML file (offline
-    mode); otherwise the Insights plugin API and platform filesets on *client*
-    are used. Reads always go through *client* either way.
+    The platform is the default destination: without *local_only*, results are
+    written through the Insights plugin API on *client*, and *insights_output*
+    (when set) additionally receives a mirror of what the platform stored. With
+    *local_only*, nothing is written to the platform and *insights_output* is
+    the sole store, so a path is required. Reads always go through *client*.
     """
-    if insights_output:
+    if local_only:
+        if not insights_output:
+            raise ValueError("local-only analysis requires an insights output path")
         return LocalAnalystBackend(client=client, path=Path(insights_output))
-    return RemoteAnalystBackend(client)
+    mirror = InsightsFileStore(Path(insights_output)) if insights_output else None
+    return RemoteAnalystBackend(client, mirror=mirror)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/analyst_backend.py
@@ -14,20 +14,23 @@ raw SDK client around. The backend owns the SDK client and exposes:
   :class:`~nemo_insights_plugin.analyst.result.AnalystResult` and stores it.
 
 Intake reads (spans, span groups, annotations, session count) always hit the
-live platform. Insight listing and result persistence vary by backend, because the
-target deployment may not have the Insights plugin installed.
-:class:`RemoteAnalystBackend` lists insights via the plugin API and persists the
-result as Insight rows via the plugin API. Given an
+live platform.
+
+Insights always go to the platform. :class:`RemoteAnalystBackend` lists them via
+the plugin API and persists the result as Insight rows through it. Given an
 :class:`InsightsFileStore`, it then mirrors what the platform stored — platform
 ids included — into a local YAML file (``--insights-file-output``), so the two
-stores speak the same identifiers and a later run's updates land in both.
-:class:`LocalAnalystBackend` (``--local-only``) never touches the plugin API: it
-lists from and persists to the file alone.
+stores speak the same identifiers and a later run's updates land in both. The
+platform is the source of truth: it is written first and the file follows, and a
+file that cannot be written degrades to a warning on the run report rather than
+failing a run whose platform writes already succeeded.
 
-The platform is the source of truth in mirror mode. Insights are written there
-first and the file follows; a file that cannot be written degrades to a warning
-on the run report rather than failing a run whose platform writes already
-succeeded.
+:class:`LocalAnalystBackend` never touches the plugin API, listing from and
+persisting to the file alone. It is **maintainer tooling, not a user-facing
+mode**: the insights testbed treats the YAML as the artifact under test and runs
+against subjects that expose Intake but not the Insights plugin (see
+``testbed/README.md``). There is no CLI flag for it; only ``make_analyst_backend``'s
+``local_only`` argument selects it.
 
 :func:`make_analyst_backend` picks one. The client's lifecycle is owned by the
 caller (the CLI), so the backend never closes it.
@@ -548,12 +551,16 @@ class RemoteAnalystBackend(AnalystBackend):
 
 
 class LocalAnalystBackend(AnalystBackend):
-    """Persist the analyst's result to a local YAML file only (``--local-only``).
+    """Persist the analyst's result to a local YAML file only.
 
-    For running against a deployment that hosts observability data but does not
-    have the Insights plugin installed: reads of traces/spans/annotations still
-    hit the live platform, but insights are both listed from and written to the
-    file, and nothing is written to the platform. Ids are minted locally, so a
+    Maintainer tooling for the insights testbed, not a user-facing mode — no CLI
+    flag reaches it. The testbed treats the YAML as the artifact under test
+    (checked in, hashed, diffed across runs) and analyzes subjects that expose
+    Intake but not the Insights plugin, so its runs must neither require nor
+    touch platform Insight rows.
+
+    Reads of traces/spans/annotations still hit the live platform, but insights
+    are both listed from and written to the file. Ids are minted locally, so a
     file written this way is an independent store rather than a mirror of
     platform rows.
 
@@ -650,11 +657,11 @@ def make_analyst_backend(
 ) -> AnalystBackend:
     """Select the analyst backend.
 
-    The platform is the default destination: without *local_only*, results are
-    written through the Insights plugin API on *client*, and *insights_output*
-    (when set) additionally receives a mirror of what the platform stored. With
-    *local_only*, nothing is written to the platform and *insights_output* is
-    the sole store, so a path is required. Reads always go through *client*.
+    Results are written through the Insights plugin API on *client*, and
+    *insights_output* (when set) additionally receives a mirror of what the
+    platform stored. *local_only* is reserved for the insights testbed: it skips
+    the platform and makes *insights_output* the sole store, so a path is
+    required. No CLI flag sets it. Reads always go through *client*.
     """
     if local_only:
         if not insights_output:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/deps.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/deps.py
@@ -31,8 +31,9 @@ class AnalystDeps:
         workspace: NMP workspace the analyst operates in.
         base_url: Base URL of the running NMP instance (run metadata; tools go
             through ``backend``).
-        insights_output: When set, the backend persists insights to this local
-            YAML file instead of the Insights plugin API (run metadata).
+        insights_output: When set, the backend also persists insights to this
+            local YAML file — as a mirror of the platform's rows, or as the
+            only store under ``--local-only`` (run metadata).
         backend: Shared data-access backend used by every tool.
         since: Optional lower bound for scheduled incremental analysis. Backend
             reads enforce this even if the model omits a time filter.

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/deps.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/deps.py
@@ -32,8 +32,8 @@ class AnalystDeps:
         base_url: Base URL of the running NMP instance (run metadata; tools go
             through ``backend``).
         insights_output: When set, the backend also persists insights to this
-            local YAML file — as a mirror of the platform's rows, or as the
-            only store under ``--local-only`` (run metadata).
+            local YAML file, mirroring the rows the platform stored (run
+            metadata).
         backend: Shared data-access backend used by every tool.
         since: Optional lower bound for scheduled incremental analysis. Backend
             reads enforce this even if the model omits a time filter.

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
@@ -61,7 +61,8 @@ async def run_analyst(
         insights_output: Optional local YAML path. Receives a mirror of the
             insights the platform stored, or the only copy under *local_only*.
         local_only: Skip the platform and persist insights to *insights_output*
-            alone. Requires *insights_output*.
+            alone. Reserved for the insights testbed — no CLI flag sets it.
+            Requires *insights_output*.
         verbose: Whether to stream model/tool events to stderr.
         since: Optional incremental lower bound enforced on trace/span reads.
         evaluation_id: Optional run scope; AND-pinned onto every span read.

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
@@ -42,6 +42,7 @@ async def run_analyst(
     base_url: str | None,
     client: AsyncNeMoPlatform,
     insights_output: str | Path | None = None,
+    local_only: bool = False,
     verbose: bool = False,
     since: datetime | None = None,
     evaluation_id: str | None = None,
@@ -57,7 +58,10 @@ async def run_analyst(
         workspace: Platform workspace.
         base_url: Platform base URL. ``None`` uses the active platform context.
         client: Platform client to use. This function closes it before returning.
-        insights_output: Optional local YAML output path for Insight writes.
+        insights_output: Optional local YAML path. Receives a mirror of the
+            insights the platform stored, or the only copy under *local_only*.
+        local_only: Skip the platform and persist insights to *insights_output*
+            alone. Requires *insights_output*.
         verbose: Whether to stream model/tool events to stderr.
         since: Optional incremental lower bound enforced on trace/span reads.
         evaluation_id: Optional run scope; AND-pinned onto every span read.
@@ -68,6 +72,7 @@ async def run_analyst(
         backend = make_analyst_backend(
             client=client,
             insights_output=insights_output_path,
+            local_only=local_only,
         )
         deps = AnalystDeps(
             agent=agent,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -54,7 +54,7 @@ class _ResolvedAnalysis:
     workspace: str
     base_url: str
     insights_output: Path | None
-    profile_output: Path | None
+    local_only: bool
     profile_dir: Path | None
     spec_checks: tuple[CheckResult, ...]
 
@@ -104,6 +104,7 @@ def _resolve_analysis(
     base_url: str | None,
     profile_path: Path | None,
     insights_output: Path | None,
+    local_only: bool,
 ) -> _ResolvedAnalysis:
     profile, profile_error = _load_profile_or_error(profile_path)
     if profile_error is not None:
@@ -131,10 +132,14 @@ def _resolve_analysis(
     spec_content, spec_checks = read_agent_spec(spec_path, spec_error)
 
     resolved_base_url = resolve_base_url(base_url)
-    profile_output = None
-    if insights_output is None and profile is not None:
-        profile_output = profile.profile_dir / ".nemo-optimizer" / "insights.yaml"
-    resolved_output = insights_output if insights_output is not None else profile_output
+    resolved_output = insights_output
+    if local_only and resolved_output is None:
+        if profile is None:
+            raise ProfileError(
+                "--local-only has nowhere to write: no optimizer.yaml profile was found. "
+                "Create a profile beside your agent or pass --insights-file-output with an explicit path."
+            )
+        resolved_output = profile.profile_dir / ".nemo-optimizer" / "insights.yaml"
     validate_insights_file(resolved_output)
 
     return _ResolvedAnalysis(
@@ -143,7 +148,7 @@ def _resolve_analysis(
         workspace=resolved_workspace,
         base_url=resolved_base_url,
         insights_output=resolved_output,
-        profile_output=profile_output,
+        local_only=local_only,
         profile_dir=profile.profile_dir if profile is not None else None,
         spec_checks=tuple(spec_checks),
     )
@@ -154,9 +159,10 @@ async def _run_analysis(analysis: _ResolvedAnalysis, *, verbose: bool) -> str:
     checks.extend(check_credentials(analysis.profile_dir, probes=_PREFLIGHT_PROBES))
     _preflight_or_exit(checks)
 
-    if analysis.profile_output is not None:
-        analysis.profile_output.parent.mkdir(parents=True, exist_ok=True)
-        typer.echo(f"Insights file: {analysis.profile_output}", err=True)
+    if analysis.insights_output is not None:
+        analysis.insights_output.parent.mkdir(parents=True, exist_ok=True)
+        role = "local only" if analysis.local_only else "mirror of the platform"
+        typer.echo(f"Insights file ({role}): {analysis.insights_output}", err=True)
     try:
         try:
             client = make_client(analysis.base_url)
@@ -169,6 +175,7 @@ async def _run_analysis(analysis: _ResolvedAnalysis, *, verbose: bool) -> str:
             base_url=analysis.base_url,
             client=client,
             insights_output=analysis.insights_output,
+            local_only=analysis.local_only,
             verbose=verbose,
         )
     except AgentRunError as exc:
@@ -225,10 +232,21 @@ def analyze(
         None,
         "--insights-file-output",
         help=(
-            "Read and write insights from this local YAML file instead "
-            "of the Insights plugin API. Lets the analyst run against a "
-            "deployment that hosts observability data but not this "
-            "plugin; each run merges into the file. Trace/feedback reads "
+            "Also write insights to this local YAML file. Insights go to "
+            "the platform first and the file mirrors what was stored, "
+            "platform ids included; each run merges into the file. Combine "
+            "with --local-only to write the file and nothing else."
+        ),
+    ),
+    local_only: bool = typer.Option(
+        False,
+        "--local-only",
+        help=(
+            "Do not write insights to the platform; keep them in the local "
+            "YAML file only. Lets the analyst run against a deployment that "
+            "hosts observability data but not the Insights plugin. Writes to "
+            "--insights-file-output, or to <profile-dir>/.nemo-optimizer/"
+            "insights.yaml when a profile is discovered. Trace/feedback reads "
             "still hit --base-url."
         ),
     ),
@@ -248,7 +266,8 @@ def analyze(
     Builds the analyst agent with ``--agent`` (and optional
     ``--agent-spec``) formatted into its instructions and tools scoped
     to ``--agent`` / ``--workspace`` / ``--base-url``, runs it, and
-    prints whatever the agent returns.
+    prints whatever the agent returns. Insights are written to the
+    platform unless ``--local-only`` is passed.
     """
     try:
         analysis = _resolve_analysis(
@@ -258,6 +277,7 @@ def analyze(
             base_url=base_url,
             profile_path=profile_path,
             insights_output=insights_output,
+            local_only=local_only,
         )
         output = asyncio.run(_run_analysis(analysis, verbose=verbose))
     except (ProfileError, EnvFileError, InsightsFileError, OSError, UnicodeError) as exc:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -54,7 +54,6 @@ class _ResolvedAnalysis:
     workspace: str
     base_url: str
     insights_output: Path | None
-    local_only: bool
     profile_dir: Path | None
     spec_checks: tuple[CheckResult, ...]
 
@@ -104,7 +103,6 @@ def _resolve_analysis(
     base_url: str | None,
     profile_path: Path | None,
     insights_output: Path | None,
-    local_only: bool,
 ) -> _ResolvedAnalysis:
     profile, profile_error = _load_profile_or_error(profile_path)
     if profile_error is not None:
@@ -132,23 +130,14 @@ def _resolve_analysis(
     spec_content, spec_checks = read_agent_spec(spec_path, spec_error)
 
     resolved_base_url = resolve_base_url(base_url)
-    resolved_output = insights_output
-    if local_only and resolved_output is None:
-        if profile is None:
-            raise ProfileError(
-                "--local-only has nowhere to write: no optimizer.yaml profile was found. "
-                "Create a profile beside your agent or pass --insights-file-output with an explicit path."
-            )
-        resolved_output = profile.profile_dir / ".nemo-optimizer" / "insights.yaml"
-    validate_insights_file(resolved_output)
+    validate_insights_file(insights_output)
 
     return _ResolvedAnalysis(
         agent=resolved_agent,
         agent_spec=spec_content,
         workspace=resolved_workspace,
         base_url=resolved_base_url,
-        insights_output=resolved_output,
-        local_only=local_only,
+        insights_output=insights_output,
         profile_dir=profile.profile_dir if profile is not None else None,
         spec_checks=tuple(spec_checks),
     )
@@ -161,8 +150,7 @@ async def _run_analysis(analysis: _ResolvedAnalysis, *, verbose: bool) -> str:
 
     if analysis.insights_output is not None:
         analysis.insights_output.parent.mkdir(parents=True, exist_ok=True)
-        role = "local only" if analysis.local_only else "mirror of the platform"
-        typer.echo(f"Insights file ({role}): {analysis.insights_output}", err=True)
+        typer.echo(f"Insights file (mirror of the platform): {analysis.insights_output}", err=True)
     try:
         try:
             client = make_client(analysis.base_url)
@@ -175,7 +163,6 @@ async def _run_analysis(analysis: _ResolvedAnalysis, *, verbose: bool) -> str:
             base_url=analysis.base_url,
             client=client,
             insights_output=analysis.insights_output,
-            local_only=analysis.local_only,
             verbose=verbose,
         )
     except AgentRunError as exc:
@@ -232,22 +219,9 @@ def analyze(
         None,
         "--insights-file-output",
         help=(
-            "Also write insights to this local YAML file. Insights go to "
-            "the platform first and the file mirrors what was stored, "
-            "platform ids included; each run merges into the file. Combine "
-            "with --local-only to write the file and nothing else."
-        ),
-    ),
-    local_only: bool = typer.Option(
-        False,
-        "--local-only",
-        help=(
-            "Do not write insights to the platform; keep them in the local "
-            "YAML file only. Lets the analyst run against a deployment that "
-            "hosts observability data but not the Insights plugin. Writes to "
-            "--insights-file-output, or to <profile-dir>/.nemo-optimizer/"
-            "insights.yaml when a profile is discovered. Trace/feedback reads "
-            "still hit --base-url."
+            "Also write insights to this local YAML file. Insights always go "
+            "to the platform first; the file mirrors what was stored, "
+            "platform ids included, and each run merges into it."
         ),
     ),
     verbose: bool = typer.Option(
@@ -267,7 +241,7 @@ def analyze(
     ``--agent-spec``) formatted into its instructions and tools scoped
     to ``--agent`` / ``--workspace`` / ``--base-url``, runs it, and
     prints whatever the agent returns. Insights are written to the
-    platform unless ``--local-only`` is passed.
+    platform, and mirrored to ``--insights-file-output`` when given.
     """
     try:
         analysis = _resolve_analysis(
@@ -277,7 +251,6 @@ def analyze(
             base_url=base_url,
             profile_path=profile_path,
             insights_output=insights_output,
-            local_only=local_only,
         )
         output = asyncio.run(_run_analysis(analysis, verbose=verbose))
     except (ProfileError, EnvFileError, InsightsFileError, OSError, UnicodeError) as exc:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -143,14 +143,35 @@ def _resolve_analysis(
     )
 
 
+def _prepare_mirror(insights_output: Path | None) -> Path | None:
+    """Ready the mirror's directory, dropping the mirror if that fails.
+
+    The mirror is a convenience beside the platform, which is the source of
+    truth, so an unusable local path must not cost the user the analysis. This
+    matches how a failed mirror *write* is reported — a warning on the run
+    report rather than a failed run.
+    """
+    if insights_output is None:
+        return None
+    try:
+        insights_output.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        typer.echo(
+            f"warning: insights mirror disabled — could not create {insights_output.parent}: "
+            f"{_one_line_error(exc)}. Insights are still written to the platform.",
+            err=True,
+        )
+        return None
+    typer.echo(f"Insights file (mirror of the platform): {insights_output}", err=True)
+    return insights_output
+
+
 async def _run_analysis(analysis: _ResolvedAnalysis, *, verbose: bool) -> str:
     checks = list(analysis.spec_checks)
     checks.extend(check_credentials(analysis.profile_dir, probes=_PREFLIGHT_PROBES))
     _preflight_or_exit(checks)
 
-    if analysis.insights_output is not None:
-        analysis.insights_output.parent.mkdir(parents=True, exist_ok=True)
-        typer.echo(f"Insights file (mirror of the platform): {analysis.insights_output}", err=True)
+    insights_output = _prepare_mirror(analysis.insights_output)
     try:
         try:
             client = make_client(analysis.base_url)
@@ -162,7 +183,7 @@ async def _run_analysis(analysis: _ResolvedAnalysis, *, verbose: bool) -> str:
             workspace=analysis.workspace,
             base_url=analysis.base_url,
             client=client,
-            insights_output=analysis.insights_output,
+            insights_output=insights_output,
             verbose=verbose,
         )
     except AgentRunError as exc:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/jobs/analyze.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/jobs/analyze.py
@@ -54,7 +54,14 @@ class AnalyzeSpec(BaseModel):
     )
     insights_output: str | None = Field(
         default=None,
-        description="Optional local JSON output path for Insight writes.",
+        description=(
+            "Optional local YAML path mirroring the Insights the platform stored. "
+            "Container-local unless it points at mounted storage."
+        ),
+    )
+    local_only: bool = Field(
+        default=False,
+        description=("Persist Insights to `insights_output` only, skipping the platform. Requires `insights_output`."),
     )
     since: datetime | None = Field(
         default=None,
@@ -158,6 +165,7 @@ class AnalyzeJob(NemoJob):
                     base_url=spec.base_url,
                     client=make_client(spec.base_url),
                     insights_output=spec.insights_output,
+                    local_only=spec.local_only,
                     since=spec.since,
                 )
             )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/jobs/analyze.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/jobs/analyze.py
@@ -59,10 +59,6 @@ class AnalyzeSpec(BaseModel):
             "Container-local unless it points at mounted storage."
         ),
     )
-    local_only: bool = Field(
-        default=False,
-        description=("Persist Insights to `insights_output` only, skipping the platform. Requires `insights_output`."),
-    )
     since: datetime | None = Field(
         default=None,
         description="Optional lower bound for incremental trace/span analysis.",
@@ -165,7 +161,6 @@ class AnalyzeJob(NemoJob):
                     base_url=spec.base_url,
                     client=make_client(spec.base_url),
                     insights_output=spec.insights_output,
-                    local_only=spec.local_only,
                     since=spec.since,
                 )
             )

--- a/plugins/nemo-insights/testbed/adapters.py
+++ b/plugins/nemo-insights/testbed/adapters.py
@@ -95,6 +95,7 @@ class IntakeAdapter:
             base_url=cfg["base_url"],
             client=client,
             insights_output=str(out_path),
+            local_only=True,
             verbose=verbose,
             since=since,
         )
@@ -301,6 +302,7 @@ class BenchmarkAdapter:
             base_url=str(record["base_url"]),
             client=make_client(str(record["base_url"])),
             insights_output=str(out_path),
+            local_only=True,
             verbose=verbose,
             since=since,
             evaluation_id=evaluation_id,

--- a/plugins/nemo-insights/tests/test_analyst_run.py
+++ b/plugins/nemo-insights/tests/test_analyst_run.py
@@ -21,8 +21,9 @@ class FakeBackend:
 
 
 def _stub_pipeline(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> None:
-    def fake_make_backend(*, client: FakeClient, insights_output: str | None) -> FakeBackend:
+    def fake_make_backend(*, client: FakeClient, insights_output: str | None, local_only: bool) -> FakeBackend:
         seen["backend_client"] = client
+        seen["local_only"] = local_only
         return FakeBackend()
 
     async def fake_run_agent(analyst: object, deps: object, *, verbose: bool) -> object:
@@ -54,7 +55,7 @@ async def test_injected_client_is_used_and_closed(monkeypatch: pytest.MonkeyPatc
 async def test_client_closed_when_backend_construction_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     client = FakeClient()
 
-    def raising_backend(*, client: FakeClient, insights_output: str | None) -> FakeBackend:
+    def raising_backend(*, client: FakeClient, insights_output: str | None, local_only: bool) -> FakeBackend:
         raise RuntimeError("backend failed")
 
     monkeypatch.setattr(run_module, "make_analyst_backend", raising_backend)

--- a/plugins/nemo-insights/tests/test_cli_profile.py
+++ b/plugins/nemo-insights/tests/test_cli_profile.py
@@ -120,6 +120,32 @@ def test_insights_file_output_is_a_mirror_not_a_redirect(
     assert "local_only" not in recorder.kwargs, "the CLI must never ask for local-only persistence"
 
 
+def test_unusable_mirror_directory_drops_the_mirror_and_still_analyzes(
+    app: typer.Typer, profile_tree: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The platform is the source of truth; a bad local path must not cost the run."""
+    recorder = AnalystRecorder()
+    output = tmp_path / "unwritable" / "insights.yaml"
+    original_mkdir = Path.mkdir
+
+    def refuse_mirror_dir(self: Path, *args: object, **kwargs: object) -> None:
+        if self == output.parent:
+            raise PermissionError(13, "Permission denied")
+        original_mkdir(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "mkdir", refuse_mirror_dir)
+    monkeypatch.setattr(cli, "run_analyst", recorder)
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["run", "--insights-file-output", str(output)])
+
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs is not None, "the analysis must still run"
+    assert recorder.kwargs["insights_output"] is None
+    assert "insights mirror disabled" in result.stderr
+    assert "still written to the platform" in result.stderr
+
+
 def test_analyze_flags_override_profile(app: typer.Typer, profile_tree: Path, monkeypatch) -> None:
     recorder = AnalystRecorder()
     monkeypatch.setattr(cli, "run_analyst", recorder)

--- a/plugins/nemo-insights/tests/test_cli_profile.py
+++ b/plugins/nemo-insights/tests/test_cli_profile.py
@@ -90,7 +90,50 @@ def test_analyze_runs_flag_free_from_profile(app: typer.Typer, profile_tree: Pat
     assert recorder.kwargs["agent"] == "flight-planner"
     assert recorder.kwargs["workspace"] == "flight-workspace"
     assert recorder.kwargs["agent_spec"] == "# Flight planner"
+    assert recorder.kwargs["insights_output"] is None
+    assert recorder.kwargs["local_only"] is False
+
+
+def test_local_only_defaults_to_the_profile_insights_file(app: typer.Typer, profile_tree: Path, monkeypatch) -> None:
+    recorder = AnalystRecorder()
+    monkeypatch.setattr(cli, "run_analyst", recorder)
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["run", "--local-only"])
+
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs is not None
     assert recorder.kwargs["insights_output"] == profile_tree / ".nemo-optimizer" / "insights.yaml"
+    assert recorder.kwargs["local_only"] is True
+
+
+def test_local_only_without_profile_or_path_errors(app: typer.Typer, tmp_path: Path, monkeypatch) -> None:
+    recorder = AnalystRecorder()
+    monkeypatch.setattr(cli, "run_analyst", recorder)
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["run", "--agent", "flight-planner", "--local-only"])
+
+    assert result.exit_code == 1
+    assert "--local-only has nowhere to write" in result.output
+    assert "--insights-file-output" in result.output
+    assert recorder.kwargs is None
+
+
+def test_insights_file_output_alone_still_writes_to_the_platform(
+    app: typer.Typer, profile_tree: Path, tmp_path: Path, monkeypatch
+) -> None:
+    recorder = AnalystRecorder()
+    output = tmp_path / "mirror.yaml"
+    monkeypatch.setattr(cli, "run_analyst", recorder)
+    monkeypatch.chdir(profile_tree)
+
+    result = runner.invoke(app, ["run", "--insights-file-output", str(output)])
+
+    assert result.exit_code == 0, result.output
+    assert recorder.kwargs is not None
+    assert recorder.kwargs["insights_output"] == output
+    assert recorder.kwargs["local_only"] is False
 
 
 def test_analyze_flags_override_profile(app: typer.Typer, profile_tree: Path, monkeypatch) -> None:
@@ -378,7 +421,7 @@ def test_malformed_discovered_profile_errors_without_agent(app: typer.Typer, tmp
     assert recorder.kwargs is None
 
 
-def test_explicit_output_overrides_profile_default(
+def test_explicit_output_overrides_profile_default_under_local_only(
     app: typer.Typer, profile_tree: Path, tmp_path: Path, monkeypatch
 ) -> None:
     recorder = AnalystRecorder()
@@ -386,11 +429,12 @@ def test_explicit_output_overrides_profile_default(
     monkeypatch.setattr(cli, "run_analyst", recorder)
     monkeypatch.chdir(profile_tree)
 
-    result = runner.invoke(app, ["run", "--insights-file-output", str(output)])
+    result = runner.invoke(app, ["run", "--local-only", "--insights-file-output", str(output)])
 
     assert result.exit_code == 0, result.output
     assert recorder.kwargs is not None
     assert recorder.kwargs["insights_output"] == output
+    assert recorder.kwargs["local_only"] is True
 
 
 def test_missing_profile_and_agent_errors(app: typer.Typer, tmp_path: Path, monkeypatch) -> None:
@@ -564,7 +608,7 @@ def test_analyze_rejects_invalid_existing_insights_file_before_runner(
     output.write_bytes(payload)
     monkeypatch.setattr(cli, "run_analyst", recorder)
     monkeypatch.chdir(profile_tree)
-    arguments = ["run", "--insights-file-output", str(output)] if explicit else ["run"]
+    arguments = ["run", "--insights-file-output", str(output), "--local-only"] if explicit else ["run", "--local-only"]
 
     result = runner.invoke(app, arguments)
 
@@ -607,7 +651,7 @@ def test_analyze_rejects_invalid_insights_records_before_runner(
     output.write_bytes(payload)
     monkeypatch.setattr(cli, "run_analyst", recorder)
     monkeypatch.chdir(profile_tree)
-    arguments = ["run", "--insights-file-output", str(output)] if explicit else ["run"]
+    arguments = ["run", "--insights-file-output", str(output), "--local-only"] if explicit else ["run", "--local-only"]
 
     result = runner.invoke(app, arguments)
 
@@ -634,7 +678,7 @@ def test_analyze_accepts_existing_insights_file_without_insights_key(
     output.write_text("metadata: retained\n", encoding="utf-8")
     monkeypatch.setattr(cli, "run_analyst", recorder)
     monkeypatch.chdir(profile_tree)
-    arguments = ["run", "--insights-file-output", str(output)] if explicit else ["run"]
+    arguments = ["run", "--insights-file-output", str(output), "--local-only"] if explicit else ["run", "--local-only"]
 
     result = runner.invoke(app, arguments)
 

--- a/plugins/nemo-insights/tests/test_cli_profile.py
+++ b/plugins/nemo-insights/tests/test_cli_profile.py
@@ -90,37 +90,21 @@ def test_analyze_runs_flag_free_from_profile(app: typer.Typer, profile_tree: Pat
     assert recorder.kwargs["agent"] == "flight-planner"
     assert recorder.kwargs["workspace"] == "flight-workspace"
     assert recorder.kwargs["agent_spec"] == "# Flight planner"
-    assert recorder.kwargs["insights_output"] is None
-    assert recorder.kwargs["local_only"] is False
+    assert recorder.kwargs["insights_output"] is None, "a discovered profile must not divert writes off the platform"
 
 
-def test_local_only_defaults_to_the_profile_insights_file(app: typer.Typer, profile_tree: Path, monkeypatch) -> None:
+def test_no_local_only_flag_is_exposed(app: typer.Typer, profile_tree: Path, monkeypatch) -> None:
     recorder = AnalystRecorder()
     monkeypatch.setattr(cli, "run_analyst", recorder)
     monkeypatch.chdir(profile_tree)
 
     result = runner.invoke(app, ["run", "--local-only"])
 
-    assert result.exit_code == 0, result.output
-    assert recorder.kwargs is not None
-    assert recorder.kwargs["insights_output"] == profile_tree / ".nemo-optimizer" / "insights.yaml"
-    assert recorder.kwargs["local_only"] is True
-
-
-def test_local_only_without_profile_or_path_errors(app: typer.Typer, tmp_path: Path, monkeypatch) -> None:
-    recorder = AnalystRecorder()
-    monkeypatch.setattr(cli, "run_analyst", recorder)
-    monkeypatch.chdir(tmp_path)
-
-    result = runner.invoke(app, ["run", "--agent", "flight-planner", "--local-only"])
-
-    assert result.exit_code == 1
-    assert "--local-only has nowhere to write" in result.output
-    assert "--insights-file-output" in result.output
+    assert result.exit_code != 0
     assert recorder.kwargs is None
 
 
-def test_insights_file_output_alone_still_writes_to_the_platform(
+def test_insights_file_output_is_a_mirror_not_a_redirect(
     app: typer.Typer, profile_tree: Path, tmp_path: Path, monkeypatch
 ) -> None:
     recorder = AnalystRecorder()
@@ -133,7 +117,7 @@ def test_insights_file_output_alone_still_writes_to_the_platform(
     assert result.exit_code == 0, result.output
     assert recorder.kwargs is not None
     assert recorder.kwargs["insights_output"] == output
-    assert recorder.kwargs["local_only"] is False
+    assert "local_only" not in recorder.kwargs, "the CLI must never ask for local-only persistence"
 
 
 def test_analyze_flags_override_profile(app: typer.Typer, profile_tree: Path, monkeypatch) -> None:
@@ -421,22 +405,6 @@ def test_malformed_discovered_profile_errors_without_agent(app: typer.Typer, tmp
     assert recorder.kwargs is None
 
 
-def test_explicit_output_overrides_profile_default_under_local_only(
-    app: typer.Typer, profile_tree: Path, tmp_path: Path, monkeypatch
-) -> None:
-    recorder = AnalystRecorder()
-    output = tmp_path / "custom.yaml"
-    monkeypatch.setattr(cli, "run_analyst", recorder)
-    monkeypatch.chdir(profile_tree)
-
-    result = runner.invoke(app, ["run", "--local-only", "--insights-file-output", str(output)])
-
-    assert result.exit_code == 0, result.output
-    assert recorder.kwargs is not None
-    assert recorder.kwargs["insights_output"] == output
-    assert recorder.kwargs["local_only"] is True
-
-
 def test_missing_profile_and_agent_errors(app: typer.Typer, tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
 
@@ -582,7 +550,6 @@ def test_analyze_constructor_failure_warns_then_exits_cleanly(
     assert "During handling of the above exception" not in result.output
 
 
-@pytest.mark.parametrize("explicit", [False, True], ids=["profile-default", "explicit-path"])
 @pytest.mark.parametrize(
     ("payload", "expected"),
     [
@@ -598,17 +565,16 @@ def test_analyze_rejects_invalid_existing_insights_file_before_runner(
     profile_tree: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    explicit: bool,
     payload: bytes,
     expected: str,
 ) -> None:
     recorder = AnalystRecorder()
-    output = tmp_path / "explicit-insights.yaml" if explicit else profile_tree / ".nemo-optimizer" / "insights.yaml"
+    output = tmp_path / "explicit-insights.yaml"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_bytes(payload)
     monkeypatch.setattr(cli, "run_analyst", recorder)
     monkeypatch.chdir(profile_tree)
-    arguments = ["run", "--insights-file-output", str(output), "--local-only"] if explicit else ["run", "--local-only"]
+    arguments = ["run", "--insights-file-output", str(output)]
 
     result = runner.invoke(app, arguments)
 
@@ -621,7 +587,6 @@ def test_analyze_rejects_invalid_existing_insights_file_before_runner(
     assert recorder.kwargs is None
 
 
-@pytest.mark.parametrize("explicit", [False, True], ids=["profile-default", "explicit-path"])
 @pytest.mark.parametrize(
     ("payload", "expected"),
     [
@@ -641,17 +606,16 @@ def test_analyze_rejects_invalid_insights_records_before_runner(
     profile_tree: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    explicit: bool,
     payload: bytes,
     expected: str,
 ) -> None:
     recorder = AnalystRecorder()
-    output = tmp_path / "explicit-insights.yaml" if explicit else profile_tree / ".nemo-optimizer" / "insights.yaml"
+    output = tmp_path / "explicit-insights.yaml"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_bytes(payload)
     monkeypatch.setattr(cli, "run_analyst", recorder)
     monkeypatch.chdir(profile_tree)
-    arguments = ["run", "--insights-file-output", str(output), "--local-only"] if explicit else ["run", "--local-only"]
+    arguments = ["run", "--insights-file-output", str(output)]
 
     result = runner.invoke(app, arguments)
 
@@ -664,21 +628,19 @@ def test_analyze_rejects_invalid_insights_records_before_runner(
     assert recorder.kwargs is None
 
 
-@pytest.mark.parametrize("explicit", [False, True], ids=["profile-default", "explicit-path"])
 def test_analyze_accepts_existing_insights_file_without_insights_key(
     app: typer.Typer,
     profile_tree: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    explicit: bool,
 ) -> None:
     recorder = AnalystRecorder()
-    output = tmp_path / "explicit-insights.yaml" if explicit else profile_tree / ".nemo-optimizer" / "insights.yaml"
+    output = tmp_path / "explicit-insights.yaml"
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text("metadata: retained\n", encoding="utf-8")
     monkeypatch.setattr(cli, "run_analyst", recorder)
     monkeypatch.chdir(profile_tree)
-    arguments = ["run", "--insights-file-output", str(output), "--local-only"] if explicit else ["run", "--local-only"]
+    arguments = ["run", "--insights-file-output", str(output)]
 
     result = runner.invoke(app, arguments)
 

--- a/plugins/nemo-insights/tests/test_periodic_analysis.py
+++ b/plugins/nemo-insights/tests/test_periodic_analysis.py
@@ -12,12 +12,14 @@ import httpx
 import pytest
 import yaml
 from nemo_insights_plugin.analyst.analyst_backend import (
+    InsightsFileStore,
     LocalAnalystBackend,
     RemoteAnalystBackend,
     _merge_eval_filter,
     _merge_since_filter,
+    make_analyst_backend,
 )
-from nemo_insights_plugin.analyst.result import AnalystResult, InsightUpdate
+from nemo_insights_plugin.analyst.result import AnalystResult, InsightUpdate, NewInsight
 from nemo_insights_plugin.config import (
     AnalystSchedulerConfig,
     Frequency,
@@ -29,6 +31,8 @@ from nemo_insights_plugin.entities import (
     AnalysisConfig,
     AnalysisConfigStatus,
     AnalysisRunStatus,
+    Insight,
+    InsightStatus,
 )
 from nemo_insights_plugin.jobs.analyze import AnalyzeJob, AnalyzeSpec
 from nemo_insights_plugin.schedule import is_due, previous_scheduled
@@ -96,6 +100,146 @@ async def test_remote_persist_validates_updates_without_trace_refs() -> None:
     assert "- updated: missing-insight" not in report
 
 
+_STAMP = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
+
+
+class _RecordingInsights:
+    """Stand-in for the Insights SDK resource that assigns platform ids."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, Insight] = {}
+
+    async def create(
+        self,
+        *,
+        workspace: str,
+        title: str,
+        agent: str,
+        description: str,
+        status: InsightStatus,
+        trace_refs: list[str],
+    ) -> Insight:
+        insight_id = f"insight-remote-{len(self.rows) + 1}"
+        row = Insight(
+            workspace=workspace,
+            name=f"{insight_id}-slug",
+            title=title,
+            agent=agent,
+            description=description,
+            status=status,
+            trace_refs=list(trace_refs or []),
+        )
+        row._id = insight_id
+        row._created_at = _STAMP
+        row._updated_at = _STAMP
+        self.rows[insight_id] = row
+        return row
+
+    async def get(self, *, workspace: str, insight_id: str) -> Insight:
+        del workspace
+        return self.rows[insight_id]
+
+    async def update(self, *, workspace: str, insight_id: str, trace_refs: list[str]) -> Insight:
+        del workspace
+        row = self.rows[insight_id]
+        row.trace_refs = list(trace_refs)
+        return row
+
+
+def _remote_backend_with_mirror(path: Path) -> tuple[RemoteAnalystBackend, _RecordingInsights]:
+    insights = _RecordingInsights()
+    client = SimpleNamespace(insights=SimpleNamespace(insights=insights))
+    backend = RemoteAnalystBackend(client, mirror=InsightsFileStore(path))  # type: ignore[arg-type]
+    return backend, insights
+
+
+@pytest.mark.asyncio
+async def test_remote_persist_mirrors_platform_records_to_the_file(tmp_path: Path) -> None:
+    path = tmp_path / "insights.yaml"
+    backend, _ = _remote_backend_with_mirror(path)
+    result = AnalystResult(
+        summary="Found one.",
+        new_insights=[NewInsight(title="Retrieval drops context", description="Long inputs.", trace_refs=["t1"])],
+    )
+
+    report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
+
+    records = yaml.safe_load(path.read_text(encoding="utf-8"))["insights"]
+    assert [r["id"] for r in records] == ["insight-remote-1"]
+    assert records[0]["trace_refs"] == ["t1"]
+    assert records[0]["created_at"] == _STAMP.isoformat()
+    assert f"- mirrored 1 insight(s) to {path}" in report
+
+
+@pytest.mark.asyncio
+async def test_mirror_updates_match_platform_ids_across_runs(tmp_path: Path) -> None:
+    path = tmp_path / "insights.yaml"
+    backend, _ = _remote_backend_with_mirror(path)
+    await backend.persist_result(
+        workspace="default",
+        agent="research-agent",
+        result=AnalystResult(
+            summary="Found one.",
+            new_insights=[NewInsight(title="Retrieval drops context", description="Long inputs.", trace_refs=["t1"])],
+        ),
+    )
+
+    await backend.persist_result(
+        workspace="default",
+        agent="research-agent",
+        result=AnalystResult(
+            summary="More evidence.",
+            updated_insights=[InsightUpdate(id="insight-remote-1", trace_refs=["t2"])],
+        ),
+    )
+
+    records = yaml.safe_load(path.read_text(encoding="utf-8"))["insights"]
+    assert len(records) == 1, "the second run must update the mirrored record, not append a second one"
+    assert records[0]["trace_refs"] == ["t1", "t2"]
+
+
+@pytest.mark.asyncio
+async def test_mirror_write_failure_warns_without_failing_the_run(tmp_path: Path) -> None:
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory", encoding="utf-8")
+    backend, insights = _remote_backend_with_mirror(blocked / "insights.yaml")
+    result = AnalystResult(
+        summary="Found one.",
+        new_insights=[NewInsight(title="Retrieval drops context", description="Long inputs.")],
+    )
+
+    report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
+
+    assert "- created: Retrieval drops context" in report
+    assert "could not be written" in report
+    assert list(insights.rows) == ["insight-remote-1"], "the platform write is the source of truth and must stand"
+
+
+def test_make_analyst_backend_defaults_to_the_platform(tmp_path: Path) -> None:
+    client = SimpleNamespace()
+
+    plain = make_analyst_backend(client=client, insights_output=None)  # type: ignore[arg-type]
+    mirrored = make_analyst_backend(client=client, insights_output=str(tmp_path / "insights.yaml"))  # type: ignore[arg-type]
+
+    assert isinstance(plain, RemoteAnalystBackend) and plain.mirror is None
+    assert isinstance(mirrored, RemoteAnalystBackend)
+    assert mirrored.mirror is not None and mirrored.mirror.path == tmp_path / "insights.yaml"
+
+
+def test_make_analyst_backend_local_only_requires_a_path(tmp_path: Path) -> None:
+    client = SimpleNamespace()
+
+    local = make_analyst_backend(  # type: ignore[arg-type]
+        client=client,  # type: ignore[arg-type]
+        insights_output=str(tmp_path / "insights.yaml"),
+        local_only=True,
+    )
+    assert isinstance(local, LocalAnalystBackend)
+
+    with pytest.raises(ValueError, match="requires an insights output path"):
+        make_analyst_backend(client=client, insights_output=None, local_only=True)  # type: ignore[arg-type]
+
+
 def test_local_backend_reads_and_writes_insights_file_with_explicit_utf8(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -116,8 +260,8 @@ def test_local_backend_reads_and_writes_insights_file_with_explicit_utf8(
     monkeypatch.setattr(Path, "write_text", spy_write_text)
 
     backend = LocalAnalystBackend(client=SimpleNamespace(), path=tmp_path / "insights.yaml")  # type: ignore[arg-type]
-    backend._write_records([])
-    backend._read_records()
+    backend.store.write_records([])
+    backend.store.read_records()
 
     assert write_calls[-1].get("encoding") == "utf-8"
     assert read_calls[-1].get("encoding") == "utf-8"
@@ -128,7 +272,7 @@ def test_local_backend_write_preserves_other_top_level_keys(tmp_path: Path) -> N
     path.write_text("metadata: retained\ninsights:\n- id: stale\n", encoding="utf-8")
     backend = LocalAnalystBackend(client=SimpleNamespace(), path=path)  # type: ignore[arg-type]
 
-    backend._write_records([{"id": "insight-1"}])
+    backend.store.write_records([{"id": "insight-1"}])
 
     assert yaml.safe_load(path.read_text(encoding="utf-8")) == {
         "metadata": "retained",

--- a/plugins/nemo-insights/tests/test_periodic_analysis.py
+++ b/plugins/nemo-insights/tests/test_periodic_analysis.py
@@ -215,7 +215,8 @@ async def test_mirror_write_failure_warns_without_failing_the_run(tmp_path: Path
     assert list(insights.rows) == ["insight-remote-1"], "the platform write is the source of truth and must stand"
 
 
-def test_make_analyst_backend_defaults_to_the_platform(tmp_path: Path) -> None:
+def test_make_analyst_backend_always_writes_to_the_platform(tmp_path: Path) -> None:
+    """An output path adds a mirror; it never diverts writes off the platform."""
     client = SimpleNamespace()
 
     plain = make_analyst_backend(client=client, insights_output=None)  # type: ignore[arg-type]
@@ -226,7 +227,8 @@ def test_make_analyst_backend_defaults_to_the_platform(tmp_path: Path) -> None:
     assert mirrored.mirror is not None and mirrored.mirror.path == tmp_path / "insights.yaml"
 
 
-def test_make_analyst_backend_local_only_requires_a_path(tmp_path: Path) -> None:
+def test_local_only_is_testbed_plumbing_and_requires_a_path(tmp_path: Path) -> None:
+    """``local_only`` stays reachable for the testbed, which no CLI flag sets."""
     client = SimpleNamespace()
 
     local = make_analyst_backend(  # type: ignore[arg-type]

--- a/plugins/nemo-insights/tests/testbed/test_adapters.py
+++ b/plugins/nemo-insights/tests/testbed/test_adapters.py
@@ -352,7 +352,7 @@ async def test_benchmark_analyze_uses_record(monkeypatch, tmp_path):
     seen: dict[str, object] = {}
 
     async def fake_run_analyst(
-        *, agent, agent_spec, workspace, base_url, client, insights_output, verbose, since, evaluation_id
+        *, agent, agent_spec, workspace, base_url, client, insights_output, local_only, verbose, since, evaluation_id
     ):
         seen.update(
             agent=agent,
@@ -360,6 +360,7 @@ async def test_benchmark_analyze_uses_record(monkeypatch, tmp_path):
             workspace=workspace,
             base_url=base_url,
             evaluation_id=evaluation_id,
+            local_only=local_only,
         )
         return "REPORT-OK"
 
@@ -385,6 +386,7 @@ async def test_benchmark_analyze_uses_record(monkeypatch, tmp_path):
     assert seen["workspace"] == "tau2-airline"  # the stable REALISTIC workspace, never the oracle one
     assert seen["evaluation_id"] == "tau2-airline-20260626-000000-abcd"  # run-scoped
     assert seen["base_url"] == "http://localhost:8080"
+    assert seen["local_only"] is True  # benchmark runs capture to file and never write to the platform
 
 
 async def test_benchmark_analyze_without_record_raises(tmp_path):


### PR DESCRIPTION
Summary

nemo agents analyst run (and its alias nemo insights analyze) now always persists insights to the platform. Previously, discovering an optimizer.yaml profile silently diverted all insight writes to a local <profile-dir>/.nemo-optimizer/insights.yaml and skipped the platform entirely — so the common flag-free invocation from an agent directory never populated the Insights API or the Studio insights tab.

--insights-file-output <path> is now purely additive: it mirrors what the platform stored into a local file. There is no longer any flag combination that keeps insights off the platform.

Behavior

┌─────────────────────────────────────────────┬────────────────────┬────────────┐
│                   Command                   │      Platform      │ Local file │
├─────────────────────────────────────────────┼────────────────────┼────────────┤
│ analyst run                                 │ ✅                 │ —          │
├─────────────────────────────────────────────┼────────────────────┼────────────┤
│ analyst run --insights-file-output out.yaml │ ✅ (written first) │ ✅ mirror  │
└─────────────────────────────────────────────┴────────────────────┴────────────┘

Mirroring: platform is the source of truth

The platform is written first, and the file receives the rows it returned — platform-assigned ids, name, and timestamps included.

That ordering is what makes the mirror correct across runs. The analyst's change-set keys updates by insight id (AnalystResult.updated_insights[].id), and list_insights reads from the platform. Had the two stores been written independently, each would mint its own ids, every subsequent update would carry an id the file had never seen, and the mirror would degrade into a create-only log that silently diverges. test_mirror_updates_match_platform_ids_across_runs guards this directly.

A mirror write that fails (unwritable path, bad permissions) is reported as a warning on the run report rather than exiting non-zero — the platform writes have already landed, so failing the run would misreport what happened.

Changes

- analyst_backend.py: RemoteAnalystBackend takes an optional mirror and writes it after the platform (_mirror, _insight_to_record). File I/O extracted into a shared InsightsFileStore (read/write/upsert-merge) so the local backend and the mirror can't drift on document shape, UTF-8 handling, or the preserve-other-top-level-keys rule.
- cli.py: removed the implicit profile-derived local default; --insights-file-output re-documented as a mirror.
- run.py / deps.py / jobs/analyze.py: docstrings and the AnalyzeSpec field description follow. Scheduled runs already passed insights_output=None and are unaffected.
- READMEs for nemo-insights and nemo-experimentalist, plus the .nemo-optimizer/ contract note in the experimentalist AGENTS.md.

Note on LocalAnalystBackend

The class and the local_only argument on make_analyst_backend / run_analyst are retained as maintainer plumbing for the insights testbed only — no CLI flag or job field reaches them, and all three docstrings say so.

The testbed genuinely needs file-only persistence: it treats the YAML as the artifact under test (checked into testbed/insights/<subject>.yaml, hashed as insights_sha256, diffed across runs, promoted by atomic swap), --update-insights seeds a run by listing priors from that file, and the glamr subject targets an external Intake behind basic auth that does not host the Insights plugin API at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Insights are now saved on the platform by default.
  * Optionally mirror platform Insights, including IDs and timestamps, to a local YAML file.
  * Added local-only analysis mode for file-based workflows.
  * Mirrored results merge across runs while preserving existing records.

* **Bug Fixes**
  * Local mirror write failures now produce warnings without blocking successful platform saves.

* **Documentation**
  * Updated CLI help and workflow guidance to reflect platform-first Insight storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->