### PR TITLE
fix(evaluator): load globbed dataset files in a deterministic order

### DIFF
--- a/e2e/test_evaluator_plugin.py
+++ b/e2e/test_evaluator_plugin.py
@@ -476,7 +476,7 @@ def test_fileset_fragment_and_glob_datasets(evaluator_sdk: NeMoPlatform) -> None
 
         cases = {
             "specific file": (f"{workspace}/{fileset_name}#part-a.json", [1.0, 0.0]),
-            "glob": (f"{workspace}/{fileset_name}#part-*.json", [1.0, 1.0, 0.0]),
+            "glob": (f"{workspace}/{fileset_name}#part-*.json", [1.0, 0.0, 1.0]),
         }
         for label, (reference, expected_scores) in cases.items():
             job = evaluator_sdk.evaluator.submit(

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/datasets/loader.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/datasets/loader.py
@@ -163,7 +163,7 @@ def discover_files(base_path: Path, pattern: str | None) -> list[Path]:
         pattern: Optional explicit file name or glob pattern.
 
     Returns:
-        List of discovered files.
+        List of discovered files, sorted by path.
 
     Raises:
         DatasetLoadError: If files cannot be found or selected paths are invalid.
@@ -172,7 +172,7 @@ def discover_files(base_path: Path, pattern: str | None) -> list[Path]:
         raise DatasetLoadError(f"Dataset directory not found: {base_path}")
 
     if pattern is None:
-        files = [f for f in base_path.rglob("*") if f.is_file()]
+        files = sorted(f for f in base_path.rglob("*") if f.is_file())
         if not files:
             raise DatasetLoadError(f"No files found in {base_path}")
         return files
@@ -184,7 +184,7 @@ def discover_files(base_path: Path, pattern: str | None) -> list[Path]:
         return [file_path]
 
     if is_glob_pattern(pattern):
-        files = list(base_path.glob(pattern))
+        files = sorted(base_path.glob(pattern))
         if not files:
             raise DatasetLoadError(f"No files found matching pattern '{pattern}' in {base_path}")
         return [f for f in files if f.is_file()]

--- a/packages/nemo_evaluator_sdk/tests/execution/test_metric_execution.py
+++ b/packages/nemo_evaluator_sdk/tests/execution/test_metric_execution.py
@@ -520,6 +520,26 @@ class TestDiscoverFiles:
 
         assert sorted(discover_files(tmp_path / "splits", "**/*.jsonl")) == sorted([train_path, validation_path])
 
+    def test_glob_pattern_returns_files_in_sorted_order(self, tmp_path: Path):
+        for name in ("part-c.json", "part-a.json", "part-b.json"):
+            (tmp_path / name).touch()
+
+        assert discover_files(tmp_path, "part-*.json") == [
+            tmp_path / "part-a.json",
+            tmp_path / "part-b.json",
+            tmp_path / "part-c.json",
+        ]
+
+    def test_directory_without_a_pattern_returns_files_in_sorted_order(self, tmp_path: Path):
+        for name in ("c.jsonl", "a.jsonl", "b.jsonl"):
+            (tmp_path / name).touch()
+
+        assert discover_files(tmp_path, None) == [
+            tmp_path / "a.jsonl",
+            tmp_path / "b.jsonl",
+            tmp_path / "c.jsonl",
+        ]
+
 
 class TestIsCompletionsEndpoint:
     @pytest.mark.parametrize(

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/datasets/loader.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/datasets/loader.py
@@ -163,7 +163,7 @@ def discover_files(base_path: Path, pattern: str | None) -> list[Path]:
         pattern: Optional explicit file name or glob pattern.
 
     Returns:
-        List of discovered files.
+        List of discovered files, sorted by path.
 
     Raises:
         DatasetLoadError: If files cannot be found or selected paths are invalid.
@@ -172,7 +172,7 @@ def discover_files(base_path: Path, pattern: str | None) -> list[Path]:
         raise DatasetLoadError(f"Dataset directory not found: {base_path}")
 
     if pattern is None:
-        files = [f for f in base_path.rglob("*") if f.is_file()]
+        files = sorted(f for f in base_path.rglob("*") if f.is_file())
         if not files:
             raise DatasetLoadError(f"No files found in {base_path}")
         return files
@@ -184,7 +184,7 @@ def discover_files(base_path: Path, pattern: str | None) -> list[Path]:
         return [file_path]
 
     if is_glob_pattern(pattern):
-        files = list(base_path.glob(pattern))
+        files = sorted(base_path.glob(pattern))
         if not files:
             raise DatasetLoadError(f"No files found matching pattern '{pattern}' in {base_path}")
         return [f for f in files if f.is_file()]


### PR DESCRIPTION
## Why

`discover_files` returned whatever order the filesystem's `readdir` handed back:

```python
files = [f for f in base_path.rglob("*") if f.is_file()]   # pattern is None
files = list(base_path.glob(pattern))                       # glob pattern
```

Rows from those files are concatenated **in that order**, and their positions become `row_index` on the resulting scores. So the same fileset scored twice could pair a row's score with a different input row — anyone correlating scores back to their inputs gets silently wrong pairings. `parallelism=1` doesn't help; this happens before scoring.

## How it surfaced

`e2e/test_evaluator_plugin.py::test_fileset_fragment_and_glob_datasets` was failing intermittently in `Kind CPU e2e`:

```
assert [1.0, 0.0, 1.0] == [1.0, 1.0, 0.0]
```

Same multiset, different order. Globbing `part-*.json` over two files gives:

| file order | rows | scores |
|---|---|---|
| part-a, part-b (sorted) | alpha, beta, gamma | `[1.0, 0.0, 1.0]` |
| part-b, part-a | gamma, alpha, beta | `[1.0, 1.0, 0.0]` |

The test had pinned the second — the arbitrary order it happened to observe — so it passed or failed on readdir order. The test was the symptom; the loader was the bug.

## After

Both branches sort. This follows what the codebase already does elsewhere for directory walks — `agent_seeds.py:66`, `harbor_runtime.py:501`, `fabric/skills.py:492` — rather than introducing a new convention.

The docstring records *why*, since "sorted" reads as cosmetic tidiness unless you know `row_index` depends on it.

- **e2e expectation** moves to sorted order, with a comment naming where the order comes from.
- **Two unit tests** in `TestDiscoverFiles` pin the guarantee, one per branch, with files created back-to-front so a filesystem returning creation order fails them. Worth noting the neighbouring `test_glob_pattern_discovers_files` wraps both sides in `sorted()` — it deliberately avoided asserting order, so it could not have caught this.

## Verification

- `ruff` clean, `ty` at the `main` baseline (9 warning-level diagnostics, unchanged).
- `packages/nemo_evaluator_sdk/tests`: **1440 passed**.
- The e2e test only runs in the Kind CPU job, so its expectation change is verified by the unit tests and by the decode above rather than executed locally — CI confirms it.

Split out of #1069, which is where the flake was diagnosed; this is an independent behavior fix and doesn't depend on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured files discovered through directories and glob patterns are processed in consistent, sorted order.
  * Made dataset row ordering and associated scores deterministic across runs and environments.

* **Tests**
  * Added coverage for sorted file discovery, including files created in varying orders.
  * Updated evaluator expectations to reflect deterministic row ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->