### PR TITLE
fix(studio): serve container-baked assets, and stop shipping a partial Studio bundle [ASTD-354]

### DIFF
--- a/docker/base/Dockerfile.nmp-studio-ui
+++ b/docker/base/Dockerfile.nmp-studio-ui
@@ -3,7 +3,9 @@ ARG NODE_VERSION=22
 ARG DOCKERHUB_MIRROR=docker.io/library
 
 # --------------- BASE --------------- #
-FROM ${DOCKERHUB_MIRROR}/node:${NODE_VERSION}-bookworm AS base
+# dist/ is architecture-independent JS/CSS/HTML, so build it once on the builder's
+# native arch. Emulated arm64 builds hang in Vite chunk rendering under QEMU.
+FROM --platform=$BUILDPLATFORM ${DOCKERHUB_MIRROR}/node:${NODE_VERSION}-bookworm AS base
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 
 # Preserve the Platform repository layout so SDK generation can resolve

--- a/docker/base/Dockerfile.nmp-studio-ui
+++ b/docker/base/Dockerfile.nmp-studio-ui
@@ -70,12 +70,17 @@ COPY web/packages/studio/env/${ENV_FILE} packages/studio/env/.env
 # so the Dockerfile can retry before the GitHub job-level timeout cancels the run.
 RUN set -eu; \
   for attempt in 1 2 3; do \
-    if VITE_VERSION_SHA="${VITE_VERSION_SHA}" NODE_ENV="${NODE_ENV}" \
+    status=0; \
+    VITE_VERSION_SHA="${VITE_VERSION_SHA}" NODE_ENV="${NODE_ENV}" \
       timeout --kill-after=30s 15m \
-      pnpm --filter nemo-studio-ui --fail-if-no-match build:fastapi; then \
+      pnpm --filter nemo-studio-ui --fail-if-no-match build:fastapi || status="$?"; \
+    if [ "${status}" = "0" ]; then \
+      if [ ! -f /app/web/packages/studio/dist/index.html ]; then \
+        echo "Studio UI build reported success but dist/index.html is missing"; \
+        exit 1; \
+      fi; \
       exit 0; \
     fi; \
-    status="$?"; \
     if [ "${status}" != "124" ] && [ "${status}" != "137" ]; then \
       exit "${status}"; \
     fi; \

--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -914,7 +914,7 @@ Configuration for the Studio service.
 
 ```yaml wordWrap
 studio:
-  # Path to the directory containing the built static UI assets. When unset, defaults to the `static/` directory bundled alongside the `nmp.studio` package (populated by the wheel build).
+  # Path to the directory containing the built static UI assets. When unset, Studio looks for the `static/` directory bundled alongside the `nmp.studio` package (populated by the wheel build), then `/static/studio` (where NeMo Platform container images place the bundle), then `web/packages/studio/dist` in a source checkout.
   static_files_path:
   # Base URL of the platform. This is used by the Studio UI to make API calls. | default: ''
   platform_base_url: ''

--- a/services/studio/src/nmp/studio/config.py
+++ b/services/studio/src/nmp/studio/config.py
@@ -62,8 +62,10 @@ class StudioConfig(create_service_config_class("studio")):  # type: ignore[misc]
         default=None,
         description=(
             "Path to the directory containing the built static UI assets. "
-            "When unset, defaults to the `static/` directory bundled alongside the "
-            "`nmp.studio` package (populated by the wheel build)."
+            "When unset, Studio looks for the `static/` directory bundled alongside the "
+            "`nmp.studio` package (populated by the wheel build), then `/static/studio` "
+            "(where NeMo Platform container images place the bundle), then "
+            "`web/packages/studio/dist` in a source checkout."
         ),
     )
     platform_base_url: str = Field(

--- a/services/studio/src/nmp/studio/service.py
+++ b/services/studio/src/nmp/studio/service.py
@@ -39,6 +39,36 @@ HOP_BY_HOP_HEADERS = {
     "upgrade",
 }
 
+CONTAINER_STATIC_FILES_PATH = Path("/static/studio")
+
+SOURCE_CHECKOUT_TIPS_HTML = """      <h2>Build tips</h2>
+      <p>Run these commands from the repository root.</p>
+      <p>Studio uses the Node.js and pnpm engines in <code>web/package.json</code>.</p>
+      <p>If you use nvm:</p>
+      <pre>source ~/.nvm/nvm.sh
+nvm install 22
+nvm use 22
+make bootstrap-studio
+nemo services restart</pre>
+      <p>If you use pnpm-managed Node.js:</p>
+      <pre>pnpm env use --global 22.18.0
+make bootstrap-studio
+nemo services restart</pre>"""
+
+PACKAGED_INSTALL_TIPS_HTML = f"""      <h2>How to fix</h2>
+      <p>This is a packaged install, not a source checkout, so there is nothing to build here.</p>
+      <p>Point Studio at a directory that already contains a built bundle:</p>
+      <pre>NMP_STUDIO_STATIC_FILES_PATH=/path/to/studio/assets</pre>
+      <p>
+        The same value can be set as <code>studio.static_files_path</code> in the NeMo Platform
+        configuration file, but the environment variable takes precedence over it.
+      </p>
+      <p>
+        Official container images ship the bundle at
+        <code>{escape(str(CONTAINER_STATIC_FILES_PATH))}</code>, which is used automatically when
+        nothing is configured.
+      </p>"""
+
 
 class StudioService(Service[StudioConfig]):
     """Studio service for serving the NeMo Studio UI static assets.
@@ -252,36 +282,29 @@ class StudioService(Service[StudioConfig]):
         @app.get("/studio/", include_in_schema=False)
         @app.get("/studio/{path:path}", include_in_schema=False)
         async def studio_static_files_missing(path: str = "") -> HTMLResponse:
-            return self._missing_static_files_response(static_path, path)
+            return self._missing_static_files_response(
+                static_path, path, source_checkout=self._source_static_files_path() is not None
+            )
 
     @staticmethod
-    def _missing_static_files_response(static_path: Path, requested_path: str = "") -> HTMLResponse:
+    def _missing_static_files_response(
+        static_path: Path, requested_path: str = "", source_checkout: bool = True
+    ) -> HTMLResponse:
         route = "/studio" if requested_path == "" else f"/studio/{requested_path}"
+        recovery_html = SOURCE_CHECKOUT_TIPS_HTML if source_checkout else PACKAGED_INSTALL_TIPS_HTML
         html = f"""<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>NeMo Studio assets are not built</title>
+    <title>NeMo Studio assets were not found</title>
   </head>
   <body>
     <main>
-      <h1>NeMo Studio assets are not built</h1>
+      <h1>NeMo Studio assets were not found</h1>
       <p>The platform is running, but Studio cannot be served because the built web assets were not found.</p>
       <p>Requested path: <code>{escape(route)}</code></p>
       <p>Expected assets at: <code>{escape(str(static_path))}</code></p>
-      <h2>Build tips</h2>
-      <p>Run these commands from the repository root.</p>
-      <p>Studio uses the Node.js and pnpm engines in <code>web/package.json</code>.</p>
-      <p>If you use nvm:</p>
-      <pre>source ~/.nvm/nvm.sh
-nvm install 22
-nvm use 22
-make bootstrap-studio
-nemo services restart</pre>
-      <p>If you use pnpm-managed Node.js:</p>
-      <pre>pnpm env use --global 22.18.0
-make bootstrap-studio
-nemo services restart</pre>
+{recovery_html}
     </main>
   </body>
 </html>
@@ -297,7 +320,8 @@ nemo services restart</pre>
 
         Returns:
             The configured static_files_path from StudioConfig, falling back to the
-            packaged `static/` directory or source checkout `web/packages/studio/dist`.
+            packaged `static/` directory, the container image bundle at
+            `/static/studio`, or source checkout `web/packages/studio/dist`.
         """
         configured = self._get_config().static_files_path
         if configured is not None:
@@ -306,6 +330,10 @@ nemo services restart</pre>
         packaged_static = self._packaged_static_files_path()
         if self._static_assets_ready(packaged_static):
             return packaged_static
+
+        container_static = self._container_static_files_path()
+        if self._static_assets_ready(container_static):
+            return container_static
 
         source_static = self._source_static_files_path()
         if source_static is not None:
@@ -317,6 +345,11 @@ nemo services restart</pre>
     def _packaged_static_files_path() -> Path:
         """Return the package-local Studio static asset directory."""
         return Path(__file__).parent / "static"
+
+    @staticmethod
+    def _container_static_files_path() -> Path:
+        """Return the Studio bundle location baked into NeMo Platform container images."""
+        return CONTAINER_STATIC_FILES_PATH
 
     @staticmethod
     def _static_assets_ready(path: Path) -> bool:

--- a/services/studio/src/nmp/studio/service.py
+++ b/services/studio/src/nmp/studio/service.py
@@ -55,19 +55,10 @@ nemo services restart</pre>
 make bootstrap-studio
 nemo services restart</pre>"""
 
-PACKAGED_INSTALL_TIPS_HTML = f"""      <h2>How to fix</h2>
-      <p>This is a packaged install, not a source checkout, so there is nothing to build here.</p>
-      <p>Point Studio at a directory that already contains a built bundle:</p>
-      <pre>NMP_STUDIO_STATIC_FILES_PATH=/path/to/studio/assets</pre>
-      <p>
-        The same value can be set as <code>studio.static_files_path</code> in the NeMo Platform
-        configuration file, but the environment variable takes precedence over it.
-      </p>
-      <p>
-        Official container images ship the bundle at
-        <code>{escape(str(CONTAINER_STATIC_FILES_PATH))}</code>, which is used automatically when
-        nothing is configured.
-      </p>"""
+DOCS_URL = "https://docs.nvidia.com/nemo-platform"
+
+PACKAGED_INSTALL_NOTICE_HTML = f"""      <p>This install ships with the Studio bundle, so this is unexpected.</p>
+      <p>See the <a href="{DOCS_URL}">NeMo Platform documentation</a> for help.</p>"""
 
 
 class StudioService(Service[StudioConfig]):
@@ -291,7 +282,7 @@ class StudioService(Service[StudioConfig]):
         static_path: Path, requested_path: str = "", source_checkout: bool = True
     ) -> HTMLResponse:
         route = "/studio" if requested_path == "" else f"/studio/{requested_path}"
-        recovery_html = SOURCE_CHECKOUT_TIPS_HTML if source_checkout else PACKAGED_INSTALL_TIPS_HTML
+        recovery_html = SOURCE_CHECKOUT_TIPS_HTML if source_checkout else PACKAGED_INSTALL_NOTICE_HTML
         html = f"""<!doctype html>
 <html lang="en">
   <head>

--- a/services/studio/tests/unit/test_service.py
+++ b/services/studio/tests/unit/test_service.py
@@ -229,13 +229,14 @@ class TestTelemetryProxy:
 class TestStaticFilesPath:
     """Tests for static_files_path configuration."""
 
-    def test_default_static_files_path(self, monkeypatch: pytest.MonkeyPatch):
+    def test_default_static_files_path(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Test that the default path is the packaged static dir."""
         import nmp.studio
 
         expected = Path(nmp.studio.__file__).parent / "static"
         service = StudioService()
         monkeypatch.setattr(service, "_source_static_files_path", lambda: None)
+        monkeypatch.setattr(service, "_container_static_files_path", lambda: tmp_path / "absent")
         path = service._get_static_files_path()
         assert path == expected
 
@@ -296,15 +297,59 @@ class TestStaticFilesPath:
         service = StudioService()
         monkeypatch.chdir(source_root)
         monkeypatch.setattr(service, "_packaged_static_files_path", lambda: packaged_static)
+        monkeypatch.setattr(service, "_container_static_files_path", lambda: tmp_path / "absent")
 
         path = service._get_static_files_path()
         assert path == studio_dir / "dist"
+
+    def test_container_bundle_used_when_packaged_static_missing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Test that the container image bundle is used when nothing is configured or packaged."""
+        container_static = tmp_path / "static" / "studio"
+        container_static.mkdir(parents=True)
+        (container_static / "index.html").write_text("<html></html>")
+
+        service = StudioService()
+        monkeypatch.setattr(service, "_packaged_static_files_path", lambda: tmp_path / "package-static")
+        monkeypatch.setattr(service, "_container_static_files_path", lambda: container_static)
+
+        assert service._get_static_files_path() == container_static
+
+    def test_configured_path_wins_over_container_bundle(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Test that an operator's configured path is never shadowed by the container bundle."""
+        container_static = tmp_path / "static" / "studio"
+        container_static.mkdir(parents=True)
+        (container_static / "index.html").write_text("<html></html>")
+        configured = tmp_path / "operator-static"
+        configured.mkdir()
+        (configured / "index.html").write_text("<html></html>")
+
+        service = StudioService().with_config(StudioConfig(static_files_path=configured))
+        monkeypatch.setattr(service, "_container_static_files_path", lambda: container_static)
+
+        assert service._get_static_files_path() == configured
+
+    def test_default_container_static_files_path(self):
+        """Test that the container fallback matches where the images place the bundle."""
+        assert StudioService()._container_static_files_path() == Path("/static/studio")
+
+    def test_env_static_files_path_shadows_the_config_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """ServiceConfig is environment-first, so images must not bake NMP_STUDIO_STATIC_FILES_PATH."""
+        from nmp.common.config import Configuration
+
+        monkeypatch.setenv("NMP_STUDIO_STATIC_FILES_PATH", str(tmp_path / "from-env"))
+
+        config = Configuration.global_settings_to_service_config(
+            {"studio": {"static_files_path": str(tmp_path / "from-yaml")}}, StudioConfig
+        )
+
+        assert config.static_files_path == tmp_path / "from-env"
 
     def test_missing_static_files_route_explains_recovery(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Test that missing Studio assets return recovery instructions instead of a bare 404."""
         missing_static = tmp_path / "missing-static"
         service = StudioService()
         monkeypatch.setattr(service, "_get_static_files_path", lambda: missing_static)
+        monkeypatch.setattr(service, "_source_static_files_path", lambda: tmp_path / "web-dist")
         app = FastAPI()
 
         service.configure_app(app)
@@ -327,6 +372,7 @@ class TestStaticFilesPath:
         missing_static = tmp_path / "missing-static"
         service = StudioService()
         monkeypatch.setattr(service, "_get_static_files_path", lambda: missing_static)
+        monkeypatch.setattr(service, "_source_static_files_path", lambda: tmp_path / "web-dist")
         app = FastAPI()
 
         service.configure_app(app)
@@ -340,12 +386,36 @@ class TestStaticFilesPath:
         assert "make bootstrap-studio" in response.text
         assert "nemo services restart" in response.text
 
+    def test_missing_static_files_route_omits_build_tips_outside_a_checkout(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Test that packaged installs are pointed at the config knob instead of a repo build."""
+        missing_static = tmp_path / "missing-static"
+        service = StudioService()
+        monkeypatch.setattr(service, "_get_static_files_path", lambda: missing_static)
+        monkeypatch.setattr(service, "_source_static_files_path", lambda: None)
+        app = FastAPI()
+
+        service.configure_app(app)
+
+        client = TestClient(app)
+        response = client.get("/studio/")
+
+        assert response.status_code == 503
+        assert "NMP_STUDIO_STATIC_FILES_PATH" in response.text
+        assert "studio.static_files_path" in response.text
+        assert "/static/studio" in response.text
+        assert "make bootstrap-studio" not in response.text
+        assert "nvm" not in response.text
+        assert str(missing_static) in response.text
+
     def test_static_dir_without_index_route_explains_recovery(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         """Test that an incomplete Studio build also returns recovery instructions."""
         incomplete_static = tmp_path / "static"
         incomplete_static.mkdir()
         service = StudioService()
         monkeypatch.setattr(service, "_get_static_files_path", lambda: incomplete_static)
+        monkeypatch.setattr(service, "_source_static_files_path", lambda: tmp_path / "web-dist")
         app = FastAPI()
 
         service.configure_app(app)

--- a/services/studio/tests/unit/test_service.py
+++ b/services/studio/tests/unit/test_service.py
@@ -389,7 +389,7 @@ class TestStaticFilesPath:
     def test_missing_static_files_route_omits_build_tips_outside_a_checkout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        """Test that packaged installs are pointed at the config knob instead of a repo build."""
+        """Test that packaged installs get a docs pointer instead of repo build steps."""
         missing_static = tmp_path / "missing-static"
         service = StudioService()
         monkeypatch.setattr(service, "_get_static_files_path", lambda: missing_static)
@@ -402,11 +402,10 @@ class TestStaticFilesPath:
         response = client.get("/studio/")
 
         assert response.status_code == 503
-        assert "NMP_STUDIO_STATIC_FILES_PATH" in response.text
-        assert "studio.static_files_path" in response.text
-        assert "/static/studio" in response.text
+        assert "https://docs.nvidia.com/nemo-platform" in response.text
         assert "make bootstrap-studio" not in response.text
         assert "nvm" not in response.text
+        assert "NMP_STUDIO_STATIC_FILES_PATH" not in response.text
         assert str(missing_static) in response.text
 
     def test_static_dir_without_index_route_explains_recovery(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
## Problem

Running `nvcr.io/nvidia/nemo-platform/nmp-api` directly — `docker run`, compose, quickstart, anything that is not the Helm chart — lands on the error page at `/studio`:

```
NeMo Studio assets are not built
Expected assets at: /app/.venv/lib/python3.13/site-packages/nmp/studio/static
```

Helm deployments are unaffected because `k8s/helm/values.yaml` sets `studio.static_files_path: "/static/studio"` explicitly, masking the gap.

Investigating this turned up a second, independent problem: the arm64 image at that tag ships a Studio bundle with no `index.html` at all. Three bugs in total — the assets were unreachable (1), a broken bundle could ship green (2), and the build chain that produced the broken bundle should never have been running (3).

## Bug 1 — the container bundle was never consulted

`docker/Dockerfile.nmp-api` copies the built bundle to `/static/studio`, but sets no config pointing at it. `StudioConfig.static_files_path` defaults to `None`, so `_get_static_files_path` falls back to the packaged `static/` dir beside the `nmp.studio` package — which is only populated by the *wheel* build (`packages/nemo_platform/pyproject.toml` `force_include`). The container builder stage runs `uv sync` without `web/dist` present, so it stays empty. Nothing ever looked at `/static/studio`.

**Fix:** add `/static/studio` to the `_get_static_files_path` fallback chain — configured → packaged → **container** → source checkout.

### Why not bake `NMP_STUDIO_STATIC_FILES_PATH` into the Dockerfile

That was the obvious one-line fix, and it is wrong here. `ServiceConfig` derives from `EnvironmentFirstSettings` (`packages/nemo_platform_plugin/src/nemo_platform_plugin/config.py:143-160`), whose `settings_customise_sources` returns `(env_settings, dotenv_settings, init_settings, file_secret_settings)` — **env ahead of init kwargs**, the reverse of the pydantic-settings default. So the env var would silently override an operator's `studio.static_files_path`. Confirmed:

```python
os.environ["NMP_STUDIO_STATIC_FILES_PATH"] = "/static/studio"
Configuration.global_settings_to_service_config(
    {"studio": {"static_files_path": "/operator/custom"}}, StudioConfig
).static_files_path
# -> /static/studio
```

The fallback chain fixes this image, covers future images that lay the bundle down without setting a var, and cannot shadow config. `docker/Dockerfile.nmp-api` is untouched. A regression test pins the env-over-YAML ordering so nobody re-adds the env var later.

## Bug 2 — the arm64 image ships a public-only `dist/`

`/static/studio` in the arm64 image at that tag contains exactly `favicon.svg`, `sample-agents/`, `sample-datasets/` — byte-for-byte the contents of `web/packages/studio/public/`. No `index.html`, no `assets/`. 877 kB.

It is arch-specific. Comparing the two manifests layer-by-layer, every layer matches within a few percent except one:

| layer 14 (compressed) | amd64 | arm64 |
|---|---|---|
| | 2,583,129 B | 293,216 B |

**Why public-only:** Vite 8 copies `publicDir` → `outDir` from the `vite:prepare-out-dir` **`renderStart`** hook — before chunks are rendered and written. Kill the build during chunk rendering and `dist/` holds public files and nothing else. The Dockerfile's own comment names that failure mode: "QEMU arm64 builds occasionally hang in Vite chunk rendering."

**Why it did not fail the build** — `docker/base/Dockerfile.nmp-studio-ui`:

```sh
if ... timeout --kill-after=30s 15m pnpm ... build:fastapi; then
  exit 0;
fi;
status="$?";                                    # <-- always 0
if [ "${status}" != "124" ] && [ "${status}" != "137" ]; then
  exit "${status}";                             # <-- exit 0
fi;
```

`$?` after `fi` is the status of the **`if` compound command**, not the failed build — a failing condition with no `else` leaves the `if` itself at 0. So a SIGKILL at the 15m timeout produced 124, was captured as 0, fell through `0 != 124 && 0 != 137`, and ran `exit 0`. The RUN succeeded, the three-attempt retry never once fired, and the partial `dist/` shipped.

**Fix (backstop):** capture the status with `|| status="$?"` outside the `if`, and assert `dist/index.html` exists before reporting success. That converts a silently broken image into a failed build — necessary, but it only makes the failure loud.

## Bug 3 — the emulated build chain should not exist

Making the build fail loudly would have turned arm64 release builds red rather than green-and-broken. The actual fix is to remove the emulation.

`nmp-studio-ui` declares `platforms = [linux/amd64, linux/arm64]`, so buildkit runs the entire node + pnpm + vite chain **twice** and emulates whichever half does not match the builder. But `dist/` is architecture-independent JS/CSS/HTML — the second chain produces the same bytes and contributes nothing except the failure mode.

**Fix:** pin the node stages to the builder's native arch.

```dockerfile
FROM --platform=$BUILDPLATFORM ${DOCKERHUB_MIRROR}/node:${NODE_VERSION}-bookworm AS base
```

`$BUILDPLATFORM` is whatever the builder host is, so this is symmetric — an amd64 runner builds amd64 natively, an arm64 runner builds arm64 natively, and neither emulates. The `FROM scratch AS artifacts` stage is still stamped per target platform, so `nmp-api` consumes it unchanged. Also collapses the expensive `pnpm install` + vite build from twice to once.

`nmp-studio-ui` has no `cache-to`/`cache-from` (unlike `nmp-api-docker`) and its only consumer is the `nmp-api-docker` named context, so there are no cache implications.

## Also in scope

The error page's recovery block printed nvm / `make bootstrap-studio` / `nemo services restart` unconditionally — meaningless inside a container, and it sent the reporting user down the wrong path. It now branches on whether a source checkout is detected.

Source checkouts keep the build tips. Packaged installs get no remediation steps at all, because a packaged install ships with the bundle and there is nothing for the operator to build — a missing bundle there is a packaging defect, not a setup mistake. They get a plain error plus a link to the docs site, the only outward-facing help pointer the repo has (README badge, `web/packages/studio/src/constants/links.ts`):

```html
<p>Expected assets at: <code>/static/studio</code></p>
<p>This install ships with the Studio bundle, so this is unexpected.</p>
<p>See the <a href="https://docs.nvidia.com/nemo-platform">NeMo Platform documentation</a> for help.</p>
```

Heading changed from "assets are not built" to "assets were not found".

## Verification

**Bug 1**, against a real `nmp-api` image with the patched `nmp/studio` package bind-mounted:

- before: falls through, no SPA
- after, no config file: `/studio/` → `200 text/html`, SPA index served
- config file setting `studio.static_files_path` → resolves to the configured path; container fallback loses
- error page rendered in-container shows the packaged-install notice and docs link, not build tips

**Bug 2**, real builds of the `nmp-studio-ui` target:

- happy path — `✓ built in 3.49s`, 12.28 MB exported, `/artifacts` has `index.html` + `assets/` (331 files). Exit 0.
- guard path — same build with `&& rm -f dist/index.html` spliced in:
  ```
  #39 4.221 Studio UI build reported success but dist/index.html is missing
  #39 ERROR: process "/bin/sh -c set -eu; ..." did not complete successfully: exit code: 1
  ```
  Under the old body that same state exited 0 and shipped.

Exit-path matrix (harness mirroring the RUN body):

| case | new | old |
|---|---|---|
| success + `index.html` | 0 | 0 |
| success, `index.html` gone | 1 | 0 |
| timeout 124 | retry ×3 → 124 | 0 |
| SIGKILL 137 | retry ×3 → 124 | 0 |
| failure 1 / 2 | 1 / 2 | 0 |

Caveat on the happy-path build above: this host is arm64, so it ran natively and did **not** exercise the emulated path that broke 0.3.0. It proves the guard and the happy path, not that emulated arm64 succeeds. Bug 3 is what addresses the emulated path.

**Bug 3**, both target platforms built on an arm64 host:

- *before* — buildkit spawns a full second chain, `[linux/amd64 base 10/29]` … `[linux/amd64 base 21/29] RUN pnpm install --frozen-lockfile`, which dies under emulation:
  ```
  #62 [linux/amd64 base 21/29] RUN pnpm install --frozen-lockfile
  #62 62.15 . postinstall: [safe-synthesizer] ✘ [ERROR] panic: runtime error: invalid memory address or nil pointer dereference
  #62 91.08 . postinstall: 💥 Some type generation failed.
  #62 ERROR: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 1
  ```
  A Go nil-pointer panic in orval SDK generation. The whole build exits 1. This host is arm64, so the emulated half is amd64 — the mirror image of CI, where an amd64 runner emulates arm64. Different symptom from the chunk-rendering hang, same root cause: the node toolchain does not survive QEMU.

- *after* — only native arm64 stages execute (no `linux/amd64 base`/`build` at all), and the two exported trees are byte-identical:
  ```
  d6dd8e840ffa8b925e13644a0b1f7497df151b9d1bd8d19eb2648e9fd3b7c570  linux_amd64/artifacts
  d6dd8e840ffa8b925e13644a0b1f7497df151b9d1bd8d19eb2648e9fd3b7c570  linux_arm64/artifacts
  ```
  `diff -r` clean, 331 assets each, `index.html` 8710 B each.

**Tests:** `pytest services/studio/tests/unit` → 107 passed. New coverage for the container fallback, configured-path precedence, the `/static/studio` constant, both error-page branches, and the env-over-YAML ordering. `ruff check` / `ruff format` / `ty check` clean.

## Note for reviewers

The `config-reference-docs` pre-commit hook cannot run from a git worktree — `uv` fails to fetch the `nooa` git dependency (`fatal: not a git repository`) before it reaches doc generation. I skipped it and hand-edited `docs/set-up/config-reference.mdx`; the line is byte-identical to what the generator emits for that field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Studio build validation to detect missing output files and report failures accurately.
  * Enhanced static asset discovery across packaged installations, container images, and source checkouts.
  * Added clearer recovery guidance when Studio assets are unavailable.
  * Preserved configuration precedence for explicitly configured asset paths and environment settings.

* **Documentation**
  * Updated configuration guidance to explain static asset fallback locations and setup options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

