### PR TITLE
fix(studio): stop evaluation fileset links 404ing by default

### DIFF
--- a/web/packages/studio/src/components/dataViews/AgentEvaluationsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/AgentEvaluationsDataView/index.tsx
@@ -29,7 +29,7 @@ import { BulkDeleteModal } from '@studio/components/BulkDeleteModal';
 import { QuickActionsMenuRoot } from '@studio/components/QuickActionsMenu/QuickActionsMenuRoot';
 import { STATUS_FILTER_OPTIONS } from '@studio/constants/platformJobs';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
-import { getAgentEvaluationDetailRoute, getFilesetDetailRoute } from '@studio/routes/utils';
+import { getAgentEvaluationDetailRoute, getFilesetRoute } from '@studio/routes/utils';
 import { getTextWithCount } from '@studio/util/strings';
 import { keepPreviousData, useQueryClient } from '@tanstack/react-query';
 import { Trash } from 'lucide-react';
@@ -133,7 +133,7 @@ export const AgentEvaluationsDataView = () => {
         const configName = evalConfigName(row.original);
         return configName ? (
           <Link
-            to={getFilesetDetailRoute(workspace, configName)}
+            to={getFilesetRoute(workspace, configName)}
             className="text-primary underline"
             onClick={(e) => e.stopPropagation()}
           >

--- a/web/packages/studio/src/components/evaluation/Jobs/DetailsPanel.tsx
+++ b/web/packages/studio/src/components/evaluation/Jobs/DetailsPanel.tsx
@@ -22,7 +22,7 @@ import type { EvaluateJob } from '@nemo/sdk/generated/evaluator/schema';
 import { Banner, Button, Flex, Modal, Panel, Stack, Text } from '@nvidia/foundations-react-core';
 import { ButtonLaunchEvaluation } from '@studio/components/evaluation/ButtonLaunchEvaluation';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
-import { getFilesetDetailRoute } from '@studio/routes/utils';
+import { getFilesetRoute } from '@studio/routes/utils';
 import { logger } from '@studio/util/logger';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChartBar, CircleX } from 'lucide-react';
@@ -111,7 +111,7 @@ export const DetailsPanel = ({ evaluationJob, error }: DetailsPanelProps) => {
   const targetIsAgent = evaluationJob.spec.target?.format !== undefined;
   const datasetRef =
     typeof evaluationJob.spec.dataset === 'string' ? evaluationJob.spec.dataset : undefined;
-  const datasetFileset = datasetRef?.split('#')[0]?.split('/').pop();
+  const datasetFileset = datasetRef?.split('#')[0];
 
   return (
     <>
@@ -208,7 +208,7 @@ export const DetailsPanel = ({ evaluationJob, error }: DetailsPanelProps) => {
               label="Dataset"
               value={
                 <Link
-                  to={getFilesetDetailRoute(workspace, datasetFileset)}
+                  to={getFilesetRoute(workspace, datasetFileset)}
                   className="text-primary underline"
                 >
                   {datasetRef}

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationDetailRoute.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationDetailRoute.tsx
@@ -44,7 +44,7 @@ import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import {
   getAgentEvaluationsListRoute,
   getAgentsListRoute,
-  getFilesetDetailRoute,
+  getFilesetRoute,
 } from '@studio/routes/utils';
 import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -223,7 +223,7 @@ export const AgentEvaluationDetailRoute: FC = () => {
                   label="Eval Config"
                   value={
                     <Link
-                      to={getFilesetDetailRoute(workspace, evalConfigName(job) ?? '')}
+                      to={getFilesetRoute(workspace, evalConfigName(job) ?? '')}
                       className="text-primary underline"
                     >
                       {evalConfigName(job)}
@@ -246,7 +246,7 @@ export const AgentEvaluationDetailRoute: FC = () => {
                   label="Artifacts"
                   value={
                     <Link
-                      to={getFilesetDetailRoute(workspace, artifactsFileset)}
+                      to={getFilesetRoute(workspace, artifactsFileset)}
                       className="text-primary underline"
                     >
                       View files

--- a/web/packages/studio/src/routes/utils.test.ts
+++ b/web/packages/studio/src/routes/utils.test.ts
@@ -9,6 +9,7 @@ import {
   getEvaluationMetricsRunRoute,
   getEvaluationSessionDetailRoute,
   getFilesetDetailsRoute,
+  getFilesetRoute,
   getIntakeSessionRoute,
   getIntakeSessionTraceRoute,
   getPromptTuningFormRoute,
@@ -63,6 +64,22 @@ describe('Evaluation route helpers', () => {
         '/workspaces/test-workspace/evaluation/benchmarks/my-benchmark'
       );
     });
+  });
+});
+
+describe('getFilesetRoute', () => {
+  const workspace = 'test-workspace';
+
+  it('routes a bare name to the panel route with a full entity reference', () => {
+    expect(getFilesetRoute(workspace, 'unchanged-blue')).toBe(
+      '/workspaces/test-workspace/filesets/test-workspace%2Funchanged-blue'
+    );
+  });
+
+  it('preserves a namespace already present on the reference', () => {
+    expect(getFilesetRoute(workspace, 'default/unchanged-blue')).toBe(
+      '/workspaces/test-workspace/filesets/default%2Funchanged-blue'
+    );
   });
 });
 

--- a/web/packages/studio/src/routes/utils.ts
+++ b/web/packages/studio/src/routes/utils.ts
@@ -488,6 +488,20 @@ export const getFilesetDetailRoute = (
   return options?.tab ? `${base}?${QUERY_PARAMETERS.tab}=${options.tab}` : base;
 };
 
+export const getFilesetRoute = (
+  workspace: string,
+  filesetRef: string,
+  options?: { tab?: FilesetDetailTab }
+) => {
+  if (FILESET_DETAILS_ENABLED) {
+    return getFilesetDetailRoute(workspace, filesetRef.split('/').pop() ?? filesetRef, options);
+  }
+  return getFilesetDetailsRoute(
+    workspace,
+    filesetRef.includes('/') ? filesetRef : `${workspace}/${filesetRef}`
+  );
+};
+
 export const getFilesetFileRoute = (workspace: string, fileset: string, filePath: string) => {
   return generatePath(ROUTES.workspace.filesetFile, {
     workspace,


### PR DESCRIPTION
https://nvbugspro.nvidia.com/bug/6581177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation to fileset details from evaluation configuration, artifact, and dataset links.
  * Preserved namespaced fileset references correctly when opening details.

* **Tests**
  * Added coverage for fileset routes using both simple and namespaced references, including encoded workspace and namespace values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->