### PR TITLE
fix(studio): make traces the canonical intake destination

### DIFF
--- a/web/packages/studio/src/components/Layouts/NavigationDrawer/index.test.tsx
+++ b/web/packages/studio/src/components/Layouts/NavigationDrawer/index.test.tsx
@@ -23,8 +23,8 @@ const mockItems = [
     group: 'Evaluate',
     items: [
       {
-        id: 'annotation',
-        slotLabel: 'Annotation',
+        id: 'traces',
+        slotLabel: 'Traces',
         subItems: [
           {
             id: 'entries',
@@ -78,7 +78,7 @@ describe('NavigationDrawer', () => {
       renderWithProjectRoute(<NavigationDrawer items={mockItems} />);
       expect(await screen.findByText('Projects')).toBeInTheDocument();
       expect(await screen.findByText('Customizations')).toBeInTheDocument();
-      expect(await screen.findByText('Annotation')).toBeInTheDocument();
+      expect(await screen.findByText('Traces')).toBeInTheDocument();
       expect(await screen.findByText('Entries')).toBeInTheDocument();
       expect(await screen.findByText('Export Jobs')).toBeInTheDocument();
     });
@@ -119,13 +119,13 @@ describe('NavigationDrawer', () => {
 
       const NavigationDrawer = await importNavigationDrawer();
       renderWithProjectRoute(<NavigationDrawer items={mockItems} />);
-      expect(await screen.findByText('Annotation')).toBeInTheDocument();
+      expect(await screen.findByText('Traces')).toBeInTheDocument();
       expect(await screen.findByText('Entries')).toBeInTheDocument();
       expect(await screen.findByText('Export Jobs')).toBeInTheDocument();
 
       // KUI v1.0 collapsible uses native <details><summary> — find the summary via text.
       // eslint-disable-next-line testing-library/no-node-access
-      const accordionTrigger = screen.getByText('Annotation').closest('summary');
+      const accordionTrigger = screen.getByText('Traces').closest('summary');
       expect(accordionTrigger).not.toBeNull();
 
       // Starts expanded

--- a/web/packages/studio/src/routes/WorkspaceLayout/WorkspaceSideNav.test.tsx
+++ b/web/packages/studio/src/routes/WorkspaceLayout/WorkspaceSideNav.test.tsx
@@ -9,6 +9,24 @@ vi.hoisted(() => {
 });
 
 describe('WorkspaceSideNav', () => {
+  it('links to the traces view by default', () => {
+    renderRoute(<WorkspaceSideNav />, {
+      history: '/workspaces/test-workspace/dashboard',
+      routes: [
+        {
+          path: '/workspaces/:workspace/*',
+          element: <WorkspaceSideNav />,
+        },
+      ],
+    });
+
+    expect(screen.getByRole('link', { name: 'Traces' })).toHaveAttribute(
+      'href',
+      '/workspaces/test-workspace/intake/traces'
+    );
+    expect(screen.queryByRole('link', { name: /annotations?/i })).not.toBeInTheDocument();
+  });
+
   it('omits Optimizer navigation when Optimizer is disabled', () => {
     renderRoute(<WorkspaceSideNav />, {
       history: '/workspaces/test-workspace/dashboard',

--- a/web/packages/studio/src/routes/WorkspaceLayout/WorkspaceSideNav.tsx
+++ b/web/packages/studio/src/routes/WorkspaceLayout/WorkspaceSideNav.tsx
@@ -39,7 +39,7 @@ import {
   getEvaluationResultsRoute,
   getExperimentRoute,
   getGuardrailsRoute,
-  getIntakeRoute,
+  getIntakeTracesRoute,
   getModelCompareRoute,
   getOptimizerRoute,
   getWorkspaceBaseModelsRoute,
@@ -62,7 +62,7 @@ import {
   Home,
   ShieldCheck,
   Sliders,
-  UserPen,
+  Activity,
   Cog,
   Columns3,
   Rocket,
@@ -125,13 +125,13 @@ export const WorkspaceSideNav = ({ collapsed }: { collapsed?: boolean }) => {
         ]
       : [];
 
-    const intakeNav = INTAKE_ENABLED
+    const tracesNav = INTAKE_ENABLED
       ? [
           {
-            id: 'annotation',
-            slotIcon: <UserPen className={iconColorClass} />,
+            id: 'traces',
+            slotIcon: <Activity className={iconColorClass} />,
             slotLabel: 'Traces',
-            href: getIntakeRoute(workspace),
+            href: getIntakeTracesRoute(workspace),
           },
         ]
       : [];
@@ -227,7 +227,7 @@ export const WorkspaceSideNav = ({ collapsed }: { collapsed?: boolean }) => {
       ...dataDesignerNav,
       ...anonymizerNav,
     ];
-    const evaluateItems = [...evalNav, ...intakeNav, ...experimentNav];
+    const evaluateItems = [...evalNav, ...tracesNav, ...experimentNav];
 
     const safetyItems = GUARDRAILS_ENABLED
       ? [

--- a/web/packages/studio/src/routes/agents/CopilotChatRoute/studioUiNavigationSuggestions.test.ts
+++ b/web/packages/studio/src/routes/agents/CopilotChatRoute/studioUiNavigationSuggestions.test.ts
@@ -65,7 +65,7 @@ describe('getStudioUiNavigationSuggestion', () => {
       },
       {
         prompt: 'Review intake annotations',
-        id: 'annotation',
+        id: 'traces',
       },
       {
         prompt: 'Open workspace settings',
@@ -100,6 +100,14 @@ describe('getStudioUiNavigationSuggestion', () => {
     for (const { prompt, id } of cases) {
       expect(getStudioUiNavigationSuggestion(prompt, workspace)).toMatchObject({ id });
     }
+  });
+
+  it('uses the traces destination for intake review prompts', () => {
+    expect(getStudioUiNavigationSuggestion('Review intake annotations', workspace)).toMatchObject({
+      id: 'traces',
+      title: 'Open Traces',
+      href: '/workspaces/default/intake/traces',
+    });
   });
 
   it('prefers agent-specific evaluation routes over general model evaluations', () => {

--- a/web/packages/studio/src/routes/agents/CopilotChatRoute/studioUiNavigationSuggestions.ts
+++ b/web/packages/studio/src/routes/agents/CopilotChatRoute/studioUiNavigationSuggestions.ts
@@ -10,7 +10,7 @@ import {
   getDataDesignerJobListRoute,
   getEvaluationResultsRoute,
   getGuardrailsRoute,
-  getIntakeRoute,
+  getIntakeTracesRoute,
   getModelCompareRoute,
   getNewDataDesignerJobRoute,
   getNewFilesetRoute,
@@ -258,10 +258,10 @@ const STUDIO_UI_DESTINATIONS: readonly StudioUiDestination[] = [
     patterns: [/\bworkspace jobs?\b/i, /\bworkspace job history\b/i],
   },
   {
-    id: 'annotation',
-    title: 'Open Annotation',
-    description: 'Studio has a UI for inspecting intake traces and annotations.',
-    getHref: getIntakeRoute,
+    id: 'traces',
+    title: 'Open Traces',
+    description: 'Studio has a UI for inspecting intake traces and recording feedback.',
+    getHref: getIntakeTracesRoute,
     requiredFeatureFlags: ['intakeEnabled'],
     patterns: [
       /\bintake (annotation|annotations|traces?|trace review)\b/i,

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -496,10 +496,6 @@ export const getFilesetFileRoute = (workspace: string, fileset: string, filePath
   });
 };
 
-export const getIntakeRoute = (workspace: string) => {
-  return generatePath(ROUTES.workspace.intake, { workspace });
-};
-
 export const getIntakeTracesRoute = (workspace: string) => {
   return generatePath(ROUTES.workspace.intakeTraces, { workspace });
 };


### PR DESCRIPTION
## Summary

- use `traces` as the Studio sidebar identity with a trace-oriented icon and direct `/intake/traces` link
- update the Copilot navigation suggestion from “Open Annotation” to “Open Traces” while retaining annotation-review intent matching
- remove the unused intermediate intake route helper and stale annotation navigation fixtures
- add regression coverage for the default Traces label and canonical route

Current `main` already displays “Traces” after #982; this follow-up removes the remaining top-level annotation identity. Span-level annotations remain unchanged because they provide feedback and notes within trace details.

## Validation

- `pnpm --filter nemo-studio-ui test src/routes/WorkspaceLayout/WorkspaceSideNav.test.tsx src/routes/agents/CopilotChatRoute/studioUiNavigationSuggestions.test.ts src/components/Layouts/NavigationDrawer/index.test.tsx` (11 tests)
- `pnpm --filter nemo-studio-ui lint`
- `pnpm --filter nemo-studio-ui typecheck`
- `uv run pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated workspace navigation to open the Intake Traces view by default.
  * Renamed intake review navigation from “Annotation” to “Traces.”
  * Updated navigation suggestions with the Traces title, description, and destination.

* **Tests**
  * Added coverage confirming Traces navigation appears correctly and annotation navigation is no longer displayed.
  * Updated existing navigation expectations and fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->