### PR TITLE
fix: Update stale skills

### DIFF
--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/SKILL.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: [describe the dataset and how PII should be handled]
 
 Do not explore the workspace first. The workflow's Learn step gives you everything you need.
 
-**Source of truth.** For anything you're unsure about, prefer the in-tree CLI docs over your memory: `docs/anonymizer/index.md`, `docs/anonymizer/cli.md`, and `docs/anonymizer/tutorials/{index,preview,run}.md`. The [NVIDIA NeMo Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) own detection, replacement strategy parameters, and rewrite-mode semantics.
+**Source of truth.** For anything you're unsure about, prefer the in-tree CLI docs over your memory: `docs/anonymizer/index.mdx`, `docs/anonymizer/cli.mdx`, and `docs/anonymizer/tutorials/{index,preview,run}.mdx`. The [NVIDIA NeMo Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) own detection, replacement strategy parameters, and rewrite-mode semantics.
 
 # Goal
 
@@ -56,7 +56,7 @@ Read **only** the workflow file that matches the selected mode, then follow it:
 # Troubleshooting
 
 - **`nemo anonymizer` CLI not found:** The plugin isn't installed in this environment. From the repo root, run `uv sync`; the root workspace includes the Anonymizer plugin. Confirm with `nemo anonymizer --help`. Do not install anything without the user's permission.
-- **`nemo anonymizer preview submit` returns 404:** The plugin service isn't mounted on the gateway. `nemo setup` does not auto-mount it. Re-run `nemo services run` (no `--services` flag) and verify the routes show up under `/apis/anonymizer/` in the OpenAPI listing. See `docs/anonymizer/tutorials/index.md` Prerequisites.
+- **`nemo anonymizer preview submit` returns 404:** The plugin service isn't mounted on the gateway. `nemo setup` does not auto-mount it. Re-run `nemo services run` (no `--services` flag) and verify the routes show up under `/apis/anonymizer/` in the OpenAPI listing. See `docs/anonymizer/tutorials/index.mdx` Prerequisites.
 - **`model_configs are required for remote execution`:** `preview submit` and `run submit` go through plugin-service / Jobs paths. Add `model_configs` referencing an Inference Gateway provider; use the inference/model-provider docs or skill for provider discovery.
 - **`Input source ... is a local path`:** Plugin-service execution rejects local paths. Either upload the file to a fileset, use an `http(s)` URL, or switch to `preview run` / `run run` (local execution).
 - **`Fileset input ... must resolve to a .csv or .parquet file`:** The `#<path>` fragment points at a directory or a non-CSV/Parquet file. Point it at a single file.

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/preview-review.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/preview-review.md
@@ -2,7 +2,7 @@
 
 Use this when the user has run a preview and asked you to evaluate plugin results before committing to a full run.
 
-Reference docs: `docs/anonymizer/tutorials/preview.md` (frame schema, surfaces, CLI usage). For detection quality, strategy behavior, and rewrite tuning, defer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills.
+Reference docs: `docs/anonymizer/tutorials/preview.mdx` (frame schema, surfaces, CLI usage). For detection quality, strategy behavior, and rewrite tuning, defer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills.
 
 ## What you get back
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/autopilot.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/autopilot.md
@@ -2,7 +2,7 @@
 
 The user has signaled they don't want to answer questions. Make defensible decisions and keep moving. Do **not** run the full `run` job autonomously — finalize with a one-line command the user can launch.
 
-Source of truth for defaults: `docs/anonymizer/tutorials/index.md` and `docs/anonymizer/tutorials/{preview,run}.md`. If anything below conflicts with the docs, the docs win.
+Source of truth for defaults: `docs/anonymizer/tutorials/index.mdx` and `docs/anonymizer/tutorials/{preview,run}.mdx`. If anything below conflicts with the docs, the docs win.
 
 1. **Resolve CLI command** — Run `command -v nemo 2>/dev/null || (test -x .venv/bin/nemo && realpath .venv/bin/nemo) || echo CLI_NOT_FOUND`.
    - If the output is `CLI_NOT_FOUND`, STOP and follow the Troubleshooting section in SKILL.md.

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/interactive.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/interactive.md
@@ -2,7 +2,7 @@
 
 This is an interactive, iterative anonymization design process. Do not disengage from the loop unless the user says they are satisfied.
 
-Source of truth for this workflow: `docs/anonymizer/tutorials/index.md`, `docs/anonymizer/tutorials/preview.md`, and `docs/anonymizer/tutorials/run.md`. Defer to them if the CLI flags or capabilities here look out of date.
+Source of truth for this workflow: `docs/anonymizer/tutorials/index.mdx`, `docs/anonymizer/tutorials/preview.mdx`, and `docs/anonymizer/tutorials/run.mdx`. Defer to them if the CLI flags or capabilities here look out of date.
 
 1. **Resolve CLI command** — Run `command -v nemo 2>/dev/null || (test -x .venv/bin/nemo && realpath .venv/bin/nemo) || echo CLI_NOT_FOUND`.
    - If the output is a path, use `<path> anonymizer` as the command prefix for all `nemo anonymizer …` invocations in this workflow.

--- a/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/SKILL.md
+++ b/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/SKILL.md
@@ -479,4 +479,4 @@ After polling reaches a **terminal** status (`completed`, `error`, or `cancelled
 | Gated HF model auth (`hf-token`, fileset `token_secret`) | `references/troubleshooting.md` § **Gated HuggingFace models** |
 | Post-training eval (base vs LoRA, CHAT format parity) | `references/post-training-eval.md`, `references/eval_helpers.py` |
 
-Related: `plugins/nemo-automodel/README.md`, `plugins/nemo-unsloth/README.md`, `plugins/nemo-rl/README.md`, `docs/customizer/nemo-rl-dpo-plugin-design.md`, `plugins/nemo-customizer/docs/CUSTOMIZATION.md`, skills **`nemo-files`**, **`nemo-status`**, **`nemo-secrets`**.
+Related: `plugins/nemo-automodel/README.md`, `plugins/nemo-unsloth/README.md`, `plugins/nemo-rl/README.md`, `plugins/nemo-customizer/docs/CUSTOMIZATION.md`, skills **`nemo-files`**, **`nemo-status`**, **`nemo-secrets`**.

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/skills/guardrails-plugin/resources/content-safety.md
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/skills/guardrails-plugin/resources/content-safety.md
@@ -16,7 +16,7 @@ Self-check rails reuse the request's main LLM. For dedicated content moderation,
 
 ## Config
 
-This is the production-grade config used in `docs/guardrails/tutorials/content-safety.md`. The two prompts share the same 23-category taxonomy and JSON output schema — they differ only in whether the conversation block includes the agent response.
+This is the production-grade config used in `docs/guardrails/tutorials/content-safety.mdx`. The two prompts share the same 23-category taxonomy and JSON output schema — they differ only in whether the conversation block includes the agent response.
 
 ```json
 {

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/SKILL.md
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/SKILL.md
@@ -41,14 +41,14 @@ Task router for agents helping a person use the NeMo Safe Synthesizer NMP plugin
 ## Answer Contract
 
 - Start with the direct command, diagnosis, or file path.
-- Cite relevant repo docs paths when useful, especially `plugins/nemo-safe-synthesizer/README.md` and `docs/safe-synthesizer/getting-started.md`.
+- Cite relevant repo docs paths when useful, especially `plugins/nemo-safe-synthesizer/README.md` and `docs/safe-synthesizer/getting-started.mdx`.
 - Include one concrete next action unless the user asks for a full walkthrough.
 - If the user asks to change CLI, config, job compilation, or task source code, inspect the plugin code before answering.
 
 ## Next Steps
 
 - Start local usage from `plugins/nemo-safe-synthesizer/README.md`.
-- For product docs, use `docs/safe-synthesizer/getting-started.md`.
+- For product docs, use `docs/safe-synthesizer/getting-started.mdx`.
 - For commands, read `workflows/run.md`.
 - For configuration, read `workflows/config.md`, then `workflows/config-runs.md` for examples.
 - For failures, read `workflows/diagnose.md`.

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/workflows/config.md
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/workflows/config.md
@@ -53,6 +53,6 @@ Use `hf_token_secret` at the top level of the job spec when model initialization
 
 ## Reusing a Previously Trained NSS Model
 
-For **`nemo safe-synthesizer run-local`**, set `config.training.pretrained_model` to the adapter directory from a prior run (for example `./nss-output/adapter`). The plugin reuses that adapter for **generation only** (no retraining). See `docs/safe-synthesizer/about/host-local-development.md`.
+For **`nemo safe-synthesizer run-local`**, set `config.training.pretrained_model` to the adapter directory from a prior run (for example `./nss-output/adapter`). The plugin reuses that adapter for **generation only** (no retraining). See `docs/safe-synthesizer/about/host-local-development.mdx`.
 
 For **platform jobs**, set `pretrained_model_job` at the top level of the job spec; the plugin resolves that job's `adapter` result from Files for generation-only reuse. Use either `pretrained_model_job` or `config.training.pretrained_model`, not both.

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/workflows/run.md
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/skills/safe-synthesizer/workflows/run.md
@@ -49,7 +49,7 @@ Run `command -v nemo 2>/dev/null || (test -x .venv/bin/nemo && realpath .venv/bi
 
 Use platform jobs for normal Safe Synthesizer usage. The platform compiles the spec into a GPU container step that runs the configured Safe Synthesizer task image.
 
-Use the Jobs API or SDK to create the job. The plugin CLI does not expose `nemo safe-synthesizer jobs` commands. For CLI users, point them to the generated Jobs/API surface available in their installed NeMo CLI, or to the Python SDK builder documented in `docs/safe-synthesizer/tutorials/safe-synthesizer-101.md`.
+Use the Jobs API or SDK to create the job. The plugin CLI does not expose `nemo safe-synthesizer jobs` commands. For CLI users, point them to the generated Jobs/API surface available in their installed NeMo CLI, or to the Python SDK builder documented in `docs/safe-synthesizer/tutorials/safe-synthesizer-101.mdx`.
 
 Use host-local execution only when the user is iterating on a local machine with CUDA/GPU access or debugging the task process outside the Jobs backend:
 
@@ -102,7 +102,7 @@ For platform submission, pass this object as the `spec` field in the Jobs API or
 ## Next Steps
 
 - Tune job parameters with `workflows/config.md` and `workflows/config-runs.md`.
-- Reuse a prior adapter or run plugin tests: `docs/safe-synthesizer/about/host-local-development.md`.
+- Reuse a prior adapter or run plugin tests: `docs/safe-synthesizer/about/host-local-development.mdx`.
 - Retrieve job result files with `workflows/results.md`.
 - Interpret output files with `workflows/artifacts.md`.
 - Debug failed runs with `workflows/diagnose.md`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated anonymizer, Guardrails, and Safe Synthesizer documentation links to point to the current `.mdx` pages.
  * Corrected troubleshooting, tutorial, workflow, configuration, and local-development references.
  * Removed an obsolete NeMo-RL DPO design document from related documentation.
  * Improved documentation navigation and reduced the risk of broken or outdated references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->