### PR TITLE
feat(experimentalist): enforce objective metric contracts

### DIFF
--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -146,6 +146,36 @@ The `--config` YAML is the other kind of configuration: it holds what *one exper
 does (`max_rounds`, `max_survivors`, per-component tuning) and takes no environment
 override, so the file is an accurate record of the run.
 
+### Objective function and regression metrics
+
+Declare what the optimizer should improve separately from what it must preserve.
+`objective_function` is one ordered list: each item may be a raw evaluator
+metric or an aggregate metric produced by the evaluator. The optimizer only receives
+reported metric values and the declared policy; it does not evaluate expressions,
+invent weights, or encode a selection algorithm.
+
+```yaml
+# A single evaluator-produced aggregate metric.
+objective_function:
+  - name: quality
+    direction: maximize
+
+# Include several metrics, for example lower token use and cost.
+objective_function:
+  - name: tokens
+    direction: minimize
+  - name: cost
+    direction: minimize
+regression_metrics:
+  - name: success_rate
+    direction: maximize
+```
+
+For an insight-driven run, Eval Author's authored insight metrics replace the
+run-level objective metrics. The configured objective targets move to
+`regression_metrics`, alongside the existing guardrails, so the insight is
+improved without giving up the run's original priorities.
+
 The agent under test is separate: it reads `AUT_MODEL_NAME`
 plus `OPENAI_API_KEY` / `OPENAI_BASE_URL`, which are the only variables forwarded
 into the evaluation container.

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/.env.example
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/.env.example
@@ -13,7 +13,7 @@ export NEMO_EXPERIMENTALIST_API_BASE="$INFERENCE_API_BASE"
 # Upstream Tau3 currently reads these compatibility variable names.
 export TAU2_USER_MODEL=openai/openai/openai/gpt-5.6-luna
 export TAU2_NL_ASSERTIONS_MODEL=openai/openai/openai/gpt-5.6-luna
-export AUT_MODEL_NAME=openai/openai/openai/gpt-5.6-luna
+export AUT_MODEL_NAME=openai/openai/openai/gpt-5-mini
 
 export NEMO_EXPERIMENTALIST_MODELS_SMART=openai/openai/openai/gpt-5.6-sol
 export NEMO_EXPERIMENTALIST_MODELS_MID=openai/openai/openai/gpt-5.6-terra

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/experimentalist-smoke.yaml
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/experimentalist-smoke.yaml
@@ -6,7 +6,6 @@ min_rounds_before_stopping: 1
 max_survivors: 1
 max_candidates: 1
 max_trajectory_tasks: 2
-max_train_batch_tasks: 4
 train_batch_seed: 20260727
 disable_trajectory_scoring: true
 disable_convergence_check: true

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/config.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/config.py
@@ -20,7 +20,7 @@ longer does.
 """
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from nemo_eval_author_plugin.eval_author.models import EvalAuthorConfig
 from nemo_experimentalist_plugin.experimentalist.components.analyzer import AnalyzerConfig
@@ -49,6 +49,77 @@ class CandidateStorageConfig(BaseModel):
     pr_title: str | None = None
     pr_body: str | None = None
     pr_labels: list[str] = Field(default_factory=list)
+
+
+class MetricTarget(BaseModel):
+    """One evaluator-produced metric and the desired direction of change."""
+
+    name: str = Field(min_length=1, description="Exact metric name emitted by the evaluator.")
+    direction: Literal["maximize", "minimize"] = Field(
+        description="Whether higher or lower values are better for this target."
+    )
+
+
+def pareto_objectives(metrics: dict[str, float], objective_function: list[MetricTarget]) -> dict[str, float]:
+    """Project evaluator metrics onto the configured objectives for Pareto ranking.
+
+    The generic Pareto utility maximizes every dimension. Minimized objective
+    values are sign-inverted here; regression metrics are intentionally absent.
+    """
+    objectives: dict[str, float] = {}
+    for target in objective_function:
+        value = metrics.get(target.name)
+        if value is None:
+            return {}
+        objectives[target.name] = float(value) if target.direction == "maximize" else -float(value)
+    return objectives
+
+
+def has_metric_dimensions(metrics: dict[str, float], targets: list[MetricTarget]) -> bool:
+    """Return whether an evaluator result contains every declared metric target."""
+    return all(target.name in metrics for target in targets)
+
+
+def satisfies_regression_constraints(
+    metrics: dict[str, float],
+    baseline_metrics: dict[str, float],
+    regression_metrics: list[MetricTarget],
+) -> bool:
+    """Return whether metrics preserve every regression target relative to baseline.
+
+    A maximize target must stay at or above the baseline value; a minimize
+    target must stay at or below it. Both candidate and baseline must report
+    every declared regression dimension.
+    """
+    if not has_metric_dimensions(metrics, regression_metrics) or not has_metric_dimensions(
+        baseline_metrics, regression_metrics
+    ):
+        return False
+    return all(
+        metrics[target.name] >= baseline_metrics[target.name]
+        if target.direction == "maximize"
+        else metrics[target.name] <= baseline_metrics[target.name]
+        for target in regression_metrics
+    )
+
+
+def is_eligible_for_metric_contract(
+    metrics: dict[str, float],
+    *,
+    objective_function: list[MetricTarget],
+    regression_metrics: list[MetricTarget],
+    baseline_metrics: dict[str, float],
+) -> bool:
+    """Return whether a result is complete and satisfies its regression guardrails.
+
+    Pareto ranking is only meaningful when every candidate supplies each
+    objective dimension. Regression targets are feasibility constraints,
+    measured against the round-0 validation baseline, rather than additional
+    Pareto dimensions.
+    """
+    return has_metric_dimensions(
+        metrics, [*objective_function, *regression_metrics]
+    ) and satisfies_regression_constraints(metrics, baseline_metrics, regression_metrics)
 
 
 class EvolutionaryOptimizerConfig(BaseModel):
@@ -97,6 +168,15 @@ class EvolutionaryOptimizerConfig(BaseModel):
     disable_convergence_check: bool = Field(
         default=False, description="Stop only on max_rounds, never on the terminator's convergence judgement."
     )
+    objective_function: list[MetricTarget] = Field(
+        default_factory=lambda: [MetricTarget(name="reward", direction="maximize")],
+        min_length=1,
+        description="Ordered evaluator metric targets this run should improve.",
+    )
+    regression_metrics: list[MetricTarget] = Field(
+        default_factory=list,
+        description="Metric target(s) that must not regress while the objective improves.",
+    )
     source: AgentSourceConfig = Field(default_factory=AgentSourceConfig)
     storage: CandidateStorageConfig = Field(default_factory=CandidateStorageConfig)
     goal_config: GoalTreeConfig = Field(default_factory=GoalTreeConfig)
@@ -105,3 +185,32 @@ class EvolutionaryOptimizerConfig(BaseModel):
     proposer: ProposerConfig = Field(default_factory=ProposerConfig)
     evaluator: dict[str, Any] = Field(default_factory=dict)
     eval_author: EvalAuthorConfig = Field(default_factory=EvalAuthorConfig)
+
+    @model_validator(mode="after")
+    def validate_metric_contract(self) -> "EvolutionaryOptimizerConfig":
+        objective_names = [target.name for target in self.objective_function]
+        if len(objective_names) != len(set(objective_names)):
+            raise ValueError("objective_function target names must be unique")
+        regression_names = [target.name for target in self.regression_metrics]
+        if len(regression_names) != len(set(regression_names)):
+            raise ValueError("regression_metrics target names must be unique")
+        overlap = set(objective_names).intersection(regression_names)
+        if overlap:
+            raise ValueError(
+                "A metric cannot be both an objective and a regression target: " + ", ".join(sorted(overlap))
+            )
+        return self
+
+    def optimization_policy(self) -> str:
+        """Render the declared metric contract for optimizer-facing reasoning prompts."""
+
+        def render(target: MetricTarget) -> str:
+            return f"{target.name} ({target.direction})"
+
+        objectives = ", ".join(render(target) for target in self.objective_function)
+        regressions = ", ".join(render(target) for target in self.regression_metrics) or "none"
+        return (
+            f"Optimize these objective metric(s): {objectives}. "
+            f"Do not regress these metric(s): {regressions}. "
+            "Metric values, including aggregates, are produced by the evaluator; do not invent formulas or weights."
+        )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/entities.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/entities.py
@@ -259,6 +259,15 @@ class Dataset(ABC):
         """
         return list(self.tasks)
 
+    def add_tasks(self, tasks: list[Task]) -> None:
+        """Add tasks to this dataset's durable backing store.
+
+        Dataset implementations define how task artifacts are imported. Callers
+        must use this method instead of mutating ``tasks`` directly so an
+        evaluator can preserve the task files needed at evaluation time.
+        """
+        raise NotImplementedError(f"{type(self).__name__} does not support adding tasks")
+
     async def validate(self) -> None:
         """Validate authored dataset content without running evaluation trials.
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
@@ -310,11 +310,15 @@ class AgentAnalyzer(Agent):
         Regression metrics: {regression_metrics}
 
         Prefer trials where:
+        - an objective metric is low relative to the other trials or is the
+          clearest evidence of why that objective is not improving
         - status/error indicates the evaluator did not complete cleanly
-        - one or more numeric metric values are below the task's expected passing
-          value
         - the trace reference is missing or unloadable
         - outputs/resources suggest repeated failures across task ids
+
+        Regression metrics are guardrails. Do not select a trial solely because
+        a regression metric is low unless it exposes why an objective-focused
+        change would violate that guardrail.
 
         Metric names are evaluator-defined. Do not assume particular metric
         names, result directories, private checks, or split paths.
@@ -332,8 +336,9 @@ class AgentAnalyzer(Agent):
         ```
 
         Every ``trial_id`` must identify a trial from ``evaluation.trials``.
-        State the concrete objective shortfall, regression risk, evaluator error,
-        or representative failure pattern that makes each selected trial useful.
+        State the concrete objective shortfall that makes each selected trial
+        useful. Mention a regression risk only as a constraint on that
+        objective-focused analysis.
         """
         ...
 
@@ -364,9 +369,11 @@ class AgentAnalyzer(Agent):
         an agent logic error (optimizable) or a mechanical error (needs an infra
         fix). Do not penalise the agent for mechanical errors.
 
-        Use `objective_metrics` and `regression_metrics` to call out objective
-        shortfalls and regression risks. Do not invent formulas or weights for
-        evaluator metrics.
+        Center systematic failures and root causes on `objective_metrics`: explain
+        how the trace behavior causes an objective metric to underperform.
+        `regression_metrics` are guardrails; report their risks separately and do
+        not classify a regression-only shortfall as the primary failure pattern.
+        Do not invent formulas or weights for evaluator metrics.
 
         Return a FailureClassification with:
         - `systematic`: list of SystematicFailure (root_cause, affected_tasks, pattern)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
@@ -34,6 +34,8 @@ from .rationalizer import Rationale, Rationalizer, RationalizerConfig  # noqa: F
 from .tools import GuardedShellTools
 from .util import load_framework_skills
 
+logger = logging.getLogger(__name__)
+
 
 class AnalyzerConfig(BaseModel):
     """Configure tuning parameters for AgentAnalyzer."""
@@ -170,6 +172,7 @@ class TrialAnalysis(BaseModel):
 
     task_id: str
     trial_id: str
+    selection_reason: str
     metrics: dict[str, float]
     diagnostic: Diagnostic
 
@@ -182,12 +185,20 @@ class TrialAnalysis(BaseModel):
         """
         metrics = ", ".join(f"{name}: {value:.3f}" for name, value in self.metrics.items()) or "no metrics"
         lines = [f"### {self.task_id} / {self.trial_id} ({metrics})"]
+        lines.append(f"Selected for analysis: {self.selection_reason}")
         lines.append(f"Outcome: {self.diagnostic.outcome}")
         lines.append(f"Summary: {self.diagnostic.summary}")
         if self.diagnostic.failure_point is not None:
             lines.append(f"Failure point: span {self.diagnostic.failure_point}")
         lines.append(f"Root cause: {self.diagnostic.root_cause}")
         return "\n".join(lines)
+
+
+class TrialSelection(BaseModel):
+    """One trial selected for analysis, with the reason it merits attention."""
+
+    trial_id: str = Field(description="ID of a trial from the evaluation result.")
+    reason: str = Field(description="Evidence-based reason this trial should be analyzed.")
 
 
 class AgentAnalysis(BaseModel):
@@ -263,8 +274,8 @@ class AgentAnalyzer(Agent):
         evaluation: EvaluationResult,
         objective_metrics: list[dict[str, str]],
         regression_metrics: list[dict[str, str]],
-    ) -> Sequence[TrialResult]:
-        """Pick which trials to analyze in depth. Return their TrialResult objects.
+    ) -> list[TrialSelection]:
+        """Pick which trials to analyze in depth and explain each choice.
 
         Args:
             agent_id: The agent to analyze.
@@ -274,7 +285,8 @@ class AgentAnalyzer(Agent):
             regression_metrics: Metrics that must not worsen.
 
         Returns:
-            Sequence[TrialResult]: The selected trials.
+            list[TrialSelection]: Selected evaluation trial IDs and the evidence-based
+                reason each was selected.
 
         ## Step 1: Get task and trial objects
 
@@ -307,11 +319,21 @@ class AgentAnalyzer(Agent):
         Metric names are evaluator-defined. Do not assume particular metric
         names, result directories, private checks, or split paths.
 
-        ## Step 4: Return TrialResult objects
+        ## Step 4: Return selected trial IDs and a reason for each
 
         ```python
-        return selected_trials
+        return [
+            TrialSelection(
+                trial_id=trial.id,
+                reason="Concise evidence-based reason to inspect this trace.",
+            )
+            for trial in selected_trials
+        ]
         ```
+
+        Every ``trial_id`` must identify a trial from ``evaluation.trials``.
+        State the concrete objective shortfall, regression risk, evaluator error,
+        or representative failure pattern that makes each selected trial useful.
         """
         ...
 
@@ -641,12 +663,25 @@ class AgentAnalyzer(Agent):
         if cached is not None:
             return cached
 
-        trials = await self.select_trials(agent_id, dataset, evaluation, objective_metrics, regression_metrics)
+        selections = await self.select_trials(agent_id, dataset, evaluation, objective_metrics, regression_metrics)
+        trials_by_id = {trial.id: trial for trial in evaluation.trials}
+        selected_trials: list[tuple[TrialResult, str]] = []
+        for selection in selections:
+            trial = trials_by_id.get(selection.trial_id)
+            if trial is None:
+                logger.warning(
+                    "Ignoring selected trial %s for %s because it is absent from evaluation %s",
+                    selection.trial_id,
+                    agent_id,
+                    evaluation.id,
+                )
+                continue
+            selected_trials.append((trial, selection.reason))
         tasks_by_id = self._tasks_by_id(dataset)
 
         missing_task_diagnostics: dict[str, Diagnostic] = {}
-        trial_tasks: list[tuple[TrialResult, Task]] = []
-        for trial in trials:
+        trial_tasks: list[tuple[TrialResult, Task, str]] = []
+        for trial, selection_reason in selected_trials:
             task = tasks_by_id.get(trial.task_id)
             if task is None:
                 missing_task_diagnostics[trial.id] = Diagnostic(
@@ -656,9 +691,9 @@ class AgentAnalyzer(Agent):
                     root_cause="evaluation_result_references_unknown_task",
                 )
                 continue
-            trial_tasks.append((trial, task))
+            trial_tasks.append((trial, task, selection_reason))
 
-        unique_tasks = {task.id: task for _, task in trial_tasks}
+        unique_tasks = {task.id: task for _, task, _ in trial_tasks}
         rationales_list = await asyncio.gather(
             *[
                 Rationalizer(
@@ -690,15 +725,18 @@ class AgentAnalyzer(Agent):
                     task=task,
                     agent_path=agent_path,
                     rationale=rationales.get(task.id),
+                    selection_reason=selection_reason,
+                    objective_metrics=objective_metrics,
+                    regression_metrics=regression_metrics,
                     client=client,
                     workspace=nmp_workspace,
                 )
-                for trial, task in trial_tasks
+                for trial, task, selection_reason in trial_tasks
             ],
             return_exceptions=True,
         )
         diagnostics_by_trial_id = dict(missing_task_diagnostics)
-        for (trial, _), result in zip(trial_tasks, diagnoses_list, strict=True):
+        for (trial, _, _), result in zip(trial_tasks, diagnoses_list, strict=True):
             if isinstance(result, asyncio.CancelledError):
                 raise result
             if isinstance(result, BaseException):
@@ -721,16 +759,23 @@ class AgentAnalyzer(Agent):
             TrialAnalysis(
                 task_id=trial.task_id,
                 trial_id=trial.id,
+                selection_reason=selection_reason,
                 metrics={name: float(metric.value) for name, metric in trial.metrics.items()},
                 diagnostic=diagnostics_by_trial_id[trial.id],
             )
-            for trial in trials
+            for trial, selection_reason in selected_trials
             if trial.id in diagnostics_by_trial_id
         ]
         diagnoses = [analysis.diagnostic for analysis in trial_analyses]
 
         classification, comparison = await asyncio.gather(
-            self.classify_failures(agent_id, diagnoses, trials, objective_metrics, regression_metrics),
+            self.classify_failures(
+                agent_id,
+                diagnoses,
+                [trial for trial, _ in selected_trials],
+                objective_metrics,
+                regression_metrics,
+            ),
             self.compare_with_peers(
                 agent_id,
                 evaluation,

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
@@ -261,6 +261,8 @@ class AgentAnalyzer(Agent):
         agent_id: str,
         dataset: Dataset,
         evaluation: EvaluationResult,
+        objective_metrics: list[dict[str, str]],
+        regression_metrics: list[dict[str, str]],
     ) -> Sequence[TrialResult]:
         """Pick which trials to analyze in depth. Return their TrialResult objects.
 
@@ -268,6 +270,8 @@ class AgentAnalyzer(Agent):
             agent_id: The agent to analyze.
             dataset: The dataset to analyze.
             evaluation: The evaluation result to analyze.
+            objective_metrics: Metrics the optimization run should improve.
+            regression_metrics: Metrics that must not worsen.
 
         Returns:
             Sequence[TrialResult]: The selected trials.
@@ -289,6 +293,9 @@ class AgentAnalyzer(Agent):
         ```
 
         ## Step 3: Triage — pick up to {self._config.max_trials} trials
+
+        Objective metrics: {objective_metrics}
+        Regression metrics: {regression_metrics}
 
         Prefer trials where:
         - status/error indicates the evaluator did not complete cleanly
@@ -317,6 +324,8 @@ class AgentAnalyzer(Agent):
         agent_id: str,
         diagnoses: list[Diagnostic],
         trials: Sequence[TrialResult],
+        objective_metrics: list[dict[str, str]],
+        regression_metrics: list[dict[str, str]],
     ) -> FailureClassification:
         """Classify diagnoses into systematic vs. one-off and agent vs. mechanical failures.
 
@@ -333,6 +342,10 @@ class AgentAnalyzer(Agent):
         an agent logic error (optimizable) or a mechanical error (needs an infra
         fix). Do not penalise the agent for mechanical errors.
 
+        Use `objective_metrics` and `regression_metrics` to call out objective
+        shortfalls and regression risks. Do not invent formulas or weights for
+        evaluator metrics.
+
         Return a FailureClassification with:
         - `systematic`: list of SystematicFailure (root_cause, affected_tasks, pattern)
         - `mechanical`: list of MechanicalError (task_id, issue_type, description)
@@ -346,6 +359,8 @@ class AgentAnalyzer(Agent):
         evaluation: EvaluationResult,
         diagnoses: list[Diagnostic],
         peer_evaluations: dict[str, EvaluationResult] | None = None,
+        objective_metrics: list[dict[str, str]] | None = None,
+        regression_metrics: list[dict[str, str]] | None = None,
     ) -> PeerComparison:
         """Compare this agent to peers and return divergent trials and complementary patterns.
 
@@ -370,7 +385,14 @@ class AgentAnalyzer(Agent):
         )
         complementary_raw = self._find_complementary_failures(agent_id, evaluation, peer_evaluations)
 
-        return await self._narrate_peer_comparison(agent_id, top_divergent, complementary_raw, diagnoses)
+        return await self._narrate_peer_comparison(
+            agent_id,
+            top_divergent,
+            complementary_raw,
+            diagnoses,
+            objective_metrics or [],
+            regression_metrics or [],
+        )
 
     def _select_divergent_pairs(
         self,
@@ -498,6 +520,8 @@ class AgentAnalyzer(Agent):
         top_divergent: list[dict[str, Any]],
         complementary_raw: dict[str, dict[str, dict[str, list[str]]]],
         diagnoses: list[Diagnostic],
+        objective_metrics: list[dict[str, str]],
+        regression_metrics: list[dict[str, str]],
     ) -> PeerComparison:
         """Write the DivergentTrial and ComplementaryPattern narratives from pre-computed data.
 
@@ -515,6 +539,11 @@ class AgentAnalyzer(Agent):
         `complementary_raw` is
         `{task_id: {metric: {"leaders": [agents], "trailers": [agents]}}}`
         — per-metric splits between the best-scoring agents and the rest.
+
+        `objective_metrics` identifies metrics to improve and
+        `regression_metrics` identifies metrics to preserve. Use them to explain
+        whether a divergence is desirable or a regression risk; do not create a
+        scalar ranking.
 
         ## For each divergent pair
 
@@ -571,6 +600,8 @@ class AgentAnalyzer(Agent):
         client: AsyncNeMoPlatform | None = None,
         nmp_workspace: str | None = None,
         agent_spec: Path | None = None,
+        objective_metrics: list[dict[str, str]] | None = None,
+        regression_metrics: list[dict[str, str]] | None = None,
     ) -> AgentAnalysis:
         """Run the full analysis pipeline for one agent in one optimization round.
 
@@ -585,6 +616,8 @@ class AgentAnalyzer(Agent):
             nmp_workspace: NeMo Platform (Intake) workspace *name* — the request
                 context for ``intake://`` trace lookups. Distinct from the
                 constructor's ``workspace: Path`` (the filesystem eval dir).
+            objective_metrics: Active metrics to improve.
+            regression_metrics: Active metrics to preserve.
 
         Returns:
             AgentAnalysis: per-trial diagnostics, failure classification, and peer
@@ -598,12 +631,17 @@ class AgentAnalyzer(Agent):
         # trace-starved. Keying on availability prevents such a degraded result
         # from being replayed on a later run that *can* load those traces.
         intake_key = ":intake:1" if client is not None and nmp_workspace is not None else ":intake:0"
-        cache_key = cache.agent_hash(f"{agent_id}:evaluation:{evaluation.id}{round_key}{intake_key}")
+        objective_metrics = objective_metrics or []
+        regression_metrics = regression_metrics or []
+        cache_key = cache.agent_hash(
+            f"{agent_id}:evaluation:{evaluation.id}{round_key}{intake_key}:"
+            f"objective-metrics:{objective_metrics}:regression-metrics:{regression_metrics}"
+        )
         cached = cache.load(self._workspace_path, cache_key, AgentAnalysis)
         if cached is not None:
             return cached
 
-        trials = await self.select_trials(agent_id, dataset, evaluation)
+        trials = await self.select_trials(agent_id, dataset, evaluation, objective_metrics, regression_metrics)
         tasks_by_id = self._tasks_by_id(dataset)
 
         missing_task_diagnostics: dict[str, Diagnostic] = {}
@@ -692,8 +730,15 @@ class AgentAnalyzer(Agent):
         diagnoses = [analysis.diagnostic for analysis in trial_analyses]
 
         classification, comparison = await asyncio.gather(
-            self.classify_failures(agent_id, diagnoses, trials),
-            self.compare_with_peers(agent_id, evaluation, diagnoses, peer_evaluations),
+            self.classify_failures(agent_id, diagnoses, trials, objective_metrics, regression_metrics),
+            self.compare_with_peers(
+                agent_id,
+                evaluation,
+                diagnoses,
+                peer_evaluations,
+                objective_metrics,
+                regression_metrics,
+            ),
         )
 
         analysis_out = AgentAnalysis(

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/cache.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/cache.py
@@ -63,6 +63,17 @@ def trace_hash(trace_path: str | Path) -> str:
     return f"trace-{digest}"
 
 
+def trace_uri_hash(trace_key: str) -> str:
+    """Return a namespaced SHA-256 digest for a trace cache identity.
+
+    ``trace_key`` may include a trace-content digest or external trace URI plus
+    analysis inputs such as the metric contract. Unlike ``trace_hash``, it does
+    not read a filesystem path.
+    """
+    digest = hashlib.sha256(trace_key.encode()).hexdigest()
+    return f"trace-uri-{digest}"
+
+
 def _cache_path(workspace: Path, key: str) -> Path:
     return workspace / "eval-and-optimize" / "cache" / f"{key}.json"
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/dataset_staging.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/dataset_staging.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
-from nemo_experimentalist_plugin.entities import DatasetRef, local_path_from_uri
+from nemo_experimentalist_plugin.entities import Dataset, DatasetRef, local_path_from_uri
 from nemo_platform import AsyncNeMoPlatform
 
 
@@ -19,6 +19,24 @@ class _StagedEvalAuthorInputs:
     train_dataset: DatasetRef
     validation_dataset: DatasetRef
     task_template: DatasetRef
+
+
+def distribute_insight_suite_tasks(
+    insight_suite: Dataset,
+    train_dataset: Dataset,
+    validation_dataset: Dataset,
+) -> None:
+    """Assign Insight-suite tasks to validation/train at a deterministic 30/70 split.
+
+    Eval Author retains the materialized suite as its provenance artifact. The
+    optimizer consumes its tasks through the train and validation datasets,
+    reserving the first 30 percent for validation and using the remaining 70
+    percent for training feedback.
+    """
+    tasks = list(insight_suite.list_tasks())
+    validation_count = (3 * len(tasks) + 9) // 10
+    validation_dataset.add_tasks(tasks[:validation_count])
+    train_dataset.add_tasks(tasks[validation_count:])
 
 
 def _local_directory(ref: DatasetRef) -> Path:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
@@ -1177,6 +1177,51 @@ class HarborDataset(Dataset):
                 return task
         raise ValueError(f"Task id not found in Harbor dataset {self.id!r}: {task_id}")
 
+    def add_tasks(self, tasks: list[Task]) -> None:
+        """Copy Harbor task directories into this dataset and register them.
+
+        The destination dataset owns independent copies, so an Insight-suite
+        task can be evaluated through train or validation without depending on
+        the suite's original directory.
+        """
+        if not tasks:
+            return
+        if self.source is None:
+            raise ValueError(f"Harbor dataset {self.id!r} has no source directory")
+        destination_root = local_path_from_uri(self.source.uri, context="Harbor dataset source").resolve()
+        if not destination_root.is_dir():
+            raise ValueError(f"Harbor dataset source is not a directory: {destination_root}")
+
+        imported: dict[str, Task] = {}
+        for task in tasks:
+            if task.uri is None:
+                raise ValueError(f"Harbor task {task.id!r} has no source directory")
+            source_dir = local_path_from_uri(task.uri, context=f"Harbor task {task.id!r}").resolve()
+            if not source_dir.is_dir() or not (source_dir / _HARBOR_CONFIG_FILENAME["name"]).is_file():
+                raise ValueError(f"Harbor task {task.id!r} is not a task directory: {source_dir}")
+            destination = destination_root / task.id
+            staging = destination_root / f".{task.id}.staging-{uuid4().hex}"
+            backup = destination_root / f".{task.id}.backup-{uuid4().hex}"
+            shutil.copytree(source_dir, staging)
+            try:
+                if destination.exists():
+                    logger.warning("Replacing existing Harbor task %s in dataset %s", task.id, self.id)
+                    destination.rename(backup)
+                staging.rename(destination)
+            except BaseException:
+                if staging.exists():
+                    shutil.rmtree(staging)
+                if backup.exists() and not destination.exists():
+                    backup.rename(destination)
+                raise
+            else:
+                if backup.exists():
+                    shutil.rmtree(backup)
+            imported[task.id] = self._from_task_dir(destination)
+
+        self.tasks = [imported.pop(task.id, task) for task in self.tasks]
+        self.tasks.extend(imported.values())
+
     async def validate(self) -> None:
         """Validate selected task verifier syntax without executing verifier code."""
         failures: list[HarborVerifierValidationFailure] = []

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
@@ -75,7 +75,6 @@ from nemo_experimentalist_plugin.experimentalist.deps import ExperimentalistDeps
 from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import (
     ExperimentalistBackend,
 )
-from nemo_experimentalist_plugin.experimentalist.reporting import reward_scalar
 from nemo_experimentalist_plugin.experimentalist.result import ExperimentalistResult
 from nemo_platform import AsyncNeMoPlatform
 from nooa import Agent, CodeActStrategy, strategy
@@ -529,7 +528,7 @@ class EvolutionaryOptimizer(Agent):
                     None,
                 )
                 if baseline_node is not None and baseline_node.val_reward:
-                    reporter.seed_baseline(reward_scalar(baseline_node.val_reward))
+                    reporter.seed_baseline(baseline_node.val_reward)
             run_entity = self._load_run_entity() or await self._create_experiment_run(
                 workspace=workspace,
                 backend=backend,
@@ -600,7 +599,8 @@ class EvolutionaryOptimizer(Agent):
                     reporter.candidate_evaluated(
                         label=candidates[0].label,
                         split="validation",
-                        reward=reward_scalar(validation_result.aggregate_metrics),
+                        metrics=validation_result.aggregate_metrics,
+                        objective_metrics=config.objective_function,
                         artifacts=self._results_dir(validation_result.id),
                     )
             except Exception:
@@ -689,7 +689,8 @@ class EvolutionaryOptimizer(Agent):
                             reporter.candidate_evaluated(
                                 label=survivor.label,
                                 split="train",
-                                reward=reward_scalar(train_candidate_results[survivor.label].aggregate_metrics),
+                                metrics=train_candidate_results[survivor.label].aggregate_metrics,
+                                objective_metrics=config.objective_function,
                                 artifacts=self._results_dir(train_candidate_results[survivor.label].id),
                             )
                 analysis = await self._analyze_round(
@@ -807,7 +808,8 @@ class EvolutionaryOptimizer(Agent):
                             reporter.candidate_evaluated(
                                 label=candidate.label,
                                 split="validation",
-                                reward=reward_scalar(validation_candidate_results[candidate.label].aggregate_metrics),
+                                metrics=validation_candidate_results[candidate.label].aggregate_metrics,
+                                objective_metrics=config.objective_function,
                                 artifacts=self._results_dir(validation_candidate_results[candidate.label].id),
                             )
                 if not config.disable_trajectory_scoring:
@@ -1854,6 +1856,6 @@ class EvolutionaryOptimizer(Agent):
         details: list[str] = []
         if winner:
             if winner.reward("validation").metrics:
-                details.append(f"validation_reward={winner.reward('validation').metrics}")
+                details.append(f"validation_metrics={winner.reward('validation').metrics}")
         suffix = f", {', '.join(details)}" if details else ""
         return f"Optimization complete: {rounds_completed} round(s) completed, winner={winner_str}{suffix}"

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
@@ -19,7 +19,12 @@ from pathlib import Path
 from typing import Any, Literal, cast, get_args
 
 from nemo_eval_author_plugin.eval_author.agent import EvalAuthor
-from nemo_experimentalist_plugin.config import EvolutionaryOptimizerConfig
+from nemo_experimentalist_plugin.config import (
+    EvolutionaryOptimizerConfig,
+    MetricTarget,
+    is_eligible_for_metric_contract,
+    pareto_objectives,
+)
 from nemo_experimentalist_plugin.entities import (
     Candidate,
     Dataset,
@@ -29,7 +34,10 @@ from nemo_experimentalist_plugin.entities import (
 )
 from nemo_experimentalist_plugin.experimentalist.components.analyzer import AgentAnalyzer
 from nemo_experimentalist_plugin.experimentalist.components.coder import Coder, CoderConfig
-from nemo_experimentalist_plugin.experimentalist.components.dataset_staging import stage_eval_author_inputs
+from nemo_experimentalist_plugin.experimentalist.components.dataset_staging import (
+    distribute_insight_suite_tasks,
+    stage_eval_author_inputs,
+)
 from nemo_experimentalist_plugin.experimentalist.components.evaluator import Evaluator
 from nemo_experimentalist_plugin.experimentalist.components.evaluator.factory import DatasetFactory, EvaluatorFactory
 from nemo_experimentalist_plugin.experimentalist.components.goal_tree import (
@@ -54,6 +62,7 @@ from nemo_experimentalist_plugin.experimentalist.components.models import (
     pareto_sort,
 )
 from nemo_experimentalist_plugin.experimentalist.components.proposer import Improvement, Proposer
+from nemo_experimentalist_plugin.experimentalist.components.selector import SurvivorSelector
 from nemo_experimentalist_plugin.experimentalist.components.terminator import Terminator
 from nemo_experimentalist_plugin.experimentalist.components.tools import (
     GuardedShellTools,
@@ -123,6 +132,28 @@ def _coerce_optimization_type(optimization_type: str | None) -> OptimizationType
     if optimization_type in get_args(OptimizationType):
         return cast(OptimizationType, optimization_type)
     return None
+
+
+def _with_insight_objective(
+    config: EvolutionaryOptimizerConfig, metric_keys: tuple[str, ...]
+) -> EvolutionaryOptimizerConfig:
+    """Make insight metrics objectives and preserve all configured targets as guardrails."""
+    if not metric_keys:
+        return config
+    insight_metric_names = set(metric_keys)
+    objective = [MetricTarget(name=metric_key, direction="maximize") for metric_key in metric_keys]
+    regression_by_name = {
+        target.name: target
+        for target in [*config.objective_function, *config.regression_metrics]
+        if target.name not in insight_metric_names
+    }
+    return EvolutionaryOptimizerConfig.model_validate(
+        config.model_dump(mode="python")
+        | {
+            "objective_function": [target.model_dump(mode="python") for target in objective],
+            "regression_metrics": [target.model_dump(mode="python") for target in regression_by_name.values()],
+        }
+    )
 
 
 def _trajectory_detail_from_reward(value: Any) -> dict[str, Any]:
@@ -315,6 +346,7 @@ class EvolutionaryOptimizer(Agent):
         self._workspace_path = self.working_dir
         self._framework_skills_dirs: list[Path] = framework_skills_dirs or []
         self.terminator = Terminator()
+        self.selector = SurvivorSelector(workspace=self.working_dir)
         self.shell = GuardedShellTools(cwd=self.working_dir)
         self.workspace = WorkspaceTool(workspace=self.working_dir)
         self.context["file_match"] = doc(Match)
@@ -363,6 +395,7 @@ class EvolutionaryOptimizer(Agent):
         backend = deps.backend
         workspace = deps.workspace
         config = deps.config if deps.config is not None else self.config
+        self.config = config
         reporter = getattr(deps, "reporter", None)
 
         # ---- Preflight: fail fast when persistence is enabled but git is missing.
@@ -462,8 +495,21 @@ class EvolutionaryOptimizer(Agent):
                 validation_dataset=validation_eval_dataset,
                 client=backend.client,
             )
+            config = _with_insight_objective(config, eval_author_result.metric_keys)
+            self.config = config
+            logger.info("[METRICS] Insight objective: %s", config.optimization_policy())
             train_eval_dataset = eval_author_result.train_dataset
             validation_eval_dataset = eval_author_result.validation_dataset
+            if eval_author_result.insight_suite is not None:
+                restore_heldout_splits(self.working_dir)
+                try:
+                    distribute_insight_suite_tasks(
+                        eval_author_result.insight_suite,
+                        train_eval_dataset,
+                        validation_eval_dataset,
+                    )
+                finally:
+                    ensure_heldout_hidden(self.working_dir)
         else:
             # Mode 2: local agent directory as baseline, no insight required.
             insight = None
@@ -593,7 +639,11 @@ class EvolutionaryOptimizer(Agent):
                     break
 
                 survivors = (
-                    await self._select_survivors([c.slim() for c in candidates], k=config.max_survivors)
+                    await self._select_survivors(
+                        [c.slim() for c in candidates],
+                        k=config.max_survivors,
+                        baseline_metrics=self._baseline_validation_metrics(evolution_tree),
+                    )
                     if len(candidates) > 1
                     else list(candidates)
                 )
@@ -838,36 +888,15 @@ class EvolutionaryOptimizer(Agent):
                 _warn_persistence_failure("publish", winner_entity.label, exc)
         return result
 
-    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=100, cell_timeout=3600.0)))
-    async def select_diverse_survivors(self, ranked: list[Candidate], k: int) -> list[Candidate]:  # pyright: ignore[reportReturnType]
-        """Choose up to k survivors from Pareto-ranked candidates.
-
-        ``ranked`` is already Pareto-sorted using outcome and trajectory scores:
-        front 0 (non-dominated) first, then front 1, etc. Inside a front,
-        candidates are incomparable, so prefer agents with distinct architecture
-        changes, complementary task coverage, and different trajectory strengths.
-
-        To avoid getting stuck on the same agents round after round:
-        1. Always include at least 1 candidate that was newly created this round. Look up
-           `self.workspace.get_metadata(c.name)["round"]` for each candidate; new candidates
-           are the ones whose round equals the max round across `ranked`.
-        2. Prefer candidates with different optimization_type values or that address different root causes.
-        3. If all new candidates sit on a worse Pareto front, still include the best new candidate.
-
-        ## MANDATORY: Prefer agents with complementary strengths
-
-        Read each candidate's per-dimension validation rewards from metadata and
-        prefer a set whose strong dimensions cover each other (one agent leads on
-        dimensions where another trails):
-
-        ```python
-        rewards = {c.id: self.workspace.get_metadata(c.name).reward("validation").metrics or {} for c in ranked}
-        ```
-
-        Between 1 to 3 survivors per round.
-        Return the selected subset, preserving the input's Pareto-front order.
-        """
-        ...
+    async def select_diverse_survivors(
+        self,
+        ranked: list[Candidate],
+        k: int,
+        objective_metrics: list[MetricTarget],
+        regression_metrics: list[MetricTarget],
+    ) -> list[Candidate]:  # pyright: ignore[reportReturnType]
+        """Backward-compatible delegate for :class:`SurvivorSelector`."""
+        return await self.selector.select(ranked, k, objective_metrics, regression_metrics)
 
     @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=100, cell_timeout=3600.0)))
     async def merge_analysis(
@@ -879,6 +908,11 @@ class EvolutionaryOptimizer(Agent):
         """Merge per-agent analyses, compare agents, and write the round analysis file.
 
         ## Step 1: Compare agents at reward level
+
+        Read ``self.config.optimization_policy()`` for the active metric contract.
+        Explain objective improvements and any regression risk in those terms.
+        Treat evaluator metrics (including aggregate metrics) as authoritative;
+        do not derive a scalar score or prescribe a selection algorithm.
 
         Read each agent's per-dimension train rewards from metadata:
 
@@ -1367,10 +1401,42 @@ class EvolutionaryOptimizer(Agent):
         self,
         candidates: list[Candidate],
         k: int,
+        baseline_metrics: dict[str, float],
     ) -> list[Candidate]:
-        """Return the top-k Pareto-optimal and architecturally diverse candidates."""
-        ranked = pareto_sort(candidates, lambda c: c.reward("validation").metrics or {})
-        return await self.select_diverse_survivors(ranked, k)
+        """Return diverse Pareto survivors that meet the complete metric contract."""
+        eligible = [
+            candidate
+            for candidate in candidates
+            if is_eligible_for_metric_contract(
+                candidate.reward("validation").metrics or {},
+                objective_function=self.config.objective_function,
+                regression_metrics=self.config.regression_metrics,
+                baseline_metrics=baseline_metrics,
+            )
+        ]
+        excluded = [candidate.label for candidate in candidates if candidate not in eligible]
+        if excluded:
+            logger.warning("[METRICS] Excluding candidates that violate the metric contract: %s", excluded)
+        ranked = pareto_sort(
+            eligible,
+            lambda candidate: pareto_objectives(
+                candidate.reward("validation").metrics or {}, self.config.objective_function
+            ),
+        )
+        return await self.select_diverse_survivors(
+            ranked,
+            k,
+            self.config.objective_function,
+            self.config.regression_metrics,
+        )
+
+    @staticmethod
+    def _baseline_validation_metrics(evolution_tree: EvolutionTree) -> dict[str, float]:
+        """Return the round-0 validation metrics used by regression guardrails."""
+        baseline = next((node for node in evolution_tree.nodes.values() if node.round == 0), None)
+        if baseline is None:
+            raise ValueError("Cannot enforce regression metrics without a round-0 baseline candidate")
+        return baseline.val_reward
 
     async def _evaluate_train_candidates(
         self,
@@ -1466,6 +1532,8 @@ class EvolutionaryOptimizer(Agent):
                     client=client,
                     nmp_workspace=nmp_workspace,
                     agent_spec=agent_spec_path,
+                    objective_metrics=[target.model_dump() for target in config.objective_function],
+                    regression_metrics=[target.model_dump() for target in config.regression_metrics],
                 )
                 for s in survivors
             ]
@@ -1715,7 +1783,25 @@ class EvolutionaryOptimizer(Agent):
         """Select the winner, copy to workspace root, write final report."""
         # Only survivors that actually have a validation reward are eligible winners.
         scored = [n for n in evolution_tree.nodes.values() if n.is_survivor and n.val_reward]
-        front = pareto_front(scored, lambda n: n.val_reward) if scored else []
+        baseline_metrics = self._baseline_validation_metrics(evolution_tree)
+        eligible = [
+            node
+            for node in scored
+            if is_eligible_for_metric_contract(
+                node.val_reward,
+                objective_function=self.config.objective_function,
+                regression_metrics=self.config.regression_metrics,
+                baseline_metrics=baseline_metrics,
+            )
+        ]
+        front = (
+            pareto_front(
+                eligible,
+                lambda node: pareto_objectives(node.val_reward, self.config.objective_function),
+            )
+            if eligible
+            else []
+        )
         best_id = front[0].label if front else None
 
         restore_heldout_splits(self.working_dir)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
@@ -1597,6 +1597,8 @@ class EvolutionaryOptimizer(Agent):
             round_num=round_num,
             phase=phase,
             max_candidates=config.max_candidates,
+            objective_metrics=[target.model_dump(mode="json") for target in config.objective_function],
+            regression_metrics=[target.model_dump(mode="json") for target in config.regression_metrics],
         )
 
     async def _implement_candidates(

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/loop.py
@@ -906,13 +906,16 @@ class EvolutionaryOptimizer(Agent):
         agent_ids: list[Candidate],
         round: int,
         per_agent_analyses: list[str],  # noqa: A002
+        objective_metrics: list[MetricTarget],
+        regression_metrics: list[MetricTarget],
     ) -> str:  # pyright: ignore[reportReturnType]
         """Merge per-agent analyses, compare agents, and write the round analysis file.
 
         ## Step 1: Compare agents at reward level
 
-        Read ``self.config.optimization_policy()`` for the active metric contract.
-        Explain objective improvements and any regression risk in those terms.
+        Active objectives: ``objective_metrics``. Active regression guardrails:
+        ``regression_metrics``. Analyze objective improvements and shortfalls first;
+        discuss regression only as a constraint on objective improvement.
         Treat evaluator metrics (including aggregate metrics) as authoritative;
         do not derive a scalar score or prescribe a selection algorithm.
 
@@ -929,7 +932,10 @@ class EvolutionaryOptimizer(Agent):
 
         Using the per-dimension rewards above, identify where agents diverge (one
         leads, another trails on a dimension) and where their strengths are
-        complementary. Ground observations in the per-agent analyses passed in.
+        complementary. Prioritize divergences on objective metrics. A regression
+        metric can identify a guardrail risk, but must not become the primary
+        failure pattern or root cause. Ground observations in the per-agent
+        analyses passed in.
 
         ## Step 3: Build the round analysis markdown
 
@@ -945,6 +951,9 @@ class EvolutionaryOptimizer(Agent):
         Mechanical/Infrastructure Errors).
 
         Fill in every included section with real data. No placeholders.
+        Every Failure Pattern and Root Cause must explain a failing or
+        underperforming objective metric. Do not write a root-cause narrative
+        solely about a regression metric; record it as a regression risk instead.
         Return the complete markdown content as a string.
         """
         ...
@@ -1540,7 +1549,13 @@ class EvolutionaryOptimizer(Agent):
                 for s in survivors
             ]
         )
-        analysis = await self.merge_analysis(survivors, round_num, [str(a) for a in per_agent])
+        analysis = await self.merge_analysis(
+            survivors,
+            round_num,
+            [str(a) for a in per_agent],
+            config.objective_function,
+            config.regression_metrics,
+        )
         analysis_path.parent.mkdir(parents=True, exist_ok=True)
         analysis_path.write_text(analysis)
         return analysis

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/proposer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/proposer.py
@@ -98,6 +98,8 @@ class Proposer(Agent):
         round_num: int,
         phase: Literal["exploration", "exploitation"],
         max_candidates: int,
+        objective_metrics: list[dict[str, str]],
+        regression_metrics: list[dict[str, str]],
     ) -> list[Improvement]:
         """Return up to max_candidates targeted improvement proposals.
 
@@ -108,6 +110,8 @@ class Proposer(Agent):
             round_num: current optimization round number; used to filter survivors.
             phase: "exploration" for novel directions, "exploitation" to refine the best.
             max_candidates: maximum number of Improvement objects to return.
+            objective_metrics: Evaluator metric dimensions this round must improve.
+            regression_metrics: Evaluator metric dimensions this round must preserve.
 
         Returns:
             list[Improvement]: up to max_candidates targeted improvement proposals.
@@ -140,7 +144,7 @@ class Proposer(Agent):
             survivor_context.append(
                 {
                     "id": s.label,
-                    "reward": s.reward("validation").metrics or {},
+                    "metrics": s.reward("validation").metrics or {},
                     "trajectory_reward": s.reward("validation-trajectory").metrics or {},
                     "metadata": meta,
                     "architecture": arch_text,
@@ -156,6 +160,8 @@ class Proposer(Agent):
             cards_index=doc(self.optimize),
             phase=phase,
             max_candidates=max_candidates,
+            objective_metrics=objective_metrics,
+            regression_metrics=regression_metrics,
         )
         self._validate_improvements(
             improvements=improvements,
@@ -204,6 +210,8 @@ class Proposer(Agent):
         cards_index: str,
         phase: Literal["exploration", "exploitation"],
         max_candidates: int,
+        objective_metrics: list[dict[str, str]],
+        regression_metrics: list[dict[str, str]],
     ) -> list[Improvement]:
         """Pick up to `max_candidates` targeted improvements grounded in root causes.
 
@@ -212,13 +220,15 @@ class Proposer(Agent):
         - evolution_history (str): markdown table of prior rounds, for context
         - tried_types (list[str]): optimization_types already attempted — AVOID these
         - available_types (list[str]): types not yet tried — PICK FROM THESE
-        - survivors (list[dict]): each {id, reward, trajectory_reward, metadata,
+        - survivors (list[dict]): each {id, metrics, trajectory_reward, metadata,
           architecture}; these are your branching candidates with their architecture.md
           already loaded
         - cards_index (str): pre-rendered `doc(self.optimize)` showing the card index.
           Load a specific card on demand via `print(doc(self.optimize.<name>))`.
         - phase (Literal): "exploration" = novel directions; "exploitation" = improve current best
         - max_candidates (int): max number of Improvements to return (typically 3)
+        - objective_metrics (list[dict]): evaluator dimensions to improve
+        - regression_metrics (list[dict]): evaluator dimensions to preserve
 
         Returns:
         - list[Improvement]: up to `max_candidates` Improvements.
@@ -231,7 +241,8 @@ class Proposer(Agent):
 
         ## Per-improvement requirements
         For each Improvement you propose:
-        1. Identify ONE root cause from the analysis: the specific reason the agent
+        1. Identify ONE root cause from the analysis that limits an active objective:
+           the specific reason the agent
            underperforms, stated as a diagnosis ("The agent fails because X is absent /
            misconfigured / too vague"). Do NOT include the proposed remedy here — that
            belongs in `optimization`. If you cannot articulate the failure cause
@@ -252,6 +263,17 @@ class Proposer(Agent):
            caused by this `root_cause` — the concrete tasks the coder should use to
            validate the fix. Pick 2-3 tasks the ancestor actually fails (or barely
            passes) for this reason; do not pad with unrelated passing tasks.
+
+        ## Metric contract
+        - Optimize these objective metrics: `objective_metrics`. Every proposed
+          change must have a concrete, evidence-based path to improving at least one
+          of these dimensions.
+        - Preserve these regression metrics: `regression_metrics`. They are
+          guardrails, not proposal targets: do not choose a root cause or frame an
+          optimization solely around improving a regression metric. Instead, ensure
+          the proposed objective improvement does not sacrifice them.
+        - Evaluator metric values are authoritative. Do not invent an aggregate,
+          scalarization, weighting, or threshold.
 
         ## Branching rules
         - Branch from any survivor — usually the top scorer, but a lower-scoring

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/selector.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/selector.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The reasoning component that selects a diverse survivor set."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from nemo_experimentalist_plugin.config import MetricTarget
+from nemo_experimentalist_plugin.entities import Candidate
+from nemo_experimentalist_plugin.experimentalist.components.model_config import get_smart_model
+from nemo_experimentalist_plugin.experimentalist.components.tools import WorkspaceTool
+from nooa import Agent, CodeActStrategy, strategy
+from nooa.config import CodeActConfig
+
+
+class SurvivorSelector(Agent):
+    """Select survivors from a Pareto-ranked population."""
+
+    def __init__(self, workspace: Path, **kwargs: Any) -> None:
+        super().__init__(llm=kwargs.pop("llm", None) or get_smart_model(), **kwargs)
+        self.workspace = WorkspaceTool(workspace=workspace)
+
+    @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=100, cell_timeout=3600.0)))
+    async def select(
+        self,
+        ranked: list[Candidate],
+        k: int,
+        objective_metrics: list[MetricTarget],
+        regression_metrics: list[MetricTarget],
+    ) -> list[Candidate]:  # pyright: ignore[reportReturnType]
+        """Choose up to k survivors from Pareto-ranked candidates.
+
+        ``ranked`` is already Pareto-sorted using outcome and trajectory scores:
+        front 0 (non-dominated) first, then front 1, etc. Inside a front,
+        candidates are incomparable, so prefer agents with distinct architecture
+        changes, complementary task coverage, and different trajectory strengths.
+
+        To avoid getting stuck on the same agents round after round:
+        1. Always include at least 1 candidate that was newly created this round. Look up
+           `self.workspace.get_metadata(c.name)["round"]` for each candidate; new candidates
+           are the ones whose round equals the max round across `ranked`.
+        2. Prefer candidates with different optimization_type values or that address different root causes.
+        3. If all new candidates sit on a worse Pareto front, still include the best new candidate.
+
+        ## MANDATORY: Prefer agents with complementary strengths
+
+        Read each candidate's per-dimension validation rewards from metadata and
+        prefer a set whose strong dimensions cover each other (one agent leads on
+        dimensions where another trails):
+
+        ```python
+        rewards = {c.id: self.workspace.get_metadata(c.name).reward("validation").metrics or {} for c in ranked}
+        ```
+
+        Between 1 to 3 survivors per round.
+        Return the selected subset, preserving the input's Pareto-front order.
+
+        ``objective_metrics`` are the evaluator metric dimensions to improve.
+        ``regression_metrics`` are evaluator metric dimensions that must not
+        worsen. Use their reported values as evidence; do not invent formulas,
+        weights, thresholds, or another mechanical selection rule.
+        """
+        ...

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
@@ -16,7 +16,12 @@ from typing import Any
 
 # Imported from `resolve` rather than `.loop`, which merely re-exports it: `loop` imports
 # this module, so going through it would be circular.
-from nemo_experimentalist_plugin.config import EvolutionaryOptimizerConfig
+from nemo_experimentalist_plugin.config import (
+    EvolutionaryOptimizerConfig,
+    MetricTarget,
+    is_eligible_for_metric_contract,
+    pareto_objectives,
+)
 from nemo_experimentalist_plugin.experimentalist.components.models import EvolutionTree, pareto_front
 from nemo_experimentalist_plugin.skills import skills_dir
 from nooa import Agent, CodeActStrategy, TextSkill, hidden, strategy
@@ -110,6 +115,8 @@ class Terminator(Agent):
             evolution_tree=evolution_tree,
             prior_analysis=prior_analysis,
             min_rounds_before_stopping=config.min_rounds_before_stopping,
+            objective_metrics=config.objective_function,
+            regression_metrics=config.regression_metrics,
         )
         if converged:
             return TerminationDecision(stop=True, reason="optimization converged (Pareto front stagnated)")
@@ -143,6 +150,8 @@ class Terminator(Agent):
         evolution_tree: EvolutionTree,
         prior_analysis: str,
         min_rounds_before_stopping: int,
+        objective_metrics: list[MetricTarget] | None = None,
+        regression_metrics: list[MetricTarget] | None = None,
     ) -> bool:
         """Return True if the optimization has converged and should stop early."""
         # Truthy check (not ``is not None``): ``EvolutionNode.val_reward`` returns ``{}`` for
@@ -156,19 +165,57 @@ class Terminator(Agent):
         old = [n for n in scored if n.round <= cutoff_round]
         if not old:
             return False
-        old_front_ids = {n.label for n in pareto_front(old, lambda n: n.val_reward)}
-        full_front_ids = {n.label for n in pareto_front(scored, lambda n: n.val_reward)}
+        active_objectives = objective_metrics or EvolutionaryOptimizerConfig().objective_function
+        active_regressions = regression_metrics or []
+        baseline = next((node for node in evolution_tree.nodes.values() if node.round == 0), None)
+        baseline_metrics = baseline.val_reward if baseline is not None else {}
+        scored = [
+            node
+            for node in scored
+            if is_eligible_for_metric_contract(
+                node.val_reward,
+                objective_function=active_objectives,
+                regression_metrics=active_regressions,
+                baseline_metrics=baseline_metrics,
+            )
+        ]
+        if not scored:
+            return False
+        old = [node for node in old if node in scored]
+        if not old:
+            return False
+        old_front_ids = {
+            node.label for node in pareto_front(old, lambda node: pareto_objectives(node.val_reward, active_objectives))
+        }
+        full_front_ids = {
+            node.label
+            for node in pareto_front(scored, lambda node: pareto_objectives(node.val_reward, active_objectives))
+        }
         if full_front_ids.issubset(old_front_ids):
             return True
-        return await self.qualitative_stop_check(prior_analysis)
+        return await self.qualitative_stop_check(
+            prior_analysis,
+            objective_metrics or [],
+            regression_metrics or [],
+        )
 
     @strategy(CodeActStrategy(config=CodeActConfig(max_iterations=5)))
-    async def qualitative_stop_check(self, analysis: str) -> bool:  # pyright: ignore[reportReturnType]
+    async def qualitative_stop_check(
+        self,
+        analysis: str,
+        objective_metrics: list[MetricTarget],
+        regression_metrics: list[MetricTarget],
+    ) -> bool:  # pyright: ignore[reportReturnType]
         """Decide whether the optimization has qualitatively plateaued; return True to stop.
 
         Judge the round ``analysis`` text against the terminator skill's stop
         heuristics (prefilled below). Return True only with concrete textual
         evidence of stagnation in ``analysis``; when in doubt, return False.
+
+        ``objective_metrics`` are the evaluator metrics being improved;
+        ``regression_metrics`` are those that must not worsen. Judge stagnation
+        only in that context; do not invent a scalar score, weights, or a new
+        selection rule.
         """
         print(doc(self.terminator_skill))
         ...

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
@@ -356,7 +356,7 @@ class TraceAnalyzer(Agent):
             f"{_trace_cache_key(trial.trace.uri)}:selection-reason:{selection_reason}:"
             f"objective-metrics:{objective_metrics or []}:regression-metrics:{regression_metrics or []}"
         )
-        key = cache.agent_hash(metric_contract_key)
+        key = cache.trace_uri_hash(metric_contract_key)
 
         cached = cache.load(self._experiment_dir, key, Diagnostic)
         if cached is not None:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
@@ -227,6 +227,9 @@ class TraceAnalyzer(Agent):
         ``objective_metrics`` (dimensions to improve) and ``regression_metrics``
         (dimensions to preserve). Do not invent scalar formulas, weights, or
         thresholds for evaluator-defined metrics.
+        Frame decision points around the objective metric shortfall. A regression
+        metric may identify a guardrail risk, but is not by itself the failure this
+        optimization round is trying to diagnose.
 
         All TraceExplorer methods are async — always `await` them.
 
@@ -285,7 +288,9 @@ class TraceAnalyzer(Agent):
         If insight is present and the trace does not match the insight's behavior,
         set ``outcome="SUCCESS"`` with ``failure_point=None``.
         Use the metric contract to distinguish objective shortfalls from regression
-        risks. Do not invent scalar formulas, weights, or thresholds.
+        risks. The root cause must explain an objective metric's underperformance;
+        describe regression effects only as constraints. Do not invent scalar
+        formulas, weights, or thresholds.
         """  # noqa: D413
         ...
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
@@ -193,6 +193,9 @@ class TraceAnalyzer(Agent):
         agent_path: Path,
         runtime: DependencyRuntime | None,
         insight: Insight | None = None,
+        selection_reason: str = "",
+        objective_metrics: list[dict[str, str]] | None = None,
+        regression_metrics: list[dict[str, str]] | None = None,
     ) -> StepAnalysis:
         """Trace the agent's path and find where it went wrong.
 
@@ -204,6 +207,10 @@ class TraceAnalyzer(Agent):
             rationale (Rationale): reference solution; may have empty steps
             insight: Production insight. If present, use its title and
                 description as the analysis lens.
+            selection_reason: Why the trial was selected for in-depth analysis.
+            objective_metrics: Evaluator metric dimensions the optimization run
+                aims to improve.
+            regression_metrics: Evaluator metric dimensions that must not worsen.
             agent_path: Local path to the agent root.
             runtime: Dependency runtime to use for analyzing the trace.
 
@@ -215,6 +222,11 @@ class TraceAnalyzer(Agent):
         If insight is present, look specifically for the behavior described by
         ``insight.title`` and ``insight.description``. If ``agent_path`` is present,
         inspect agent code there when it helps explain the trace.
+        Use ``selection_reason`` to focus on the evidence that motivated this
+        analysis. Interpret the trace and ``trial.metrics`` against
+        ``objective_metrics`` (dimensions to improve) and ``regression_metrics``
+        (dimensions to preserve). Do not invent scalar formulas, weights, or
+        thresholds for evaluator-defined metrics.
 
         All TraceExplorer methods are async — always `await` them.
 
@@ -244,6 +256,8 @@ class TraceAnalyzer(Agent):
         trace: TraceExplorer,
         analysis: StepAnalysis,
         insight: Insight | None = None,
+        objective_metrics: list[dict[str, str]] | None = None,
+        regression_metrics: list[dict[str, str]] | None = None,
     ) -> Diagnostic:
         """Determine the primary root cause and produce a Diagnostic.
 
@@ -252,6 +266,9 @@ class TraceAnalyzer(Agent):
             analysis (StepAnalysis): result from analyze_trajectory
             insight: Optional production insight. If present, diagnose the root cause
                 of that insight's failure behavior.
+            objective_metrics: Evaluator metric dimensions the optimization run
+                aims to improve.
+            regression_metrics: Evaluator metric dimensions that must not worsen.
 
         Returns:
             Diagnostic: result with outcome, summary, failure_point, and root_cause.
@@ -267,6 +284,8 @@ class TraceAnalyzer(Agent):
         Return a complete Diagnostic with outcome, summary, failure_point, and root_cause.
         If insight is present and the trace does not match the insight's behavior,
         set ``outcome="SUCCESS"`` with ``failure_point=None``.
+        Use the metric contract to distinguish objective shortfalls from regression
+        risks. Do not invent scalar formulas, weights, or thresholds.
         """  # noqa: D413
         ...
 
@@ -277,6 +296,9 @@ class TraceAnalyzer(Agent):
         agent_path: Path,
         rationale: Rationale | None = None,
         insight: Insight | None = None,
+        selection_reason: str = "",
+        objective_metrics: list[dict[str, str]] | None = None,
+        regression_metrics: list[dict[str, str]] | None = None,
         client: AsyncNeMoPlatform | None = None,
         workspace: str | None = None,
     ) -> Diagnostic:
@@ -289,6 +311,10 @@ class TraceAnalyzer(Agent):
             rationale: Optional reference solution produced by Rationalizer; used as
                 a compass for trajectory analysis. Pass ``None`` to skip comparison.
             insight: Optional production insight to use as the failure lens.
+            selection_reason: Why the analyzer selected this trial for inspection.
+            objective_metrics: Evaluator metric dimensions the optimization run
+                aims to improve.
+            regression_metrics: Evaluator metric dimensions that must not worsen.
             client: Existing NeMo Platform client for Intake trace identifiers.
             workspace: NMP workspace request context for Intake trace identifiers.
 
@@ -326,7 +352,11 @@ class TraceAnalyzer(Agent):
         # only ever diagnosed through one lens and cannot collide here. If a future
         # caller analyzes the same trace under different insights in one experiment_dir,
         # fold the insight identity into this key to avoid returning a stale-lens Diagnostic.
-        key = _trace_cache_key(trial.trace.uri)
+        metric_contract_key = (
+            f"{_trace_cache_key(trial.trace.uri)}:selection-reason:{selection_reason}:"
+            f"objective-metrics:{objective_metrics or []}:regression-metrics:{regression_metrics or []}"
+        )
+        key = cache.agent_hash(metric_contract_key)
 
         cached = cache.load(self._experiment_dir, key, Diagnostic)
         if cached is not None:
@@ -343,9 +373,18 @@ class TraceAnalyzer(Agent):
                 overview=overview,
                 rationale=rationale,
                 insight=insight,
+                selection_reason=selection_reason,
+                objective_metrics=objective_metrics,
+                regression_metrics=regression_metrics,
                 agent_path=agent_path,
                 runtime=runtime,
             )
-            diagnostic = await self.diagnose(trace, analysis, insight)
+            diagnostic = await self.diagnose(
+                trace,
+                analysis,
+                insight,
+                objective_metrics,
+                regression_metrics,
+            )
             cache.store(self._experiment_dir, key, diagnostic)
         return diagnostic

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
@@ -480,8 +480,8 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
             if sib.label == _BASELINE_AGENT_LABEL:
                 continue
             marker = " (winner)" if sib.label == candidate.label else ""
-            reward = sib.reward("validation").metrics or sib.reward("train").metrics or {}
-            lines.append(f"- `{sib.label}`{marker}: `{self._candidate_branch(sib)}` — reward={reward}")
+            metrics = sib.reward("validation").metrics or sib.reward("train").metrics or {}
+            lines.append(f"- `{sib.label}`{marker}: `{self._candidate_branch(sib)}` — metrics={metrics}")
         return summary + "\n" + "\n".join(lines) + "\n"
 
     # -- Agent reads ---------------------------------------------------------

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/reporting.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/reporting.py
@@ -17,6 +17,8 @@ from enum import Enum
 from pathlib import Path
 from typing import TextIO
 
+from nemo_experimentalist_plugin.config import MetricTarget
+
 _RULE = "═" * 62
 _THIN = "─" * 62
 
@@ -33,11 +35,6 @@ class Verbosity(str, Enum):
     NORMAL = "normal"
 
 
-def reward_scalar(aggregate_metrics: dict[str, float | int]) -> float:
-    """Extract the scalar reward from an evaluation's aggregate metrics."""
-    return float(aggregate_metrics.get("reward", 0.0))
-
-
 class RunReporter:
     """Formats run-progress narration to a sink. Never raises into the run."""
 
@@ -49,7 +46,8 @@ class RunReporter:
     ) -> None:
         self._sink: TextIO = sink if sink is not None else sys.stderr
         self._verbosity = verbosity
-        self._baseline_val: float | None = None
+        self._baseline_metrics: dict[str, float] | None = None
+        self._objective_metrics: list[MetricTarget] = []
 
     def _emit(self, line: str) -> None:
         try:
@@ -58,7 +56,7 @@ class RunReporter:
         except Exception:  # noqa: BLE001 - narration must never break the run
             pass
 
-    def seed_baseline(self, reward: float) -> None:
+    def seed_baseline(self, metrics: dict[str, float | int]) -> None:
         """Set the validation delta reference without emitting a line.
 
         Used on resume, where agent-0 is not re-evaluated: without this, the
@@ -67,8 +65,8 @@ class RunReporter:
         baseline is already set.
         """
         try:
-            if self._baseline_val is None:
-                self._baseline_val = reward
+            if self._baseline_metrics is None:
+                self._baseline_metrics = {name: float(value) for name, value in metrics.items()}
         except Exception:  # noqa: BLE001
             pass
 
@@ -109,32 +107,65 @@ class RunReporter:
         except Exception:  # noqa: BLE001
             pass
 
-    def candidate_evaluated(self, *, label: str, split: str, reward: float, artifacts: Path) -> None:
+    def candidate_evaluated(
+        self,
+        *,
+        label: str,
+        split: str,
+        metrics: dict[str, float | int],
+        objective_metrics: list[MetricTarget],
+        artifacts: Path,
+    ) -> None:
+        """Narrate an evaluation using all configured objective metrics.
+
+        Objective directions determine whether validation deltas are displayed
+        as improvements or declines. Regression metrics are guardrails and are
+        intentionally not presented as progress dimensions.
+        """
         if self._verbosity is Verbosity.QUIET:
             return
         try:
-            delta = ""
+            self._objective_metrics = objective_metrics
+            has_baseline = self._baseline_metrics is not None
             if split == "validation":
-                if self._baseline_val is None:
-                    self._baseline_val = reward
-                else:
-                    d = reward - self._baseline_val
-                    delta = f"  {'▲' if d >= 0 else '▼'}{d:+.3f}"
-            self._emit(f"   {label} · {split:<10} · reward {reward:.3f}{delta}   → {artifacts}")
+                self.seed_baseline(metrics)
+            rendered_metrics: list[str] = []
+            for target in objective_metrics:
+                value = metrics.get(target.name)
+                if value is None:
+                    rendered_metrics.append(f"{target.name} n/a")
+                    continue
+                rendered = f"{target.name} {float(value):.3f}"
+                baseline_value = (self._baseline_metrics or {}).get(target.name)
+                if split == "validation" and has_baseline and baseline_value is not None:
+                    delta = float(value) - baseline_value
+                    improved = delta >= 0 if target.direction == "maximize" else delta <= 0
+                    rendered += f" {'▲' if improved else '▼'}{delta:+.3f}"
+                rendered_metrics.append(rendered)
+            self._emit(f"   {label} · {split:<10} · {', '.join(rendered_metrics)}   → {artifacts}")
         except Exception:  # noqa: BLE001
             pass
 
-    def run_finished(self, *, winner: str | None, scores: dict[str, float], report_path: Path | None) -> None:
+    def run_finished(
+        self,
+        *,
+        winner: str | None,
+        scores: dict[str, float],
+        report_path: Path | None,
+    ) -> None:
         try:
             self._emit(_THIN)
             if winner is None:
                 self._emit(" Finished · no winner (no scored candidates)")
             else:
                 head = f" Finished · winner={winner}"
-                val = scores.get("reward")
-                if val is not None:
-                    base = f" (baseline {self._baseline_val:.3f})" if self._baseline_val is not None else ""
-                    head += f" · validation {val:.3f}{base}"
+                rendered_metrics = [
+                    f"{target.name} {float(scores[target.name]):.3f}"
+                    for target in self._objective_metrics
+                    if target.name in scores
+                ]
+                if rendered_metrics:
+                    head += f" · validation {', '.join(rendered_metrics)}"
                 self._emit(head)
             if report_path is not None:
                 self._emit(f" report:  {report_path}")

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging.py
@@ -6,11 +6,13 @@ from types import SimpleNamespace
 from typing import cast
 
 import pytest
-from nemo_experimentalist_plugin.entities import DatasetRef
+from nemo_experimentalist_plugin.entities import Dataset, DatasetRef, Task
 from nemo_experimentalist_plugin.experimentalist.components.dataset_staging import (
+    distribute_insight_suite_tasks,
     stage_eval_author_inputs,
     stage_task_template,
 )
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor import HarborDataset
 from nemo_platform import AsyncNeMoPlatform
 
 
@@ -18,6 +20,49 @@ def _write_tree(root: Path, content: str) -> None:
     tests = root / "task-1" / "tests"
     tests.mkdir(parents=True)
     (tests / "test.sh").write_text(content, encoding="utf-8")
+
+
+class _MemoryDataset(Dataset):
+    def add_tasks(self, tasks: list[Task]) -> None:
+        self.tasks.extend(tasks)
+
+
+def test_distribute_insight_suite_tasks_uses_a_30_70_validation_train_split() -> None:
+    insight_suite = _MemoryDataset(id="insight", tasks=[Task(id=f"task-{index}") for index in range(10)])
+    train_dataset = _MemoryDataset(id="train")
+    validation_dataset = _MemoryDataset(id="validation")
+
+    distribute_insight_suite_tasks(insight_suite, train_dataset, validation_dataset)
+
+    assert [task.id for task in validation_dataset.list_tasks()] == ["task-0", "task-1", "task-2"]
+    assert [task.id for task in train_dataset.list_tasks()] == [
+        "task-3",
+        "task-4",
+        "task-5",
+        "task-6",
+        "task-7",
+        "task-8",
+        "task-9",
+    ]
+
+
+def test_harbor_dataset_add_tasks_copies_task_directories(tmp_path: Path) -> None:
+    source_root = tmp_path / "insight-suite"
+    destination_root = tmp_path / "train"
+    (source_root / "insight-task" / "task.toml").parent.mkdir(parents=True)
+    (source_root / "insight-task" / "task.toml").write_text("", encoding="utf-8")
+    (destination_root / "insight-task" / "task.toml").parent.mkdir(parents=True)
+    (destination_root / "insight-task" / "stale.txt").write_text("old", encoding="utf-8")
+    (destination_root / "insight-task" / "task.toml").write_text("", encoding="utf-8")
+    insight_suite = HarborDataset.from_path(source_root)
+    train_dataset = HarborDataset.from_path(destination_root)
+
+    train_dataset.add_tasks(list(insight_suite.list_tasks()))
+
+    assert (destination_root / "insight-task" / "task.toml").is_file()
+    assert not (destination_root / "insight-task" / "stale.txt").exists()
+    assert [task.id for task in train_dataset.list_tasks()] == ["insight-task"]
+    assert Path(train_dataset.get_task("insight-task").uri.removeprefix("file://")) == destination_root / "insight-task"
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging_loop.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging_loop.py
@@ -39,10 +39,8 @@ async def test_insight_run_stages_inputs_and_stops_at_eval_author_handoff(
         def __init__(self, train_dataset: SimpleNamespace, validation_dataset: SimpleNamespace) -> None:
             self.train_dataset = train_dataset
             self.validation_dataset = validation_dataset
-
-        @property
-        def insight_suite(self) -> None:
-            raise AssertionError("Experimentalist must not consume the authored Insight suite yet")
+            self.insight_suite = None
+            self.metric_keys = ("reward",)
 
     class RecordingDatasetFactory:
         def build_dataset(self, evaluator_type: str, ref: DatasetRef) -> SimpleNamespace:

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_reporting.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_reporting.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 import io
 from pathlib import Path
 
-from nemo_experimentalist_plugin.experimentalist.reporting import (
-    RunReporter,
-    Verbosity,
-    reward_scalar,
-)
+from nemo_experimentalist_plugin.config import MetricTarget
+from nemo_experimentalist_plugin.experimentalist.reporting import RunReporter, Verbosity
+
+OBJECTIVES = [
+    MetricTarget(name="success", direction="maximize"),
+    MetricTarget(name="tokens", direction="minimize"),
+]
 
 
 def _reporter(verbosity: Verbosity = Verbosity.NORMAL) -> tuple[RunReporter, io.StringIO]:
@@ -46,19 +48,28 @@ def test_progress_renders_fraction_and_bare_phase() -> None:
     assert "proposing candidates" in out
 
 
-def test_candidate_evaluated_sets_baseline_then_shows_delta() -> None:
+def test_candidate_evaluated_shows_all_objectives_and_direction_aware_deltas() -> None:
     r, sink = _reporter()
     r.candidate_evaluated(
-        label="agent-0", split="validation", reward=0.05, artifacts=Path("/exp/results/agent-0-validation")
+        label="agent-0",
+        split="validation",
+        metrics={"success": 0.05, "tokens": 100.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-0-validation"),
     )
     r.candidate_evaluated(
-        label="agent-1", split="validation", reward=0.19, artifacts=Path("/exp/results/agent-1-validation")
+        label="agent-1",
+        split="validation",
+        metrics={"success": 0.19, "tokens": 80.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-1-validation"),
     )
     lines = sink.getvalue().splitlines()
-    assert "reward 0.050" in lines[0]
-    assert "▲" not in lines[0]  # baseline has no delta
-    assert "reward 0.190" in lines[1]
-    assert "+0.140" in lines[1]  # delta vs baseline
+    assert "success 0.050" in lines[0]
+    assert "tokens 100.000" in lines[0]
+    assert "▲" not in lines[0]
+    assert "success 0.190 ▲+0.140" in lines[1]
+    assert "tokens 80.000 ▲-20.000" in lines[1]
 
 
 def test_seed_baseline_sets_delta_reference_silently_for_resume() -> None:
@@ -66,43 +77,66 @@ def test_seed_baseline_sets_delta_reference_silently_for_resume() -> None:
     # reference from its cached reward without emitting a line, so the first
     # newly evaluated candidate is measured against agent-0, not itself.
     r, sink = _reporter()
-    r.seed_baseline(0.05)
+    r.seed_baseline({"success": 0.05, "tokens": 100.0})
     assert sink.getvalue() == ""  # silent: no line emitted
     r.candidate_evaluated(
-        label="agent-1", split="validation", reward=0.19, artifacts=Path("/exp/results/agent-1-validation")
+        label="agent-1",
+        split="validation",
+        metrics={"success": 0.19, "tokens": 80.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-1-validation"),
     )
     out = sink.getvalue()
-    assert "reward 0.190" in out
+    assert "success 0.190" in out
     assert "+0.140" in out  # delta measured against the seeded 0.05 baseline
 
 
 def test_seed_baseline_is_noop_once_baseline_set() -> None:
     r, sink = _reporter()
     r.candidate_evaluated(
-        label="agent-0", split="validation", reward=0.05, artifacts=Path("/exp/results/agent-0-validation")
+        label="agent-0",
+        split="validation",
+        metrics={"success": 0.05, "tokens": 100.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-0-validation"),
     )
-    r.seed_baseline(0.99)  # must not clobber the real baseline
+    r.seed_baseline({"success": 0.99, "tokens": 1.0})  # must not clobber the real baseline
     r.candidate_evaluated(
-        label="agent-1", split="validation", reward=0.19, artifacts=Path("/exp/results/agent-1-validation")
+        label="agent-1",
+        split="validation",
+        metrics={"success": 0.19, "tokens": 80.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-1-validation"),
     )
     assert "+0.140" in sink.getvalue()  # still measured against 0.05, not 0.99
 
 
 def test_train_split_shows_no_delta() -> None:
     r, sink = _reporter()
-    r.candidate_evaluated(label="agent-0", split="train", reward=0.23, artifacts=Path("/exp/results/agent-0-train"))
+    r.candidate_evaluated(
+        label="agent-0",
+        split="train",
+        metrics={"success": 0.23, "tokens": 50.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-0-train"),
+    )
     assert "▲" not in sink.getvalue()
     assert "▼" not in sink.getvalue()
 
 
 def test_run_finished_winner_and_no_winner() -> None:
     r, sink = _reporter()
-    r.candidate_evaluated(label="agent-0", split="validation", reward=0.05, artifacts=Path("/x"))
-    r.run_finished(winner="agent-1", scores={"reward": 0.19}, report_path=Path("/exp/final_report.md"))
+    r.candidate_evaluated(
+        label="agent-0",
+        split="validation",
+        metrics={"success": 0.05, "tokens": 100.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/x"),
+    )
+    r.run_finished(winner="agent-1", scores={"success": 0.19, "tokens": 80.0}, report_path=Path("/exp/final_report.md"))
     out = sink.getvalue()
     assert "winner=agent-1" in out
-    assert "validation 0.190" in out
-    assert "baseline 0.050" in out
+    assert "validation success 0.190, tokens 80.000" in out
     assert "final_report.md" in out
 
     r2, sink2 = _reporter()
@@ -114,13 +148,19 @@ def test_quiet_suppresses_phase_and_candidate_but_keeps_header_footer() -> None:
     r, sink = _reporter(Verbosity.QUIET)
     r.run_started(run_dir=Path("/x"), agent="a", insight=None, strategy="evolutionary")
     r.progress(phase="baseline", completed=0, total=15)
-    r.candidate_evaluated(label="agent-0", split="validation", reward=0.05, artifacts=Path("/x"))
-    r.run_finished(winner="agent-0", scores={"reward": 0.05}, report_path=None)
+    r.candidate_evaluated(
+        label="agent-0",
+        split="validation",
+        metrics={"success": 0.05, "tokens": 100.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/x"),
+    )
+    r.run_finished(winner="agent-0", scores={"success": 0.05, "tokens": 100.0}, report_path=None)
     out = sink.getvalue()
     assert "strategy=evolutionary" in out  # header kept
     assert "winner=agent-0" in out  # footer kept
     assert "baseline" not in out  # phase suppressed
-    assert "reward 0.050" not in out  # candidate suppressed
+    assert "success 0.050" not in out  # candidate suppressed
 
 
 def test_methods_never_raise_on_broken_sink() -> None:
@@ -133,14 +173,15 @@ def test_methods_never_raise_on_broken_sink() -> None:
     r.run_started(run_dir=Path("/x"), agent="a", insight=None, strategy="s")
     r.progress(phase="p", completed=1, total=2)
     r.candidate_started(label="agent-1", optimization="x", i=1, n=3)
-    r.candidate_evaluated(label="agent-1", split="validation", reward=0.1, artifacts=Path("/x"))
-    r.run_finished(winner="agent-1", scores={"reward": 0.1}, report_path=None)
+    r.candidate_evaluated(
+        label="agent-1",
+        split="validation",
+        metrics={"success": 0.1, "tokens": 10.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/x"),
+    )
+    r.run_finished(winner="agent-1", scores={"success": 0.1, "tokens": 10.0}, report_path=None)
     r.note("hello")
-
-
-def test_reward_scalar_defaults_to_zero_when_absent() -> None:
-    assert reward_scalar({"reward": 0.42}) == 0.42
-    assert reward_scalar({}) == 0.0
 
 
 def test_candidate_evaluated_renders_subset_style_result_id_verbatim() -> None:
@@ -150,7 +191,8 @@ def test_candidate_evaluated_renders_subset_style_result_id_verbatim() -> None:
     r.candidate_evaluated(
         label="agent-1",
         split="train",
-        reward=0.2,
+        metrics={"success": 0.2, "tokens": 20.0},
+        objective_metrics=OBJECTIVES,
         artifacts=Path("/exp/results/agent-1-train-subset-1-42e2eab5a4e0"),
     )
     assert "agent-1-train-subset-1-42e2eab5a4e0" in sink.getvalue()
@@ -163,15 +205,29 @@ def test_full_run_transcript_is_the_loop_emission_contract() -> None:
     r.run_started(run_dir=Path("/exp/run-1"), agent="nemo-oo-airline", insight="insight-892a", strategy="evolutionary")
     r.progress(phase="baseline", completed=0, total=15)
     r.candidate_evaluated(
-        label="agent-0", split="validation", reward=0.05, artifacts=Path("/exp/results/agent-0-validation")
+        label="agent-0",
+        split="validation",
+        metrics={"success": 0.05, "tokens": 100.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-0-validation"),
     )
-    r.candidate_evaluated(label="agent-0", split="train", reward=0.23, artifacts=Path("/exp/results/agent-0-train"))
+    r.candidate_evaluated(
+        label="agent-0",
+        split="train",
+        metrics={"success": 0.23, "tokens": 50.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-0-train"),
+    )
     r.progress(phase="evaluating candidates", completed=1, total=15)
     r.candidate_started(label="agent-1", optimization="ground tool signatures", i=1, n=3)
     r.candidate_evaluated(
-        label="agent-1", split="validation", reward=0.19, artifacts=Path("/exp/results/agent-1-validation")
+        label="agent-1",
+        split="validation",
+        metrics={"success": 0.19, "tokens": 80.0},
+        objective_metrics=OBJECTIVES,
+        artifacts=Path("/exp/results/agent-1-validation"),
     )
-    r.run_finished(winner="agent-1", scores={"reward": 0.19}, report_path=Path("/exp/final_report.md"))
+    r.run_finished(winner="agent-1", scores={"success": 0.19, "tokens": 80.0}, report_path=Path("/exp/final_report.md"))
     out = sink.getvalue()
     # ordering sanity: baseline before round-1 before finish
     assert out.index("baseline") < out.index("evaluating candidates") < out.index("Finished")

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_terminator.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_terminator.py
@@ -14,6 +14,7 @@ import json
 from dataclasses import dataclass, field
 from types import SimpleNamespace
 
+from nemo_experimentalist_plugin.config import MetricTarget
 from nemo_experimentalist_plugin.experimentalist.components.loop import EvolutionaryOptimizerConfig
 from nemo_experimentalist_plugin.experimentalist.components.terminator import (
     TerminationDecision,
@@ -108,7 +109,11 @@ async def test_run_stops_on_convergence_when_budget_not_hit() -> None:
         round_num=2,
         evolution_tree=tree,
         prior_analysis="prior analysis",
-        config=EvolutionaryOptimizerConfig(max_rounds=15, min_rounds_before_stopping=2),
+        config=EvolutionaryOptimizerConfig(
+            max_rounds=15,
+            min_rounds_before_stopping=2,
+            objective_function=[MetricTarget(name="score", direction="maximize")],
+        ),
     )
     assert decision.stop is True
     assert "converged" in decision.reason
@@ -214,6 +219,7 @@ async def test_has_converged_true_when_front_stagnates() -> None:
             evolution_tree=tree,
             prior_analysis="ignored",
             min_rounds_before_stopping=2,
+            objective_metrics=[MetricTarget(name="score", direction="maximize")],
         )
         is True
     )
@@ -238,6 +244,7 @@ async def test_qualitative_fallback_true() -> None:
             evolution_tree=tree,
             prior_analysis="plateaued: same root cause every round",
             min_rounds_before_stopping=2,
+            objective_metrics=[MetricTarget(name="score", direction="maximize")],
         )
         is True
     )

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
@@ -27,6 +27,7 @@ from nemo_experimentalist_plugin.experimentalist.components.analyzer import (
     AnalyzerConfig,
     FailureClassification,
     PeerComparison,
+    TrialSelection,
 )
 from nemo_experimentalist_plugin.experimentalist.components.rationalizer import Rationale
 from nemo_experimentalist_plugin.experimentalist.components.trace_analyzer import Diagnostic
@@ -62,6 +63,7 @@ class _FakeDataset:
 class _FakeEvaluation:
     id: str = "eval-1"
     aggregate_metrics: dict[str, float] = field(default_factory=lambda: {"reward": 1.0})
+    trials: list[_FakeTrial] = field(default_factory=list)
 
 
 class _RecordingTraceAnalyzer:
@@ -85,10 +87,21 @@ class _RecordingTraceAnalyzer:
         agent_path: Any,
         rationale: Any = None,
         insight: Any = None,
+        selection_reason: str = "",
+        objective_metrics: list[dict[str, str]] | None = None,
+        regression_metrics: list[dict[str, str]] | None = None,
         client: Any = None,
         workspace: Any = None,
     ) -> Diagnostic:
-        type(self).calls.append({"client": client, "workspace": workspace})
+        type(self).calls.append(
+            {
+                "client": client,
+                "workspace": workspace,
+                "selection_reason": selection_reason,
+                "objective_metrics": objective_metrics,
+                "regression_metrics": regression_metrics,
+            }
+        )
         return Diagnostic(outcome="SUCCESS", summary="stub", failure_point=None, root_cause="stub")
 
 
@@ -115,8 +128,10 @@ class _SelectTrials:
         evaluation: Any,
         objective_metrics: list[dict[str, str]],
         regression_metrics: list[dict[str, str]],
-    ) -> list[Any]:
-        return self._trials
+    ) -> list[TrialSelection]:
+        return [
+            TrialSelection(trial_id=trial.id, reason=f"Analyze {trial.id} for this test.") for trial in self._trials
+        ]
 
 
 class _ClassifyFailures:
@@ -168,7 +183,7 @@ def _install_fakes(monkeypatch: pytest.MonkeyPatch, calls: list[dict[str, Any]])
 def _fixtures() -> tuple[_FakeTrial, _FakeDataset, _FakeEvaluation]:
     trial = _FakeTrial(id="trial-1", task_id="task-1", trace=object(), metrics={"reward": _FakeMetric(0.0)})
     dataset = _FakeDataset(tasks=[_FakeTask(id="task-1")])
-    return trial, dataset, _FakeEvaluation()
+    return trial, dataset, _FakeEvaluation(trials=[trial])
 
 
 @pytest.mark.asyncio
@@ -195,6 +210,9 @@ async def test_run_threads_client_and_workspace_into_trace_analyzer(
     assert len(calls) == 1
     assert calls[0]["client"] is sentinel_client
     assert calls[0]["workspace"] == "tau2-airline-ws"
+    assert calls[0]["selection_reason"] == "Analyze trial-1 for this test."
+    assert calls[0]["objective_metrics"] == []
+    assert calls[0]["regression_metrics"] == []
 
 
 @pytest.mark.asyncio
@@ -210,6 +228,29 @@ async def test_run_defaults_client_and_workspace_to_none(tmp_path: Path, monkeyp
     assert len(calls) == 1
     assert calls[0]["client"] is None
     assert calls[0]["workspace"] is None
+
+
+@pytest.mark.asyncio
+async def test_run_threads_metric_contract_into_trace_analyzer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Trace analysis receives the same objective and regression metrics as selection."""
+    calls: list[dict[str, Any]] = []
+    _install_fakes(monkeypatch, calls)
+    trial, dataset, evaluation = _fixtures()
+    analyzer = _make_analyzer(tmp_path, [trial])
+    objective_metrics = [{"name": "success_rate", "direction": "maximize"}]
+    regression_metrics = [{"name": "tokens", "direction": "minimize"}]
+
+    await analyzer.run(
+        agent="agent-a",
+        dataset=cast(Any, dataset),
+        evaluation=cast(Any, evaluation),
+        round=0,
+        objective_metrics=objective_metrics,
+        regression_metrics=regression_metrics,
+    )
+
+    assert calls[0]["objective_metrics"] == objective_metrics
+    assert calls[0]["regression_metrics"] == regression_metrics
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
@@ -108,18 +108,38 @@ class _SelectTrials:
     def __init__(self, trials: list[Any]) -> None:
         self._trials = trials
 
-    async def __call__(self, agent_id: str, dataset: Any, evaluation: Any) -> list[Any]:
+    async def __call__(
+        self,
+        agent_id: str,
+        dataset: Any,
+        evaluation: Any,
+        objective_metrics: list[dict[str, str]],
+        regression_metrics: list[dict[str, str]],
+    ) -> list[Any]:
         return self._trials
 
 
 class _ClassifyFailures:
-    async def __call__(self, agent_id: str, diagnoses: Any, trials: Any) -> FailureClassification:
+    async def __call__(
+        self,
+        agent_id: str,
+        diagnoses: Any,
+        trials: Any,
+        objective_metrics: list[dict[str, str]],
+        regression_metrics: list[dict[str, str]],
+    ) -> FailureClassification:
         return FailureClassification(systematic=[], mechanical=[])
 
 
 class _CompareWithPeers:
     async def __call__(
-        self, agent_id: str, evaluation: Any, diagnoses: Any, peer_evaluations: Any = None
+        self,
+        agent_id: str,
+        evaluation: Any,
+        diagnoses: Any,
+        peer_evaluations: Any = None,
+        objective_metrics: list[dict[str, str]] | None = None,
+        regression_metrics: list[dict[str, str]] | None = None,
     ) -> PeerComparison:
         return PeerComparison(divergent_trials=[], complementary_patterns=[])
 

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
@@ -22,6 +22,7 @@ from typing import Any, ClassVar, cast
 
 import pytest
 from nemo_experimentalist_plugin.experimentalist.components import analyzer as analyzer_module
+from nemo_experimentalist_plugin.experimentalist.components import cache
 from nemo_experimentalist_plugin.experimentalist.components.analyzer import (
     AgentAnalyzer,
     AnalyzerConfig,
@@ -184,6 +185,11 @@ def _fixtures() -> tuple[_FakeTrial, _FakeDataset, _FakeEvaluation]:
     trial = _FakeTrial(id="trial-1", task_id="task-1", trace=object(), metrics={"reward": _FakeMetric(0.0)})
     dataset = _FakeDataset(tasks=[_FakeTask(id="task-1")])
     return trial, dataset, _FakeEvaluation(trials=[trial])
+
+
+def test_trace_cache_key_uses_trace_uri_namespace() -> None:
+    """Trace-analysis cache files must not be named as agent-analysis cache files."""
+    assert cache.trace_uri_hash("intake://trace-1:objective-metrics:[]").startswith("trace-uri-")
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-experimentalist/tests/test_metric_contract.py
+++ b/plugins/nemo-experimentalist/tests/test_metric_contract.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from nemo_experimentalist_plugin.config import (
+    EvolutionaryOptimizerConfig,
+    MetricTarget,
+    is_eligible_for_metric_contract,
+    pareto_objectives,
+)
+from nemo_experimentalist_plugin.experimentalist.components.loop import _with_insight_objective
+
+
+def test_metric_contract_supports_multiple_objective_metrics() -> None:
+    config = EvolutionaryOptimizerConfig.model_validate(
+        {
+            "objective_function": [
+                {"name": "tokens", "direction": "minimize"},
+                {"name": "cost", "direction": "minimize"},
+            ],
+            "regression_metrics": [{"name": "success_rate", "direction": "maximize"}],
+        }
+    )
+
+    assert config.optimization_policy() == (
+        "Optimize these objective metric(s): tokens (minimize), cost (minimize). "
+        "Do not regress these metric(s): success_rate (maximize). "
+        "Metric values, including aggregates, are produced by the evaluator; do not invent formulas or weights."
+    )
+
+
+def test_metric_contract_treats_an_evaluator_aggregate_as_a_metric() -> None:
+    config = EvolutionaryOptimizerConfig.model_validate(
+        {"objective_function": [{"name": "quality", "direction": "maximize"}]}
+    )
+
+    assert [target.name for target in config.objective_function] == ["quality"]
+
+
+def test_pareto_ranking_uses_only_objectives_and_normalizes_minimization() -> None:
+    config = EvolutionaryOptimizerConfig.model_validate(
+        {
+            "objective_function": [
+                {"name": "tokens", "direction": "minimize"},
+                {"name": "cost", "direction": "minimize"},
+            ],
+            "regression_metrics": [{"name": "success", "direction": "maximize"}],
+        }
+    )
+
+    assert pareto_objectives({"tokens": 10.0, "cost": 2.0, "success": 0.9}, config.objective_function) == {
+        "tokens": -10.0,
+        "cost": -2.0,
+    }
+
+
+def test_metric_contract_excludes_incomplete_or_regressing_candidates() -> None:
+    objectives = [MetricTarget(name="quality", direction="maximize")]
+    regressions = [MetricTarget(name="cost", direction="minimize")]
+    baseline = {"quality": 0.5, "cost": 10.0}
+
+    assert not is_eligible_for_metric_contract(
+        {"cost": 8.0},
+        objective_function=objectives,
+        regression_metrics=regressions,
+        baseline_metrics=baseline,
+    )
+    assert not is_eligible_for_metric_contract(
+        {"quality": 0.9, "cost": 11.0},
+        objective_function=objectives,
+        regression_metrics=regressions,
+        baseline_metrics=baseline,
+    )
+    assert is_eligible_for_metric_contract(
+        {"quality": 0.9, "cost": 8.0},
+        objective_function=objectives,
+        regression_metrics=regressions,
+        baseline_metrics=baseline,
+    )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"objective_function": []},
+        {
+            "objective_function": [
+                {"name": "reward", "direction": "maximize"},
+                {"name": "reward", "direction": "minimize"},
+            ]
+        },
+        {
+            "objective_function": [{"name": "reward", "direction": "maximize"}],
+            "regression_metrics": [{"name": "reward", "direction": "maximize"}],
+        },
+    ],
+)
+def test_metric_contract_rejects_ambiguous_or_overlapping_targets(config: dict[str, object]) -> None:
+    with pytest.raises(ValueError):
+        EvolutionaryOptimizerConfig.model_validate(config)
+
+
+def test_insight_metrics_become_objectives_and_existing_targets_become_guardrails() -> None:
+    config = EvolutionaryOptimizerConfig.model_validate(
+        {
+            "objective_function": [{"name": "cost", "direction": "minimize"}],
+            "regression_metrics": [{"name": "safety", "direction": "maximize"}],
+        }
+    )
+
+    effective = _with_insight_objective(config, ("uses_required_tool", "cites_source"))
+
+    assert [target.name for target in effective.objective_function] == ["uses_required_tool", "cites_source"]
+    assert all(target.direction == "maximize" for target in effective.objective_function)
+    assert [target.model_dump() for target in effective.regression_metrics] == [
+        {"name": "cost", "direction": "minimize"},
+        {"name": "safety", "direction": "maximize"},
+    ]


### PR DESCRIPTION
## Additions
- Define objective and regression metric contracts for evolutionary optimization
- Enforce complete objective results and baseline-relative regression guardrails in selection and analysis 
- Distribute authored Insight tasks across validation/train through dataset-owned task imports

## Changes 
- Switched to a weaker model to allow for improvement 

## Validation
- uv run --frozen ruff check (changed Experimentalist sources)
- uv run --frozen pytest plugins/nemo-experimentalist/tests/test_metric_contract.py plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging.py plugins/nemo-experimentalist/tests/experimentalist/test_dataset_staging_loop.py plugins/nemo-experimentalist/tests/experimentalist/test_terminator.py -q