### PR TITLE
feat(experimentalist): support ATIF agent traces

### DIFF
--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -51,6 +51,41 @@ effective inputs:
 $NEMO agents experimentalist doctor
 ```
 
+## Agent trace formats
+
+The agent under test can emit traces as OTLP or ATIF. **OTLP is the default** —
+skip this section unless your agent emits ATIF.
+
+To use an ATIF-emitting agent:
+
+1. Have the agent write its trajectory under its trace directory (`/app/traces`
+   in the Harbor task container) with a `.atif.json` suffix.
+2. Select the format on the evaluator:
+
+   ```yaml
+   optimizer:
+     evaluator:
+       trace_format: atif   # otlp (default) | atif
+   ```
+
+3. Run against a platform, which ATIF requires:
+
+   ```bash
+   $NEMO agents experimentalist run --base-url https://<platform-host> ...
+   ```
+
+Experiment grouping, run counts, and evaluator scores in Studio behave the same
+as for OTLP. ATIF traces do not carry per-step timing, so individual step
+durations show as zero.
+
+### Troubleshooting
+
+- *"configured `trace_format='otlp'` matched no trace artifact, but atif
+  artifacts are present"* — set `trace_format: atif`.
+- *"Cannot read ATIF trajectory from disk … this trace was never uploaded"* — the
+  run had no reachable platform, so the trace was never ingested. Supply
+  `--base-url` and a workspace.
+
 ## Run the Experimentalist locally
 
 `nemo agents experimentalist run` runs the local Experimentalist loop. It evaluates

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -60,10 +60,10 @@ To use an ATIF-emitting agent:
 
 1. Have the agent write its trajectory under its trace directory (`/app/traces`
    in the Harbor task container) with a `.atif.json` suffix.
-2. Select the format on the evaluator:
+2. Select the format on the evaluator, in the profile's `experiment_config`:
 
    ```yaml
-   optimizer:
+   experiment_config:
      evaluator:
        trace_format: atif   # otlp (default) | atif
    ```

--- a/plugins/nemo-experimentalist/artifacts/.gitignore
+++ b/plugins/nemo-experimentalist/artifacts/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/plugins/nemo-experimentalist/artifacts/.gitignore
+++ b/plugins/nemo-experimentalist/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/harbor_wrapper.py
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/harbor_wrapper.py
@@ -153,7 +153,11 @@ class WrappedAgent(BaseAgent):
             context.n_input_tokens = metrics["n_input_tokens"]
             context.n_output_tokens = metrics["n_output_tokens"]
             context.n_cache_tokens = metrics["n_cache_tokens"]
-        except (FileNotFoundError, OSError, ValueError) as exc:
+        # RuntimeError covers the environment refusing to copy /app/traces at all, which
+        # is what happens when the agent died before writing any: the traces directory
+        # never exists. Letting that escape would mask the agent's own failure below,
+        # reporting a Docker copy error instead of the traceback that caused it.
+        except (FileNotFoundError, OSError, RuntimeError, ValueError) as exc:
             metrics_error = f"Trace metrics unavailable: {type(exc).__name__}: {exc}"
             logger.warning(metrics_error)
         finally:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/atif.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/atif.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""ATIF trajectory helpers for reading and uploading agent traces.
+
+Kept separate from ``otlp.py``: the two formats share no representation, and
+mixing an ATIF reader into a module named for OTLP would blur a clean boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from nemo_experimentalist_plugin.entities import ResourceRef
+
+# ATIF carries agent identity on the trajectory; the Experimentalist carries it as
+# OTLP-style span attributes. This maps one onto the other.
+_AGENT_FIELD_BY_ATTR: tuple[tuple[str, str], ...] = (
+    ("name", "gen_ai.agent.name"),
+    ("version", "agent.version"),
+    ("model_name", "gen_ai.request.model"),
+)
+
+
+def _load(ref: ResourceRef) -> dict[str, Any]:
+    """Parse the ATIF trajectory a ResourceRef points at."""
+    path = Path(urlparse(ref.uri).path)
+    trajectory = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(trajectory, dict):
+        raise ValueError(f"ATIF trajectory is not a JSON object: {ref.uri}")
+    return trajectory
+
+
+def read_session_id(ref: ResourceRef) -> str:
+    """Return the trajectory's session_id, which Intake uses as the trace id.
+
+    Args:
+        ref(ResourceRef): Resource reference to the ATIF trajectory file.
+
+    Returns:
+        str: The trajectory session id.
+    """
+    session_id = _load(ref).get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        raise ValueError(f"No session_id found in {ref.uri}")
+    return session_id
+
+
+def build_ingest_payload(
+    ref: ResourceRef,
+    *,
+    experiment_id: str,
+    task_id: str,
+    agent_attrs: dict[str, str],
+) -> dict[str, Any]:
+    """Load a trajectory and stamp evaluation identity onto it for Intake ingest.
+
+    Agent fields the producer already set are left alone; ``agent_attrs`` only
+    fills blanks, so a well-behaved producer stays authoritative.
+
+    ``extra.verifier_result`` is deliberately not injected: the backend already
+    creates ``evaluator_results`` rows per trial metric, and letting Intake derive
+    a second set from the trajectory would double-count them.
+
+    Args:
+        ref(ResourceRef): Resource reference to the ATIF trajectory file.
+        experiment_id(str): Evaluation name, used as ``evaluation_context.evaluation_id``.
+        task_id(str): Test case id, used as ``evaluation_context.test_case_id``.
+        agent_attrs(dict[str, str]): OTLP-style agent attributes used as fallbacks.
+
+    Returns:
+        dict[str, Any]: The ATIF ingest request body.
+    """
+    trajectory = _load(ref)
+    trajectory["evaluation_context"] = {
+        "evaluation_id": experiment_id,
+        "test_case_id": task_id,
+    }
+    agent = trajectory.get("agent")
+    if not isinstance(agent, dict):
+        agent = {}
+    for field, attr in _AGENT_FIELD_BY_ATTR:
+        if not agent.get(field) and attr in agent_attrs:
+            agent[field] = agent_attrs[attr]
+    trajectory["agent"] = agent
+    return trajectory

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType, TracebackType
-from typing import Any, TypeAlias, TypedDict
+from typing import Any, Literal, TypeAlias, TypedDict
 from uuid import uuid4
 
 from harbor.constants import MAIN_SERVICE_NAME
@@ -112,6 +112,7 @@ _TASK_TREE_RESOURCES: tuple[TreeResourceSpec, ...] = (
 )
 _TRACE_ARTIFACT_SOURCE = "/app/traces"
 _TRACE_ARTIFACT_DESTINATION = "traces"
+_ATIF_TRACE_SUFFIX = ".atif.json"
 _SHELL_SYNTAX_TIMEOUT_SEC = 10.0
 _AGENT_IMPORT_ROOT = "_nemo_experimentalist_eval_agents"
 _IDENTIFIER_RE = re.compile(r"\W+")
@@ -188,6 +189,13 @@ class HarborEvaluatorConfig(EvaluatorConfig):
     retry: RetryConfig = Field(default=RetryConfig(exclude_exceptions=set()))
     import_path: str = Field(default="harbor_wrapper:WrappedAgent")
     trace_dir: str = Field(default=_TRACE_ARTIFACT_SOURCE)
+    trace_format: Literal["otlp", "atif"] = Field(
+        default="otlp",
+        description=(
+            "Which trace artifact becomes the trial's trace. Both are still collected and "
+            "exposed in resources; this only selects the one that gets uploaded and analysed."
+        ),
+    )
 
 
 class HarborDependencyRuntime(DependencyRuntime):
@@ -646,7 +654,9 @@ def _trial_metrics(trial_dir: Path, trial_data: dict[str, Any], spec: MetricSpec
     return metrics
 
 
-def _trial_resources(trial_dir: Path) -> tuple[dict[str, ResourceRef], ResourceRef | None]:
+def _trial_resources(
+    trial_dir: Path, *, trace_format: str = "otlp"
+) -> tuple[dict[str, ResourceRef], ResourceRef | None]:
     resources: dict[str, ResourceRef] = {
         "trial_dir": ResourceRef(
             uri=trial_dir.resolve().as_uri(),
@@ -656,7 +666,8 @@ def _trial_resources(trial_dir: Path) -> tuple[dict[str, ResourceRef], ResourceR
             ),
         )
     }
-    trace_ref = None
+    otlp_trace_ref: ResourceRef | None = None
+    atif_trace_ref: ResourceRef | None = None
 
     for path in sorted(candidate for candidate in trial_dir.rglob("*") if candidate.is_file()):
         relative_path = path.relative_to(trial_dir).as_posix()
@@ -680,8 +691,15 @@ def _trial_resources(trial_dir: Path) -> tuple[dict[str, ResourceRef], ResourceR
         elif path.suffix == ".jsonl" and "traces" in Path(relative_path).parts[:-1]:
             trace_relative_path = relative_path.removeprefix("artifacts/")
             description = f"Agent execution trace JSONL for {trace_relative_path}."
-            trace_ref = trace_ref or ResourceRef(uri=uri, description=description)
-            resources[f"trace:{trace_relative_path}"] = ResourceRef(uri=uri, description=description)
+            ref = ResourceRef(uri=uri, description=description, metadata={"trace_format": "otlp"})
+            otlp_trace_ref = otlp_trace_ref or ref
+            resources[f"trace:{trace_relative_path}"] = ref
+        elif relative_path.endswith(_ATIF_TRACE_SUFFIX) and "traces" in Path(relative_path).parts[:-1]:
+            trace_relative_path = relative_path.removeprefix("artifacts/")
+            description = f"Agent execution ATIF trajectory for {trace_relative_path}."
+            ref = ResourceRef(uri=uri, description=description, metadata={"trace_format": "atif"})
+            atif_trace_ref = atif_trace_ref or ref
+            resources[f"trace:{trace_relative_path}"] = ref
         elif _is_trial_log_path(relative_path):
             description = _TRIAL_LOG_DESCRIPTIONS.get(relative_path)
             if description is None and relative_path.startswith("agent/command-"):
@@ -709,7 +727,16 @@ def _trial_resources(trial_dir: Path) -> tuple[dict[str, ResourceRef], ResourceR
                 description=f"Collected Harbor artifact {relative_path}.",
             )
 
-    return resources, trace_ref
+    selected = atif_trace_ref if trace_format == "atif" else otlp_trace_ref
+    other = otlp_trace_ref if trace_format == "atif" else atif_trace_ref
+    if selected is None and other is not None:
+        found = "otlp" if trace_format == "atif" else "atif"
+        logger.warning(
+            f"Trial {trial_dir.name}: configured trace_format='{trace_format}' matched no trace "
+            f"artifact, but {found} artifacts are present. This trial will have no trace — set "
+            f"trace_format='{found}' if the agent under test emits {found.upper()}."
+        )
+    return resources, selected
 
 
 class HarborDataset(Dataset):
@@ -1261,6 +1288,8 @@ class HarborEvaluator(Evaluator):
         options_dict["job_name"] = options.job_name or f"{agent.name}-{dataset.id}"
         import_path: str = options_dict.pop("import_path")
         trace_dir: str = options_dict.pop("trace_dir", _TRACE_ARTIFACT_SOURCE)
+        # Harbor's JobConfig forbids unknown keys, so this must not survive into it.
+        trace_format: str = options_dict.pop("trace_format", "otlp")
         options_dict["artifacts"] = _with_trace_artifact(options_dict.get("artifacts") or [], trace_dir)
         force_rerun: bool = options_dict.pop("force_rerun", False)
 
@@ -1286,10 +1315,12 @@ class HarborEvaluator(Evaluator):
         finally:
             _cleanup_scoped_imports(scoped_package)
 
-        trials = await self._trials_from_dir(job.job_dir, dataset.tasks)
+        trials = await self._trials_from_dir(job.job_dir, dataset.tasks, trace_format=trace_format)
         return trials
 
-    async def _trials_from_dir(self, job_dir: Path, tasks: Sequence[Task]) -> Sequence[TrialResult]:
+    async def _trials_from_dir(
+        self, job_dir: Path, tasks: Sequence[Task], *, trace_format: str = "otlp"
+    ) -> Sequence[TrialResult]:
         task_map = {task.id: task for task in tasks}
         trials: list[TrialResult] = []
         for trial_dir in sorted(path for path in job_dir.iterdir() if path.is_dir()):
@@ -1310,7 +1341,7 @@ class HarborEvaluator(Evaluator):
             metric_spec = metric_spec or _trial_metric_spec(trial_dir, trial_data)
 
             exception_info = trial_data.get("exception_info")
-            resources, trace = _trial_resources(trial_dir)
+            resources, trace = _trial_resources(trial_dir, trace_format=trace_format)
 
             trials.append(
                 TrialResult(

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_explorer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_explorer.py
@@ -892,7 +892,12 @@ def _span_from_intake_row(row: dict[str, Any]) -> TraceSpan:
         return ToolSpan(
             **base,
             tool_name=str(row.get("tool_name") or row.get("name") or ""),
-            tool_call_id=_atif_tool_call_id(attrs) if is_atif else "",
+            # Intake has no tool_call_id column, so these keys survive in raw_attributes
+            # for OTLP rows. ATIF preserves the id inside its tool_call payload instead.
+            tool_call_id=str(
+                _attr(attrs, "tool_call.id", "tool.id", "tool_call_id")
+                or (_atif_tool_call_id(attrs) if is_atif else "")
+            ),
             input_value=_json_text(input_value) if input_value is not None else None,
             input_mime_type=_attr(attrs, "input.mime_type"),
             output_value=_json_text(output_value) if output_value is not None else None,

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_explorer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_explorer.py
@@ -636,7 +636,7 @@ def _raw_attrs(raw: dict[str, Any]) -> dict[str, Any]:
     return attrs
 
 
-def _span_from_record(raw: dict[str, Any], resource_attrs: dict[str, Any] | None = None) -> TraceSpan:
+def _span_from_otlp_record(raw: dict[str, Any], resource_attrs: dict[str, Any] | None = None) -> TraceSpan:
     attrs = _raw_attrs(raw)
     if resource_attrs:
         for key, value in resource_attrs.items():
@@ -736,6 +736,198 @@ def _span_from_record(raw: dict[str, Any], resource_attrs: dict[str, Any] | None
             output_value=_json_text(output_value) if output_value is not None else None,
             output_mime_type=_attr(attrs, "output.mime_type"),
             score=_attr(attrs, "score", "evaluator.score") or raw.get("score"),
+        )
+
+    return Span(**base, kind=kind)
+
+
+# Intake column -> the token_counts key trace_explorer exposes.
+_TOKEN_COLUMN_BY_KEY: tuple[tuple[str, str], ...] = (
+    ("prompt", "input_tokens"),
+    ("completion", "output_tokens"),
+    ("cached", "cached_tokens"),
+    ("total", "total_tokens"),
+)
+
+# ATIF step source -> chat message role.
+_ROLE_BY_ATIF_SOURCE: dict[str, str] = {"user": "user", "system": "system", "agent": "assistant"}
+_ATIF_INPUT_ROLES = frozenset({"user", "system"})
+
+
+def _column_int(value: Any) -> int | None:
+    """Coerce an Intake numeric column, tolerating strings and rejecting bools."""
+    if value is None or isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, float, str)):
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def _intake_token_counts(row: dict[str, Any]) -> dict[str, int]:
+    """Read token counts from the row's typed columns.
+
+    Intake strips the ``llm.token_count.*`` keys from raw_attributes because it
+    exposes them as columns, so the columns are the only source here.
+    """
+    counts: dict[str, int] = {}
+    for key, column in _TOKEN_COLUMN_BY_KEY:
+        parsed = _column_int(row.get(column))
+        if parsed is not None:
+            counts[key] = parsed
+    return counts
+
+
+def _intake_error_fields(row: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Read error type and message from the row's typed columns."""
+
+    def pick(value: Any) -> str | None:
+        return str(value) if value not in (None, "") else None
+
+    return pick(row.get("error_type")), pick(row.get("error_message"))
+
+
+def _atif_messages(attrs: dict[str, Any]) -> tuple[list[LLMMessage], list[LLMMessage]]:
+    """Synthesize messages from an ATIF step's source and message.
+
+    ATIF records a step's text as a bare string plus a ``source`` discriminator,
+    so there is no message list to recover — one is built from those two fields.
+    """
+    message = attrs.get("message")
+    if not isinstance(message, str) or not message:
+        return [], []
+    role = _ROLE_BY_ATIF_SOURCE.get(str(attrs.get("source")), "assistant")
+    entry = LLMMessage(role=role, content=message)
+    if role in _ATIF_INPUT_ROLES:
+        return [entry], []
+    return [], [entry]
+
+
+def _atif_tool_definitions(attrs: dict[str, Any]) -> list[ToolDefinition]:
+    """Return the tool definitions ATIF preserved on the trajectory root span."""
+    agent = attrs.get("agent")
+    if not isinstance(agent, dict):
+        return []
+    definitions = agent.get("tool_definitions")
+    if not isinstance(definitions, list):
+        return []
+    return [
+        ToolDefinition(
+            name=str(definition.get("name") or ""),
+            description=str(definition.get("description") or ""),
+            parameters=definition.get("parameters") if isinstance(definition.get("parameters"), dict) else {},
+        )
+        for definition in definitions
+        if isinstance(definition, dict) and definition.get("name")
+    ]
+
+
+def _atif_tool_call_id(attrs: dict[str, Any]) -> str:
+    """Return the tool call id ATIF preserved on a TOOL span."""
+    tool_call = attrs.get("tool_call")
+    if isinstance(tool_call, dict):
+        call_id = tool_call.get("tool_call_id")
+        if isinstance(call_id, str):
+            return call_id
+    return ""
+
+
+def _looks_like_intake_row(record: dict[str, Any]) -> bool:
+    """Intake rows always carry the source column; OTLP file records never do."""
+    return "source" in record and ("span_id" in record or "external_span_id" in record)
+
+
+def _span_from_intake_row(row: dict[str, Any]) -> TraceSpan:
+    """Build a span from an Intake row, reading promoted values from columns.
+
+    Intake lifts known attributes into typed columns and strips those keys from
+    ``raw_attributes``, so the columns are authoritative here. Only values Intake
+    preserved rather than promoted — ATIF's raw step payload, mime types,
+    invocation parameters — are read from the attribute bag.
+    """
+    attrs = _raw_attrs(row)
+    start_time = _time_ns(row.get("started_at"))
+    end_time = _time_ns(row.get("ended_at"))
+    status = _status_from_raw(row.get("status"), attrs)
+    kind = _kind(row.get("kind"))
+    error_type, error_message = _intake_error_fields(row)
+    parent_span_id = row.get("parent_span_id") or row.get("external_parent_span_id")
+    input_value = row.get("input")
+    output_value = row.get("output")
+    is_atif = row.get("source") == "atif"
+
+    base: dict[str, Any] = dict(
+        span_id=str(row.get("span_id") or row.get("external_span_id") or ""),
+        trace_id=str(row.get("trace_id") or ""),
+        parent_span_id=str(parent_span_id) if parent_span_id else None,
+        name=str(row.get("name") or ""),
+        start_time=start_time,
+        end_time=end_time,
+        duration_ns=end_time - start_time if start_time and end_time else 0,
+        status=status,
+        attributes=attrs,
+        events=[],
+    )
+
+    if kind == "LLM":
+        atif_input, atif_output = _atif_messages(attrs) if is_atif else ([], [])
+        return LLMSpan(
+            **base,
+            provider=str(row.get("provider") or ""),
+            model_name=str(row.get("model") or ""),
+            invocation_parameters=_parse_jsonish(_attr(attrs, "llm.invocation_parameters")) or {},
+            input_value=_json_text(input_value) if input_value is not None else None,
+            input_mime_type=_attr(attrs, "input.mime_type"),
+            output_value=_json_text(output_value) if output_value is not None else None,
+            output_mime_type=_attr(attrs, "output.mime_type"),
+            input_messages=_messages_from_payload(input_value) or atif_input,
+            output_messages=_messages_from_payload(output_value) or atif_output,
+            tools=_tools_from_attrs(attrs) or (_atif_tool_definitions(attrs) if is_atif else []),
+            token_counts=_intake_token_counts(row),
+        )
+
+    if kind == "TOOL":
+        return ToolSpan(
+            **base,
+            tool_name=str(row.get("tool_name") or row.get("name") or ""),
+            tool_call_id=_atif_tool_call_id(attrs) if is_atif else "",
+            input_value=_json_text(input_value) if input_value is not None else None,
+            input_mime_type=_attr(attrs, "input.mime_type"),
+            output_value=_json_text(output_value) if output_value is not None else None,
+            output_mime_type=_attr(attrs, "output.mime_type"),
+            error_type=error_type,
+            error_message=error_message or status.description,
+        )
+
+    if kind == "AGENT":
+        return AgentSpan(
+            **base,
+            agent_name=str(row.get("agent_name") or "Agent"),
+            method_name=str(row.get("name") or "run"),
+            input_value=_json_text(input_value) if input_value is not None else None,
+            output_value=_json_text(output_value) if output_value is not None else None,
+            error_type=error_type,
+            error_message=error_message or status.description,
+        )
+
+    if kind == "CHAIN":
+        return ChainSpan(
+            **base,
+            input_value=_json_text(input_value) if input_value is not None else None,
+            output_value=_json_text(output_value) if output_value is not None else None,
+        )
+
+    if kind == "EVALUATOR":
+        return EvaluatorSpan(
+            **base,
+            evaluator_name=str(row.get("name") or ""),
+            input_value=_json_text(input_value) if input_value is not None else None,
+            input_mime_type=_attr(attrs, "input.mime_type"),
+            output_value=_json_text(output_value) if output_value is not None else None,
+            output_mime_type=_attr(attrs, "output.mime_type"),
+            score=_attr(attrs, "score", "evaluator.score"),
         )
 
     return Span(**base, kind=kind)
@@ -848,7 +1040,14 @@ def _load_trace_models(
     eval_contexts: list[EvalContextData] = []
     for document in documents:
         for record, resource_attrs in _iter_span_records(document):
-            span = _span_from_record(record, resource_attrs)
+            # This path deliberately accepts either shape — _looks_like_span_record
+            # matches Intake-shaped records, so a dumped Intake payload must keep
+            # working here. Only from_intake, which knows its source, skips the check.
+            span = (
+                _span_from_intake_row(record)
+                if _looks_like_intake_row(record)
+                else _span_from_otlp_record(record, resource_attrs)
+            )
             if span.span_id:
                 spans.append(span)
         eval_contexts.extend(_eval_context_from_record(record) for record in _iter_evaluator_result_records(document))
@@ -1337,6 +1536,12 @@ class TraceExplorer:
     ) -> TraceExplorer:
         """Load a trace from a resource reference."""
         if ref.uri.startswith("file://"):
+            if ref.uri.endswith(".atif.json"):
+                raise ValueError(
+                    f"Cannot read ATIF trajectory from disk: {ref.uri}. ATIF becomes spans only "
+                    "through Intake ingest, so this trace was never uploaded — check for an earlier "
+                    "persistence failure, or supply a client and workspace to load it from Intake."
+                )
             return await cls.from_file(ref.uri[len("file://") :])
         elif ref.uri.startswith("intake://") and client is not None and workspace is not None:
             # Trial/eval traces are stored as ``intake://traces/<id>`` (see the
@@ -1374,7 +1579,7 @@ class TraceExplorer:
             row = item.model_dump(mode="json", exclude_none=True)
             if row.get("session_id"):
                 session_ids.add(str(row["session_id"]))
-            spans.append(_span_from_record(row))
+            spans.append(_span_from_intake_row(row))
 
         eval_contexts = await _fetch_intake_eval_contexts(
             client=client,

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
@@ -32,6 +32,7 @@ from nemo_experimentalist_plugin.entities import (
     ResourceRef,
     TrialResult,
 )
+from nemo_experimentalist_plugin.experimentalist.atif import build_ingest_payload, read_session_id
 from nemo_experimentalist_plugin.experimentalist.components.repository import (
     AgentSource,
     PRPublisher,
@@ -79,6 +80,32 @@ async def _upload_trace_otlp(
             content=payload,
             options={"headers": {"Content-Type": "application/x-protobuf"}},
         )
+
+
+async def _upload_trace_atif(
+    client: AsyncNeMoPlatform,
+    workspace: str,
+    ref: ResourceRef,
+    *,
+    experiment_id: str,
+    task_id: str,
+    extra_attrs: dict[str, str] | None = None,
+) -> None:
+    """Upload an ATIF trajectory to Intake as JSON.
+
+    Trial identity travels as the trajectory's own ``session_id``, which Intake
+    adopts as the trace id — so unlike the OTLP path there is no separate
+    ``trial_id`` to stamp. Intake performs the ATIF-to-spans mapping server-side.
+    """
+
+    payload = build_ingest_payload(
+        ref,
+        experiment_id=experiment_id,
+        task_id=task_id,
+        agent_attrs=extra_attrs or {},
+    )
+    url = f"/apis/intake/v2/workspaces/{workspace}/ingest/atif"
+    await client.post(url, cast_to=object, body=payload)
 
 
 _BASELINE_AGENT_LABEL = "agent-0"
@@ -615,6 +642,10 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
         }
         for trial in result.trials:
             if trial.trace is None:
+                logger.warning(
+                    f"[INTAKE] Trial {trial.id} ({trial.task_id}) has no trace; skipping persistence. "
+                    "The evaluator found no trace artifact in the configured format."
+                )
                 continue
             try:
                 await self._persist_trial(
@@ -658,22 +689,33 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
                     )
                 trace = await self._retrieve_trace_with_retry(trace_id, workspace=workspace)
         else:
+            trace_format = str(trial.trace.metadata.get("trace_format", "otlp"))
             try:
-                trace_id = read_trace_id(trial.trace)
+                trace_id = read_session_id(trial.trace) if trace_format == "atif" else read_trace_id(trial.trace)
             except (ValueError, json.JSONDecodeError, FileNotFoundError) as exc:
                 # Empty, invalid, or missing trace file (e.g., cancelled trial) — skip upload
                 logger.debug(f"[INTAKE] No valid trace found for trial {trial.id}: {exc}; skipping upload")
                 return
             original_uri = uri
-            await _upload_trace_otlp(
-                self.client,
-                workspace,
-                trial.trace,
-                experiment_id=experiment_id,
-                trial_id=trial.id,
-                task_id=trial.task_id,
-                extra_attrs=agent_attrs,
-            )
+            if trace_format == "atif":
+                await _upload_trace_atif(
+                    self.client,
+                    workspace,
+                    trial.trace,
+                    experiment_id=experiment_id,
+                    task_id=trial.task_id,
+                    extra_attrs=agent_attrs,
+                )
+            else:
+                await _upload_trace_otlp(
+                    self.client,
+                    workspace,
+                    trial.trace,
+                    experiment_id=experiment_id,
+                    trial_id=trial.id,
+                    task_id=trial.task_id,
+                    extra_attrs=agent_attrs,
+                )
             trial.trace = ResourceRef(
                 uri=f"intake://traces/{trace_id}",
                 description=trial.trace.description,

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import logging
 import os
 import shutil
 import sys
@@ -1887,3 +1888,89 @@ def test_with_trace_artifact_string_match():
 def test_with_trace_artifact_string_destination_match():
     result = _with_trace_artifact([_TRACE_ARTIFACT_DESTINATION], _TRACE_ARTIFACT_SOURCE)
     assert result == [_TRACE_ARTIFACT_DESTINATION]
+
+
+# ---------------------------------------------------------------------------
+# trace format discovery
+# ---------------------------------------------------------------------------
+
+
+def _trial_dir_with_traces(tmp_path: Path) -> Path:
+    trial_dir = tmp_path / "trial-1"
+    traces = trial_dir / "artifacts" / "traces"
+    traces.mkdir(parents=True)
+    (traces / "trace.jsonl").write_text('{"resourceSpans": []}\n', encoding="utf-8")
+    (traces / "trajectory-abc123.atif.json").write_text(
+        '{"schema_version": "ATIF-v1.7", "session_id": "abc123"}', encoding="utf-8"
+    )
+    return trial_dir
+
+
+def test_trial_resources_defaults_to_the_otlp_trace(tmp_path):
+    _, trace = _trial_resources(_trial_dir_with_traces(tmp_path))
+    assert trace is not None
+    assert trace.uri.endswith("trace.jsonl")
+    assert trace.metadata["trace_format"] == "otlp"
+
+
+def test_trial_resources_selects_the_atif_trace_when_configured(tmp_path):
+    _, trace = _trial_resources(_trial_dir_with_traces(tmp_path), trace_format="atif")
+    assert trace is not None
+    assert trace.uri.endswith("trajectory-abc123.atif.json")
+    assert trace.metadata["trace_format"] == "atif"
+
+
+def test_trial_resources_exposes_both_formats_regardless_of_selection(tmp_path):
+    resources, _ = _trial_resources(_trial_dir_with_traces(tmp_path), trace_format="otlp")
+    assert "trace:traces/trace.jsonl" in resources
+    assert "trace:traces/trajectory-abc123.atif.json" in resources
+
+
+def test_trial_resources_returns_no_trace_when_selected_format_is_absent(tmp_path):
+    trial_dir = tmp_path / "trial-2"
+    traces = trial_dir / "artifacts" / "traces"
+    traces.mkdir(parents=True)
+    (traces / "trace.jsonl").write_text('{"resourceSpans": []}\n', encoding="utf-8")
+
+    _, trace = _trial_resources(trial_dir, trace_format="atif")
+    assert trace is None
+
+
+def test_trial_resources_warns_when_only_the_other_format_is_present(tmp_path, caplog):
+    # An ATIF-only agent under the default otlp config would otherwise produce
+    # trace-less trials with no explanation anywhere.
+    trial_dir = tmp_path / "trial-3"
+    traces = trial_dir / "artifacts" / "traces"
+    traces.mkdir(parents=True)
+    (traces / "trajectory-abc123.atif.json").write_text(
+        '{"schema_version": "ATIF-v1.7", "session_id": "abc123"}', encoding="utf-8"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        _, trace = _trial_resources(trial_dir, trace_format="otlp")
+
+    assert trace is None
+    assert "trace_format='otlp'" in caplog.text
+    assert "atif" in caplog.text
+
+
+def test_trial_resources_is_quiet_when_no_traces_exist_at_all(tmp_path, caplog):
+    trial_dir = tmp_path / "trial-4"
+    (trial_dir / "artifacts").mkdir(parents=True)
+
+    with caplog.at_level(logging.WARNING):
+        _, trace = _trial_resources(trial_dir, trace_format="otlp")
+
+    assert trace is None
+    assert "trace_format" not in caplog.text
+
+
+def test_harbor_config_defaults_trace_format_to_otlp():
+    assert HarborEvaluatorConfig().trace_format == "otlp"
+
+
+def test_trace_format_is_not_passed_to_harbor_job_config():
+    # JobConfig rejects unknown keys; trace_format must be popped in _run.
+    from harbor.models.job.config import JobConfig
+
+    assert "trace_format" not in JobConfig.model_fields

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_tau3_nooa_wrapper.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_tau3_nooa_wrapper.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Behavioral tests for the tau3 NOOA agent's Harbor wrapper.
+
+The example is a standalone uv project, so the wrapper is loaded by path
+rather than imported as a package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+AGENT_DIR = REPO_ROOT / "examples" / "tau3-nooa-agent"
+
+
+def _load_wrapper() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("tau3_harbor_wrapper", AGENT_DIR / "harbor_wrapper.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _CrashedAgentEnvironment:
+    """An environment whose agent died before writing any traces.
+
+    ``download_dir`` then fails the way Harbor's Docker backend does: the
+    traces directory was never created, so the copy has no source.
+    """
+
+    def __init__(self) -> None:
+        self.default_user = "root"
+
+    async def exec(self, command, user=None, env=None, cwd=None, timeout_sec=None):
+        return SimpleNamespace(
+            stdout="",
+            stderr="IndentationError: unexpected indent (main.py, line 69)",
+            return_code=1,
+        )
+
+    async def download_dir(self, source_dir, target_dir):
+        raise RuntimeError(f"Docker compose command failed. Could not find the file {source_dir}/. in container abc123")
+
+
+async def test_crashed_agent_reports_its_own_failure_not_the_missing_traces_dir(tmp_path):
+    # A missing /app/traces is a symptom of the agent dying, never the cause. If the
+    # copy failure escapes, it masks the traceback that explains the run.
+    wrapper = _load_wrapper()
+    agent = wrapper.WrappedAgent(logs_dir=tmp_path)
+    context = SimpleNamespace(n_input_tokens=None, n_output_tokens=None, n_cache_tokens=None, metadata=None)
+
+    with pytest.raises(RuntimeError, match="Agent process failed with exit code 1"):
+        await agent.run("do the task", _CrashedAgentEnvironment(), context)
+
+
+async def test_crashed_agent_surfaces_the_agent_stderr(tmp_path):
+    wrapper = _load_wrapper()
+    agent = wrapper.WrappedAgent(logs_dir=tmp_path)
+    context = SimpleNamespace(n_input_tokens=None, n_output_tokens=None, n_cache_tokens=None, metadata=None)
+
+    with pytest.raises(RuntimeError, match="IndentationError"):
+        await agent.run("do the task", _CrashedAgentEnvironment(), context)
+
+
+async def test_missing_traces_is_recorded_as_a_metrics_error(tmp_path):
+    wrapper = _load_wrapper()
+    agent = wrapper.WrappedAgent(logs_dir=tmp_path)
+    context = SimpleNamespace(n_input_tokens=None, n_output_tokens=None, n_cache_tokens=None, metadata=None)
+
+    with pytest.raises(RuntimeError):
+        await agent.run("do the task", _CrashedAgentEnvironment(), context)
+
+    assert context.metadata is not None
+    assert "Trace metrics unavailable" in context.metadata["metrics_error"]
+    assert context.metadata["returncode"] == 1

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_trace_explorer_from_ref.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_trace_explorer_from_ref.py
@@ -175,6 +175,20 @@ def test_intake_tool_row_reads_the_preserved_tool_call_id():
     assert span.tool_call_id == "c1"
 
 
+def test_intake_otlp_tool_row_keeps_its_attribute_tool_call_id():
+    # tool_call_id has no Intake column, so OTLP rows carry it in raw_attributes.
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    row = _intake_llm_row(
+        source="otlp",
+        kind="TOOL",
+        tool_name="Bash",
+        raw_attributes=json.dumps({"tool_call.id": "call_otlp_1"}),
+    )
+    span = _span_from_intake_row(row)
+    assert span.tool_call_id == "call_otlp_1"
+
+
 def test_intake_row_reads_error_fields_from_columns():
     from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
 

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_trace_explorer_from_ref.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_trace_explorer_from_ref.py
@@ -10,6 +10,7 @@ with a ``traces/<id>`` id that never matches and are silently skipped, even once
 the platform client/workspace are correctly plumbed in.
 """
 
+import json
 from typing import Any, cast
 
 import pytest
@@ -68,3 +69,184 @@ async def test_from_ref_requires_client_and_workspace(
         await TraceExplorer.from_ref(ref, None, None)
 
     assert capture_from_intake == []
+
+
+# ---------------------------------------------------------------------------
+# backend-specific parsing
+# ---------------------------------------------------------------------------
+
+
+def _intake_llm_row(**overrides):
+    row = {
+        "span_id": "span-1",
+        "trace_id": "trace-1",
+        "source": "atif",
+        "kind": "LLM",
+        "name": "agent-step",
+        "model": "provider/model",
+        "input_tokens": 25773,
+        "output_tokens": 131,
+        "input": "book me a flight",
+        "output": "booked",
+        "raw_attributes": json.dumps({"source": "agent", "message": "booked", "step_id": 2}),
+    }
+    row.update(overrides)
+    return row
+
+
+def test_intake_row_reads_token_counts_from_columns():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    span = _span_from_intake_row(_intake_llm_row())
+    assert span.token_counts == {"prompt": 25773, "completion": 131}
+
+
+def test_intake_row_reads_all_four_token_columns():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    row = _intake_llm_row(cached_tokens=8, total_tokens=25904)
+    span = _span_from_intake_row(row)
+    assert span.token_counts == {
+        "prompt": 25773,
+        "completion": 131,
+        "cached": 8,
+        "total": 25904,
+    }
+
+
+def test_intake_row_ignores_absent_token_columns():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    row = _intake_llm_row()
+    del row["input_tokens"]
+    span = _span_from_intake_row(row)
+    assert span.token_counts == {"completion": 131}
+
+
+def test_intake_row_reads_model_and_payloads_from_columns():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    span = _span_from_intake_row(_intake_llm_row())
+    assert span.model_name == "provider/model"
+    assert span.input_value == "book me a flight"
+    assert span.output_value == "booked"
+
+
+def test_intake_atif_row_synthesizes_output_messages():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    span = _span_from_intake_row(_intake_llm_row())
+    assert [message.role for message in span.output_messages] == ["assistant"]
+    assert span.output_messages[0].content == "booked"
+
+
+def test_intake_atif_row_synthesizes_input_messages_for_user_steps():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    row = _intake_llm_row(
+        raw_attributes=json.dumps({"source": "user", "message": "book me a flight", "step_id": 1}),
+        output="",
+    )
+    span = _span_from_intake_row(row)
+    assert [message.role for message in span.input_messages] == ["user"]
+    assert span.output_messages == []
+
+
+def test_intake_otlp_row_does_not_synthesize_messages():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    # source='otlp' means the ATIF branch must not fire, even if the bag happens
+    # to carry a message-shaped key.
+    row = _intake_llm_row(source="otlp")
+    span = _span_from_intake_row(row)
+    assert span.output_messages == []
+
+
+def test_intake_tool_row_reads_the_preserved_tool_call_id():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    row = _intake_llm_row(
+        kind="TOOL",
+        tool_name="Bash",
+        raw_attributes=json.dumps({"tool_call": {"tool_call_id": "c1", "function_name": "Bash"}}),
+    )
+    span = _span_from_intake_row(row)
+    assert span.tool_name == "Bash"
+    assert span.tool_call_id == "c1"
+
+
+def test_intake_row_reads_error_fields_from_columns():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    row = _intake_llm_row(kind="TOOL", error_type="TimeoutError", error_message="tool timed out")
+    span = _span_from_intake_row(row)
+    assert span.error_type == "TimeoutError"
+    assert span.error_message == "tool timed out"
+
+
+def test_intake_row_reads_tool_definitions_from_the_agent_block():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    row = _intake_llm_row(
+        raw_attributes=json.dumps({"agent": {"tool_definitions": [{"name": "Bash", "description": "run a command"}]}})
+    )
+    span = _span_from_intake_row(row)
+    assert [tool.name for tool in span.tools] == ["Bash"]
+
+
+def test_intake_row_preserves_parent_and_kind():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_intake_row
+
+    row = _intake_llm_row(kind="AGENT", parent_span_id="span-0", agent_name="Codeact")
+    span = _span_from_intake_row(row)
+    assert span.kind == "AGENT"
+    assert span.parent_span_id == "span-0"
+    assert span.agent_name == "Codeact"
+
+
+def test_otlp_record_still_reads_token_counts_from_attributes():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _span_from_otlp_record
+
+    record = {
+        "spanId": "abc",
+        "traceId": "def",
+        "name": "llm",
+        "attributes": {
+            "openinference.span.kind": "LLM",
+            "llm.token_count.prompt": 100,
+            "llm.token_count.completion": 20,
+        },
+    }
+    span = _span_from_otlp_record(record)
+    assert span.token_counts == {"prompt": 100, "completion": 20}
+
+
+def test_intake_shaped_records_in_a_file_route_to_the_intake_parser():
+    from nemo_experimentalist_plugin.experimentalist.components.trace_explorer import _looks_like_intake_row
+
+    assert _looks_like_intake_row(_intake_llm_row()) is True
+    assert _looks_like_intake_row({"spanId": "abc", "attributes": {}}) is False
+
+
+async def test_from_ref_explains_why_a_local_atif_trajectory_cannot_be_read(tmp_path):
+    path = tmp_path / "trajectory-abc123.atif.json"
+    path.write_text('{"schema_version": "ATIF-v1.7", "session_id": "abc123"}', encoding="utf-8")
+    ref = ResourceRef(uri=f"file://{path}", description="", metadata={"trace_format": "atif"})
+
+    with pytest.raises(ValueError, match="never uploaded"):
+        await TraceExplorer.from_ref(ref)
+
+
+async def test_from_ref_still_reads_a_local_otlp_jsonl(tmp_path):
+    span = {
+        "spanId": "abc",
+        "traceId": "def",
+        "name": "llm",
+        "attributes": {"openinference.span.kind": "LLM"},
+    }
+    path = tmp_path / "trace.jsonl"
+    path.write_text(json.dumps({"resourceSpans": [{"scopeSpans": [{"spans": [span]}]}]}) + "\n", encoding="utf-8")
+    ref = ResourceRef(uri=f"file://{path}", description="", metadata={"trace_format": "otlp"})
+
+    explorer = await TraceExplorer.from_ref(ref)
+    assert explorer is not None

--- a/plugins/nemo-experimentalist/tests/test_atif.py
+++ b/plugins/nemo-experimentalist/tests/test_atif.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Behavioral tests for the ATIF trajectory helpers.
+
+Asserted through observable output — the session id string or the assembled
+payload dict — never through private helpers.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from nemo_experimentalist_plugin.entities import ResourceRef
+from nemo_experimentalist_plugin.experimentalist.atif import build_ingest_payload, read_session_id
+
+SESSION_ID = "d074dfb7-3691-443c-b137-720d75e40afa"
+
+AGENT_ATTRS = {
+    "gen_ai.agent.name": "nemo-experimentalist-tau3-nooa",
+    "agent.version": "1.0.0",
+    "gen_ai.request.model": "openai/openai/openai/gpt-5-mini",
+}
+
+
+def _trajectory(**overrides: object) -> dict:
+    base: dict = {
+        "schema_version": "ATIF-v1.7",
+        "session_id": SESSION_ID,
+        "agent": {"name": "Codeact", "version": "0.0.0"},
+        "steps": [{"step_id": 1, "source": "user", "message": "hi"}],
+    }
+    base.update(overrides)
+    return base
+
+
+def _ref(tmp_path: Path, trajectory: dict) -> ResourceRef:
+    path = tmp_path / f"trajectory-{SESSION_ID}.atif.json"
+    path.write_text(json.dumps(trajectory), encoding="utf-8")
+    return ResourceRef(uri=f"file://{path}", description="", metadata={})
+
+
+# ---------------------------------------------------------------------------
+# read_session_id
+# ---------------------------------------------------------------------------
+
+
+def test_read_session_id_returns_the_trajectory_session_id(tmp_path):
+    assert read_session_id(_ref(tmp_path, _trajectory())) == SESSION_ID
+
+
+def test_read_session_id_raises_when_absent(tmp_path):
+    ref = _ref(tmp_path, _trajectory(session_id=None))
+    with pytest.raises(ValueError, match="No session_id"):
+        read_session_id(ref)
+
+
+def test_read_session_id_raises_on_empty_string(tmp_path):
+    ref = _ref(tmp_path, _trajectory(session_id=""))
+    with pytest.raises(ValueError, match="No session_id"):
+        read_session_id(ref)
+
+
+# ---------------------------------------------------------------------------
+# build_ingest_payload
+# ---------------------------------------------------------------------------
+
+
+def test_build_ingest_payload_stamps_evaluation_context(tmp_path):
+    payload = build_ingest_payload(
+        _ref(tmp_path, _trajectory()),
+        experiment_id="exp-1",
+        task_id="tau3-airline/case-a",
+        agent_attrs={},
+    )
+    assert payload["evaluation_context"] == {
+        "evaluation_id": "exp-1",
+        "test_case_id": "tau3-airline/case-a",
+    }
+
+
+def test_build_ingest_payload_preserves_producer_fields(tmp_path):
+    payload = build_ingest_payload(
+        _ref(tmp_path, _trajectory()),
+        experiment_id="exp-1",
+        task_id="case-a",
+        agent_attrs={},
+    )
+    assert payload["schema_version"] == "ATIF-v1.7"
+    assert payload["session_id"] == SESSION_ID
+    assert payload["steps"] == [{"step_id": 1, "source": "user", "message": "hi"}]
+
+
+def test_build_ingest_payload_fills_only_blank_agent_fields(tmp_path):
+    # Producer set name and version; model_name is absent.
+    payload = build_ingest_payload(
+        _ref(tmp_path, _trajectory()),
+        experiment_id="exp-1",
+        task_id="case-a",
+        agent_attrs=AGENT_ATTRS,
+    )
+    assert payload["agent"]["name"] == "Codeact"  # not overwritten
+    assert payload["agent"]["version"] == "0.0.0"  # not overwritten
+    assert payload["agent"]["model_name"] == "openai/openai/openai/gpt-5-mini"  # filled
+
+
+def test_build_ingest_payload_fills_missing_agent_block(tmp_path):
+    trajectory = _trajectory()
+    del trajectory["agent"]
+    payload = build_ingest_payload(
+        _ref(tmp_path, trajectory),
+        experiment_id="exp-1",
+        task_id="case-a",
+        agent_attrs=AGENT_ATTRS,
+    )
+    assert payload["agent"] == {
+        "name": "nemo-experimentalist-tau3-nooa",
+        "version": "1.0.0",
+        "model_name": "openai/openai/openai/gpt-5-mini",
+    }
+
+
+def test_build_ingest_payload_does_not_inject_verifier_result(tmp_path):
+    payload = build_ingest_payload(
+        _ref(tmp_path, _trajectory()),
+        experiment_id="exp-1",
+        task_id="case-a",
+        agent_attrs=AGENT_ATTRS,
+    )
+    assert "verifier_result" not in payload.get("extra", {})

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_backend.py
@@ -13,7 +13,7 @@ import asyncio
 import json
 import traceback
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -353,3 +353,69 @@ async def test_persist_result_preserves_generated_optimization_report(tmp_path: 
     await backend.persist_result(workspace="w", result=result)
 
     assert report_path.read_text() == "# Full optimization report\n\nInsight Suite Metrics"
+
+
+# ---------------------------------------------------------------------------
+# ATIF upload
+# ---------------------------------------------------------------------------
+
+
+class _RecordingClient:
+    """Captures posts so the payload and URL can be asserted directly."""
+
+    def __init__(self) -> None:
+        self.posts: list[dict] = []
+
+    async def post(self, url, *, cast_to, body=None, content=None, options=None):
+        self.posts.append({"url": url, "body": body, "content": content, "options": options})
+        return {}
+
+
+def _atif_ref(tmp_path, session_id="sess-1"):
+    from nemo_experimentalist_plugin.entities import ResourceRef
+
+    path = tmp_path / f"trajectory-{session_id}.atif.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "ATIF-v1.7",
+                "session_id": session_id,
+                "agent": {"name": "Codeact", "version": "0.0.0"},
+                "steps": [{"step_id": 1, "source": "user", "message": "hi"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return ResourceRef(uri=f"file://{path}", description="", metadata={"trace_format": "atif"})
+
+
+async def test_upload_trace_atif_posts_to_the_atif_ingest_endpoint(tmp_path):
+    from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import _upload_trace_atif
+
+    client = _RecordingClient()
+    await _upload_trace_atif(
+        cast(Any, client),
+        "ws-1",
+        _atif_ref(tmp_path),
+        experiment_id="exp-1",
+        task_id="case-a",
+        extra_attrs={"gen_ai.request.model": "gpt-5-mini"},
+    )
+
+    assert len(client.posts) == 1
+    post = client.posts[0]
+    assert post["url"] == "/apis/intake/v2/workspaces/ws-1/ingest/atif"
+    assert post["body"]["evaluation_context"] == {
+        "evaluation_id": "exp-1",
+        "test_case_id": "case-a",
+    }
+    assert post["body"]["agent"]["model_name"] == "gpt-5-mini"
+
+
+async def test_upload_trace_atif_sends_json_not_protobuf(tmp_path):
+    from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import _upload_trace_atif
+
+    client = _RecordingClient()
+    await _upload_trace_atif(cast(Any, client), "ws-1", _atif_ref(tmp_path), experiment_id="exp-1", task_id="case-a")
+    assert client.posts[0]["content"] is None
+    assert client.posts[0]["body"] is not None


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Experimentalist read agent traces as OTLP only, so an agent emitting ATIF produced trials with no trace at all — silently. Discovery found no `*.jsonl`, the trial was skipped, and nothing said why. This teaches the trace path to carry its format from discovery through analysis, so an ATIF-emitting agent can be optimized. OTLP remains the default and its behavior is unchanged.

## Changes

**ATIF trace support** (`feat` commit)

- **Discovery** — `_trial_resources` recognises `*.atif.json` alongside `*.jsonl` and stamps `trace_format` on the `ResourceRef`, so the format is decided once and carried forward rather than re-derived downstream. New `HarborEvaluatorConfig.trace_format` selects which artifact becomes the trial's trace; both stay exposed in `resources`.
- **Upload** — new `experimentalist/atif.py` reads the trajectory and builds the ingest payload; `_persist_trial` dispatches on the stamped format and posts to Intake's ATIF ingest with `evaluation_context` carrying experiment and test-case identity. Trial identity rides on the trajectory's own `session_id`, which Intake adopts as the trace id.
- **Read-back** — Intake promotes known attributes into typed columns and strips those keys from `raw_attributes`, so a reader that knows only the OpenInference names finds nothing. Token counts and error fields were missing on **every** span read back from storage, OTLP included. `from_intake` now parses the columns directly; `_load_trace_models` keeps a per-record shape check because it deliberately accepts Intake-shaped payloads from disk. An ATIF branch keyed on the `source` column covers fields that have no column at all.
- **Three silent failures become diagnosable** — discovery warns when the configured format matches nothing but the other format's artifacts are present; `persist_evaluation` logs the trial it drops; `from_ref` rejects a local `.atif.json` with a message naming the real cause instead of reporting an empty trace.
- **Docs** — a README section covering the `trace_format` setting, the artifact contract, the Intake requirement, and the two diagnostics.

**Independent of ATIF**, kept as separate commits so they can be reviewed or cherry-picked on their own:

- `fix(tau3-nooa-agent)` — when the agent dies before writing traces, `/app/traces` never exists and the environment refuses to copy it, raising `RuntimeError`. That escaped the metrics guard and replaced the agent's own error with a Docker copy failure. Catching it lets the run reach the existing check that raises with the agent's exit code and stderr.
- `chore(experimentalist)` — ignore `artifacts/experimentalist-benchmarks/`. It is generated output, and because the optimizer writes candidate agents there, a candidate whose generated code does not compile was failing `ruff check plugins/nemo-experimentalist/`.

**Review fixes** (`fix(experimentalist)` commit, from CodeRabbit)

- `tool_call_id` has no Intake column, so `tool_call.id` / `tool.id` / `tool_call_id` survive in `raw_attributes`. The new Intake parser hardcoded an empty value for non-ATIF rows, so OTLP traces read back from Intake lost their tool call ids — a regression against the shared parser it replaced. Restores the attribute lookup, with ATIF's preserved payload as the fallback only for ATIF rows, and adds a regression test.
- The README documented `trace_format` under an `optimizer` key. That is the benchmark config's shape; an agent profile roots the same model at `experiment_config`, where `evaluator` is a top-level field. Corrected.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

31 tests added across four files: `test_atif.py` (payload construction), `test_evaluator_harbor.py` (format discovery and selection), `test_experimentalist_backend.py` (ATIF upload), `test_trace_explorer_from_ref.py` (Intake-row parsing, both backends). The `fix` commit's 3 tests were confirmed to fail without the fix and pass with it.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
uv run pre-commit run -a
  → all hooks Passed (ruff, ruff format, ty typechecks, config reference,
    helm docs, uv lock, uv lock drift, copyright headers, UI lint-staged,
    plugin import boundary, merge conflicts)

uv run --frozen pytest <the 5 test files this PR touches> -q
  → 142 passed

uv run --frozen pytest plugins/nemo-experimentalist/tests/ -q
  → 631 passed

uv run ruff check plugins/nemo-experimentalist/
  → All checks passed

uv run ruff format --check
  → 3030 files already formatted

git diff --check origin/main...HEAD
  → clean
```

**End-to-end verification against a live platform.** Beyond the unit tests, the ATIF path was exercised with a real agent and a running Intake: trajectories were accepted by Intake's validators, 7 traces / 86 spans landed with correct `evaluation_id` and `test_case_id` grouping, and spans read back with token counts and tool call ids populated. The agent-side scaffolding used for that run was reverted before this PR; only the feature remains.

**Known limitation.** Per-step durations are absent on ATIF-derived spans: Intake takes a step's end time only from a producer-supplied invocation block, and infers nothing from adjacent steps. Trajectory-level duration and the Studio rollup are unaffected. This is documented in the README.
