### PR TITLE
chore: update NOTICE with cyrus-sasl2 BSD4 license

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ Dockerfile.bake
 .dockerignore
 **/__pycache__
 **/node_modules
+web/packages/sdk/generated/
 sdk/python/nemo-platform/_dev/nmp
 # nemo-agents optimize-skills artifacts. These ephemeral run outputs can
 # contain root-owned files (the harbor agent runs as root inside the

--- a/NOTICE
+++ b/NOTICE
@@ -4,12 +4,12 @@ Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 Licensed under the Apache License, Version 2.0.
 
 ================================================================================
-Third-Party / Vendored Code
+Third-Party / Vendored and Distributed Components
 ================================================================================
 
-This repository includes vendored third-party components listed below.
-Each component retains its original license, which can be found in the
-respective directory.
+This repository includes vendored and distributed third-party components listed
+below. Each component retains its original license, which can be found in the
+respective directory or package metadata.
 
 --------------------------------------------------------------------------------
 packages/garak_api/
@@ -66,6 +66,17 @@ services/auditor/third-party/
   This directory contains a pyproject.toml and lockfile used to collect
   Garak and its transitive dependencies for license auditing. No vendored
   source code is present; Garak is installed at build time from PyPI.
+
+--------------------------------------------------------------------------------
+cyrus-sasl2 / Cyrus SASL
+  License: BSD-4-Clause
+  Copyright (c) 1998-2003 Carnegie Mellon University. All rights reserved.
+  Home: https://www.cyrusimap.org/sasl/
+
+  Redistributions of any form whatsoever must retain the following
+  acknowledgment:
+  "This product includes software developed by Computing Services
+   at Carnegie Mellon University (http://www.cmu.edu/computing/)."
 
 --------------------------------------------------------------------------------
 web/packages/studio/src/generated/styles.css


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Add the cyrus-sasl2 (Cyrus SASL) BSD-4-Clause license attribution to the NOTICE file and update the third-party section header to cover distributed (not just vendored) components.

## Changes

- Add cyrus-sasl2 / Cyrus SASL entry with BSD-4-Clause license, copyright notice, and required acknowledgment text
- Update section header from "Third-Party / Vendored Code" to "Third-Party / Vendored and Distributed Components" to accurately describe the scope
- Adjust introductory text to reference "package metadata" in addition to directories

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: NOTICE file is a legal attribution document with no runtime behavior
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: NOTICE file change only; no user-facing docs needed

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Change is limited to the `NOTICE` file — no code, config, or dependency changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified wording for third-party components and where their licenses may be located.
  * Added the required Cyrus SASL license notice, copyright information, homepage, and acknowledgment text.

* **Chores**
  * Excluded generated SDK files from Docker build contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->