### PR TITLE
fix(studio): add delete action menu to guardrail detail page header

### DIFF
--- a/docs/studio/guardrails.mdx
+++ b/docs/studio/guardrails.mdx
@@ -35,6 +35,6 @@ The **Edit** action is not yet available. To modify a configuration, use the `ne
 
 ## Delete a Guardrail Config
 
-Select **Delete** from the row actions menu on the list page, or select **Delete** in the detail page header. Confirm the prompt to remove the configuration. Deletion is permanent.
+Select **Delete** from the row actions menu on the list page, or open the actions menu (**⋯**) in the detail page header and select **Delete**. Confirm the prompt to remove the configuration. Deletion is permanent.
 
 Before deleting a config, check whether it is referenced by any virtual model middleware pipeline. Removing a config that is wired to a virtual model does not automatically remove the middleware reference.

--- a/web/packages/studio/src/routes/guardrails/GuardrailDetailRoute/GuardrailDetailActions.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailDetailRoute/GuardrailDetailActions.tsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useGuardrailsDeleteConfig } from '@nemo/sdk/generated/platform/api';
+import type { GuardrailConfig } from '@nemo/sdk/generated/platform/schema';
+import { DeleteConfirmationModal } from '@studio/components/DeleteConfirmationModal';
+import {
+  type QuickActionItem,
+  QuickActionsMenuRoot,
+} from '@studio/components/QuickActionsMenu/QuickActionsMenuRoot';
+import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { getGuardrailsRoute } from '@studio/routes/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { type FC, useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
+
+interface GuardrailDetailActionsProps {
+  config: GuardrailConfig;
+}
+
+export const GuardrailDetailActions: FC<GuardrailDetailActionsProps> = ({ config }) => {
+  const workspace = useWorkspaceFromPath();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+  const { mutateAsync: deleteConfig } = useGuardrailsDeleteConfig();
+
+  const handleDelete = useCallback(async (): Promise<boolean> => {
+    if (!config.name) return false;
+    try {
+      await deleteConfig({ workspace, name: config.name });
+      await queryClient.invalidateQueries({
+        queryKey: [`/apis/guardrails/v2/workspaces/${workspace}/configs`],
+      });
+      void navigate(getGuardrailsRoute(workspace));
+      return true;
+    } catch {
+      return false;
+    }
+  }, [config.name, deleteConfig, navigate, queryClient, workspace]);
+
+  const actions = useMemo<QuickActionItem[]>(
+    () => [
+      {
+        label: 'Delete',
+        onSelect: () => setShowDeleteModal(true),
+        danger: true,
+      },
+    ],
+    []
+  );
+
+  return (
+    <>
+      <QuickActionsMenuRoot actions={actions} />
+      {showDeleteModal ? (
+        <DeleteConfirmationModal
+          open
+          simpleConfirm
+          title={`Delete guardrail config: ${config.name}`}
+          successText="Guardrail config deleted successfully."
+          errorText="Failed to delete the guardrail config. Please try again."
+          onDelete={handleDelete}
+          onClose={() => setShowDeleteModal(false)}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/web/packages/studio/src/routes/guardrails/GuardrailDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailDetailRoute/index.tsx
@@ -10,6 +10,7 @@ import { Loading } from '@studio/components/Layouts/Loading';
 import { ROUTE_PARAMS, ROUTES } from '@studio/constants/routes';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
+import { GuardrailDetailActions } from '@studio/routes/guardrails/GuardrailDetailRoute/GuardrailDetailActions';
 import { GuardrailFormProvider } from '@studio/routes/guardrails/GuardrailForm/GuardrailFormProvider';
 import { GuardrailHeaderActions } from '@studio/routes/guardrails/GuardrailForm/GuardrailHeaderActions';
 import {
@@ -75,7 +76,10 @@ export const GuardrailDetailRoute: FC = () => {
                 <span className="min-w-0 truncate" title={config.name}>
                   {config.name}
                 </span>
-                <GuardrailHeaderActions />
+                <Flex gap="density-sm" align="center">
+                  <GuardrailHeaderActions />
+                  <GuardrailDetailActions config={config} />
+                </Flex>
               </Flex>
             }
           />


### PR DESCRIPTION
## Summary

- Adds a ⋯ actions menu to the `GuardrailDetailRoute` header with a single **Delete** action
- On confirm, deletes the config and redirects to the guardrails list
- Updates `docs/studio/guardrails.mdx` to reflect the new UX (menu instead of a standalone header button)

## Test plan

- [ ] Open a guardrail config detail page
- [ ] Confirm the ⋯ menu appears in the header alongside the Save/Reset buttons
- [ ] Click ⋯ → Delete, confirm the dialog, verify redirect to the guardrails list
- [ ] Verify the deleted config no longer appears in the list

<img width="1307" height="489" alt="image" src="https://github.com/user-attachments/assets/5be54bdd-b368-4a40-85f4-7ada683c24d3" />

<img width="1314" height="547" alt="image" src="https://github.com/user-attachments/assets/f1b60567-1757-4139-bc6c-eb55291893b4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Delete action to guardrail detail pages.
  - Added a confirmation step with success and failure feedback.
  - Returns to the guardrails list after successful deletion.

- **Documentation**
  - Updated deletion instructions to explain using the detail-page actions menu (**⋯**) before selecting **Delete**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->