### PR TITLE
fix: add generate alias for SDK generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ refresh-openapi:  ## Generate the OpenAPI specification
 stainless: ## Run Stainless to generate the OpenAPI spec and sync it with the SDK
 	SDK_RELEASE_TIER=ga ./sdk/stainless.sh sync
 
+.PHONY: generate
+generate: stainless ## Alias for SDK generation via Stainless
+
 .PHONY: update-web-sdk
 update-web-sdk: ## Regenerate the TypeScript web SDK (web/packages/sdk) from the OpenAPI spec via Orval
 	cd web && pnpm gen


### PR DESCRIPTION
## Summary
- Add root `make generate` as an alias for the existing Stainless SDK generation target.

## NVBug
- 6556557

## Validation
- `grep -nE '^generate:' Makefile`
- `make -n generate`
- `make help`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `generate` command for streamlined SDK generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Latest push
- Pushed no-code signed amend `94d839929` to rerun the stale semantic-title check against the current conventional PR title. DCO audit passed.
