### PR TITLE
fix(studio): show spans while trace details arrive

### DIFF
--- a/web/packages/studio/src/components/IntakeDetail/SessionDetailView.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/SessionDetailView.tsx
@@ -180,6 +180,7 @@ export const SessionDetailView: FC<SessionDetailViewProps> = ({
             sessionId={sessionId}
             parentBreadcrumbs={traceParentBreadcrumbs}
             traceSummary={trajectories.find(({ trace }) => trace.id === traceId)?.trace}
+            isTraceSummaryLoading={explorer.isSpansFetching && !explorer.spansLoaded}
           >
             {(trace) => (
               <TraceSpanAccordions

--- a/web/packages/studio/src/components/IntakeDetail/SessionDetailView.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/SessionDetailView.tsx
@@ -180,7 +180,10 @@ export const SessionDetailView: FC<SessionDetailViewProps> = ({
             sessionId={sessionId}
             parentBreadcrumbs={traceParentBreadcrumbs}
             traceSummary={trajectories.find(({ trace }) => trace.id === traceId)?.trace}
-            isTraceSummaryLoading={explorer.isSpansFetching && !explorer.spansLoaded}
+            traceSummaryStatus={
+              explorer.spansLoaded ? 'resolved' : explorer.spansError ? 'error' : 'loading'
+            }
+            traceSummaryErrorMessage={explorer.spansError?.message}
           >
             {(trace) => (
               <TraceSpanAccordions

--- a/web/packages/studio/src/components/IntakeDetail/TraceDetailView.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/TraceDetailView.tsx
@@ -4,7 +4,7 @@
 import { IntakeAccordion } from '@nemo/common/src/components/IntakeAccordion';
 import { useGetTrace } from '@nemo/sdk/generated/platform/api';
 import type { Trace } from '@nemo/sdk/generated/platform/schema';
-import { Stack, StatusMessage, Text } from '@nvidia/foundations-react-core';
+import { Banner, Stack, StatusMessage, Text } from '@nvidia/foundations-react-core';
 import { KeyValueRows } from '@studio/components/IntakeDetail/IntakeComponents/KeyValueRows';
 import { RawJsonDebug } from '@studio/components/IntakeDetail/IntakeComponents/RawJsonDebug';
 import {
@@ -29,6 +29,7 @@ interface TraceDetailViewProps {
   traceId: string;
   sessionId: string;
   traceSummary?: Trace;
+  isTraceSummaryLoading?: boolean;
   parentBreadcrumbs: BreadcrumbsItemProps[];
   children: (trace: Trace) => ReactNode;
 }
@@ -39,6 +40,7 @@ export const TraceDetailView: FC<TraceDetailViewProps> = ({
   traceId,
   sessionId,
   traceSummary,
+  isTraceSummaryLoading = false,
   parentBreadcrumbs,
   children,
 }) => {
@@ -53,6 +55,7 @@ export const TraceDetailView: FC<TraceDetailViewProps> = ({
   // The session already owns enough trace data to keep its explorer mounted
   // while the selected trace's full payload hydrates in the background.
   const resolvedTrace = trace ?? traceSummary;
+  const traceNotFound = error?.response?.status === 404;
 
   const { setBreadcrumbs } = useBreadcrumbs();
   const traceBreadcrumbLabel = resolvedTrace ? getTraceDisplayName(resolvedTrace) : traceId;
@@ -70,17 +73,17 @@ export const TraceDetailView: FC<TraceDetailViewProps> = ({
     setBreadcrumbs([...parentBreadcrumbs, { slotLabel: `Trace ${traceBreadcrumbLabel}` }]);
   }, [parentBreadcrumbs, setBreadcrumbs, traceBreadcrumbLabel]);
 
-  if (error?.response?.status === 404) {
+  if (!resolvedTrace && (isLoading || (traceNotFound && isTraceSummaryLoading))) {
+    return <Loading description="Loading trace..." />;
+  }
+
+  if (traceNotFound && !resolvedTrace) {
     return (
       <NotFound
         subheader="Trace Not Found"
         message="The trace does not exist or you do not have permission to view it."
       />
     );
-  }
-
-  if (isLoading && !resolvedTrace) {
-    return <Loading description="Loading trace..." />;
   }
 
   if (error && !resolvedTrace) {
@@ -110,6 +113,11 @@ export const TraceDetailView: FC<TraceDetailViewProps> = ({
 
   return (
     <>
+      {traceNotFound && (
+        <Banner kind="inline" status="info">
+          Trace details are still arriving. The activity received so far is shown below.
+        </Banner>
+      )}
       {children(resolvedTrace)}
       <IntakeAccordion
         variant="section"

--- a/web/packages/studio/src/components/IntakeDetail/TraceDetailView.tsx
+++ b/web/packages/studio/src/components/IntakeDetail/TraceDetailView.tsx
@@ -29,7 +29,8 @@ interface TraceDetailViewProps {
   traceId: string;
   sessionId: string;
   traceSummary?: Trace;
-  isTraceSummaryLoading?: boolean;
+  traceSummaryStatus: 'loading' | 'resolved' | 'error';
+  traceSummaryErrorMessage?: string;
   parentBreadcrumbs: BreadcrumbsItemProps[];
   children: (trace: Trace) => ReactNode;
 }
@@ -40,7 +41,8 @@ export const TraceDetailView: FC<TraceDetailViewProps> = ({
   traceId,
   sessionId,
   traceSummary,
-  isTraceSummaryLoading = false,
+  traceSummaryStatus,
+  traceSummaryErrorMessage,
   parentBreadcrumbs,
   children,
 }) => {
@@ -73,8 +75,20 @@ export const TraceDetailView: FC<TraceDetailViewProps> = ({
     setBreadcrumbs([...parentBreadcrumbs, { slotLabel: `Trace ${traceBreadcrumbLabel}` }]);
   }, [parentBreadcrumbs, setBreadcrumbs, traceBreadcrumbLabel]);
 
-  if (!resolvedTrace && (isLoading || (traceNotFound && isTraceSummaryLoading))) {
+  if (!resolvedTrace && (isLoading || (traceNotFound && traceSummaryStatus === 'loading'))) {
     return <Loading description="Loading trace..." />;
+  }
+
+  if (traceNotFound && !resolvedTrace && traceSummaryStatus === 'error') {
+    return (
+      <StatusMessage
+        className="mx-auto mt-density-2xl"
+        size="medium"
+        slotMedia={<CircleAlert width={65} height={65} />}
+        slotHeading="Error loading trace activity"
+        slotSubheading={traceSummaryErrorMessage}
+      />
+    );
   }
 
   if (traceNotFound && !resolvedTrace) {

--- a/web/packages/studio/src/components/IntakeDetail/useSessionTrajectories.ts
+++ b/web/packages/studio/src/components/IntakeDetail/useSessionTrajectories.ts
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useGetSession, useListSpans, useListTraces } from '@nemo/sdk/generated/platform/api';
-import type { Span } from '@nemo/sdk/generated/platform/schema';
+import { type Span, SpanStatus, type Trace } from '@nemo/sdk/generated/platform/schema';
 import { type SessionExplorerData } from '@studio/components/IntakeDetail/TraceSpanAccordions';
-import { buildSpanTree, type SessionTrajectory } from '@studio/util/intakeTelemetry';
+import {
+  buildSpanTree,
+  compareSpansByStartedAt,
+  type SessionTrajectory,
+} from '@studio/util/intakeTelemetry';
 import { useMemo } from 'react';
 
 const SESSION_TRACES_PAGE_SIZE = 1000;
@@ -57,11 +61,33 @@ export function useSessionTrajectories(workspace: string, sessionId: string) {
       traceSpans.push(span);
       groupedSpans.set(span.trace_id, traceSpans);
     }
-    return traces.map((trace) => {
+
+    const traceSummaries: Trace[] = [...traces];
+    const knownTraceIds = new Set(traces.map((trace) => trace.id));
+    for (const [traceId, spans] of groupedSpans) {
+      if (knownTraceIds.has(traceId)) continue;
+      const earliestSpan = spans.reduce((earliest, span) =>
+        compareSpansByStartedAt(span, earliest) < 0 ? span : earliest
+      );
+      traceSummaries.push({
+        id: traceId,
+        session_id: sessionId,
+        workspace,
+        started_at: earliestSpan.started_at,
+        status: SpanStatus.unknown,
+        span_count: spans.length,
+      });
+    }
+
+    traceSummaries.sort((a, b) => {
+      const startedAtDifference = Date.parse(a.started_at) - Date.parse(b.started_at);
+      return startedAtDifference || a.id.localeCompare(b.id);
+    });
+    return traceSummaries.map((trace) => {
       const spans = groupedSpans.get(trace.id) ?? [];
       return { trace, spans, spanTree: buildSpanTree(spans) };
     });
-  }, [sessionSpansResponse?.data, traces]);
+  }, [sessionId, sessionSpansResponse?.data, traces, workspace]);
 
   const explorer = useMemo<SessionExplorerData>(
     () => ({

--- a/web/packages/studio/src/routes/IntakeSessionDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/IntakeSessionDetailRoute/index.test.tsx
@@ -477,6 +477,36 @@ describe('IntakeSessionDetailRoute', () => {
     expect(screen.queryByText(/Trace details are still arriving/)).not.toBeInTheDocument();
   });
 
+  it('shows an error when trace details are missing and session spans fail to load', async () => {
+    const traceId = 'trace-with-failed-activity-request';
+    server.use(
+      http.get('*/apis/intake/v2/workspaces/:workspace/traces', () =>
+        HttpResponse.json({
+          ...mockTracesPage,
+          data: [],
+          pagination: {
+            ...mockTracesPage.pagination,
+            current_page_size: 0,
+            total_results: 0,
+          },
+        })
+      ),
+      http.get(
+        '*/apis/intake/v2/workspaces/:workspace/traces/:traceId',
+        () => new HttpResponse(null, { status: 404 })
+      ),
+      http.get(
+        '*/apis/intake/v2/workspaces/:workspace/spans',
+        () => new HttpResponse(null, { status: 500 })
+      )
+    );
+
+    renderSessionDetail('session-agent-run-001', `?traceId=${traceId}`);
+
+    expect(await screen.findByText('Error loading trace activity')).toBeInTheDocument();
+    expect(screen.queryByText('Trace Not Found')).not.toBeInTheDocument();
+  });
+
   it('rejects a trace deep link that belongs to another session', async () => {
     renderSessionDetail('session-agent-run-001', '?traceId=trace-agent-run-002');
 

--- a/web/packages/studio/src/routes/IntakeSessionDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/IntakeSessionDetailRoute/index.test.tsx
@@ -387,6 +387,96 @@ describe('IntakeSessionDetailRoute', () => {
     expect((await screen.findAllByText('Outside page span')).length).toBeGreaterThan(0);
   });
 
+  it('renders received spans while trace details are still arriving', async () => {
+    const traceId = 'trace-still-arriving';
+    const receivedSpan = {
+      ...mockSpanById('span-llm-001')!,
+      span_id: 'span-received-before-trace',
+      parent_span_id: 'span-root-not-received',
+      trace_id: traceId,
+      name: 'Generate response from received activity',
+    };
+
+    server.use(
+      http.get('*/apis/intake/v2/workspaces/:workspace/traces', () =>
+        HttpResponse.json({
+          ...mockTracesPage,
+          data: [],
+          pagination: {
+            ...mockTracesPage.pagination,
+            current_page_size: 0,
+            total_results: 0,
+          },
+        })
+      ),
+      http.get('*/apis/intake/v2/workspaces/:workspace/traces/:traceId', ({ params }) =>
+        params['traceId'] === traceId
+          ? new HttpResponse(null, { status: 404 })
+          : new HttpResponse(null, { status: 500 })
+      ),
+      http.get('*/apis/intake/v2/workspaces/:workspace/spans', () =>
+        HttpResponse.json({
+          ...mockSpansPage,
+          data: [receivedSpan],
+          pagination: {
+            ...mockSpansPage.pagination,
+            current_page_size: 1,
+            total_results: 1,
+          },
+        })
+      )
+    );
+
+    renderSessionDetail('session-agent-run-001', `?traceId=${traceId}`);
+
+    expect(
+      await screen.findByText(
+        'Trace details are still arriving. The activity received so far is shown below.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Trace Not Found')).not.toBeInTheDocument();
+    expect(
+      (await screen.findAllByText('Generate response from received activity')).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('shows not found when neither trace details nor matching spans exist', async () => {
+    const traceId = 'trace-never-received';
+    server.use(
+      http.get('*/apis/intake/v2/workspaces/:workspace/traces', () =>
+        HttpResponse.json({
+          ...mockTracesPage,
+          data: [],
+          pagination: {
+            ...mockTracesPage.pagination,
+            current_page_size: 0,
+            total_results: 0,
+          },
+        })
+      ),
+      http.get(
+        '*/apis/intake/v2/workspaces/:workspace/traces/:traceId',
+        () => new HttpResponse(null, { status: 404 })
+      ),
+      http.get('*/apis/intake/v2/workspaces/:workspace/spans', () =>
+        HttpResponse.json({
+          ...mockSpansPage,
+          data: [],
+          pagination: {
+            ...mockSpansPage.pagination,
+            current_page_size: 0,
+            total_results: 0,
+          },
+        })
+      )
+    );
+
+    renderSessionDetail('session-agent-run-001', `?traceId=${traceId}`);
+
+    expect(await screen.findByText('Trace Not Found')).toBeInTheDocument();
+    expect(screen.queryByText(/Trace details are still arriving/)).not.toBeInTheDocument();
+  });
+
   it('rejects a trace deep link that belongs to another session', async () => {
     renderSessionDetail('session-agent-run-001', '?traceId=trace-agent-run-002');
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Studio now renders activity already received for a session even when its trace details are not available yet. Previously, a direct trace link showed "Trace Not Found" and hid those spans; it now shows the available span tree with a brief informational banner, while genuinely missing traces still use the existing not-found view.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Build in-memory trace summaries for session spans whose trace is absent from the trace list response.
- Keep the trace detail route loading until the span fallback has resolved, then render available activity, not-found, or request-error states accurately when the trace detail request returns 404.
- Use the existing inline information banner pattern to explain that trace details are still arriving.
- Add route coverage for both partial traces and genuinely missing traces.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: The change uses existing Studio behavior and explanatory UI copy; no user workflow or API changes.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `pnpm --filter nemo-studio-ui test src/routes/IntakeSessionDetailRoute/index.test.tsx` — 14 tests passed.
- `pnpm --filter nemo-studio-ui test:ci` — 313 test files and 2,835 tests passed with coverage enabled.
- `pnpm --filter nemo-studio-ui typecheck` — passed.
- `pnpm --filter nemo-studio-ui lint` — passed.
- `pnpm --filter nemo-studio-ui format` — passed.
- `uv run pre-commit run -a` — all hooks passed.

Manual reproduction represented by the route regression test:

1. Return no matching item from the session trace list and return 404 from the matching trace detail request.
2. Return a session span with that trace ID and a parent span ID that has not been received.
3. Open the session URL with that trace selected and verify the informational banner and received activity render instead of "Trace Not Found."
4. Return no matching trace or spans and verify the existing "Trace Not Found" view still renders.
5. Make the session span request fail and verify an error state renders instead of "Trace Not Found."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Trace details now load progressively, displaying available summary information while full details are retrieved.
  * Added clearer messaging for traces that are still arriving, unavailable, or encounter activity-loading errors.
  * Session timelines now include traces inferred from received spans and sort them chronologically.

* **Tests**
  * Added coverage for deep-linked traces, loading states, arriving traces, missing traces, and activity-loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->