### PR TITLE
fix(cli): persist Anthropic auth header format during setup

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -542,9 +542,7 @@ def _create_provider(
     if secret_name:
         kwargs["api_key_secret_name"] = secret_name
     if auth_header_format:
-        header_name, _, header_value = auth_header_format.partition(":")
-        if header_name and header_value:
-            kwargs["required_extra_headers"] = {header_name.strip(): header_value.strip()}
+        kwargs["auth_header_format"] = auth_header_format
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
     provider_type = _provider_type_for_connection(name, host_url)
@@ -571,6 +569,7 @@ def _update_provider(
     host_url: str,
     secret_name: str | None,
     workspace: str,
+    auth_header_format: str | None = None,
     default_extra_headers: dict[str, str] | None = None,
 ) -> None:
     kwargs: dict = {
@@ -579,6 +578,8 @@ def _update_provider(
     }
     if secret_name:
         kwargs["api_key_secret_name"] = secret_name
+    if auth_header_format:
+        kwargs["auth_header_format"] = auth_header_format
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
     provider_type = _provider_type_for_connection(name, host_url)
@@ -1734,6 +1735,7 @@ def _register_provider_interactive(
             host_url=host_url,
             secret_name=secret_name,
             workspace=workspace,
+            auth_header_format=auth_header_format,
             default_extra_headers=default_extra_headers,
         )
         console.print(f"  {CHECK} Updated provider '{provider_name}' ({host_url})")
@@ -1904,6 +1906,7 @@ def _auto_setup(client: NeMoPlatform, workspace: str) -> bool:
                 host_url=host_url,
                 secret_name=secret_name,
                 workspace=workspace,
+                auth_header_format=auth_header_format,
                 default_extra_headers=default_extra_headers,
             )
             console.print(f"  {CHECK} Updated provider '{provider_name}' ({host_url})")

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -580,6 +580,7 @@ def _update_provider(
         kwargs["api_key_secret_name"] = secret_name
     if auth_header_format:
         kwargs["auth_header_format"] = auth_header_format
+        kwargs["required_extra_headers"] = None
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
     provider_type = _provider_type_for_connection(name, host_url)

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -391,7 +391,7 @@ class TestCreateProvider:
         return client
 
     def test_anthropic_provider_kwargs(self):
-        """auth_header_format must be mapped to required_extra_headers, not passed raw."""
+        """Provider creation keeps auth templating in the dedicated field."""
         client = self._make_client()
         _create_provider(
             client,
@@ -403,12 +403,13 @@ class TestCreateProvider:
             default_extra_headers={"anthropic-version": "2023-06-01"},
         )
         call_kwargs = client.inference.providers.create.call_args.kwargs
-        assert "auth_header_format" not in call_kwargs
-        assert call_kwargs["required_extra_headers"]["X-Api-Key"] == "{{ auth_secret }}"
+        assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
+        assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
+        assert "required_extra_headers" not in call_kwargs
         assert call_kwargs["default_extra_headers"] == {"anthropic-version": "2023-06-01"}
 
-    def test_no_auth_header_format_skips_required_extra_headers(self):
-        """When auth_header_format is None, required_extra_headers should not be added."""
+    def test_no_auth_header_format_skips_auth_fields(self):
+        """Providers using default Bearer auth do not send auth overrides."""
         client = self._make_client()
         _create_provider(
             client,
@@ -526,15 +527,18 @@ class TestAutoSetup:
         assert create_kwargs.kwargs["name"] == "anthropic"
 
     def test_anthropic_auto_setup_maps_auth_header(self):
-        """Auto-setup with ANTHROPIC_API_KEY must map auth_header_format to required_extra_headers."""
+        """Auto-setup persists the Anthropic auth template without exposing the key."""
         client = _make_mock_client()
-        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-test"}, clear=True):
+        api_key = "sk-ant-test"
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": api_key}, clear=True):
             result = _auto_setup(client, "default")
         assert result is True
         call_kwargs = client.inference.providers.create.call_args.kwargs
         assert call_kwargs["name"] == "anthropic"
-        assert "auth_header_format" not in call_kwargs
-        assert "X-Api-Key" in call_kwargs["required_extra_headers"]
+        assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
+        assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
+        assert "required_extra_headers" not in call_kwargs
+        assert api_key not in str(call_kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -1690,20 +1694,37 @@ class TestProviderIdempotency:
         client.inference.providers.update.assert_not_called()
 
     def test_existing_provider_updated_with_extra_headers(self):
-        """Provider update passes through default_extra_headers (auth_header_format is create-only)."""
+        """Provider update repairs Anthropic auth without exposing the API key."""
         client = _make_mock_client(secret_exists=False, provider_exists=True)
+        api_key = "sk-ant-test"
         _register_provider_interactive(
             client,
             provider_name="anthropic",
             host_url="https://api.anthropic.com",
-            api_key="sk-ant-test",
+            api_key=api_key,
             workspace="default",
             auth_header_format="X-Api-Key: {{ auth_secret }}",
             default_extra_headers={"anthropic-version": "2023-06-01"},
         )
         call_kwargs = client.inference.providers.update.call_args.kwargs
-        assert "auth_header_format" not in call_kwargs
+        assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
+        assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
+        assert "required_extra_headers" not in call_kwargs
+        assert api_key not in str(call_kwargs)
         assert call_kwargs["default_extra_headers"] == {"anthropic-version": "2023-06-01"}
+
+    def test_auto_setup_updates_existing_anthropic_auth(self):
+        """Auto setup repairs an existing Anthropic provider's auth template."""
+        client = _make_mock_client(provider_exists=True, secret_exists=True)
+        api_key = "sk-ant-updated"
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": api_key}, clear=True):
+            result = _auto_setup(client, "default")
+        assert result is True
+        call_kwargs = client.inference.providers.update.call_args.kwargs
+        assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
+        assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
+        assert "required_extra_headers" not in call_kwargs
+        assert api_key not in str(call_kwargs)
 
     # -- auto path --
 

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -1709,7 +1709,7 @@ class TestProviderIdempotency:
         call_kwargs = client.inference.providers.update.call_args.kwargs
         assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
         assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
-        assert "required_extra_headers" not in call_kwargs
+        assert call_kwargs["required_extra_headers"] is None
         assert api_key not in str(call_kwargs)
         assert call_kwargs["default_extra_headers"] == {"anthropic-version": "2023-06-01"}
 
@@ -1723,7 +1723,7 @@ class TestProviderIdempotency:
         call_kwargs = client.inference.providers.update.call_args.kwargs
         assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
         assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
-        assert "required_extra_headers" not in call_kwargs
+        assert call_kwargs["required_extra_headers"] is None
         assert api_key not in str(call_kwargs)
 
     # -- auto path --

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -542,9 +542,7 @@ def _create_provider(
     if secret_name:
         kwargs["api_key_secret_name"] = secret_name
     if auth_header_format:
-        header_name, _, header_value = auth_header_format.partition(":")
-        if header_name and header_value:
-            kwargs["required_extra_headers"] = {header_name.strip(): header_value.strip()}
+        kwargs["auth_header_format"] = auth_header_format
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
     provider_type = _provider_type_for_connection(name, host_url)
@@ -571,6 +569,7 @@ def _update_provider(
     host_url: str,
     secret_name: str | None,
     workspace: str,
+    auth_header_format: str | None = None,
     default_extra_headers: dict[str, str] | None = None,
 ) -> None:
     kwargs: dict = {
@@ -579,6 +578,8 @@ def _update_provider(
     }
     if secret_name:
         kwargs["api_key_secret_name"] = secret_name
+    if auth_header_format:
+        kwargs["auth_header_format"] = auth_header_format
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
     provider_type = _provider_type_for_connection(name, host_url)
@@ -1734,6 +1735,7 @@ def _register_provider_interactive(
             host_url=host_url,
             secret_name=secret_name,
             workspace=workspace,
+            auth_header_format=auth_header_format,
             default_extra_headers=default_extra_headers,
         )
         console.print(f"  {CHECK} Updated provider '{provider_name}' ({host_url})")
@@ -1904,6 +1906,7 @@ def _auto_setup(client: NeMoPlatform, workspace: str) -> bool:
                 host_url=host_url,
                 secret_name=secret_name,
                 workspace=workspace,
+                auth_header_format=auth_header_format,
                 default_extra_headers=default_extra_headers,
             )
             console.print(f"  {CHECK} Updated provider '{provider_name}' ({host_url})")

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -580,6 +580,7 @@ def _update_provider(
         kwargs["api_key_secret_name"] = secret_name
     if auth_header_format:
         kwargs["auth_header_format"] = auth_header_format
+        kwargs["required_extra_headers"] = None
     if default_extra_headers:
         kwargs["default_extra_headers"] = default_extra_headers
     provider_type = _provider_type_for_connection(name, host_url)

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -391,7 +391,7 @@ class TestCreateProvider:
         return client
 
     def test_anthropic_provider_kwargs(self):
-        """auth_header_format must be mapped to required_extra_headers, not passed raw."""
+        """Provider creation keeps auth templating in the dedicated field."""
         client = self._make_client()
         _create_provider(
             client,
@@ -403,12 +403,13 @@ class TestCreateProvider:
             default_extra_headers={"anthropic-version": "2023-06-01"},
         )
         call_kwargs = client.inference.providers.create.call_args.kwargs
-        assert "auth_header_format" not in call_kwargs
-        assert call_kwargs["required_extra_headers"]["X-Api-Key"] == "{{ auth_secret }}"
+        assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
+        assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
+        assert "required_extra_headers" not in call_kwargs
         assert call_kwargs["default_extra_headers"] == {"anthropic-version": "2023-06-01"}
 
-    def test_no_auth_header_format_skips_required_extra_headers(self):
-        """When auth_header_format is None, required_extra_headers should not be added."""
+    def test_no_auth_header_format_skips_auth_fields(self):
+        """Providers using default Bearer auth do not send auth overrides."""
         client = self._make_client()
         _create_provider(
             client,
@@ -526,15 +527,18 @@ class TestAutoSetup:
         assert create_kwargs.kwargs["name"] == "anthropic"
 
     def test_anthropic_auto_setup_maps_auth_header(self):
-        """Auto-setup with ANTHROPIC_API_KEY must map auth_header_format to required_extra_headers."""
+        """Auto-setup persists the Anthropic auth template without exposing the key."""
         client = _make_mock_client()
-        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-test"}, clear=True):
+        api_key = "sk-ant-test"
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": api_key}, clear=True):
             result = _auto_setup(client, "default")
         assert result is True
         call_kwargs = client.inference.providers.create.call_args.kwargs
         assert call_kwargs["name"] == "anthropic"
-        assert "auth_header_format" not in call_kwargs
-        assert "X-Api-Key" in call_kwargs["required_extra_headers"]
+        assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
+        assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
+        assert "required_extra_headers" not in call_kwargs
+        assert api_key not in str(call_kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -1690,20 +1694,37 @@ class TestProviderIdempotency:
         client.inference.providers.update.assert_not_called()
 
     def test_existing_provider_updated_with_extra_headers(self):
-        """Provider update passes through default_extra_headers (auth_header_format is create-only)."""
+        """Provider update repairs Anthropic auth without exposing the API key."""
         client = _make_mock_client(secret_exists=False, provider_exists=True)
+        api_key = "sk-ant-test"
         _register_provider_interactive(
             client,
             provider_name="anthropic",
             host_url="https://api.anthropic.com",
-            api_key="sk-ant-test",
+            api_key=api_key,
             workspace="default",
             auth_header_format="X-Api-Key: {{ auth_secret }}",
             default_extra_headers={"anthropic-version": "2023-06-01"},
         )
         call_kwargs = client.inference.providers.update.call_args.kwargs
-        assert "auth_header_format" not in call_kwargs
+        assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
+        assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
+        assert "required_extra_headers" not in call_kwargs
+        assert api_key not in str(call_kwargs)
         assert call_kwargs["default_extra_headers"] == {"anthropic-version": "2023-06-01"}
+
+    def test_auto_setup_updates_existing_anthropic_auth(self):
+        """Auto setup repairs an existing Anthropic provider's auth template."""
+        client = _make_mock_client(provider_exists=True, secret_exists=True)
+        api_key = "sk-ant-updated"
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": api_key}, clear=True):
+            result = _auto_setup(client, "default")
+        assert result is True
+        call_kwargs = client.inference.providers.update.call_args.kwargs
+        assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
+        assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
+        assert "required_extra_headers" not in call_kwargs
+        assert api_key not in str(call_kwargs)
 
     # -- auto path --
 

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -1709,7 +1709,7 @@ class TestProviderIdempotency:
         call_kwargs = client.inference.providers.update.call_args.kwargs
         assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
         assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
-        assert "required_extra_headers" not in call_kwargs
+        assert call_kwargs["required_extra_headers"] is None
         assert api_key not in str(call_kwargs)
         assert call_kwargs["default_extra_headers"] == {"anthropic-version": "2023-06-01"}
 
@@ -1723,7 +1723,7 @@ class TestProviderIdempotency:
         call_kwargs = client.inference.providers.update.call_args.kwargs
         assert call_kwargs["api_key_secret_name"] == "anthropic-api-key"
         assert call_kwargs["auth_header_format"] == "X-Api-Key: {{ auth_secret }}"
-        assert "required_extra_headers" not in call_kwargs
+        assert call_kwargs["required_extra_headers"] is None
         assert api_key not in str(call_kwargs)
 
     # -- auto path --


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

`nemo setup` currently stores Anthropic's `X-Api-Key` template in `required_extra_headers`, where it remains the literal string `{{ auth_secret }}` and Anthropic rejects every request. This change persists the existing provider definition's `auth_header_format` field on both create and update, so the inference gateway renders the secret at request time; default Bearer-auth providers are unchanged.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Pass the provider definition's `auth_header_format` through setup provider create and update calls.
- Repair existing Anthropic providers by explicitly clearing legacy `required_extra_headers` when interactive or automatic setup is rerun.
- Add create, interactive-update, auto-update, and raw-key non-disclosure regression coverage.
- Regenerate the vendored NeMo Platform SDK source and tests.
- Keep the fix scoped to setup: no Models or inference-gateway implementation changes.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the supported Anthropic provider command and `auth_header_format` behavior are already documented; this fixes `nemo setup` to follow that contract.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation on current head (`242b66df17`):

```bash
uv run --frozen pytest \
  packages/nemo_platform_ext/tests/cli/commands/test_setup.py -v
# 217 passed

uv run --frozen pytest \
  sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py -v
# 217 passed

uv run ruff check \
  packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py \
  packages/nemo_platform_ext/tests/cli/commands/test_setup.py
# passed

uv run ruff format --check \
  packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py \
  packages/nemo_platform_ext/tests/cli/commands/test_setup.py
# passed

uv run --frozen ty check \
  packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
# passed

uv run --frozen pre-commit run -a
# all hooks passed

make vendor-nemo-platform-ext
# completed; expected source and test copies regenerated

git diff --check
# passed
```

### Live reproduction on `origin/main` before the fix

Prerequisites: a local Platform at `http://localhost:8080` and a valid `ANTHROPIC_API_KEY` exported in the shell. I used an isolated workspace and removed other provider credential variables from the repro shell so automatic setup selected Anthropic.

```bash
export NMP_BASE_URL=http://localhost:8080
export REPRO_WORKSPACE=anthropic-auth-repro
unset NVIDIA_API_KEY OPENAI_API_KEY GEMINI_API_KEY
test -n "$ANTHROPIC_API_KEY"

uv run nemo setup --auto \
  --workspace "$REPRO_WORKSPACE" \
  --no-start-services \
  --no-install-skills \
  --no-deploy-agent

uv run nemo inference providers get anthropic \
  --workspace "$REPRO_WORKSPACE" \
  --output-format json \
  | jq '{auth_header_format, required_extra_headers, default_extra_headers}'
```

Observed provider state:

```json
{
  "auth_header_format": null,
  "required_extra_headers": {"X-Api-Key": "{{ auth_secret }}"},
  "default_extra_headers": {"anthropic-version": "2023-06-01"}
}
```

A real Anthropic Messages request through the provider route then failed:

```bash
curl --fail-with-body --silent --show-error \
  -X POST \
  "${NMP_BASE_URL}/apis/inference-gateway/v2/workspaces/${REPRO_WORKSPACE}/provider/anthropic/-/v1/messages" \
  -H 'Accept-Encoding: identity' \
  -H 'Content-Type: application/json' \
  -d '{"model":"claude-sonnet-4-5-20250929","max_tokens":8,"messages":[{"role":"user","content":"Reply with OK."}]}'
```

Observed result: Platform HTTP 502 wrapping Anthropic HTTP 401 `authentication_error: invalid x-api-key`.

### Live verification after the fix

Rerunning the same setup command updated the existing secret and provider. On a second clean Platform instance created from `origin/main`, the fixed CLI also created the provider successfully from scratch.

```bash
uv run nemo setup --auto \
  --workspace "$REPRO_WORKSPACE" \
  --no-start-services \
  --no-install-skills \
  --no-deploy-agent

uv run nemo inference providers get anthropic \
  --workspace "$REPRO_WORKSPACE" \
  --output-format json \
  | jq '{auth_header_format, required_extra_headers, status, served_models: (.served_models | length)}'
```

Observed provider state after reconciliation:

```json
{
  "auth_header_format": "X-Api-Key: {{ auth_secret }}",
  "required_extra_headers": null,
  "status": "READY",
  "served_models": 10
}
```

The real Anthropic Messages request then succeeded:

```bash
curl --fail-with-body --silent --show-error \
  -X POST \
  "${NMP_BASE_URL}/apis/inference-gateway/v2/workspaces/${REPRO_WORKSPACE}/provider/anthropic/-/v1/messages" \
  -H 'Accept-Encoding: identity' \
  -H 'Content-Type: application/json' \
  -d '{"model":"claude-haiku-4-5-20251001","max_tokens":8,"messages":[{"role":"user","content":"Reply with OK."}]}' \
  | jq '{type, role, model, stop_reason, text: .content[0].text, error}'
```

Observed HTTP 200 response:

```json
{
  "type": "message",
  "role": "assistant",
  "model": "claude-haiku-4-5-20251001",
  "stop_reason": "end_turn",
  "text": "OK.",
  "error": null
}
```

The real key was loaded locally from the existing environment and was never printed, logged, written to a tracked file, or included in this pull request. Setup sent the raw value only to the Secrets service; provider create/update received the secret name plus the inert `X-Api-Key: {{ auth_secret }}` template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider setup and updates for Anthropic authentication.
  * Authentication header formats are now handled correctly during interactive and automatic registration.
  * API keys remain protected while secret bindings and default headers are preserved.
  * Provider registrations now maintain consistent authentication settings when created or updated.
  * Existing provider configurations are updated without exposing sensitive credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
