### PR TITLE
fix: improve setup recovery diagnostics

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -103,6 +103,7 @@ nemo setup [OPTIONS]
 * `--skills-scope <CHOICE>`: Install scope for skills: 'project' (this repo) or 'user' (home). Default: project. Only applied when --install-skills is set. [possible values: project, user]
 * `--skills-from`: Comma-separated list of skill sources to install from (e.g. 'nemo-platform,nemo-evaluator-plugin'). Use 'nemo-platform' for the built-in set. Default: all sources. Only applied when --install-skills is set.
 * `--deploy-agent, --no-deploy-agent`: Deploy the demo calculator agent
+* `--resume`: Retry an interrupted setup using the normal idempotent setup path.
 * `--ready-timeout <INTEGER>`: Seconds to wait for platform readiness (default: 240)
 
 **Help:**

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -49,6 +49,7 @@ from nemo_platform_ext.client.tls import client_verify_from_env
 from nemo_platform_ext.config.config import Config
 from nemo_platform_ext.config.models import DEFAULT_BASE_URL, ConfigFile, ConfigParams, LocalServicesConfig, NoAuthUser
 from nemo_platform_ext.local.process import (
+    PortConflict,
     check_port_available_for_start,
     compute_scope,
     format_port_conflict,
@@ -997,6 +998,14 @@ _DOCKER_FAILURE_LOG_MARKERS = (
     "Error while fetching server API version",
 )
 
+_PORT_CONFLICT_LOG_MARKERS = (
+    "EADDRINUSE",
+    "address already in use",
+    "address is already in use",
+    "Errno 98",
+    "Only one usage of each socket address",
+)
+
 
 def _services_log_suggests_docker_failure(log_path: Path | None) -> bool:
     """Return True when services.log contains known Docker skip / daemon errors."""
@@ -1007,6 +1016,36 @@ def _services_log_suggests_docker_failure(log_path: Path | None) -> bool:
     except OSError:
         return False
     return any(marker in text for marker in _DOCKER_FAILURE_LOG_MARKERS)
+
+
+def _services_log_suggests_port_conflict(log_path: Path | None) -> bool:
+    """Return True when services.log contains known TCP bind failure markers."""
+    if log_path is None or not log_path.is_file():
+        return False
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    lower_text = text.lower()
+    return any(marker.lower() in lower_text for marker in _PORT_CONFLICT_LOG_MARKERS)
+
+
+def _detect_startup_port_conflict(base_url: str, log_path: Path | None) -> PortConflict | None:
+    """Detect a startup-time port conflict after the services process exits.
+
+    The preflight normally catches busy ports before spawning services. This
+    fallback handles races where the port becomes busy between preflight and
+    uvicorn binding, or where the service process writes the bind failure to
+    ``services.log`` before exiting.
+    """
+    port = _resolve_services_port(base_url)
+    scope = compute_scope(port=port)
+    conflict = check_port_available_for_start(DEFAULT_LOCAL_SERVICES_BIND_HOST, port, scope)
+    if conflict is not None:
+        return conflict
+    if _services_log_suggests_port_conflict(log_path):
+        return PortConflict(kind="foreign", port=port)
+    return None
 
 
 def _should_hint_docker_unavailable(*, exit_code: int | None, log_path: Path | None) -> bool:
@@ -1134,7 +1173,13 @@ def _maybe_start_services(
 
     if not _wait_for_platform(base_url, timeout=timeout, log_path=log, proc=proc):
         exit_code = proc.poll()
-        if exit_code is not None:
+        startup_conflict = _detect_startup_port_conflict(base_url, log) if exit_code is not None else None
+        if startup_conflict is not None:
+            lines = format_port_conflict(startup_conflict)
+            console.print(f"{CROSS} {lines[0]}")
+            for line in lines[1:]:
+                console.print(f"  {line}")
+        elif exit_code is not None:
             console.print(f"{CROSS} Service process exited early (exit code {exit_code})")
         else:
             proc.terminate()
@@ -2073,6 +2118,13 @@ def setup_command(
         bool | None,
         typer.Option("--deploy-agent/--no-deploy-agent", help="Deploy the demo calculator agent"),
     ] = None,
+    resume: Annotated[
+        bool,
+        typer.Option(
+            "--resume",
+            help="Retry an interrupted setup using the normal idempotent setup path.",
+        ),
+    ] = False,
     ready_timeout: Annotated[
         int | None,
         typer.Option(
@@ -2120,6 +2172,8 @@ def setup_command(
     base_url = cli_context.get_base_url() or DEFAULT_BASE_URL
 
     console.print("\n[bold cyan]NeMo Platform Setup[/bold cyan]\n")
+    if resume:
+        console.print(f"{CHECK} Retrying setup using the normal idempotent setup path.\n")
 
     if not auto and not is_interactive():
         console.print(f"\n{CROSS} Detected non-interactive shell. Pass [bold]--auto[/bold] or run in a TTY.\n")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/local/process.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/local/process.py
@@ -288,7 +288,7 @@ def format_port_conflict(err: PortConflict) -> list[str]:
             "Or restart with:    nemo services restart",
         ]
     return [
-        f"Port {err.port} is already in use by another process.",
+        f"Port {err.port} is already in use by another process (EADDRINUSE).",
         "Free the port or choose a different one:",
         f"lsof -i :{err.port}          (see what's listening)",
         f"nemo services run --port {SUGGESTED_ALT_PORT}",

--- a/packages/nemo_platform_ext/tests/cli/commands/test_services_lifecycle.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_services_lifecycle.py
@@ -724,7 +724,7 @@ class TestPortAvailability:
         [
             (
                 PortConflict(kind="foreign", port=8080),
-                ("already in use", "lsof -i :8080"),
+                ("already in use", "EADDRINUSE", "lsof -i :8080"),
             ),
             (
                 PortConflict(kind="nemo_instance", port=8080, scope="abc-8080"),

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -47,6 +47,7 @@ from nemo_platform_ext.cli.commands.setup import (
     _create_provider,
     _deploy_demo_agent,
     _detect_coding_agents,
+    _detect_startup_port_conflict,
     _ensure_port_available_for_start,
     _filter_agents_by_scope,
     _find_project_root,
@@ -68,6 +69,7 @@ from nemo_platform_ext.cli.commands.setup import (
     _run_interactive_mode,
     _save_data_dir,
     _select_model_pair,
+    _services_log_suggests_port_conflict,
     _start_services_background,
     _validate_api_key,
     _verify_platform_health,
@@ -864,8 +866,33 @@ class TestMaybeStartServices:
         maybe_start_preflight_mocks.assert_not_called()
         captured = capsys.readouterr()
         assert "already in use" in captured.err
+        assert "EADDRINUSE" in captured.err
         assert "lsof" in captured.err
         assert "services.log" not in captured.err
+
+    def test_early_exit_names_eaddrinuse_when_startup_log_has_bind_failure(
+        self, maybe_start_preflight_mocks, capsys, tmp_path
+    ):
+        """Post-spawn bind failures should not collapse to a generic early-exit message."""
+        dead = MagicMock(pid=999)
+        dead.poll.return_value = 1
+        log = tmp_path / "services.log"
+        log.write_text("OSError: [Errno 98] Address already in use\n", encoding="utf-8")
+        with (
+            patch(f"{SETUP_MOD}.check_port_available_for_start", return_value=None),
+            patch(f"{SETUP_MOD}._wait_for_platform", return_value=False),
+            patch(f"{SETUP_MOD}.log_path_for", return_value=log),
+            patch(f"{SETUP_MOD}.validate_docker_available", return_value=True),
+            patch(f"{SETUP_MOD}._pause"),
+            pytest.raises(ClickExit),
+        ):
+            maybe_start_preflight_mocks.return_value = dead
+            _maybe_start_services("http://localhost:8080", auto=False, start_services=True)
+        captured = capsys.readouterr()
+        assert "Port 8080" in captured.err
+        assert "EADDRINUSE" in captured.err
+        assert "lsof -i :8080" in captured.err
+        assert "Service process exited early" not in captured.err
 
     def test_allows_start_when_port_free(self, maybe_start_preflight_mocks):
         with (
@@ -936,6 +963,25 @@ class TestMaybeStartServices:
             _maybe_start_services("http://localhost:8080", auto=False, start_services=True)
         captured = capsys.readouterr()
         assert "Docker does not appear to be available" in captured.err
+
+    def test_startup_port_conflict_prefers_live_port_probe(self, tmp_path):
+        log = tmp_path / "services.log"
+        log.write_text("", encoding="utf-8")
+        conflict = PortConflict(kind="foreign", port=9090)
+        with patch(f"{SETUP_MOD}.check_port_available_for_start", return_value=conflict):
+            assert _detect_startup_port_conflict("http://localhost:9090", log) is conflict
+
+    def test_startup_port_conflict_detects_log_marker(self, tmp_path):
+        log = tmp_path / "services.log"
+        log.write_text("RuntimeError: EADDRINUSE while binding\n", encoding="utf-8")
+        with patch(f"{SETUP_MOD}.check_port_available_for_start", return_value=None):
+            conflict = _detect_startup_port_conflict("http://localhost:9090", log)
+        assert conflict == PortConflict(kind="foreign", port=9090)
+
+    def test_services_log_suggests_port_conflict(self, tmp_path):
+        log = tmp_path / "services.log"
+        log.write_text("uvicorn failed: address already in use\n", encoding="utf-8")
+        assert _services_log_suggests_port_conflict(log) is True
 
 
 class TestRemoteConnection:
@@ -1223,6 +1269,7 @@ class TestLocalDataDirHelpers:
         with (
             patch(f"{SETUP_MOD}._check_platform_reachable", return_value=False),
             patch(f"{SETUP_MOD}._kill_existing_services"),
+            patch(f"{SETUP_MOD}.check_port_available_for_start", return_value=None),
             patch(f"{SETUP_MOD}._start_services_background") as mock_start,
             patch(f"{SETUP_MOD}._wait_for_platform", return_value=True),
             patch(f"{SETUP_MOD}._prompt_data_dir") as mock_prompt,
@@ -3155,6 +3202,14 @@ class TestNonTtyEarlyExit:
 
         assert exc_info.value.exit_code == 0
         assert "Setup cancelled" in capsys.readouterr().err
+
+    def test_resume_runs_idempotent_setup_path(self, capsys):
+        ctx, _cli_context = _make_setup_command_ctx()
+        with _patch_setup_command() as mocks:
+            setup_command(ctx, resume=True)
+
+        assert "Retrying setup using the normal idempotent setup path" in capsys.readouterr().err
+        mocks.run_interactive.assert_called_once()
 
 
 class TestSetupCommandRemoteFlow:

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup_cli.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup_cli.py
@@ -15,6 +15,14 @@ from typer.testing import CliRunner
 SETUP_MOD = "nemo_platform_ext.cli.commands.setup"
 
 
+def test_setup_help_documents_resume_flag() -> None:
+    result = CliRunner().invoke(app, ["setup", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--resume" in result.output
+    assert "Retry an interrupted setup using the normal idempotent setup path." in result.output
+
+
 def test_remote_choice_retries_and_persists_connection(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -49,6 +49,7 @@ from nemo_platform.client.tls import client_verify_from_env
 from nemo_platform.config.config import Config
 from nemo_platform.config.models import DEFAULT_BASE_URL, ConfigFile, ConfigParams, LocalServicesConfig, NoAuthUser
 from nemo_platform.local.process import (
+    PortConflict,
     check_port_available_for_start,
     compute_scope,
     format_port_conflict,
@@ -997,6 +998,14 @@ _DOCKER_FAILURE_LOG_MARKERS = (
     "Error while fetching server API version",
 )
 
+_PORT_CONFLICT_LOG_MARKERS = (
+    "EADDRINUSE",
+    "address already in use",
+    "address is already in use",
+    "Errno 98",
+    "Only one usage of each socket address",
+)
+
 
 def _services_log_suggests_docker_failure(log_path: Path | None) -> bool:
     """Return True when services.log contains known Docker skip / daemon errors."""
@@ -1007,6 +1016,36 @@ def _services_log_suggests_docker_failure(log_path: Path | None) -> bool:
     except OSError:
         return False
     return any(marker in text for marker in _DOCKER_FAILURE_LOG_MARKERS)
+
+
+def _services_log_suggests_port_conflict(log_path: Path | None) -> bool:
+    """Return True when services.log contains known TCP bind failure markers."""
+    if log_path is None or not log_path.is_file():
+        return False
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    lower_text = text.lower()
+    return any(marker.lower() in lower_text for marker in _PORT_CONFLICT_LOG_MARKERS)
+
+
+def _detect_startup_port_conflict(base_url: str, log_path: Path | None) -> PortConflict | None:
+    """Detect a startup-time port conflict after the services process exits.
+
+    The preflight normally catches busy ports before spawning services. This
+    fallback handles races where the port becomes busy between preflight and
+    uvicorn binding, or where the service process writes the bind failure to
+    ``services.log`` before exiting.
+    """
+    port = _resolve_services_port(base_url)
+    scope = compute_scope(port=port)
+    conflict = check_port_available_for_start(DEFAULT_LOCAL_SERVICES_BIND_HOST, port, scope)
+    if conflict is not None:
+        return conflict
+    if _services_log_suggests_port_conflict(log_path):
+        return PortConflict(kind="foreign", port=port)
+    return None
 
 
 def _should_hint_docker_unavailable(*, exit_code: int | None, log_path: Path | None) -> bool:
@@ -1134,7 +1173,13 @@ def _maybe_start_services(
 
     if not _wait_for_platform(base_url, timeout=timeout, log_path=log, proc=proc):
         exit_code = proc.poll()
-        if exit_code is not None:
+        startup_conflict = _detect_startup_port_conflict(base_url, log) if exit_code is not None else None
+        if startup_conflict is not None:
+            lines = format_port_conflict(startup_conflict)
+            console.print(f"{CROSS} {lines[0]}")
+            for line in lines[1:]:
+                console.print(f"  {line}")
+        elif exit_code is not None:
             console.print(f"{CROSS} Service process exited early (exit code {exit_code})")
         else:
             proc.terminate()
@@ -2073,6 +2118,13 @@ def setup_command(
         bool | None,
         typer.Option("--deploy-agent/--no-deploy-agent", help="Deploy the demo calculator agent"),
     ] = None,
+    resume: Annotated[
+        bool,
+        typer.Option(
+            "--resume",
+            help="Retry an interrupted setup using the normal idempotent setup path.",
+        ),
+    ] = False,
     ready_timeout: Annotated[
         int | None,
         typer.Option(
@@ -2120,6 +2172,8 @@ def setup_command(
     base_url = cli_context.get_base_url() or DEFAULT_BASE_URL
 
     console.print("\n[bold cyan]NeMo Platform Setup[/bold cyan]\n")
+    if resume:
+        console.print(f"{CHECK} Retrying setup using the normal idempotent setup path.\n")
 
     if not auto and not is_interactive():
         console.print(f"\n{CROSS} Detected non-interactive shell. Pass [bold]--auto[/bold] or run in a TTY.\n")

--- a/sdk/python/nemo-platform/src/nemo_platform/local/process.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/local/process.py
@@ -288,7 +288,7 @@ def format_port_conflict(err: PortConflict) -> list[str]:
             "Or restart with:    nemo services restart",
         ]
     return [
-        f"Port {err.port} is already in use by another process.",
+        f"Port {err.port} is already in use by another process (EADDRINUSE).",
         "Free the port or choose a different one:",
         f"lsof -i :{err.port}          (see what's listening)",
         f"nemo services run --port {SUGGESTED_ALT_PORT}",

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_lifecycle.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_services_lifecycle.py
@@ -724,7 +724,7 @@ class TestPortAvailability:
         [
             (
                 PortConflict(kind="foreign", port=8080),
-                ("already in use", "lsof -i :8080"),
+                ("already in use", "EADDRINUSE", "lsof -i :8080"),
             ),
             (
                 PortConflict(kind="nemo_instance", port=8080, scope="abc-8080"),

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -47,6 +47,7 @@ from nemo_platform.cli.commands.setup import (
     _create_provider,
     _deploy_demo_agent,
     _detect_coding_agents,
+    _detect_startup_port_conflict,
     _ensure_port_available_for_start,
     _filter_agents_by_scope,
     _find_project_root,
@@ -68,6 +69,7 @@ from nemo_platform.cli.commands.setup import (
     _run_interactive_mode,
     _save_data_dir,
     _select_model_pair,
+    _services_log_suggests_port_conflict,
     _start_services_background,
     _validate_api_key,
     _verify_platform_health,
@@ -864,8 +866,33 @@ class TestMaybeStartServices:
         maybe_start_preflight_mocks.assert_not_called()
         captured = capsys.readouterr()
         assert "already in use" in captured.err
+        assert "EADDRINUSE" in captured.err
         assert "lsof" in captured.err
         assert "services.log" not in captured.err
+
+    def test_early_exit_names_eaddrinuse_when_startup_log_has_bind_failure(
+        self, maybe_start_preflight_mocks, capsys, tmp_path
+    ):
+        """Post-spawn bind failures should not collapse to a generic early-exit message."""
+        dead = MagicMock(pid=999)
+        dead.poll.return_value = 1
+        log = tmp_path / "services.log"
+        log.write_text("OSError: [Errno 98] Address already in use\n", encoding="utf-8")
+        with (
+            patch(f"{SETUP_MOD}.check_port_available_for_start", return_value=None),
+            patch(f"{SETUP_MOD}._wait_for_platform", return_value=False),
+            patch(f"{SETUP_MOD}.log_path_for", return_value=log),
+            patch(f"{SETUP_MOD}.validate_docker_available", return_value=True),
+            patch(f"{SETUP_MOD}._pause"),
+            pytest.raises(ClickExit),
+        ):
+            maybe_start_preflight_mocks.return_value = dead
+            _maybe_start_services("http://localhost:8080", auto=False, start_services=True)
+        captured = capsys.readouterr()
+        assert "Port 8080" in captured.err
+        assert "EADDRINUSE" in captured.err
+        assert "lsof -i :8080" in captured.err
+        assert "Service process exited early" not in captured.err
 
     def test_allows_start_when_port_free(self, maybe_start_preflight_mocks):
         with (
@@ -936,6 +963,25 @@ class TestMaybeStartServices:
             _maybe_start_services("http://localhost:8080", auto=False, start_services=True)
         captured = capsys.readouterr()
         assert "Docker does not appear to be available" in captured.err
+
+    def test_startup_port_conflict_prefers_live_port_probe(self, tmp_path):
+        log = tmp_path / "services.log"
+        log.write_text("", encoding="utf-8")
+        conflict = PortConflict(kind="foreign", port=9090)
+        with patch(f"{SETUP_MOD}.check_port_available_for_start", return_value=conflict):
+            assert _detect_startup_port_conflict("http://localhost:9090", log) is conflict
+
+    def test_startup_port_conflict_detects_log_marker(self, tmp_path):
+        log = tmp_path / "services.log"
+        log.write_text("RuntimeError: EADDRINUSE while binding\n", encoding="utf-8")
+        with patch(f"{SETUP_MOD}.check_port_available_for_start", return_value=None):
+            conflict = _detect_startup_port_conflict("http://localhost:9090", log)
+        assert conflict == PortConflict(kind="foreign", port=9090)
+
+    def test_services_log_suggests_port_conflict(self, tmp_path):
+        log = tmp_path / "services.log"
+        log.write_text("uvicorn failed: address already in use\n", encoding="utf-8")
+        assert _services_log_suggests_port_conflict(log) is True
 
 
 class TestRemoteConnection:
@@ -1223,6 +1269,7 @@ class TestLocalDataDirHelpers:
         with (
             patch(f"{SETUP_MOD}._check_platform_reachable", return_value=False),
             patch(f"{SETUP_MOD}._kill_existing_services"),
+            patch(f"{SETUP_MOD}.check_port_available_for_start", return_value=None),
             patch(f"{SETUP_MOD}._start_services_background") as mock_start,
             patch(f"{SETUP_MOD}._wait_for_platform", return_value=True),
             patch(f"{SETUP_MOD}._prompt_data_dir") as mock_prompt,
@@ -3155,6 +3202,14 @@ class TestNonTtyEarlyExit:
 
         assert exc_info.value.exit_code == 0
         assert "Setup cancelled" in capsys.readouterr().err
+
+    def test_resume_runs_idempotent_setup_path(self, capsys):
+        ctx, _cli_context = _make_setup_command_ctx()
+        with _patch_setup_command() as mocks:
+            setup_command(ctx, resume=True)
+
+        assert "Retrying setup using the normal idempotent setup path" in capsys.readouterr().err
+        mocks.run_interactive.assert_called_once()
 
 
 class TestSetupCommandRemoteFlow:

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup_cli.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup_cli.py
@@ -15,6 +15,14 @@ from typer.testing import CliRunner
 SETUP_MOD = "nemo_platform.cli.commands.setup"
 
 
+def test_setup_help_documents_resume_flag() -> None:
+    result = CliRunner().invoke(app, ["setup", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--resume" in result.output
+    assert "Retry an interrupted setup using the normal idempotent setup path." in result.output
+
+
 def test_remote_choice_retries_and_persists_connection(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Report setup port conflicts with the port and `EADDRINUSE`, including when service startup exits early after a bind failure.
- Keep `nemo setup --resume` as a retry marker, but clarify it uses the normal idempotent setup path rather than a special recovery flow.
- Remove the `nemo setup --resume` example from command help so the loaded help matches the manual manifest entry.
- Vendor the setup/process changes into the SDK copy.

## NVBugs
- 6556551
- 6556559

## Validation
- `uv run --frozen pytest packages/nemo_platform_ext/tests/cli/test_app.py::test_manifest_help_matches_loaded_manual_entry packages/nemo_platform_ext/tests/cli/commands/test_setup.py::TestNonTtyEarlyExit::test_resume_runs_idempotent_setup_path -q`: 13 passed
- `uv run --frozen ruff check packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py packages/nemo_platform_ext/tests/cli/commands/test_setup.py sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py`: passed
- `make vendor-nemo-platform-ext`
- `make generate-cli-reference-docs`
- Earlier focused setup lifecycle tests: 248 passed against source and vendored SDK copies
- Earlier live source and SDK port-conflict smoke with a temporary listener

## Review follow-up
- `0b355c100` tones down `--resume` help/banner text and fixes the manifest help mismatch that failed CI.
- `eeb5037c7` resolves the merge conflict against current main with a signed merge commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--resume` option to retry interrupted setup through the normal setup process.
  * Added clearer guidance when required ports are already in use.

* **Bug Fixes**
  * Port conflicts now show specific address-in-use diagnostics instead of generic startup failures.
  * Error messages include the `EADDRINUSE` code, affected-port details, and troubleshooting guidance.

* **Documentation**
  * Documented the new `--resume` setup option in the CLI reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->