### PR TITLE
fix(deployments): deliver config_files on the openshell backend (AIRCORE-999)

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
@@ -89,6 +89,23 @@ _SERVE_PIDFILE = "/tmp/nemo-serve.pid"
 # otherwise cannot prove the write happened is a failed, not a silent, delivery.
 _CONFIG_DELIVERED_MARKER = "__nmp_config_delivered__"
 
+
+def _delivery_script(path: str, mode: int) -> str:
+    """Shell one-liner that writes a config file from stdin and self-attests the write.
+
+    ``set -e`` aborts before ``cat`` if the parent directory cannot be made; the content
+    arrives on stdin so it stays opaque bytes to the shell (no escaping, no argv/env size
+    limit, no metacharacter interpretation). The trailing ``printf`` runs only if every
+    step succeeded, so its marker on stdout is positive proof the file was written.
+    """
+    directory = posixpath.dirname(path) or "/"
+    return (
+        f"set -e; mkdir -p {shlex.quote(directory)}; "
+        f"cat > {shlex.quote(path)}; chmod {mode:o} {shlex.quote(path)}; "
+        f"printf %s {_CONFIG_DELIVERED_MARKER}"
+    )
+
+
 # OpenShell rejects a longer sandbox or service name with INVALID_ARGUMENT: three
 # segments plus two "--" delimiters must fit a 63-char DNS label.
 _MAX_ROUTABLE_NAME_LEN = 19
@@ -675,32 +692,21 @@ class OpenShellDeploymentBackend(DeploymentBackend):
         """Write each declared config file into the sandbox before serve launch.
 
         Returns None on success, or a terminal FAILED update naming the file when a write
-        does not succeed. A missing config file is a deterministic config error, so it is
-        reported loudly rather than silently dropped (the historical defect) and the
-        provisioning caller tears the sandbox down.
+        does not succeed. A file that cannot be written fails loudly and the provisioning
+        caller tears the sandbox down; it never reaches READY with the file absent.
 
-        Delivery runs through ``ExecSandbox`` as the sandbox user (the RPC has no user
-        field; the policy pins ``run_as_user`` to the non-root sandbox user). It can
-        therefore only write paths that user owns -- ``/home/sandbox``, ``/sandbox``,
-        ``/tmp`` -- and NOT ``/workspace``, which the packaged agent image chowns to its
-        own ``agent`` user even though the sandbox policy lists it read-write. A target
-        the sandbox user cannot write fails here with the path and the shell's own error,
-        instead of reaching READY with the file absent. When OpenShell grows a native
-        file-transfer RPC, swap the ``cat`` for it; callers only ever emit a first-class
-        ``ConfigFile(path, content)`` and never learn how the bytes arrived.
+        Delivery runs through ``ExecSandbox`` as the sandbox user (the RPC pins
+        ``run_as_user`` to the non-root sandbox user), so it can only write paths that
+        user owns -- ``/home/sandbox``, ``/sandbox``, ``/tmp`` -- and not ``/workspace``,
+        which the packaged agent image chowns to its own ``agent`` user even though the
+        sandbox policy lists it read-write. A path that user cannot write to fails here
+        with the shell's own error. When OpenShell grows a native file-transfer RPC, swap
+        the ``cat`` for it; callers only ever emit a first-class ``ConfigFile(path,
+        content)`` and never learn how the bytes arrived.
         """
         for config_file in config_files:
             path = config_file.path
-            directory = posixpath.dirname(path) or "/"
-            # set -e aborts before cat if the directory cannot be made; content arrives on
-            # stdin so it is opaque bytes to the shell (no escaping, no argv/env limit). The
-            # trailing printf runs only if every step succeeded, so its marker on stdout is
-            # positive proof the file was written -- see the marker check below.
-            script = (
-                f"set -e; mkdir -p {shlex.quote(directory)}; "
-                f"cat > {shlex.quote(path)}; chmod {config_file.mode:o} {shlex.quote(path)}; "
-                f"printf %s {_CONFIG_DELIVERED_MARKER}"
-            )
+            script = _delivery_script(path, config_file.mode)
             try:
                 exit_code, output = await self._exec_detached(
                     sandbox_id, ["/bin/sh", "-c", script], stdin=config_file.content.encode("utf-8")
@@ -717,10 +723,9 @@ class OpenShellDeploymentBackend(DeploymentBackend):
                 if detail:
                     message = f"{message}: {detail}"
                 return BackendStatusUpdate(status="FAILED", status_message=message)
-            # Self-attesting delivery: require the completion marker rather than trusting a
-            # zero/None exit. This closes the residual silent-drop hole where a stream ends
-            # without an exit event (exit_code None) yet the write never happened -- an
-            # unconfirmed delivery fails loudly instead of advancing to READY file-less.
+            # Require the completion marker rather than trusting a zero/None exit: a stream
+            # can end without an exit event (exit_code None) while the write never happened.
+            # An unconfirmed delivery fails loudly instead of advancing to READY file-less.
             if _CONFIG_DELIVERED_MARKER not in output:
                 return BackendStatusUpdate(
                     status="FAILED",

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import posixpath
 import shlex
 from typing import TYPE_CHECKING, Any, Literal, cast
 
@@ -55,7 +56,7 @@ from nemo_deployments_plugin.backends.openshell.policy import (
     normalize_loaded_policy,
 )
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
-from nemo_deployments_plugin.entities import Container, DeploymentConfig
+from nemo_deployments_plugin.entities import ConfigFile, Container, DeploymentConfig
 from nemo_deployments_plugin.secrets import SecretResolutionError, resolve_deployment_config_secrets
 from nemo_deployments_plugin.types import DeploymentStatus, Endpoint
 from nemo_platform_plugin.client.adapter import client_from_platform
@@ -81,6 +82,12 @@ _SERVE_LOG = "/tmp/nemo-serve.log"
 # deciding whether a missing pidfile is a slow start or a launcher that never ran.
 _LAUNCH_MARKER = "/tmp/nemo-serve.launched"
 _SERVE_PIDFILE = "/tmp/nemo-serve.pid"
+
+# Token the config-delivery script prints on stdout only after mkdir+cat+chmod all
+# succeed (guarded by set -e). Requiring it in the drained output makes delivery
+# self-attesting: a stream that ends without an exit event (exit_code is None) or
+# otherwise cannot prove the write happened is a failed, not a silent, delivery.
+_CONFIG_DELIVERED_MARKER = "__nmp_config_delivered__"
 
 # OpenShell rejects a longer sandbox or service name with INVALID_ARGUMENT: three
 # segments plus two "--" delimiters must fit a 63-char DNS label.
@@ -497,8 +504,14 @@ class OpenShellDeploymentBackend(DeploymentBackend):
         container = config.containers[0]
 
         # Launch the serve command once; the launcher writes a marker so a later poll
-        # does not relaunch it (read_status keeps no state across calls).
+        # does not relaunch it (read_status keeps no state across calls). Config files are
+        # delivered inside this once-only guard, immediately before launch, so the serve
+        # process finds them on disk and they are written exactly once per deployment.
         if not await self._serve_launched(sandbox_id):
+            failure = await self._deliver_config_files(sandbox_id, config.config_files)
+            if failure is not None:
+                await self._delete_sandbox_best_effort(sandbox_nm)
+                return failure
             failure = await self._launch_serve(sandbox_id, list(container.command) + list(container.args))
             if failure is not None:
                 await self._delete_sandbox_best_effort(sandbox_nm)
@@ -627,10 +640,20 @@ class OpenShellDeploymentBackend(DeploymentBackend):
             raise
         return response.sandbox
 
-    async def _exec_detached(self, sandbox_id: str, command: list[str]) -> tuple[int | None, str]:
-        """Run a command, draining its event stream. Returns (exit_code, combined output)."""
+    async def _exec_detached(
+        self, sandbox_id: str, command: list[str], *, stdin: bytes | None = None
+    ) -> tuple[int | None, str]:
+        """Run a command, draining its event stream. Returns (exit_code, combined output).
+
+        When *stdin* is given it is streamed to the command as its standard input. The
+        ExecSandboxRequest carries a first-class ``stdin`` bytes field, so config-file
+        content is piped verbatim into ``cat``: the bytes never touch the argv nor the
+        (single-line-only, size-capped) sandbox environment.
+        """
         timeout = self._executor_config.request_timeout_seconds
         request = pb.ExecSandboxRequest(sandbox_id=sandbox_id, command=command, timeout_seconds=timeout)
+        if stdin is not None:
+            request.stdin = stdin
 
         def _drain() -> tuple[int | None, str]:
             exit_code: int | None = None
@@ -645,6 +668,65 @@ class OpenShellDeploymentBackend(DeploymentBackend):
             return exit_code, "".join(chunks)
 
         return await asyncio.to_thread(_drain)
+
+    async def _deliver_config_files(
+        self, sandbox_id: str, config_files: list[ConfigFile]
+    ) -> BackendStatusUpdate | None:
+        """Write each declared config file into the sandbox before serve launch.
+
+        Returns None on success, or a terminal FAILED update naming the file when a write
+        does not succeed. A missing config file is a deterministic config error, so it is
+        reported loudly rather than silently dropped (the historical defect) and the
+        provisioning caller tears the sandbox down.
+
+        Delivery runs through ``ExecSandbox`` as the sandbox user (the RPC has no user
+        field; the policy pins ``run_as_user`` to the non-root sandbox user). It can
+        therefore only write paths that user owns -- ``/home/sandbox``, ``/sandbox``,
+        ``/tmp`` -- and NOT ``/workspace``, which the packaged agent image chowns to its
+        own ``agent`` user even though the sandbox policy lists it read-write. A target
+        the sandbox user cannot write fails here with the path and the shell's own error,
+        instead of reaching READY with the file absent. When OpenShell grows a native
+        file-transfer RPC, swap the ``cat`` for it; callers only ever emit a first-class
+        ``ConfigFile(path, content)`` and never learn how the bytes arrived.
+        """
+        for config_file in config_files:
+            path = config_file.path
+            directory = posixpath.dirname(path) or "/"
+            # set -e aborts before cat if the directory cannot be made; content arrives on
+            # stdin so it is opaque bytes to the shell (no escaping, no argv/env limit). The
+            # trailing printf runs only if every step succeeded, so its marker on stdout is
+            # positive proof the file was written -- see the marker check below.
+            script = (
+                f"set -e; mkdir -p {shlex.quote(directory)}; "
+                f"cat > {shlex.quote(path)}; chmod {config_file.mode:o} {shlex.quote(path)}; "
+                f"printf %s {_CONFIG_DELIVERED_MARKER}"
+            )
+            try:
+                exit_code, output = await self._exec_detached(
+                    sandbox_id, ["/bin/sh", "-c", script], stdin=config_file.content.encode("utf-8")
+                )
+            except grpc.RpcError as exc:
+                return BackendStatusUpdate(
+                    status="FAILED", status_message=f"Failed to write config file {path}: {_rpc_detail(exc)}"
+                )
+            # A definitively non-zero exit is a failure (e.g. a /workspace write denied by the
+            # sandbox user's permissions); surface the shell's own error with the path.
+            if exit_code not in (None, 0):
+                detail = output.strip()
+                message = f"Failed to write config file {path} (exit {exit_code})"
+                if detail:
+                    message = f"{message}: {detail}"
+                return BackendStatusUpdate(status="FAILED", status_message=message)
+            # Self-attesting delivery: require the completion marker rather than trusting a
+            # zero/None exit. This closes the residual silent-drop hole where a stream ends
+            # without an exit event (exit_code None) yet the write never happened -- an
+            # unconfirmed delivery fails loudly instead of advancing to READY file-less.
+            if _CONFIG_DELIVERED_MARKER not in output:
+                return BackendStatusUpdate(
+                    status="FAILED",
+                    status_message=f"Config file {path} delivery could not be confirmed (no completion marker)",
+                )
+        return None
 
     async def _list_endpoints(self, sandbox_nm: str) -> list[Endpoint]:
         """Return the sandbox's currently exposed services as endpoints."""

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_backend_mocked.py
@@ -21,6 +21,7 @@ from nemo_deployments_plugin.backends.labels import (
     MANAGED_BY_KEY,
 )
 from nemo_deployments_plugin.backends.openshell.backend import (
+    _CONFIG_DELIVERED_MARKER,
     _LAUNCH_MARKER,
     _LIVENESS_PROBE,
     _MAX_ROUTABLE_NAME_LEN,
@@ -34,7 +35,7 @@ from nemo_deployments_plugin.backends.openshell.backend import (
 )
 from nemo_deployments_plugin.backends.registry import BACKEND_CLASSES
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
-from nemo_deployments_plugin.entities import Container, ContainerPort, DeploymentConfig, EnvVar
+from nemo_deployments_plugin.entities import ConfigFile, Container, ContainerPort, DeploymentConfig, EnvVar
 from nemo_deployments_plugin.secrets import SecretResolutionError
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
@@ -108,6 +109,22 @@ def _exec_events(exit_code: int, *, stdout: str = "", stderr: str = "") -> list[
     return events
 
 
+def _delivery_ok() -> list[MagicMock]:
+    """A successful config-delivery exec: prints the completion marker on stdout, exits 0."""
+    return _exec_events(0, stdout=_CONFIG_DELIVERED_MARKER)
+
+
+def _stream_without_exit(stdout: str = "") -> list[MagicMock]:
+    """An ExecSandbox stream that never yields an exit event (drains to exit_code None)."""
+    events: list[MagicMock] = []
+    if stdout:
+        out = MagicMock()
+        out.HasField.side_effect = lambda field: field == "stdout"
+        out.stdout.data = stdout.encode()
+        events.append(out)
+    return events
+
+
 def _config_with_env(env: list[EnvVar]) -> DeploymentConfig:
     return DeploymentConfig(
         name="cfg1",
@@ -123,6 +140,33 @@ def _config_with_env(env: list[EnvVar]) -> DeploymentConfig:
             )
         ],
     )
+
+
+def _config_with_config_files(config_files: list[ConfigFile]) -> DeploymentConfig:
+    return DeploymentConfig(
+        name="cfg1",
+        workspace="default",
+        containers=[
+            Container(
+                name="web",
+                image="img:latest",
+                command=["python3", "-m", "http.server"],
+                args=["8000"],
+                ports=[ContainerPort(containerPort=8000, name="http")],
+            )
+        ],
+        configFiles=config_files,
+    )
+
+
+def _exec_requests(mock_stub: MagicMock) -> list[pb.ExecSandboxRequest]:
+    """Every ExecSandboxRequest the backend sent, in call order."""
+    return [call.args[0] for call in mock_stub.ExecSandbox.call_args_list]
+
+
+def _delivery_requests(mock_stub: MagicMock) -> list[pb.ExecSandboxRequest]:
+    """The subset of exec calls that are config-file writes (``cat >`` scripts)."""
+    return [req for req in _exec_requests(mock_stub) if any("cat >" in part for part in req.command)]
 
 
 def test_registry_contains_openshell() -> None:
@@ -608,3 +652,254 @@ def test_liveness_probe_is_pending_when_the_marker_is_unusable(tmp_path: Path, m
     # No usable launch time means no basis to call it dead, so stay undecided rather
     # than fail a deployment on a garbled marker.
     assert _run_probe(tmp_path, pid=None, marker=marker) == _SERVE_PENDING_EXIT
+
+
+# --- AIRCORE-999: config_files are delivered into the sandbox, or fail loudly ---
+
+
+async def test_delivers_config_file_before_launch_streaming_content_on_stdin(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    # READY, marker absent -> deliver the config file, then launch. The file content must
+    # ride the exec's stdin (opaque bytes), never the argv, and delivery must precede launch.
+    content = "hello: world\nnested:\n  a: 1\n"
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/home/sandbox/injected.yaml", content=content)]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    # marker absent, delivery ok (prints completion marker), launch ok
+    mock_stub.ExecSandbox.side_effect = [_exec_events(1), _delivery_ok(), _exec_events(0)]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "STARTING"
+    deliveries = _delivery_requests(mock_stub)
+    assert len(deliveries) == 1
+    write = deliveries[0]
+    script = write.command[-1]
+    assert "cat > /home/sandbox/injected.yaml" in script
+    assert "mkdir -p /home/sandbox" in script
+    assert "chmod 644 /home/sandbox/injected.yaml" in script
+    # Content is streamed, not embedded in the command.
+    assert write.stdin == content.encode("utf-8")
+    assert content not in script
+    # Delivery happened before the serve launch (setsid) exec.
+    kinds = [
+        "deliver"
+        if any("cat >" in p for p in r.command)
+        else ("launch" if any("setsid" in p for p in r.command) else "probe")
+        for r in _exec_requests(mock_stub)
+    ]
+    assert kinds.index("deliver") < kinds.index("launch")
+
+
+async def test_delivers_multiple_config_files_each_on_its_own_stdin(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    files = [
+        ConfigFile(path="/home/sandbox/agent.yaml", content="a: 1\n"),
+        ConfigFile(path="/home/sandbox/skills/tool.yaml", content="tool: search\n"),
+    ]
+    mock_entities.get.return_value = _config_with_config_files(files)
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [_exec_events(1), _delivery_ok(), _delivery_ok(), _exec_events(0)]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "STARTING"
+    deliveries = _delivery_requests(mock_stub)
+    assert len(deliveries) == 2
+    assert deliveries[0].stdin == b"a: 1\n"
+    assert "cat > /home/sandbox/agent.yaml" in deliveries[0].command[-1]
+    assert deliveries[1].stdin == b"tool: search\n"
+    assert "mkdir -p /home/sandbox/skills" in deliveries[1].command[-1]
+
+
+@pytest.mark.parametrize(("mode", "expected"), [(0o644, "chmod 644"), (0o600, "chmod 600"), (0o755, "chmod 755")])
+async def test_config_file_mode_is_applied_as_octal(
+    openshell_backend: OpenShellDeploymentBackend,
+    mock_stub: MagicMock,
+    mock_entities: AsyncMock,
+    mode: int,
+    expected: str,
+) -> None:
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/home/sandbox/x.yaml", content="k: v\n", mode=mode)]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [_exec_events(1), _delivery_ok(), _exec_events(0)]
+
+    await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert f"{expected} /home/sandbox/x.yaml" in _delivery_requests(mock_stub)[0].command[-1]
+
+
+async def test_config_content_with_shell_metacharacters_is_not_interpreted(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    # The adversarial case: content that would be catastrophic if it reached the shell.
+    # Because it is streamed on stdin, it stays opaque bytes and never appears in the argv.
+    content = 'x: "$(rm -rf /)"\ny: `reboot`\nz: ; cat /etc/shadow #\n'
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/home/sandbox/evil.yaml", content=content)]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [_exec_events(1), _delivery_ok(), _exec_events(0)]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "STARTING"
+    write = _delivery_requests(mock_stub)[0]
+    assert write.stdin == content.encode("utf-8")
+    script = write.command[-1]
+    for needle in ("rm -rf /", "reboot", "cat /etc/shadow"):
+        assert needle not in script
+
+
+async def test_config_path_with_spaces_is_quoted(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/home/sandbox/my config.yaml", content="k: v\n")]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [_exec_events(1), _delivery_ok(), _exec_events(0)]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "STARTING"
+    script = _delivery_requests(mock_stub)[0].command[-1]
+    # shlex.quote wraps the path so the space cannot split it into two arguments.
+    assert "'/home/sandbox/my config.yaml'" in script
+
+
+async def test_unwritable_config_path_fails_loudly_and_deletes_sandbox(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    # The /workspace boundary: delivery runs as the sandbox user, so a target it cannot
+    # write (the image chowns /workspace to 'agent') makes cat exit non-zero. That must
+    # surface as a terminal FAILED naming the path and the shell's error -- never a silent
+    # drop that reaches READY -- and the sandbox is torn down. Launch never happens.
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/workspace/injected.yaml", content="k: v\n")]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [
+        _exec_events(1),  # marker absent
+        # the real failure is a shell redirection error (cat never runs), not a cat error
+        _exec_events(1, stderr="sh: 1: cannot create /workspace/injected.yaml: Permission denied"),
+    ]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "FAILED"
+    assert "/workspace/injected.yaml" in update.status_message
+    assert "Permission denied" in update.status_message
+    mock_stub.DeleteSandbox.assert_called_once()
+    # No launch was attempted after the failed write.
+    assert not any("setsid" in p for r in _exec_requests(mock_stub) for p in r.command)
+
+
+async def test_config_delivery_rpc_error_fails_loudly_and_deletes_sandbox(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/home/sandbox/x.yaml", content="k: v\n")]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [_exec_events(1), FakeRpcError(grpc.StatusCode.INTERNAL, "exec boom")]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "FAILED"
+    assert "/home/sandbox/x.yaml" in update.status_message
+    mock_stub.DeleteSandbox.assert_called_once()
+
+
+async def test_no_config_files_delivers_nothing(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    # A deployment with no config_files must not add any delivery exec: only the marker
+    # probe and the launch. Guards the empty-list no-op that keeps every prior test valid.
+    mock_entities.get.return_value = _config()
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [_exec_events(1), _exec_events(0)]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "STARTING"
+    assert _delivery_requests(mock_stub) == []
+    assert mock_stub.ExecSandbox.call_count == 2
+
+
+async def test_config_files_not_redelivered_once_serve_is_launched(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    # Delivery lives inside the once-only launch guard. On a later poll where the marker is
+    # present, the backend advances to expose without rewriting the files (write exactly once).
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/home/sandbox/x.yaml", content="k: v\n")]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.return_value = _exec_events(0)  # marker present, liveness alive
+    mock_stub.ExposeService.return_value = MagicMock(url="http://nmp-x--http.openshell.localhost:17670/")
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "READY"
+    assert _delivery_requests(mock_stub) == []
+
+
+@pytest.mark.parametrize(
+    "delivery_stream",
+    [_exec_events(0), _stream_without_exit(stdout="partial")],
+    ids=["zero-exit-no-marker", "stream-without-exit-event"],
+)
+async def test_config_delivery_without_completion_marker_fails_loudly(
+    openshell_backend: OpenShellDeploymentBackend,
+    mock_stub: MagicMock,
+    mock_entities: AsyncMock,
+    delivery_stream: list[MagicMock],
+) -> None:
+    # Self-attesting delivery: a write that cannot prove it happened -- a zero exit with no
+    # marker, or a stream that ends without an exit event (exit_code None) -- must fail
+    # loudly, never advance to launch. This is the residual silent-drop path the marker closes.
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/home/sandbox/x.yaml", content="k: v\n")]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [_exec_events(1), delivery_stream]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "FAILED"
+    assert "could not be confirmed" in update.status_message
+    assert "/home/sandbox/x.yaml" in update.status_message
+    mock_stub.DeleteSandbox.assert_called_once()
+    assert not any("setsid" in p for r in _exec_requests(mock_stub) for p in r.command)
+
+
+async def test_multi_file_partial_failure_aborts_and_deletes_sandbox(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    # File 1 delivers, file 2 fails: the loop aborts mid-stream, the deployment fails naming
+    # the offending file, the sandbox is torn down, and serve is never launched.
+    files = [
+        ConfigFile(path="/home/sandbox/agent.yaml", content="a: 1\n"),
+        ConfigFile(path="/home/sandbox/skills/tool.yaml", content="t: 1\n"),
+    ]
+    mock_entities.get.return_value = _config_with_config_files(files)
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [
+        _exec_events(1),  # marker absent
+        _delivery_ok(),  # file 1 ok
+        _exec_events(1, stderr="sh: 1: cannot create /home/sandbox/skills/tool.yaml: Permission denied"),
+    ]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "FAILED"
+    assert "/home/sandbox/skills/tool.yaml" in update.status_message
+    assert len(_delivery_requests(mock_stub)) == 2  # both attempted; aborted after the failure
+    mock_stub.DeleteSandbox.assert_called_once()
+    assert not any("setsid" in p for r in _exec_requests(mock_stub) for p in r.command)

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_backend_mocked.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_backend_mocked.py
@@ -30,6 +30,7 @@ from nemo_deployments_plugin.backends.openshell.backend import (
     _SERVE_PID_GRACE_SECONDS,
     _SERVE_PIDFILE,
     OpenShellDeploymentBackend,
+    _delivery_script,
     _sandbox_name,
     _service_name,
 )
@@ -756,6 +757,49 @@ async def test_config_content_with_shell_metacharacters_is_not_interpreted(
         assert needle not in script
 
 
+def test_delivery_script_writes_bytes_verbatim_and_never_executes_content(tmp_path: Path) -> None:
+    # Run the exact script the backend generates through a real /bin/sh with adversarial
+    # content on stdin, and prove the shell writes it verbatim without ever interpreting it:
+    # shell-injection payloads in the content stay inert bytes and land in the file 1:1.
+    target = tmp_path / "nested" / "dir" / "agent.yaml"
+    canary = tmp_path / "canary"  # a side effect would delete or overwrite this
+    canary.write_text("alive")
+    # Every shell-injection vector: command substitution, backticks, and a statement break.
+    content = f'x: "$(rm -f {canary})"\ny: `printf pwned > {canary}`\nz: ; printf pwned > {canary} #\n'
+
+    proc = subprocess.run(
+        ["/bin/sh", "-c", _delivery_script(str(target), 0o600)],
+        input=content.encode("utf-8"),
+        capture_output=True,
+    )
+
+    assert proc.returncode == 0
+    assert _CONFIG_DELIVERED_MARKER.encode() in proc.stdout
+    assert target.read_bytes() == content.encode("utf-8")
+    assert canary.read_text() == "alive"  # untouched: the injection payload never executed
+    assert (target.stat().st_mode & 0o777) == 0o600
+
+
+@pytest.mark.skipif(hasattr(os, "getuid") and os.getuid() == 0, reason="root bypasses write permissions")
+def test_delivery_script_fails_without_marker_when_target_is_unwritable(tmp_path: Path) -> None:
+    # The real failure branch: a target under a read-only directory makes the shell exit
+    # non-zero and never print the marker -- exactly what the backend treats as FAILED.
+    readonly = tmp_path / "readonly"
+    readonly.mkdir()
+    readonly.chmod(0o500)  # r-x: the sandbox user cannot create files here
+    try:
+        proc = subprocess.run(
+            ["/bin/sh", "-c", _delivery_script(str(readonly / "denied.yaml"), 0o644)],
+            input=b"k: v\n",
+            capture_output=True,
+        )
+    finally:
+        readonly.chmod(0o700)  # restore so tmp_path cleanup can remove it
+
+    assert proc.returncode != 0
+    assert _CONFIG_DELIVERED_MARKER.encode() not in proc.stdout
+
+
 async def test_config_path_with_spaces_is_quoted(
     openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
 ) -> None:
@@ -903,3 +947,30 @@ async def test_multi_file_partial_failure_aborts_and_deletes_sandbox(
     assert len(_delivery_requests(mock_stub)) == 2  # both attempted; aborted after the failure
     mock_stub.DeleteSandbox.assert_called_once()
     assert not any("setsid" in p for r in _exec_requests(mock_stub) for p in r.command)
+
+
+async def test_config_delivery_with_marker_but_no_exit_event_succeeds(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    # A response stream can lose its exit event (exit_code None) yet still carry the
+    # completion marker. The marker prints only after set -e clears mkdir+cat+chmod, and the
+    # file content is sent atomically in the ExecSandbox *request* (stdin is one bytes field,
+    # not the response stream), so a marker in the output is positive proof the file was
+    # written. Delivery is therefore confirmed and launch proceeds -- requiring exit_code == 0
+    # here would false-fail a proven-good delivery and tear down the sandbox.
+    mock_entities.get.return_value = _config_with_config_files(
+        [ConfigFile(path="/home/sandbox/x.yaml", content="k: v\n")]
+    )
+    mock_stub.GetSandbox.return_value = _sandbox(pb.SANDBOX_PHASE_READY)
+    mock_stub.ExecSandbox.side_effect = [
+        _exec_events(1),  # marker absent -> not yet launched
+        _stream_without_exit(stdout=_CONFIG_DELIVERED_MARKER),  # write proven, exit event lost
+        _exec_events(0),  # launch ok
+    ]
+
+    update = await openshell_backend.read_status(workspace="default", name="srv")
+
+    assert update.status == "STARTING"
+    assert len(_delivery_requests(mock_stub)) == 1
+    # Launch proceeded after the confirmed delivery.
+    assert any("setsid" in p for r in _exec_requests(mock_stub) for p in r.command)


### PR DESCRIPTION
## Summary

`DeploymentConfig.config_files` is a first-class API field (accepted, validated, given a default `mode`, echoed back), but only the k8s backend implemented it. The openshell backend accepted the field, reached `READY`, and never wrote the files: a silent drop, so a caller had every reason to believe its config was delivered. This makes openshell deliver the files, or fail loudly when it cannot.

## Related Issue

AIRCORE-999.

## Changes

- Deliver each `config_files` entry into the sandbox before serve launch via `ExecSandbox`, with the content on the RPC's first-class `stdin` bytes field (`sh -c 'set -e; mkdir -p <dir>; cat > <path>; chmod <mode> <path>'`). The content is streamed, so it never touches the argv nor the single-line, size-capped sandbox environment. `_exec_detached` gained a `stdin` kwarg.
- Delivery runs inside the once-only launch guard in `_advance_provisioning`, immediately before launch, so files are written exactly once per deployment. Delivery runs as the non-root sandbox user (ExecSandbox has no user field; the policy pins `run_as_user`), so a target that user cannot write (e.g. `/workspace`, which the packaged agent image chowns to `agent` even though the sandbox policy lists it read-write) fails with a terminal `FAILED` naming the path and the shell's error, and the sandbox is torn down, rather than reaching `READY` file-less.
- Delivery is self-attesting: the script prints a completion marker only after `set -e` clears mkdir/cat/chmod, and a write is accepted only when that marker is present in the output. This closes the residual silent-drop path where an `ExecSandbox` stream ends without an exit event, without changing the shared exec probes' "only positive evidence flaps a deployment" semantics.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-visible API or CLI surface change. A doc note on the openshell writable-path constraint can ride the docs work already tracked under AIRCORE-981.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pre-commit run --files <changed files>`: ruff, ruff format, ty, copyright headers, plugin-import guard, and merge-conflict hooks all pass; the remaining hooks skip as not-applicable. Run scoped to the changed files rather than `-a` because a full workspace sync could not be built in this worktree (a transitive dependency needs `Python.h`); the applicable hooks are the ones exercised above.
- `pytest plugins/nemo-deployments/tests/unit/backends/openshell`: 93 passed. Adversarial cases include stdin-streaming with delivery-before-launch, multi-file, octal mode, shell-metacharacter content that must not be interpreted, spaced-path quoting, unwritable `/workspace` failing loudly and deleting the sandbox, rpc-error failing loudly, unconfirmed-delivery (no completion marker) failing loudly, multi-file partial failure, empty-list no-op, and write-exactly-once.
- Full `plugins/nemo-deployments/tests/unit`: passes except `test_ports.py::test_find_available_port_excludes_pending_assignments`, a pre-existing real-socket flake that reproduces identically on unmodified `main` (host port 9000 is occupied on the dev box) and is unrelated to this change, which touches only the openshell backend.

## Notes

Docker delivery and deleting the nemo-agents `NAT_CONFIG_YAML` env-var workaround are deferred to a follow-up ticket, along with a possible fileset-id delivery path for large artifacts. This PR scopes to the openshell backend, whose delivery mechanism is proven.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment configuration files are now delivered to the sandbox before the service starts.
  * Files are written to their configured paths with the correct permissions.
  * Multiple configuration files are supported and delivered in the correct order.

* **Bug Fixes**
  * Deployment now stops safely when configuration delivery fails, is incomplete, or cannot be verified.
  * Failed deployments clean up the sandbox and do not launch the service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->