### PR TITLE
fix(auditor): isolate garak cache per pytest-xdist worker

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,14 +12,21 @@ files for more specific fixtures.
 import logging
 import os
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
-from typing import Generator
 
-import pytest
-from nmp.testing.pytest_outcomes import pytest_skip as skip_test
+from tests.xdist_cache import xdist_worker_xdg_cache_home
 
-from tests.auth_idp.xdist import append_xdist_group_suffix
-from tests.discovery_exclusions import TEST_DISCOVERY_EXCLUSIONS
+_xdist_cache_home = xdist_worker_xdg_cache_home(os.environ)
+if _xdist_cache_home is not None:
+    os.environ["XDG_CACHE_HOME"] = _xdist_cache_home
+    os.environ["NMP_PYTEST_XDIST_CACHE_HOME_ISOLATED"] = "1"
+
+import pytest  # noqa: E402
+from nmp.testing.pytest_outcomes import pytest_skip as skip_test  # noqa: E402
+
+from tests.auth_idp.xdist import append_xdist_group_suffix  # noqa: E402
+from tests.discovery_exclusions import TEST_DISCOVERY_EXCLUSIONS  # noqa: E402
 
 # Set test environment variables BEFORE any imports
 # This must happen at module level, before pytest even starts processing

--- a/tests/unit/test_pytest_xdist_cache.py
+++ b/tests/unit/test_pytest_xdist_cache.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from tests.xdist_cache import xdist_worker_xdg_cache_home
+
+
+def test_xdist_worker_xdg_cache_home_uses_worker_specific_path(tmp_path):
+    environ = {
+        "XDG_CACHE_HOME": str(tmp_path),
+        "PYTEST_XDIST_TESTRUNUID": "run123",
+        "PYTEST_XDIST_WORKER": "gw2",
+    }
+
+    assert xdist_worker_xdg_cache_home(environ) == str(tmp_path / "pytest-xdist" / "run123" / "gw2")
+
+
+def test_xdist_worker_xdg_cache_home_skips_non_xdist_process():
+    assert xdist_worker_xdg_cache_home({}) is None

--- a/tests/xdist_cache.py
+++ b/tests/xdist_cache.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+
+
+def xdist_worker_xdg_cache_home(environ: Mapping[str, str]) -> str | None:
+    """Return an isolated XDG cache path for each pytest-xdist worker.
+
+    garakapi copies its packaged plugin cache into ``$XDG_CACHE_HOME/garak`` at
+    import time, then immediately reads the copied JSON file. During xdist
+    collection, multiple workers can import garakapi at the same time and race on
+    the shared cache file, which can surface as intermittent JSONDecodeError
+    during test collection. Isolating XDG_CACHE_HOME per worker keeps that
+    test-only behavior out of garakapi's production code.
+    """
+    worker_id = environ.get("PYTEST_XDIST_WORKER")
+    if not worker_id or environ.get("NMP_PYTEST_XDIST_CACHE_HOME_ISOLATED"):
+        return None
+
+    base_cache_home = Path(environ.get("XDG_CACHE_HOME") or environ.get("RUNNER_TEMP") or tempfile.gettempdir())
+    run_uid = environ.get("PYTEST_XDIST_TESTRUNUID", "default")
+    return str(base_cache_home / "pytest-xdist" / run_uid / worker_id)


### PR DESCRIPTION
When running tests in parallel with pytest-xdist, multiple workers share the same XDG_CACHE_HOME, causing garak to read and write cached data concurrently and producing flaky test failures.

Set a worker-specific XDG_CACHE_HOME (scoped by test run UID and worker ID) before any imports so that each xdist worker gets its own isolated cache directory. A no-op env var (NMP_PYTEST_XDIST_CACHE_HOME_ISOLATED) prevents nested conftest files from re-applying the override. Adds unit tests for the path-derivation logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running tests in parallel by isolating cache data for each worker.
  * Prevented cache-related conflicts during test collection.
  * Preserved existing cache behavior for standard, non-parallel test runs.

* **Tests**
  * Added coverage for worker-specific cache directory paths.
  * Added coverage confirming isolation is disabled when parallel execution is inactive or already configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->