### PR TITLE
build: allow newer uv for source checkouts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,49 @@ jobs:
       - name: Run NGC metadata unit tests
         run: uv run --no-cache .github/scripts/tests/test_ngc_metadata.py
 
+  uv-lock:
+    name: Check uv lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install platform uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          version: "0.9.14"
+          enable-cache: false
+          python-version: "3.12"
+
+      - name: Show uv version
+        run: uv --version
+
+      - name: Check lock with platform uv
+        run: bash script/uv-lock.sh --check
+
+  uv-latest-compatibility:
+    name: Check latest uv compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Install latest uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+        with:
+          enable-cache: false
+          python-version: "3.12"
+
+      - name: Show uv version
+        run: uv --version
+
+      - name: Check sync with latest uv
+        run: uv sync --frozen --all-packages
+
   docker-bake-graph:
     name: Docker bake graph
     needs: [changes]
@@ -1929,6 +1972,8 @@ jobs:
     needs:
       - changes
       - actionlint
+      - uv-lock
+      - uv-latest-compatibility
       - docker-bake-graph
       - build-cpu-smoke-images
       - kind-cpu-smoke

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,8 +83,8 @@ repos:
   - repo: local
     hooks:
       - id: uv-lock
-        name: Run uv lock
-        entry: uv lock
+        name: Run uv lock with platform uv
+        entry: bash script/uv-lock.sh
         language: system
         files: 'pyproject\.toml$'
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ Pre-commit hooks run automatically before commits and pushes to ensure code qual
 - **Ruff linter** - Automatically fixes linting issues in Python code (excludes SDK)
 - **Ruff formatter** - Formats Python code (excludes SDK)
 - **Type checking (ty)** - Runs type checks on Python code (may need manual fixes)
-- **uv lock** - Automatically updates `uv.lock` when `pyproject.toml` changes
+- **uv lock** - Automatically updates `uv.lock` with the platform uv version when `pyproject.toml` changes
 - **uv lock check** - Verifies `uv.lock` is in sync with `pyproject.toml`
 - **Helm Docs Container** - Runs `helm-docs` container to regenerate Helm documentation in `k8s/helm/README.md`
 - **Check merge conflicts** - Detects merge conflict markers
@@ -245,7 +245,7 @@ Ensure all pre-commit hooks pass by running `uv run pre-commit run -a`. A clean 
 
 ### Bootstrap prerequisites
 
-- **uv version pin:** Root `pyproject.toml` requires `uv>=0.9.14,<0.10.0`, and newer releases (e.g. 0.11.x) fail `uv sync` with a version mismatch. `mise.toml` pins a matching uv and the `make` targets call it through `mise exec --`, so a global uv outside that range no longer needs downgrading — run `make bootstrap` first so mise is installed. Pass `NMP_SKIP_MISE=1` to use the uv already on PATH.
+- **uv version:** Root `pyproject.toml` requires and supports `uv>=0.9.14` for source checkout bootstrap. `uv.lock` updates must use uv `0.9.14`, matching the platform containers and CI lock check. CI separately validates latest uv compatibility.
 - **Native build deps:** `make bootstrap-python` builds `annoy` (via `nemoguardrails`). Install system headers once per VM image: `sudo apt-get install -y python3-dev build-essential`.
 - **Python bootstrap:** Run `make bootstrap-python` from repo root (creates `.venv`, runs `uv sync --frozen --all-packages`). See [SETUP.md](SETUP.md) for the full playbook.
 - **Studio (optional):** `make bootstrap-studio` resolves the Node.js/pnpm versions pinned in `mise.toml`, so a VM shipping an older Node doesn't need upgrading. API services still run without Studio assets. Pass `NMP_SKIP_MISE=1` to bootstrap against the toolchain already on PATH.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ NeMo Platform brings NVIDIA NeMo libraries together under one CLI, Python SDK, a
 
 ## Get started
 
-**Prerequisites:** Python 3.12-3.13, `uv>=0.9.14,<0.10.0`, and an API key for an inference provider (NVIDIA Build, OpenAI, Anthropic, Google Gemini, or a local Ollama instance). For source development, you also need Git, GNU Make, and — if you want the web UI — Node.js `>=22.23.2 <23` with `pnpm>=10.34.5`.
+**Prerequisites:** Python 3.12-3.13, `uv>=0.9.14`, and an API key for an inference provider (NVIDIA Build, OpenAI, Anthropic, Google Gemini, or a local Ollama instance). For source development, you also need Git, GNU Make, and — if you want the web UI — Node.js `>=22.23.2 <23` with `pnpm>=10.34.5`.
 
 Quick install from PyPI:
 

--- a/docs/get-started/setup.mdx
+++ b/docs/get-started/setup.mdx
@@ -13,7 +13,7 @@ Install NeMo Platform and start working with AI agents.
 - An API key from one of: [NVIDIA Build](https://build.nvidia.com), [OpenAI](https://platform.openai.com/api-keys), [Anthropic](https://console.anthropic.com/settings/keys), [Google Gemini](https://aistudio.google.com/apikey), or a local [Ollama](https://ollama.com) instance (no key needed)
 - 16 GB available disk space and 8 GB RAM
 - For the PyPI install: `pip` in a Python environment
-- For the source checkout install: [Git](https://git-scm.com/), GNU Make, [uv](https://docs.astral.sh/uv/) `>=0.9.14,<0.10.0`, [Node.js (≥22.23.2, \<23)](https://nodejs.org/en/download) satisfying `web/package.json`, and [pnpm](https://pnpm.io/installation)
+- For the source checkout install: [Git](https://git-scm.com/), GNU Make, [uv](https://docs.astral.sh/uv/) `>=0.9.14`, [Node.js (≥22.23.2, \<23)](https://nodejs.org/en/download) satisfying `web/package.json`, and [pnpm](https://pnpm.io/installation)
 
 ## Install
 

--- a/docs/requirements.mdx
+++ b/docs/requirements.mdx
@@ -15,7 +15,7 @@ clusters, use the NeMo Platform Helm chart on Kubernetes.
 | Component | Requirement | Notes |
 |-----------|-------------|-------|
 | Python | 3.12 or 3.13 | Use an isolated virtual environment. |
-| Package installer | `uv>=0.9.14,<0.10.0` recommended; `pip` supported | The one-line installer sets up `uv` automatically when needed. |
+| Package installer | `uv>=0.9.14` recommended for source checkouts; `pip` supported for published packages | The one-line installer sets up `uv` automatically when needed. |
 | Operating system | Recent Linux or macOS release | See the [Support Matrix](/documentation/reference/support-matrix) for the supported OS list. |
 | Memory | 8 GB RAM minimum | 16 GB or more is recommended for larger local workflows. |
 | Disk space | 16 GB free disk space minimum | Additional space is needed for datasets, job outputs, and local model artifacts. |

--- a/docs/support-matrix.mdx
+++ b/docs/support-matrix.mdx
@@ -23,7 +23,7 @@ self-managed Kubernetes deployments installed with the NeMo Platform Helm chart.
 
 | Area | Supported | Notes |
 |------|-----------|-------|
-| Package installation | `uv>=0.9.14,<0.10.0` recommended; `pip` supported | The one-line installer sets up `uv` automatically. Published packages can also be installed with `pip install "nemo-platform[all]"`. |
+| Package installation | `uv>=0.9.14` recommended for source checkouts; `pip` supported for published packages | The one-line installer sets up `uv` automatically. Published packages can also be installed with `pip install "nemo-platform[all]"`. |
 | Shell | Bash or zsh | Used by the installer, setup commands, and documented examples. |
 | Browser | Current Chrome, Edge, Firefox, or Safari | Required for the Studio UI and generated documentation. |
 

--- a/plugins/nemo-experimentalist/README.md
+++ b/plugins/nemo-experimentalist/README.md
@@ -18,7 +18,7 @@ uv sync
 export NEMO="$PWD/.venv/bin/nemo"
 ```
 
-Requires `uv >=0.9.14,<0.10.0`.
+Requires `uv >=0.9.14`.
 
 **To verify an end-to-end run, follow
 [Get started with an example agent](../../docs/get-started/example-agent.mdx).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ generate-config-docs = "script.generate_config_docs:main"
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
 index-strategy = "unsafe-best-match"
-required-version = ">=0.9.14,<0.10.0"
+required-version = ">=0.9.14"
 cache-keys = [{ file = "pyproject.toml" }]
 # Keep uv's implicit dev default and also install enabled plugins on bare `uv sync`.
 default-groups = ["dev", "enabled-plugins"]
@@ -310,7 +310,7 @@ constraint-dependencies = [
   "sqlfluff>=4.2.2",
   "starlette>=1.3.1",
   "urllib3>=2.7.0",
-  "uv>=0.9.14,<0.10.0",
+  "uv>=0.9.14",
 ]
 
 override-dependencies = [

--- a/script/uv-lock.sh
+++ b/script/uv-lock.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -euo pipefail
+
+required_uv_version="0.9.14"
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required to update uv.lock." >&2
+  echo "Install uv ${required_uv_version}: curl -LsSf https://astral.sh/uv/${required_uv_version}/install.sh | sh" >&2
+  exit 1
+fi
+
+uv_version_output="$(uv --version)"
+actual_uv_version="$(printf '%s\n' "${uv_version_output}" | awk '{print $2}')"
+
+if [[ "${actual_uv_version}" != "${required_uv_version}" ]]; then
+  echo "uv.lock must be checked or updated with uv ${required_uv_version}, matching platform containers and CI." >&2
+  echo "Current uv: ${uv_version_output}" >&2
+  echo "Install uv ${required_uv_version}: curl -LsSf https://astral.sh/uv/${required_uv_version}/install.sh | sh" >&2
+  exit 1
+fi
+
+exec uv lock "$@"

--- a/uv.lock
+++ b/uv.lock
@@ -113,7 +113,7 @@ constraints = [
     { name = "sqlfluff", specifier = ">=4.2.2" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "urllib3", specifier = ">=2.7.0" },
-    { name = "uv", specifier = ">=0.9.14,<0.10.0" },
+    { name = "uv", specifier = ">=0.9.14" },
 ]
 overrides = [
     { name = "aiodns", specifier = "==3.5.0" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Relaxes the `uv` version upper bound from `>=0.9.14,<0.10.0` to `>=0.9.14`, allowing developers and CI to use newer uv releases (0.10.x, 0.11.x, etc.) for source checkouts. Lockfile updates are still pinned to uv 0.9.14 for reproducibility.

## Changes

- **`pyproject.toml`**: Removed `<0.10.0` upper bound from `required-version` and `constraint-dependencies`
- **`script/uv-lock.sh`** (new): Wrapper script that enforces uv 0.9.14 for `uv lock` operations, ensuring lockfile consistency across contributors
- **`.pre-commit-config.yaml`**: Updated the `uv-lock` hook to use the new wrapper script
- **CI (`.github/workflows/ci.yaml`)**: Added two new jobs:
  - `uv-lock`: Validates lockfile with pinned uv 0.9.14
  - `uv-latest-compatibility`: Runs `uv sync --frozen --all-packages` with latest uv to verify forward compatibility
- **Documentation**: Updated `README.md`, `AGENTS.md`, `docs/get-started/setup.mdx`, `docs/requirements.mdx`, `docs/support-matrix.mdx`, and `plugins/nemo-experimentalist/README.md` to reflect the relaxed requirement
- **`uv.lock`**: Re-resolved with uv 0.9.14 (removes transient packages no longer pulled in)

## Type of Change

- [x] Code change with documentation updates
- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation updated for user-visible behavior

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] No secrets, API keys, or credentials are included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup and support guidance to allow `uv` version 0.9.14 or later.
  - Clarified that `pip` remains supported for published packages.

- **CI**
  - Added checks for lockfile consistency and compatibility with both pinned and latest `uv` versions.

- **Developer Experience**
  - Added validation and guidance for using the required `uv` version when updating lockfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->