### PR TITLE
feat(deployments): Add per-deployment OpenShell backend config

### DIFF
--- a/plugins/nemo-deployments/openapi/openapi.yaml
+++ b/plugins/nemo-deployments/openapi/openapi.yaml
@@ -1220,8 +1220,8 @@ components:
       properties:
         policyPath:
           title: Policypath
-          description: Path to a sandbox policy YAML file inside the sandbox image.
-            Overrides the executor-level default_policy_path for this deployment only.
+          description: Path to a sandbox policy YAML file on the backend host. Overrides
+            the executor-level default_policy_path for this deployment only.
           type: string
       type: object
       title: OpenShellDeploymentConfig

--- a/plugins/nemo-deployments/openapi/openapi.yaml
+++ b/plugins/nemo-deployments/openapi/openapi.yaml
@@ -847,6 +847,8 @@ components:
           $ref: '#/components/schemas/DockerDeploymentConfig'
         k8s:
           $ref: '#/components/schemas/K8sDeploymentConfig'
+        openshell:
+          $ref: '#/components/schemas/OpenShellDeploymentConfig'
       type: object
       title: DeploymentBackendConfig
     DeploymentConfig:
@@ -1214,6 +1216,15 @@ components:
       required:
       - data
       title: NemoListResponse_Volume_
+    OpenShellDeploymentConfig:
+      properties:
+        policyPath:
+          title: Policypath
+          description: Path to a sandbox policy YAML file inside the sandbox image.
+            Overrides the executor-level default_policy_path for this deployment only.
+          type: string
+      type: object
+      title: OpenShellDeploymentConfig
     PaginationData:
       properties:
         page:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
@@ -56,7 +56,7 @@ from nemo_deployments_plugin.backends.openshell.policy import (
     normalize_loaded_policy,
 )
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
-from nemo_deployments_plugin.entities import Container, DeploymentConfig, OpenShellDeploymentConfig
+from nemo_deployments_plugin.entities import ConfigFile, Container, DeploymentConfig, OpenShellDeploymentConfig
 from nemo_deployments_plugin.secrets import SecretResolutionError, resolve_deployment_config_secrets
 from nemo_deployments_plugin.types import DeploymentStatus, Endpoint
 from nemo_platform_plugin.client.adapter import client_from_platform

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
@@ -56,7 +56,7 @@ from nemo_deployments_plugin.backends.openshell.policy import (
     normalize_loaded_policy,
 )
 from nemo_deployments_plugin.constants import MANAGED_BY_LABEL
-from nemo_deployments_plugin.entities import ConfigFile, Container, DeploymentConfig
+from nemo_deployments_plugin.entities import Container, DeploymentConfig, OpenShellDeploymentConfig
 from nemo_deployments_plugin.secrets import SecretResolutionError, resolve_deployment_config_secrets
 from nemo_deployments_plugin.types import DeploymentStatus, Endpoint
 from nemo_platform_plugin.client.adapter import client_from_platform
@@ -246,6 +246,37 @@ class OpenShellDeploymentBackend(DeploymentBackend):
             inject_platform_egress(policy_dict, egress)
         return build_sandbox_policy(policy_dict)
 
+    def _build_deployment_policy(self, policy_path_override: str | None) -> Any:
+        """Return the effective policy for a single deployment.
+
+        Uses the per-deployment ``policy_path`` if set; otherwise falls back to
+        the executor-level default built at init time (``self._policy``).
+        The executor's egress rule is always re-injected so the deployment can
+        never lose its path back to the platform, even with a hand-written policy.
+        """
+        if not policy_path_override:
+            return self._policy
+        cfg = self._executor_config.platform_egress
+        egress = (
+            PlatformEgress(
+                host=cfg.host,
+                port=cfg.port,
+                protocol=cfg.protocol,
+                tls=cfg.tls,
+                access=cfg.access,
+                binaries=tuple(cfg.binaries) or DEFAULT_EGRESS_BINARIES,
+            )
+            if cfg is not None
+            else None
+        )
+        compat = self._executor_config.landlock_compatibility
+        policy_dict = normalize_loaded_policy(load_policy_dict(policy_path_override), landlock_compatibility=compat)
+
+        if egress is not None:
+            inject_platform_egress(policy_dict, egress)
+
+        return build_sandbox_policy(policy_dict)
+
     def _create_channel(self) -> grpc.Channel:
         target = self._executor_config.grpc_target()
         if self._executor_config.use_insecure():
@@ -280,7 +311,7 @@ class OpenShellDeploymentBackend(DeploymentBackend):
         labels: dict[str, str],
         backend_config: dict[str, Any],
     ) -> BackendStatusUpdate:
-        del backend_config  # per-deployment openshell overrides: needs entity field + SDK regen (follow-up)
+        openshell_cfg = OpenShellDeploymentConfig.model_validate(backend_config.get("openshell") or {})
         sandbox_nm = _sandbox_name(workspace, name)
 
         existing = await self._try_get_sandbox(sandbox_nm)
@@ -353,8 +384,9 @@ class OpenShellDeploymentBackend(DeploymentBackend):
             ),
         }
 
+        policy = self._build_deployment_policy(openshell_cfg.policy_path)
         template = pb.SandboxTemplate(image=container.image, environment=env, labels=all_labels)
-        spec = pb.SandboxSpec(template=template, environment=env, policy=self._policy)
+        spec = pb.SandboxSpec(template=template, environment=env, policy=policy)
         request = pb.CreateSandboxRequest(spec=spec, name=sandbox_nm, labels=all_labels)
 
         try:

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -179,7 +179,7 @@ class OpenShellDeploymentConfig(BaseModel):
         default=None,
         alias="policyPath",
         description=(
-            "Path to a sandbox policy YAML file inside the sandbox image. "
+            "Path to a sandbox policy YAML file on the backend host. "
             "Overrides the executor-level default_policy_path for this deployment only."
         ),
     )

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/entities.py
@@ -174,9 +174,23 @@ class K8sDeploymentConfig(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+class OpenShellDeploymentConfig(BaseModel):
+    policy_path: str | None = Field(
+        default=None,
+        alias="policyPath",
+        description=(
+            "Path to a sandbox policy YAML file inside the sandbox image. "
+            "Overrides the executor-level default_policy_path for this deployment only."
+        ),
+    )
+
+    model_config = {"populate_by_name": True}
+
+
 class DeploymentBackendConfig(BaseModel):
     docker: DockerDeploymentConfig | None = None
     k8s: K8sDeploymentConfig | None = None
+    openshell: OpenShellDeploymentConfig | None = None
 
 
 class DockerVolumeConfig(BaseModel):

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py
@@ -297,7 +297,7 @@ async def test_create_uses_executor_policy_when_no_policy_path_override(
     )
 
     spec = mock_stub.CreateSandbox.call_args.args[0].spec
-    assert spec.policy is executor_policy
+    assert spec.policy == executor_policy
 
 
 async def test_create_uses_per_deployment_policy_when_policy_path_set(
@@ -322,7 +322,7 @@ async def test_create_uses_per_deployment_policy_when_policy_path_set(
     )
 
     spec = mock_stub.CreateSandbox.call_args.args[0].spec
-    assert spec.policy is not executor_policy
+    assert spec.policy != executor_policy
 
 
 async def test_create_requires_serve_command(

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py
@@ -284,6 +284,47 @@ async def test_read_status_not_found_is_lost(
     assert update.status == "LOST"
 
 
+async def test_create_uses_executor_policy_when_no_policy_path_override(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = _config()
+    mock_stub.GetSandbox.side_effect = _not_found()
+    mock_stub.CreateSandbox.return_value = MagicMock()
+
+    executor_policy = openshell_backend._policy
+    await openshell_backend.create_deployment(
+        workspace="default", name="srv", config_name="cfg1", labels={}, backend_config={}
+    )
+
+    spec = mock_stub.CreateSandbox.call_args.args[0].spec
+    assert spec.policy is executor_policy
+
+
+async def test_create_uses_per_deployment_policy_when_policy_path_set(
+    openshell_backend: OpenShellDeploymentBackend,
+    mock_stub: MagicMock,
+    mock_entities: AsyncMock,
+    tmp_path: Path,
+) -> None:
+    policy_file = tmp_path / "policy.yaml"
+    policy_file.write_text("version: 1\nprocess:\n  run_as_user: sandbox\n  run_as_group: sandbox\n")
+    mock_entities.get.return_value = _config()
+    mock_stub.GetSandbox.side_effect = _not_found()
+    mock_stub.CreateSandbox.return_value = MagicMock()
+
+    executor_policy = openshell_backend._policy
+    await openshell_backend.create_deployment(
+        workspace="default",
+        name="srv",
+        config_name="cfg1",
+        labels={},
+        backend_config={"openshell": {"policyPath": str(policy_file)}},
+    )
+
+    spec = mock_stub.CreateSandbox.call_args.args[0].spec
+    assert spec.policy is not executor_policy
+
+
 async def test_create_requires_serve_command(
     openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
 ) -> None:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This PR enables individual OpenShell deployments to specify a custom sandbox policy YAML (via `policyPath`) instead of inheriting the executor-level default.

## Related Issue

## Changes

- Add `openshell: OpenShellDeploymentConfig | None` to `DeploymentBackendConfig` alongside existing `docker` and `k8s` fields
- Replace `del backend_config` stub in `OpenShellDeploymentBackend.create_deployment` with parsing of the `openshell` section
- Add `_build_deployment_policy` to `OpenShellDeploymentBackend`: returns the executor-level policy unchanged when no `policyPath` is set, otherwise builds a fresh policy from the specified file with the executor's egress rule always re-injected

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: the `policyPath` override path follows the same policy-building logic already covered by `test_openshell_policy.py`; the no-override path is unchanged behavior
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs cover per-deployment backend config for OpenShell today

## Verification

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

uv run --frozen pytest plugins/nemo-deployments/tests/unit/ -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShell as a supported deployment backend.
  * Added optional per-deployment policy file configuration through `policyPath`.
  * Deployment-specific policies are applied when provided; otherwise, the default executor policy remains in use.
* **Bug Fixes**
  * Added validation and policy handling to ensure configured OpenShell policies are applied consistently.
* **Tests**
  * Added coverage for default and deployment-specific policy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->