### PR TITLE
feat(eval-author): reject an Insight suite whose metrics were never authored

### DIFF
--- a/plugins/nemo-eval-author/src/nemo_eval_author_plugin/eval_author/agent.py
+++ b/plugins/nemo-eval-author/src/nemo_eval_author_plugin/eval_author/agent.py
@@ -9,6 +9,7 @@ before beginning insight-driven optimization.
 
 import asyncio
 import logging
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,38 @@ from nooa.config.summarizer_config import TokenBudgetConfig
 from nooa.tools import TodoManager
 
 logger = logging.getLogger(__name__)
+
+
+class EvalAuthorUnauthoredTasksError(DatasetValidationError):
+    """Metric authoring left at least one task in the Insight suite untouched.
+
+    Subclasses ``DatasetValidationError`` so the caller's repair loop treats a skipped
+    task the same as a malformed one and feeds this message back as validation feedback.
+    """
+
+    def __init__(self, paths: Sequence[str]) -> None:
+        """Name the tasks whose verifiers never changed, and what to do about it."""
+        self.paths = tuple(paths)
+        listed = "\n".join(f"  - {path}" for path in self.paths)
+        super().__init__(
+            f"Metric authoring left {len(self.paths)} of the Insight suite's verifiers byte-identical, "
+            f"so those tasks carry no Insight metric:\n{listed}\n"
+            "Every task in the suite needs the same Insight metric key set. Add it to each task listed above."
+        )
+
+
+def _assert_every_task_authored(suite: InsightSuite, before: dict[str, str]) -> None:
+    """Fail when a task's verifier is unchanged since before metric authoring.
+
+    A static comparison, so a skipped task costs seconds here instead of surfacing as an
+    aggregation error after a full evaluation has already run. ``before`` stays pinned to
+    the pre-authoring snapshot across repair attempts: the question is whether a task was
+    ever authored, not whether it changed on the most recent attempt.
+    """
+    after = suite.verifier_hashes()
+    unauthored = sorted(path for path, digest in after.items() if before.get(path) == digest)
+    if unauthored:
+        raise EvalAuthorUnauthoredTasksError(unauthored)
 
 
 class EvalAuthor(Agent):
@@ -186,6 +219,21 @@ class EvalAuthor(Agent):
         The root cause is that the agent does not retrieve the full set of relevant database
         objects for Y, so X is missing from its context.  Measure whether the agent retrieves
         all required objects, not merely whether X appears in the final answer.
+
+        **Never score a trial you could not measure**
+
+        ``0.0`` means the agent definitively exhibited the bad behavior, so it must never
+        double as "the check could not run".  When the runtime artifact is missing or
+        unparseable, a judge call raises, or a judge response will not parse, let the
+        exception propagate and exit non-zero without writing the metric file.  The harness
+        then marks the trial failed, excludes it from aggregation, and surfaces the error.
+
+        An ``except Exception: score = 0.0`` fallback is forbidden.  It reports maximum
+        failure on every trial, which no downstream consumer can tell apart from a real
+        regression: the metric looks healthy, sits at a constant, and gives an optimizer
+        nothing to climb.  Equally, never write a partial metric file and never drop the
+        metric key while still exiting zero — completed trials that disagree on metric keys
+        abort aggregation outright.
 
         Return a concise summary naming the new metric key(s), what they measure, and
         which runtime evidence they score. The caller retains the materialized suite and
@@ -394,6 +442,7 @@ class EvalAuthor(Agent):
         runner_conventions = await self.discover_runner(materialized_dataset)
         if reporter is not None:
             reporter.progress(phase="eval author · authoring metrics")
+        verifiers_before_authoring = insight_suite.verifier_hashes()
         summary = await self.author_insight_metrics(
             insight,
             diagnostics,
@@ -402,6 +451,7 @@ class EvalAuthor(Agent):
         )
         for repair_attempt in range(self._config.max_validation_repair_attempts + 1):
             try:
+                _assert_every_task_authored(insight_suite, verifiers_before_authoring)
                 await materialized_dataset.validate()
             except DatasetValidationError as exc:
                 if repair_attempt >= self._config.max_validation_repair_attempts:

--- a/plugins/nemo-eval-author/src/nemo_eval_author_plugin/eval_author/materialization.py
+++ b/plugins/nemo-eval-author/src/nemo_eval_author_plugin/eval_author/materialization.py
@@ -315,6 +315,28 @@ class InsightSuite:
         pending_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         os.replace(pending_path, manifest_path)
 
+    def verifier_hashes(self) -> dict[str, str]:
+        """Return each promoted task's verifier content hash, keyed by task directory.
+
+        Comparing these before and after metric authoring is what proves the authoring
+        agent reached every task. A hash that survives unchanged means that task never
+        received the Insight metric, which otherwise surfaces much later as a ragged
+        metric key set that aborts aggregation partway through an evaluation.
+        """
+        manifest = json.loads((self.suite_dir / "manifest.json").read_text(encoding="utf-8"))
+        raw_tasks = manifest.get("tasks")
+        if not isinstance(raw_tasks, list):
+            raise ValueError(f"Insight suite manifest has invalid tasks: {self.suite_dir / 'manifest.json'}")
+
+        hashes: dict[str, str] = {}
+        for entry in raw_tasks:
+            relative_path = entry.get("path") if isinstance(entry, dict) else None
+            if not isinstance(relative_path, str) or not relative_path:
+                raise ValueError(f"Insight suite manifest task has invalid path: {entry!r}")
+            verifier_dir = _verifier_dir(self.suite_dir / relative_path)
+            hashes[relative_path] = f"sha256:{_canonical_digest(_file_hashes(verifier_dir))}"
+        return hashes
+
     def finalize(self) -> FinalizedInsightSuite:
         """Persist content identities on the experiment-local authored suite."""
         manifest_path = self.suite_dir / "manifest.json"

--- a/plugins/nemo-eval-author/tests/test_eval_author_agent.py
+++ b/plugins/nemo-eval-author/tests/test_eval_author_agent.py
@@ -6,7 +6,7 @@
 import asyncio
 import inspect
 import io
-from collections.abc import Sequence
+from collections.abc import Callable, Collection, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
@@ -14,7 +14,7 @@ from typing import Any, cast
 
 import pytest
 from nemo_eval_author_plugin.eval_author import agent as eval_author_module
-from nemo_eval_author_plugin.eval_author.agent import EvalAuthor
+from nemo_eval_author_plugin.eval_author.agent import EvalAuthor, EvalAuthorUnauthoredTasksError
 from nemo_eval_author_plugin.eval_author.models import EvalAuthorConfig
 from nemo_experimentalist_plugin.entities import Dataset, DatasetValidationError, Task, TrialResult
 from nemo_experimentalist_plugin.experimentalist.components.trace_analyzer import (
@@ -57,6 +57,9 @@ class _PipelineCalls:
     discovered_datasets: list[Dataset]
     author_args: list[tuple[Insight, list[tuple[str, Diagnostic]], Dataset, str, str | None]]
     suite_discards: int
+    # Tests that swap in their own authoring fake call this to act like an agent that
+    # edited every verifier, so the authoring-coverage check sees the suite as authored.
+    mark_all_authored: Callable[[], None]
 
 
 @dataclass
@@ -152,7 +155,25 @@ def _install_pipeline(
     eval_author: EvalAuthor,
     *,
     materialized_dataset: Dataset | None = None,
+    skip_authoring: Sequence[Collection[str]] = (),
 ) -> _PipelineCalls:
+    """Install fakes for one Eval Author pipeline run.
+
+    ``skip_authoring`` names the task ids the authoring fake leaves untouched, indexed by
+    authoring attempt, so a test can reproduce the real agent silently missing a task.
+    """
+    next_analyzer = 0
+    # Stands in for the verifier content hashes on disk: promotion seeds it and each
+    # authoring attempt advances the tasks it actually edited.
+    verifier_state: dict[str, str] = {}
+    authoring_rounds = 0
+
+    def mark_all_authored() -> None:
+        nonlocal authoring_rounds
+        authoring_rounds += 1
+        for task_id in verifier_state:
+            verifier_state[task_id] = f"sha256:authored-{authoring_rounds}"
+
     calls = _PipelineCalls(
         fill_task_template=[],
         analyzer_init=[],
@@ -160,8 +181,8 @@ def _install_pipeline(
         discovered_datasets=[],
         author_args=[],
         suite_discards=0,
+        mark_all_authored=mark_all_authored,
     )
-    next_analyzer = 0
 
     class FakeInsightSuite:
         def __init__(self, *, task_template: Task, **_: Any) -> None:
@@ -185,12 +206,17 @@ def _install_pipeline(
         def promote_local(self, trace_refs: list[str], staged_tasks: list[Any]) -> Dataset:
             assert trace_refs == [staged.trace_ref for staged in staged_tasks]
             tasks = [staged.result for staged in staged_tasks]
+            verifier_state.clear()
+            verifier_state.update({task.id: "sha256:pre-authoring" for task in tasks})
             if materialized_dataset is not None:
                 materialized_dataset.tasks = tasks
                 self.materialized_dataset = materialized_dataset
                 return materialized_dataset
             self.materialized_dataset = Dataset(id="insight-suite", tasks=tasks)
             return self.materialized_dataset
+
+        def verifier_hashes(self) -> dict[str, str]:
+            return dict(verifier_state)
 
         def discard(self) -> None:
             calls.suite_discards += 1
@@ -295,6 +321,14 @@ def _install_pipeline(
                     validation_feedback,
                 )
             )
+            attempt = len(calls.author_args) - 1
+            skipped = skip_authoring[attempt] if attempt < len(skip_authoring) else ()
+            if not skipped:
+                mark_all_authored()
+            else:
+                for task_id in verifier_state:
+                    if task_id not in skipped:
+                        verifier_state[task_id] = f"sha256:authored-{attempt}-partial"
             return "authored insight metrics"
 
     eval_author.fill_task_template = cast(Any, FillTaskTemplate())
@@ -599,7 +633,7 @@ async def test_run_feeds_validation_failures_back_for_one_repair_attempt(
 ) -> None:
     eval_author = _eval_author(tmp_path)
     insight_dataset = _RepairableDataset("insight-suite", "task 'insight-a': check.py:2:1: invalid syntax")
-    _install_pipeline(
+    calls = _install_pipeline(
         monkeypatch,
         [_diagnostic("diagnostic")],
         eval_author,
@@ -621,6 +655,7 @@ async def test_run_feeds_validation_failures_back_for_one_repair_attempt(
             validation_feedback: str | None = None,
         ) -> str:
             feedback.append(validation_feedback)
+            calls.mark_all_authored()
             if validation_feedback is not None:
                 insight_dataset.error = None
             return "repaired insight metric"
@@ -674,6 +709,124 @@ async def test_run_raises_after_validation_repair_budget_is_exhausted(
     assert calls.author_args[0][-1] is None
     assert calls.author_args[1][-1] is not None
     assert insight_dataset.validate_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_run_repairs_a_task_metric_authoring_silently_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Static checks pass on a task that was never touched, because a verifier missing the
+    # Insight metric is still valid Python. The gap only shows up as ragged metric keys
+    # after a full evaluation has run, so compare verifier hashes and repair immediately.
+    eval_author = _eval_author(tmp_path, max_validation_repair_attempts=1)
+    calls = _install_pipeline(
+        monkeypatch,
+        [_diagnostic("one"), _diagnostic("two")],
+        eval_author,
+        skip_authoring=[{"task-trace-2"}],
+    )
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: None)
+
+    result = await eval_author.run(
+        _insight(["trace-1", "trace-2"]),
+        Path("agent"),
+        Task(id="template"),
+        Dataset(id="train"),
+        Dataset(id="validation"),
+        client=cast(Any, object()),
+    )
+
+    assert len(calls.author_args) == 2
+    feedback = calls.author_args[1][-1]
+    assert feedback is not None
+    assert "task-trace-2" in feedback
+    assert "byte-identical" in feedback
+    assert result.insight_suite_identity is not None
+
+
+@pytest.mark.asyncio
+async def test_run_raises_when_a_task_is_never_authored_within_the_repair_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    eval_author = _eval_author(tmp_path, max_validation_repair_attempts=1)
+    calls = _install_pipeline(
+        monkeypatch,
+        [_diagnostic("one"), _diagnostic("two")],
+        eval_author,
+        skip_authoring=[{"task-trace-2"}, {"task-trace-2"}],
+    )
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: None)
+
+    with pytest.raises(EvalAuthorUnauthoredTasksError) as exc_info:
+        await eval_author.run(
+            _insight(["trace-1", "trace-2"]),
+            Path("agent"),
+            Task(id="template"),
+            Dataset(id="train"),
+            Dataset(id="validation"),
+            client=cast(Any, object()),
+        )
+
+    assert exc_info.value.paths == ("task-trace-2",)
+    assert len(calls.author_args) == 2
+
+
+class _FailsValidationOnceDataset(Dataset):
+    def __init__(self, id: str) -> None:
+        super().__init__(id=id)
+        self.validate_calls = 0
+
+    async def validate(self) -> None:
+        self.validate_calls += 1
+        if self.validate_calls == 1:
+            raise DatasetValidationError("task 'insight-a': check.py:2:1: invalid syntax")
+
+
+@pytest.mark.asyncio
+async def test_run_accepts_a_task_authored_on_an_earlier_repair_attempt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The pre-authoring snapshot is the baseline for every attempt, so a task authored on
+    # attempt one must not be reported as skipped when a later repair touches only its
+    # sibling. The check asks whether a task was ever authored, not whether it changed last.
+    eval_author = _eval_author(tmp_path, max_validation_repair_attempts=2)
+    insight_dataset = _FailsValidationOnceDataset("insight-suite")
+    calls = _install_pipeline(
+        monkeypatch,
+        [_diagnostic("one"), _diagnostic("two")],
+        eval_author,
+        materialized_dataset=insight_dataset,
+        skip_authoring=[(), {"task-trace-1"}],
+    )
+    monkeypatch.setattr(eval_author_module.cache, "store", lambda *args: None)
+
+    result = await eval_author.run(
+        _insight(["trace-1", "trace-2"]),
+        Path("agent"),
+        Task(id="template"),
+        Dataset(id="train"),
+        Dataset(id="validation"),
+        client=cast(Any, object()),
+    )
+
+    assert len(calls.author_args) == 2
+    assert insight_dataset.validate_calls == 2
+    assert result.insight_suite_identity is not None
+
+
+def test_eval_author_prompts_forbid_scoring_a_trial_that_could_not_be_measured() -> None:
+    # A judge that crashes and writes 0.0 is indistinguishable from a real regression: the
+    # metric reads as healthy while sitting at a constant, so nothing can improve it.
+    prompt = _prompt(EvalAuthor.author_insight_metrics)
+
+    assert "Never score a trial you could not measure" in prompt
+    assert 'must never double as "the check could not run"' in prompt
+    assert "let the exception propagate and exit non-zero without writing the metric file" in prompt
+    assert "``except Exception: score = 0.0`` fallback is forbidden" in prompt
+    assert "never drop the metric key while still exiting zero" in prompt
 
 
 def test_eval_author_config_defaults_and_bounds_validation_repair_attempts() -> None:
@@ -755,7 +908,7 @@ async def test_run_with_reporter_emits_repair_progress(
     reporter, sink = _string_reporter()
     eval_author = _eval_author(tmp_path, max_validation_repair_attempts=2, reporter=reporter)
     insight_dataset = _RepairableDataset("insight-suite", "task 'insight-a': check.py:2:1: invalid syntax")
-    _install_pipeline(
+    calls = _install_pipeline(
         monkeypatch,
         [_diagnostic("diagnostic")],
         eval_author,
@@ -772,6 +925,7 @@ async def test_run_with_reporter_emits_repair_progress(
             runner_conventions: str,
             validation_feedback: str | None = None,
         ) -> str:
+            calls.mark_all_authored()
             if validation_feedback is not None:
                 insight_dataset.error = None
             return "repaired insight metric"

--- a/plugins/nemo-eval-author/tests/test_eval_author_materialization.py
+++ b/plugins/nemo-eval-author/tests/test_eval_author_materialization.py
@@ -276,3 +276,44 @@ def test_finalized_suite_identity_is_stable_and_changes_with_task_or_verifier_co
     assert changed_verifier_identity != first_identity
     assert changed_scorer_identity != first_scorer_identity
     assert list((tmp_path / "eval-and-optimize" / "eval_author").glob("*/artifacts")) == []
+
+
+def test_verifier_hashes_track_each_task_independently(tmp_path: Path) -> None:
+    # The caller snapshots these around metric authoring to catch a task the authoring
+    # agent never touched, so an edit to one verifier must not perturb its siblings.
+    template = _write_template(tmp_path / "template")
+    refs = ["trace-1", "trace-2"]
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+
+    staged = suite.stage(refs)
+    for index, task in enumerate(staged, start=1):
+        (task.path / "instruction.md").write_text(f"Reproduce scenario {index}.\n", encoding="utf-8")
+        suite.validate(task)
+    suite.promote_local(refs, staged)
+
+    before = suite.verifier_hashes()
+    assert sorted(before) == sorted(task.slug for task in staged)
+
+    authored = suite.suite_dir / staged[0].slug / "tests" / "check_behavior.py"
+    authored.write_text("print('scored')\n", encoding="utf-8")
+    after = suite.verifier_hashes()
+
+    assert after[staged[0].slug] != before[staged[0].slug]
+    assert after[staged[1].slug] == before[staged[1].slug]
+
+
+def test_verifier_hashes_ignore_edits_outside_the_verifier_directory(tmp_path: Path) -> None:
+    # Authoring is only allowed to add grades, so a changed instruction must not read as
+    # an authored verifier and let a skipped task slip through the coverage check.
+    template = _write_template(tmp_path / "template")
+    suite = InsightSuite(experiment_dir=tmp_path, insight_id="insight-1", task_template=template)
+
+    staged = suite.stage(["trace-1"])
+    (staged[0].path / "instruction.md").write_text("Reproduce the scenario.\n", encoding="utf-8")
+    suite.validate(staged[0])
+    suite.promote_local(["trace-1"], staged)
+
+    before = suite.verifier_hashes()
+    (suite.suite_dir / staged[0].slug / "instruction.md").write_text("Rewritten.\n", encoding="utf-8")
+
+    assert suite.verifier_hashes() == before


### PR DESCRIPTION
Tracking: [ASE-780](https://linear.app/nvidia/issue/ASE-780/fix-eval-author-bugs-with-insight-suite-passing-to)

## Summary

Two ways the Insight suite could ship without the signal it exists to provide. Both turned up while running the authoring pipeline end to end against a real agent, and both are silent — the suite looks healthy in every artifact and report.

**A task was never authored.** The authoring agent augmented six of seven verifiers and nothing noticed. A verifier missing the Insight metric is still valid Python, so every static check passed; the gap only surfaced after a full evaluation had run, as a ragged metric key set that aborted aggregation. This snapshots each task's verifier content hash around authoring and compares them. A hash that survives byte-identical means that task never received the metric. `EvalAuthorUnauthoredTasksError` subclasses `DatasetValidationError`, so the existing repair loop feeds it back as validation feedback and names the offending tasks — turning a wasted evaluation into a few seconds.

The snapshot stays pinned to the pre-authoring baseline across repair attempts, because the question is whether a task was *ever* authored, not whether it changed on the latest pass.

**A judge that could not run reported maximum failure.** An authored LLM judge wrapped itself in `except Exception: score = 0.0`. In a run where the judge was misconfigured, all 50 trials recorded a valid-looking `0.0` — indistinguishable downstream from an agent that genuinely exhibited the bad behavior. The metric read as healthy while pinned to a constant, contributing a tied Pareto axis and no gradient for any consumer to climb. The authoring prompt already defines `0.0` as "complete failure" and gave the model no way to express "could not evaluate", so `except: score = 0.0` was the natural thing to write. It now instructs the model to let the exception propagate and leave the metric file unwritten, which marks the trial failed and excludes it from aggregation.

## Scope note

An earlier attempt at this grew ~2,030 lines into `loop.py`, `models.py`, `terminator.py`, and `analyzer.py`, splitting the suite into held-out halves and wiring the validation half into Pareto selection. That ran against the direction `tests/test_plugin_boundary.py` already declares — *"Eval Author is meant to end up standalone, with Experimentalist depending on it and not the other way around"* — so it has been handed to the Experimentalist team as #1086 instead.

The Eval Author's deliverable is a well-formed dataset of tasks, verifiers, and metrics derived from an Insight's production traces. Consumers decide how to use it: the suite ships flat, each task carries its `source_trace_ref` so a consumer can split by trace without leakage, and the user's train and validation datasets are still returned untouched. This PR therefore adds no Experimentalist-side code and no new rows to the boundary allowlist.

## Verification

- `plugins/nemo-eval-author`: 64 passed, 2 skipped
- `plugins/nemo-experimentalist`: 594 passed (the consumer, unchanged)
- `ruff check`, `ruff format --check`, and `ty check` clean

New tests cover a skipped task routing into repair and recovering, a task never authored exhausting the repair budget, a task authored on an earlier attempt not being re-flagged when a later repair touches only its sibling, per-task hash independence, and hashes ignoring edits outside the verifier directory.

## Test plan

- [ ] Re-run the authoring pipeline against an Insight with more traces and a working judge, and confirm the authored metric produces varying scores rather than a constant