### PR TITLE
fix(deploy-sandbox skill): use non-destructive uv pip install for openshell extras

### DIFF
--- a/plugins/nemo-deployments/examples/openshell/DEMO.ipynb
+++ b/plugins/nemo-deployments/examples/openshell/DEMO.ipynb
@@ -51,8 +51,10 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "# install the deployments backend's openshell extra (a bootstrapped workspace already has it)\n",
-    "uv sync --package nemo-deployments-plugin --extra openshell"
+    "# install the deployments backend's openshell extra additively (a bootstrapped workspace already has it).\n",
+    "# Do NOT use `uv sync --package nemo-deployments-plugin --extra openshell`: it narrows the workspace\n",
+    "# venv to that one package and uninstalls the platform, breaking `nemo services run`.\n",
+    "uv pip install \"openshell>=0.0.92\" \"grpcio>=1.78.0\" \"protobuf>=6.31.1\""
    ]
   },
   {

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/skills/deploy-sandbox/SKILL.md
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/skills/deploy-sandbox/SKILL.md
@@ -152,11 +152,23 @@ Commands below assume `nemo` and `openshell` are on your PATH. In a repo checkou
    .venv/bin/python -c "import python_on_whales, openshell" && echo DEPS_OK || echo DEPS_MISSING
    ```
 
-   If `DEPS_MISSING`, install the extras: `uv sync --package nemo-deployments-plugin
-   --extra openshell` for the backend, and `uv pip install -e
-   'plugins/nemo-agents[container]'` for packaging. Base `make bootstrap-python` does
-   not install the platform-restricted `openshell` wheel or the agents `container`
-   extra, so both need this step.
+   If `DEPS_MISSING`, add the extras INTO the existing workspace venv with `uv pip
+   install`. These commands install the two missing pieces without touching the rest
+   of the venv:
+
+   ```bash
+   uv pip install "openshell>=0.0.92" "grpcio>=1.78.0" "protobuf>=6.31.1"
+   uv pip install -e 'plugins/nemo-agents[container]'
+   ```
+
+   The first line adds the OpenShell SDK the backend needs; the second adds
+   `python-on-whales` (the agents `container` extra) for packaging. Base `make
+   bootstrap-python` installs neither, so both need this step. Do NOT run `uv sync
+   --package nemo-deployments-plugin --extra openshell` here: `uv sync --package`
+   narrows the venv to that one package's dependency set, which uninstalls `nmp`,
+   `nemo_agents_plugin`, and `python-on-whales`, so `nemo services run` then fails
+   with `No module named 'nmp.platform_runner'`. `uv pip install` adds the deps
+   additively and leaves the platform intact.
 
 Convenience variable for the curl steps:
 
@@ -349,7 +361,7 @@ docker compose -f plugins/nemo-deployments/examples/openshell/docker-compose.yml
 | Invoke returns 503 `inference service unavailable` (in the response or the serve log) | The `inference.local` route resolved, but the gateway's upstream hop to the platform failed | Almost always a platform bound to `127.0.0.1`; restart it with `--host 0.0.0.0`. Confirm the address the sandbox actually dials with `openshell sandbox exec --name <nmp-hash> -- cat /etc/hosts` (look for `host.openshell.internal`) and check the platform answers there (`curl -sf http://<that-ip>:8080/health/ready`). A clean `openshell inference set` does NOT rule this out: it validates from the host |
 | Invoke returns empty/error `value`, or serve log shows connection refused to `inference.local` | `inference.local` route not wired, or model misbehaved | Confirm `openshell inference get` shows the `nemo-igw` provider + your model; re-run Step 1's `provider create` / `inference set`; try a gpt-4o-mini-class model |
 | `example.com` reachable in Step 7 | Egress policy not applied | Confirm executor is `openshell-local` and the generated default-deny policy is attached to the sandbox |
-| `ModuleNotFoundError: openshell` at deploy, or `python-on-whales` missing at package | workspace extras not installed | `uv sync --package nemo-deployments-plugin --extra openshell` and `uv pip install -e 'plugins/nemo-agents[container]'` |
+| `ModuleNotFoundError: openshell` at deploy, or `python-on-whales` missing at package | workspace extras not installed | `uv pip install "openshell>=0.0.92" "grpcio>=1.78.0" "protobuf>=6.31.1"` then `uv pip install -e 'plugins/nemo-agents[container]'` (do NOT use `uv sync --package`: it narrows the venv and uninstalls `nmp`/`nemo_agents_plugin`/`python-on-whales`, breaking `nemo services run`) |
 
 Do not claim the deployment succeeded until Step 6 prints a non-empty `value`.
 


### PR DESCRIPTION
## Root cause

Pre-flight step 3 and the "If verification fails" recovery table of the deploy-sandbox skill told users to install the openshell extra with:

```
uv sync --package nemo-deployments-plugin --extra openshell
```

`uv sync --package` narrows the workspace venv to that one package's dependency set. It uninstalls `nmp`, `nemo_agents_plugin`, and `python_on_whales` from the venv, so `nemo services run` then fails with `No module named 'nmp.platform_runner'`. The step's own precondition check (`import python_on_whales, openshell`) reports `DEPS_MISSING` both before and after, because the first remedy removes exactly what the second (`uv pip install -e 'plugins/nemo-agents[container]'`) reinstalls.

## Fix

Replace both occurrences of the destructive command with the additive form:

```
uv pip install "openshell>=0.0.92" "grpcio>=1.78.0" "protobuf>=6.31.1"
uv pip install -e 'plugins/nemo-agents[container]'
```

`uv pip install` adds the two missing pieces into the existing workspace venv without narrowing it, so the platform stays intact. The surrounding prose now spells out why `uv sync --package` is wrong here.

## Adversarial verification

Run in an isolated worktree venv, proving the new command is non-destructive:

1. `uv sync --frozen --all-packages` -> baseline platform venv.
2. Platform imports: `python -c 'import nmp.platform_runner'` -> `platform ok`; `nemo services --help` loads its CLI group cleanly.
3. DEPS_MISSING precondition: `.venv/bin/python -c 'import python_on_whales, openshell'` -> `ModuleNotFoundError: No module named 'python_on_whales'` (DEPS_MISSING), matching the skill's own check.
4. Ran the NEW commands verbatim -> installed `openshell==0.0.97` and `python-on-whales==0.81.0`.
5. Re-verified: `import python_on_whales, openshell` -> `DEPS_OK` **AND** `import nmp.platform_runner` -> `platform ok` **AND** `nemo services --help` still loads.

Step 5 is the proof: the new commands add the extras while leaving the platform importable. The old `uv sync --package` command was not run against this venv on purpose (it would break the platform, which is the whole bug); the platform-still-imports evidence is the critical half.

Fixes AIRCORE-980
https://linear.app/nvidia/issue/AIRCORE-980


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment setup instructions to install required dependencies additively.
  * Revised recovery guidance to preserve existing platform and packaging dependencies.
  * Updated the deployment example notebook with the corrected installation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->