### PR TITLE
fix(auth): Skip token refresh attempt when cluster has auth disabled

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
@@ -147,6 +147,17 @@ _TOKEN_PROVIDER_CACHE: dict[_ProviderCacheKey, OIDCTokenProvider] = {}
 # OIDC discovery
 # ---------------------------------------------------------------------------
 
+# Fallback returned when discovery fails. auth_enabled=False ensures downstream
+# code treats the cluster as non-OIDC; empty endpoint means no refresh is
+# attempted against a real token endpoint.
+_OIDC_DISCOVERY_FALLBACK = NMPOIDCConfig(
+    auth_enabled=False,
+    client_id="",
+    token_endpoint="",
+    default_scopes="openid profile email",
+    scope_prefix=None,
+)
+
 
 def _discover_oidc_client_settings(base_url: str) -> NMPOIDCConfig:
     """Fetch OIDC config from the NeMo Platform cluster's discovery endpoint.
@@ -159,13 +170,7 @@ def _discover_oidc_client_settings(base_url: str) -> NMPOIDCConfig:
         return discover_nmp_config(base_url)
     except Exception:
         logger.debug("Could not discover OIDC settings from %s", base_url, exc_info=True)
-        return NMPOIDCConfig(
-            auth_enabled=False,
-            client_id="",
-            token_endpoint="",
-            default_scopes="openid profile email",
-            scope_prefix=None,
-        )
+        return _OIDC_DISCOVERY_FALLBACK
 
 
 def _workload_identity_token_file_from_env() -> Path | None:
@@ -522,15 +527,18 @@ def _resolve_bootstrap(
         return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
 
     # --- OAuth path: set up transparent token refresh ---
-    oidc_config = _discover_oidc_client_settings(base_url)
-
-    if not oidc_config.auth_enabled and access_token is None:
-        # The context's user is an OAuthUser, but this cluster has no OIDC
-        # configured (this can happen if the context was previously authenticated
-        # against a different cluster). There's no token endpoint to refresh
-        # against, so fall back to no-auth instead of attempting a refresh_token
-        # grant against an empty endpoint, which would fail.
-        return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
+    try:
+        oidc_config = discover_nmp_config(base_url)
+        if not oidc_config.auth_enabled and access_token is None:
+            # Discovery succeeded and confirmed the cluster has no OIDC. The
+            # stored OAuthUser token can't be refreshed here (no endpoint), so
+            # fall back to no-auth. This guard only fires on a successful
+            # discovery response — not on discovery failures, where the stored
+            # token may still be valid and should be used as-is.
+            return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
+    except Exception:
+        logger.debug("Could not discover OIDC settings from %s", base_url, exc_info=True)
+        oidc_config = _OIDC_DISCOVERY_FALLBACK
 
     tokens = TokenSet.from_access_token(
         resolved.user.token.get_secret_value(),

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
@@ -530,8 +530,6 @@ def _resolve_bootstrap(
         # against a different cluster). There's no token endpoint to refresh
         # against, so fall back to no-auth instead of attempting a refresh_token
         # grant against an empty endpoint, which would fail.
-        # Note: when access_token is provided explicitly (e.g. NMP_ACCESS_TOKEN),
-        # we skip this guard and let the caller's token flow through as-is.
         return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
 
     tokens = TokenSet.from_access_token(

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
@@ -147,9 +147,7 @@ _TOKEN_PROVIDER_CACHE: dict[_ProviderCacheKey, OIDCTokenProvider] = {}
 # OIDC discovery
 # ---------------------------------------------------------------------------
 
-# Fallback returned when discovery fails. auth_enabled=False ensures downstream
-# code treats the cluster as non-OIDC; empty endpoint means no refresh is
-# attempted against a real token endpoint.
+# Fallback returned when NMP configdiscovery fails.
 _OIDC_DISCOVERY_FALLBACK = NMPOIDCConfig(
     auth_enabled=False,
     client_id="",

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py
@@ -523,6 +523,17 @@ def _resolve_bootstrap(
 
     # --- OAuth path: set up transparent token refresh ---
     oidc_config = _discover_oidc_client_settings(base_url)
+
+    if not oidc_config.auth_enabled and access_token is None:
+        # The context's user is an OAuthUser, but this cluster has no OIDC
+        # configured (this can happen if the context was previously authenticated
+        # against a different cluster). There's no token endpoint to refresh
+        # against, so fall back to no-auth instead of attempting a refresh_token
+        # grant against an empty endpoint, which would fail.
+        # Note: when access_token is provided explicitly (e.g. NMP_ACCESS_TOKEN),
+        # we skip this guard and let the caller's token flow through as-is.
+        return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
+
     tokens = TokenSet.from_access_token(
         resolved.user.token.get_secret_value(),
         resolved.user.refresh_token.get_secret_value() if resolved.user.refresh_token else None,

--- a/packages/nemo_platform_ext/tests/client/test_client.py
+++ b/packages/nemo_platform_ext/tests/client/test_client.py
@@ -181,15 +181,63 @@ class TestCreateClientOAuth:
         assert saved_user["token"] == new_token
         assert saved_user["refresh_token"] == "new_refresh"
 
-    def test_env_access_token_overrides_user_auth(self, tmp_path, monkeypatch):
+    @patch("nemo_platform_ext.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_explicit_access_token_overrides_config_auth(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="nvapi-test-key-123")
-        monkeypatch.setenv("NMP_ACCESS_TOKEN", "env-access-token-123")
 
-        client = create_client(config_path=config_path)
+        client = create_client(config_path=config_path, access_token="explicit-access-token-123")
 
         request = client._client.build_request("GET", "http://localhost:8080/test")
         client._client._event_hooks["request"][0](request)
-        assert request.headers["Authorization"] == "Bearer env-access-token-123"
+        assert request.headers["Authorization"] == "Bearer explicit-access-token-123"
+
+
+class TestCreateClientOAuthUserAuthDisabledCluster:
+    """Regression tests: OAuthUser context pointed at a cluster with no auth.
+
+    This happens when a config context was previously authenticated against a
+    real OIDC cluster and is later pointed at a local/no-auth instance. Once
+    the stored access token expires, the client must not attempt a
+    refresh_token grant against an empty token endpoint.
+    """
+
+    @patch(
+        "nemo_platform_ext.client.factory.discover_nmp_config",
+        return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
+    )
+    @patch("nemo_platform_ext.auth.token_provider.httpx.post")
+    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(
+        self, mock_post, _mock_discover, tmp_path
+    ):
+        expired_token = _make_jwt({"exp": int(time.time()) - 100, "sub": "user1"})
+        config_path = _write_config(
+            tmp_path,
+            token=expired_token,
+            refresh_token="refresh_abc",
+        )
+
+        client = create_client(config_path=config_path)
+
+        assert str(client.base_url).rstrip("/") == "http://localhost:8080"
+        mock_post.assert_not_called()
+        assert "Authorization" not in client._custom_headers
+
+    @patch(
+        "nemo_platform_ext.client.factory.discover_nmp_config",
+        return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
+    )
+    def test_valid_token_on_auth_disabled_cluster_skips_token_provider(self, _mock_discover, tmp_path):
+        token = _make_jwt({"exp": int(time.time()) + 3600, "sub": "user1"})
+        config_path = _write_config(
+            tmp_path,
+            token=token,
+            refresh_token="refresh_abc",
+        )
+
+        client = create_client(config_path=config_path)
+
+        assert "Authorization" not in client._custom_headers
+        assert client._client._event_hooks["request"] == []
 
 
 class TestCreateClientWorkloadIdentity:
@@ -277,7 +325,8 @@ class TestCreateClientWorkloadIdentity:
 
 
 class TestCreateClientApiKey:
-    def test_creates_client_with_api_key(self, tmp_path):
+    @patch("nemo_platform_ext.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_creates_client_with_api_key(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="nvapi-test-key-123")
 
         client = create_client(config_path=config_path)
@@ -287,7 +336,8 @@ class TestCreateClientApiKey:
         assert "Authorization" in client._custom_headers
         assert client._custom_headers["Authorization"] == "Bearer nvapi-test-key-123"
 
-    def test_creates_client_with_email_api_key(self, tmp_path):
+    @patch("nemo_platform_ext.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_creates_client_with_email_api_key(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="admin@example.com")
 
         client = create_client(config_path=config_path)
@@ -355,7 +405,8 @@ class TestCreateClientProviderReuse:
 
 
 class TestCreateClientOverrides:
-    def test_base_url_override_uses_explicit_url_with_context_auth(self, tmp_path):
+    @patch("nemo_platform_ext.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_base_url_override_uses_explicit_url_with_context_auth(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="nvapi-test-key-123")
 
         client = create_client(config_path=config_path, base_url="http://localhost:9090")
@@ -364,7 +415,8 @@ class TestCreateClientOverrides:
         assert client.workspace == "test-workspace"
         assert client._custom_headers["Authorization"] == "Bearer nvapi-test-key-123"
 
-    def test_context_override_uses_selected_context(self, tmp_path):
+    @patch("nemo_platform_ext.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_context_override_uses_selected_context(self, _mock_discover, tmp_path):
         config = {
             "current_context": "default",
             "clusters": [
@@ -646,7 +698,8 @@ class TestClientConstructorBootstrapBypass:
 
 class TestAsyncNeMoPlatformInit:
     @pytest.mark.asyncio
-    async def test_async_client_uses_config_for_api_key(self, tmp_path):
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    async def test_async_client_uses_config_for_api_key(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="nvapi-test-key-123")
 
         client = AsyncNeMoPlatform(config_path=config_path)
@@ -716,8 +769,9 @@ class TestPluginSDKMounting:
             await client.close()
 
     @pytest.mark.asyncio
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
     @patch("nemo_platform_ext.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
-    async def test_async_client_oauth_hook_injects_fresh_token(self, _mock_discover, tmp_path):
+    async def test_async_client_oauth_hook_injects_fresh_token(self, _mock_ext_discover, _mock_sdk_discover, tmp_path):
         token = _make_jwt({"exp": int(time.time()) + 3600, "sub": "user1"})
         config_path = _write_config(
             tmp_path,

--- a/packages/nemo_platform_ext/tests/client/test_client.py
+++ b/packages/nemo_platform_ext/tests/client/test_client.py
@@ -237,6 +237,22 @@ class TestCreateClientOAuthUserAuthDisabledCluster:
         assert "Authorization" not in client._custom_headers
         assert client._client._event_hooks["request"] == []
 
+    @patch(
+        "nemo_platform_ext.client.factory.discover_nmp_config",
+        side_effect=Exception("network error"),
+    )
+    def test_discovery_failure_preserves_stored_token(self, _mock_discover, tmp_path):
+        # A discovery failure must not strip auth — the stored token may still
+        # be valid and should be used as-is without attempting a refresh.
+        token = _make_jwt({"exp": int(time.time()) + 3600, "sub": "user1"})
+        config_path = _write_config(tmp_path, token=token, refresh_token="refresh_abc")
+
+        client = create_client(config_path=config_path)
+
+        request = client._client.build_request("GET", "http://localhost:8080/test")
+        client._client._event_hooks["request"][0](request)
+        assert request.headers["Authorization"] == f"Bearer {token}"
+
 
 class TestCreateClientWorkloadIdentity:
     @patch("nemo_platform_ext.client.factory.discover_nmp_config", return_value=_MOCK_WORKLOAD_NMP_CONFIG)

--- a/packages/nemo_platform_ext/tests/client/test_client.py
+++ b/packages/nemo_platform_ext/tests/client/test_client.py
@@ -206,9 +206,7 @@ class TestCreateClientOAuthUserAuthDisabledCluster:
         return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
     )
     @patch("nemo_platform_ext.auth.token_provider.httpx.post")
-    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(
-        self, mock_post, _mock_discover, tmp_path
-    ):
+    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(self, mock_post, _mock_discover, tmp_path):
         expired_token = _make_jwt({"exp": int(time.time()) - 100, "sub": "user1"})
         config_path = _write_config(
             tmp_path,

--- a/packages/nemo_platform_ext/tests/client/test_client.py
+++ b/packages/nemo_platform_ext/tests/client/test_client.py
@@ -202,11 +202,17 @@ class TestCreateClientOAuthUserAuthDisabledCluster:
     """
 
     @patch(
+        "nemo_platform.client.factory.discover_nmp_config",
+        return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
+    )
+    @patch(
         "nemo_platform_ext.client.factory.discover_nmp_config",
         return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
     )
     @patch("nemo_platform_ext.auth.token_provider.httpx.post")
-    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(self, mock_post, _mock_discover, tmp_path):
+    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(
+        self, mock_post, _mock_ext_discover, _mock_sdk_discover, tmp_path
+    ):
         expired_token = _make_jwt({"exp": int(time.time()) - 100, "sub": "user1"})
         config_path = _write_config(
             tmp_path,
@@ -221,10 +227,16 @@ class TestCreateClientOAuthUserAuthDisabledCluster:
         assert "Authorization" not in client._custom_headers
 
     @patch(
+        "nemo_platform.client.factory.discover_nmp_config",
+        return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
+    )
+    @patch(
         "nemo_platform_ext.client.factory.discover_nmp_config",
         return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
     )
-    def test_valid_token_on_auth_disabled_cluster_skips_token_provider(self, _mock_discover, tmp_path):
+    def test_valid_token_on_auth_disabled_cluster_skips_token_provider(
+        self, _mock_ext_discover, _mock_sdk_discover, tmp_path
+    ):
         token = _make_jwt({"exp": int(time.time()) + 3600, "sub": "user1"})
         config_path = _write_config(
             tmp_path,

--- a/sdk/python/nemo-platform/src/nemo_platform/client/factory.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/client/factory.py
@@ -530,8 +530,6 @@ def _resolve_bootstrap(
         # against a different cluster). There's no token endpoint to refresh
         # against, so fall back to no-auth instead of attempting a refresh_token
         # grant against an empty endpoint, which would fail.
-        # Note: when access_token is provided explicitly (e.g. NMP_ACCESS_TOKEN),
-        # we skip this guard and let the caller's token flow through as-is.
         return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
 
     tokens = TokenSet.from_access_token(

--- a/sdk/python/nemo-platform/src/nemo_platform/client/factory.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/client/factory.py
@@ -147,6 +147,15 @@ _TOKEN_PROVIDER_CACHE: dict[_ProviderCacheKey, OIDCTokenProvider] = {}
 # OIDC discovery
 # ---------------------------------------------------------------------------
 
+# Fallback returned when NMP config discovery fails.
+_OIDC_DISCOVERY_FALLBACK = NMPOIDCConfig(
+    auth_enabled=False,
+    client_id="",
+    token_endpoint="",
+    default_scopes="openid profile email",
+    scope_prefix=None,
+)
+
 
 def _discover_oidc_client_settings(base_url: str) -> NMPOIDCConfig:
     """Fetch OIDC config from the NeMo Platform cluster's discovery endpoint.
@@ -159,13 +168,7 @@ def _discover_oidc_client_settings(base_url: str) -> NMPOIDCConfig:
         return discover_nmp_config(base_url)
     except Exception:
         logger.debug("Could not discover OIDC settings from %s", base_url, exc_info=True)
-        return NMPOIDCConfig(
-            auth_enabled=False,
-            client_id="",
-            token_endpoint="",
-            default_scopes="openid profile email",
-            scope_prefix=None,
-        )
+        return _OIDC_DISCOVERY_FALLBACK
 
 
 def _workload_identity_token_file_from_env() -> Path | None:
@@ -522,15 +525,18 @@ def _resolve_bootstrap(
         return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
 
     # --- OAuth path: set up transparent token refresh ---
-    oidc_config = _discover_oidc_client_settings(base_url)
-
-    if not oidc_config.auth_enabled and access_token is None:
-        # The context's user is an OAuthUser, but this cluster has no OIDC
-        # configured (this can happen if the context was previously authenticated
-        # against a different cluster). There's no token endpoint to refresh
-        # against, so fall back to no-auth instead of attempting a refresh_token
-        # grant against an empty endpoint, which would fail.
-        return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
+    try:
+        oidc_config = discover_nmp_config(base_url)
+        if not oidc_config.auth_enabled and access_token is None:
+            # Discovery succeeded and confirmed the cluster has no OIDC. The
+            # stored OAuthUser token can't be refreshed here (no endpoint), so
+            # fall back to no-auth. This guard only fires on a successful
+            # discovery response — not on discovery failures, where the stored
+            # token may still be valid and should be used as-is.
+            return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
+    except Exception:
+        logger.debug("Could not discover OIDC settings from %s", base_url, exc_info=True)
+        oidc_config = _OIDC_DISCOVERY_FALLBACK
 
     tokens = TokenSet.from_access_token(
         resolved.user.token.get_secret_value(),

--- a/sdk/python/nemo-platform/src/nemo_platform/client/factory.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/client/factory.py
@@ -147,7 +147,7 @@ _TOKEN_PROVIDER_CACHE: dict[_ProviderCacheKey, OIDCTokenProvider] = {}
 # OIDC discovery
 # ---------------------------------------------------------------------------
 
-# Fallback returned when NMP config discovery fails.
+# Fallback returned when NMP configdiscovery fails.
 _OIDC_DISCOVERY_FALLBACK = NMPOIDCConfig(
     auth_enabled=False,
     client_id="",

--- a/sdk/python/nemo-platform/src/nemo_platform/client/factory.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/client/factory.py
@@ -523,6 +523,17 @@ def _resolve_bootstrap(
 
     # --- OAuth path: set up transparent token refresh ---
     oidc_config = _discover_oidc_client_settings(base_url)
+
+    if not oidc_config.auth_enabled and access_token is None:
+        # The context's user is an OAuthUser, but this cluster has no OIDC
+        # configured (this can happen if the context was previously authenticated
+        # against a different cluster). There's no token endpoint to refresh
+        # against, so fall back to no-auth instead of attempting a refresh_token
+        # grant against an empty endpoint, which would fail.
+        # Note: when access_token is provided explicitly (e.g. NMP_ACCESS_TOKEN),
+        # we skip this guard and let the caller's token flow through as-is.
+        return _ResolvedBootstrap(base_url, resolved.workspace, headers, None)
+
     tokens = TokenSet.from_access_token(
         resolved.user.token.get_secret_value(),
         resolved.user.refresh_token.get_secret_value() if resolved.user.refresh_token else None,

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/client/test_client.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/client/test_client.py
@@ -206,9 +206,7 @@ class TestCreateClientOAuthUserAuthDisabledCluster:
         return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
     )
     @patch("nemo_platform.auth.token_provider.httpx.post")
-    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(
-        self, mock_post, _mock_discover, tmp_path
-    ):
+    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(self, mock_post, _mock_discover, tmp_path):
         expired_token = _make_jwt({"exp": int(time.time()) - 100, "sub": "user1"})
         config_path = _write_config(
             tmp_path,

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/client/test_client.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/client/test_client.py
@@ -205,8 +205,14 @@ class TestCreateClientOAuthUserAuthDisabledCluster:
         "nemo_platform.client.factory.discover_nmp_config",
         return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
     )
+    @patch(
+        "nemo_platform.client.factory.discover_nmp_config",
+        return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
+    )
     @patch("nemo_platform.auth.token_provider.httpx.post")
-    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(self, mock_post, _mock_discover, tmp_path):
+    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(
+        self, mock_post, _mock_ext_discover, _mock_sdk_discover, tmp_path
+    ):
         expired_token = _make_jwt({"exp": int(time.time()) - 100, "sub": "user1"})
         config_path = _write_config(
             tmp_path,
@@ -224,7 +230,13 @@ class TestCreateClientOAuthUserAuthDisabledCluster:
         "nemo_platform.client.factory.discover_nmp_config",
         return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
     )
-    def test_valid_token_on_auth_disabled_cluster_skips_token_provider(self, _mock_discover, tmp_path):
+    @patch(
+        "nemo_platform.client.factory.discover_nmp_config",
+        return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
+    )
+    def test_valid_token_on_auth_disabled_cluster_skips_token_provider(
+        self, _mock_ext_discover, _mock_sdk_discover, tmp_path
+    ):
         token = _make_jwt({"exp": int(time.time()) + 3600, "sub": "user1"})
         config_path = _write_config(
             tmp_path,

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/client/test_client.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/client/test_client.py
@@ -237,6 +237,22 @@ class TestCreateClientOAuthUserAuthDisabledCluster:
         assert "Authorization" not in client._custom_headers
         assert client._client._event_hooks["request"] == []
 
+    @patch(
+        "nemo_platform.client.factory.discover_nmp_config",
+        side_effect=Exception("network error"),
+    )
+    def test_discovery_failure_preserves_stored_token(self, _mock_discover, tmp_path):
+        # A discovery failure must not strip auth — the stored token may still
+        # be valid and should be used as-is without attempting a refresh.
+        token = _make_jwt({"exp": int(time.time()) + 3600, "sub": "user1"})
+        config_path = _write_config(tmp_path, token=token, refresh_token="refresh_abc")
+
+        client = create_client(config_path=config_path)
+
+        request = client._client.build_request("GET", "http://localhost:8080/test")
+        client._client._event_hooks["request"][0](request)
+        assert request.headers["Authorization"] == f"Bearer {token}"
+
 
 class TestCreateClientWorkloadIdentity:
     @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_WORKLOAD_NMP_CONFIG)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/client/test_client.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/client/test_client.py
@@ -181,15 +181,63 @@ class TestCreateClientOAuth:
         assert saved_user["token"] == new_token
         assert saved_user["refresh_token"] == "new_refresh"
 
-    def test_env_access_token_overrides_user_auth(self, tmp_path, monkeypatch):
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_explicit_access_token_overrides_config_auth(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="nvapi-test-key-123")
-        monkeypatch.setenv("NMP_ACCESS_TOKEN", "env-access-token-123")
 
-        client = create_client(config_path=config_path)
+        client = create_client(config_path=config_path, access_token="explicit-access-token-123")
 
         request = client._client.build_request("GET", "http://localhost:8080/test")
         client._client._event_hooks["request"][0](request)
-        assert request.headers["Authorization"] == "Bearer env-access-token-123"
+        assert request.headers["Authorization"] == "Bearer explicit-access-token-123"
+
+
+class TestCreateClientOAuthUserAuthDisabledCluster:
+    """Regression tests: OAuthUser context pointed at a cluster with no auth.
+
+    This happens when a config context was previously authenticated against a
+    real OIDC cluster and is later pointed at a local/no-auth instance. Once
+    the stored access token expires, the client must not attempt a
+    refresh_token grant against an empty token endpoint.
+    """
+
+    @patch(
+        "nemo_platform.client.factory.discover_nmp_config",
+        return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
+    )
+    @patch("nemo_platform.auth.token_provider.httpx.post")
+    def test_expired_token_on_auth_disabled_cluster_does_not_attempt_refresh(
+        self, mock_post, _mock_discover, tmp_path
+    ):
+        expired_token = _make_jwt({"exp": int(time.time()) - 100, "sub": "user1"})
+        config_path = _write_config(
+            tmp_path,
+            token=expired_token,
+            refresh_token="refresh_abc",
+        )
+
+        client = create_client(config_path=config_path)
+
+        assert str(client.base_url).rstrip("/") == "http://localhost:8080"
+        mock_post.assert_not_called()
+        assert "Authorization" not in client._custom_headers
+
+    @patch(
+        "nemo_platform.client.factory.discover_nmp_config",
+        return_value=NMPOIDCConfig(auth_enabled=False, client_id="", token_endpoint=""),
+    )
+    def test_valid_token_on_auth_disabled_cluster_skips_token_provider(self, _mock_discover, tmp_path):
+        token = _make_jwt({"exp": int(time.time()) + 3600, "sub": "user1"})
+        config_path = _write_config(
+            tmp_path,
+            token=token,
+            refresh_token="refresh_abc",
+        )
+
+        client = create_client(config_path=config_path)
+
+        assert "Authorization" not in client._custom_headers
+        assert client._client._event_hooks["request"] == []
 
 
 class TestCreateClientWorkloadIdentity:
@@ -277,7 +325,8 @@ class TestCreateClientWorkloadIdentity:
 
 
 class TestCreateClientApiKey:
-    def test_creates_client_with_api_key(self, tmp_path):
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_creates_client_with_api_key(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="nvapi-test-key-123")
 
         client = create_client(config_path=config_path)
@@ -287,7 +336,8 @@ class TestCreateClientApiKey:
         assert "Authorization" in client._custom_headers
         assert client._custom_headers["Authorization"] == "Bearer nvapi-test-key-123"
 
-    def test_creates_client_with_email_api_key(self, tmp_path):
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_creates_client_with_email_api_key(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="admin@example.com")
 
         client = create_client(config_path=config_path)
@@ -355,7 +405,8 @@ class TestCreateClientProviderReuse:
 
 
 class TestCreateClientOverrides:
-    def test_base_url_override_uses_explicit_url_with_context_auth(self, tmp_path):
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_base_url_override_uses_explicit_url_with_context_auth(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="nvapi-test-key-123")
 
         client = create_client(config_path=config_path, base_url="http://localhost:9090")
@@ -364,7 +415,8 @@ class TestCreateClientOverrides:
         assert client.workspace == "test-workspace"
         assert client._custom_headers["Authorization"] == "Bearer nvapi-test-key-123"
 
-    def test_context_override_uses_selected_context(self, tmp_path):
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    def test_context_override_uses_selected_context(self, _mock_discover, tmp_path):
         config = {
             "current_context": "default",
             "clusters": [
@@ -646,7 +698,8 @@ class TestClientConstructorBootstrapBypass:
 
 class TestAsyncNeMoPlatformInit:
     @pytest.mark.asyncio
-    async def test_async_client_uses_config_for_api_key(self, tmp_path):
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    async def test_async_client_uses_config_for_api_key(self, _mock_discover, tmp_path):
         config_path = _write_config(tmp_path, user_type="api-key", api_key="nvapi-test-key-123")
 
         client = AsyncNeMoPlatform(config_path=config_path)
@@ -717,7 +770,8 @@ class TestPluginSDKMounting:
 
     @pytest.mark.asyncio
     @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
-    async def test_async_client_oauth_hook_injects_fresh_token(self, _mock_discover, tmp_path):
+    @patch("nemo_platform.client.factory.discover_nmp_config", return_value=_MOCK_NMP_CONFIG)
+    async def test_async_client_oauth_hook_injects_fresh_token(self, _mock_ext_discover, _mock_sdk_discover, tmp_path):
         token = _make_jwt({"exp": int(time.time()) + 3600, "sub": "user1"})
         config_path = _write_config(
             tmp_path,


### PR DESCRIPTION
## Summary

When an `nmp` config file contains an `OAuthUser` from a previous `nemo auth login` session, but the active cluster has auth disabled, client construction would crash with an opaque `UnsupportedProtocol: Request URL is missing an 'http://' or 'https://' protocol` error.

**Root cause:** `_resolve_bootstrap` was building an `OIDCTokenProvider` with an empty `token_endpoint` (what discovery returns for no-auth clusters) and immediately attempting a token refresh against it. The fix adds an early-return in `_resolve_bootstrap` to skip refreshing the token when auth is disabled.

**Before:** `nemo setup` throws an error:
```
Unexpected error: NeMoPlatform client initialization failed: Request URL is missing an 
'http://' or 'https://' protocol.
```
**After:** `nemo setup` doesn't throw an error and proceeds with the setup flow.

## Related Issue

None.

## Changes

- `packages/nemo_platform_ext/src/nemo_platform_ext/client/factory.py`: Added guard in `_resolve_bootstrap`: when the cluster's discovery endpoint returns `auth_enabled=False` and no explicit `access_token` was provided, return a no-auth bootstrap instead of constructing an `OIDCTokenProvider` with an empty endpoint.
- `packages/nemo_platform_ext/tests/client/test_client.py`: Added `TestCreateClientOAuthUserAuthDisabledCluster` with two regression tests. Fixed six existing tests that were relying on the accidental behavior of a failing discovery call being silently ignored - each now mocks `discover_nmp_config` to reflect a cluster that actually accepts auth. Renamed `test_env_access_token_overrides_user_auth` → `test_explicit_access_token_overrides_config_auth` to accurately describe what `create_client` tests (explicit param, not env var reading).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal client factory behavior, no user-facing docs surface.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth connection handling when authentication is disabled and no access token is provided.
  * Prevented unnecessary token refreshes and authorization setup in authentication-disabled environments.
  * Preserved existing behavior when an explicit access token is supplied.
  * Maintained authorization with valid stored tokens when configuration discovery fails.

* **Tests**
  * Expanded coverage for API-key, override, asynchronous, and OAuth connection scenarios, including authentication-disabled environments and discovery failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->