### PR TITLE
fix(docker): install pip once in nmp-api image and add build-time pip smoke check

### DIFF
--- a/docker/Dockerfile.nmp-api
+++ b/docker/Dockerfile.nmp-api
@@ -15,8 +15,14 @@ COPY --from=policy-wasm-artifacts /artifacts/policy.wasm /app/services/core/auth
 # When ANNOY_COMPILER_ARGS is set, annoy uses these arguments as-is, replacing its defaults.
 ENV ANNOY_COMPILER_ARGS="-D_CRT_SECURE_NO_WARNINGS,-DANNOYLIB_MULTITHREADED_BUILD"
 
+# --reinstall-package pip forces uv to uninstall the seed pip (planted by
+# `uv venv --seed` in the base image) via its RECORD before installing the
+# locked pip, so exactly one pip remains. Without it, uv copies the locked pip
+# over the seed pip without removing stale files, leaving two pip-*.dist-info
+# dirs and a mixed file tree whose `pip` import is broken.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --only-group functional-services --no-editable
+    uv sync --frozen --only-group functional-services --no-editable \
+    --reinstall-package pip
 
 # annoy must be reinstalled from the committed lockfile without wheel cache reuse: uv's wheel cache
 # key does not include env vars, so the first sync can reuse a stale native-compiled wheel that
@@ -25,6 +31,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     VIRTUAL_ENV=/app/.venv \
     uv sync --frozen --active --only-group functional-services --no-editable \
     --reinstall-package annoy --refresh-package annoy --no-binary-package annoy --no-cache
+
+# Fail the build if pip is broken or duplicated (regression guard).
+RUN /app/.venv/bin/pip --version && \
+    test "$(ls -d /app/.venv/lib/python3.13/site-packages/pip-*.dist-info | wc -l)" -eq 1
 
 # Fail the image build if the installed auth package cannot see its generated policy.
 RUN /app/.venv/bin/python -c 'from nmp.core.auth.app.embedded_pdp.policy_wasm import ensure_embedded_policy_wasm; ensure_embedded_policy_wasm(auto_build=False)'


### PR DESCRIPTION
## Summary

The `pip` inside the published `nmp-api` container is broken: every invocation, including `pip --version`, dies with `ImportError: cannot import name 'get_runnable_pip' from 'pip._internal.utils.misc'`. The venv contains two pip dist-info dirs (`pip-26.1.1.dist-info` and `pip-26.2.dist-info`) and a file tree mixed from both releases. This breaks anyone extending the image (`RUN pip install ...`), debugging in a running container, or following a doc that uses pip. Fixes AIRCORE-979.

## Why this happens

Two different mechanisms install pip into `/app/.venv`, and they can disagree:

1. `uv venv --seed` (in the shared base `Dockerfile.nmp-python-base`) plants a **seed pip resolved from PyPI at image-build time**, i.e. whatever pip is newest the moment the image builds. This is not vendored in uv and does not track our lockfile (verified: an online seed installs the current PyPI latest; an offline seed with an empty cache fails as unsatisfiable).
2. `uv sync --frozen --only-group functional-services` then installs the **lock-pinned pip** (`pip==26.1.1`), a transitive runtime dep of `nvidia-nat-core`.

With `UV_LINK_MODE=copy`, step 2 copies the locked pip over the seed pip **without removing the seed's stale files**. When the two versions have incompatible internal layouts, the result is a mixed tree (`build_env` present as both a module and a package, from different releases) and pip's import breaks. This is a known uv behavior (astral-sh/uv#10566, "uv sync not removing former seed packages").

## Why it surfaced now, and not before

The dirty-overwrite has always been latent; it only produces a *broken* pip when the seed and the locked pip differ **and** have incompatible file layouts.

- When the lock was cut, it resolved to the pip that was newest at the time, so seed == locked and the overwrite was a no-op.
- Later drift stayed within a single patch line (e.g. seed `26.1.2` over locked `26.1.1`). Patch releases keep the same internal layout, so the stale-file overwrite left only redundant metadata and pip still ran. Benign, so it went unnoticed.
- pip `26.2` (released 2026-07-29) was the first *minor* release since the lock. It relocated internals (the `build_env` module-vs-package change), so laying `26.1.1` over a `26.2` seed tree was the first time the overwrite produced an inconsistent package and a broken import. It appeared in the `nightly-20260801` image two days later.

Because the seed always resolves to PyPI-latest at build time, pinning or bumping the locked pip does not fix this: the next newer pip release puts the seed ahead of the lock again, and the next layout-changing release breaks it again.

## Fix

Add `--reinstall-package pip` to the first `uv sync` in `docker/Dockerfile.nmp-api`. This forces uv to uninstall the seed pip via its RECORD (removing all of its files) before installing the locked pip, leaving exactly one pip. It is version- and layout-agnostic, so it survives future pip releases without anyone touching the lockfile.

Why this over the alternatives:
- **Bump the locked pip:** does not work. The seed is PyPI-latest at build time, so any pin is overtaken by the next pip release. It also touches `uv.lock` and ripples to every consumer of pip in the graph.
- **Pin the seed pip to match the lock:** not possible. `uv venv --seed` has no version knob (it only selects which of pip/setuptools/wheel to install) and ignores constraints on the seed path (verified: `UV_CONSTRAINT=pip==26.1.1` still seeds PyPI-latest).
- **Drop `--seed` from the base:** wider blast radius. `--seed` lives in the shared base, and `nmp-core` / `nmp-cpu-tasks` do not pull pip transitively, so they would silently lose pip. Keeping the change in `nmp-api` avoids that.
- **Follows an existing pattern:** this file already uses `--reinstall-package annoy` a few lines below for a similar clean-reinstall need.

## Build-time smoke check

Added a regression guard in the builder stage after the venv is finalized:

```dockerfile
RUN /app/.venv/bin/pip --version && \
    test "$(ls -d /app/.venv/lib/python3.13/site-packages/pip-*.dist-info | wc -l)" -eq 1
```

The build fails if pip cannot run or if more than one pip dist-info is present. This also acts as a canary for any future seed-vs-lock drift.

## Validation

Dockerfile-only, no `pyproject.toml` / `uv.lock` changes, so ruff/ty and the lockfile are untouched. This cannot be image-built locally in this environment; the real validation is the CI image build. The seed-vs-lock behavior above was reproduced directly against `python:3.13.14-slim-trixie` + `uv 0.9.14`.

## Notes

- `docker/Dockerfile.nmp-api` is also edited by sibling worktree AIRCORE-978 (an `import openshell` build check). This change is minimal and localized to the builder-stage sync / smoke-check region to keep the overlap small.

Fixes AIRCORE-979
https://linear.app/nvidia/issue/AIRCORE-979


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build reliability by ensuring the bundled package installer is correctly installed.
  * Added validation to detect incomplete or duplicate installer metadata during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->