### PR TITLE
fix(cli): expose intake and experiments commands

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1363,7 +1363,7 @@ nemo files filesets list [OPTIONS]
 * `--workspace`
 * `--page <INTEGER>`: Page number.
 * `--page-size <INTEGER>`: Page size.
-* `--sort <CHOICE>`: The field to sort by. To sort in decreasing order, use `-` in front of the field name. [possible values: created_at, -created_at, updated_at, -updated_at, name, -name]
+* `--sort <CHOICE>`: The field to sort by. To sort in decreasing order, use `-` in front of the field name. [possible values: -created_at, created_at, -updated_at, updated_at, -name, name]
 * `--all-pages`: Fetch all pages
 
 **Filter Options:**
@@ -3185,7 +3185,7 @@ nemo inference prompts list [OPTIONS]
 * `--workspace`
 * `--page <INTEGER>`: Page number.
 * `--page-size <INTEGER>`: Page size.
-* `--sort <CHOICE>`: The field to sort by. To sort in decreasing order, use `-` in front of the field name. [possible values: created_at, -created_at, updated_at, -updated_at, name, -name]
+* `--sort <CHOICE>`: The field to sort by. To sort in decreasing order, use `-` in front of the field name. [possible values: -created_at, created_at, -updated_at, updated_at, -name, name]
 * `--all-pages`: Fetch all pages
 
 **Filter Options:**
@@ -4690,7 +4690,7 @@ nemo models list [OPTIONS]
 * `--workspace`
 * `--page <INTEGER>`: Page number.
 * `--page-size <INTEGER>`: Page size.
-* `--sort <CHOICE>`: The field to sort by. To sort in decreasing order, use `-` in front of the field name. [possible values: created_at, -created_at, updated_at, -updated_at, name, -name]
+* `--sort <CHOICE>`: The field to sort by. To sort in decreasing order, use `-` in front of the field name. [possible values: -created_at, created_at, -updated_at, updated_at, -name, name]
 * `--verbose`: Whether to include full spec details
 * `--all-pages`: Fetch all pages
 
@@ -5339,7 +5339,7 @@ nemo workspaces list [OPTIONS]
 - Object (JSON): `{"name":{"$like":"value"}}` with operators `$eq`, `$like`, `$lt`, `$lte`, `$gt`, `$gte`, `$in`, `$nin`, `$and`, `$or`, `$not`
 * `--page <INTEGER>`: Page number
 * `--page-size <INTEGER>`: Items per page
-* `--sort <CHOICE>`: Sort field [possible values: created_at, -created_at, updated_at, -updated_at, name, -name]
+* `--sort <CHOICE>`: Sort field [possible values: -created_at, created_at, -updated_at, updated_at, -name, name]
 * `--all-pages`: Fetch all pages
 
 **Help:**
@@ -5816,7 +5816,7 @@ nemo guardrail configs list [OPTIONS]
 * `--workspace`
 * `--page <INTEGER>`: Page number.
 * `--page-size <INTEGER>`: Page size.
-* `--sort <CHOICE>`: The field to sort by. To sort in decreasing order, use `-` in front of the field name. [possible values: created_at, -created_at, updated_at, -updated_at, name, -name]
+* `--sort <CHOICE>`: The field to sort by. To sort in decreasing order, use `-` in front of the field name. [possible values: -created_at, created_at, -updated_at, updated_at, -name, name]
 * `--all-pages`: Fetch all pages
 
 **Filter Options:**
@@ -5898,6 +5898,213 @@ nemo guardrail configs update [OPTIONS] NAME
 * `--workspace`
 * `--data`: Guardrail configuration data (JSON string)
 * `--description`: Description of the guardrail config
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Input Options:**
+
+* `--input-file`: Path to JSON file (use '-' for stdin)
+* `--input-data`: Input data for the request (JSON or YAML)
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+### nemo experiments
+
+Manage experiments.
+
+**Usage:**
+
+```shell
+nemo experiments [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `create`: Create Experiment
+* `delete`: Delete Experiment
+* `list`: List Experiments
+* `get`: Get Experiment
+* `update`: Update Experiment
+
+#### nemo experiments create
+
+Create Experiment
+
+**Required fields:** name
+
+**Examples:**
+
+```shell
+nemo experiments create <name> --input-file config.json
+nemo experiments create <name> --input-data '{"name": "value"}'
+echo '{"json": "data"}' | nemo experiments create <name> --input-file -
+nemo experiments create <name> --<option> "value"
+```
+
+**Usage:**
+
+```shell
+nemo experiments create [OPTIONS] [NAME]
+```
+
+**Arguments:**
+
+* `<NAME>`: Workspace-unique experiment name.
+
+**Options:**
+
+* `--workspace`
+* `--default-sort`: Default sort for this experiment's evaluations list, as a `sort`-param string: a comma-separated, ordered list of fields where the first is the primary sort and the rest break ties (leading '-' on a field = descending), e.g. '-evaluators.reward.mean,cost_usd.mean'. Defaults to '-created_at'. Accepts any field the evaluations list `sort` param does; clients apply it as the list `sort` param.
+* `--description`: Human-readable purpose of the experiment.
+* `--insight-id`: Reference to an external insight that seeded this experiment, if any.
+* `--metadata`: Free-form producer metadata for the experiment. (JSON string)
+* `--pareto`: Default X/Y metrics for a group's cost-vs-accuracy Pareto view. Metric ids use the same vocabulary as the evaluations list sort/filter fields — `cost_usd`, `latency_ms`, or `evaluators.<name>`. Defaults to cost (x) vs latency (y): both exist for every group, so the chart always has something to render before anyone customizes it. (JSON string)
+* `--summary`: Human- or agent-authored summary of the experiment's findings.
+* `--exist-ok`: Do not raise an error if the resource already exists. Returns the existing resource.
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Input Options:**
+
+* `--input-file`: Path to JSON file (use '-' for stdin)
+* `--input-data`: Input data for the request (JSON or YAML)
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+#### nemo experiments delete
+
+Delete Experiment
+
+**Usage:**
+
+```shell
+nemo experiments delete [OPTIONS] NAME
+```
+
+**Arguments:**
+
+* `<NAME>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+#### nemo experiments list
+
+List Experiments
+
+**Usage:**
+
+```shell
+nemo experiments list [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+* `--page <INTEGER>`: Page number.
+* `--page-size <INTEGER>`: Page size.
+* `--sort <CHOICE>`: Sort field; prefix with '-' for descending. [possible values: -created_at, created_at, -updated_at, updated_at, -name, name]
+* `--all-pages`: Fetch all pages
+
+**Filter Options:**
+
+* `--filter FILTER_JSON`: Use --filter with JSON for complex/nested queries, or --filter. FIELD options for simple fields. Both can be combined, with field options taking precedence.
+JSON-only fields:
+  metadata: dict[str, str]
+
+Filter experiments by name, insight_id, is_deleted, or a metadata key/value (filter[metadata.\<key>]=\<value>). Pass is_deleted=true to return only soft-deleted experiments; omit to see only live ones.
+* `--filter.insight-id`
+* `--filter.is-deleted`
+* `--filter.name`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for the list of results. [possible values: table, json, yaml, markdown, csv, raw, code]
+* `--no-truncate`: Don't truncate long values in table/markdown/csv output.
+* `--output-columns, -c`: Columns to display: 'default', 'all', or comma-separated names. Only affects table/csv/markdown formats.
+
+#### nemo experiments get
+
+Get Experiment
+
+**Usage:**
+
+```shell
+nemo experiments get [OPTIONS] NAME
+```
+
+**Arguments:**
+
+* `<NAME>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+#### nemo experiments update
+
+Update Experiment
+
+**Required fields:** body_name
+
+**Examples:**
+
+```shell
+nemo experiments update <path_name> --input-file config.json
+nemo experiments update <path_name> --input-data '{"body_name": "value"}'
+echo '{"json": "data"}' | nemo experiments update <path_name> --input-file -
+nemo experiments update <path_name> --<option> "value"
+```
+
+**Usage:**
+
+```shell
+nemo experiments update [OPTIONS] PATH_NAME
+```
+
+**Arguments:**
+
+* `<PATH_NAME>`
+
+**Options:**
+
+* `--workspace`
+* `--body-name`: Workspace-unique experiment name.
+* `--default-sort`: Default sort for this experiment's evaluations list, as a `sort`-param string: a comma-separated, ordered list of fields where the first is the primary sort and the rest break ties (leading '-' on a field = descending), e.g. '-evaluators.reward.mean,cost_usd.mean'. Defaults to '-created_at'. Accepts any field the evaluations list `sort` param does; clients apply it as the list `sort` param.
+* `--description`: Human-readable purpose of the experiment.
+* `--insight-id`: Reference to an external insight that seeded this experiment, if any.
+* `--metadata`: Free-form producer metadata for the experiment. (JSON string)
+* `--pareto`: Default X/Y metrics for a group's cost-vs-accuracy Pareto view. Metric ids use the same vocabulary as the evaluations list sort/filter fields — `cost_usd`, `latency_ms`, or `evaluators.<name>`. Defaults to cost (x) vs latency (y): both exist for every group, so the chart always has something to render before anyone customizes it. (JSON string)
+* `--summary`: Human- or agent-authored summary of the experiment's findings.
 
 **Help:**
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -5911,3 +5911,923 @@ nemo guardrail configs update [OPTIONS] NAME
 **Output Options:**
 
 * `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+### nemo intake
+
+Intake operations.
+
+**Usage:**
+
+```shell
+nemo intake [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `annotations`: Manage annotations
+* `evaluator-results`: Manage evaluator_results
+* `ingest`: Ingest operations
+* `sessions`: Manage sessions
+* `spans`: Manage spans
+* `traces`: Manage traces
+
+#### nemo intake annotations
+
+Manage annotations
+
+**Usage:**
+
+```shell
+nemo intake annotations [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `create`: Create annotations.
+* `delete`: Delete Annotation
+* `list`: List Annotations
+* `get`: Get Annotation
+
+##### nemo intake annotations create
+
+Create annotations.
+
+**Required fields:** kind, session_id
+
+**Examples:**
+
+```shell
+nemo intake annotations create <name> --input-file config.json
+nemo intake annotations create <name> --input-data '{"kind": "value", "session_id": "value"}'
+echo '{"json": "data"}' | nemo intake annotations create <name> --input-file -
+nemo intake annotations create <name> --<option> "value"
+```
+
+**Usage:**
+
+```shell
+nemo intake annotations create [OPTIONS] [NAME]
+```
+
+**Arguments:**
+
+* `<NAME>`
+
+**Options:**
+
+* `--workspace`
+* `--kind <CHOICE>`: (required) [possible values: feedback, note, metadata, label]
+* `--session-id`: (required)
+* `--value`
+* `--span-id`
+* `--text`
+* `--metadata`: JSON string
+* `--value-type <CHOICE>`: [possible values: text, numeric]
+* `--exist-ok`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Input Options:**
+
+* `--input-file`: Path to JSON file (use '-' for stdin)
+* `--input-data`: Input data for the request (JSON or YAML)
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+##### nemo intake annotations delete
+
+Delete Annotation
+
+**Usage:**
+
+```shell
+nemo intake annotations delete [OPTIONS] ANNOTATION_ID
+```
+
+**Arguments:**
+
+* `<ANNOTATION_ID>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+##### nemo intake annotations list
+
+List Annotations
+
+**Usage:**
+
+```shell
+nemo intake annotations list [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+* `--page <INTEGER>`: Page number.
+* `--page-size <INTEGER>`: Page size.
+* `--sort <CHOICE>`: [possible values: created_at, -created_at]
+* `--all-pages`: Fetch all pages
+
+**Filter Options:**
+
+* `--filter FILTER_JSON`: Use --filter with JSON for complex/nested queries, or --filter. FIELD options for simple fields. Both can be combined, with field options taking precedence.
+JSON-only fields:
+  created_at: \{gte: str, lte: str}
+  value_numeric: \{gte: float, lte: float}
+
+Filter annotations by span_id, session_id, kind, name, created_by, and created_at range.
+* `--filter.created-by`
+* `--filter.kind`
+* `--filter.name`
+* `--filter.session-id`
+* `--filter.span-id`
+* `--filter.value-text`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for the list of results. [possible values: table, json, yaml, markdown, csv, raw, code]
+* `--no-truncate`: Don't truncate long values in table/markdown/csv output.
+* `--output-columns, -c`: Columns to display: 'default', 'all', or comma-separated names. Only affects table/csv/markdown formats.
+
+##### nemo intake annotations get
+
+Get Annotation
+
+**Usage:**
+
+```shell
+nemo intake annotations get [OPTIONS] ANNOTATION_ID
+```
+
+**Arguments:**
+
+* `<ANNOTATION_ID>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+#### nemo intake evaluator-results
+
+Manage evaluator_results
+
+**Usage:**
+
+```shell
+nemo intake evaluator-results [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `create`: Create Evaluator Result
+* `list`: List Evaluator Results
+* `get`: Get Evaluator Result
+
+##### nemo intake evaluator-results create
+
+Create Evaluator Result
+
+**Required fields:** data_type, name, session_id, span_id
+
+**Examples:**
+
+```shell
+nemo intake evaluator-results create <name> --input-file config.json
+nemo intake evaluator-results create <name> --input-data '{"data_type": "value", "name": "value", "session_id": "value", "span_id": "value"}'
+echo '{"json": "data"}' | nemo intake evaluator-results create <name> --input-file -
+nemo intake evaluator-results create <name> --<option> "value"
+```
+
+**Usage:**
+
+```shell
+nemo intake evaluator-results create [OPTIONS] [NAME]
+```
+
+**Arguments:**
+
+* `<NAME>`: Evaluator / metric identity (e.g. 'faithfulness/v1').
+
+**Options:**
+
+* `--workspace`
+* `--data-type <CHOICE>`: Discriminator for which of value / string_value carries the payload.  [possible values: NUMERIC, CATEGORICAL, BOOLEAN, TEXT]
+* `--session-id`: Session id the target span belongs to. Denormalized so session-scoped reads stay fast.
+* `--span-id`: Target span id. Not validated against existing spans (loose target policy).
+* `--comment`: Free-text rationale or explanation.
+* `--string-value`: String value. Required when data_type is CATEGORICAL or TEXT.
+* `--value <FLOAT>`: Numeric value. Required when data_type is NUMERIC or BOOLEAN (0|1).
+* `--exist-ok`: Do not raise an error if the resource already exists. Returns the existing resource.
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Input Options:**
+
+* `--input-file`: Path to JSON file (use '-' for stdin)
+* `--input-data`: Input data for the request (JSON or YAML)
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+##### nemo intake evaluator-results list
+
+List Evaluator Results
+
+**Usage:**
+
+```shell
+nemo intake evaluator-results list [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+* `--page <INTEGER>`: Page number.
+* `--page-size <INTEGER>`: Page size.
+* `--sort <CHOICE>`: [possible values: created_at, -created_at, value, -value]
+* `--all-pages`: Fetch all pages
+
+**Filter Options:**
+
+* `--filter FILTER_JSON`: Use --filter with JSON for complex/nested queries, or --filter. FIELD options for simple fields. Both can be combined, with field options taking precedence.
+JSON-only fields:
+  created_at: \{gte: str, lte: str}
+  value: \{gte: float, lte: float}
+
+Filter evaluator results by span_id, session_id, name, data_type, created_by, value range, and created_at range.
+* `--filter.created-by`
+* `--filter.data-type`
+* `--filter.name`
+* `--filter.session-id`
+* `--filter.span-id`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for the list of results. [possible values: table, json, yaml, markdown, csv, raw, code]
+* `--no-truncate`: Don't truncate long values in table/markdown/csv output.
+* `--output-columns, -c`: Columns to display: 'default', 'all', or comma-separated names. Only affects table/csv/markdown formats.
+
+##### nemo intake evaluator-results get
+
+Get Evaluator Result
+
+**Usage:**
+
+```shell
+nemo intake evaluator-results get [OPTIONS] EVALUATOR_RESULT_ID
+```
+
+**Arguments:**
+
+* `<EVALUATOR_RESULT_ID>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+#### nemo intake ingest
+
+Ingest operations
+
+**Usage:**
+
+```shell
+nemo intake ingest [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `atif`: Manage atif
+* `chat-completions`: Manage chat_completions
+* `otlp`: Otlp operations
+
+##### nemo intake ingest atif
+
+Manage atif
+
+**Usage:**
+
+```shell
+nemo intake ingest atif [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `create`: Ingest Atif
+
+###### nemo intake ingest atif create
+
+Ingest Atif
+
+**Required fields:** agent, schema_version
+
+**Examples:**
+
+```shell
+nemo intake ingest atif create --input-file config.json
+nemo intake ingest atif create --input-data '{"agent": {}, "schema_version": "value"}'
+echo '{"json": "data"}' | nemo intake ingest atif create --input-file -
+nemo intake ingest atif create --<option> "value"
+```
+
+**Usage:**
+
+```shell
+nemo intake ingest atif create [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+* `--agent`: JSON string
+* `--schema-version <CHOICE>`: (required) [possible values: ATIF-v1.0, ATIF-v1.1, ATIF-v1.2, ATIF-v1.3, ATIF-v1.4, ATIF-v1.5, ATIF-v1.6, ATIF-v1.7]
+* `--continued-trajectory-ref`
+* `--evaluation-context`: Evaluation context accepted by ingest endpoints (the canonical shape).`extra="ignore"` so a producer still sending retired keys (evaluation_sha, evaluation_run_id, metadata) keeps ingesting without error rather than being rejected. (JSON string)
+* `--extra`: JSON string
+* `--final-metrics`: JSON string
+* `--notes`
+* `--session-id`
+* `--steps`: JSON string
+* `--subagent-trajectories`: JSON string
+* `--trajectory-id`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Input Options:**
+
+* `--input-file`: Path to JSON file (use '-' for stdin)
+* `--input-data`: Input data for the request (JSON or YAML)
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+##### nemo intake ingest chat-completions
+
+Manage chat_completions
+
+**Usage:**
+
+```shell
+nemo intake ingest chat-completions [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `create`: Ingest Chat Completion
+
+###### nemo intake ingest chat-completions create
+
+Ingest Chat Completion
+
+**Required fields:** request, response
+
+**Examples:**
+
+```shell
+nemo intake ingest chat-completions create --input-file config.json
+nemo intake ingest chat-completions create --input-data '{"request": {}, "response": {}}'
+echo '{"json": "data"}' | nemo intake ingest chat-completions create --input-file -
+nemo intake ingest chat-completions create --<option> "value"
+```
+
+**Usage:**
+
+```shell
+nemo intake ingest chat-completions create [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+* `--request`: Flexible captured chat-completions request. (JSON string)
+* `--response`: Flexible captured chat-completions response. (JSON string)
+* `--cost-details`: Additional estimated cost breakdown fields in USD. (JSON string)
+* `--cost-input-usd <FLOAT>`: Estimated input-token cost of this model call in USD.
+* `--cost-output-usd <FLOAT>`: Estimated output-token cost of this model call in USD.
+* `--cost-usd <FLOAT>`: Total estimated cost of this model call in USD. This matches ATIF step metrics; Intake stores it as semantic cost_total_usd on spans.
+* `--evaluation-context`: Evaluation context accepted by ingest endpoints (the canonical shape).`extra="ignore"` so a producer still sending retired keys (evaluation_sha, evaluation_run_id, metadata) keeps ingesting without error rather than being rejected. (JSON string)
+* `--provider`
+* `--session-id`: Groups related chat-completions calls without forcing them into the same trace.
+* `--trace-id`: Opt into joining an existing trace built via OTel or ATIF. This is not a grouping mechanism for chat-completions calls; use session_id to group related calls.
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Input Options:**
+
+* `--input-file`: Path to JSON file (use '-' for stdin)
+* `--input-data`: Input data for the request (JSON or YAML)
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+##### nemo intake ingest otlp
+
+Otlp operations
+
+**Usage:**
+
+```shell
+nemo intake ingest otlp [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `v1`: V1 operations
+
+###### nemo intake ingest otlp v1
+
+V1 operations
+
+**Usage:**
+
+```shell
+nemo intake ingest otlp v1 [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `traces`: Manage traces
+
+**nemo intake ingest otlp v1 traces**
+
+Manage traces
+
+**Usage:**
+
+```shell
+nemo intake ingest otlp v1 traces [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `create`: Ingest Otlp Traces
+
+**nemo intake ingest otlp v1 traces create**
+
+Ingest Otlp Traces
+
+**Examples:**
+
+```shell
+nemo intake ingest otlp v1 traces create --input-file config.json
+nemo intake ingest otlp v1 traces create --input-data '{"field": "value"}'
+echo '{"json": "data"}' | nemo intake ingest otlp v1 traces create --input-file -
+nemo intake ingest otlp v1 traces create --<option> "value"
+```
+
+**Usage:**
+
+```shell
+nemo intake ingest otlp v1 traces create [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Input Options:**
+
+* `--input-file`: Path to JSON file (use '-' for stdin)
+* `--input-data`: Input data for the request (JSON or YAML)
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+#### nemo intake sessions
+
+Manage sessions
+
+**Usage:**
+
+```shell
+nemo intake sessions [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `get`: Get Session
+
+##### nemo intake sessions get
+
+Get Session
+
+**Usage:**
+
+```shell
+nemo intake sessions get [OPTIONS] ID
+```
+
+**Arguments:**
+
+* `<ID>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+#### nemo intake spans
+
+Manage spans
+
+**Usage:**
+
+```shell
+nemo intake spans [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `list`: List Spans
+* `get`: Get Span
+* `evaluator-results`: Manage evaluator_results
+* `groups`: Manage groups
+
+##### nemo intake spans list
+
+List Spans
+
+**Usage:**
+
+```shell
+nemo intake spans list [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+* `--mode <CHOICE>`: Response mode. summary omits payloads and raw attributes; preview includes input and output truncated to 300 characters; detailed returns full payloads and raw attributes. [possible values: summary, preview, detailed]
+* `--page <INTEGER>`: Page number.
+* `--page-size <INTEGER>`: Page size.
+* `--sort <CHOICE>`: [possible values: started_at, -started_at]
+* `--all-pages`: Fetch all pages
+
+**Filter Options:**
+
+* `--filter FILTER_JSON`: Use --filter with JSON for complex/nested queries, or --filter. FIELD options for simple fields. Both can be combined, with field options taking precedence.
+JSON-only fields:
+  started_at: \{gte: str, lte: str}
+
+Filter spans by session_id, trace_id, parent_span_id, project, evaluation context fields, source, kind, status, model, tool_name, provider, agent_id, agent_name, prompt_name, prompt_version, and started_at.
+* `--filter.agent-id`
+* `--filter.agent-name`
+* `--filter.dataset-id`
+* `--filter.dataset-name`
+* `--filter.dataset-version`
+* `--filter.evaluation-id`
+* `--filter.kind`
+* `--filter.model`
+* `--filter.parent-span-id`
+* `--filter.project`
+* `--filter.prompt-name`
+* `--filter.prompt-version`
+* `--filter.provider`
+* `--filter.session-id`
+* `--filter.source`
+* `--filter.status`
+* `--filter.test-case-id`
+* `--filter.tool-name`
+* `--filter.trace-id`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for the list of results. [possible values: table, json, yaml, markdown, csv, raw, code]
+* `--no-truncate`: Don't truncate long values in table/markdown/csv output.
+* `--output-columns, -c`: Columns to display: 'default', 'all', or comma-separated names. Only affects table/csv/markdown formats.
+
+##### nemo intake spans get
+
+Get Span
+
+**Usage:**
+
+```shell
+nemo intake spans get [OPTIONS] SPAN_ID
+```
+
+**Arguments:**
+
+* `<SPAN_ID>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]
+
+##### nemo intake spans evaluator-results
+
+Manage evaluator_results
+
+**Usage:**
+
+```shell
+nemo intake spans evaluator-results [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `list`: List Evaluator Results For Span
+
+###### nemo intake spans evaluator-results list
+
+List Evaluator Results For Span
+
+**Usage:**
+
+```shell
+nemo intake spans evaluator-results list [OPTIONS] SPAN_ID
+```
+
+**Arguments:**
+
+* `<SPAN_ID>`
+
+**Options:**
+
+* `--workspace`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for the list of results. [possible values: table, json, yaml, markdown, csv, raw, code]
+* `--no-truncate`: Don't truncate long values in table/markdown/csv output.
+* `--output-columns, -c`: Columns to display: 'default', 'all', or comma-separated names. Only affects table/csv/markdown formats.
+
+##### nemo intake spans groups
+
+Manage groups
+
+**Usage:**
+
+```shell
+nemo intake spans groups [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `list`: List Span Groups
+
+###### nemo intake spans groups list
+
+List Span Groups
+
+**Usage:**
+
+```shell
+nemo intake spans groups list [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+* `--by`: Comma-separated span fields to group by, e.g.
+* `--page <INTEGER>`: Page number.
+* `--page-size <INTEGER>`: Page size.
+* `--sort <CHOICE>`: [possible values: span_count, -span_count]
+* `--all-pages`: Fetch all pages
+
+**Filter Options:**
+
+* `--filter FILTER_JSON`: Use --filter with JSON for complex/nested queries, or --filter. FIELD options for simple fields. Both can be combined, with field options taking precedence.
+JSON-only fields:
+  started_at: \{gte: str, lte: str}
+
+Filter spans by the same fields as the span list endpoint, then group matching spans by the comma-separated fields in the by query parameter.
+* `--filter.agent-id`
+* `--filter.agent-name`
+* `--filter.dataset-id`
+* `--filter.dataset-name`
+* `--filter.dataset-version`
+* `--filter.evaluation-id`
+* `--filter.kind`
+* `--filter.model`
+* `--filter.parent-span-id`
+* `--filter.project`
+* `--filter.prompt-name`
+* `--filter.prompt-version`
+* `--filter.provider`
+* `--filter.session-id`
+* `--filter.source`
+* `--filter.status`
+* `--filter.test-case-id`
+* `--filter.tool-name`
+* `--filter.trace-id`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for the list of results. [possible values: table, json, yaml, markdown, csv, raw, code]
+* `--no-truncate`: Don't truncate long values in table/markdown/csv output.
+* `--output-columns, -c`: Columns to display: 'default', 'all', or comma-separated names. Only affects table/csv/markdown formats.
+
+#### nemo intake traces
+
+Manage traces
+
+**Usage:**
+
+```shell
+nemo intake traces [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `list`: List Traces
+* `get`: Get Trace
+
+##### nemo intake traces list
+
+List Traces
+
+**Usage:**
+
+```shell
+nemo intake traces list [OPTIONS]
+```
+
+**Options:**
+
+* `--workspace`
+* `--mode <CHOICE>`: Response mode. summary returns root-span fields without payloads or rollups; preview adds token, cost, and span-count rollups plus 300-character input/output previews; detailed returns rollups and full payloads. [possible values: summary, preview, detailed]
+* `--page <INTEGER>`: Page number.
+* `--page-size <INTEGER>`: Page size.
+* `--sort <CHOICE>`: [possible values: started_at, -started_at]
+* `--all-pages`: Fetch all pages
+
+**Filter Options:**
+
+* `--filter FILTER_JSON`: Use --filter with JSON for complex/nested queries, or --filter. FIELD options for simple fields. Both can be combined, with field options taking precedence.
+JSON-only fields:
+  started_at: \{gte: str, lte: str}
+
+Filter root-span-backed traces by id, session_id, root status, root span started_at, evaluation_id, and test_case_id.
+* `--filter.id`
+* `--filter.evaluation-id`
+* `--filter.session-id`
+* `--filter.status`
+* `--filter.test-case-id`
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for the list of results. [possible values: table, json, yaml, markdown, csv, raw, code]
+* `--no-truncate`: Don't truncate long values in table/markdown/csv output.
+* `--output-columns, -c`: Columns to display: 'default', 'all', or comma-separated names. Only affects table/csv/markdown formats.
+
+##### nemo intake traces get
+
+Get Trace
+
+**Usage:**
+
+```shell
+nemo intake traces get [OPTIONS] ID
+```
+
+**Arguments:**
+
+* `<ID>`
+
+**Options:**
+
+* `--workspace`
+* `--mode <CHOICE>`: Response mode. [possible values: summary, preview, detailed]
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--output-format, -f <CHOICE>`: Output format for an entity. [possible values: json, yaml, raw, code]

--- a/docs/fern/snippets/_snippets/cli-summary.mdx
+++ b/docs/fern/snippets/_snippets/cli-summary.mdx
@@ -21,4 +21,4 @@ description: ""
 | Setup | `setup`, `auth`, `services`, `skills` | Set up and run local platform components |
 | CLI functions | `chat`, `docs`, `wait`, `agent`, `plugins` | Interactive, documentation, and agent-oriented workflows |
 | Core plugins | `files`, `inference`, `jobs`, `models`, `secrets`, `workspaces` | Core platform resources |
-| Functional plugins | `guardrail` | Functional service and plugin commands |
+| Functional plugins | `guardrail`, `intake` | Functional service and plugin commands |

--- a/docs/fern/snippets/_snippets/cli-summary.mdx
+++ b/docs/fern/snippets/_snippets/cli-summary.mdx
@@ -21,4 +21,4 @@ description: ""
 | Setup | `setup`, `auth`, `services`, `skills` | Set up and run local platform components |
 | CLI functions | `chat`, `docs`, `wait`, `agent`, `plugins` | Interactive, documentation, and agent-oriented workflows |
 | Core plugins | `files`, `inference`, `jobs`, `models`, `secrets`, `workspaces` | Core platform resources |
-| Functional plugins | `guardrail`, `intake` | Functional service and plugin commands |
+| Functional plugins | `guardrail`, `experiments`, `intake` | Functional service and plugin commands |

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/__init__.py
@@ -53,7 +53,7 @@ API_TOP_LEVEL_ENTRIES = (
         help="Intake operations.",
         panel="Functional plugins",
         kind="group",
-        hidden=True,
+        hidden=False,
     ),
     TopLevelEntry(
         import_path=f"{__package__}.jobs:app",

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/__init__.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/__init__.py
@@ -16,6 +16,14 @@ API_TOP_LEVEL_ENTRIES = (
         hidden=True,
     ),
     TopLevelEntry(
+        import_path=f"{__package__}.experiments:app",
+        name="experiments",
+        help="Manage experiments.",
+        panel="Functional plugins",
+        kind="group",
+        hidden=False,
+    ),
+    TopLevelEntry(
         import_path=f"{__package__}.files:app",
         name="files",
         help="Manage files.",

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/experiments.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/experiments.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: This file is auto-generated
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+import typer
+
+from nemo_platform_ext.cli.core.api import build_kwargs, merge_filter_dict
+from nemo_platform_ext.cli.core.code_generator import handle_code_generation
+from nemo_platform_ext.cli.core.context import CLIContext
+from nemo_platform_ext.cli.core.errors import handle_errors
+from nemo_platform_ext.cli.core.formatters import Column, check_output_columns_with_format, format_output
+from nemo_platform_ext.cli.core.help_formatter import collect_warnings, create_typer_app
+from nemo_platform_ext.cli.core.pagination import PaginationType, fetch_all_pages, warn_if_more_pages
+from nemo_platform_ext.cli.core.stdin_utils import read_data_input_with_flags, read_payload, validate_required_fields
+from nemo_platform_ext.cli.core.types import (
+    EntityOutputFormatOption,
+    ListOutputFormatOption,
+    NoTruncateOption,
+    OutputColumnsOption,
+)
+
+app = create_typer_app(name="experiments", help="Manage experiments")
+
+
+@app.command("create")
+@collect_warnings
+@handle_errors
+def create_experiments(
+    ctx: typer.Context,
+    name: Annotated[str | None, typer.Argument(help="Workspace-unique experiment name. (required)")] = None,
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    default_sort: Annotated[
+        str | None,
+        typer.Option(
+            "--default-sort",
+            help="Default sort for this experiment's evaluations list, as a `sort`-param string: a comma-separated, ordered list of fields where the first is the primary sort and the rest break ties (leading '-' on a field = descending), e.g. '-evaluators.reward.mean,cost_usd.mean'. Defaults to '-created_at'. Accepts any field the evaluations list `sort` param does; clients apply it as the list `sort` param.",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="Human-readable purpose of the experiment.")
+    ] = None,
+    insight_id: Annotated[
+        str | None,
+        typer.Option("--insight-id", help="Reference to an external insight that seeded this experiment, if any."),
+    ] = None,
+    metadata: Annotated[
+        str | None, typer.Option("--metadata", help="Free-form producer metadata for the experiment. (JSON string)")
+    ] = None,
+    pareto: Annotated[
+        str | None,
+        typer.Option(
+            "--pareto",
+            help="Default X/Y metrics for a group's cost-vs-accuracy Pareto view.Metric ids use the same vocabulary as the evaluations list sort/filter fields — `cost_usd`, `latency_ms`, or `evaluators.<name>`. Defaults to cost (x) vs latency (y): both exist for every group, so the chart always has something to render before anyone customizes it. (JSON string)",
+        ),
+    ] = None,
+    summary: Annotated[
+        str | None, typer.Option("--summary", help="Human- or agent-authored summary of the experiment's findings.")
+    ] = None,
+    exist_ok: Annotated[
+        bool | None,
+        typer.Option(
+            "--exist-ok", help="Do not raise an error if the resource already exists. Returns the existing resource."
+        ),
+    ] = None,
+    input_file: Annotated[
+        str | None,
+        typer.Option("--input-file", help="Path to JSON file (use '-' for stdin)", rich_help_panel="Input Options"),
+    ] = None,
+    input_data: Annotated[
+        str | None,
+        typer.Option("--input-data", help="Input data for the request (JSON or YAML)", rich_help_panel="Input Options"),
+    ] = None,
+    output_format: EntityOutputFormatOption = None,
+) -> None:
+    """Create Experiment
+
+    [bold red]Required fields:[/] name
+
+    [green]Examples:[/]
+    nemo experiments create <name> --input-file config.json
+    nemo experiments create <name> --input-data '{"name": "value"}'
+    echo '{"json": "data"}' | nemo experiments create <name> --input-file -
+    nemo experiments create <name> --<option> "value"
+    """
+    # Read base input (optional if all fields provided via flags)
+    if input_file or input_data:
+        input_payload = read_data_input_with_flags(input_file=input_file, input_data=input_data)
+    else:
+        input_payload = {}
+
+    # Apply CLI flag overrides (flags take precedence)
+    if workspace is not None:
+        input_payload["workspace"] = workspace
+    if name is not None:
+        input_payload["name"] = name
+    if default_sort is not None:
+        input_payload["default_sort"] = default_sort
+    if description is not None:
+        input_payload["description"] = description
+    if insight_id is not None:
+        input_payload["insight_id"] = insight_id
+    if metadata is not None:
+        input_payload["metadata"] = read_payload("metadata", metadata)
+    if pareto is not None:
+        input_payload["pareto"] = read_payload("pareto", pareto)
+    if summary is not None:
+        input_payload["summary"] = summary
+    if exist_ok is not None:
+        input_payload["exist_ok"] = exist_ok
+    # Validate required fields are present after merging
+    validate_required_fields(
+        input_payload,
+        ["name"],
+        "experiments create",
+        {
+            "name": "Workspace-unique experiment name. (required)",
+        },
+    )
+
+    all_kwargs = input_payload
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    if handle_code_generation(["experiments"], "create", all_kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    result = client.experiments.create(**all_kwargs)
+
+    format_output(
+        result,
+        is_list=False,
+        output_format=output_format,
+        no_truncate=state.get_no_truncate(),
+        timestamp_format=state.get_timestamp_format(),
+    )
+
+
+@app.command("delete")
+@collect_warnings
+@handle_errors
+def delete_experiments(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Argument()],
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+) -> None:
+    """Delete Experiment"""
+    state: CLIContext = ctx.obj
+    client = state.get_client()
+
+    kwargs = build_kwargs(
+        workspace=workspace,
+    )
+    client.experiments.delete(name, **kwargs)
+
+    typer.echo("✓ Deleted successfully")
+
+
+@app.command("list")
+@collect_warnings
+@handle_errors
+def list_experiments(
+    ctx: typer.Context,
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    filter: Annotated[
+        str | None,
+        typer.Option(
+            "--filter",
+            metavar="FILTER_JSON",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  metadata: dict[str, str]\n\nFilter experiments by name, insight_id, is_deleted, or a metadata key/value (filter[metadata.<key>]=<value>). Pass is_deleted=true to return only soft-deleted experiments; omit to see only live ones.",
+            rich_help_panel="Filter Options",
+        ),
+    ] = None,
+    filter_insight_id: Annotated[
+        str | None, typer.Option("--filter.insight-id", rich_help_panel="Filter Options")
+    ] = None,
+    filter_is_deleted: Annotated[
+        bool | None, typer.Option("--filter.is-deleted", rich_help_panel="Filter Options")
+    ] = None,
+    filter_name: Annotated[str | None, typer.Option("--filter.name", rich_help_panel="Filter Options")] = None,
+    page: Annotated[int | None, typer.Option("--page", help="Page number.")] = None,
+    page_size: Annotated[int | None, typer.Option("--page-size", help="Page size.")] = None,
+    sort: Annotated[
+        Literal["-created_at", "created_at", "-updated_at", "updated_at", "-name", "name"] | None,
+        typer.Option("--sort", help="Sort field; prefix with '-' for descending."),
+    ] = None,
+    output_format: ListOutputFormatOption = None,
+    no_truncate: NoTruncateOption = None,
+    columns: OutputColumnsOption = None,
+    all_pages: Annotated[bool, typer.Option("--all-pages", help="Fetch all pages")] = False,
+) -> None:
+    """List Experiments"""
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    check_output_columns_with_format(columns, output_format)
+
+    default_columns = [
+        Column("name", None),
+        Column("workspace", None),
+        Column("created_at", None),
+    ]
+    if columns is None or str(columns).strip() == "default":
+        columns = default_columns
+
+    kwargs = build_kwargs(
+        workspace=workspace,
+        filter=merge_filter_dict(filter, insight_id=filter_insight_id, is_deleted=filter_is_deleted, name=filter_name),
+        page=page,
+        page_size=page_size,
+        sort=sort,
+    )
+
+    if handle_code_generation(["experiments"], "list", kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    path_args = ()
+    pagination_type = PaginationType.PAGE_NUMBER
+    if all_pages:
+        items = fetch_all_pages(
+            client.experiments.list,
+            path_args=path_args,
+            body_args=kwargs,
+            pagination_type=pagination_type,
+        )
+    else:
+        items = client.experiments.list(*path_args, **kwargs)
+
+    format_output(
+        items,
+        is_list=True,
+        output_format=output_format,
+        output_columns=columns,
+        no_truncate=state.get_no_truncate(no_truncate),
+        timestamp_format=state.get_timestamp_format(),
+    )
+    if not all_pages:
+        warn_if_more_pages(items, pagination_type)
+
+
+@app.command("get")
+@collect_warnings
+@handle_errors
+def retrieve_experiments(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Argument()],
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    output_format: EntityOutputFormatOption = None,
+) -> None:
+    """Get Experiment"""
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    kwargs = build_kwargs(
+        workspace=workspace,
+    )
+    if handle_code_generation(["experiments"], "retrieve", kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    result = client.experiments.retrieve(name, **kwargs)
+
+    format_output(
+        result,
+        is_list=False,
+        output_format=output_format,
+        no_truncate=state.get_no_truncate(),
+        timestamp_format=state.get_timestamp_format(),
+    )
+
+
+@app.command("update")
+@collect_warnings
+@handle_errors
+def update_experiments(
+    ctx: typer.Context,
+    path_name: Annotated[str, typer.Argument()],
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    body_name: Annotated[
+        str | None, typer.Option("--body-name", help="Workspace-unique experiment name. (required)")
+    ] = None,
+    default_sort: Annotated[
+        str | None,
+        typer.Option(
+            "--default-sort",
+            help="Default sort for this experiment's evaluations list, as a `sort`-param string: a comma-separated, ordered list of fields where the first is the primary sort and the rest break ties (leading '-' on a field = descending), e.g. '-evaluators.reward.mean,cost_usd.mean'. Defaults to '-created_at'. Accepts any field the evaluations list `sort` param does; clients apply it as the list `sort` param.",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="Human-readable purpose of the experiment.")
+    ] = None,
+    insight_id: Annotated[
+        str | None,
+        typer.Option("--insight-id", help="Reference to an external insight that seeded this experiment, if any."),
+    ] = None,
+    metadata: Annotated[
+        str | None, typer.Option("--metadata", help="Free-form producer metadata for the experiment. (JSON string)")
+    ] = None,
+    pareto: Annotated[
+        str | None,
+        typer.Option(
+            "--pareto",
+            help="Default X/Y metrics for a group's cost-vs-accuracy Pareto view.Metric ids use the same vocabulary as the evaluations list sort/filter fields — `cost_usd`, `latency_ms`, or `evaluators.<name>`. Defaults to cost (x) vs latency (y): both exist for every group, so the chart always has something to render before anyone customizes it. (JSON string)",
+        ),
+    ] = None,
+    summary: Annotated[
+        str | None, typer.Option("--summary", help="Human- or agent-authored summary of the experiment's findings.")
+    ] = None,
+    input_file: Annotated[
+        str | None,
+        typer.Option("--input-file", help="Path to JSON file (use '-' for stdin)", rich_help_panel="Input Options"),
+    ] = None,
+    input_data: Annotated[
+        str | None,
+        typer.Option("--input-data", help="Input data for the request (JSON or YAML)", rich_help_panel="Input Options"),
+    ] = None,
+    output_format: EntityOutputFormatOption = None,
+) -> None:
+    """Update Experiment
+
+    [bold red]Required fields:[/] body_name
+
+    [green]Examples:[/]
+    nemo experiments update <path_name> --input-file config.json
+    nemo experiments update <path_name> --input-data '{"body_name": "value"}'
+    echo '{"json": "data"}' | nemo experiments update <path_name> --input-file -
+    nemo experiments update <path_name> --<option> "value"
+    """
+    # Read base input (optional if all fields provided via flags)
+    if input_file or input_data:
+        input_payload = read_data_input_with_flags(input_file=input_file, input_data=input_data)
+    else:
+        input_payload = {}
+
+    # Apply CLI flag overrides (flags take precedence)
+    if workspace is not None:
+        input_payload["workspace"] = workspace
+    if body_name is not None:
+        input_payload["body_name"] = body_name
+    if default_sort is not None:
+        input_payload["default_sort"] = default_sort
+    if description is not None:
+        input_payload["description"] = description
+    if insight_id is not None:
+        input_payload["insight_id"] = insight_id
+    if metadata is not None:
+        input_payload["metadata"] = read_payload("metadata", metadata)
+    if pareto is not None:
+        input_payload["pareto"] = read_payload("pareto", pareto)
+    if summary is not None:
+        input_payload["summary"] = summary
+    # Validate required fields are present after merging
+    validate_required_fields(
+        input_payload,
+        ["body_name"],
+        "experiments update",
+        {
+            "body_name": "Workspace-unique experiment name. (required)",
+        },
+    )
+
+    all_kwargs = {"path_name": path_name, **input_payload}
+
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    if handle_code_generation(["experiments"], "update", all_kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    result = client.experiments.update(**all_kwargs)
+
+    format_output(
+        result,
+        is_list=False,
+        output_format=output_format,
+        no_truncate=state.get_no_truncate(),
+        timestamp_format=state.get_timestamp_format(),
+    )

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/filesets.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/files/filesets.py
@@ -202,7 +202,7 @@ def list_filesets(
     page: Annotated[int | None, typer.Option("--page", help="Page number.")] = None,
     page_size: Annotated[int | None, typer.Option("--page-size", help="Page size.")] = None,
     sort: Annotated[
-        Literal["created_at", "-created_at", "updated_at", "-updated_at", "name", "-name"] | None,
+        Literal["-created_at", "created_at", "-updated_at", "updated_at", "-name", "name"] | None,
         typer.Option(
             "--sort", help="The field to sort by. To sort in decreasing order, use `-` in front of the field name."
         ),

--- a/packages/nemo_platform_ext/tests/cli/commands/test_agent.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_agent.py
@@ -193,4 +193,5 @@ class TestAgentCommands:
             "| nemo data-designer | Functional plugins | Plugin commands for data-designer. |",
             "| nemo guardrail | Functional plugins | Manage guardrails. |",
             "| nemo anonymizer | Functional plugins | Plugin commands for anonymizer. |",
+            "| nemo intake | Functional plugins | Intake operations. |",
         ]

--- a/packages/nemo_platform_ext/tests/cli/commands/test_agent.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_agent.py
@@ -193,5 +193,6 @@ class TestAgentCommands:
             "| nemo data-designer | Functional plugins | Plugin commands for data-designer. |",
             "| nemo guardrail | Functional plugins | Manage guardrails. |",
             "| nemo anonymizer | Functional plugins | Plugin commands for anonymizer. |",
+            "| nemo experiments | Functional plugins | Manage experiments. |",
             "| nemo intake | Functional plugins | Intake operations. |",
         ]

--- a/packages/nemo_platform_ext/tests/cli/test_app.py
+++ b/packages/nemo_platform_ext/tests/cli/test_app.py
@@ -198,6 +198,7 @@ def test_generated_api_group_no_arg_help_exits_successfully():
 def test_root_help_includes_lazy_api_commands():
     runner = CliRunner()
     sys.modules.pop("nemo_platform_ext.cli.commands.api.entities", None)
+    sys.modules.pop("nemo_platform_ext.cli.commands.api.experiments", None)
     sys.modules.pop("nemo_platform_ext.cli.commands.api.files", None)
     sys.modules.pop("nemo_platform_ext.cli.commands.api.intake", None)
     sys.modules.pop("nemo_platform_ext.cli.commands.auth", None)
@@ -210,12 +211,15 @@ def test_root_help_includes_lazy_api_commands():
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
+    assert "experiments" in result.stdout
+    assert "Manage experiments." in result.stdout
     assert "files" in result.stdout
     assert "Manage files" in result.stdout
     assert "intake" in result.stdout
     assert "Intake operations." in result.stdout
     assert "entities" not in result.stdout
     assert "nemo_platform_ext.cli.commands.api.entities" not in sys.modules
+    assert "nemo_platform_ext.cli.commands.api.experiments" not in sys.modules
     assert "nemo_platform_ext.cli.commands.api.files" not in sys.modules
     assert "nemo_platform_ext.cli.commands.api.intake" not in sys.modules
     assert "nemo_platform_ext.cli.commands.auth" not in sys.modules

--- a/packages/nemo_platform_ext/tests/cli/test_app.py
+++ b/packages/nemo_platform_ext/tests/cli/test_app.py
@@ -199,6 +199,7 @@ def test_root_help_includes_lazy_api_commands():
     runner = CliRunner()
     sys.modules.pop("nemo_platform_ext.cli.commands.api.entities", None)
     sys.modules.pop("nemo_platform_ext.cli.commands.api.files", None)
+    sys.modules.pop("nemo_platform_ext.cli.commands.api.intake", None)
     sys.modules.pop("nemo_platform_ext.cli.commands.auth", None)
     sys.modules.pop("nemo_platform_ext.cli.commands.use_cases.chat", None)
     sys.modules.pop("nemo_platform_ext.cli.commands.config", None)
@@ -211,9 +212,12 @@ def test_root_help_includes_lazy_api_commands():
     assert result.exit_code == 0
     assert "files" in result.stdout
     assert "Manage files" in result.stdout
+    assert "intake" in result.stdout
+    assert "Intake operations." in result.stdout
     assert "entities" not in result.stdout
     assert "nemo_platform_ext.cli.commands.api.entities" not in sys.modules
     assert "nemo_platform_ext.cli.commands.api.files" not in sys.modules
+    assert "nemo_platform_ext.cli.commands.api.intake" not in sys.modules
     assert "nemo_platform_ext.cli.commands.auth" not in sys.modules
     assert "nemo_platform_ext.cli.commands.use_cases.chat" not in sys.modules
     assert "nemo_platform_ext.cli.commands.config" not in sys.modules

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/__init__.py
@@ -53,7 +53,7 @@ API_TOP_LEVEL_ENTRIES = (
         help="Intake operations.",
         panel="Functional plugins",
         kind="group",
-        hidden=True,
+        hidden=False,
     ),
     TopLevelEntry(
         import_path=f"{__package__}.jobs:app",

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/__init__.py
@@ -16,6 +16,14 @@ API_TOP_LEVEL_ENTRIES = (
         hidden=True,
     ),
     TopLevelEntry(
+        import_path=f"{__package__}.experiments:app",
+        name="experiments",
+        help="Manage experiments.",
+        panel="Functional plugins",
+        kind="group",
+        hidden=False,
+    ),
+    TopLevelEntry(
         import_path=f"{__package__}.files:app",
         name="files",
         help="Manage files.",

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/experiments.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/experiments.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: This file is auto-generated
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+import typer
+
+from nemo_platform.cli.core.api import build_kwargs, merge_filter_dict
+from nemo_platform.cli.core.code_generator import handle_code_generation
+from nemo_platform.cli.core.context import CLIContext
+from nemo_platform.cli.core.errors import handle_errors
+from nemo_platform.cli.core.formatters import Column, check_output_columns_with_format, format_output
+from nemo_platform.cli.core.help_formatter import collect_warnings, create_typer_app
+from nemo_platform.cli.core.pagination import PaginationType, fetch_all_pages, warn_if_more_pages
+from nemo_platform.cli.core.stdin_utils import read_data_input_with_flags, read_payload, validate_required_fields
+from nemo_platform.cli.core.types import (
+    EntityOutputFormatOption,
+    ListOutputFormatOption,
+    NoTruncateOption,
+    OutputColumnsOption,
+)
+
+app = create_typer_app(name="experiments", help="Manage experiments")
+
+
+@app.command("create")
+@collect_warnings
+@handle_errors
+def create_experiments(
+    ctx: typer.Context,
+    name: Annotated[str | None, typer.Argument(help="Workspace-unique experiment name. (required)")] = None,
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    default_sort: Annotated[
+        str | None,
+        typer.Option(
+            "--default-sort",
+            help="Default sort for this experiment's evaluations list, as a `sort`-param string: a comma-separated, ordered list of fields where the first is the primary sort and the rest break ties (leading '-' on a field = descending), e.g. '-evaluators.reward.mean,cost_usd.mean'. Defaults to '-created_at'. Accepts any field the evaluations list `sort` param does; clients apply it as the list `sort` param.",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="Human-readable purpose of the experiment.")
+    ] = None,
+    insight_id: Annotated[
+        str | None,
+        typer.Option("--insight-id", help="Reference to an external insight that seeded this experiment, if any."),
+    ] = None,
+    metadata: Annotated[
+        str | None, typer.Option("--metadata", help="Free-form producer metadata for the experiment. (JSON string)")
+    ] = None,
+    pareto: Annotated[
+        str | None,
+        typer.Option(
+            "--pareto",
+            help="Default X/Y metrics for a group's cost-vs-accuracy Pareto view.Metric ids use the same vocabulary as the evaluations list sort/filter fields — `cost_usd`, `latency_ms`, or `evaluators.<name>`. Defaults to cost (x) vs latency (y): both exist for every group, so the chart always has something to render before anyone customizes it. (JSON string)",
+        ),
+    ] = None,
+    summary: Annotated[
+        str | None, typer.Option("--summary", help="Human- or agent-authored summary of the experiment's findings.")
+    ] = None,
+    exist_ok: Annotated[
+        bool | None,
+        typer.Option(
+            "--exist-ok", help="Do not raise an error if the resource already exists. Returns the existing resource."
+        ),
+    ] = None,
+    input_file: Annotated[
+        str | None,
+        typer.Option("--input-file", help="Path to JSON file (use '-' for stdin)", rich_help_panel="Input Options"),
+    ] = None,
+    input_data: Annotated[
+        str | None,
+        typer.Option("--input-data", help="Input data for the request (JSON or YAML)", rich_help_panel="Input Options"),
+    ] = None,
+    output_format: EntityOutputFormatOption = None,
+) -> None:
+    """Create Experiment
+
+    [bold red]Required fields:[/] name
+
+    [green]Examples:[/]
+    nemo experiments create <name> --input-file config.json
+    nemo experiments create <name> --input-data '{"name": "value"}'
+    echo '{"json": "data"}' | nemo experiments create <name> --input-file -
+    nemo experiments create <name> --<option> "value"
+    """
+    # Read base input (optional if all fields provided via flags)
+    if input_file or input_data:
+        input_payload = read_data_input_with_flags(input_file=input_file, input_data=input_data)
+    else:
+        input_payload = {}
+
+    # Apply CLI flag overrides (flags take precedence)
+    if workspace is not None:
+        input_payload["workspace"] = workspace
+    if name is not None:
+        input_payload["name"] = name
+    if default_sort is not None:
+        input_payload["default_sort"] = default_sort
+    if description is not None:
+        input_payload["description"] = description
+    if insight_id is not None:
+        input_payload["insight_id"] = insight_id
+    if metadata is not None:
+        input_payload["metadata"] = read_payload("metadata", metadata)
+    if pareto is not None:
+        input_payload["pareto"] = read_payload("pareto", pareto)
+    if summary is not None:
+        input_payload["summary"] = summary
+    if exist_ok is not None:
+        input_payload["exist_ok"] = exist_ok
+    # Validate required fields are present after merging
+    validate_required_fields(
+        input_payload,
+        ["name"],
+        "experiments create",
+        {
+            "name": "Workspace-unique experiment name. (required)",
+        },
+    )
+
+    all_kwargs = input_payload
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    if handle_code_generation(["experiments"], "create", all_kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    result = client.experiments.create(**all_kwargs)
+
+    format_output(
+        result,
+        is_list=False,
+        output_format=output_format,
+        no_truncate=state.get_no_truncate(),
+        timestamp_format=state.get_timestamp_format(),
+    )
+
+
+@app.command("delete")
+@collect_warnings
+@handle_errors
+def delete_experiments(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Argument()],
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+) -> None:
+    """Delete Experiment"""
+    state: CLIContext = ctx.obj
+    client = state.get_client()
+
+    kwargs = build_kwargs(
+        workspace=workspace,
+    )
+    client.experiments.delete(name, **kwargs)
+
+    typer.echo("✓ Deleted successfully")
+
+
+@app.command("list")
+@collect_warnings
+@handle_errors
+def list_experiments(
+    ctx: typer.Context,
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    filter: Annotated[
+        str | None,
+        typer.Option(
+            "--filter",
+            metavar="FILTER_JSON",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  metadata: dict[str, str]\n\nFilter experiments by name, insight_id, is_deleted, or a metadata key/value (filter[metadata.<key>]=<value>). Pass is_deleted=true to return only soft-deleted experiments; omit to see only live ones.",
+            rich_help_panel="Filter Options",
+        ),
+    ] = None,
+    filter_insight_id: Annotated[
+        str | None, typer.Option("--filter.insight-id", rich_help_panel="Filter Options")
+    ] = None,
+    filter_is_deleted: Annotated[
+        bool | None, typer.Option("--filter.is-deleted", rich_help_panel="Filter Options")
+    ] = None,
+    filter_name: Annotated[str | None, typer.Option("--filter.name", rich_help_panel="Filter Options")] = None,
+    page: Annotated[int | None, typer.Option("--page", help="Page number.")] = None,
+    page_size: Annotated[int | None, typer.Option("--page-size", help="Page size.")] = None,
+    sort: Annotated[
+        Literal["-created_at", "created_at", "-updated_at", "updated_at", "-name", "name"] | None,
+        typer.Option("--sort", help="Sort field; prefix with '-' for descending."),
+    ] = None,
+    output_format: ListOutputFormatOption = None,
+    no_truncate: NoTruncateOption = None,
+    columns: OutputColumnsOption = None,
+    all_pages: Annotated[bool, typer.Option("--all-pages", help="Fetch all pages")] = False,
+) -> None:
+    """List Experiments"""
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    check_output_columns_with_format(columns, output_format)
+
+    default_columns = [
+        Column("name", None),
+        Column("workspace", None),
+        Column("created_at", None),
+    ]
+    if columns is None or str(columns).strip() == "default":
+        columns = default_columns
+
+    kwargs = build_kwargs(
+        workspace=workspace,
+        filter=merge_filter_dict(filter, insight_id=filter_insight_id, is_deleted=filter_is_deleted, name=filter_name),
+        page=page,
+        page_size=page_size,
+        sort=sort,
+    )
+
+    if handle_code_generation(["experiments"], "list", kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    path_args = ()
+    pagination_type = PaginationType.PAGE_NUMBER
+    if all_pages:
+        items = fetch_all_pages(
+            client.experiments.list,
+            path_args=path_args,
+            body_args=kwargs,
+            pagination_type=pagination_type,
+        )
+    else:
+        items = client.experiments.list(*path_args, **kwargs)
+
+    format_output(
+        items,
+        is_list=True,
+        output_format=output_format,
+        output_columns=columns,
+        no_truncate=state.get_no_truncate(no_truncate),
+        timestamp_format=state.get_timestamp_format(),
+    )
+    if not all_pages:
+        warn_if_more_pages(items, pagination_type)
+
+
+@app.command("get")
+@collect_warnings
+@handle_errors
+def retrieve_experiments(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Argument()],
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    output_format: EntityOutputFormatOption = None,
+) -> None:
+    """Get Experiment"""
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    kwargs = build_kwargs(
+        workspace=workspace,
+    )
+    if handle_code_generation(["experiments"], "retrieve", kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    result = client.experiments.retrieve(name, **kwargs)
+
+    format_output(
+        result,
+        is_list=False,
+        output_format=output_format,
+        no_truncate=state.get_no_truncate(),
+        timestamp_format=state.get_timestamp_format(),
+    )
+
+
+@app.command("update")
+@collect_warnings
+@handle_errors
+def update_experiments(
+    ctx: typer.Context,
+    path_name: Annotated[str, typer.Argument()],
+    workspace: Annotated[str | None, typer.Option("--workspace")] = None,
+    body_name: Annotated[
+        str | None, typer.Option("--body-name", help="Workspace-unique experiment name. (required)")
+    ] = None,
+    default_sort: Annotated[
+        str | None,
+        typer.Option(
+            "--default-sort",
+            help="Default sort for this experiment's evaluations list, as a `sort`-param string: a comma-separated, ordered list of fields where the first is the primary sort and the rest break ties (leading '-' on a field = descending), e.g. '-evaluators.reward.mean,cost_usd.mean'. Defaults to '-created_at'. Accepts any field the evaluations list `sort` param does; clients apply it as the list `sort` param.",
+        ),
+    ] = None,
+    description: Annotated[
+        str | None, typer.Option("--description", help="Human-readable purpose of the experiment.")
+    ] = None,
+    insight_id: Annotated[
+        str | None,
+        typer.Option("--insight-id", help="Reference to an external insight that seeded this experiment, if any."),
+    ] = None,
+    metadata: Annotated[
+        str | None, typer.Option("--metadata", help="Free-form producer metadata for the experiment. (JSON string)")
+    ] = None,
+    pareto: Annotated[
+        str | None,
+        typer.Option(
+            "--pareto",
+            help="Default X/Y metrics for a group's cost-vs-accuracy Pareto view.Metric ids use the same vocabulary as the evaluations list sort/filter fields — `cost_usd`, `latency_ms`, or `evaluators.<name>`. Defaults to cost (x) vs latency (y): both exist for every group, so the chart always has something to render before anyone customizes it. (JSON string)",
+        ),
+    ] = None,
+    summary: Annotated[
+        str | None, typer.Option("--summary", help="Human- or agent-authored summary of the experiment's findings.")
+    ] = None,
+    input_file: Annotated[
+        str | None,
+        typer.Option("--input-file", help="Path to JSON file (use '-' for stdin)", rich_help_panel="Input Options"),
+    ] = None,
+    input_data: Annotated[
+        str | None,
+        typer.Option("--input-data", help="Input data for the request (JSON or YAML)", rich_help_panel="Input Options"),
+    ] = None,
+    output_format: EntityOutputFormatOption = None,
+) -> None:
+    """Update Experiment
+
+    [bold red]Required fields:[/] body_name
+
+    [green]Examples:[/]
+    nemo experiments update <path_name> --input-file config.json
+    nemo experiments update <path_name> --input-data '{"body_name": "value"}'
+    echo '{"json": "data"}' | nemo experiments update <path_name> --input-file -
+    nemo experiments update <path_name> --<option> "value"
+    """
+    # Read base input (optional if all fields provided via flags)
+    if input_file or input_data:
+        input_payload = read_data_input_with_flags(input_file=input_file, input_data=input_data)
+    else:
+        input_payload = {}
+
+    # Apply CLI flag overrides (flags take precedence)
+    if workspace is not None:
+        input_payload["workspace"] = workspace
+    if body_name is not None:
+        input_payload["body_name"] = body_name
+    if default_sort is not None:
+        input_payload["default_sort"] = default_sort
+    if description is not None:
+        input_payload["description"] = description
+    if insight_id is not None:
+        input_payload["insight_id"] = insight_id
+    if metadata is not None:
+        input_payload["metadata"] = read_payload("metadata", metadata)
+    if pareto is not None:
+        input_payload["pareto"] = read_payload("pareto", pareto)
+    if summary is not None:
+        input_payload["summary"] = summary
+    # Validate required fields are present after merging
+    validate_required_fields(
+        input_payload,
+        ["body_name"],
+        "experiments update",
+        {
+            "body_name": "Workspace-unique experiment name. (required)",
+        },
+    )
+
+    all_kwargs = {"path_name": path_name, **input_payload}
+
+    state: CLIContext = ctx.obj
+    output_format = state.get_output_format(output_format)
+
+    if handle_code_generation(["experiments"], "update", all_kwargs, output_format, state):
+        return
+
+    client = state.get_client()
+    result = client.experiments.update(**all_kwargs)
+
+    format_output(
+        result,
+        is_list=False,
+        output_format=output_format,
+        no_truncate=state.get_no_truncate(),
+        timestamp_format=state.get_timestamp_format(),
+    )

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/filesets.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/files/filesets.py
@@ -202,7 +202,7 @@ def list_filesets(
     page: Annotated[int | None, typer.Option("--page", help="Page number.")] = None,
     page_size: Annotated[int | None, typer.Option("--page-size", help="Page size.")] = None,
     sort: Annotated[
-        Literal["created_at", "-created_at", "updated_at", "-updated_at", "name", "-name"] | None,
+        Literal["-created_at", "created_at", "-updated_at", "updated_at", "-name", "name"] | None,
         typer.Option(
             "--sort", help="The field to sort by. To sort in decreasing order, use `-` in front of the field name."
         ),

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_agent.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_agent.py
@@ -193,4 +193,5 @@ class TestAgentCommands:
             "| nemo data-designer | Functional plugins | Plugin commands for data-designer. |",
             "| nemo guardrail | Functional plugins | Manage guardrails. |",
             "| nemo anonymizer | Functional plugins | Plugin commands for anonymizer. |",
+            "| nemo intake | Functional plugins | Intake operations. |",
         ]

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_agent.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_agent.py
@@ -193,5 +193,6 @@ class TestAgentCommands:
             "| nemo data-designer | Functional plugins | Plugin commands for data-designer. |",
             "| nemo guardrail | Functional plugins | Manage guardrails. |",
             "| nemo anonymizer | Functional plugins | Plugin commands for anonymizer. |",
+            "| nemo experiments | Functional plugins | Manage experiments. |",
             "| nemo intake | Functional plugins | Intake operations. |",
         ]

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/test_app.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/test_app.py
@@ -199,6 +199,7 @@ def test_root_help_includes_lazy_api_commands():
     runner = CliRunner()
     sys.modules.pop("nemo_platform.cli.commands.api.entities", None)
     sys.modules.pop("nemo_platform.cli.commands.api.files", None)
+    sys.modules.pop("nemo_platform.cli.commands.api.intake", None)
     sys.modules.pop("nemo_platform.cli.commands.auth", None)
     sys.modules.pop("nemo_platform.cli.commands.use_cases.chat", None)
     sys.modules.pop("nemo_platform.cli.commands.config", None)
@@ -211,9 +212,12 @@ def test_root_help_includes_lazy_api_commands():
     assert result.exit_code == 0
     assert "files" in result.stdout
     assert "Manage files" in result.stdout
+    assert "intake" in result.stdout
+    assert "Intake operations." in result.stdout
     assert "entities" not in result.stdout
     assert "nemo_platform.cli.commands.api.entities" not in sys.modules
     assert "nemo_platform.cli.commands.api.files" not in sys.modules
+    assert "nemo_platform.cli.commands.api.intake" not in sys.modules
     assert "nemo_platform.cli.commands.auth" not in sys.modules
     assert "nemo_platform.cli.commands.use_cases.chat" not in sys.modules
     assert "nemo_platform.cli.commands.config" not in sys.modules

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/test_app.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/test_app.py
@@ -198,6 +198,7 @@ def test_generated_api_group_no_arg_help_exits_successfully():
 def test_root_help_includes_lazy_api_commands():
     runner = CliRunner()
     sys.modules.pop("nemo_platform.cli.commands.api.entities", None)
+    sys.modules.pop("nemo_platform.cli.commands.api.experiments", None)
     sys.modules.pop("nemo_platform.cli.commands.api.files", None)
     sys.modules.pop("nemo_platform.cli.commands.api.intake", None)
     sys.modules.pop("nemo_platform.cli.commands.auth", None)
@@ -210,12 +211,15 @@ def test_root_help_includes_lazy_api_commands():
     result = runner.invoke(app, ["--help"])
 
     assert result.exit_code == 0
+    assert "experiments" in result.stdout
+    assert "Manage experiments." in result.stdout
     assert "files" in result.stdout
     assert "Manage files" in result.stdout
     assert "intake" in result.stdout
     assert "Intake operations." in result.stdout
     assert "entities" not in result.stdout
     assert "nemo_platform.cli.commands.api.entities" not in sys.modules
+    assert "nemo_platform.cli.commands.api.experiments" not in sys.modules
     assert "nemo_platform.cli.commands.api.files" not in sys.modules
     assert "nemo_platform.cli.commands.api.intake" not in sys.modules
     assert "nemo_platform.cli.commands.auth" not in sys.modules

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/cli_config.yaml
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/cli_config.yaml
@@ -45,7 +45,6 @@ top_level:
   intake:
     panel: Functional plugins
     help: Intake operations.
-    hidden: true
   jobs:
     panel: Core plugins
     help: Manage jobs.

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/cli_config.yaml
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/cli_generator/cli_config.yaml
@@ -29,6 +29,9 @@ top_level:
     hidden: true
   audit:
     panel: Functional plugins
+  experiments:
+    panel: Functional plugins
+    help: Manage experiments.
   files:
     panel: Core plugins
     help: Manage files.
@@ -292,12 +295,7 @@ config:
     live_global:
       skip: true
 
-# Experiments are in the OpenAPI spec and SDK (for the frontend) but not yet exposed
-# as CLI commands; drop the skip once the feature is production-ready.
 - resource: [evaluations]
-  skip: true
-
-- resource: [experiments]
   skip: true
 
 - resource: [secrets]


### PR DESCRIPTION
## Summary

- expose `nemo intake` in root CLI help and the agent command inventory
- enable the standalone generated `nemo experiments` entrypoint with create, delete, list, get, and update commands
- regenerate extension/SDK CLI metadata and reference documentation
- add regression coverage for command visibility and lazy loading

## Testing

- `uv run --frozen pytest packages/nemo_platform_ext/tests/cli/ -q` (1132 passed, 2 skipped)
- `uv run --package nemo-platform-sdk-tools pytest tools/nemo-platform-sdk-tools/tests/sdk/cli_generator/ -q` (136 passed)
- `uv run --frozen _nemo --help`
- `uv run --frozen _nemo experiments --help`
- `uv run pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `nemo experiments` command group with create, retrieve, update, delete, and list operations.
  * Added experiment metadata, filtering, sorting, pagination, Pareto settings, and flexible output options.
  * Added the `nemo intake` command group for annotations, evaluator results, ingestion, sessions, spans, span groups, and traces.
  * Intake and experiments now appear in CLI help and documentation.

* **Documentation**
  * Standardized list sorting options across CLI resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->