### PR TITLE
fix(studio): give Insights rows a working actions menu and truncate insight descriptions

### DIFF
--- a/web/packages/studio/src/routes/EvaluationDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/EvaluationDetailRoute/index.test.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@studio/constants/routes';
 import { server } from '@studio/mocks/node';
 import { EvaluationDetailRoute } from '@studio/routes/EvaluationDetailRoute';
 import { renderRoute, screen } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 
 vi.hoisted(() => {
@@ -34,49 +35,55 @@ const group = {
   evaluation_count: 0,
 } satisfies Partial<ExperimentResponse>;
 
+const mockRoutes = (insightDescription: string) =>
+  server.use(
+    http.get('*/apis/intake/v2/workspaces/:workspace/evaluations/:name', () =>
+      HttpResponse.json(evaluation)
+    ),
+    http.get('*/apis/intake/v2/workspaces/:workspace/experiments/:name', () =>
+      HttpResponse.json(group)
+    ),
+    http.get('*/apis/intake/v2/workspaces/:workspace/evaluations/:name/sessions', () =>
+      HttpResponse.json({
+        data: [],
+        pagination: {
+          page: 1,
+          page_size: 25,
+          current_page_size: 0,
+          total_pages: 0,
+          total_results: 0,
+        },
+      })
+    ),
+    http.get('*/apis/insights/v2/workspaces/:workspace/insights/:insightId', () =>
+      HttpResponse.json({
+        id: 'insight-id',
+        name: 'insight',
+        title: 'Insight',
+        description: insightDescription,
+        agent: 'agent',
+        status: 'open',
+        trace_refs: [],
+      })
+    )
+  );
+
+const renderEvaluation = () =>
+  renderRoute(<EvaluationDetailRoute />, {
+    history: `/workspaces/${WORKSPACE}/experiment/${GROUP_NAME}/${EVALUATION_NAME}`,
+    routes: [
+      {
+        path: ROUTES.workspace.evaluationDetail,
+        element: <EvaluationDetailRoute />,
+      },
+    ],
+  });
+
 describe('EvaluationDetailRoute with Optimizer enabled', () => {
   it('renders the originating insight description instead of relabeling the evaluation description', async () => {
-    server.use(
-      http.get('*/apis/intake/v2/workspaces/:workspace/evaluations/:name', () =>
-        HttpResponse.json(evaluation)
-      ),
-      http.get('*/apis/intake/v2/workspaces/:workspace/experiments/:name', () =>
-        HttpResponse.json(group)
-      ),
-      http.get('*/apis/intake/v2/workspaces/:workspace/evaluations/:name/sessions', () =>
-        HttpResponse.json({
-          data: [],
-          pagination: {
-            page: 1,
-            page_size: 25,
-            current_page_size: 0,
-            total_pages: 0,
-            total_results: 0,
-          },
-        })
-      ),
-      http.get('*/apis/insights/v2/workspaces/:workspace/insights/:insightId', () =>
-        HttpResponse.json({
-          id: 'insight-id',
-          name: 'insight',
-          title: 'Insight',
-          description: 'Actual insight description',
-          agent: 'agent',
-          status: 'open',
-          trace_refs: [],
-        })
-      )
-    );
+    mockRoutes('Actual insight description');
 
-    renderRoute(<EvaluationDetailRoute />, {
-      history: `/workspaces/${WORKSPACE}/experiment/${GROUP_NAME}/${EVALUATION_NAME}`,
-      routes: [
-        {
-          path: ROUTES.workspace.evaluationDetail,
-          element: <EvaluationDetailRoute />,
-        },
-      ],
-    });
+    renderEvaluation();
 
     expect(await screen.findByText('Actual insight description')).toBeInTheDocument();
     expect(screen.getByText('Insight description')).toBeInTheDocument();
@@ -85,5 +92,20 @@ describe('EvaluationDetailRoute with Optimizer enabled', () => {
       'href',
       `/workspaces/${WORKSPACE}/optimizer/insight-id`
     );
+  });
+
+  it('truncates a long insight description until it is expanded', async () => {
+    const description = `${'Observed behavior. '.repeat(40)}End of description.`;
+    mockRoutes(description);
+
+    renderEvaluation();
+
+    const showMore = await screen.findByText('Show more');
+    expect(screen.queryByText(description)).not.toBeInTheDocument();
+
+    await userEvent.click(showMore);
+
+    expect(screen.getByText(description)).toBeInTheDocument();
+    expect(screen.getByText('Show less')).toBeInTheDocument();
   });
 });

--- a/web/packages/studio/src/routes/EvaluationDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/EvaluationDetailRoute/index.tsx
@@ -6,6 +6,7 @@ import { Badge, Card, Flex, PageHeader, Stack, Text } from '@nvidia/foundations-
 import { useOptimizerGetInsight } from '@studio/api/optimizer';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { EvaluationSessionsDataView } from '@studio/components/dataViews/EvaluationSessionsDataView';
+import { ExpandableMessage } from '@studio/components/ExpandableMessage';
 import { OriginatingInsightLink } from '@studio/components/OriginatingInsightLink';
 import { OPTIMIZER_ENABLED } from '@studio/constants/environment';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
@@ -58,7 +59,10 @@ export const EvaluationDetailRoute: FC = () => {
                 <Text kind="label/bold/lg">Insight description</Text>
                 <OriginatingInsightLink insightId={insightId} />
               </Flex>
-              <Text kind="body/regular/md">{insight?.description}</Text>
+              <ExpandableMessage
+                message={insight?.description}
+                attributes={{ Text: { kind: 'body/regular/md' } }}
+              />
             </Stack>
           </Card>
         ) : null}

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -7,6 +7,7 @@ import { Button, Card, Flex, PageHeader, Stack, Text } from '@nvidia/foundations
 import { useOptimizerGetInsight } from '@studio/api/optimizer';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { ExperimentDataView } from '@studio/components/dataViews/ExperimentDataView';
+import { ExpandableMessage } from '@studio/components/ExpandableMessage';
 import { ExperimentEditModal } from '@studio/components/ExperimentEditModal';
 import { OriginatingInsightLink } from '@studio/components/OriginatingInsightLink';
 import { OPTIMIZER_ENABLED } from '@studio/constants/environment';
@@ -80,7 +81,10 @@ export const ExperimentDetailRoute: FC = () => {
                         <Text kind="label/bold/lg">Insight description</Text>
                         <OriginatingInsightLink insightId={insight.id} />
                       </Flex>
-                      <Text kind="body/regular/md">{insight.description}</Text>
+                      <ExpandableMessage
+                        message={insight.description}
+                        attributes={{ Text: { kind: 'body/regular/md' } }}
+                      />
                     </Stack>
                   </Card>
                 ) : null}

--- a/web/packages/studio/src/routes/optimizer/OptimizerInsightRoute/index.tsx
+++ b/web/packages/studio/src/routes/optimizer/OptimizerInsightRoute/index.tsx
@@ -4,7 +4,6 @@
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { KVPair } from '@nemo/common/src/components/KVPair';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
-import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import {
   Anchor,
   Button,
@@ -16,13 +15,7 @@ import {
   Tag,
   Text,
 } from '@nvidia/foundations-react-core';
-import {
-  getOptimizerGetInsightQueryKey,
-  getOptimizerListInsightsQueryKey,
-  useOptimizerGetInsight,
-  useOptimizerUpdateInsight,
-  type InsightStatus,
-} from '@studio/api/optimizer';
+import { useOptimizerGetInsight } from '@studio/api/optimizer';
 import { AccessibleTitle } from '@studio/components/AccessibleTitle';
 import { ExpandableMessage } from '@studio/components/ExpandableMessage';
 import { FeatureFlagBadge } from '@studio/components/FeatureFlagBadge';
@@ -30,20 +23,18 @@ import { Loading } from '@studio/components/Layouts/Loading';
 import { LINK_DOCS_STUDIO_EVALUATION } from '@studio/constants/links';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import { InsightOpenModal } from '@studio/routes/optimizer/InsightOpenModal';
 import { insightActions, insightStatusColor } from '@studio/routes/optimizer/insightStatus';
 import { InsightTracesTable } from '@studio/routes/optimizer/InsightTracesTable';
 import { InsightExperiments } from '@studio/routes/optimizer/OptimizerInsightRoute/InsightExperiments';
+import { useInsightStatusActions } from '@studio/routes/optimizer/useInsightStatusActions';
 import { getOptimizerRoute } from '@studio/routes/utils';
-import { useQueryClient } from '@tanstack/react-query';
-import { type FC, useState } from 'react';
+import { type FC } from 'react';
 import { Link, useParams } from 'react-router';
 
 export const OptimizerInsightRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
   const { insightId = '' } = useParams<{ insightId: string }>();
-  const queryClient = useQueryClient();
-  const toast = useToast();
+  const statusActions = useInsightStatusActions(workspace);
 
   const {
     data: insight,
@@ -51,31 +42,6 @@ export const OptimizerInsightRoute: FC = () => {
     isError,
     refetch,
   } = useOptimizerGetInsight(workspace, insightId);
-
-  const { mutate: updateInsight, isPending: isUpdating } = useOptimizerUpdateInsight({
-    mutation: {
-      onSuccess: () => {
-        queryClient.invalidateQueries({
-          queryKey: getOptimizerGetInsightQueryKey(workspace, insightId),
-        });
-        queryClient.invalidateQueries({
-          queryKey: getOptimizerListInsightsQueryKey(workspace),
-        });
-      },
-      onError: () => toast.error('Failed to update insight.'),
-    },
-  });
-
-  const [openModalOpen, setOpenModalOpen] = useState(false);
-
-  // The external agent changes the status after it creates the experiment.
-  const handleAction = (target: InsightStatus) => {
-    if (target === 'open') {
-      setOpenModalOpen(true);
-      return;
-    }
-    updateInsight({ workspace, insightId, data: { status: target } });
-  };
 
   useBreadcrumbs({
     items: [
@@ -139,8 +105,8 @@ export const OptimizerInsightRoute: FC = () => {
                   key={action.target}
                   kind={action.kind}
                   color={action.color}
-                  disabled={isUpdating}
-                  onClick={() => handleAction(action.target)}
+                  disabled={statusActions.isPending}
+                  onClick={() => statusActions.run(insight, action.target)}
                 >
                   {action.label}
                 </Button>
@@ -194,8 +160,8 @@ export const OptimizerInsightRoute: FC = () => {
             <InsightExperiments
               workspace={workspace}
               insightId={insightId}
-              onRunExperiment={() => handleAction('open')}
-              runExperimentDisabled={isUpdating}
+              onRunExperiment={() => statusActions.run(insight, 'open')}
+              runExperimentDisabled={statusActions.isPending}
             />
           </Card>
         </div>
@@ -205,13 +171,7 @@ export const OptimizerInsightRoute: FC = () => {
           <InsightTracesTable workspace={workspace} traceIds={traceRefs} />
         </Stack>
       </Stack>
-
-      <InsightOpenModal
-        open={openModalOpen}
-        insight={insight}
-        workspace={workspace}
-        onClose={() => setOpenModalOpen(false)}
-      />
+      {statusActions.slotModal}
     </AccessibleTitle>
   );
 };

--- a/web/packages/studio/src/routes/optimizer/OptimizerRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/optimizer/OptimizerRoute/index.test.tsx
@@ -8,7 +8,8 @@ import { ROUTES } from '@studio/constants/routes';
 import { server } from '@studio/mocks/node';
 import { OptimizerRoute } from '@studio/routes/optimizer/OptimizerRoute';
 import { getOptimizerRoute } from '@studio/routes/utils';
-import { renderRoute, screen, within } from '@studio/tests/util/render';
+import { renderRoute, screen, waitFor, within } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 
 const INSIGHTS_URL = `${PLATFORM_BASE_URL}/apis/insights/v2/workspaces/:workspace/insights`;
@@ -76,11 +77,49 @@ describe('OptimizerRoute', () => {
     expect(await findCell('Positive count', 'Experiments')).toHaveTextContent('7');
     expect(await findCell('Zero count', 'Experiments')).toHaveTextContent('0');
     expect(await findCell('Null count', 'Experiments')).toHaveTextContent('—');
+    // eslint-disable-next-line testing-library/no-node-access -- <time> has no accessible role
     expect((await findCell('Positive count', 'Last Seen')).querySelector('time')).toHaveAttribute(
       'datetime',
       '2026-07-21T12:00:00Z'
     );
     expect(await findCell('Zero count', 'Last Seen')).toHaveTextContent('—');
     expect(experimentRequest).not.toHaveBeenCalled();
+  });
+
+  it('runs the status actions for a row from its row actions menu', async () => {
+    const user = userEvent.setup();
+    const patches: Array<{ insightId: string; body: unknown }> = [];
+    server.use(
+      http.get(INSIGHTS_URL, () =>
+        HttpResponse.json(
+          insightsPage([
+            makeInsight('open-insight', 'Open insight'),
+            { ...makeInsight('resolved-insight', 'Resolved insight'), status: 'resolved' },
+          ])
+        )
+      ),
+      http.patch(`${INSIGHTS_URL}/:insightId`, async ({ params, request }) => {
+        patches.push({ insightId: String(params.insightId), body: await request.json() });
+        return HttpResponse.json({});
+      })
+    );
+
+    renderList();
+
+    const openRow = await screen.findByRole('row', { name: /Open insight/ });
+    await user.click(within(openRow).getByRole('button', { name: 'Row Actions' }));
+    expect(await screen.findByText('Delete')).toBeInTheDocument();
+    await user.click(screen.getByText('Resolve'));
+
+    await waitFor(() =>
+      expect(patches).toEqual([{ insightId: 'open-insight', body: { status: 'resolved' } }])
+    );
+
+    // A resolved insight can only be re-opened by running an experiment, which the CLI does.
+    const resolvedRow = screen.getByRole('row', { name: /Resolved insight/ });
+    await user.click(within(resolvedRow).getByRole('button', { name: 'Row Actions' }));
+    await user.click(await screen.findByText('Run experiment'));
+
+    expect(await screen.findByText(/Run the following CLI command/)).toBeInTheDocument();
   });
 });

--- a/web/packages/studio/src/routes/optimizer/OptimizerRoute/index.tsx
+++ b/web/packages/studio/src/routes/optimizer/OptimizerRoute/index.tsx
@@ -16,7 +16,8 @@ import { ErrorPanel } from '@studio/components/ErrorPanel';
 import { FeatureFlagBadge } from '@studio/components/FeatureFlagBadge';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
-import { insightStatusColor } from '@studio/routes/optimizer/insightStatus';
+import { insightActions, insightStatusColor } from '@studio/routes/optimizer/insightStatus';
+import { useInsightStatusActions } from '@studio/routes/optimizer/useInsightStatusActions';
 import { getOptimizerInsightRoute, getOptimizerRoute } from '@studio/routes/utils';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Lightbulb } from 'lucide-react';
@@ -31,6 +32,7 @@ export const OptimizerRoute: FC = () => {
   });
 
   const navigate = useNavigate();
+  const statusActions = useInsightStatusActions(workspace);
 
   const dataViewState = useStudioDataViewState({
     defaultSort: [{ id: 'created_at', desc: true }],
@@ -126,7 +128,13 @@ export const OptimizerRoute: FC = () => {
     rowActionsColumn({
       size: ROW_ACTIONS_COLUMN_SIZE,
       enableResizing: false,
-      rowActions: () => [],
+      rowActions: (insight) =>
+        insightActions(insight.status).map((action) => ({
+          children: action.label,
+          danger: action.target === 'deleted',
+          disabled: statusActions.isPending,
+          onSelect: () => statusActions.run(insight, action.target),
+        })),
     }),
   ];
 
@@ -170,6 +178,7 @@ export const OptimizerRoute: FC = () => {
           }}
         />
       </Stack>
+      {statusActions.slotModal}
     </AccessibleTitle>
   );
 };

--- a/web/packages/studio/src/routes/optimizer/useInsightStatusActions.tsx
+++ b/web/packages/studio/src/routes/optimizer/useInsightStatusActions.tsx
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import {
+  getOptimizerGetInsightQueryKey,
+  getOptimizerListInsightsQueryKey,
+  useOptimizerUpdateInsight,
+  type Insight,
+  type InsightStatus,
+} from '@studio/api/optimizer';
+import { InsightOpenModal } from '@studio/routes/optimizer/InsightOpenModal';
+import { useQueryClient } from '@tanstack/react-query';
+import { type ReactNode, useState } from 'react';
+
+export interface InsightStatusActions {
+  /** Runs an action returned by `insightActions`. */
+  run: (insight: Insight, target: InsightStatus) => void;
+  /** True while a status change is in flight. */
+  isPending: boolean;
+  /** The run-experiment modal. Render it once per page. */
+  slotModal: ReactNode;
+}
+
+/**
+ * Status-change behaviour shared by the insight list rows and the insight page header,
+ * so both offer the same actions and refresh the same queries.
+ */
+export const useInsightStatusActions = (workspace: string): InsightStatusActions => {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [runExperimentFor, setRunExperimentFor] = useState<Insight | null>(null);
+
+  const { mutate, isPending } = useOptimizerUpdateInsight({
+    mutation: {
+      onSuccess: (_insight, { insightId }) => {
+        queryClient.invalidateQueries({
+          queryKey: getOptimizerGetInsightQueryKey(workspace, insightId),
+        });
+        queryClient.invalidateQueries({
+          queryKey: getOptimizerListInsightsQueryKey(workspace),
+        });
+      },
+      onError: () => toast.error('Failed to update insight.'),
+    },
+  });
+
+  return {
+    // The external agent changes the status after it creates the experiment.
+    run: (insight, target) => {
+      if (target === 'open') {
+        setRunExperimentFor(insight);
+        return;
+      }
+      mutate({ workspace, insightId: insight.id, data: { status: target } });
+    },
+    isPending,
+    slotModal: runExperimentFor ? (
+      <InsightOpenModal
+        open
+        insight={runExperimentFor}
+        workspace={workspace}
+        onClose={() => setRunExperimentFor(null)}
+      />
+    ) : null,
+  };
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the NV bug filed against the Studio Insights page, plus the follow-up request to truncate long insight descriptions.

## Empty row-actions menu on the Insights list

`OptimizerRoute` declared `rowActions: () => []`. `RowActionsCell` renders the dropdown whenever the callback returns a truthy value, and `[]` is truthy, so every row got a 3-dot button whose menu had no items — clicking it looked like nothing happened.

Rows now offer the same status actions the insight page already offers, taken from `insightActions(status)`: `Delete` / `Resolve` for an open insight, `Run experiment` for one that is resolved or deleted. Because that helper always returns at least one action, no status renders an empty menu.

The mutation, error toast, query invalidation, and run-experiment modal previously lived inline in `OptimizerInsightRoute`. They moved into `useInsightStatusActions`, which both the list and the insight page now use, so the two surfaces cannot drift on which actions exist or which queries get refreshed. The insight page behaves exactly as before.

[Before: the row-actions menu opens empty](https://cursor.com/agents/bc-af703d0e-2f73-42ea-84df-76aba5103015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_empty_row_actions_menu.png)

[After: the menu lists Delete and Resolve](https://cursor.com/agents/bc-af703d0e-2f73-42ea-84df-76aba5103015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_row_actions_menu.png)

## Insight descriptions no longer flood the detail pages

Analyst insight descriptions run to a few thousand characters and pushed the rest of the Experiment and Evaluation detail pages off screen. Both now render the description through `ExpandableMessage`, the component `OptimizerInsightRoute` already uses for the same field, so it clamps at 300 characters behind a `Show more` / `Show less` toggle.

[Experiment detail page with the insight description truncated](https://cursor.com/agents/bc-af703d0e-2f73-42ea-84df-76aba5103015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexperiment_detail_description_truncated.png)

[Evaluation detail page with the insight description expanded](https://cursor.com/agents/bc-af703d0e-2f73-42ea-84df-76aba5103015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fevaluation_detail_description_expanded.png)

## Verification

Full end-to-end run against a local platform: opening both row menus, resolving an insight (real `PATCH`, row tag flips to `resolved`), the run-experiment modal, and the truncation toggle on both detail pages.

[insights_row_actions_and_truncation_demo.mp4](https://cursor.com/agents/bc-af703d0e-2f73-42ea-84df-76aba5103015/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finsights_row_actions_and_truncation_demo.mp4)

- `pnpm --filter nemo-studio-ui test` — 2853 tests pass.
- New test in `OptimizerRoute/index.test.tsx` opens the row menu, clicks `Resolve`, asserts the `PATCH` body, then checks the resolved row offers `Run experiment`. It fails against the old `rowActions: () => []`.
- New test in `EvaluationDetailRoute/index.test.tsx` asserts a long description is truncated until `Show more` is clicked. The mock setup in that file is now shared between its two tests.
- `tsc --noEmit`, `eslint`, and `prettier --check` are clean.

One pre-existing line needed an `eslint-disable` comment: importing `@testing-library/user-event` into `OptimizerRoute/index.test.tsx` switches on the testing-library plugin's rules for that file, which then flagged an existing `querySelector('time')` assertion (`<time>` has no accessible role).

The Insights list endpoint enriches rows from ClickHouse, which cannot run in this sandbox (container image layer downloads are blocked), so during manual testing that one `GET` was served by a local proxy that assembles the page from the real per-insight API. Everything else in the recording — the Studio bundle, the status `PATCH`, the refetch, and both detail pages — went to the real platform.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af703d0e-2f73-42ea-84df-76aba5103015?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af703d0e-2f73-42ea-84df-76aba5103015&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

