### PR TITLE
fix: structure MCP tool error envelopes

### DIFF
--- a/packages/nmp_common/src/nmp/common/mcp/README.md
+++ b/packages/nmp_common/src/nmp/common/mcp/README.md
@@ -44,7 +44,8 @@ Converts exceptions into standardized error responses with automatic logging.
     "error": {
         "code": "ConnectionError",
         "message": "Connection refused to localhost:8080",
-        "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state."
+        "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state.",
+        "retryable": True
     }
 }
 ```
@@ -71,7 +72,7 @@ async def deploy_model(model_id: str) -> dict[str, Any]:
 **Why Use This Pattern**:
 
 - AI agents can reliably check `success` field
-- Consistent structured `error.code`, `error.message`, and `error.hint` across all tools
+- Consistent structured `error.code`, `error.message`, `error.hint`, and `error.retryable` across all tools
 - Automatic error logging with stack traces
 - Easy to add richer retry hints or sanitization
 - Success responses manually constructed with explicit fields
@@ -199,7 +200,7 @@ def format_error_response(error: Exception) -> dict[str, Any]:
             "code": type(error).__name__,
             "message": str(error),
             "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state.",
-            "retryable": isinstance(error, (ConnectionError, TimeoutError))
+            "retryable": isinstance(error, (ConnectionError, TimeoutError)),
         }
     }
 ```

--- a/packages/nmp_common/src/nmp/common/mcp/README.md
+++ b/packages/nmp_common/src/nmp/common/mcp/README.md
@@ -41,8 +41,11 @@ Converts exceptions into standardized error responses with automatic logging.
 ```python
 {
     "success": False,
-    "error": "Connection refused to localhost:8080",
-    "error_type": "ConnectionError"
+    "error": {
+        "code": "ConnectionError",
+        "message": "Connection refused to localhost:8080",
+        "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state."
+    }
 }
 ```
 
@@ -68,9 +71,9 @@ async def deploy_model(model_id: str) -> dict[str, Any]:
 **Why Use This Pattern**:
 
 - AI agents can reliably check `success` field
-- Consistent error structure across all tools
+- Consistent structured `error.code`, `error.message`, and `error.hint` across all tools
 - Automatic error logging with stack traces
-- Easy to add error codes, retry hints, or sanitization
+- Easy to add richer retry hints or sanitization
 - Success responses manually constructed with explicit fields
 
 ---
@@ -190,19 +193,14 @@ See `packages/nmp_common/src/nmp/common/sdk_factory.py` for SDK factory implemen
 def format_error_response(error: Exception) -> dict[str, Any]:
     logger.error(f"Error in MCP tool: {error}", exc_info=True)
 
-    # Map exception types to codes
-    error_codes = {
-        "ConnectionError": "PLATFORM_UNAVAILABLE",
-        "TimeoutError": "PLATFORM_TIMEOUT",
-        "HTTPStatusError": "API_ERROR",
-    }
-
     return {
         "success": False,
-        "error": str(error),
-        "error_type": type(error).__name__,
-        "error_code": error_codes.get(type(error).__name__, "UNKNOWN_ERROR"),
-        "retryable": isinstance(error, (ConnectionError, TimeoutError))
+        "error": {
+            "code": type(error).__name__,
+            "message": str(error),
+            "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state.",
+            "retryable": isinstance(error, (ConnectionError, TimeoutError))
+        }
     }
 ```
 

--- a/packages/nmp_common/src/nmp/common/mcp/error_handling.py
+++ b/packages/nmp_common/src/nmp/common/mcp/error_handling.py
@@ -10,6 +10,8 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_ERROR_HINT = "Check the MCP server logs for details, then retry after fixing the request or platform state."
+
 
 def format_error_response(error: Exception) -> dict[str, Any]:
     """
@@ -21,7 +23,7 @@ def format_error_response(error: Exception) -> dict[str, Any]:
         error: The exception to format
 
     Returns:
-        Dictionary with success=False, error message, and error type
+        Dictionary with success=False and a structured error object
 
     Example:
         >>> try:
@@ -30,8 +32,12 @@ def format_error_response(error: Exception) -> dict[str, Any]:
         ...     return format_error_response(e)
     """
     logger.error(f"Error in MCP tool: {error}", exc_info=True)
+    message = str(error) or type(error).__name__
     return {
         "success": False,
-        "error": str(error),
-        "error_type": type(error).__name__,
+        "error": {
+            "code": type(error).__name__,
+            "message": message,
+            "hint": _DEFAULT_ERROR_HINT,
+        },
     }

--- a/packages/nmp_common/src/nmp/common/mcp/error_handling.py
+++ b/packages/nmp_common/src/nmp/common/mcp/error_handling.py
@@ -39,5 +39,6 @@ def format_error_response(error: Exception) -> dict[str, Any]:
             "code": type(error).__name__,
             "message": message,
             "hint": _DEFAULT_ERROR_HINT,
+            "retryable": isinstance(error, (ConnectionError, TimeoutError)),
         },
     }

--- a/packages/nmp_common/tests/mcp/test_error_handling.py
+++ b/packages/nmp_common/tests/mcp/test_error_handling.py
@@ -16,6 +16,7 @@ def test_format_error_response_returns_structured_error() -> None:
         "code": "ValueError",
         "message": "bad input",
         "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state.",
+        "retryable": False,
     }
     assert "error_type" not in response
 
@@ -28,3 +29,15 @@ def test_format_error_response_uses_exception_type_when_message_empty() -> None:
 
     assert response["error"]["code"] == "EmptyMessageError"
     assert response["error"]["message"] == "EmptyMessageError"
+
+
+def test_format_error_response_marks_connection_failures_retryable() -> None:
+    response = format_error_response(ConnectionError("connection reset"))
+
+    assert response["error"]["retryable"] is True
+
+
+def test_format_error_response_marks_timeouts_retryable() -> None:
+    response = format_error_response(TimeoutError("request timed out"))
+
+    assert response["error"]["retryable"] is True

--- a/packages/nmp_common/tests/mcp/test_error_handling.py
+++ b/packages/nmp_common/tests/mcp/test_error_handling.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for shared MCP error response formatting."""
+
+from __future__ import annotations
+
+from nmp.common.mcp import format_error_response
+
+
+def test_format_error_response_returns_structured_error() -> None:
+    response = format_error_response(ValueError("bad input"))
+
+    assert response["success"] is False
+    assert response["error"] == {
+        "code": "ValueError",
+        "message": "bad input",
+        "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state.",
+    }
+    assert "error_type" not in response
+
+
+def test_format_error_response_uses_exception_type_when_message_empty() -> None:
+    class EmptyMessageError(Exception):
+        pass
+
+    response = format_error_response(EmptyMessageError())
+
+    assert response["error"]["code"] == "EmptyMessageError"
+    assert response["error"]["message"] == "EmptyMessageError"

--- a/services/core/entities/tests/integration/smoke_test_mcp.py
+++ b/services/core/entities/tests/integration/smoke_test_mcp.py
@@ -10,10 +10,11 @@ Creates and tests an MCP server instance that is connected to a running NeMo Pla
 from __future__ import annotations
 
 import os
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
 from fastmcp import FastMCP
+from mcp.types import TextContent
 from nemo_platform import NeMoPlatform
 from nmp.common.sdk_factory import get_platform_sdk
 from nmp.core.entities.mcp.server import create_server
@@ -38,6 +39,12 @@ def mcp_server(nmp_base_url: str) -> Generator[FastMCP, None, None]:
     """Create entities MCP server instance."""
     server = create_server(nmp_base_url)
     yield server
+
+
+def _text_content(tool_result: Any) -> str:
+    first_content = tool_result.content[0]
+    assert isinstance(first_content, TextContent)
+    return first_content.text
 
 
 class TestEntitiesMCPServerSmoke:
@@ -78,7 +85,7 @@ class TestEntitiesMCPServerSmoke:
         # Get workspaces via MCP tool
         tool_result = await mcp_server.call_tool("list_workspaces", {})
 
-        mcp_result = json.loads(tool_result.content[0].text)
+        mcp_result = json.loads(_text_content(tool_result))
         assert isinstance(mcp_result, dict)  # Type narrowing for ty
         assert mcp_result["success"] is True
 
@@ -94,20 +101,38 @@ class TestEntitiesMCPServerSmoke:
         )
 
     @pytest.mark.asyncio
-    async def test_list_workspaces_error_handling(self) -> None:
+    async def test_list_workspaces_error_handling(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """
         Verify list_workspaces handles connection errors gracefully.
 
-        Creates a server with invalid URL to test error handling.
+        Creates a server with a controlled failing SDK client to test error handling.
         """
         import json
 
-        bad_server = create_server("http://invalid-host:9999")
+        class FailingWorkspacesClient:
+            def list(self, *args: object, **kwargs: object) -> object:
+                raise RuntimeError("platform unavailable")
+
+        class FailingPlatformClient:
+            workspaces = FailingWorkspacesClient()
+
+        def get_failing_platform_sdk(base_url: str | None = None) -> FailingPlatformClient:
+            _ = base_url
+            return FailingPlatformClient()
+
+        monkeypatch.setattr(
+            "nmp.core.entities.mcp.server.get_platform_sdk",
+            get_failing_platform_sdk,
+        )
+        bad_server = create_server("http://unused.example.com")
         tool_result = await bad_server.call_tool("list_workspaces", {})
 
-        result = json.loads(tool_result.content[0].text)
+        result = json.loads(_text_content(tool_result))
 
         assert isinstance(result, dict)
         assert result["success"] is False, "Should indicate failure"
-        assert "error" in result, "Should contain error message"
-        assert "error_type" in result, "Should contain error type"
+        assert "error_type" not in result
+        assert isinstance(result["error"], dict), "Should contain structured error details"
+        assert result["error"]["code"], "Should contain stable error code"
+        assert result["error"]["message"], "Should contain error message"
+        assert result["error"]["hint"], "Should contain remediation hint"

--- a/services/core/entities/tests/integration/smoke_test_mcp.py
+++ b/services/core/entities/tests/integration/smoke_test_mcp.py
@@ -129,10 +129,12 @@ class TestEntitiesMCPServerSmoke:
 
         result = json.loads(_text_content(tool_result))
 
-        assert isinstance(result, dict)
-        assert result["success"] is False, "Should indicate failure"
-        assert "error_type" not in result
-        assert isinstance(result["error"], dict), "Should contain structured error details"
-        assert result["error"]["code"], "Should contain stable error code"
-        assert result["error"]["message"], "Should contain error message"
-        assert result["error"]["hint"], "Should contain remediation hint"
+        assert result == {
+            "success": False,
+            "error": {
+                "code": "RuntimeError",
+                "message": "platform unavailable",
+                "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state.",
+                "retryable": False,
+            },
+        }

--- a/services/core/mcp/tests/integration/smoke_test.py
+++ b/services/core/mcp/tests/integration/smoke_test.py
@@ -10,15 +10,14 @@ Creates and tests an MCP server instance that is connected to a running NeMo Pla
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Generator
+from typing import Any, Generator
 
 import pytest
+from fastmcp import FastMCP
+from mcp.types import TextContent
+from nemo_platform import NeMoPlatform
 from nmp.common.sdk_factory import get_platform_sdk
 from nmp.core.mcp.server import create_server
-
-if TYPE_CHECKING:
-    from fastmcp import FastMCP
-    from nemo_platform import NeMoPlatform
 
 
 @pytest.fixture(scope="module")
@@ -39,6 +38,12 @@ def mcp_server(nmp_base_url: str) -> Generator[FastMCP, None, None]:
     """Create MCP server instance."""
     server = create_server(nmp_base_url)
     yield server
+
+
+def _text_content(tool_result: Any) -> str:
+    first_content = tool_result.content[0]
+    assert isinstance(first_content, TextContent)
+    return first_content.text
 
 
 class TestMCPServerSmoke:
@@ -79,7 +84,7 @@ class TestMCPServerSmoke:
         # Get workspaces via MCP tool
         tool_result = await mcp_server.call_tool("list_workspaces", {})
 
-        mcp_result = json.loads(tool_result.content[0].text)
+        mcp_result = json.loads(_text_content(tool_result))
         assert isinstance(mcp_result, dict)  # Type narrowing for ty
 
         # Verify MCP returns same workspace IDs
@@ -95,24 +100,42 @@ class TestMCPServerSmoke:
         )
 
     @pytest.mark.asyncio
-    async def test_list_workspaces_error_handling(self, nmp_base_url: str) -> None:
+    async def test_list_workspaces_error_handling(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """
         Verify tool handles connection errors gracefully.
 
-        Creates a server with invalid URL to test error handling.
+        Mounts a controlled failing tool to test error handling.
         """
         import json
 
-        # Create server with invalid URL
-        bad_server = create_server("http://invalid-host:9999")
+        import nmp.core.mcp.server as mcp_server_module
+        from nmp.common.mcp import format_error_response
+
+        def create_failing_entities_mcp(_base_url: str | None = None) -> FastMCP:
+            server = FastMCP("Failing Entities Service")
+
+            @server.tool(description="List workspaces in the NeMo platform")
+            async def list_workspaces() -> dict[str, object]:
+                try:
+                    raise RuntimeError("platform unavailable")
+                except Exception as e:
+                    return format_error_response(e)
+
+            return server
+
+        monkeypatch.setattr(mcp_server_module, "create_entities_mcp", create_failing_entities_mcp)
+        bad_server = mcp_server_module.create_server("http://unused.example.com")
 
         # Execute tool - should return error, not raise
         tool_result = await bad_server.call_tool("list_workspaces", {})
 
-        result = json.loads(tool_result.content[0].text)
+        result = json.loads(_text_content(tool_result))
 
         # Verify error response structure
         assert isinstance(result, dict)
         assert result["success"] is False, "Should indicate failure"
-        assert "error" in result, "Should contain error message"
-        assert "error_type" in result, "Should contain error type"
+        assert "error_type" not in result
+        assert isinstance(result["error"], dict), "Should contain structured error details"
+        assert result["error"]["code"], "Should contain stable error code"
+        assert result["error"]["message"], "Should contain error message"
+        assert result["error"]["hint"], "Should contain remediation hint"

--- a/services/core/mcp/tests/integration/smoke_test.py
+++ b/services/core/mcp/tests/integration/smoke_test.py
@@ -131,11 +131,12 @@ class TestMCPServerSmoke:
 
         result = json.loads(_text_content(tool_result))
 
-        # Verify error response structure
-        assert isinstance(result, dict)
-        assert result["success"] is False, "Should indicate failure"
-        assert "error_type" not in result
-        assert isinstance(result["error"], dict), "Should contain structured error details"
-        assert result["error"]["code"], "Should contain stable error code"
-        assert result["error"]["message"], "Should contain error message"
-        assert result["error"]["hint"], "Should contain remediation hint"
+        assert result == {
+            "success": False,
+            "error": {
+                "code": "RuntimeError",
+                "message": "platform unavailable",
+                "hint": "Check the MCP server logs for details, then retry after fixing the request or platform state.",
+                "retryable": False,
+            },
+        }


### PR DESCRIPTION
## Summary
- Change shared MCP `format_error_response` to return a nested `error` object with stable `code`, `message`, and `hint` fields.
- Remove the old top-level `error_type` shape from the shared helper.
- Update MCP smoke tests to assert the structured error envelope deterministically.
- Document the MCP error response shape.

## NVBug
- 6556550

## Validation
- `uv run --frozen pytest packages/nmp_common/tests/mcp/test_error_handling.py services/core/mcp/tests/integration/smoke_test.py::TestMCPServerSmoke::test_list_workspaces_error_handling services/core/entities/tests/integration/smoke_test_mcp.py::TestEntitiesMCPServerSmoke::test_list_workspaces_error_handling -q`: 4 passed
- `uv run --frozen ruff check ...` on touched MCP files
- `uv run --frozen ty check ...` on touched MCP files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Error responses now provide structured details, including an error code, message, remediation hint, and retryability status.
  - Connection and timeout errors are identified as retryable.
  - Empty error messages now fall back to a meaningful error description.

- **Documentation**
  - Updated MCP error-handling documentation to describe the structured response format and retry guidance.

- **Bug Fixes**
  - Removed the legacy `error_type` field from error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up
- Pushed `4c66b6b05` (`fix: include retryable MCP error metadata`).
- Validation: MCP formatter and smoke tests `6 passed`; targeted Ruff and ty checks passed.
- Note: `uv run pre-commit run -a` is blocked by the same `helm-docs` hook fetch HTTP 503 noted on the related PR.
