### PR TITLE
chore(customizer): fix CVEs in RL image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -100,7 +100,7 @@ variable "NEMO_RL_REPO" {
 # RL pins Gym as a git submodule (-> soluwalana/Gym over https), so Gym rides in with the RL git ADD
 # - no separate Gym pin needed.
 variable "NEMO_RL_REF" {
-  default = "edba0f96edcecd8349302a3d93b1249d8a067d0e" # soluwalana/RL nmp/customizer
+  default = "1427564b347ee0a4b672182a8a98048ed2785217" # soluwalana/RL nmp/customizer
 }
 variable "RL_BASE_CONTEXT" {
   default = ""
@@ -426,14 +426,10 @@ target "rl-platform-workspace" {
 
 # Heavy base: cuda-dl-base + NeMo-RL (with its Gym/Automodel/Megatron-Bridge submodules) built FROM
 # SOURCE (Python 3.13, CUDA 13). RL is pinned via NEMO_RL_REF; Gym rides in as RL's own submodule
-# (no separate pin). The ffmpeg-vlm wheels are reused for the cp313 av/opencv/decord2 CVE swap.
 target "nmp-rl-base-builder" {
   target     = "nmp-rl-base"
   context    = "."
   dockerfile = "docker/rl/Dockerfile.nmp-rl-base"
-  contexts = {
-    ffmpeg-vlm-wheel-image = ffmpeg_vlm_wheel_context()
-  }
   args = {
     NEMO_RL_REPO = NEMO_RL_REPO
     NEMO_RL_REF  = NEMO_RL_REF

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -100,7 +100,7 @@ variable "NEMO_RL_REPO" {
 # RL pins Gym as a git submodule (-> soluwalana/Gym over https), so Gym rides in with the RL git ADD
 # - no separate Gym pin needed.
 variable "NEMO_RL_REF" {
-  default = "1427564b347ee0a4b672182a8a98048ed2785217" # soluwalana/RL nmp/customizer
+  default = "ace40313d474f33cabc9a8fdf13d8dd4dda218c8" # soluwalana/RL nmp/customizer
 }
 variable "RL_BASE_CONTEXT" {
   default = ""

--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -41,10 +41,6 @@ ARG UV_VERSION=0.11.33
 ARG PYTHON_VERSION=3.13.14
 ARG CMAKE_VERSION=4.0.3
 
-# Reuse the shared FFmpeg/VLM wheels (cp313 av / opencv-headless / decord2), supplied by bake as a
-# named context (see docker/base/Dockerfile.python-wheels). Replaces the FFmpeg-bundling PyPI copies.
-FROM ffmpeg-vlm-wheel-image AS ffmpeg-vlm-wheel-src
-
 # ---- RL source (+ its submodules, incl. Gym) via BuildKit's git ADD ----
 # RL pins Gym, Automodel and Megatron-Bridge (+ nested Megatron-LM) as git submodules, all over
 # https, so `ADD <repo>#<ref>` recurses and fetches them anonymously. Submodule CONTENT arrives
@@ -249,22 +245,17 @@ find "${UV_CACHE_DIR}" -type d -path "*ray/_private/runtime_env/agent/thirdparty
 # jackson-databind / jackson-core CVEs: drop ray's bundled ray_dist.jar, which only backs Ray's Java
 # worker support (unused - no JVM here). Removed before the prefetch so no venv symlinks to it.
 find "${UV_CACHE_DIR}" -type d -path "*/ray/jars" -exec rm -rf {} + || true
-EOF
 
-# Replace the FFmpeg-bundling av / opencv / decord2 copies with vendored cp313 wheels (CVE).
-RUN --mount=from=ffmpeg-vlm-wheel-src,target=/tmp/ffmpeg,readonly <<"EOF" bash -exu
-for site in /opt/nemo_rl_venv/lib/python*/site-packages; do
-    [ -d "${site}" ] || continue
-    rm -rf \
-        "${site}/av" "${site}"/av-*.dist-info "${site}/av.libs" \
-        "${site}/cv2" "${site}/opencv_python_headless.libs" "${site}"/opencv_python_headless-*.dist-info \
-        "${site}/decord" "${site}"/decord-*.dist-info "${site}/decord.libs" \
-        "${site}/decord2" "${site}"/decord2-*.dist-info "${site}/decord2.libs"
-done
-uv pip install --python /opt/nemo_rl_venv/bin/python --no-cache --no-deps --reinstall \
-    /tmp/ffmpeg/wheels/av-*-abi3-manylinux_2_28_*.whl \
-    /tmp/ffmpeg/wheels/opencv_python_headless-*cp313*.whl \
-    /tmp/ffmpeg/wheels/decord2-*cp313*.whl
+# FFmpeg CVEs (CVE-2026-8461 + CVE-2026-64830..64835): PyNvVideoCodec bundles FFmpeg 8.1.1 shared
+# libraries, which the scan reports as `ffmpeg` whatever the Python package version is. vLLM pins it
+# so it cannot leave the lock, but nothing on the DPO/GRPO path reaches it: vLLM defaults to the
+# `opencv` video backend and imports PyNvVideoCodec inside decode_frames_pynvvideocodec(), so only
+# the opt-in `pynvvideocodec` backend breaks. Upgrading does not help - 2.2.0 ships FFmpeg 8.1.2,
+# which fixes only one of the seven. The second pattern is the wheel's vendored FFmpeg source
+# tarball. Removed before the prefetch so no venv symlinks into it; only these two directories go,
+# so uv still sees the package as cached and does not re-download it.
+find "${UV_CACHE_DIR}" -type d \
+    \( -name PyNvVideoCodec -o -name 'pynvvideocodec-*.data' \) -exec rm -rf {} + || true
 EOF
 
 # Full RL source including submodules (Automodel, Megatron-Bridge + nested Megatron-LM, Gym). Copied

--- a/docker/rl/README.md
+++ b/docker/rl/README.md
@@ -349,19 +349,6 @@ the uv cache + venv prefetch rather than via wheel images:
   stages pinned to RL's exact commits, kept in lockstep with `uv.lock`.
 - **Transformer-Engine** is the longest compile, but it is not built at all now — it
   only exists in the unused `automodel` / `mcore` extras (see the note above).
-
-## CVE handling
-
-- **Version floors** for the ecosystem (aiohttp, cryptography, urllib3, protobuf, av,
-  …) come from NeMo-RL's `constraint-dependencies` / `override-dependencies` in its
-  `pyproject.toml`. We inherit them by building from RL's lock — nothing to do here.
-- **FFmpeg-bundling wheels** (`av`, `opencv-python-headless`, `decord2`) statically
-  embed FFmpeg codec libraries that carry CVEs regardless of the Python package
-  version, so a version bump alone doesn't fix them. The base deletes the PyPI copies
-  and reinstalls clean `cp313` wheels built against a patched FFmpeg (from
-  `docker/base/Dockerfile.python-wheels`).
-- **Ray's bundled aiohttp** is removed from the uv cache to fully address its CVE.
-- **The interpreter needs `UV_PYTHON`, not just `PYTHON_VERSION`.** NeMo-RL ships a
   `.python-version` pinning an exact patch release, which uv honours over whatever
   `uv python install` provisioned. Bumping `PYTHON_VERSION` alone therefore fixed nothing:
   every venv came up on RL's version while ours sat unused on disk, so the image shipped


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Fix CVEs for RL image

## Changes

**CVEs fixed:**
- removed the ffmpeg wheel, doesn't fix CVEs, more like a cleanup
  - We were installing `av`, `opencv-python-headless`, `decord2` from this wheel that RL specifically removes in [pyproject.toml](https://github.com/soluwalana/RL/blob/nmp/customizer/pyproject.toml#L410) and in PRs, [3107](https://github.com/NVIDIA-NeMo/RL/pull/3107) and [3339](https://github.com/NVIDIA-NeMo/RL/pull/3339), both are in our RL fork, so there's essentially no use of it.
- 154 findings come from FFmpeg vendored inside PyNvVideoCodec, `/opt/uv_cache/archive-v0/y7K6jcDvx-Obnh8H/PyNvVideoCodec/` that is removed
  - `PyNvVideoCodec==2.0.4` comes in from a pin from vllm and GRPO needs vllm, but removing PyNvVideoCodec from cache is safe because nothing on the DPO/GRPO path can reach it
  - it's needed for video decoding which is not part of DPO/GRPO at all.
   - the `import PyNvVideoCodec` is *function-local*, inside `decode_frames_pynvvideocodec()`, so it only executes if that backend is explicitly selected - https://github.com/vllm-project/vllm/blob/752a3a504485790a2e8491cacbb35c137339ad34/vllm/multimodal/video.py#L799
  - also it is never the default, vllm defaults to the `opencv` backend - https://github.com/vllm-project/vllm/blob/752a3a504485790a2e8491cacbb35c137339ad34/vllm/envs.py#L83
- `aiohttp` 3.14.2 bumped up to 3.14.3 in PR - https://github.com/soluwalana/RL/pull/10
- `cryptography` 48.0.1 bumped up to to 50.0.0 in PR - https://github.com/soluwalana/RL/pull/10

**remaining can't be fixed:**
- `grpc v1.82.0` (needs 1.82.1) from `/opt/uv_cache/archive-v0/Lt4dmx5C-VX-edr9/wandb/bin/wandb-core` - already on the latest wandb (0.28.1); needs an upstream Go rebuild
- `stdlib go1.26.4` - same `wandb-core` binary, same reason, latest wandb already
- `grpc v1.79.3` (needs 1.82.1) comes from `/opt/uv_cache/archive-v0/0zovx6DYaLJWcATd/mooncake/libetcd_wrapper.so` - already on the latest `mooncake-transfer-engine-cuda13` 0.3.12.post1; no fix released yet
- `stdlib go1.25.10`  from same `libetcd_wrapper.so` - but we're on latest mooncake already
- `flash-attn 2.8.1` - no fix yet
- CVE-2026-11940, CVE-2026-11972, CVE-2026-15308 from python-3.13.14, I looked up there is a new version of python with the fixes - https://docs.python.org/release/3.14.7/whatsnew/changelog.html, but  we don't install Python from python.org. uv installs prebuilt interpreters from the `python-build-standalone` project, and that project has not published the latest version yet, it tops out at 3.13.14.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the reinforcement-learning container build to use a newer pinned component revision.
  - Simplified container setup by removing bundled video-processing wheel replacement steps.
  - Removed bundled FFmpeg payload files while retaining the related package dependency; the optional video backend is no longer included.

- **Documentation**
  - Removed CVE-handling guidance from the reinforcement-learning container documentation, including related dependency and interpreter configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->