### PR TITLE
chore: handle OTEL vars the same in helm v3/v4

### DIFF
--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -495,8 +495,10 @@ Usage:
 {{- end }}
 
 {{- range $key, $val := $merged }}
+{{- if not (kindIs "invalid" $val) }}
 - name: {{ $key }}
   value: {{ $val | quote }}
+{{- end }}
 {{- end }}
 {{- end -}}
 

--- a/tools/lint/lint-helm.sh
+++ b/tools/lint/lint-helm.sh
@@ -176,6 +176,26 @@ fi
 grep -Fq "app.kubernetes.io/component: clickhouse" <<<"${clickhouse_pvc_template}"
 grep -Fq "app.kubernetes.io/instance: ${HELM_RELEASE_NAME}" <<<"${clickhouse_pvc_template}"
 
+# Null telemetry endpoint defaults mean "unset"; they must not render empty env
+# vars that override the generic OTLP endpoint. Explicit empty strings remain
+# valid user overrides and should render.
+otel_default_output=$(helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
+  --show-only templates/api/api-deployment.yaml)
+if grep -Fq "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" <<<"${otel_default_output}"; then
+  echo "Default null OTEL metrics endpoint rendered an empty env var" >&2
+  exit 1
+fi
+if grep -Fq "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" <<<"${otel_default_output}"; then
+  echo "Default null OTEL traces endpoint rendered an empty env var" >&2
+  exit 1
+fi
+otel_explicit_empty_output=$(helm template "${HELM_RELEASE_NAME}" "${HELM_FOLDER}" \
+  --show-only templates/api/api-deployment.yaml \
+  --set-string telemetry.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT= \
+  --set-string telemetry.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=)
+grep -Fq "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT" <<<"${otel_explicit_empty_output}"
+grep -Fq "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT" <<<"${otel_explicit_empty_output}"
+
 # Validate the Helm chart by rendering templates with all values files in ci/ directory
 shopt -s nullglob
 for value_file in "${HELM_FOLDER}"/ci/*.yaml; do


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry environment variables are now omitted when their values are invalid or unset.
  * Explicitly configured empty telemetry endpoint values continue to be rendered correctly.

* **Tests**
  * Added Helm validation checks covering unset defaults and explicitly empty telemetry endpoint configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->