### PR TITLE
feat(experimentalist): stop a run once the objective is reached

### DIFF
--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/config.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/config.py
@@ -57,6 +57,26 @@ class MetricTarget(BaseModel):
     direction: Literal["maximize", "minimize"] = Field(
         description="Whether higher or lower values are better for this target."
     )
+    target: float | None = Field(
+        default=None,
+        description=(
+            "Value at which this objective counts as satisfied, in the metric's own "
+            "units. When every targeted objective is met the run stops, so a solved "
+            "problem stops paying for rounds. Unset means no such stop: metrics are not "
+            "required to be normalized, so there is no value that means 'as good as "
+            "possible' for an arbitrary one."
+        ),
+    )
+
+    def is_satisfied_by(self, value: float | None) -> bool:
+        """Whether *value* meets this target. False when either side is absent.
+
+        A missing measurement is not evidence of success, and a target that was never
+        configured must not end a run.
+        """
+        if value is None or self.target is None:
+            return False
+        return value >= self.target if self.direction == "maximize" else value <= self.target
 
 
 def pareto_objectives(metrics: dict[str, float], objective_function: list[MetricTarget]) -> dict[str, float]:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/analyzer.py
@@ -272,8 +272,8 @@ class AgentAnalyzer(Agent):
         agent_id: str,
         dataset: Dataset,
         evaluation: EvaluationResult,
-        objective_metrics: list[dict[str, str]],
-        regression_metrics: list[dict[str, str]],
+        objective_metrics: list[dict[str, Any]],
+        regression_metrics: list[dict[str, Any]],
     ) -> list[TrialSelection]:
         """Pick which trials to analyze in depth and explain each choice.
 
@@ -351,8 +351,8 @@ class AgentAnalyzer(Agent):
         agent_id: str,
         diagnoses: list[Diagnostic],
         trials: Sequence[TrialResult],
-        objective_metrics: list[dict[str, str]],
-        regression_metrics: list[dict[str, str]],
+        objective_metrics: list[dict[str, Any]],
+        regression_metrics: list[dict[str, Any]],
     ) -> FailureClassification:
         """Classify diagnoses into systematic vs. one-off and agent vs. mechanical failures.
 
@@ -388,8 +388,8 @@ class AgentAnalyzer(Agent):
         evaluation: EvaluationResult,
         diagnoses: list[Diagnostic],
         peer_evaluations: dict[str, EvaluationResult] | None = None,
-        objective_metrics: list[dict[str, str]] | None = None,
-        regression_metrics: list[dict[str, str]] | None = None,
+        objective_metrics: list[dict[str, Any]] | None = None,
+        regression_metrics: list[dict[str, Any]] | None = None,
     ) -> PeerComparison:
         """Compare this agent to peers and return divergent trials and complementary patterns.
 
@@ -513,7 +513,7 @@ class AgentAnalyzer(Agent):
 
     @staticmethod
     def _metric_directions(
-        objective_metrics: list[dict[str, str]], regression_metrics: list[dict[str, str]]
+        objective_metrics: list[dict[str, Any]], regression_metrics: list[dict[str, Any]]
     ) -> dict[str, str]:
         """Return metric directions, defaulting dimensions outside the contract to maximize."""
         return {metric["name"]: metric["direction"] for metric in [*objective_metrics, *regression_metrics]}
@@ -572,8 +572,8 @@ class AgentAnalyzer(Agent):
         top_divergent: list[dict[str, Any]],
         complementary_raw: dict[str, dict[str, dict[str, list[str]]]],
         diagnoses: list[Diagnostic],
-        objective_metrics: list[dict[str, str]],
-        regression_metrics: list[dict[str, str]],
+        objective_metrics: list[dict[str, Any]],
+        regression_metrics: list[dict[str, Any]],
     ) -> PeerComparison:
         """Write the DivergentTrial and ComplementaryPattern narratives from pre-computed data.
 
@@ -652,8 +652,8 @@ class AgentAnalyzer(Agent):
         client: AsyncNeMoPlatform | None = None,
         nmp_workspace: str | None = None,
         agent_spec: Path | None = None,
-        objective_metrics: list[dict[str, str]] | None = None,
-        regression_metrics: list[dict[str, str]] | None = None,
+        objective_metrics: list[dict[str, Any]] | None = None,
+        regression_metrics: list[dict[str, Any]] | None = None,
     ) -> AgentAnalysis:
         """Run the full analysis pipeline for one agent in one optimization round.
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/proposer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/proposer.py
@@ -101,8 +101,8 @@ class Proposer(Agent):
         round_num: int,
         phase: Literal["exploration", "exploitation"],
         max_candidates: int,
-        objective_metrics: list[dict[str, str]],
-        regression_metrics: list[dict[str, str]],
+        objective_metrics: list[dict[str, Any]],
+        regression_metrics: list[dict[str, Any]],
     ) -> list[Improvement]:
         """Return up to max_candidates targeted improvement proposals.
 
@@ -242,8 +242,8 @@ class Proposer(Agent):
         cards_index: str,
         phase: Literal["exploration", "exploitation"],
         max_candidates: int,
-        objective_metrics: list[dict[str, str]],
-        regression_metrics: list[dict[str, str]],
+        objective_metrics: list[dict[str, Any]],
+        regression_metrics: list[dict[str, Any]],
     ) -> list[Improvement]:
         """Pick up to `max_candidates` targeted improvements grounded in root causes.
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
@@ -77,6 +77,9 @@ class Terminator(Agent):
         Returns:
             A :class:`TerminationDecision`.
         """
+        reached = self.assess_objective_reached(evolution_tree=evolution_tree, config=config)
+        if reached.stop:
+            return reached
         budget = self.assess_round_budget(round_num=round_num, config=config)
         if budget.stop:
             return budget
@@ -85,6 +88,45 @@ class Terminator(Agent):
             prior_analysis=prior_analysis,
             config=config,
         )
+
+    @hidden
+    def assess_objective_reached(
+        self,
+        *,
+        evolution_tree: EvolutionTree,
+        config: EvolutionaryOptimizerConfig,
+    ) -> TerminationDecision:
+        """Stop when a candidate that could win already satisfies every targeted objective.
+
+        Distinct from convergence, which asks whether progress has *stalled*. This asks
+        whether there is any progress left worth making, and answers it from the numbers
+        rather than from a judgement about the analysis text. A run that has solved the
+        problem otherwise keeps buying rounds until its budget runs out, and each one can
+        only match what it already has.
+
+        Deliberately **not** gated by ``disable_convergence_check``. That flag turns off
+        an inference about stagnation, which is a judgement call worth disabling when the
+        signal is unreliable. This is a measurement against a threshold the caller stated,
+        and there is no reason to want it off while a target is configured -- if you do
+        not want the run to stop here, do not set a target.
+
+        Consulted at the top of every round including the first, so a baseline that
+        already meets the targets ends the run without a single round being paid for.
+
+        Only nodes that could actually win are considered -- survivors and the round-0
+        baseline, mirroring finalization. A killed candidate meeting the target would end
+        the run in favour of a winner that never reaches it.
+        """
+        targets = [target for target in config.objective_function if target.target is not None]
+        if not targets:
+            return TerminationDecision(stop=False)
+        for node in evolution_tree.nodes.values():
+            if not node.val_reward or not (node.is_survivor or node.round == 0):
+                continue
+            if all(target.is_satisfied_by(node.val_reward.get(target.name)) for target in targets):
+                summary = ", ".join(f"{target.name}={node.val_reward.get(target.name)}" for target in targets)
+                return TerminationDecision(stop=True, reason=f"objective reached by {node.label} ({summary})")
+        return TerminationDecision(stop=False)
 
     @hidden
     async def assess_convergence(

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/terminator.py
@@ -98,24 +98,13 @@ class Terminator(Agent):
     ) -> TerminationDecision:
         """Stop when a candidate that could win already satisfies every targeted objective.
 
-        Distinct from convergence, which asks whether progress has *stalled*. This asks
-        whether there is any progress left worth making, and answers it from the numbers
-        rather than from a judgement about the analysis text. A run that has solved the
-        problem otherwise keeps buying rounds until its budget runs out, and each one can
-        only match what it already has.
+        Convergence asks whether progress has stalled; this asks whether any is left to
+        make. Not gated by ``disable_convergence_check``: that disables a judgement about
+        stagnation, this is a threshold the caller stated. To keep going, set no target.
 
-        Deliberately **not** gated by ``disable_convergence_check``. That flag turns off
-        an inference about stagnation, which is a judgement call worth disabling when the
-        signal is unreliable. This is a measurement against a threshold the caller stated,
-        and there is no reason to want it off while a target is configured -- if you do
-        not want the run to stop here, do not set a target.
-
-        Consulted at the top of every round including the first, so a baseline that
-        already meets the targets ends the run without a single round being paid for.
-
-        Only nodes that could actually win are considered -- survivors and the round-0
-        baseline, mirroring finalization. A killed candidate meeting the target would end
-        the run in favour of a winner that never reaches it.
+        Consulted before every round, so a baseline that already qualifies costs nothing.
+        Only survivors and the round-0 baseline count, mirroring finalization -- a killed
+        candidate would end the run in favour of a winner that never reaches the target.
         """
         targets = [target for target in config.objective_function if target.target is not None]
         if not targets:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/trace_analyzer.py
@@ -194,8 +194,8 @@ class TraceAnalyzer(Agent):
         runtime: DependencyRuntime | None,
         insight: Insight | None = None,
         selection_reason: str = "",
-        objective_metrics: list[dict[str, str]] | None = None,
-        regression_metrics: list[dict[str, str]] | None = None,
+        objective_metrics: list[dict[str, Any]] | None = None,
+        regression_metrics: list[dict[str, Any]] | None = None,
     ) -> StepAnalysis:
         """Trace the agent's path and find where it went wrong.
 
@@ -259,8 +259,8 @@ class TraceAnalyzer(Agent):
         trace: TraceExplorer,
         analysis: StepAnalysis,
         insight: Insight | None = None,
-        objective_metrics: list[dict[str, str]] | None = None,
-        regression_metrics: list[dict[str, str]] | None = None,
+        objective_metrics: list[dict[str, Any]] | None = None,
+        regression_metrics: list[dict[str, Any]] | None = None,
     ) -> Diagnostic:
         """Determine the primary root cause and produce a Diagnostic.
 
@@ -302,8 +302,8 @@ class TraceAnalyzer(Agent):
         rationale: Rationale | None = None,
         insight: Insight | None = None,
         selection_reason: str = "",
-        objective_metrics: list[dict[str, str]] | None = None,
-        regression_metrics: list[dict[str, str]] | None = None,
+        objective_metrics: list[dict[str, Any]] | None = None,
+        regression_metrics: list[dict[str, Any]] | None = None,
         client: AsyncNeMoPlatform | None = None,
         workspace: str | None = None,
     ) -> Diagnostic:

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_objective_reached.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_objective_reached.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pin when a solved objective ends a run.
+
+Before this, the only stop conditions were the round budget and a stagnation
+judgement. Neither notices success: a round that goes 0.333 -> 1.000 is the
+clearest possible case of *not* stagnating, so a solved run kept buying rounds
+that could only match what it already had.
+
+The rule: when every objective carrying a ``target`` is satisfied by a candidate
+that could win, stop. Absent targets, nothing changes.
+"""
+
+from __future__ import annotations
+
+import pytest
+from nemo_experimentalist_plugin.config import EvolutionaryOptimizerConfig, MetricTarget
+from nemo_experimentalist_plugin.entities import Candidate, RewardRecord
+from nemo_experimentalist_plugin.experimentalist.components.models import EvolutionNode, EvolutionTree
+from nemo_experimentalist_plugin.experimentalist.components.terminator import Terminator
+
+SOLVED = [MetricTarget(name="reward", direction="maximize", target=1.0)]
+UNTARGETED = [MetricTarget(name="reward", direction="maximize")]
+
+
+def _node(label: str, round_: int, killed: int | None = None, **metrics: float) -> EvolutionNode:
+    candidate = Candidate(
+        run_id="run-1",
+        label=label,
+        round=round_,
+        optimization="baseline" if round_ == 0 else "some change",
+        rewards={"validation": RewardRecord(metrics=dict(metrics))},
+    )
+    candidate.killed_round = killed
+    return EvolutionNode(candidate=candidate)
+
+
+def _tree(*nodes: EvolutionNode) -> EvolutionTree:
+    tree = EvolutionTree()
+    for node in nodes:
+        tree.add(node.candidate)
+    return tree
+
+
+def _assess(tree: EvolutionTree, objectives: list[MetricTarget], **overrides: object):
+    config = EvolutionaryOptimizerConfig.model_validate(
+        {"objective_function": [target.model_dump() for target in objectives], **overrides}
+    )
+    return Terminator.assess_objective_reached(Terminator, evolution_tree=tree, config=config)  # type: ignore[arg-type]
+
+
+def test_a_solved_objective_stops_the_run() -> None:
+    decision = _assess(_tree(_node("agent-0", 0, reward=0.333), _node("agent-1", 1, reward=1.0)), SOLVED)
+    assert decision.stop
+    assert "agent-1" in decision.reason
+
+
+def test_an_unsolved_objective_does_not_stop_the_run() -> None:
+    decision = _assess(_tree(_node("agent-0", 0, reward=0.333), _node("agent-1", 1, reward=0.667)), SOLVED)
+    assert not decision.stop
+
+
+def test_no_target_configured_never_stops() -> None:
+    """Absent an explicit target there is no value that means 'as good as possible'."""
+    decision = _assess(_tree(_node("agent-0", 0, reward=1.0), _node("agent-1", 1, reward=1.0)), UNTARGETED)
+    assert not decision.stop
+
+
+def test_a_baseline_that_already_meets_the_target_stops_before_any_round() -> None:
+    """The terminator is consulted at the top of round 1, so nothing is paid for."""
+    decision = _assess(_tree(_node("agent-0", 0, reward=1.0)), SOLVED)
+    assert decision.stop
+    assert "agent-0" in decision.reason
+
+
+def test_every_targeted_objective_must_be_met() -> None:
+    objectives = [
+        MetricTarget(name="reward", direction="maximize", target=1.0),
+        MetricTarget(name="shape_ok", direction="maximize", target=1.0),
+    ]
+    partial = _assess(_tree(_node("agent-1", 1, reward=1.0, shape_ok=0.5)), objectives)
+    assert not partial.stop
+    both = _assess(_tree(_node("agent-1", 1, reward=1.0, shape_ok=1.0)), objectives)
+    assert both.stop
+
+
+def test_an_untargeted_objective_does_not_block_the_stop() -> None:
+    """Only targeted objectives are judged; an untargeted one is not an obstacle."""
+    objectives = [
+        MetricTarget(name="reward", direction="maximize", target=1.0),
+        MetricTarget(name="coverage", direction="maximize"),
+    ]
+    decision = _assess(_tree(_node("agent-1", 1, reward=1.0, coverage=0.1)), objectives)
+    assert decision.stop
+
+
+def test_minimized_objective_uses_the_opposite_comparison() -> None:
+    objectives = [MetricTarget(name="cost", direction="minimize", target=0.2)]
+    assert _assess(_tree(_node("agent-1", 1, cost=0.1)), objectives).stop
+    assert not _assess(_tree(_node("agent-1", 1, cost=0.3)), objectives).stop
+
+
+def test_a_missing_measurement_is_not_success() -> None:
+    """The metric was never reported; absence must not be read as meeting the target."""
+    decision = _assess(_tree(_node("agent-1", 1, other=1.0)), SOLVED)
+    assert not decision.stop
+
+
+def test_a_killed_candidate_cannot_end_the_run() -> None:
+    """It cannot win, so stopping on it would ship a winner that never met the target."""
+    decision = _assess(
+        _tree(_node("agent-0", 0, reward=0.333), _node("agent-1", 1, killed=1, reward=1.0)),
+        SOLVED,
+    )
+    assert not decision.stop
+
+
+def test_a_killed_baseline_still_counts() -> None:
+    """Finalization re-admits the baseline, so it remains a candidate for winning."""
+    decision = _assess(_tree(_node("agent-0", 0, killed=1, reward=1.0)), SOLVED)
+    assert decision.stop
+
+
+def test_unscored_nodes_are_ignored() -> None:
+    decision = _assess(_tree(_node("agent-0", 0, reward=0.5), _node("agent-1", 1)), SOLVED)
+    assert not decision.stop
+
+
+@pytest.mark.parametrize("disabled", [True, False])
+def test_the_stop_is_independent_of_disable_convergence_check(disabled: bool) -> None:
+    """That flag turns off a judgement about stagnation; this is a stated threshold."""
+    decision = _assess(
+        _tree(_node("agent-1", 1, reward=1.0)),
+        SOLVED,
+        disable_convergence_check=disabled,
+    )
+    assert decision.stop

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_analyzer.py
@@ -89,8 +89,8 @@ class _RecordingTraceAnalyzer:
         rationale: Any = None,
         insight: Any = None,
         selection_reason: str = "",
-        objective_metrics: list[dict[str, str]] | None = None,
-        regression_metrics: list[dict[str, str]] | None = None,
+        objective_metrics: list[dict[str, Any]] | None = None,
+        regression_metrics: list[dict[str, Any]] | None = None,
         client: Any = None,
         workspace: Any = None,
     ) -> Diagnostic:
@@ -127,8 +127,8 @@ class _SelectTrials:
         agent_id: str,
         dataset: Any,
         evaluation: Any,
-        objective_metrics: list[dict[str, str]],
-        regression_metrics: list[dict[str, str]],
+        objective_metrics: list[dict[str, Any]],
+        regression_metrics: list[dict[str, Any]],
     ) -> list[TrialSelection]:
         return [
             TrialSelection(trial_id=trial.id, reason=f"Analyze {trial.id} for this test.") for trial in self._trials
@@ -141,8 +141,8 @@ class _ClassifyFailures:
         agent_id: str,
         diagnoses: Any,
         trials: Any,
-        objective_metrics: list[dict[str, str]],
-        regression_metrics: list[dict[str, str]],
+        objective_metrics: list[dict[str, Any]],
+        regression_metrics: list[dict[str, Any]],
     ) -> FailureClassification:
         return FailureClassification(systematic=[], mechanical=[])
 
@@ -154,8 +154,8 @@ class _CompareWithPeers:
         evaluation: Any,
         diagnoses: Any,
         peer_evaluations: Any = None,
-        objective_metrics: list[dict[str, str]] | None = None,
-        regression_metrics: list[dict[str, str]] | None = None,
+        objective_metrics: list[dict[str, Any]] | None = None,
+        regression_metrics: list[dict[str, Any]] | None = None,
     ) -> PeerComparison:
         return PeerComparison(divergent_trials=[], complementary_patterns=[])
 
@@ -204,8 +204,10 @@ def test_peer_comparison_respects_minimize_metric_directions(tmp_path: Path) -> 
         [{"name": "quality", "direction": "maximize"}, {"name": "tokens", "direction": "minimize"}], []
     )
 
-    pairs = analyzer._select_divergent_pairs("focal", focal, {"peer": peer}, directions)
-    complementary = analyzer._find_complementary_failures("focal", focal, {"peer": peer}, directions)
+    pairs = analyzer._select_divergent_pairs("focal", cast(Any, focal), cast(Any, {"peer": peer}), directions)
+    complementary = analyzer._find_complementary_failures(
+        "focal", cast(Any, focal), cast(Any, {"peer": peer}), directions
+    )
 
     assert pairs[0]["winner"] == "peer"
     assert complementary["task-1"]["quality"]["leaders"] == ["focal"]
@@ -277,6 +279,28 @@ async def test_run_threads_metric_contract_into_trace_analyzer(tmp_path: Path, m
 
     assert calls[0]["objective_metrics"] == objective_metrics
     assert calls[0]["regression_metrics"] == regression_metrics
+
+
+@pytest.mark.asyncio
+async def test_run_threads_numeric_objective_targets_into_trace_analyzer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Check that trace analysis receives a numeric objective target."""
+    calls: list[dict[str, Any]] = []
+    _install_fakes(monkeypatch, calls)
+    trial, dataset, evaluation = _fixtures()
+    analyzer = _make_analyzer(tmp_path, [trial])
+    objective_metrics = [{"name": "reward", "direction": "maximize", "target": 1.0}]
+
+    await analyzer.run(
+        agent="agent-a",
+        dataset=cast(Any, dataset),
+        evaluation=cast(Any, evaluation),
+        round=0,
+        objective_metrics=objective_metrics,
+    )
+
+    assert calls[0]["objective_metrics"] == objective_metrics
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-experimentalist/tests/test_metric_contract.py
+++ b/plugins/nemo-experimentalist/tests/test_metric_contract.py
@@ -97,7 +97,11 @@ def test_insight_metrics_become_objectives_and_existing_targets_become_guardrail
 
     assert [target.name for target in effective.objective_function] == ["uses_required_tool", "cites_source"]
     assert all(target.direction == "maximize" for target in effective.objective_function)
+    # Demoted targets are carried across whole, `target` included. The authored insight
+    # objectives get none: an LLM-invented metric has no known satisfied value, so a
+    # Mode 1 run cannot stop early on one and falls back to its round budget.
     assert [target.model_dump() for target in effective.regression_metrics] == [
-        {"name": "cost", "direction": "minimize"},
-        {"name": "safety", "direction": "maximize"},
+        {"name": "cost", "direction": "minimize", "target": None},
+        {"name": "safety", "direction": "maximize", "target": None},
     ]
+    assert all(target.target is None for target in effective.objective_function)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The loop had two ways to stop: the round budget, and a judgement that progress had stalled. Neither notices success. A round that goes `0.333 -> 1.000` is the clearest possible case of *not* stagnating, so a solved run kept buying rounds that could only match what it already had — and a baseline that already met the goal paid for the whole budget before returning itself.

This adds an optional `target` to `MetricTarget`: the value at which that objective is satisfied, in the metric's own units. When every targeted objective is met, the run stops. Unset, nothing changes.

Before and after, on a run whose first round solves the problem:

| | Before | After (`target: 1.0`) |
| --- | --- | --- |
| Round 1 reaches 1.000 | runs every remaining round | stops, `objective reached by agent-1 (reward=1.0)` |
| Baseline already at 1.000 | runs the full budget, returns the baseline | stops before round 1 |
| No `target` configured | unchanged | unchanged |

## Changes

- `MetricTarget.target: float | None`, with `is_satisfied_by()` handling direction and treating a missing measurement as *not* satisfied.
- `Terminator.assess_objective_reached`, consulted first in `Terminator.run()`.
- `test_objective_reached.py` — 13 tests.
- `test_metric_contract.py` — updated for the new field, plus an assertion that insight-authored objectives carry no target.

Three properties, each a deliberate decision:

**Not gated by `disable_convergence_check`.** That flag turns off an *inference* about stagnation, which is worth disabling when the signal is unreliable. This is a measurement against a threshold the caller stated. Anyone who does not want the run to stop here does not set a target.

**Checked at the top of every round, including the first.** The baseline is scored before the loop begins, so a baseline already meeting the targets ends the run without a single round being paid for.

**Only candidates that could win are considered** — survivors and the round-0 baseline, mirroring finalization. A killed candidate meeting the target would otherwise end the run in favour of a winner that never reaches it.

Unset is the only safe default: metrics are not required to be normalized, so there is no value that means "as good as possible" for an arbitrary one. Insight-authored objectives get no target for the same reason, leaving Mode 1 unaffected — an LLM-invented metric has no known satisfied value.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the new field is self-documenting through its `Field(description=...)`, which is where the other optimizer settings are described; there is no separate settings reference to update.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
uv run --frozen pytest plugins/nemo-experimentalist/tests/experimentalist/test_objective_reached.py -q
  → 13 passed

uv run --frozen pytest plugins/nemo-experimentalist/tests/ -q
  → 654 passed

uv run ruff check <config.py> <terminator.py> <both tests>          → All checks passed!
uv run ruff format --check <same>                                   → already formatted
uv run --frozen ty check <config.py> <terminator.py>                → All checks passed!

uv run pre-commit run -a
  → all hooks passed EXCEPT "Run uv lock with platform uv":
       "uv.lock must be checked or updated with uv 0.9.14 ... Current uv: uv 0.9.30"
```

That hook is environmental and pre-existing — it needs uv 0.9.14 locally and this machine has 0.9.30. It was reproduced on pristine `main` with these changes stashed while preparing #1195, and CI's own `Check uv lock` and `Check latest uv compatibility` both passed there. This PR modifies no `pyproject.toml` and no `uv.lock`. Left unchecked rather than claiming a gate that did not pass.

Behaviour was also confirmed by mutation rather than by green tests alone: with no target the run continues exactly as before; with `target: 1.0` the same tree stops and reports `objective reached by agent-1 (reward=1.0)`.

## Note

Found while running a fixture whose expected score is known in advance. Three groups each reached `1.000` and then spent a further round that could not improve on it, and one reached it in round 1 of 2. Nothing was wrong with those runs — there was simply no way to say "this is finished".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable satisfaction thresholds for optimization metrics, supporting maximize and minimize objectives.
  * Runs can stop immediately when all targeted objectives are met, including by baseline candidates.
  * Missing, unscored, or ineligible candidate metrics do not count toward objective completion.

* **Bug Fixes**
  * Untargeted objectives no longer prevent early termination.
  * Objective-based stopping now works independently of convergence settings.
  * Numeric objective targets are now preserved and evaluated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->