### PR TITLE
chore(evaluator): regenerate plugin OpenAPI spec

### DIFF
--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -2665,9 +2665,12 @@ components:
           title: Name
           description: Name of the score.
         count:
-          type: integer
           title: Count
-          description: Number of samples evaluated (excluding NaN).
+          description: "Number of samples evaluated (excluding NaN). None when the\
+            \ sample size is unknown \u2014 e.g. a figure imported from a backend\
+            \ that reports statistics without the n behind them. Distinct from 0,\
+            \ which asserts that nothing was evaluated."
+          type: integer
         nan_count:
           type: integer
           title: Nan Count
@@ -2688,13 +2691,33 @@ components:
           title: Max
           description: Maximum score value.
           type: number
+        median:
+          title: Median
+          description: Median score value. Equal to percentiles.p50 when a percentile
+            distribution is also present; carried separately because a backend may
+            report a median without one.
+          type: number
         std_dev:
           title: Std Dev
-          description: Standard deviation of the scores.
+          description: Population standard deviation of the scores (divides by n).
+            Describes the spread of the values actually evaluated. See sample_std_dev
+            to estimate the spread of the wider process.
           type: number
         variance:
           title: Variance
-          description: Variance of the scores.
+          description: Population variance of the scores (divides by n). See sample_variance.
+          type: number
+        sample_std_dev:
+          title: Sample Std Dev
+          description: "Sample standard deviation of the scores (Bessel-corrected,\
+            \ divides by n-1). Estimates the spread of the process the values were\
+            \ drawn from \u2014 the right choice when repeated trials sample a stochastic\
+            \ system. None when fewer than two values (undefined, not zero)."
+          type: number
+        sample_variance:
+          title: Sample Variance
+          description: Sample variance of the scores (Bessel-corrected, divides by
+            n-1). None when fewer than two values.
           type: number
         score_type:
           type: string
@@ -2714,7 +2737,6 @@ components:
       type: object
       required:
       - name
-      - count
       - nan_count
       title: AggregateRangeScore
       description: Aggregated statistics for a range-type score with percentiles and
@@ -2726,9 +2748,12 @@ components:
           title: Name
           description: Name of the score.
         count:
-          type: integer
           title: Count
-          description: Number of samples evaluated (excluding NaN).
+          description: "Number of samples evaluated (excluding NaN). None when the\
+            \ sample size is unknown \u2014 e.g. a figure imported from a backend\
+            \ that reports statistics without the n behind them. Distinct from 0,\
+            \ which asserts that nothing was evaluated."
+          type: integer
         nan_count:
           type: integer
           title: Nan Count
@@ -2749,13 +2774,33 @@ components:
           title: Max
           description: Maximum score value.
           type: number
+        median:
+          title: Median
+          description: Median score value. Equal to percentiles.p50 when a percentile
+            distribution is also present; carried separately because a backend may
+            report a median without one.
+          type: number
         std_dev:
           title: Std Dev
-          description: Standard deviation of the scores.
+          description: Population standard deviation of the scores (divides by n).
+            Describes the spread of the values actually evaluated. See sample_std_dev
+            to estimate the spread of the wider process.
           type: number
         variance:
           title: Variance
-          description: Variance of the scores.
+          description: Population variance of the scores (divides by n). See sample_variance.
+          type: number
+        sample_std_dev:
+          title: Sample Std Dev
+          description: "Sample standard deviation of the scores (Bessel-corrected,\
+            \ divides by n-1). Estimates the spread of the process the values were\
+            \ drawn from \u2014 the right choice when repeated trials sample a stochastic\
+            \ system. None when fewer than two values (undefined, not zero)."
+          type: number
+        sample_variance:
+          title: Sample Variance
+          description: Sample variance of the scores (Bessel-corrected, divides by
+            n-1). None when fewer than two values.
           type: number
         score_type:
           type: string
@@ -2777,11 +2822,105 @@ components:
       type: object
       required:
       - name
-      - count
       - nan_count
       - rubric_distribution
       title: AggregateRubricScore
       description: Aggregated statistics for a rubric-type score with category distribution.
+    AggregateScalarScore:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: Name of the score.
+        count:
+          title: Count
+          description: "Number of samples evaluated (excluding NaN). None when the\
+            \ sample size is unknown \u2014 e.g. a figure imported from a backend\
+            \ that reports statistics without the n behind them. Distinct from 0,\
+            \ which asserts that nothing was evaluated."
+          type: integer
+        nan_count:
+          type: integer
+          title: Nan Count
+          description: Number of samples that produced NaN scores.
+        sum:
+          title: Sum
+          description: Sum of all score values.
+          type: number
+        mean:
+          title: Mean
+          description: Mean score value.
+          type: number
+        min:
+          title: Min
+          description: Minimum score value.
+          type: number
+        max:
+          title: Max
+          description: Maximum score value.
+          type: number
+        median:
+          title: Median
+          description: Median score value. Equal to percentiles.p50 when a percentile
+            distribution is also present; carried separately because a backend may
+            report a median without one.
+          type: number
+        std_dev:
+          title: Std Dev
+          description: Population standard deviation of the scores (divides by n).
+            Describes the spread of the values actually evaluated. See sample_std_dev
+            to estimate the spread of the wider process.
+          type: number
+        variance:
+          title: Variance
+          description: Population variance of the scores (divides by n). See sample_variance.
+          type: number
+        sample_std_dev:
+          title: Sample Std Dev
+          description: "Sample standard deviation of the scores (Bessel-corrected,\
+            \ divides by n-1). Estimates the spread of the process the values were\
+            \ drawn from \u2014 the right choice when repeated trials sample a stochastic\
+            \ system. None when fewer than two values (undefined, not zero)."
+          type: number
+        sample_variance:
+          title: Sample Variance
+          description: Sample variance of the scores (Bessel-corrected, divides by
+            n-1). None when fewer than two values.
+          type: number
+        score_type:
+          type: string
+          const: scalar
+          title: Score Type
+          description: Type of score.
+          default: scalar
+        value:
+          type: number
+          title: Value
+          description: The reported value.
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      - nan_count
+      - value
+      title: AggregateScalarScore
+      description: 'A single pre-computed value with no underlying distribution available.
+
+
+        For figures a backend reports as one number (e.g. an environment''s own ``pass@1``
+        or Elo) rather
+
+        than a set of per-sample values the SDK could aggregate itself. ``value``
+        carries the number;
+
+        ``mean``/``min``/``max`` are left unset because there is no sample to describe.
+        Distinct from
+
+        :class:`AggregateRangeScore` so a reader can tell "this is the whole story"
+        from "this summarizes
+
+        ``count`` samples", instead of seeing a range score with a suspicious ``count``
+        of 1.'
     AggregatedMetricResult:
       properties:
         scores:
@@ -2789,6 +2928,7 @@ components:
             anyOf:
             - $ref: '#/components/schemas/AggregateRangeScore'
             - $ref: '#/components/schemas/AggregateRubricScore'
+            - $ref: '#/components/schemas/AggregateScalarScore'
           type: array
           title: Scores
           description: The list of aggregated scores.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The committed evaluator plugin OpenAPI spec has been stale on `main` since #1065 (`8e7179a141`), which changed the aggregate-score models but did not regenerate the spec. The last regen was #1023 (`c71ca675dc`), which landed earlier the same day. Because the gap lives on `main`, every regen since has faithfully reproduced it, and it has been surfacing as unexplained `AggregatedMetricResult` drift in unrelated contributors' PRs — repeatedly diagnosed as a codegen bug and reverted, which is why it kept coming back. This regenerates the spec so the diff stops re-appearing for everyone.

## Related Issue

<!-- None. -->

## Changes

Regenerated `plugins/nemo-evaluator/openapi/openapi.yaml` with `make refresh-openapi`. The diff is entirely the aggregate-score schemas catching up to `packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/results.py`:

- Add `median`, `sample_std_dev`, and `sample_variance` to the three aggregate-score schemas.
- Drop `count` from `required` — the source field is `count: int | None = None`, so it is genuinely optional.
- Add the `AggregateScalarScore` schema.

No source or behavior changes; generated output only. Every line traces to #1065.

Note that the stale file is the **plugin** spec (`plugins/nemo-evaluator/openapi/openapi.yaml`), not the root `openapi/openapi.yaml`. Grepping the root spec for `AggregatedMetricResult` returns nothing, which is likely why this kept being read as phantom drift.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: generated artifact only; no source or runtime behavior changes. The models this spec is generated from are already covered by the evaluator SDK suite.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the spec is generated output; field descriptions come from the source model docstrings landed in #1065.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `make refresh-openapi` — succeeded; produced exactly this diff (150 insertions, 10 deletions).
- **Idempotency:** ran the generator twice and diffed the outputs — byte-identical, so the generator is deterministic and this diff is genuine staleness rather than codegen noise.
- **Post-commit drift check:** re-ran `make refresh-openapi` after committing — working tree clean, so the committed spec now matches generator output exactly.
- `tools/lint/lint-openapi.sh` — exit 0.
- `uv run pre-commit run -a` — **not fully green.** Two hooks fail, both reproduced on a pristine `origin/main` checkout with zero changes applied, so neither is caused by this PR:
  - **`Check for uv.lock drift`** — the `uv lock` hook rewrites `uv.lock` on a local macOS/arm64 machine, stripping ~412 lines of non-native platform wheels (`armv7l`, `ppc64le`, `s390x`, `riscv64`). Local uv is 0.9.30, which is inside the `>=0.9.14,<0.10.0` pin, so this looks like skew between the committed lock and the current uv resolver rather than an out-of-range toolchain. `uv.lock` is deliberately **not** included in this PR. Flagging separately; it needs its own fix.
  - **`Run UI lint-staged`** — local mise toolchain is not provisioned (`mise.toml` untrusted, no `pnpm` shim version set). No `web/` files are touched by this PR.
  - All other hooks pass: `ruff`, `ruff format`, `ty` typechecks, config-reference doc, Helm docs, copyright headers, plugin-import check, merge-conflict check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for aggregated scalar scores in metric results.
  * Added median, sample standard deviation, and sample variance statistics to range and rubric scores.
  * Aggregate scores can now omit the count when unavailable.

* **Documentation**
  * Clarified that standard deviation and variance fields represent population statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->