### PR TITLE
ci: improve uv and Docker build caching

### DIFF
--- a/.github/actions/setup-kind-cluster/action.yaml
+++ b/.github/actions/setup-kind-cluster/action.yaml
@@ -107,7 +107,12 @@ runs:
         python-version: "3.13"
         enable-cache: true
         version-file: pyproject.toml
-        cache-dependency-glob: uv.lock
+        cache-dependency-glob: |
+          pyproject.toml
+          uv.lock
+        cache-suffix: workspace-v1
+        prune-cache: false
+        save-cache: false
 
     - name: Start kind cluster
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,11 @@ env:
   # required-version out of pyproject.toml, actions/setup-node pins Node), so
   # the Makefile should call those rather than a mise it never installed.
   NMP_SKIP_MISE: 1
+  # Repository events consume the cache maintained by full main-push CI. Fork
+  # pull requests cannot authenticate to private GHCR packages, so leave their
+  # cache source empty. Only trusted main pushes may update the shared cache.
+  BAKE_CACHE_SOURCE_BRANCH: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'main' || '' }}
+  BAKE_CACHE_TARGET_BRANCH: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'main' || '' }}
 
 jobs:
   changes:
@@ -175,6 +180,25 @@ jobs:
           make docker-print TARGET=nmp-automodel-gpu-wheels
           make docker-print TARGET=nmp-automodel
           make docker-print TARGET=nmp-unsloth
+      - name: Verify multi-platform registry cache graph
+        shell: bash
+        env:
+          BAKE_CACHE_SOURCE_BRANCH: main
+          BAKE_CACHE_TARGET_BRANCH: main
+          CACHE_REGISTRY: ghcr.io/example/nemo-platform
+        run: |
+          set -euo pipefail
+          graph="${RUNNER_TEMP}/docker-bake-cache-graph.json"
+          docker buildx bake -f docker-bake.hcl --print nmp-api-docker > "$graph"
+          jq -e --arg ref "${CACHE_REGISTRY}/nmp-api:cache-main" \
+            '.target["nmp-api-docker"]["cache-to"] | any(.type == "registry" and .ref == $ref and .mode == "max")' \
+            "$graph"
+          jq -e --arg ref "${CACHE_REGISTRY}/nmp-api:cache-main" \
+            '.target["nmp-api-docker"]["cache-from"] | any(.type == "registry" and .ref == $ref)' \
+            "$graph"
+          jq -e \
+            '.target["nmp-api-docker"].platforms == ["linux/amd64", "linux/arm64"]' \
+            "$graph"
 
   build-cpu-smoke-images:
     name: Build CPU smoke images
@@ -288,7 +312,7 @@ jobs:
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           version-file: pyproject.toml
-          cache-dependency-glob: uv.lock
+          enable-cache: false
 
       - name: Populate fastembed model cache
         if: steps.fastembed-cache.outputs.cache-hit != 'true'
@@ -304,7 +328,7 @@ jobs:
             -mindepth 1 -maxdepth 1 -type d -print -quit | grep -q .
 
       - name: Log in to GHCR
-        if: env.PUBLISH_IMAGES == 'true'
+        if: env.PUBLISH_IMAGES == 'true' || env.BAKE_CACHE_SOURCE_BRANCH != ''
         shell: bash
         env:
           GHCR_TOKEN: ${{ github.token }}
@@ -346,6 +370,7 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -389,6 +414,15 @@ jobs:
             printf 'CI_COMMIT_SHA=%s\n' "$source_sha"
           } >> "$GITHUB_ENV"
 
+      - name: Log in to GHCR for registry cache
+        if: env.BAKE_CACHE_SOURCE_BRANCH != ''
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
+
       - name: Print Docker bake graph
         shell: bash
         run: make docker-print TARGET=docker-auditor
@@ -409,6 +443,7 @@ jobs:
     timeout-minutes: 120
     permissions:
       contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -455,6 +490,15 @@ jobs:
             printf 'BAKE_TAG=%s\n' "$bake_tag"
             printf 'CI_COMMIT_SHA=%s\n' "$source_sha"
           } >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR for registry cache
+        if: env.BAKE_CACHE_SOURCE_BRANCH != ''
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 
       - name: Print Docker bake graph
         shell: bash
@@ -786,7 +830,13 @@ jobs:
         with:
           enable-cache: true
           python-version: "3.12"
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          # Isolate full-workspace installs from lightweight jobs. The versioned,
+          # unpruned profile also replaces the undersized exact-hit cache.
+          cache-suffix: workspace-v1
+          prune-cache: false
       - name: Check uv lockfile
         run: uv lock --check
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -858,7 +908,12 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          cache-suffix: workspace-v1
+          prune-cache: false
+          save-cache: false
       - name: Run tools unit tests
         run: uv run pytest tools -v --junit-xml=report.xml
       - name: Upload test artifacts
@@ -890,7 +945,11 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          cache-suffix: workspace-v1
+          prune-cache: false
       - name: Run unit tests
         run: make test-unit-ci
         env:
@@ -1021,7 +1080,11 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          cache-suffix: workspace-v1
+          prune-cache: false
       - name: Log in to Docker Hub
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -1076,7 +1139,12 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          cache-suffix: workspace-v1
+          prune-cache: false
+          save-cache: false
       - name: Run auth-idp static tests
         run: |
           set -euo pipefail
@@ -1148,7 +1216,12 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          cache-suffix: workspace-v1
+          prune-cache: false
+          save-cache: false
       - name: Setup Kind cluster
         if: matrix.backend == 'kubernetes'
         uses: ./.github/actions/setup-kind-cluster
@@ -1383,7 +1456,11 @@ jobs:
         with:
           python-version: "3.13"
           enable-cache: true
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          cache-suffix: workspace-v1
+          prune-cache: false
       - name: Run e2e tests
         run: make test-e2e
         env:
@@ -1447,7 +1524,12 @@ jobs:
         with:
           python-version: "3.13"
           enable-cache: true
-          cache-dependency-glob: uv.lock
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
+          cache-suffix: workspace-v1
+          prune-cache: false
+          save-cache: false
       - name: Log in to GHCR
         shell: bash
         env:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -237,7 +237,10 @@ function "sha_and_maybe_latest_tags" {
 function "maybe_registry_cache_to" {
   params = [name]
   result = [
-    and(notequal(BAKE_CACHE_TARGET_BRANCH, ""), notequal(BUILD_ARCH, "")) ? "type=registry,ref=${CACHE_REGISTRY}/${name}:${CACHE_VERSION}-${BAKE_CACHE_TARGET_BRANCH}-${get_arch_tag()},mode=max,compression=zstd,force-compression=true" : ""
+    # BUILD_ARCH is empty for the multi-platform GitHub Actions build, which
+    # writes one aggregate cache manifest. Per-architecture builders retain
+    # their existing suffixed cache tags.
+    notequal(BAKE_CACHE_TARGET_BRANCH, "") ? "type=registry,ref=${CACHE_REGISTRY}/${name}:${CACHE_VERSION}-${BAKE_CACHE_TARGET_BRANCH}${notequal(BUILD_ARCH, "") ? "-${get_arch_tag()}" : ""},mode=max,compression=zstd,force-compression=true" : ""
   ]
 }
 
@@ -249,8 +252,12 @@ function "image_output" {
 function "maybe_registry_cache_from" {
   params = [name]
   result = [
+    # Prefer the aggregate multi-platform cache, then fall back to the legacy
+    # per-architecture caches populated by split builders.
+    notequal(BAKE_CACHE_SOURCE_BRANCH, "") ? "type=registry,ref=${CACHE_REGISTRY}/${name}:${CACHE_VERSION}-${BAKE_CACHE_SOURCE_BRANCH}" : "",
     notequal(BAKE_CACHE_SOURCE_BRANCH, "") ? "type=registry,ref=${CACHE_REGISTRY}/${name}:${CACHE_VERSION}-${BAKE_CACHE_SOURCE_BRANCH}-linux-arm64" : "",
     notequal(BAKE_CACHE_SOURCE_BRANCH, "") ? "type=registry,ref=${CACHE_REGISTRY}/${name}:${CACHE_VERSION}-${BAKE_CACHE_SOURCE_BRANCH}-linux-amd64" : "",
+    and(notequal(CACHE_REGISTRY_BACKUP, ""), notequal(BAKE_CACHE_SOURCE_BRANCH, "")) ? "type=registry,ref=${CACHE_REGISTRY_BACKUP}/${name}:${CACHE_VERSION}-${BAKE_CACHE_SOURCE_BRANCH}" : "",
     and(notequal(CACHE_REGISTRY_BACKUP, ""), notequal(BAKE_CACHE_SOURCE_BRANCH, "")) ? "type=registry,ref=${CACHE_REGISTRY_BACKUP}/${name}:${CACHE_VERSION}-${BAKE_CACHE_SOURCE_BRANCH}-linux-arm64" : "",
     and(notequal(CACHE_REGISTRY_BACKUP, ""), notequal(BAKE_CACHE_SOURCE_BRANCH, "")) ? "type=registry,ref=${CACHE_REGISTRY_BACKUP}/${name}:${CACHE_VERSION}-${BAKE_CACHE_SOURCE_BRANCH}-linux-amd64" : "",
   ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Improve CI cache effectiveness without reducing full `push: main` coverage.
Heavy uv jobs now use an isolated, unpruned workspace cache, while trusted
builds consume a shared multi-platform BuildKit cache that only main pushes
can update.

## Changes

- isolate full-workspace uv installs from lightweight jobs with a versioned cache profile
- keep lightweight workspace consumers restore-only so they cannot publish undersized exact-hit caches
- key workspace caches on both `pyproject.toml` and `uv.lock`
- let trusted PR and merge-queue builds read the main BuildKit cache while restricting writes to `push: main`
- support aggregate multi-platform cache manifests with legacy per-architecture fallbacks
- add a Docker bake graph assertion for the multi-platform registry cache configuration

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: This changes internal CI
  cache policy and does not alter user-facing behavior.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `CI=1 uv run pre-commit run -a` with uv 0.9.14 on `PATH` — passed
- `actionlint` v1.7.12 — passed
- `docker buildx bake -f docker-bake.hcl --print nmp-api-docker` for
  cache-disabled, read-only, aggregate multi-platform, and per-architecture
  configurations — passed
- `docker buildx bake -f docker-bake.hcl --print` for the CPU, auditor, and
  Safe Synthesizer CI image groups — passed
