### PR TITLE
docs(experimentalist): point the nooa pin at the file that actually has it

### DIFF
--- a/plugins/nemo-experimentalist/AGENTS.md
+++ b/plugins/nemo-experimentalist/AGENTS.md
@@ -120,11 +120,14 @@ instead of restoring Curator imports, configuration, or aliases. The obsolete
   Configure Platform services, trace storage, and Insights analysis according
   to the Platform documentation; this repository does not own a service,
   scheduler, or testbed setup.
-- `nooa` is pinned to an immutable public GitHub revision in `pyproject.toml`,
-  currently a commit rather than a tag because the MCP transport-timeout fix
-  landed after `v0.0.6`. Update the revision, the matching pin in
-  `examples/tau3-nooa-agent/pyproject.toml`, and both lock files together. Keep
-  the Platform-supplied Insights plugin separate.
+- `nooa` is pinned to an immutable public GitHub revision in the workspace root
+  `pyproject.toml` under `[tool.uv.sources]`; this plugin's `pyproject.toml` only
+  declares the dependency. It is a commit rather than a tag because the callable
+  `@strategy(llm=...)` support this plugin depends on landed after `v0.0.8`.
+  Update the root pin, the matching pin in
+  `examples/tau3-nooa-agent/pyproject.toml`, the revision quoted in
+  `framework-skills/nooa/SKILL.md`, and both lock files together. Keep the
+  Platform-supplied Insights plugin separate.
 - This branch uses merged Platform PR 718 contracts only. After the Platform
   handoff lands, rebase and repin before adopting any new Platform testbed or
   installer interfaces.

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -23,9 +23,10 @@ Requires `uv >=0.9.14,<0.10.0`.
 **To verify an end-to-end run, follow
 [Get started with an example agent](../../docs/get-started/example-agent.mdx).**
 
-The source dependencies are pinned to tagged or immutable revisions in
-`pyproject.toml`. NVIDIA-labs OO Agents (NOOA) is pinned to a public GitHub
-commit, currently one past `v0.0.6` that carries an MCP transport-timeout fix.
+The source dependencies are pinned to tagged or immutable revisions in the
+workspace root `pyproject.toml` under `[tool.uv.sources]`. NVIDIA-labs OO Agents
+(NOOA) is pinned to a public GitHub commit past `v0.0.8` that carries the
+callable `@strategy(llm=...)` support this plugin depends on.
 
 ## Insight-to-experiment flow
 

--- a/plugins/nemo-experimentalist/framework-skills/nooa/SKILL.md
+++ b/plugins/nemo-experimentalist/framework-skills/nooa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: nooa
 description: Build, modify, debug, or optimize agents using NVIDIA-labs OO Agents (NOOA). Use for nooa.Agent subclasses, ellipsis generation methods, CodeAct or Predict strategies, ShellTools, Skill/TextSkill, context and persistence, MCP, tracing, middleware, channels, or trace analysis.
-compatibility: Python >= 3.12,<3.14; uv; nooa at the revision pinned in pyproject.toml
+compatibility: Python >= 3.12,<3.14; uv; nooa at the revision pinned in the workspace root pyproject.toml
 metadata:
   upstream: https://github.com/NVIDIA-NeMo/labs-OO-Agents
   revision: 6e0274dd03f883254a084cfb9f871ea580e03434
@@ -11,14 +11,16 @@ metadata:
 
 # NVIDIA-labs OO Agents (NOOA)
 
-Use the `nooa` package and namespace pinned in this repository.
+Use the `nooa` package and namespace this repository pins. The revision is set in
+the workspace root `pyproject.toml` under `[tool.uv.sources]` — the plugin's own
+`pyproject.toml` declares `nooa` without one.
 
 For detailed framework guidance, consult the skills at the immutable upstream
 revision this repository pins:
 https://github.com/NVIDIA-NeMo/labs-OO-Agents/tree/6e0274dd03f883254a084cfb9f871ea580e03434/skills
 
 Before changing framework behavior, inspect the pinned implementation or the
-matching upstream skill instead of guessing. In Optimizer:
+matching upstream skill instead of guessing. In Experimentalist:
 
 - Call `super().__init__()` before attaching tools or skills.
 - Use `GuardedShellTools` where workspace access must remain restricted.


### PR DESCRIPTION
the nooa framework skill tells you to use the revision "pinned in `pyproject.toml`," but `plugins/nemo-experimentalist/pyproject.toml` declares a bare `nooa` with no revision.

The pin is in the **workspace root** `pyproject.toml` under `[tool.uv.sources]`, which is where uv resolves workspace members from, and `uv.lock` pins the commit accordingly. So this is a docs pointer bug, not a missing pin. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated NOOA dependency guidance to reference the workspace-root pinned revision.
  - Documented support for callable `@strategy(llm=...)` usage with newer NOOA revisions.
  - Clarified which related files must be updated together and where to review compatibility details.
  - Removed outdated references to the previous version and transport-timeout fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->