### PR TITLE
fix(studio): unblock the dev server's blank page [ASTD-355]

### DIFF
--- a/web/packages/studio/vite.config.ts
+++ b/web/packages/studio/vite.config.ts
@@ -270,11 +270,15 @@ function vendorPlugin(): Plugin {
     // beats optimizeDeps. In build mode rolldownOptions.external handles
     // the same specifiers; resolveId is a no-op there.
     enforce: 'pre',
-    configResolved(config) {
+    // Awaited here, not in configureServer: Vite snapshots publicDir before
+    // the server starts, and any bundle written after that snapshot is 404ed
+    // by the public middleware — a blank app on a cold dev start.
+    async configResolved(config) {
       base = config.base;
       isServe = config.command === 'serve';
       projectRoot = config.root;
       outdir = path.resolve(projectRoot, 'public', 'vendor');
+      await ensureBuilt();
     },
     buildStart() {
       return ensureBuilt();
@@ -462,6 +466,10 @@ export default defineConfig(({ mode }) => {
     // them to /vendor/* instead without Vite racing to pre-bundle first.
     optimizeDeps: {
       exclude: [...VENDOR_EXTERNALS],
+      // KUI's `/lib` subpath escapes the vendor bundle and, being under an
+      // excluded package, is served unoptimized — so its CJS
+      // react-compiler-runtime import needs pre-bundling for `c` to resolve.
+      include: ['@nvidia/foundations-react-core > react-compiler-runtime'],
     },
     build: {
       rolldownOptions: {

--- a/web/packages/studio/vite.config.ts
+++ b/web/packages/studio/vite.config.ts
@@ -244,6 +244,7 @@ function vendorPlugin(): Plugin {
   let outdir = '';
   let projectRoot = '';
   let isServe = false;
+  let isPreview = false;
   let pending: Promise<void> | null = null;
 
   // buildVendorBundles wipes outdir and rebuilds on every vite process start,
@@ -275,14 +276,21 @@ function vendorPlugin(): Plugin {
     // beats optimizeDeps. In build mode rolldownOptions.external handles
     // the same specifiers; resolveId is a no-op there.
     enforce: 'pre',
+    // `command` is 'serve' under `vite preview` too, and isPreview is only on
+    // ConfigEnv — preview serves an existing dist, so it must not rebuild.
+    config(_, env) {
+      isPreview = env.isPreview === true;
+    },
     async configResolved(config) {
       base = config.base;
-      isServe = config.command === 'serve';
+      isServe = config.command === 'serve' && !isPreview;
       projectRoot = config.root;
       outdir = isServe
         ? path.resolve(projectRoot, DEV_VENDOR_DIR)
         : path.resolve(projectRoot, 'public', 'vendor');
-      await ensureBuilt();
+      if (!isPreview) {
+        await ensureBuilt();
+      }
     },
     buildStart() {
       return ensureBuilt();

--- a/web/packages/studio/vite.config.ts
+++ b/web/packages/studio/vite.config.ts
@@ -270,7 +270,6 @@ function vendorPlugin(): Plugin {
     // beats optimizeDeps. In build mode rolldownOptions.external handles
     // the same specifiers; resolveId is a no-op there.
     enforce: 'pre',
-    // Vite snapshots publicDir at startup and 404s bundles written after it.
     async configResolved(config) {
       base = config.base;
       isServe = config.command === 'serve';
@@ -464,8 +463,6 @@ export default defineConfig(({ mode }) => {
     // them to /vendor/* instead without Vite racing to pre-bundle first.
     optimizeDeps: {
       exclude: [...VENDOR_EXTERNALS],
-      // KUI's unoptimized `/lib` subpath imports this as CJS; without
-      // pre-bundling it, the named `c` export is missing.
       include: ['@nvidia/foundations-react-core > react-compiler-runtime'],
     },
     build: {

--- a/web/packages/studio/vite.config.ts
+++ b/web/packages/studio/vite.config.ts
@@ -270,9 +270,7 @@ function vendorPlugin(): Plugin {
     // beats optimizeDeps. In build mode rolldownOptions.external handles
     // the same specifiers; resolveId is a no-op there.
     enforce: 'pre',
-    // Awaited here, not in configureServer: Vite snapshots publicDir before
-    // the server starts, and any bundle written after that snapshot is 404ed
-    // by the public middleware — a blank app on a cold dev start.
+    // Vite snapshots publicDir at startup and 404s bundles written after it.
     async configResolved(config) {
       base = config.base;
       isServe = config.command === 'serve';
@@ -466,9 +464,8 @@ export default defineConfig(({ mode }) => {
     // them to /vendor/* instead without Vite racing to pre-bundle first.
     optimizeDeps: {
       exclude: [...VENDOR_EXTERNALS],
-      // KUI's `/lib` subpath escapes the vendor bundle and, being under an
-      // excluded package, is served unoptimized — so its CJS
-      // react-compiler-runtime import needs pre-bundling for `c` to resolve.
+      // KUI's unoptimized `/lib` subpath imports this as CJS; without
+      // pre-bundling it, the named `c` export is missing.
       include: ['@nvidia/foundations-react-core > react-compiler-runtime'],
     },
     build: {

--- a/web/packages/studio/vite.config.ts
+++ b/web/packages/studio/vite.config.ts
@@ -53,6 +53,8 @@ const VENDOR_EXTERNALS = [
   '@tanstack/react-query',
 ] as const;
 
+const DEV_VENDOR_DIR = 'node_modules/.vendor';
+
 // Each import specifier in the map resolves to a single vendor bundle.
 // 'react/jsx-runtime' shares react.js and 'react-dom/client' shares
 // react-dom.js so there's exactly one copy of each package's internals.
@@ -257,10 +259,13 @@ function vendorPlugin(): Plugin {
   // the document base URL, which on SPA-fallback deep links can be anywhere
   // inside the app, so relative './vendor/…' paths would break. Absolute
   // paths prefixed with Vite's `base` resolve identically from any route.
+  const vendorUrl = (bundle: string) =>
+    isServe ? `${base}${DEV_VENDOR_DIR}/${bundle}` : `${base}vendor/${bundle}`;
+
   const importMapJson = () =>
     JSON.stringify({
       imports: Object.fromEntries(
-        Object.entries(VENDOR_IMPORT_MAP).map(([k, v]) => [k, `${base}vendor/${v}`])
+        Object.entries(VENDOR_IMPORT_MAP).map(([k, v]) => [k, vendorUrl(v)])
       ),
     });
 
@@ -274,7 +279,9 @@ function vendorPlugin(): Plugin {
       base = config.base;
       isServe = config.command === 'serve';
       projectRoot = config.root;
-      outdir = path.resolve(projectRoot, 'public', 'vendor');
+      outdir = isServe
+        ? path.resolve(projectRoot, DEV_VENDOR_DIR)
+        : path.resolve(projectRoot, 'public', 'vendor');
       await ensureBuilt();
     },
     buildStart() {
@@ -285,14 +292,13 @@ function vendorPlugin(): Plugin {
     },
     // Without this, Vite pre-bundles bare 'react' into .vite/deps and
     // rewrites Studio's imports to that URL, giving Studio its own React
-    // while plugins use the vendor copy. Redirecting to the vendor URL
-    // in dev matches the prod externalization so a single React instance
-    // is shared at runtime.
+    // while plugins use the vendor copy. Resolving to the same file the
+    // dev import map points at keeps one shared instance at runtime.
     resolveId(id) {
       if (!isServe) return null;
       const mapped = VENDOR_IMPORT_MAP[id];
       if (mapped) {
-        return { id: `${base}vendor/${mapped}`, external: true };
+        return path.resolve(outdir, mapped);
       }
       return null;
     },


### PR DESCRIPTION
`pnpm dev:app` serves a blank Studio — `#app` stays empty and no React tree mounts. Reproduces on `origin/main` (f45c965677), not just feature branches. Two independent causes, plus ~300 error lines per start that hid both.

Linear: [ASTD-355](https://linear.app/nvidia/issue/ASTD-355)

## 1. `react-compiler-runtime` CJS interop (deterministic)

```
SyntaxError: The requested module '.../react-compiler-runtime/dist/index.js?v=...'
does not provide an export named 'c'
```

`packages/common` imports `childrenToText` from `@nvidia/foundations-react-core/lib` (5 call sites). That subpath isn't in `VENDOR_IMPORT_MAP`, so it isn't served from the vendor bundle, and its parent package *is* in `optimizeDeps.exclude` — so Vite serves KUI's raw dist. That dist is React Compiler output importing CJS `react-compiler-runtime`, which never gets pre-bundled, so the named export `c` doesn't exist. The module graph throws before `createRoot` runs.

Plain `include: ['react-compiler-runtime']` fails under pnpm (`Failed to resolve dependency` — not a direct dep), so the nested `>` form is required.

## 2. Vendor bundle 404 race (intermittent)

On a cold start, `react-router.js` and `react-router-dom.js` 404'd despite being on disk — also a blank app. `buildVendorBundles` wipes and rewrites its output dir from `configureServer`, after Vite has already snapshotted `publicDir` and started gating requests on that cached file set. Bundles landing after the snapshot were unservable, and which ones lost the race varied per run. Building in `configResolved` puts every bundle on disk before the server comes up.

## 3. ~300 `Pre-transform error` lines per dev start

```
Pre-transform error: Failed to load url /vendor/react.js (resolved id: /vendor/react.js)
in .../main.tsx. This file is in /public and will be copied as-is during build ...
```

`vendorPlugin.resolveId` returned `{ id, external: true }`, but Vite's client dev environment ignores plugin-set `external` — `importAnalysis.normalizeUrl` only short-circuits protocol URLs, and `shouldExternalize` is gated on `ssr`. Same in Vite v5 through v8, so this is long-standing, not a v8 regression. Every rewritten import therefore entered the module graph, where a file under `publicDir` can only be served as a static asset and never resolved as a module.

Dev now builds the bundles to `node_modules/.vendor` and points both the rewrite and the import map there, so Vite resolves them as ordinary modules. Production is unchanged: still `public/vendor`, still `/vendor/*` in the import map.

Harmless at runtime — the browser fetched the static copy either way — but it buried both failures above, which is why this is worth fixing rather than filtering.

## Testing

Headless Chromium against the dev server: app mounts, nav and the Agents page render, each of the six vendor bundles is fetched exactly once from `/node_modules/.vendor/` (one shared React instance), and the dev log is clean — 0 pre-transform errors, down from ~300. Only remaining console failures are `localhost:8080/apis/plugins` 404s from not running the backend.

`vite build` verified separately: `dist/vendor/*` emitted as before and the shipped import map still points at `/vendor/*`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-time dependency resolution for more reliable local builds and previews.
  * Updated development vendor asset handling to prevent stale or missing local assets, while preserving production behavior.
  * Improved preview mode so existing vendor bundles are served consistently without unnecessary rebuilding.
* **Performance**
  * Enhanced dependency pre-bundling to support Foundations more efficiently and improve development startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->