### PR TITLE
feat(anonymizer): advertise the preview num_records maximum [ASTD-356]

### DIFF
--- a/plugins/nemo-anonymizer/openapi/openapi.yaml
+++ b/plugins/nemo-anonymizer/openapi/openapi.yaml
@@ -1301,6 +1301,7 @@ components:
           $ref: '#/components/schemas/SelectedModelsOverrides'
         num_records:
           type: integer
+          maximum: 10.0
           minimum: 1.0
           title: Num Records
           default: 10

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/task_config.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/task_config.py
@@ -12,6 +12,7 @@ from anonymizer.config.anonymizer_config import AnonymizerConfig
 from anonymizer.config.replace_strategies import Annotate, Hash, Redact, ReplaceMethodBase, Substitute
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
 from nemo_anonymizer_plugin.app.model_configs import SelectedModelsOverrides
+from nemo_anonymizer_plugin.config import DEFAULT_MAX_PREVIEW_NUM_RECORDS
 from pydantic import BaseModel, Field, field_serializer
 
 _REPLACE_METHOD_KINDS: dict[type[ReplaceMethodBase], str] = {
@@ -54,7 +55,12 @@ class AnonymizerRequest(BaseModel):
 
 
 class PreviewRequest(AnonymizerRequest):
-    num_records: int = Field(default=10, ge=1)
+    # Annotated, not `le=`: deployments may raise `preview_num_records.max` past this.
+    num_records: int = Field(
+        default=DEFAULT_MAX_PREVIEW_NUM_RECORDS,
+        ge=1,
+        json_schema_extra={"maximum": DEFAULT_MAX_PREVIEW_NUM_RECORDS},
+    )
 
 
 class AnonymizerStepConfig(BaseModel):

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/config.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/config.py
@@ -21,9 +21,14 @@ if _dd_bundled_tiktoken_cache.is_dir():
     os.environ.setdefault("TIKTOKEN_CACHE_DIR", str(_dd_bundled_tiktoken_cache))
 
 
+#: Advertised as ``maximum`` on ``PreviewRequest.num_records``; deployments may raise the
+#: runtime bound past it, so the schema states the default rather than the effective limit.
+DEFAULT_MAX_PREVIEW_NUM_RECORDS = 10
+
+
 class PreviewNumRecords(BaseModel):
-    max: int = Field(default=10, ge=1)
-    default: int = Field(default=10, ge=1)
+    max: int = Field(default=DEFAULT_MAX_PREVIEW_NUM_RECORDS, ge=1)
+    default: int = Field(default=DEFAULT_MAX_PREVIEW_NUM_RECORDS, ge=1)
 
     @model_validator(mode="after")
     def check_compatibility(self) -> Self:

--- a/plugins/nemo-anonymizer/tests/unit/test_task_config.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_task_config.py
@@ -11,6 +11,7 @@ from anonymizer.config.anonymizer_config import AnonymizerConfig
 from anonymizer.config.replace_strategies import Redact
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
 from nemo_anonymizer_plugin.app.task_config import AnonymizerRequest, PreviewRequest
+from nemo_anonymizer_plugin.config import DEFAULT_MAX_PREVIEW_NUM_RECORDS
 
 
 def _config() -> AnonymizerConfig:
@@ -43,6 +44,23 @@ def test_anonymizer_request_accepts_fileset_source_without_local_path_validation
     )
 
     assert req.data.source == "team-a/pii-inputs#data/input.parquet"
+
+
+def test_preview_num_records_advertises_the_default_maximum() -> None:
+    schema = PreviewRequest.model_json_schema()["properties"]["num_records"]
+
+    assert schema["minimum"] == 1
+    assert schema["maximum"] == DEFAULT_MAX_PREVIEW_NUM_RECORDS
+
+
+def test_preview_num_records_leaves_the_ceiling_to_the_configured_max() -> None:
+    req = PreviewRequest(
+        config=_config(),
+        data=AnonymizerInputSpec(source="https://example.com/x.csv", text_column="text"),
+        num_records=DEFAULT_MAX_PREVIEW_NUM_RECORDS + 1,
+    )
+
+    assert req.num_records == DEFAULT_MAX_PREVIEW_NUM_RECORDS + 1
 
 
 def test_request_dump_preserves_replace_discriminator() -> None:

--- a/plugins/nemo-anonymizer/tests/unit/test_task_config.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_task_config.py
@@ -51,6 +51,7 @@ def test_preview_num_records_advertises_the_default_maximum() -> None:
 
     assert schema["minimum"] == 1
     assert schema["maximum"] == DEFAULT_MAX_PREVIEW_NUM_RECORDS
+    assert schema["default"] == DEFAULT_MAX_PREVIEW_NUM_RECORDS
 
 
 def test_preview_num_records_leaves_the_ceiling_to_the_configured_max() -> None:


### PR DESCRIPTION
Puts the anonymizer preview's `num_records` ceiling into the API schema, so clients stop having to guess it.

Closes [ASTD-356](https://linear.app/nvidia/issue/ASTD-356/express-the-anonymizer-preview-num-records-bound-in-the-api-schema).

## The problem

The preview endpoint has always capped `num_records`, but only imperatively:

```python
# functions/preview.py:168-178
if requested_num_records > config.preview_num_records.max:
    raise HTTPException(status_code=422, detail=f"Max num records for preview requests is {...}")
```

The field itself declared just a lower bound (`Field(default=10, ge=1)`), so the maximum never reached `openapi.yaml`, the generated `PreviewRequest.ts`, or the zod validator. A client that trusted the schema sent `num_records: 500` and got a 422 it had no way to anticipate. ASTD-332 worked around this by hardcoding `MAX_PREVIEW_ROWS = 10` in Studio — duplicating a server-owned value.

## Why `json_schema_extra` and not `le=`

`le=10` would be simpler and self-enforcing, and it's wrong here. The effective ceiling is `preview_num_records.max`, which an operator can raise via `NEMO_ANONYMIZER_PREVIEW_NUM_RECORDS_MAX` or `platformConfig.anonymizer`. Pydantic validates before the handler runs, so a static `le=` would reject 11 on a server configured to accept 50 — quietly capping the knob at its default and turning the config into a lie.

Building the constraint from `get_config()` at import time was the other option and is worse: `make refresh-openapi` output would depend on local env, so anyone with that variable set would commit spec drift.

So the annotation states the *default* bound — what a client can know without asking the server — and runtime enforcement stays where it belongs. The accepted cost is that a deployment which raises the max advertises a stale `maximum: 10`. Strictly better than advertising nothing.

## What lands

`DEFAULT_MAX_PREVIEW_NUM_RECORDS` is now the single source for both the `PreviewNumRecords` default and the field annotation, so they can't drift.

The spec regenerated to exactly one added line (`maximum: 10.0`) — no incidental churn. `web/packages/sdk/generated/` is gitignored, so there's nothing to commit for it, but `pnpm gen` confirms it picks the bound up: `PreviewRequest.ts` gains `@maximum 10` and the zod schema emits `anonymizerPreviewfunctionRouteBodyNumRecordsMax = 10` with `.max(...)`. Studio inherits it on the next regen.

Two tests: one asserts the schema reports `maximum`, the other constructs a `PreviewRequest` with 11 and asserts it *succeeds* — that one is the real guard, since it fails the moment someone "tidies" this into `le=`.

## Verification

`ruff check` and `ruff format --check` clean. Plugin unit tests pass (12/12 across `test_task_config.py`, `test_config.py`, `test_preview_function.py`). `ty` reports 7 diagnostics in the plugin — identical before and after this change (verified by stashing), all pre-existing on `main`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview requests now advertise a maximum of 10 records in the API schema.
  * The default preview record limit is consistently set to 10.

* **Bug Fixes**
  * Preview request validation now correctly supports higher record counts when deployment-specific limits allow them.
  * Preview requests continue to enforce a minimum of 1 record.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->