### PR TITLE
feat(evaluator): make nemo_evaluator_sdk __init__ lazy

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/__init__.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/__init__.py
@@ -1,90 +1,180 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""NeMo Evaluator SDK."""
+"""NeMo Evaluator SDK.
+
+The public surface resolves lazily (PEP 562). Importing this package must not drag in the
+execution/backend or metric stack: importing any submodule runs this module first, so eager
+re-exports made ``import nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime`` — all the
+optimizer needs — cost ~1400 modules (openai, sacrebleu, zstandard, pyarrow, ...) instead
+of ~480, and turned every one of those transitive packages into an evaluation-time failure mode
+for the SDK-backed evaluator.
+
+Add a new re-export to ``_LAZY_ATTRS``, the ``TYPE_CHECKING`` block and ``__all__`` — never as a
+module-level import. ``tests/test_lazy_public_api.py`` locks the boundary in.
+"""
 
 # ruff: noqa: I001 - the vendored SDK mirror uses different import-order settings.
 
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _package_version
+from typing import TYPE_CHECKING
 
-from nemo_evaluator_sdk.agent_stream_translation import (
-    AgentStreamTranslation,
-    AgentStreamTranslationContext,
-    AgentStreamTranslator,
-    SseFrame,
-)
-from nemo_evaluator_sdk.datasets import DatasetLoadError, load_dataset, load_dataset_as_dicts
-from nemo_evaluator_sdk.execution.backends.local.backend import LocalBackend
-from nemo_evaluator_sdk.execution.evaluator import Evaluator
-from nemo_evaluator_sdk.execution.values import (
-    EvaluationError,
-    EvaluationPhase,
-)
-from nemo_evaluator_sdk.metrics.bleu import BLEUMetric
-from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
-from nemo_evaluator_sdk.metrics.f1 import F1Metric
-from nemo_evaluator_sdk.metrics.llm_judge import LLMJudgeMetric
-from nemo_evaluator_sdk.metrics.number_check import NumberCheckMetric
-from nemo_evaluator_sdk.metrics.protocol import (
-    Metric,
-    MetricTypeName,
-    validate_metric_result,
-)
-from nemo_evaluator_sdk.metrics.remote import NemoAgentToolkitRemoteMetric, RemoteMetric
-from nemo_evaluator_sdk.metrics.rouge import ROUGEMetric
-from nemo_evaluator_sdk.metrics.string_check import StringCheckMetric
-from nemo_evaluator_sdk.metrics.tool_calling import ToolCallingMetric
-from nemo_evaluator_sdk.metrics.tunable_rag_evaluator import TunableRagEvaluatorMetric
-from nemo_evaluator_sdk.resolver_protocols import ModelResolver, SecretResolver
-from nemo_evaluator_sdk.resolvers import LocalModelResolver, LocalSecretResolver
-from nemo_evaluator_sdk.structured_output import (
-    InferenceFn,
-    InferenceStructuredOutput,
-    StructuredOutput,
-    StructuredOutputMode,
-    default_structured_output_mode,
-    detect_structured_output_mode,
-)
-from nemo_evaluator_sdk.values import (
-    Agent,
-    AgentBase,
-    BooleanValue,
-    CandidateOutput,
-    ContinuousScore,
-    DatasetRow,
-    DatasetRows,
-    DiscreteScore,
-    EvaluationResult,
-    FieldMapping,
-    InferenceParams,
-    JSONScoreParser,
-    Label,
-    MetricDescriptor,
-    MetricDiagnostic,
-    MetricInput,
-    MetricOutput,
-    MetricOutputSpec,
-    MetricResult,
-    Model,
-    ModelRef,
-    GenericAgent,
-    NatAgentConfig,
-    NemoAgentToolkitAgent,
-    RangeScore,
-    ReasoningParams,
-    RemoteScore,
-    RubricScore,
-    RunConfig,
-    RunConfigOnline,
-    RunConfigOnlineModel,
-    SecretRef,
-)
+if TYPE_CHECKING:
+    # Annotations and static analysis only; these must never execute at run time. Listing the
+    # names in ``__all__`` is what marks them as re-exports for ruff and the type checkers.
+    from nemo_evaluator_sdk.agent_stream_translation import (
+        AgentStreamTranslation,
+        AgentStreamTranslationContext,
+        AgentStreamTranslator,
+        SseFrame,
+    )
+    from nemo_evaluator_sdk.datasets import DatasetLoadError, load_dataset, load_dataset_as_dicts
+    from nemo_evaluator_sdk.execution.backends.local.backend import LocalBackend
+    from nemo_evaluator_sdk.execution.evaluator import Evaluator
+    from nemo_evaluator_sdk.execution.values import (
+        EvaluationError,
+        EvaluationPhase,
+    )
+    from nemo_evaluator_sdk.metrics.bleu import BLEUMetric
+    from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
+    from nemo_evaluator_sdk.metrics.f1 import F1Metric
+    from nemo_evaluator_sdk.metrics.llm_judge import LLMJudgeMetric
+    from nemo_evaluator_sdk.metrics.number_check import NumberCheckMetric
+    from nemo_evaluator_sdk.metrics.protocol import (
+        Metric,
+        MetricTypeName,
+        validate_metric_result,
+    )
+    from nemo_evaluator_sdk.metrics.remote import NemoAgentToolkitRemoteMetric, RemoteMetric
+    from nemo_evaluator_sdk.metrics.rouge import ROUGEMetric
+    from nemo_evaluator_sdk.metrics.string_check import StringCheckMetric
+    from nemo_evaluator_sdk.metrics.tool_calling import ToolCallingMetric
+    from nemo_evaluator_sdk.metrics.tunable_rag_evaluator import TunableRagEvaluatorMetric
+    from nemo_evaluator_sdk.resolver_protocols import ModelResolver, SecretResolver
+    from nemo_evaluator_sdk.resolvers import LocalModelResolver, LocalSecretResolver
+    from nemo_evaluator_sdk.structured_output import (
+        InferenceFn,
+        InferenceStructuredOutput,
+        StructuredOutput,
+        StructuredOutputMode,
+        default_structured_output_mode,
+        detect_structured_output_mode,
+    )
+    from nemo_evaluator_sdk.values import (
+        Agent,
+        AgentBase,
+        BooleanValue,
+        CandidateOutput,
+        ContinuousScore,
+        DatasetRow,
+        DatasetRows,
+        DiscreteScore,
+        EvaluationResult,
+        FieldMapping,
+        InferenceParams,
+        JSONScoreParser,
+        Label,
+        MetricDescriptor,
+        MetricDiagnostic,
+        MetricInput,
+        MetricOutput,
+        MetricOutputSpec,
+        MetricResult,
+        Model,
+        ModelRef,
+        GenericAgent,
+        NatAgentConfig,
+        NemoAgentToolkitAgent,
+        RangeScore,
+        ReasoningParams,
+        RemoteScore,
+        RubricScore,
+        RunConfig,
+        RunConfigOnline,
+        RunConfigOnlineModel,
+        SecretRef,
+    )
 
 try:
     version = _package_version("nemo-evaluator-sdk")
 except PackageNotFoundError:
     version = "0.0.0"
+
+# Re-exported name -> the submodule that defines it, relative to this package. Relative on
+# purpose: the vendoring tool mirrors this file into nemo_platform.beta.evaluator by rewriting
+# module paths, and a relative name has nothing to rewrite, so the mirror is correct by
+# construction. Mirrors the TYPE_CHECKING block above, in the same order.
+_LAZY_ATTRS: dict[str, str] = {
+    "AgentStreamTranslation": ".agent_stream_translation",
+    "AgentStreamTranslationContext": ".agent_stream_translation",
+    "AgentStreamTranslator": ".agent_stream_translation",
+    "SseFrame": ".agent_stream_translation",
+    "DatasetLoadError": ".datasets",
+    "load_dataset": ".datasets",
+    "load_dataset_as_dicts": ".datasets",
+    "LocalBackend": ".execution.backends.local.backend",
+    "Evaluator": ".execution.evaluator",
+    "EvaluationError": ".execution.values",
+    "EvaluationPhase": ".execution.values",
+    "BLEUMetric": ".metrics.bleu",
+    "ExactMatchMetric": ".metrics.exact_match",
+    "F1Metric": ".metrics.f1",
+    "LLMJudgeMetric": ".metrics.llm_judge",
+    "NumberCheckMetric": ".metrics.number_check",
+    "Metric": ".metrics.protocol",
+    "MetricTypeName": ".metrics.protocol",
+    "validate_metric_result": ".metrics.protocol",
+    "NemoAgentToolkitRemoteMetric": ".metrics.remote",
+    "RemoteMetric": ".metrics.remote",
+    "ROUGEMetric": ".metrics.rouge",
+    "StringCheckMetric": ".metrics.string_check",
+    "ToolCallingMetric": ".metrics.tool_calling",
+    "TunableRagEvaluatorMetric": ".metrics.tunable_rag_evaluator",
+    "ModelResolver": ".resolver_protocols",
+    "SecretResolver": ".resolver_protocols",
+    "LocalModelResolver": ".resolvers",
+    "LocalSecretResolver": ".resolvers",
+    "InferenceFn": ".structured_output",
+    "InferenceStructuredOutput": ".structured_output",
+    "StructuredOutput": ".structured_output",
+    "StructuredOutputMode": ".structured_output",
+    "default_structured_output_mode": ".structured_output",
+    "detect_structured_output_mode": ".structured_output",
+    "Agent": ".values",
+    "AgentBase": ".values",
+    "BooleanValue": ".values",
+    "CandidateOutput": ".values",
+    "ContinuousScore": ".values",
+    "DatasetRow": ".values",
+    "DatasetRows": ".values",
+    "DiscreteScore": ".values",
+    "EvaluationResult": ".values",
+    "FieldMapping": ".values",
+    "InferenceParams": ".values",
+    "JSONScoreParser": ".values",
+    "Label": ".values",
+    "MetricDescriptor": ".values",
+    "MetricDiagnostic": ".values",
+    "MetricInput": ".values",
+    "MetricOutput": ".values",
+    "MetricOutputSpec": ".values",
+    "MetricResult": ".values",
+    "Model": ".values",
+    "ModelRef": ".values",
+    "GenericAgent": ".values",
+    "NatAgentConfig": ".values",
+    "NemoAgentToolkitAgent": ".values",
+    "RangeScore": ".values",
+    "ReasoningParams": ".values",
+    "RemoteScore": ".values",
+    "RubricScore": ".values",
+    "RunConfig": ".values",
+    "RunConfigOnline": ".values",
+    "RunConfigOnlineModel": ".values",
+    "SecretRef": ".values",
+}
 
 __all__ = [
     "BLEUMetric",
@@ -156,3 +246,26 @@ __all__ = [
     "validate_metric_result",
     "version",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Import the submodule that defines ``name`` on first access (PEP 562).
+
+    ``AttributeError`` is the required failure mode, not ``ImportError``: ``from pkg import sub``
+    only falls back to importing a submodule when attribute lookup raises ``AttributeError``, and
+    ``hasattr`` checks against this package depend on it too.
+    """
+    submodule = _LAZY_ATTRS.get(name)
+    if submodule is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(submodule, __name__), name)
+    globals()[name] = value  # cache, so later lookups skip __getattr__ entirely
+    return value
+
+
+def __dir__() -> list[str]:
+    # The declared surface plus any submodule the caller has already imported. ``import_module``
+    # and ``TYPE_CHECKING`` are machinery for __getattr__, not API, so keep them out of
+    # autocomplete and inspect.getmembers.
+    public = {name for name in globals() if not name.startswith("_")} - {"TYPE_CHECKING", "import_module"}
+    return sorted(set(__all__) | public)

--- a/packages/nemo_evaluator_sdk/tests/test_lazy_public_api.py
+++ b/packages/nemo_evaluator_sdk/tests/test_lazy_public_api.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Guards the lazy (PEP 562) public surface of ``nemo_evaluator_sdk/__init__.py``.
+
+Importing any submodule runs the package ``__init__`` first, so a single convenience
+``from nemo_evaluator_sdk.… import …`` added at module scope silently re-drags the whole
+backend/benchmark/metric stack into every consumer that only wanted ``agent_eval`` — the
+regression these tests exist to catch (AALGO-429).
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+# Imported out-of-process on purpose: by the time this module runs under pytest, sibling suites
+# have already pulled the execution stack into sys.modules, so an in-process check proves nothing.
+_PROBE = """
+import json, sys
+from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import HarborAgentTaskRunner
+assert HarborAgentTaskRunner is not None
+print(json.dumps(sorted(sys.modules)))
+"""
+
+
+def test_agent_eval_import_does_not_pull_the_execution_stack() -> None:
+    """The optimizer imports only ``agent_eval``; it must not pay for backends and benchmarks.
+
+    Beyond start-up cost, every module loaded here is a package whose import failure becomes an
+    SDK-path failure at evaluation time. Keeping the boundary tight is what lets the consumer's
+    deferred SDK import actually contain a broken install.
+    """
+    proc = subprocess.run([sys.executable, "-c", _PROBE], capture_output=True, text=True, timeout=120)
+    assert proc.returncode == 0, proc.stderr
+
+    # Last line only: the child inherits the environment, so a sitecustomize banner or an
+    # import-time print() would otherwise turn this into an opaque JSONDecodeError.
+    modules = set(json.loads(proc.stdout.strip().splitlines()[-1]))
+
+    leaked = sorted(name for name in modules if name.startswith("nemo_evaluator_sdk.execution"))
+    assert leaked == [], f"the package __init__ re-drags the execution stack: {leaked}"
+
+    # Exactly the packages the eager __init__ used to drag in; each one goes red if it returns.
+    # rouge_score is deliberately absent: metrics/rouge.py already defers it into a
+    # cached_property, so it was never on this path and asserting it would prove nothing.
+    heavy = {"openai", "sacrebleu", "zstandard"} & modules
+    assert heavy == set(), f"heavy metric-stack dependencies pulled in: {sorted(heavy)}"
+
+    # A canary, not a spec: measured at 483 modules when this landed, down from 1416. Raise the
+    # bound if a genuine agent_eval dependency lands; a jump of >100 means something re-drags a
+    # barrel module and should be investigated rather than accommodated.
+    assert len(modules) < 700, f"agent_eval import surface grew to {len(modules)} modules"
+
+
+def test_every_public_name_resolves() -> None:
+    """``__all__`` and ``_LAZY_ATTRS`` must not drift apart.
+
+    A typo in the lazy table is invisible until a consumer hits that one attribute, so resolve
+    the whole surface in one pass.
+    """
+    import nemo_evaluator_sdk
+
+    for name in nemo_evaluator_sdk.__all__:
+        assert getattr(nemo_evaluator_sdk, name) is not None, name
+
+    assert set(nemo_evaluator_sdk.__all__) <= set(dir(nemo_evaluator_sdk))
+
+
+def test_unknown_attribute_raises_attribute_error() -> None:
+    """``from pkg import submodule`` and ``hasattr`` both rely on ``AttributeError`` here."""
+    import nemo_evaluator_sdk
+
+    with pytest.raises(AttributeError):
+        nemo_evaluator_sdk.NoSuchName  # noqa: B018
+
+    # The submodule fallback that AttributeError enables.
+    from nemo_evaluator_sdk import values
+
+    assert values.__name__ == "nemo_evaluator_sdk.values"

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/__init__.py
@@ -1,90 +1,180 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""NeMo Evaluator SDK."""
+"""NeMo Evaluator SDK.
+
+The public surface resolves lazily (PEP 562). Importing this package must not drag in the
+execution/backend or metric stack: importing any submodule runs this module first, so eager
+re-exports made ``import nemo_platform.beta.evaluator.agent_eval.runtimes.harbor_runtime`` — all the
+optimizer needs — cost ~1400 modules (openai, sacrebleu, zstandard, pyarrow, ...) instead
+of ~480, and turned every one of those transitive packages into an evaluation-time failure mode
+for the SDK-backed evaluator.
+
+Add a new re-export to ``_LAZY_ATTRS``, the ``TYPE_CHECKING`` block and ``__all__`` — never as a
+module-level import. ``tests/test_lazy_public_api.py`` locks the boundary in.
+"""
 
 # ruff: noqa: I001 - the vendored SDK mirror uses different import-order settings.
 
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _package_version
+from typing import TYPE_CHECKING
 
-from nemo_platform.beta.evaluator.agent_stream_translation import (
-    AgentStreamTranslation,
-    AgentStreamTranslationContext,
-    AgentStreamTranslator,
-    SseFrame,
-)
-from nemo_platform.beta.evaluator.datasets import DatasetLoadError, load_dataset, load_dataset_as_dicts
-from nemo_platform.beta.evaluator.execution.backends.local.backend import LocalBackend
-from nemo_platform.beta.evaluator.execution.evaluator import Evaluator
-from nemo_platform.beta.evaluator.execution.values import (
-    EvaluationError,
-    EvaluationPhase,
-)
-from nemo_platform.beta.evaluator.metrics.bleu import BLEUMetric
-from nemo_platform.beta.evaluator.metrics.exact_match import ExactMatchMetric
-from nemo_platform.beta.evaluator.metrics.f1 import F1Metric
-from nemo_platform.beta.evaluator.metrics.llm_judge import LLMJudgeMetric
-from nemo_platform.beta.evaluator.metrics.number_check import NumberCheckMetric
-from nemo_platform.beta.evaluator.metrics.protocol import (
-    Metric,
-    MetricTypeName,
-    validate_metric_result,
-)
-from nemo_platform.beta.evaluator.metrics.remote import NemoAgentToolkitRemoteMetric, RemoteMetric
-from nemo_platform.beta.evaluator.metrics.rouge import ROUGEMetric
-from nemo_platform.beta.evaluator.metrics.string_check import StringCheckMetric
-from nemo_platform.beta.evaluator.metrics.tool_calling import ToolCallingMetric
-from nemo_platform.beta.evaluator.metrics.tunable_rag_evaluator import TunableRagEvaluatorMetric
-from nemo_platform.beta.evaluator.resolver_protocols import ModelResolver, SecretResolver
-from nemo_platform.beta.evaluator.resolvers import LocalModelResolver, LocalSecretResolver
-from nemo_platform.beta.evaluator.structured_output import (
-    InferenceFn,
-    InferenceStructuredOutput,
-    StructuredOutput,
-    StructuredOutputMode,
-    default_structured_output_mode,
-    detect_structured_output_mode,
-)
-from nemo_platform.beta.evaluator.values import (
-    Agent,
-    AgentBase,
-    BooleanValue,
-    CandidateOutput,
-    ContinuousScore,
-    DatasetRow,
-    DatasetRows,
-    DiscreteScore,
-    EvaluationResult,
-    FieldMapping,
-    InferenceParams,
-    JSONScoreParser,
-    Label,
-    MetricDescriptor,
-    MetricDiagnostic,
-    MetricInput,
-    MetricOutput,
-    MetricOutputSpec,
-    MetricResult,
-    Model,
-    ModelRef,
-    GenericAgent,
-    NatAgentConfig,
-    NemoAgentToolkitAgent,
-    RangeScore,
-    ReasoningParams,
-    RemoteScore,
-    RubricScore,
-    RunConfig,
-    RunConfigOnline,
-    RunConfigOnlineModel,
-    SecretRef,
-)
+if TYPE_CHECKING:
+    # Annotations and static analysis only; these must never execute at run time. Listing the
+    # names in ``__all__`` is what marks them as re-exports for ruff and the type checkers.
+    from nemo_platform.beta.evaluator.agent_stream_translation import (
+        AgentStreamTranslation,
+        AgentStreamTranslationContext,
+        AgentStreamTranslator,
+        SseFrame,
+    )
+    from nemo_platform.beta.evaluator.datasets import DatasetLoadError, load_dataset, load_dataset_as_dicts
+    from nemo_platform.beta.evaluator.execution.backends.local.backend import LocalBackend
+    from nemo_platform.beta.evaluator.execution.evaluator import Evaluator
+    from nemo_platform.beta.evaluator.execution.values import (
+        EvaluationError,
+        EvaluationPhase,
+    )
+    from nemo_platform.beta.evaluator.metrics.bleu import BLEUMetric
+    from nemo_platform.beta.evaluator.metrics.exact_match import ExactMatchMetric
+    from nemo_platform.beta.evaluator.metrics.f1 import F1Metric
+    from nemo_platform.beta.evaluator.metrics.llm_judge import LLMJudgeMetric
+    from nemo_platform.beta.evaluator.metrics.number_check import NumberCheckMetric
+    from nemo_platform.beta.evaluator.metrics.protocol import (
+        Metric,
+        MetricTypeName,
+        validate_metric_result,
+    )
+    from nemo_platform.beta.evaluator.metrics.remote import NemoAgentToolkitRemoteMetric, RemoteMetric
+    from nemo_platform.beta.evaluator.metrics.rouge import ROUGEMetric
+    from nemo_platform.beta.evaluator.metrics.string_check import StringCheckMetric
+    from nemo_platform.beta.evaluator.metrics.tool_calling import ToolCallingMetric
+    from nemo_platform.beta.evaluator.metrics.tunable_rag_evaluator import TunableRagEvaluatorMetric
+    from nemo_platform.beta.evaluator.resolver_protocols import ModelResolver, SecretResolver
+    from nemo_platform.beta.evaluator.resolvers import LocalModelResolver, LocalSecretResolver
+    from nemo_platform.beta.evaluator.structured_output import (
+        InferenceFn,
+        InferenceStructuredOutput,
+        StructuredOutput,
+        StructuredOutputMode,
+        default_structured_output_mode,
+        detect_structured_output_mode,
+    )
+    from nemo_platform.beta.evaluator.values import (
+        Agent,
+        AgentBase,
+        BooleanValue,
+        CandidateOutput,
+        ContinuousScore,
+        DatasetRow,
+        DatasetRows,
+        DiscreteScore,
+        EvaluationResult,
+        FieldMapping,
+        InferenceParams,
+        JSONScoreParser,
+        Label,
+        MetricDescriptor,
+        MetricDiagnostic,
+        MetricInput,
+        MetricOutput,
+        MetricOutputSpec,
+        MetricResult,
+        Model,
+        ModelRef,
+        GenericAgent,
+        NatAgentConfig,
+        NemoAgentToolkitAgent,
+        RangeScore,
+        ReasoningParams,
+        RemoteScore,
+        RubricScore,
+        RunConfig,
+        RunConfigOnline,
+        RunConfigOnlineModel,
+        SecretRef,
+    )
 
 try:
     version = _package_version("nemo-evaluator-sdk")
 except PackageNotFoundError:
     version = "0.0.0"
+
+# Re-exported name -> the submodule that defines it, relative to this package. Relative on
+# purpose: the vendoring tool mirrors this file into nemo_platform.beta.evaluator by rewriting
+# module paths, and a relative name has nothing to rewrite, so the mirror is correct by
+# construction. Mirrors the TYPE_CHECKING block above, in the same order.
+_LAZY_ATTRS: dict[str, str] = {
+    "AgentStreamTranslation": ".agent_stream_translation",
+    "AgentStreamTranslationContext": ".agent_stream_translation",
+    "AgentStreamTranslator": ".agent_stream_translation",
+    "SseFrame": ".agent_stream_translation",
+    "DatasetLoadError": ".datasets",
+    "load_dataset": ".datasets",
+    "load_dataset_as_dicts": ".datasets",
+    "LocalBackend": ".execution.backends.local.backend",
+    "Evaluator": ".execution.evaluator",
+    "EvaluationError": ".execution.values",
+    "EvaluationPhase": ".execution.values",
+    "BLEUMetric": ".metrics.bleu",
+    "ExactMatchMetric": ".metrics.exact_match",
+    "F1Metric": ".metrics.f1",
+    "LLMJudgeMetric": ".metrics.llm_judge",
+    "NumberCheckMetric": ".metrics.number_check",
+    "Metric": ".metrics.protocol",
+    "MetricTypeName": ".metrics.protocol",
+    "validate_metric_result": ".metrics.protocol",
+    "NemoAgentToolkitRemoteMetric": ".metrics.remote",
+    "RemoteMetric": ".metrics.remote",
+    "ROUGEMetric": ".metrics.rouge",
+    "StringCheckMetric": ".metrics.string_check",
+    "ToolCallingMetric": ".metrics.tool_calling",
+    "TunableRagEvaluatorMetric": ".metrics.tunable_rag_evaluator",
+    "ModelResolver": ".resolver_protocols",
+    "SecretResolver": ".resolver_protocols",
+    "LocalModelResolver": ".resolvers",
+    "LocalSecretResolver": ".resolvers",
+    "InferenceFn": ".structured_output",
+    "InferenceStructuredOutput": ".structured_output",
+    "StructuredOutput": ".structured_output",
+    "StructuredOutputMode": ".structured_output",
+    "default_structured_output_mode": ".structured_output",
+    "detect_structured_output_mode": ".structured_output",
+    "Agent": ".values",
+    "AgentBase": ".values",
+    "BooleanValue": ".values",
+    "CandidateOutput": ".values",
+    "ContinuousScore": ".values",
+    "DatasetRow": ".values",
+    "DatasetRows": ".values",
+    "DiscreteScore": ".values",
+    "EvaluationResult": ".values",
+    "FieldMapping": ".values",
+    "InferenceParams": ".values",
+    "JSONScoreParser": ".values",
+    "Label": ".values",
+    "MetricDescriptor": ".values",
+    "MetricDiagnostic": ".values",
+    "MetricInput": ".values",
+    "MetricOutput": ".values",
+    "MetricOutputSpec": ".values",
+    "MetricResult": ".values",
+    "Model": ".values",
+    "ModelRef": ".values",
+    "GenericAgent": ".values",
+    "NatAgentConfig": ".values",
+    "NemoAgentToolkitAgent": ".values",
+    "RangeScore": ".values",
+    "ReasoningParams": ".values",
+    "RemoteScore": ".values",
+    "RubricScore": ".values",
+    "RunConfig": ".values",
+    "RunConfigOnline": ".values",
+    "RunConfigOnlineModel": ".values",
+    "SecretRef": ".values",
+}
 
 __all__ = [
     "BLEUMetric",
@@ -156,3 +246,26 @@ __all__ = [
     "validate_metric_result",
     "version",
 ]
+
+
+def __getattr__(name: str) -> object:
+    """Import the submodule that defines ``name`` on first access (PEP 562).
+
+    ``AttributeError`` is the required failure mode, not ``ImportError``: ``from pkg import sub``
+    only falls back to importing a submodule when attribute lookup raises ``AttributeError``, and
+    ``hasattr`` checks against this package depend on it too.
+    """
+    submodule = _LAZY_ATTRS.get(name)
+    if submodule is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(submodule, __name__), name)
+    globals()[name] = value  # cache, so later lookups skip __getattr__ entirely
+    return value
+
+
+def __dir__() -> list[str]:
+    # The declared surface plus any submodule the caller has already imported. ``import_module``
+    # and ``TYPE_CHECKING`` are machinery for __getattr__, not API, so keep them out of
+    # autocomplete and inspect.getmembers.
+    public = {name for name in globals() if not name.startswith("_")} - {"TYPE_CHECKING", "import_module"}
+    return sorted(set(__all__) | public)


### PR DESCRIPTION
Closes [AALGO-429](https://linear.app/nvidia/issue/AALGO-429/lighten-init-py-agent-eval-imports-drag-the-benchmarkbackend-stack-p) — P2.1 in the evaluator/optimizer integration plan

## Problem

- `nemo_evaluator_sdk/__init__.py` eagerly re-exported 67 names across 10 subpackages.
- Importing any submodule runs the parent `__init__` first, so `import nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime` — all the optimizer / experimentalist path needs — dragged in the whole backend, benchmark-execution and metric stack.
- This partly defeated the consumer's lazy-import design: the deferred SDK import still contained an *import failure*, but once it fired it loaded a far wider **runtime** surface, so any of those transitive packages failing to import became an SDK-path failure at evaluation time.

## Measured (py3.12, warm `__pycache__`, asserting the real `HarborAgentTaskRunner` was imported)

| | Before | After |
| --- | --- | --- |
| Wall | 2.32 s | **0.95 s** (−59%) |
| Modules loaded | 1416 | **485** (−66%) |
| `nemo_evaluator_sdk.execution.*` in `sys.modules` | 15 | **0** |
| Heavy third-party | pyarrow, sacrebleu, openai, zstandard, numpy, jinja2, jsonschema | pyarrow, numpy, jinja2, jsonschema |

`openai`, `sacrebleu` and `zstandard` leave the `agent_eval` path entirely. 485 lands on the 483 target measured with the parent stubbed.

## Change

- The 67 re-exports move under `if TYPE_CHECKING:` (unchanged, so type checkers and autocomplete still see the full surface) and resolve through a table-driven module `__getattr__` that caches into `globals()`. `__all__` is byte-identical; `dir()` stays aligned with the declared surface.
- `_LAZY_ATTRS` maps each name to a **relative** submodule (`".execution.backends.local.backend"`). Deliberate: the vendoring tool mirrors this file into `nemo_platform.beta.evaluator` by rewriting module paths, and a relative name has nothing to rewrite — the mirror is correct by construction.
- New `tests/test_lazy_public_api.py`: an out-of-process probe asserting no `execution.*` / heavy-package leakage plus a module-count canary, a loop over `__all__` that catches any drift in the lazy table, and an `AttributeError` test covering the `from pkg import submodule` fallback.

## Why it's safe

- Public API unchanged — `from nemo_evaluator_sdk import LocalBackend` still works.
- Object identity preserved for every re-export, including the `MetricInput`/`MetricOutput`/`MetricOutputSpec`/`MetricResult` names that exist in both `values` and `metrics.protocol` (the table matches the original import source).
- No key in `_LAZY_ATTRS` shadows a submodule name; `_LAZY_ATTRS` and `__all__` are in sync both ways; no SDK module imports from its own package root, so no new cycle.
- Repo-wide, only 16 of the 58 `__all__` names are ever reached through the top-level path, and there are no `import *`, no `getattr(nemo_evaluator_sdk, …)` and no top-level `mock.patch` targets. `mock.patch` round-trips correctly against a never-yet-accessed lazy name.
- Vendored mirror regenerated with `make vendor` (idempotent); `tools/lint/lint-sdk-vendored.sh` passes.

## Verification

- `pytest packages/nemo_evaluator_sdk/tests` — 1411 passed
- `pytest plugins/nemo-evaluator/tests docs/evaluator/test_doc_examples.py` — 727 passed (2 pre-existing failures in `test_publish_to_intake.py`, a local-platform integration test, unchanged with the diff stashed)
- `ruff check` / `ruff format --check` clean; `ty check` 783 → 782 diagnostics
- `pre-commit run --files <changed>` — all hooks pass

## Follow-up

Input for [AALGO-311](https://linear.app/nvidia/issue/AALGO-311/figure-out-the-dependency-path-between-nemo-optimiser-and-nemo) C2 / P2.2 — with the `__init__` lightened, the residual heavy closure for the `agent_eval` path is pydantic + **pyarrow, numpy, jinja2, jsonschema**, reached via `values/common.py → values/datasets.py` and `values/metrics.py → dataset_schemas/common.py`. Measured separately: lazifying `values/__init__.py` buys nothing (484 vs 483 modules) — those are module-to-module edges, not barrel imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved package startup by loading public components only when they are accessed.
  - Reduced unnecessary loading of execution modules and heavy evaluation dependencies.

- **Compatibility**
  - Existing public names remain available through the package’s public API.
  - Unknown attributes now produce clear attribute errors.

- **Tests**
  - Added coverage for lazy loading, public API resolution, and attribute handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->