### PR TITLE
feat(studio): Preserve guardrails result route on reload

### DIFF
--- a/web/packages/studio/src/constants/routes.ts
+++ b/web/packages/studio/src/constants/routes.ts
@@ -42,6 +42,7 @@ export const ROUTE_PARAMS = {
   insightId: 'insightId',
   evaluationName: 'evaluationName',
   guardrailConfigName: 'guardrailConfigName',
+  guardrailChecksSubTab: 'guardrailChecksSubTab',
 } as const;
 
 // Just an alias to make the routes more readable
@@ -120,6 +121,7 @@ export const ROUTES = {
     guardrailDetail: `/workspaces/:${P.workspace}/guardrails/:${P.guardrailConfigName}`,
     guardrailConfig: `/workspaces/:${P.workspace}/guardrails/:${P.guardrailConfigName}/config`,
     guardrailChecks: `/workspaces/:${P.workspace}/guardrails/:${P.guardrailConfigName}/checks`,
+    guardrailChecksSubTab: `/workspaces/:${P.workspace}/guardrails/:${P.guardrailConfigName}/checks/:${P.guardrailChecksSubTab}`,
     settings: `/workspaces/:${P.workspace}/settings`,
     /** Workspace members and role-based access (Entities role bindings) */
     members: `/workspaces/:${P.workspace}/members`,

--- a/web/packages/studio/src/routes/groups/guardrailsRoutes.tsx
+++ b/web/packages/studio/src/routes/groups/guardrailsRoutes.tsx
@@ -3,6 +3,7 @@
 
 import { ErrorPanel } from '@studio/components/ErrorPanel';
 import { ROUTES } from '@studio/constants/routes';
+import { GUARDRAIL_CHECKS_DEFAULT_SUB_TAB } from '@studio/routes/guardrails/GuardrailChecksTab/constants';
 import { gateGuardrailsRoutes } from '@studio/routes/utils';
 import { lazy } from 'react';
 import { Navigate, type RouteObject } from 'react-router-dom';
@@ -52,6 +53,10 @@ export const guardrailsRoutes: RouteObject[] = gateGuardrailsRoutes([
       },
       {
         path: ROUTES.workspace.guardrailChecks,
+        element: <Navigate to={GUARDRAIL_CHECKS_DEFAULT_SUB_TAB} replace />,
+      },
+      {
+        path: ROUTES.workspace.guardrailChecksSubTab,
         element: <GuardrailChecksTab />,
       },
     ],

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCasesEditor.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCasesEditor.tsx
@@ -3,25 +3,24 @@
 
 import { LoadingButton } from '@nemo/common/src/components/LoadingButton';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
-import {
-  Button,
-  Flex,
-  Stack,
-  TabsList,
-  TabsRoot,
-  TabsTrigger,
-  Text,
-} from '@nvidia/foundations-react-core';
+import { Button, Flex, Stack, Tabs, Text } from '@nvidia/foundations-react-core';
 import { getErrorMessage } from '@studio/api/common/utils';
 import { useCreateGuardrailCheck, useRunGuardrailChecks } from '@studio/api/guardrail-checks/hooks';
 import type { GuardrailCheckEntity } from '@studio/api/guardrail-checks/types';
 import { GuardrailChecksDataView } from '@studio/components/dataViews/GuardrailChecksDataView';
 import { ResultSummary } from '@studio/components/dataViews/GuardrailChecksDataView/ResultSummary';
+import { ROUTE_PARAMS } from '@studio/constants/routes';
+import {
+  GUARDRAIL_CHECKS_DEFAULT_SUB_TAB,
+  GuardrailChecksSubTab,
+  isGuardrailChecksSubTab,
+} from '@studio/routes/guardrails/GuardrailChecksTab/constants';
 import { GuardrailTestCard } from '@studio/routes/guardrails/GuardrailChecksTab/GuardrailTestCard';
+import { getGuardrailChecksSubTabRoute } from '@studio/routes/utils';
+import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
 import { ListChecks, Plus, Settings } from 'lucide-react';
-import { type FC, useState } from 'react';
-
-type SubTab = 'tests' | 'results';
+import type { FC } from 'react';
+import { Link, useParams } from 'react-router-dom';
 
 interface GuardrailTestCasesEditorProps {
   workspace: string;
@@ -35,7 +34,15 @@ export const GuardrailTestCasesEditor: FC<GuardrailTestCasesEditorProps> = ({
   checks,
 }) => {
   const toast = useToast();
-  const [subTab, setSubTab] = useState<SubTab>('tests');
+  const { guardrailConfigName } = useRequiredPathParams([ROUTE_PARAMS.guardrailConfigName]);
+
+  // An unknown segment falls back to the default rather than redirecting, so a hand-typed
+  // URL still renders something useful.
+  const params = useParams();
+  const subTabParam = params[ROUTE_PARAMS.guardrailChecksSubTab];
+  const subTab = isGuardrailChecksSubTab(subTabParam)
+    ? subTabParam
+    : GUARDRAIL_CHECKS_DEFAULT_SUB_TAB;
 
   const runMutation = useRunGuardrailChecks({
     onSuccess: (results) => {
@@ -97,15 +104,34 @@ export const GuardrailTestCasesEditor: FC<GuardrailTestCasesEditorProps> = ({
       </Flex>
 
       {/* Sub-tab switcher */}
-      <TabsRoot value={subTab} onValueChange={(v) => setSubTab(v as SubTab)}>
-        <TabsList>
-          <TabsTrigger value="tests">Tests</TabsTrigger>
-          <TabsTrigger value="results">Test Results</TabsTrigger>
-        </TabsList>
-      </TabsRoot>
+      <Tabs
+        aria-label="Guardrail test views"
+        value={subTab}
+        items={[
+          {
+            value: GuardrailChecksSubTab.Tests,
+            children: 'Tests',
+            href: getGuardrailChecksSubTabRoute(
+              workspace,
+              guardrailConfigName,
+              GuardrailChecksSubTab.Tests
+            ),
+          },
+          {
+            value: GuardrailChecksSubTab.Results,
+            children: 'Test Results',
+            href: getGuardrailChecksSubTabRoute(
+              workspace,
+              guardrailConfigName,
+              GuardrailChecksSubTab.Results
+            ),
+          },
+        ]}
+        renderLink={(item) => <Link to={item.href!}>{item.children}</Link>}
+      />
 
       {/* Tests tab */}
-      {subTab === 'tests' ? (
+      {subTab === GuardrailChecksSubTab.Tests ? (
         <Stack gap="density-lg">
           {checks.map((check, i) => (
             <GuardrailTestCard key={check.id} check={check} index={i} workspace={workspace} />

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/constants.ts
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/constants.ts
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Sub-tab IDs for a guardrail's Test and Validate tab, used as both the tab
+ * `value` and the trailing `/checks/<id>` URL segment.
+ *
+ * Kept out of the tab component so the route table can import these without
+ * eagerly pulling in the lazily-loaded component.
+ */
+export enum GuardrailChecksSubTab {
+  Tests = 'tests',
+  Results = 'results',
+}
+
+export const GUARDRAIL_CHECKS_DEFAULT_SUB_TAB = GuardrailChecksSubTab.Tests;
+
+export const isGuardrailChecksSubTab = (
+  value: string | undefined
+): value is GuardrailChecksSubTab =>
+  Object.values(GuardrailChecksSubTab).includes(value as GuardrailChecksSubTab);

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.test.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.test.tsx
@@ -6,14 +6,18 @@ import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { ROUTES } from '@studio/constants/routes';
 import { server } from '@studio/mocks/node';
 import { GuardrailChecksTab } from '@studio/routes/guardrails/GuardrailChecksTab';
+import {
+  GUARDRAIL_CHECKS_DEFAULT_SUB_TAB,
+  GuardrailChecksSubTab,
+} from '@studio/routes/guardrails/GuardrailChecksTab/constants';
 import { GuardrailConfigTab } from '@studio/routes/guardrails/GuardrailConfigTab';
 import { GuardrailDetailRoute } from '@studio/routes/guardrails/GuardrailDetailRoute';
-import { getGuardrailChecksRoute } from '@studio/routes/utils';
+import { getGuardrailChecksRoute, getGuardrailChecksSubTabRoute } from '@studio/routes/utils';
 import { XL_SELECTOR_TIMEOUT } from '@studio/tests/util/constants';
 import { renderRoute, screen } from '@studio/tests/util/render';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 
 const WORKSPACE = 'default';
 
@@ -23,6 +27,11 @@ beforeEach(() => {
   localStorage.clear();
 });
 
+const LocationProbe = () => {
+  const location = useLocation();
+  return <div data-testid="checks-location">{location.pathname}</div>;
+};
+
 const routes = [
   {
     path: ROUTES.workspace.guardrailDetail,
@@ -30,7 +39,19 @@ const routes = [
     children: [
       { index: true, element: <Navigate to="config" replace /> },
       { path: ROUTES.workspace.guardrailConfig, element: <GuardrailConfigTab /> },
-      { path: ROUTES.workspace.guardrailChecks, element: <GuardrailChecksTab /> },
+      {
+        path: ROUTES.workspace.guardrailChecks,
+        element: <Navigate to={GUARDRAIL_CHECKS_DEFAULT_SUB_TAB} replace />,
+      },
+      {
+        path: ROUTES.workspace.guardrailChecksSubTab,
+        element: (
+          <>
+            <GuardrailChecksTab />
+            <LocationProbe />
+          </>
+        ),
+      },
     ],
   },
   {
@@ -39,11 +60,8 @@ const routes = [
   },
 ];
 
-const renderChecks = (name: string) =>
-  renderRoute(undefined, {
-    history: getGuardrailChecksRoute(WORKSPACE, name),
-    routes,
-  });
+const renderChecks = (name: string, history = getGuardrailChecksRoute(WORKSPACE, name)) =>
+  renderRoute(undefined, { history, routes });
 
 describe('GuardrailChecksTab', () => {
   it('renders the test cases editor when the config and checks both load', async () => {
@@ -55,6 +73,15 @@ describe('GuardrailChecksTab', () => {
     expect(screen.getByText('Test 1')).toBeInTheDocument();
     expect(screen.getByText('Test 2')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Run 2 Tests/ })).toBeInTheDocument();
+  });
+
+  it('redirects the bare checks URL onto the default sub-tab', async () => {
+    renderChecks('pii-filter');
+
+    await screen.findByText('Guardrail Test Cases', undefined, { timeout: XL_SELECTOR_TIMEOUT });
+    expect(screen.getByTestId('checks-location')).toHaveTextContent(
+      getGuardrailChecksSubTabRoute(WORKSPACE, 'pii-filter', GuardrailChecksSubTab.Tests)
+    );
   });
 
   it('shows the summary and the results table on the Test Results sub-tab', async () => {
@@ -69,6 +96,25 @@ describe('GuardrailChecksTab', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('row', { name: /My SSN is 123-45-6789/ })).toHaveTextContent('Guarded');
     expect(screen.getByRole('row', { name: /Hello there/ })).toHaveTextContent('Not run');
+    expect(screen.getByTestId('checks-location')).toHaveTextContent(
+      getGuardrailChecksSubTabRoute(WORKSPACE, 'pii-filter', GuardrailChecksSubTab.Results)
+    );
+  });
+
+  it('restores the Test Results sub-tab when loaded straight from its URL', async () => {
+    renderChecks(
+      'pii-filter',
+      getGuardrailChecksSubTabRoute(WORKSPACE, 'pii-filter', GuardrailChecksSubTab.Results)
+    );
+
+    expect(
+      await screen.findByText('Result Summary', undefined, { timeout: XL_SELECTOR_TIMEOUT })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Test Results' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    expect(screen.queryByText('Add Another Test')).not.toBeInTheDocument();
   });
 
   it('shows an error state when the checks cannot be loaded', async () => {

--- a/web/packages/studio/src/routes/guardrails/GuardrailDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailDetailRoute/index.test.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@studio/constants/routes';
 import { mockGuardrailConfigs } from '@studio/mocks/handlers/guardrails';
 import { server } from '@studio/mocks/node';
 import { GuardrailChecksTab } from '@studio/routes/guardrails/GuardrailChecksTab';
+import { GUARDRAIL_CHECKS_DEFAULT_SUB_TAB } from '@studio/routes/guardrails/GuardrailChecksTab/constants';
 import { GuardrailConfigTab } from '@studio/routes/guardrails/GuardrailConfigTab';
 import { GuardrailDetailRoute } from '@studio/routes/guardrails/GuardrailDetailRoute';
 import { getGuardrailDetailRoute } from '@studio/routes/utils';
@@ -28,7 +29,11 @@ const routes = [
     children: [
       { index: true, element: <Navigate to="config" replace /> },
       { path: ROUTES.workspace.guardrailConfig, element: <GuardrailConfigTab /> },
-      { path: ROUTES.workspace.guardrailChecks, element: <GuardrailChecksTab /> },
+      {
+        path: ROUTES.workspace.guardrailChecks,
+        element: <Navigate to={GUARDRAIL_CHECKS_DEFAULT_SUB_TAB} replace />,
+      },
+      { path: ROUTES.workspace.guardrailChecksSubTab, element: <GuardrailChecksTab /> },
     ],
   },
   {

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -428,7 +428,7 @@ export const getGuardrailChecksSubTabRoute = (
   workspace: string,
   guardrailConfigName: string,
   subTab: GuardrailChecksSubTab
-) => {
+): ReturnType<typeof generatePath> => {
   return generatePath(ROUTES.workspace.guardrailChecksSubTab, {
     workspace,
     guardrailConfigName,

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -30,6 +30,7 @@ import {
 import { ROUTES } from '@studio/constants/routes';
 import { QUERY_PARAMETERS } from '@studio/routes/constants';
 import { FilesetDetailTab } from '@studio/routes/FilesetDetailRoute/constants';
+import { GuardrailChecksSubTab } from '@studio/routes/guardrails/GuardrailChecksTab/constants';
 import { generatePath, RouteObject } from 'react-router';
 
 const gateRoutes = (enabled: boolean, routes: RouteObject | RouteObject[]) => {
@@ -420,6 +421,18 @@ export const getGuardrailChecksRoute = (workspace: string, guardrailConfigName: 
   return generatePath(ROUTES.workspace.guardrailChecks, {
     workspace,
     guardrailConfigName,
+  });
+};
+
+export const getGuardrailChecksSubTabRoute = (
+  workspace: string,
+  guardrailConfigName: string,
+  subTab: GuardrailChecksSubTab
+) => {
+  return generatePath(ROUTES.workspace.guardrailChecksSubTab, {
+    workspace,
+    guardrailConfigName,
+    guardrailChecksSubTab: subTab,
   });
 };
 

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -30,7 +30,7 @@ import {
 import { ROUTES } from '@studio/constants/routes';
 import { QUERY_PARAMETERS } from '@studio/routes/constants';
 import { FilesetDetailTab } from '@studio/routes/FilesetDetailRoute/constants';
-import { GuardrailChecksSubTab } from '@studio/routes/guardrails/GuardrailChecksTab/constants';
+import type { GuardrailChecksSubTab } from '@studio/routes/guardrails/GuardrailChecksTab/constants';
 import { generatePath, RouteObject } from 'react-router';
 
 const gateRoutes = (enabled: boolean, routes: RouteObject | RouteObject[]) => {

--- a/web/packages/studio/src/tests/title-change.test.tsx
+++ b/web/packages/studio/src/tests/title-change.test.tsx
@@ -8,6 +8,7 @@ import { dataset1 } from '@studio/mocks/entity-store/datasets';
 import { entityStorePromptTunedModel1 } from '@studio/mocks/entity-store/models';
 import { workspace1 } from '@studio/mocks/entity-store/projects';
 import { metricEvaluationJob1 } from '@studio/mocks/evaluation/v1/evaluations';
+import { GuardrailChecksSubTab } from '@studio/routes/guardrails/GuardrailChecksTab/constants';
 import { renderWithRouter, waitFor } from '@studio/tests/util/render';
 import { generatePath } from 'react-router';
 
@@ -38,6 +39,7 @@ const pathParams = {
   [RP.evaluationName]: 'test-experiment',
   [RP.insightId]: 'test-insight',
   [RP.guardrailConfigName]: 'test-guardrail-config',
+  [RP.guardrailChecksSubTab]: GuardrailChecksSubTab.Tests,
 };
 
 describe('AccessibleTitleE2E', () => {


### PR DESCRIPTION

https://github.com/user-attachments/assets/7ff6cdb2-e4c0-43bf-9615-96e7482dc67e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated **Tests** and **Results** sub-tabs to guardrail checks.
  * Guardrail checks now support direct links to either sub-tab.
  * Visiting the main guardrail checks page automatically opens the Tests tab.
  * Invalid or unknown sub-tab links fall back to the default Tests tab.

* **Tests**
  * Added coverage for sub-tab navigation, redirects, and restoring the Results tab from its URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->