### PR TITLE
feat(agents): serve a Fabric agent manifest at GET /manifest

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/manifest.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/manifest.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public manifest describing a served Fabric agent's operational contract.
+
+The manifest is an allowlist projection of :class:`AgentConfig`, never a dump.
+It is served unauthenticated, so a field reaches it only by being named here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import PurePath
+from typing import Literal
+
+from nemo_agents_plugin.agent_config import AgentConfig
+from nemo_agents_plugin.fabric.serving_models import SESSION_ID_HEADER
+from pydantic import BaseModel, Field
+
+MANIFEST_SCHEMA_VERSION = "nemo-agent-manifest/v1"
+
+_FABRIC_DISTRIBUTION = "nemo-fabric"
+
+
+class ManifestAgent(BaseModel):
+    """Identity of the served agent."""
+
+    name: str
+    description: str = ""
+    revision: str
+
+
+class ManifestHarness(BaseModel):
+    """Harness driving the agent."""
+
+    kind: str
+
+
+class ManifestRuntime(BaseModel):
+    """Runtime executing the agent."""
+
+    harness: ManifestHarness
+    fabric_version: str | None = None
+
+
+class ManifestSessions(BaseModel):
+    """How the server scopes conversation state."""
+
+    header: str = SESSION_ID_HEADER
+    default: Literal["ephemeral"] = "ephemeral"
+
+
+class ManifestServing(BaseModel):
+    """Invocation contract a caller must respect."""
+
+    protocol: Literal["openai-chat-completions"] = "openai-chat-completions"
+    streaming: bool = True
+    sessions: ManifestSessions = Field(default_factory=ManifestSessions)
+    max_concurrent_invocations: int
+
+
+class ManifestEnvironment(BaseModel):
+    """Environment the agent executes in.
+
+    ``workspace_scope`` is ``agent`` when one workspace is shared by every
+    session, which means invocations are not isolated from each other.
+    """
+
+    provider: str
+    workspace_scope: Literal["agent", "session"]
+
+
+class ManifestMcpServer(BaseModel):
+    """An MCP server the agent can reach, by name only."""
+
+    name: str
+    transport: str
+    exposure: str
+
+
+class ManifestCapabilities(BaseModel):
+    """What the agent can do, by name."""
+
+    skills: list[str] = Field(default_factory=list)
+    mcp_servers: list[ManifestMcpServer] = Field(default_factory=list)
+    tools_blocked: list[str] = Field(default_factory=list)
+
+
+class ManifestModel(BaseModel):
+    """A model the agent is configured to call."""
+
+    alias: str
+    provider: str
+    model: str
+
+
+class ManifestTelemetry(BaseModel):
+    """Whether the agent already emits its own traces."""
+
+    emits: bool
+    formats: list[str] = Field(default_factory=list)
+
+
+class ManifestTunable(BaseModel):
+    """Knob names an optimizer may sweep. Names only, never values."""
+
+    prompts: list[str] = Field(default_factory=list)
+    harness_settings: list[str] = Field(default_factory=list)
+
+
+class AgentManifest(BaseModel):
+    """Operational contract published at ``GET /manifest``."""
+
+    schema_version: str = MANIFEST_SCHEMA_VERSION
+    agent: ManifestAgent
+    runtime: ManifestRuntime
+    serving: ManifestServing
+    environment: ManifestEnvironment
+    capabilities: ManifestCapabilities
+    models: list[ManifestModel] = Field(default_factory=list)
+    telemetry: ManifestTelemetry
+    tunable: ManifestTunable
+
+
+def build_agent_manifest(config: AgentConfig, *, max_concurrent_invocations: int) -> AgentManifest:
+    """Project an agent config into its public manifest."""
+    manifest = AgentManifest(
+        agent=ManifestAgent(name=config.name, description=config.description, revision=""),
+        runtime=_runtime(config),
+        serving=ManifestServing(max_concurrent_invocations=max_concurrent_invocations),
+        environment=ManifestEnvironment(provider=config.environment.provider, workspace_scope="agent"),
+        capabilities=_capabilities(config),
+        models=_models(config),
+        telemetry=_telemetry(config),
+        tunable=_tunable(config),
+    )
+    return _stamp_revision(manifest)
+
+
+def _runtime(config: AgentConfig) -> ManifestRuntime:
+    harness = config.harnesses[config.default_harness]
+    return ManifestRuntime(harness=ManifestHarness(kind=harness.kind), fabric_version=_fabric_version())
+
+
+def _fabric_version() -> str | None:
+    try:
+        return version(_FABRIC_DISTRIBUTION)
+    except PackageNotFoundError:
+        return None
+
+
+def _capabilities(config: AgentConfig) -> ManifestCapabilities:
+    servers = config.mcp.servers if config.mcp else {}
+    return ManifestCapabilities(
+        skills=_skill_names(config),
+        mcp_servers=[
+            ManifestMcpServer(name=name, transport=server.transport, exposure=server.exposure)
+            for name, server in sorted(servers.items())
+        ],
+        tools_blocked=sorted(config.tools.blocked) if config.tools else [],
+    )
+
+
+def _skill_names(config: AgentConfig) -> list[str]:
+    """Skill directory names, never the host paths they were loaded from."""
+    if config.skills is None:
+        return []
+
+    names: list[str] = []
+    for path in config.skills.paths:
+        name = PurePath(path).name
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _models(config: AgentConfig) -> list[ManifestModel]:
+    models = [
+        ManifestModel(alias=alias, provider=model.provider, model=model.model)
+        for alias, model in sorted(config.models.items())
+    ]
+    models.extend(
+        ManifestModel(alias=f"harness:{name}", provider=harness.model.provider, model=harness.model.model)
+        for name, harness in sorted(config.harnesses.items())
+        if harness.model is not None
+    )
+    return models
+
+
+def _telemetry(config: AgentConfig) -> ManifestTelemetry:
+    telemetry = config.telemetry
+    formats = [name for name, payload in (("atif", telemetry.atif), ("atof", telemetry.atof)) if payload is not None]
+    return ManifestTelemetry(emits=telemetry.enabled, formats=formats)
+
+
+def _tunable(config: AgentConfig) -> ManifestTunable:
+    harness = config.harnesses[config.default_harness]
+    return ManifestTunable(prompts=sorted(config.prompts), harness_settings=sorted(harness.settings))
+
+
+def _stamp_revision(manifest: AgentManifest) -> AgentManifest:
+    """Fingerprint the redacted projection, so the hash cannot leak what it omits."""
+    payload = manifest.model_dump(mode="json")
+    payload["agent"].pop("revision", None)
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    revision = f"sha256:{hashlib.sha256(canonical.encode('utf-8')).hexdigest()}"
+    return manifest.model_copy(update={"agent": manifest.agent.model_copy(update={"revision": revision})})

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -19,6 +19,7 @@ from typing import Annotated, Any
 from fastapi import FastAPI, Header, HTTPException, Response
 from fastapi.responses import StreamingResponse
 from nemo_agents_plugin.agent_config import AgentConfig, load_agent_config
+from nemo_agents_plugin.fabric.manifest import AgentManifest, build_agent_manifest
 from nemo_agents_plugin.fabric.runtime import (
     FabricInvocationRequest,
     FabricRuntimeExecutionError,
@@ -27,6 +28,7 @@ from nemo_agents_plugin.fabric.runtime import (
     FabricRuntimeTimeoutError,
 )
 from nemo_agents_plugin.fabric.serving_models import (
+    SESSION_ID_HEADER,
     ChatCompletionChoice,
     ChatCompletionRequest,
     ChatCompletionResponse,
@@ -48,8 +50,6 @@ from nemo_agents_plugin.fabric.streaming import (
 )
 
 logger = logging.getLogger(__name__)
-
-SESSION_ID_HEADER = "X-Nemo-Session-Id"
 
 
 @dataclass(frozen=True, slots=True)
@@ -250,6 +250,10 @@ def create_fabric_serving_app(
         app.state.agent_config = agent_config
         app.state.base_dir = config_path.parent
         app.state.validation_result = validation_result
+        app.state.manifest = build_agent_manifest(
+            agent_config,
+            max_concurrent_invocations=settings.max_concurrent_invocations,
+        )
         session_registry = FabricSessionRegistry()
         app.state.session_registry = session_registry
         session_manager = FabricSessionManager(
@@ -283,6 +287,10 @@ def create_fabric_serving_app(
     @app.get("/health")
     async def health() -> dict[str, str]:
         return {"status": "ok"}
+
+    @app.get("/manifest", response_model=AgentManifest)
+    async def manifest() -> AgentManifest:
+        return app.state.manifest
 
     @app.post("/v1/chat/completions", response_model=None, response_model_exclude_none=True)
     async def chat_completions(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/serving_models.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/serving_models.py
@@ -10,6 +10,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+SESSION_ID_HEADER = "X-Nemo-Session-Id"
+
 
 class ChatCompletionMessage(BaseModel):
     """Supported OpenAI-compatible chat message."""

--- a/plugins/nemo-agents/tests/unit/test_fabric_manifest.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_manifest.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+from nemo_agents_plugin.agent_config import AgentConfig
+from nemo_agents_plugin.fabric import server
+from nemo_agents_plugin.fabric.manifest import MANIFEST_SCHEMA_VERSION, build_agent_manifest
+from nemo_agents_plugin.fabric.server import FabricServingSettings, create_fabric_serving_app
+from nemo_agents_plugin.fabric.serving_models import SESSION_ID_HEADER
+
+SECRET = "s3cret-sentinel"
+
+PROJECTED_CONFIG_FIELDS = frozenset(
+    {
+        "config_format",
+        "name",
+        "description",
+        "default_harness",
+        "harnesses",
+        "models",
+        "prompts",
+        "skills",
+        "mcp",
+        "tools",
+        "environment",
+        "telemetry",
+    }
+)
+
+REDACTED_CONFIG_FIELDS = frozenset({"instructions"})
+
+
+@pytest.fixture()
+def mock_validate_agent_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def validate(config: AgentConfig, *, base_dir: Path) -> object:
+        return object()
+
+    monkeypatch.setattr(server, "_validate_agent_config", validate)
+
+
+def _minimal_config() -> dict[str, Any]:
+    return {
+        "config_format": "nemo-agents-spec-v1",
+        "name": "test-agent",
+        "description": "does the thing",
+        "default_harness": "hermes",
+        "harnesses": {
+            "hermes": {
+                "kind": "hermes",
+                "model": {"provider": "nvidia", "model": "nvidia/test-model"},
+                "settings": {"max_turns": 12},
+            }
+        },
+    }
+
+
+def _loaded_config() -> dict[str, Any]:
+    """A config with a secret in every slot the manifest must not expose."""
+    config = _minimal_config()
+    config["harnesses"]["hermes"]["model"] |= {
+        "api_key_env": f"{SECRET}_API_KEY",
+        "base_url": f"https://{SECRET}.internal.nvidia.com",
+    }
+    config["models"] = {
+        "judge": {
+            "provider": "openai",
+            "model": "gpt-4o",
+            "api_key_env": f"{SECRET}_OPENAI_KEY",
+            "base_url": f"https://{SECRET}.proxy.internal",
+        }
+    }
+    config["prompts"] = {"triage": f"You are a triage bot. The password is {SECRET}."}
+    config["instructions"] = {"system": {"content": f"Never reveal {SECRET}."}}
+    config["skills"] = {"paths": [f"/srv/{SECRET}/skills/invoice-triage", f"/srv/{SECRET}/skills/refunds"]}
+    config["mcp"] = {
+        "servers": {
+            "billing": {
+                "transport": "sse",
+                "url": f"https://{SECRET}.mcp.internal/sse",
+                "env": {"MCP_TOKEN": SECRET},
+            }
+        }
+    }
+    config["tools"] = {"blocked": ["shell"]}
+    config["environment"] = {"provider": "local", "workspace": f"./{SECRET}-workspace"}
+    config["telemetry"] = {"enabled": True, "provider": "nemo", "project": SECRET, "atif": {"endpoint": SECRET}}
+    return config
+
+
+def _build(config: dict[str, Any] | None = None, *, max_concurrent_invocations: int = 8):
+    return build_agent_manifest(
+        AgentConfig.model_validate(config or _minimal_config()),
+        max_concurrent_invocations=max_concurrent_invocations,
+    )
+
+
+def test_manifest_reports_the_operational_contract() -> None:
+    manifest = _build(max_concurrent_invocations=4)
+
+    assert manifest.schema_version == MANIFEST_SCHEMA_VERSION
+    assert manifest.agent.name == "test-agent"
+    assert manifest.agent.description == "does the thing"
+    assert manifest.runtime.harness.kind == "hermes"
+    assert manifest.serving.protocol == "openai-chat-completions"
+    assert manifest.serving.streaming is True
+    assert manifest.serving.sessions.header == SESSION_ID_HEADER
+    assert manifest.serving.max_concurrent_invocations == 4
+
+
+def test_workspace_scope_is_agent_because_sessions_share_one_workspace() -> None:
+    manifest = _build()
+
+    assert manifest.environment.provider == "local"
+    assert manifest.environment.workspace_scope == "agent"
+
+
+def test_no_secret_reaches_the_manifest() -> None:
+    serialized = _build(_loaded_config()).model_dump_json()
+
+    assert SECRET not in serialized
+
+
+def test_every_agent_config_field_is_classified() -> None:
+    unclassified = set(AgentConfig.model_fields) - PROJECTED_CONFIG_FIELDS - REDACTED_CONFIG_FIELDS
+
+    assert not unclassified, f"Classify these AgentConfig fields as projected or redacted: {sorted(unclassified)}"
+
+
+def test_skills_are_names_not_host_paths() -> None:
+    manifest = _build(_loaded_config())
+
+    assert manifest.capabilities.skills == ["invoice-triage", "refunds"]
+
+
+def test_mcp_servers_expose_only_name_and_transport() -> None:
+    manifest = _build(_loaded_config())
+
+    assert [server.model_dump() for server in manifest.capabilities.mcp_servers] == [
+        {"name": "billing", "transport": "sse", "exposure": "harness_native"}
+    ]
+
+
+def test_models_include_harness_models_alongside_named_aliases() -> None:
+    manifest = _build(_loaded_config())
+
+    assert [(model.alias, model.model) for model in manifest.models] == [
+        ("judge", "gpt-4o"),
+        ("harness:hermes", "nvidia/test-model"),
+    ]
+
+
+def test_tunable_lists_knob_names_without_values() -> None:
+    manifest = _build(_loaded_config())
+
+    assert manifest.tunable.prompts == ["triage"]
+    assert manifest.tunable.harness_settings == ["max_turns"]
+
+
+def test_telemetry_reports_emission_and_formats() -> None:
+    assert _build(_loaded_config()).telemetry.model_dump() == {"emits": True, "formats": ["atif"]}
+    assert _build().telemetry.model_dump() == {"emits": False, "formats": []}
+
+
+def test_revision_is_stable_for_the_same_config() -> None:
+    assert _build().agent.revision == _build().agent.revision
+    assert _build().agent.revision.startswith("sha256:")
+
+
+def test_revision_changes_when_the_config_changes() -> None:
+    changed = _minimal_config()
+    changed["harnesses"]["hermes"]["model"]["model"] = "nvidia/other-model"
+
+    assert _build().agent.revision != _build(changed).agent.revision
+
+
+def test_revision_ignores_redacted_values() -> None:
+    config = _loaded_config()
+    leaked = _loaded_config()
+    leaked["instructions"]["system"]["content"] = "a completely different system prompt"
+    leaked["mcp"]["servers"]["billing"]["env"] = {"MCP_TOKEN": "rotated"}
+
+    assert _build(config).agent.revision == _build(leaked).agent.revision
+
+
+def test_manifest_route_serves_the_projection(tmp_path: Path, mock_validate_agent_config: None) -> None:
+    config_path = tmp_path / "agent.yaml"
+    config_path.write_text(yaml.safe_dump(_loaded_config()), encoding="utf-8")
+    app = create_fabric_serving_app(config_path, settings=FabricServingSettings(max_concurrent_invocations=3))
+
+    with TestClient(app) as client:
+        response = client.get("/manifest")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == MANIFEST_SCHEMA_VERSION
+    assert payload["agent"]["name"] == "test-agent"
+    assert payload["serving"]["max_concurrent_invocations"] == 3
+    assert SECRET not in json.dumps(payload)


### PR DESCRIPTION
## Summary

A Fabric agent server exposes only `/health` and `/v1/chat/completions`, so anything driving it — Studio, eval, intake — has to guess the contract it must respect. This adds `GET /manifest`, an allowlist projection of the `AgentConfig` the server already holds in `app.state`, describing the agent's operational contract.

Groundwork for external agents on Fabric (ASTD-314): once an agent can describe itself, registering one by URL can discover it instead of asking the user to type everything. Nothing consumes the endpoint yet — that is ASTD-383.

## Related Issue

ASTD-382 (Linear). Parent: ASTD-314.

## Changes

- **`fabric/manifest.py`** (new) — manifest models and `build_agent_manifest()`. Pure read model over `AgentConfig`, no I/O.
- **`fabric/server.py`** — builds the manifest once during lifespan startup, serves it at `GET /manifest`.
- **`fabric/serving_models.py`** — `SESSION_ID_HEADER` moved here so the manifest and the server can both read it without an import cycle. `server.SESSION_ID_HEADER` still resolves via re-export, so existing imports are unchanged.
- **`tests/unit/test_fabric_manifest.py`** (new) — 13 tests.

## What the manifest carries, and why

Descriptive fields are the cheap part. These are the ones the platform gets wrong when it has to guess:

- `environment.workspace_scope` — `open_session` passes the same `base_dir` to `ensure_local_workspace_dir` and `fabric.start_runtime` on every session, so one workspace is shared by all of them. Reported as `agent` scope, which tells a caller invocations are **not** isolated. An eval that doesn't know this lets row 1 leak into row 200 and reads the result as variance.
- `serving.max_concurrent_invocations` — surfaces the semaphore `FabricSessionManager` already enforces, so a caller can size its batch instead of queueing or tripping the 503 path.
- `telemetry.emits` — keeps intake from double-instrumenting an agent that already ships ATIF.
- `agent.revision` — content hash, so a consumer can tell whether the agent changed underneath a set of results.
- `tunable` — knob *names* for `nemo-optimization` (prompt keys, harness settings keys). Names only.

Two shape notes: `workspace_scope` is an enum rather than a `stateful` bool because scope is a fact about the server that survives Fabric gaining per-session environments, where a bool would need redefining. And `models` includes harness-level models as `harness:<name>` — the common agent (including this repo's own fixture) declares no top-level `models` at all, so reading only `config.models` would report zero.

## Redaction

The route is unauthenticated, so this is an allowlist, never a `model_dump()`. Excluded: `api_key_env`, `base_url`, `McpServerConfig.url`/`.env`, `prompts` values, `instructions.system.content`, and host filesystem paths (skills are emitted as basenames).

`revision` hashes the **redacted** projection rather than the raw config, so the fingerprint cannot become a side channel on the values it omits.

Two test layers back this: one sentinel value is planted in every dangerous config slot and asserted absent from the serialized manifest; and `test_every_agent_config_field_is_classified` walks `AgentConfig.model_fields` against projected/redacted sets, so a newly added config field fails the suite until someone classifies it.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the endpoint has no consumer yet; user-facing docs land with ASTD-383, which is what actually surfaces it.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest plugins/nemo-agents/tests/unit/test_fabric_manifest.py plugins/nemo-agents/tests/unit/test_fabric_server.py` → **39 passed**
- `pytest plugins/nemo-agents/tests/unit` → **988 passed, 3 failed**. All three failures (`test_optimize_submit_targets_agents_route`, `test_deployments_list_defaults_to_table`, `test_jobs_discovered_via_entry_points`) are pre-existing and caused by `nemo_optimization` not being installed in this venv — confirmed by re-running them with this branch's changes stashed and getting the identical three. `test_service.py` fails collection for the same reason, also pre-existing.
- `ruff check` and `ruff format --check` on the changed paths → clean
- `ty check` on the changed paths → clean
- `uv run pre-commit run -a` was **not** run repo-wide. Pre-commit ran at commit time over the changed files: ruff, ruff format, ty, copyright headers, plugin-import check, merge-conflict check — all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public agent manifest describing runtime, serving, capabilities, models, telemetry, and configurable settings.
  * Added a `GET /manifest` endpoint for retrieving the manifest.
  * Included stable revision identifiers and redaction of sensitive configuration details.
  * Standardized the session ID header as `X-Nemo-Session-Id`.

* **Tests**
  * Added coverage for manifest generation, security redaction, revision stability, and endpoint responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->