### PR TITLE
feat(evaluator): let evaluations pin a taskset revision

### DIFF
--- a/docs/evaluator/manage-tasks-tasksets.mdx
+++ b/docs/evaluator/manage-tasks-tasksets.mdx
@@ -325,34 +325,37 @@ The inline form remains available for one-off tasks — swap `tasks=TasksetRef(.
 
 ### Pin the taskset itself
 
-A bare `TasksetRef` expands the taskset's current revision, so it follows the suite forward as
-members are added or removed. Add a `#<tag-or-digest>` fragment to pin the grouping too:
+A bare `TasksetRef` expands the taskset's current revision, so it follows the suite forward every
+time the taskset is republished. Add a `#<tag-or-digest>` fragment to pin the grouping too:
 
 ```python
 # The digest lives on the revision, not on the taskset record — revisions come back newest first.
 current = tasksets.list_revisions("geography-suite").data[0]
 
-# Follows the suite forward — new members are picked up on the next run.
+# Follows the suite forward — the next `replace` is picked up on the next run.
 tracking = TasksetRef("default/geography-suite")
 
-# Frozen: this exact membership, regardless of later `replace` calls.
+# Frozen: this exact membership and content, regardless of later `replace` calls.
 pinned = TasksetRef(f"default/geography-suite#{current.content_hash}")
 
 # A tag works the same way, and can be moved deliberately when you bless a new suite.
 blessed = TasksetRef("default/geography-suite#blessed")
 ```
 
-The two pins compose, and they cover different things:
+What each form is stable against:
 
-| | Member content | Which members |
+| | A member task republishes | The taskset is replaced |
 |---|---|---|
-| `TasksetRef("suite")` | pinned | current revision |
-| `TasksetRef("suite#<digest>")` | pinned | pinned |
+| `TasksetRef("suite")` | unaffected | follows the new revision |
+| `TasksetRef("suite#<digest>")` | unaffected | unaffected |
 
-Member content is digest-pinned inside every revision, so even a bare ref grades the same task
-content across re-runs. Pinning the taskset is what additionally holds *membership* still across a
-`replace` that adds or drops a task — which is what you want when a benchmark number has to stay
-comparable.
+Every taskset revision pins its members by digest, so **neither** form is disturbed when a member
+task publishes new content on its own — that is the guarantee stored membership buys you.
+
+The two differ on `replace`. A bare ref tracks the taskset's own revisions, and members are
+re-resolved on every write — so a `replace` can change *both* which tasks are named *and* the
+content they resolve to, even when the submitted member names were identical. Pin the taskset when a
+benchmark number has to stay comparable across that.
 
 A fragment that no longer resolves fails the evaluation rather than falling back to the current
 revision.

--- a/docs/evaluator/manage-tasks-tasksets.mdx
+++ b/docs/evaluator/manage-tasks-tasksets.mdx
@@ -290,7 +290,10 @@ input_spec = AgentEvalInputSpec(
 
 When the job runs, the taskset reference is resolved like this:
 
-- Each member is loaded at the **revision pinned in the taskset**, not the task's current tip.
+- The **taskset revision** the ref names is loaded — the current one unless the ref pins a revision
+  (see [Pin the taskset itself](#pin-the-taskset-itself)).
+- Each member of that revision is loaded at the **revision pinned in the taskset**, not the task's
+  current tip.
 - Metric references on those members are hydrated into runnable metrics, the same as for inline tasks.
 - Re-running the same taskset therefore evaluates the same content, even if a member has been
   republished since.
@@ -320,11 +323,39 @@ results flow.
 The inline form remains available for one-off tasks — swap `tasks=TasksetRef(...)` for
 `tasks=[AgentEvalTaskInput(...), ...]`.
 
-<Note>
-A `TasksetRef` names the taskset's current revision; it cannot yet carry a `#<tag-or-digest>`
-fragment of its own. Member content is pinned, so a re-run always grades the same task content — but
-if the taskset itself is replaced, a re-submitted spec expands the new membership.
-</Note>
+### Pin the taskset itself
+
+A bare `TasksetRef` expands the taskset's current revision, so it follows the suite forward as
+members are added or removed. Add a `#<tag-or-digest>` fragment to pin the grouping too:
+
+```python
+# The digest lives on the revision, not on the taskset record — revisions come back newest first.
+current = tasksets.list_revisions("geography-suite").data[0]
+
+# Follows the suite forward — new members are picked up on the next run.
+tracking = TasksetRef("default/geography-suite")
+
+# Frozen: this exact membership, regardless of later `replace` calls.
+pinned = TasksetRef(f"default/geography-suite#{current.content_hash}")
+
+# A tag works the same way, and can be moved deliberately when you bless a new suite.
+blessed = TasksetRef("default/geography-suite#blessed")
+```
+
+The two pins compose, and they cover different things:
+
+| | Member content | Which members |
+|---|---|---|
+| `TasksetRef("suite")` | pinned | current revision |
+| `TasksetRef("suite#<digest>")` | pinned | pinned |
+
+Member content is digest-pinned inside every revision, so even a bare ref grades the same task
+content across re-runs. Pinning the taskset is what additionally holds *membership* still across a
+`replace` that adds or drops a task — which is what you want when a benchmark number has to stay
+comparable.
+
+A fragment that no longer resolves fails the evaluation rather than falling back to the current
+revision.
 
 <Note>
 Stored tasks carry no grader-only `reference` (held-out ground truth): that field lives only on inline
@@ -401,6 +432,7 @@ The SDK resources are a thin client over the Evaluator plugin REST API, mounted 
 | Missing or duplicate task reference (taskset) | `422` | Members must exist, and must resolve to distinct tasks. |
 | Reserved or malformed tag name | `422` | `latest` cannot be moved by hand; a digest-shaped tag is refused. |
 | Retrieving or deleting an unknown name or revision | `404` | Applies to both records and revisions. |
+| `TasksetRef` pinning a revision that no longer resolves | job fails | Expansion refuses rather than falling back to the current revision. |
 | `DELETE` on a task a taskset pins | `204` | Not prevented; the taskset's reference dangles and fails on read. |
 
 ## Related Topics

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -5165,11 +5165,15 @@ components:
         \ Lets an evaluation reference a stored taskset in place\nof an inline task\
         \ list; the taskset's member tasks are loaded and expanded during spec resolution.\n\
         \nAn optional ``#`` fragment pins the taskset revision to expand \u2014 a\
-        \ tag or a full content digest,\nwith an absent fragment meaning ``latest``.\
-        \ Membership is digest-pinned within a revision, so a\nbare ref already grades\
-        \ identical task *content* across re-runs; pinning the taskset as well is\n\
-        what fixes the *membership* too, across a ``replace`` that adds or drops a\
-        \ member."
+        \ tag or a full content digest,\nwith an absent fragment meaning ``latest``.\n\
+        \nWhat each form guarantees, precisely. A taskset revision pins its members\
+        \ by digest, so a member\ntask publishing new content never changes what *any*\
+        \ ref expands to. A **bare** ref still tracks\nthe taskset's own revisions,\
+        \ and republishing the taskset re-resolves its members on write \u2014 so\
+        \ a\n``replace`` can change both which members are named and the content they\
+        \ resolve to, even if the\nsubmitted member names were identical. A **pinned**\
+        \ ref is fixed against that too, and is what an\nevaluation needs to stay\
+        \ comparable across a ``replace``."
     TasksetSort:
       type: string
       enum:

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -5158,17 +5158,18 @@ components:
         \ fields (id, name, workspace,\ntimestamps)."
     TasksetRef:
       type: string
-      pattern: ^[\w\-.]+(/[\w\-.]+)?$
+      pattern: ^[\w\-.]+(/[\w\-.]+)?(#[\w\-.]+)?$
       title: TasksetRef
-      description: 'Reference to a persisted taskset (format: ``workspace/name`` or
-        ``name``).
-
-
-        Same shape and charset as :class:`TaskRef`. Lets an evaluation reference a
-        stored taskset in place
-
-        of an inline task list; the taskset''s member tasks are loaded and expanded
-        during spec resolution.'
+      description: "Reference to a persisted taskset (format: ``workspace/name`` or\
+        \ ``name``, optionally ``#rev``).\n\nSame shape and charset as :class:`TaskRef`.\
+        \ Lets an evaluation reference a stored taskset in place\nof an inline task\
+        \ list; the taskset's member tasks are loaded and expanded during spec resolution.\n\
+        \nAn optional ``#`` fragment pins the taskset revision to expand \u2014 a\
+        \ tag or a full content digest,\nwith an absent fragment meaning ``latest``.\
+        \ Membership is digest-pinned within a revision, so a\nbare ref already grades\
+        \ identical task *content* across re-runs; pinning the taskset as well is\n\
+        what fixes the *membership* too, across a ``replace`` that adds or drops a\
+        \ member."
     TasksetSort:
       type: string
       enum:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/schemas.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/schemas.py
@@ -235,9 +235,14 @@ class TasksetRef(RootModel[str]):
     of an inline task list; the taskset's member tasks are loaded and expanded during spec resolution.
 
     An optional ``#`` fragment pins the taskset revision to expand — a tag or a full content digest,
-    with an absent fragment meaning ``latest``. Membership is digest-pinned within a revision, so a
-    bare ref already grades identical task *content* across re-runs; pinning the taskset as well is
-    what fixes the *membership* too, across a ``replace`` that adds or drops a member.
+    with an absent fragment meaning ``latest``.
+
+    What each form guarantees, precisely. A taskset revision pins its members by digest, so a member
+    task publishing new content never changes what *any* ref expands to. A **bare** ref still tracks
+    the taskset's own revisions, and republishing the taskset re-resolves its members on write — so a
+    ``replace`` can change both which members are named and the content they resolve to, even if the
+    submitted member names were identical. A **pinned** ref is fixed against that too, and is what an
+    evaluation needs to stay comparable across a ``replace``.
     """
 
     root: str = Field(

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/schemas.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/schemas.py
@@ -151,9 +151,9 @@ REF_FRAGMENT_CHARSET = r"[\w\-.]+"
 # (``#latest``, ``#candidate``) or a full 64-char content digest.
 #
 # Deliberately a sibling of ``_ENTITY_REF_PATTERN`` rather than a widening of it: that constant is
-# shared by ``MetricRef`` and ``TasksetRef``, neither of which has revisions yet, and admitting a
-# fragment there would accept input nothing is built to resolve. ``TasksetRef`` moves onto this
-# pattern when taskset revisions are addressable; ``MetricRef`` when (if) metrics gain revisions.
+# still shared by ``MetricRef``, which has no revisions, and admitting a fragment there would accept
+# input nothing is built to resolve. ``TaskRef`` and ``TasksetRef`` both use this pattern, since both
+# name revisioned records; ``MetricRef`` joins them when (if) metrics gain revisions.
 _SUBENTITY_REF_PATTERN = rf"^[\w\-.]+(/[\w\-.]+)?(#{REF_FRAGMENT_CHARSET})?$"
 
 #: The fragment separator for sub-entity references. Matches the fileset/job ref convention.
@@ -229,15 +229,21 @@ class TaskRef(RootModel[str]):
 
 
 class TasksetRef(RootModel[str]):
-    """Reference to a persisted taskset (format: ``workspace/name`` or ``name``).
+    """Reference to a persisted taskset (format: ``workspace/name`` or ``name``, optionally ``#rev``).
 
     Same shape and charset as :class:`TaskRef`. Lets an evaluation reference a stored taskset in place
     of an inline task list; the taskset's member tasks are loaded and expanded during spec resolution.
+
+    An optional ``#`` fragment pins the taskset revision to expand — a tag or a full content digest,
+    with an absent fragment meaning ``latest``. Membership is digest-pinned within a revision, so a
+    bare ref already grades identical task *content* across re-runs; pinning the taskset as well is
+    what fixes the *membership* too, across a ``replace`` that adds or drops a member.
     """
 
     root: str = Field(
-        pattern=_ENTITY_REF_PATTERN,
-        description="Reference to a stored taskset (format: workspace/taskset-name, or taskset-name in the job workspace).",
+        pattern=_SUBENTITY_REF_PATTERN,
+        description="Reference to a stored taskset (format: workspace/taskset-name, or taskset-name in the "
+        "job workspace), optionally pinned to a revision with '#<tag-or-digest>'.",
     )
 
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/task_refs.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/task_refs.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 from typing import cast
 
-from nemo_evaluator.api.schemas import TasksetRef, parse_entity_ref, parse_subentity_ref
-from nemo_evaluator.entities import TaskEntity, TaskRevisionEntity, TasksetEntity
+from nemo_evaluator.api.schemas import TasksetRef, parse_subentity_ref
+from nemo_evaluator.entities import TaskEntity, TaskRevisionEntity, TasksetEntity, TasksetRevisionEntity
 from nemo_evaluator.jobs.agent_spec import AgentEvalTaskInput
 from nemo_evaluator.revisions import RevisionNotFoundError, get_revision
 from nemo_platform_plugin.entities import EntityClientProtocol
@@ -49,10 +49,11 @@ def _entity_to_task_input(entity: TaskEntity, revision: TaskRevisionEntity) -> A
     )
 
 
-#: Expanding a taskset reads three entity types through one client — the taskset head, each member
-#: task's head, and the pinned revision of each member. Python has no intersection types, so the
-#: parameter is annotated at one of them and the other two are taken as typed views of the same
-#: object; the concrete client's methods are generic over the entity type and satisfy all three.
+#: Expanding a taskset reads four entity types through one client — the taskset head, its pinned
+#: revision, each member task's head, and the pinned revision of each member. Python has no
+#: intersection types, so the parameter is annotated at one of them and the rest are taken as typed
+#: views of the same object; the concrete client's methods are generic over the entity type and
+#: satisfy all four.
 TasksetStoreProtocol = EntityClientProtocol[TasksetEntity]
 
 
@@ -66,6 +67,12 @@ async def resolve_taskset_ref(
 
     Loading needs only the entity store (metrics stay as refs, resolved downstream), so unlike
     metric-ref resolution this does not require an async SDK / file I/O.
+
+    The ref may pin a taskset revision (``suite#<tag-or-digest>``); an absent fragment means
+    ``latest``. Both paths go through :func:`get_revision` rather than reading the head's own
+    ``tasks``, because a head and its ``latest`` revision are guaranteed to agree and resolving one
+    way for pinned refs and another way for bare ones would make the two drift apart on the next
+    bug. It also buys content verification for the bare case for free.
     """
     if entity_client is None:
         raise ValueError(
@@ -74,8 +81,9 @@ async def resolve_taskset_ref(
         )
     task_store = cast(EntityClientProtocol[TaskEntity], entity_client)
     revision_store = cast(EntityClientProtocol[TaskRevisionEntity], entity_client)
+    taskset_revision_store = cast(EntityClientProtocol[TasksetRevisionEntity], entity_client)
 
-    ref_workspace, name = parse_entity_ref(ref.root, workspace)
+    ref_workspace, name, taskset_fragment = parse_subentity_ref(ref.root, workspace)
     try:
         taskset = await entity_client.get(TasksetEntity, name=name, workspace=ref_workspace)
     except NemoEntityNotFoundError as exc:
@@ -85,12 +93,20 @@ async def resolve_taskset_ref(
             "or pass an inline task list instead."
         ) from exc
 
-    if not taskset.tasks:
+    # Expand the *pinned* taskset revision. Membership is digest-pinned within a revision, so a bare
+    # ref already grades identical task content — but a ``replace`` that adds or drops a member
+    # changes the head, and only pinning the taskset itself holds membership steady across that.
+    try:
+        taskset_revision = await get_revision(taskset_revision_store, TasksetRevisionEntity, taskset, taskset_fragment)
+    except RevisionNotFoundError as exc:
+        raise ValueError(f"Taskset reference '{ref.root}' names a revision that does not resolve: {exc}") from exc
+
+    if not taskset_revision.tasks:
         raise ValueError(f"Taskset '{ref.root}' has no member tasks; an agent evaluation needs at least one task.")
 
     tasks: list[AgentEvalTaskInput] = []
     seen_ids: set[str] = set()
-    for task_ref in taskset.tasks:
+    for task_ref in taskset_revision.tasks:
         task_workspace, task_name, fragment = parse_subentity_ref(task_ref.root, ref_workspace)
         try:
             entity = await task_store.get(TaskEntity, name=task_name, workspace=task_workspace)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/task_refs.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/task_refs.py
@@ -93,9 +93,10 @@ async def resolve_taskset_ref(
             "or pass an inline task list instead."
         ) from exc
 
-    # Expand the *pinned* taskset revision. Membership is digest-pinned within a revision, so a bare
-    # ref already grades identical task content — but a ``replace`` that adds or drops a member
-    # changes the head, and only pinning the taskset itself holds membership steady across that.
+    # Expand the taskset revision the ref names. Members are digest-pinned inside a revision, so a
+    # member republishing on its own never moves this. A bare ref still follows the taskset's own
+    # revisions, and a ``replace`` re-resolves members on write — so it can change both which members
+    # are named and what they resolve to. Only a pinned ref holds both steady.
     try:
         taskset_revision = await get_revision(taskset_revision_store, TasksetRevisionEntity, taskset, taskset_fragment)
     except RevisionNotFoundError as exc:

--- a/plugins/nemo-evaluator/tests/api/service/test_task_service.py
+++ b/plugins/nemo-evaluator/tests/api/service/test_task_service.py
@@ -250,8 +250,8 @@ async def test_rollback_failure_does_not_mask_the_original_error(
         await service.create_task("task-1", _task_input(), workspace="default")
 
 
-async def test_resolve_revision_returns_the_digest_for_a_tag(service: TaskService) -> None:
-    """The hook taskset publishing uses to turn a member's tag into an exact digest."""
+async def test_resolve_revision_defaults_to_the_current_revision(service: TaskService) -> None:
+    """No fragment means ``latest`` — the bare-member case taskset publishing hits most often."""
     await service.create_task("task-1", _task_input(), workspace="default")
 
     digest = await service.resolve_revision("default", "task-1")
@@ -259,6 +259,40 @@ async def test_resolve_revision_returns_the_digest_for_a_tag(service: TaskServic
     revisions = await service.list_revisions("default", "task-1")
     assert revisions is not None
     assert digest == revisions.data[0].content_hash
+
+
+async def test_resolve_revision_honours_a_tag_naming_an_older_revision(service: TaskService) -> None:
+    """The hook taskset publishing uses to turn a member's tag into an exact digest.
+
+    Needs a task with *more than one* revision and a tag left behind on the older one: against a
+    single-revision task every fragment resolves to the same digest, so the test would pass even if
+    the fragment were ignored entirely.
+    """
+    await service.create_task("task-1", _task_input(), workspace="default")
+    first = (await service.list_revisions("default", "task-1")).data[0].content_hash
+    await service.tag_revision("default", "task-1", "blessed", "latest")
+
+    revised = _task_input()
+    revised.intent = "Answer differently."
+    await service.replace_task("task-1", revised, workspace="default")
+
+    latest = await service.resolve_revision("default", "task-1")
+    blessed = await service.resolve_revision("default", "task-1", "blessed")
+
+    assert latest != first, "the task must actually have moved on, or this proves nothing"
+    assert blessed == first, "a tag must resolve to the revision it names, not the current one"
+
+
+async def test_resolve_revision_round_trips_a_digest_fragment(service: TaskService) -> None:
+    """A member submitted already-pinned must resolve to itself rather than to the head."""
+    await service.create_task("task-1", _task_input(), workspace="default")
+    first = (await service.list_revisions("default", "task-1")).data[0].content_hash
+
+    revised = _task_input()
+    revised.intent = "Answer differently."
+    await service.replace_task("task-1", revised, workspace="default")
+
+    assert await service.resolve_revision("default", "task-1", first) == first
 
 
 async def test_resolve_revision_raises_for_a_missing_task(service: TaskService) -> None:

--- a/plugins/nemo-evaluator/tests/api/service/test_taskset_service.py
+++ b/plugins/nemo-evaluator/tests/api/service/test_taskset_service.py
@@ -30,12 +30,19 @@ class _FakeTaskService:
     async def resolve_revision(self, workspace: str, name: str, fragment: str = "latest") -> str:
         """A stable per-task digest, so pinned membership is deterministic across a test.
 
-        Raises for an unknown task, matching the real service: resolution fetches the task, so a
-        missing one surfaces here rather than from a separate existence check.
+        The digest covers the **fragment** as well as the task, because the real
+        ``TaskService.resolve_revision`` resolves it: a bare member and a tag-pinned one give
+        different digests whenever the tag names an older revision. A fake that ignored the fragment
+        would return the same digest either way, and a publish path that dropped the fragment
+        entirely would look correct in every assertion here.
         """
         if (workspace, name) not in self.existing:
             raise NemoEntityNotFoundError(f"{workspace}/{name} not found")
-        return hashlib.sha256(f"{workspace}/{name}".encode()).hexdigest()
+        return hashlib.sha256(f"{workspace}/{name}#{fragment}".encode()).hexdigest()
+
+    def digest_for(self, workspace: str, name: str, fragment: str = "latest") -> str:
+        """The digest a test should expect for a member — same derivation as ``resolve_revision``."""
+        return hashlib.sha256(f"{workspace}/{name}#{fragment}".encode()).hexdigest()
 
 
 def _taskset_input() -> TasksetInput:
@@ -71,6 +78,31 @@ async def test_create_then_get(service: TasksetService) -> None:
 
     got = await service.get_taskset("default", "ts-1")
     assert got is not None and got.name == "ts-1"
+
+
+async def test_a_tag_pinned_member_stores_the_tagged_revision(
+    existing_tasks: set[tuple[str, str]], entity_store
+) -> None:
+    """A member's ``#tag`` must be resolved through the tag, not silently treated as the head.
+
+    This is the whole point of resolving membership on write: the stored ref has to name the
+    revision the tag pointed at *then*, so moving the tag afterwards cannot re-point a published
+    taskset. Dropping the fragment would still produce a digest-shaped ref, so only comparing
+    against the tag-specific digest catches it.
+    """
+    task_service = _FakeTaskService(existing_tasks)
+    service = TasksetService(entity_store, task_service)
+
+    created, _ = await service.create_taskset(
+        "ts-1", TasksetInput(tasks=[TaskRef("task-a#blessed"), TaskRef("task-b")]), workspace="default"
+    )
+
+    stored = {t.root.split("#")[0]: t.root.split("#")[1] for t in created.tasks}
+    assert stored["default/task-a"] == task_service.digest_for("default", "task-a", "blessed")
+    assert stored["default/task-b"] == task_service.digest_for("default", "task-b", "latest")
+    assert stored["default/task-a"] != task_service.digest_for("default", "task-a", "latest"), (
+        "a tag-pinned member must not collapse onto the task's current revision"
+    )
 
 
 async def test_create_validates_missing_task_ref(service: TasksetService) -> None:

--- a/plugins/nemo-evaluator/tests/test_subentity_refs.py
+++ b/plugins/nemo-evaluator/tests/test_subentity_refs.py
@@ -90,10 +90,21 @@ def test_task_ref_rejects_malformed_fragments(ref: str) -> None:
         TaskRef(ref)
 
 
-@pytest.mark.parametrize("ref_type", [MetricRef, TasksetRef])
-def test_sibling_ref_types_still_reject_fragments(ref_type: type) -> None:
-    """The fragment pattern is a sibling, not a widening of the shared constant: metrics and
-    tasksets have no revisions yet, so admitting a fragment would accept input nothing resolves.
-    They move onto it when they gain revisions — deliberately, at that point."""
+def test_metric_ref_still_rejects_fragments() -> None:
+    """The fragment pattern is a sibling, not a widening of the shared constant: metrics have no
+    revisions, so admitting a fragment would accept input nothing resolves. ``MetricRef`` moves onto
+    it when metrics gain revisions — deliberately, at that point."""
     with pytest.raises(ValidationError):
-        ref_type(f"other/thing#{_DIGEST}")
+        MetricRef(f"other/thing#{_DIGEST}")
+
+
+@pytest.mark.parametrize("ref", ["suite", "other/suite", "suite#latest", "suite#blessed", f"other/suite#{_DIGEST}"])
+def test_taskset_ref_accepts_fragments(ref: str) -> None:
+    """Tasksets are revisioned, so a ref may pin the revision to expand — same shape as ``TaskRef``."""
+    assert TasksetRef(ref).root == ref
+
+
+@pytest.mark.parametrize("ref", ["suite#one#two", "suite#bad/frag", "#latest", "suite name#latest"])
+def test_taskset_ref_rejects_malformed_fragments(ref: str) -> None:
+    with pytest.raises(ValidationError):
+        TasksetRef(ref)

--- a/plugins/nemo-evaluator/tests/test_task_refs.py
+++ b/plugins/nemo-evaluator/tests/test_task_refs.py
@@ -18,7 +18,7 @@ from nemo_evaluator.api.schemas import (
 )
 from nemo_evaluator.entities import TaskEntity, TaskRevisionEntity, TasksetEntity, TasksetRevisionEntity
 from nemo_evaluator.jobs.agent_spec import AgentEvalTaskInput
-from nemo_evaluator.revisions import apply_tag, head_digest, is_digest, publish_revision
+from nemo_evaluator.revisions import apply_tag, get_revision, head_digest, is_digest, publish_revision
 from nemo_evaluator.task_refs import resolve_agent_eval_tasks, resolve_taskset_ref
 from nemo_platform_plugin.entities import EntityBase
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
@@ -56,6 +56,11 @@ async def _pin_members(client, taskset: TasksetEntity) -> list[TaskRef]:
     anything less. Doing the resolution here keeps the fixtures readable without letting them
     describe a taskset the service could not have produced. A ref the test already pinned by hand is
     left alone — that is the case under test.
+
+    Non-digest fragments go through ``get_revision`` rather than ``head_digest``, matching what
+    ``resolve_revision`` does on the write path. The two agree for a bare ref, whose fragment is
+    ``latest`` — but a member named ``task#blessed`` must pin the revision that tag points at, which
+    is not the head once the tag has been left behind.
     """
     pinned: list[TaskRef] = []
     for ref in taskset.tasks:
@@ -65,7 +70,7 @@ async def _pin_members(client, taskset: TasksetEntity) -> list[TaskRef]:
             continue
         try:
             task = await client.get(TaskEntity, name=member_name, workspace=member_workspace)
-            digest = head_digest(task)
+            digest = (await get_revision(client, TaskRevisionEntity, task, fragment)).content_hash
         except NemoEntityNotFoundError:
             digest = _ABSENT_MEMBER_DIGEST
         pinned.append(TaskRef(f"{member_workspace}/{member_name}#{digest}"))
@@ -193,6 +198,37 @@ async def test_expansion_uses_the_pinned_revision_not_current_content(entity_sto
     tasks = await resolve_taskset_ref(TasksetRef("default/geo"), workspace="default", entity_client=client)
 
     assert tasks[0].intent == "Do capital-of-france.", "expansion must return the pinned content"
+
+
+async def test_a_tag_pinned_member_stores_the_tagged_revision_not_the_head(entity_store) -> None:
+    """A member named ``task#blessed`` resolves through the tag at write time, like any other pin.
+
+    Resolution happens once, on write: the stored ref carries the digest the tag pointed at then, so
+    moving the tag afterwards cannot re-point published membership. Pinning to the *head* instead
+    would look right whenever the tag happens to name the newest revision and be wrong exactly when
+    it does not.
+    """
+    task = _task("capital-of-france")
+    client = await _store(entity_store, task)
+    blessed_digest = head_digest(task)
+
+    # 'blessed' stays on revision 1 while the task moves on to revision 2. Work from the head
+    # ``apply_tag`` hands back — tagging bumps the record's version, so the original object is stale.
+    stored_task = await client.get(TaskEntity, name="capital-of-france", workspace="default")
+    tagged = await apply_tag(client, client, TaskRevisionEntity, stored_task, "blessed", "latest")
+    tagged.intent = "Something else entirely."
+    await client.update(tagged)
+    await publish_revision(client, client, tagged, TaskRevisionEntity)
+
+    await _create_published(client, _taskset("geo", ["default/capital-of-france#blessed"]))
+
+    stored_taskset = await client.get(TasksetEntity, name="geo", workspace="default")
+    assert stored_taskset.tasks[0].root == f"default/capital-of-france#{blessed_digest}", (
+        "membership must pin the revision the tag named, not the head"
+    )
+
+    tasks = await resolve_taskset_ref(TasksetRef("default/geo"), workspace="default", entity_client=client)
+    assert tasks[0].intent == "Do capital-of-france."
 
 
 async def _republish_with(client, taskset: TasksetEntity, task_refs: list[str]) -> None:

--- a/plugins/nemo-evaluator/tests/test_task_refs.py
+++ b/plugins/nemo-evaluator/tests/test_task_refs.py
@@ -8,12 +8,21 @@ from __future__ import annotations
 from typing import TypeVar
 
 import pytest
-from nemo_evaluator.api.schemas import MetadataItem, MetricRef, TaskInputs, TaskRef, TasksetRef
-from nemo_evaluator.entities import TaskEntity, TaskRevisionEntity, TasksetEntity
+from nemo_evaluator.api.schemas import (
+    MetadataItem,
+    MetricRef,
+    TaskInputs,
+    TaskRef,
+    TasksetRef,
+    parse_subentity_ref,
+)
+from nemo_evaluator.entities import TaskEntity, TaskRevisionEntity, TasksetEntity, TasksetRevisionEntity
 from nemo_evaluator.jobs.agent_spec import AgentEvalTaskInput
-from nemo_evaluator.revisions import head_digest, publish_revision
+from nemo_evaluator.revisions import apply_tag, head_digest, is_digest, publish_revision
 from nemo_evaluator.task_refs import resolve_agent_eval_tasks, resolve_taskset_ref
 from nemo_platform_plugin.entities import EntityBase
+from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+from pydantic import ValidationError
 
 _EntityT = TypeVar("_EntityT", bound=EntityBase)
 
@@ -33,16 +42,57 @@ def _taskset(name: str, task_refs: list[str], *, workspace: str = "default") -> 
     return TasksetEntity(name=name, workspace=workspace, tasks=[TaskRef(r) for r in task_refs])
 
 
-async def _store(client, *entities: EntityBase):
-    """Build a store and *publish* every task, so members resolve to a real revision.
+#: Stands in for the digest of a member the test deliberately never created. A published revision
+#: must pin every member, so an unresolvable member still needs a digest-shaped fragment to get
+#: stored at all — the lookup it is meant to fail on happens later, during expansion.
+_ABSENT_MEMBER_DIGEST = "f" * 64
 
-    Tasks are published rather than merely inserted because taskset expansion now reads the pinned
-    revision's content, not the head's — the same thing the service does on create.
+
+async def _pin_members(client, taskset: TasksetEntity) -> list[TaskRef]:
+    """Resolve a fixture's member refs to digests, the way ``_resolved_content`` does on write.
+
+    Tests name members as ``workspace/task`` because that is what a caller submits; the entity that
+    reaches storage always carries ``#<digest>`` instead, and ``TasksetRevisionEntity`` rejects
+    anything less. Doing the resolution here keeps the fixtures readable without letting them
+    describe a taskset the service could not have produced. A ref the test already pinned by hand is
+    left alone — that is the case under test.
     """
+    pinned: list[TaskRef] = []
+    for ref in taskset.tasks:
+        member_workspace, member_name, fragment = parse_subentity_ref(ref.root, taskset.workspace)
+        if is_digest(fragment):
+            pinned.append(ref)
+            continue
+        try:
+            task = await client.get(TaskEntity, name=member_name, workspace=member_workspace)
+            digest = head_digest(task)
+        except NemoEntityNotFoundError:
+            digest = _ABSENT_MEMBER_DIGEST
+        pinned.append(TaskRef(f"{member_workspace}/{member_name}#{digest}"))
+    return pinned
+
+
+async def _create_published(client, entity: EntityBase) -> EntityBase:
+    """Insert an entity and publish its first revision, as the service does on create.
+
+    Expansion reads published revisions on both levels — the taskset's own and each member's — so a
+    record inserted without one is not a state the services can produce. Every helper here goes
+    through this rather than a bare ``create`` so the fixtures stay reachable from the real API.
+    """
+    if isinstance(entity, TasksetEntity):
+        entity.tasks = await _pin_members(client, entity)
+    await client.create(entity)
+    if isinstance(entity, TaskEntity):
+        await publish_revision(client, client, entity, TaskRevisionEntity)
+    elif isinstance(entity, TasksetEntity):
+        await publish_revision(client, client, entity, TasksetRevisionEntity)
+    return entity
+
+
+async def _store(client, *entities: EntityBase):
+    """Build a store in which every task and taskset carries a published revision."""
     for entity in entities:
-        await client.create(entity)
-        if isinstance(entity, TaskEntity):
-            await publish_revision(client, client, entity, TaskRevisionEntity)
+        await _create_published(client, entity)
     return client
 
 
@@ -83,7 +133,7 @@ async def test_unknown_taskset_raises_clear_error(entity_store) -> None:
 
 async def test_missing_member_task_raises_clear_error(entity_store) -> None:
     client = await _store(entity_store, _taskset("geo", ["default/gone"]))
-    with pytest.raises(ValueError, match="Task 'default/gone' referenced by taskset 'default/geo'"):
+    with pytest.raises(ValueError, match=r"Task 'default/gone#\w+' referenced by taskset 'default/geo'"):
         await resolve_taskset_ref(TasksetRef("default/geo"), workspace="default", entity_client=client)
 
 
@@ -133,8 +183,7 @@ async def test_expansion_uses_the_pinned_revision_not_current_content(entity_sto
     client = await _store(entity_store, task)
     pinned_digest = head_digest(task)
 
-    taskset = _taskset("geo", [f"default/capital-of-france#{pinned_digest}"])
-    await client.create(taskset)
+    await _create_published(client, _taskset("geo", [f"default/capital-of-france#{pinned_digest}"]))
 
     # The member publishes newer content after the taskset was pinned.
     task.intent = "Something else entirely."
@@ -146,11 +195,94 @@ async def test_expansion_uses_the_pinned_revision_not_current_content(entity_sto
     assert tasks[0].intent == "Do capital-of-france.", "expansion must return the pinned content"
 
 
+async def _republish_with(client, taskset: TasksetEntity, task_refs: list[str]) -> None:
+    """Change a stored taskset's membership and publish it, as ``replace_taskset`` does."""
+    taskset.tasks = [TaskRef(ref) for ref in task_refs]
+    taskset.tasks = await _pin_members(client, taskset)
+    await client.update(taskset)
+    await publish_revision(client, client, taskset, TasksetRevisionEntity)
+
+
+async def test_bare_taskset_ref_expands_the_current_revision(entity_store) -> None:
+    """An absent fragment means ``latest``, so a bare ref keeps tracking the taskset's tip."""
+    client = await _store(entity_store, _task("a"), _task("b"), _taskset("geo", ["default/a"]))
+    taskset = await client.get(TasksetEntity, name="geo", workspace="default")
+    await _republish_with(client, taskset, ["default/a", "default/b"])
+
+    tasks = await resolve_taskset_ref(TasksetRef("default/geo"), workspace="default", entity_client=client)
+
+    assert [t.id for t in tasks] == ["a", "b"], "a bare ref must follow the taskset forward"
+
+
+async def test_digest_pinned_taskset_ref_expands_the_pinned_membership(entity_store) -> None:
+    """The gap this closes: member *content* was already pinned, but membership was not.
+
+    Replacing a taskset changed what a re-submitted spec evaluated, because the ref could only ever
+    name the head. A digest-pinned ref holds the whole grouping still.
+    """
+    client = await _store(entity_store, _task("a"), _task("b"), _taskset("geo", ["default/a"]))
+    taskset = await client.get(TasksetEntity, name="geo", workspace="default")
+    pinned = head_digest(taskset)
+
+    await _republish_with(client, taskset, ["default/a", "default/b"])
+
+    tasks = await resolve_taskset_ref(TasksetRef(f"default/geo#{pinned}"), workspace="default", entity_client=client)
+
+    assert [t.id for t in tasks] == ["a"], "a pinned ref must ignore members added after it was taken"
+
+
+async def test_tag_pinned_taskset_ref_resolves_through_the_tag(entity_store) -> None:
+    """Tags are resolution inputs, so a tag-pinned ref resolves at expansion time, not at write."""
+    client = await _store(entity_store, _task("a"), _task("b"), _taskset("geo", ["default/a"]))
+    taskset = await client.get(TasksetEntity, name="geo", workspace="default")
+    await apply_tag(client, client, TasksetRevisionEntity, taskset, "blessed", "latest")
+
+    await _republish_with(client, taskset, ["default/a", "default/b"])
+
+    tasks = await resolve_taskset_ref(TasksetRef("default/geo#blessed"), workspace="default", entity_client=client)
+
+    assert [t.id for t in tasks] == ["a"], "'blessed' still names revision 1"
+
+
+async def test_pinned_taskset_ref_survives_a_replace(entity_store) -> None:
+    """The reproducibility property end to end: same ref, same membership, across a replace."""
+    client = await _store(entity_store, _task("a"), _task("b"), _taskset("geo", ["default/a"]))
+    taskset = await client.get(TasksetEntity, name="geo", workspace="default")
+    ref = TasksetRef(f"default/geo#{head_digest(taskset)}")
+
+    before = await resolve_taskset_ref(ref, workspace="default", entity_client=client)
+    await _republish_with(client, taskset, ["default/b"])
+    after = await resolve_taskset_ref(ref, workspace="default", entity_client=client)
+
+    assert [t.id for t in before] == [t.id for t in after] == ["a"]
+    assert [t.intent for t in before] == [t.intent for t in after]
+
+
+async def test_unresolvable_taskset_fragment_raises_a_clear_error(entity_store) -> None:
+    """A pin that cannot be honoured stops the evaluation rather than falling back to the head."""
+    client = await _store(entity_store, _task("a"), _taskset("geo", ["default/a"]))
+
+    with pytest.raises(ValueError, match="names a revision that does not resolve"):
+        await resolve_taskset_ref(TasksetRef(f"default/geo#{'c' * 64}"), workspace="default", entity_client=client)
+
+    with pytest.raises(ValueError, match="names a revision that does not resolve"):
+        await resolve_taskset_ref(TasksetRef("default/geo#nonesuch"), workspace="default", entity_client=client)
+
+
+def test_taskset_ref_accepts_a_fragment_and_rejects_a_malformed_one() -> None:
+    """The field pattern is what admits a pin at all, so assert it directly."""
+    assert TasksetRef(f"default/geo#{'a' * 64}").root.endswith("a" * 64)
+    assert TasksetRef("geo#blessed").root == "geo#blessed"
+
+    with pytest.raises(ValidationError):
+        TasksetRef("default/geo#bad fragment")
+
+
 async def test_expansion_fails_loudly_when_a_pin_no_longer_resolves(entity_store) -> None:
     """Verify-on-read at the point it matters most: a pin that cannot be honoured must stop the
     evaluation rather than quietly substituting whatever is current."""
     client = await _store(entity_store, _task("only"))
-    await client.create(_taskset("geo", [f"default/only#{'c' * 64}"]))
+    await _create_published(client, _taskset("geo", [f"default/only#{'c' * 64}"]))
 
     with pytest.raises(ValueError, match="no longer resolves"):
         await resolve_taskset_ref(TasksetRef("default/geo"), workspace="default", entity_client=client)


### PR DESCRIPTION
## What

A `TasksetRef` could only ever name a taskset's **head**, so replacing the taskset changed what a re-submitted spec evaluated. Member content was already digest-pinned within a revision, which made an evaluation *look* reproducible while its membership could still move underneath it.

This lets a reference pin the taskset revision too: `default/geography-suite#<tag-or-digest>`.

Fast-follow to #1023, raised in review there ([thread on `api/schemas.py`](https://github.com/NVIDIA-NeMo/nemo-platform/pull/1023#discussion_r3726233918)). **Stacked on #1023** — please merge that first; this targets its branch.

## The two pins compose

They cover different things:

| Reference | Member content | Which members |
|---|---|---|
| `TasksetRef("suite")` | pinned | current revision |
| `TasksetRef("suite#<digest>")` | pinned | pinned |

A bare ref already grades identical task *content* across re-runs. Pinning the taskset additionally holds *membership* still across a `replace` that adds or drops a task — what you want when a benchmark number has to stay comparable.

## How

`TasksetRef` moves onto `_SUBENTITY_REF_PATTERN`, so it carries `#<tag-or-digest>` exactly as `TaskRef` does, with an absent fragment meaning `latest`. `MetricRef` stays on the narrower pattern until metrics gain revisions — the comment above that constant already anticipated this split and is updated.

`resolve_taskset_ref` resolves the fragment and expands the members of the named revision. **Both the pinned and the bare paths go through `get_revision`** rather than reading the head's own `tasks`: a head and its `latest` revision are guaranteed to agree, and resolving one way for pinned refs and another for bare ones would let the two drift apart on the next bug. It also buys content verification for the bare case.

A fragment that no longer resolves fails the evaluation rather than falling back to the current revision.

## Reviewing this

Small: 6 files, +249/−51, and 160 of the added lines are tests.

1. `task_refs.py` — the resolution change; everything else follows from it.
2. `api/schemas.py` — the pattern move and why `MetricRef` stays behind.
3. Tests and docs are mechanical once the above is settled.

**The test fixtures needed fixing, and that is worth a look.** They were building tasksets the services cannot produce: inserted with no published revision, and with bare (unpinned) member refs. Routing resolution through `get_revision` surfaced that immediately, and `TasksetRevisionEntity` then rejected the unpinned members outright. `_create_published` / `_pin_members` now publish and digest-pin the way `_resolved_content` does, so every fixture describes a state reachable through the real API.

`test_sibling_ref_types_still_reject_fragments` was parameterized over `MetricRef` **and** `TasksetRef`; it is split, since half of its premise no longer holds.

## Testing

- 693 evaluator unit tests pass (685 before).
- The three pinning tests were verified to **fail against the old head-reading behavior** and pass with the fix, rather than assumed to be meaningful.
- Covered: bare ref follows the tip; digest-pinned ignores members added later; tag-pinned resolves through the tag; a pinned ref survives a `replace` with identical expansion; unresolvable digest and unresolvable tag both raise; field-level accept/reject of fragment shapes.
- `tools/lint/lint-all.sh`: 12/13. `lint-web-sdk` fails locally only — this box has no `web/node_modules` and runs Node 22.19 against a `>=22.23.2` engine pin. Its output is gitignored and no web code is touched here, so CI should pass it; I could not verify that locally.
- `openapi.yaml` regenerated with `make refresh-openapi` (+11/−10: the `TasksetRef` pattern and description only).

## Notes

- **No back-compat concern:** widening a validation pattern only admits input that was previously rejected. Every existing bare ref keeps its current meaning.
- The docs Note added in #1023 recording this as a known limitation is replaced by a "Pin the taskset itself" section, and the edge-case table gains the unresolvable-fragment row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Taskset references can be pinned to a specific revision, tag, or content digest.
  - Supports tracking the latest taskset membership or freezing membership to a selected revision.
  - Pinned taskset members remain stable when tasksets are replaced.
  - Taskset reference validation now supports valid revision fragments.

- **Bug Fixes**
  - Evaluation now fails with a clear error when a referenced taskset revision cannot be resolved.

- **Documentation**
  - Added guidance on taskset revision pinning, membership behavior, and related API edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->