### PR TITLE
fix(nemo-deployments): wrap AsyncEntitiesClient via client_from_platform in OpenShell backend

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
@@ -58,7 +58,8 @@ from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
 from nemo_deployments_plugin.entities import Container, DeploymentConfig
 from nemo_deployments_plugin.secrets import SecretResolutionError, resolve_deployment_config_secrets
 from nemo_deployments_plugin.types import DeploymentStatus, Endpoint
-from nemo_platform.resources.entities import AsyncEntitiesResource
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
 
 if TYPE_CHECKING:
@@ -154,7 +155,7 @@ class OpenShellDeploymentBackend(DeploymentBackend):
     def init(self) -> None:
         _ensure_openshell()
         self._executor_config = OpenShellExecutorConfig.model_validate(self._config)
-        self._entities = NemoEntitiesClient(AsyncEntitiesResource(self._sdk))
+        self._entities = NemoEntitiesClient(client_from_platform(self._sdk, AsyncEntitiesClient))
         # Build the policy once (fail fast on a bad path/shape). The gateway default
         # policy would not permit the agent's own exec paths, so we always apply one.
         self._policy = self._build_executor_policy()

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
@@ -71,7 +71,7 @@ logger = logging.getLogger(__name__)
 
 _OPENSHELL_INSTALL_HINT = (
     "The 'openshell' package is required for OpenShellDeploymentBackend. "
-    "Install it with: uv sync --package nemo-deployments-plugin --extra openshell"
+    'Install it with: uv pip install "openshell>=0.0.92" "grpcio>=1.78.0" "protobuf>=6.31.1"'
 )
 
 _SERVE_LOG = "/tmp/nemo-serve.log"

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/policy.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/policy.py
@@ -187,7 +187,7 @@ def generate_sandbox_policy(*, filesystem: SandboxFilesystem, egress: PlatformEg
 
 _OPENSHELL_INSTALL_HINT = (
     "The 'openshell' package is required to build OpenShell sandbox policies. "
-    "Install it with: uv sync --package nemo-deployments-plugin --extra openshell"
+    'Install it with: uv pip install "openshell>=0.0.92" "grpcio>=1.78.0" "protobuf>=6.31.1"'
 )
 
 

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/conftest.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/conftest.py
@@ -35,7 +35,7 @@ def openshell_backend(
     mock_sdk: MagicMock, mock_entities: AsyncMock, mock_stub: MagicMock
 ) -> Iterator[OpenShellDeploymentBackend]:
     with (
-        patch("nemo_deployments_plugin.backends.openshell.backend.AsyncEntitiesResource"),
+        patch("nemo_deployments_plugin.backends.openshell.backend.client_from_platform"),
         patch("nemo_deployments_plugin.backends.openshell.backend.NemoEntitiesClient", return_value=mock_entities),
         patch("grpc.insecure_channel", return_value=MagicMock()),
     ):

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_backend_mocked.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import grpc
+import httpx
 import pytest
 from nemo_deployments_plugin.backends.labels import (
     CONFIG_NAME_LABEL,
@@ -35,6 +36,8 @@ from nemo_deployments_plugin.backends.registry import BACKEND_CLASSES
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
 from nemo_deployments_plugin.entities import Container, ContainerPort, DeploymentConfig, EnvVar
 from nemo_deployments_plugin.secrets import SecretResolutionError
+from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
 
 pytest.importorskip("openshell")  # platform-restricted extra; skip where not installed (e.g. CI)
 
@@ -124,6 +127,34 @@ def _config_with_env(env: list[EnvVar]) -> DeploymentConfig:
 
 def test_registry_contains_openshell() -> None:
     assert BACKEND_CLASSES["openshell"] is OpenShellDeploymentBackend
+
+
+async def test_load_deployment_config_wraps_an_entities_client_that_accepts_query_params() -> None:
+    """init() must adapt the SDK with client_from_platform(AsyncEntitiesClient), not wrap the
+    raw generated AsyncEntitiesResource (AIRCORE-977).
+
+    NemoEntitiesClient.get() forwards a ``query_params`` kwarg. The generated resource does not
+    accept it, so wrapping the resource made every first reconcile die with
+    ``TypeError: ... unexpected keyword argument 'query_params'`` before any request left the box.
+    Drive the real contract with a live entities client over a mock transport: a 404 must surface
+    as NemoEntityNotFoundError, which is only reachable once ``get_entity_by_name(query_params=...)``
+    is accepted and the request actually goes out.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "not found"}, request=request)
+
+    sdk = AsyncNeMoPlatform(
+        base_url="http://entities.test",
+        workspace="default",
+        http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    with patch("grpc.insecure_channel", return_value=MagicMock()):
+        backend = OpenShellDeploymentBackend(sdk, {"gateway_endpoint": "http://127.0.0.1:17670"})
+
+    # Old (buggy) wrapping raised TypeError about query_params here; the fix reaches the 404.
+    with pytest.raises(NemoEntityNotFoundError):
+        await backend._load_deployment_config("default", "missing-config")
 
 
 def test_sandbox_name_within_limit_and_deterministic() -> None:


### PR DESCRIPTION
## Summary

Every deployment to an `openshell`-backed executor failed on its first reconcile. Docker-backed deploys of the same config reached READY, isolating the defect to the openshell backend.

Two independent fixes, one commit each.

## 1. Wrong entities client wrapping (root cause, `Fixes AIRCORE-977`)

`OpenShellDeploymentBackend.init()` wrapped the SDK's generated `AsyncEntitiesResource` directly:

```python
self._entities = NemoEntitiesClient(AsyncEntitiesResource(self._sdk))
```

`NemoEntitiesClient.get()` forwards a `query_params` kwarg that the generated resource does not accept, so `_load_deployment_config` died with:

```
TypeError: AsyncEntitiesResource.get_entity_by_name() got an unexpected keyword argument 'query_params'
```

The docker and k8s backends already do the correct thing: adapt the SDK with `client_from_platform(self._sdk, AsyncEntitiesClient)`. This change mirrors them:

```python
self._entities = NemoEntitiesClient(client_from_platform(self._sdk, AsyncEntitiesClient))
```

### Regression test

Added `test_load_deployment_config_wraps_an_entities_client_that_accepts_query_params`, which drives the real contract instead of a hollow constructor assert: it builds the backend against a real `AsyncNeMoPlatform` SDK backed by an httpx `MockTransport` that returns 404, then calls `_load_deployment_config`. A 404 surfaces as `NemoEntityNotFoundError`, which is only reachable once `get_entity_by_name(query_params=...)` is accepted and the request actually goes out.

I verified it is genuinely adversarial: with the source fix reverted the test fails with the exact `TypeError ... unexpected keyword argument 'query_params'`; with the fix applied it passes. The openshell conftest was updated to patch `client_from_platform` instead of the removed `AsyncEntitiesResource`.

## 2. Broken install hint (separate commit)

The `MissingBackendDependencyError` hint in `backend.py` and `policy.py` told users to run `uv sync --package nemo-deployments-plugin --extra openshell`, which narrows the workspace venv and uninstalls the platform (AIRCORE-980). Both copies now use the non-destructive form:

```
uv pip install "openshell>=0.0.92" "grpcio>=1.78.0" "protobuf>=6.31.1"
```

## Testing

- `make test-deployments-openshell` (installs the openshell extra, runs the backend unit suite): 79 passed.
- Adversarial check: new test fails pre-fix with the query_params `TypeError`, passes post-fix.
- `uv run ruff format` / `uv run ruff check` on all changed files: clean.
- `uv run --frozen ty check plugins/nemo-deployments`: no new diagnostics in changed files. The 17 pre-existing diagnostics are unrelated (unused `# ty: ignore[unresolved-import]` on the openshell imports, which only fire when the openshell extra is installed, plus unrelated pre-existing test typing issues).

Fixes AIRCORE-977
https://linear.app/nvidia/issue/AIRCORE-977


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenShell deployment configuration loading when requests include query parameters.
  * Deployment-not-found responses are now reported with the appropriate error.
  * Updated OpenShell client setup for improved compatibility.

* **Documentation**
  * Updated installation guidance to use `uv pip install` with the required OpenShell, gRPC, and Protocol Buffers packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->