### PR TITLE
revert: stop automatic NVSkills pull request checks

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -3,14 +3,11 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
-      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

- Stops ordinary pull request events from automatically invoking the NVSkills reusable workflow. Before this change, opening or updating any PR caused the reusable workflow to inspect watched paths, including `plugins/`; afterward, NVSkills requests remain limited to maintainer `/nvskills-ci` comments and trusted signature pushes.
- Broke this in the #1179 when switched to an updated template: https://github.com/NVIDIA/skills/blob/main/.github/workflows/request-nvskills-ci.yml - missed the change that it's triggered on each PR now instead of being triggered on comment as before

## Changes

- Remove the `pull_request` trigger added by #1179.
- Remove the unconditional `github.event_name == 'pull_request'` job condition.
- Preserve the current reusable workflow revision, permissions, signing-bot identity, and manual request behavior.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This change only narrows GitHub Actions event routing; the workflow is validated directly with actionlint and repository hooks.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: The change restores the documented manual-request and trusted-signature behavior.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/request-nvskills-ci.yml` — passed.
- `mise exec uv@0.9.14 node@22.23.2 pnpm@10.34 -- uv run pre-commit run -a` — passed with the existing matching Studio dependencies supplied to the isolated worktree.
- `git diff --check origin/main...HEAD` — passed.
- DCO audit for `origin/main..HEAD` — passed.
