### PR TITLE
fix(evaluator): keep a Fabric trial completed when only Relay teardown failed

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/fabric/runtime.py
@@ -110,6 +110,13 @@ _ATIF_FILENAME_TEMPLATE = "trajectory-{session_id}.atif.json"
 _ATOF_FILENAME = "events.atof.jsonl"
 # ``kind`` Fabric stamps on the promoted Relay ATIF artifact; used to surface it as trace evidence.
 _ATIF_ARTIFACT_KIND = "atif"
+# Signature of a NeMo Relay telemetry-teardown fault (NVBug 6562846). Relay keeps one process-global
+# LIFO scope stack in a ``ContextVar``; LangGraph schedules child tasks with ``copy_context()``, which
+# shares that same mutable stack, so overlapping chain callbacks close out of LIFO order and Relay's
+# scope validator rejects the pop with exactly this message. The Fabric adapter catches it in the same
+# ``try`` that guards the invocation, so a purely observability-side fault is reported as an agent
+# failure. The string is emitted only by Relay's scope validation, so matching it is unambiguous.
+_RELAY_SCOPE_STACK_ERROR = "scope handle is not at the top of the stack"
 
 
 class FabricAgentRuntime:
@@ -446,7 +453,26 @@ class FabricAgentRuntime:
                     evidence=self._evidence(result, result_path, workspace_dir),
                     metadata={**base_metadata, "generated": True, "agent_ok": True},
                 )
-            return self._failed_trial(task, evidence_dir, _result_error(result), extra_metadata=base_metadata)
+            telemetry_error = _telemetry_teardown_error(result)
+            if telemetry_error is None:
+                return self._failed_trial(task, evidence_dir, _result_error(result), extra_metadata=base_metadata)
+            # The agent finished its turn and produced a final response; only Relay's telemetry teardown
+            # failed, and the Fabric adapter's single try/except rewrote that into an invocation failure
+            # (NVBug 6562846). Treat the trial as completed rather than scoring a false negative, and
+            # record the fault so the recovery is auditable and the (possibly truncated) trajectory
+            # evidence is not read as complete. Fall through to the success path so the recovered trial
+            # carries the same output and evidence any other completed trial would.
+            logger.warning(
+                "Fabric task %s completed but Relay telemetry teardown failed; recovering the trial: %s",
+                task.id,
+                telemetry_error,
+            )
+            base_metadata = {
+                **base_metadata,
+                "fabric_status": result.status,
+                "recovered_from_telemetry_fault": True,
+                "telemetry_error": telemetry_error,
+            }
 
         # Fabric wraps the output in a ``RunOutput`` mapping (RunOutput response contract, #52),
         # which is not itself a JSON value; normalize it to a plain mapping so it round-trips through the
@@ -706,6 +732,33 @@ def _extract_output_text(output: object) -> str | None:
             if isinstance(value, str):
                 return value
     return json.dumps(output, default=str)
+
+
+def _telemetry_teardown_error(result: RunResult) -> str | None:
+    """Return the adapter error when a Fabric failure is only a Relay telemetry-teardown fault.
+
+    ``None`` means the failure is not recoverable here and the trial must stay failed. Recovery needs
+    both halves of the evidence, so this deliberately stays narrow:
+
+    * the adapter's own ``output.error`` carries the Relay scope-stack signature — a failure raised
+      while closing the telemetry scope, not while running the agent; and
+    * ``output.response`` holds a non-empty final assistant message, so the agent phase did reach a
+      terminal answer. A run that died mid-turn has no final response and stays failed.
+
+    Note ``output.error`` is read rather than ``result.error``: Fabric normalizes any adapter-reported
+    failure to the same top-level ``adapter_reported_failure`` code, so only the adapter's own error
+    string distinguishes a telemetry teardown from a real agent failure.
+    """
+    output = result.output
+    if not isinstance(output, Mapping):
+        return None
+    error = output.get("error")
+    if not isinstance(error, str) or _RELAY_SCOPE_STACK_ERROR not in error:
+        return None
+    response = output.get("response")
+    if not isinstance(response, str) or not response.strip():
+        return None
+    return error
 
 
 def _result_error(result: RunResult) -> Mapping[str, Any]:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py
@@ -652,6 +652,101 @@ async def test_fabric_runtime_maps_failed_result_to_failed_trial(
     assert "error" in trial.evidence.descriptors
 
 
+# NVBug 6562846: Relay keeps one process-global LIFO scope stack, LangGraph shares it across the child
+# tasks it schedules with ``copy_context()``, and overlapping chain callbacks therefore close out of
+# order. The Fabric adapter catches that teardown error in the same ``try`` that guards the invocation,
+# so a completed DeepAgents turn comes back as ``status=failed`` with the full response still in
+# ``output``. Verbatim adapter error string from the bug's reproduction.
+_RELAY_TEARDOWN_ERROR = "RuntimeError: invalid argument: scope handle is not at the top of the stack"
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_recovers_trial_when_only_relay_teardown_failed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        return _FakeResult(
+            status="failed",
+            output={
+                "response": "Both files are done",
+                "completed": False,
+                "failed": True,
+                "error": _RELAY_TEARDOWN_ERROR,
+            },
+            error=_FakeError(stage="invoke", code="adapter_reported_failure", message=_RELAY_TEARDOWN_ERROR),
+        )
+
+    _install_fake_fabric(monkeypatch, handler)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", capture_trajectory=False)
+
+    trial = (await runtime.run_tasks([_TASK]))[0]
+
+    assert trial.status == "completed"
+    assert trial.output is not None
+    assert trial.output.output_text == "Both files are done"
+    # The recovery is explicit, never silent: the original Fabric verdict and the telemetry error are
+    # both retained so a recovered trial can be audited (and its trajectory treated as suspect).
+    assert trial.metadata["recovered_from_telemetry_fault"] is True
+    assert trial.metadata["fabric_status"] == "failed"
+    assert trial.metadata["telemetry_error"] == _RELAY_TEARDOWN_ERROR
+    # AgentPhaseSuccessMetric reads agent_ok; the agent phase did finish cleanly.
+    assert trial.metadata["agent_ok"] is True
+    assert trial.evidence is not None
+    assert "result" in trial.evidence.descriptors
+    assert "workspace" in trial.evidence.descriptors
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_keeps_relay_teardown_failure_without_a_final_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Half the evidence is not enough: without a final assistant message the agent never reached a
+    # terminal answer, so the trial stays failed even though the error is the telemetry one.
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        return _FakeResult(
+            status="failed",
+            output={"response": "  ", "completed": False, "failed": True, "error": _RELAY_TEARDOWN_ERROR},
+            error=_FakeError(stage="invoke", code="adapter_reported_failure", message=_RELAY_TEARDOWN_ERROR),
+        )
+
+    _install_fake_fabric(monkeypatch, handler)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", capture_trajectory=False)
+
+    trial = (await runtime.run_tasks([_TASK]))[0]
+
+    assert trial.status == "failed"
+    assert trial.metadata["agent_ok"] is False
+    assert "recovered_from_telemetry_fault" not in trial.metadata
+
+
+@pytest.mark.asyncio
+async def test_fabric_runtime_keeps_non_telemetry_failure_with_a_final_response(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Guard against the recovery widening into general failure suppression: a real agent failure that
+    # happens to carry a response must still fail.
+    def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:
+        return _FakeResult(
+            status="failed",
+            output={
+                "response": "partial answer",
+                "completed": False,
+                "failed": True,
+                "error": "RuntimeError: model call failed",
+            },
+            error=_FakeError(stage="invoke", code="adapter_reported_failure", message="model call failed"),
+        )
+
+    _install_fake_fabric(monkeypatch, handler)
+    runtime = fabric_runtime.FabricAgentRuntime(config=_CONFIG, work_root=tmp_path / "fabric", capture_trajectory=False)
+
+    trial = (await runtime.run_tasks([_TASK]))[0]
+
+    assert trial.status == "failed"
+    assert trial.metadata["error"] == "model call failed"
+    assert "recovered_from_telemetry_fault" not in trial.metadata
+
+
 @pytest.mark.asyncio
 async def test_fabric_runtime_maps_timeout_to_failed_trial(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def handler(agent: Any, kwargs: dict[str, Any]) -> _FakeResult:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/fabric/runtime.py
@@ -110,6 +110,13 @@ _ATIF_FILENAME_TEMPLATE = "trajectory-{session_id}.atif.json"
 _ATOF_FILENAME = "events.atof.jsonl"
 # ``kind`` Fabric stamps on the promoted Relay ATIF artifact; used to surface it as trace evidence.
 _ATIF_ARTIFACT_KIND = "atif"
+# Signature of a NeMo Relay telemetry-teardown fault (NVBug 6562846). Relay keeps one process-global
+# LIFO scope stack in a ``ContextVar``; LangGraph schedules child tasks with ``copy_context()``, which
+# shares that same mutable stack, so overlapping chain callbacks close out of LIFO order and Relay's
+# scope validator rejects the pop with exactly this message. The Fabric adapter catches it in the same
+# ``try`` that guards the invocation, so a purely observability-side fault is reported as an agent
+# failure. The string is emitted only by Relay's scope validation, so matching it is unambiguous.
+_RELAY_SCOPE_STACK_ERROR = "scope handle is not at the top of the stack"
 
 
 class FabricAgentRuntime:
@@ -446,7 +453,26 @@ class FabricAgentRuntime:
                     evidence=self._evidence(result, result_path, workspace_dir),
                     metadata={**base_metadata, "generated": True, "agent_ok": True},
                 )
-            return self._failed_trial(task, evidence_dir, _result_error(result), extra_metadata=base_metadata)
+            telemetry_error = _telemetry_teardown_error(result)
+            if telemetry_error is None:
+                return self._failed_trial(task, evidence_dir, _result_error(result), extra_metadata=base_metadata)
+            # The agent finished its turn and produced a final response; only Relay's telemetry teardown
+            # failed, and the Fabric adapter's single try/except rewrote that into an invocation failure
+            # (NVBug 6562846). Treat the trial as completed rather than scoring a false negative, and
+            # record the fault so the recovery is auditable and the (possibly truncated) trajectory
+            # evidence is not read as complete. Fall through to the success path so the recovered trial
+            # carries the same output and evidence any other completed trial would.
+            logger.warning(
+                "Fabric task %s completed but Relay telemetry teardown failed; recovering the trial: %s",
+                task.id,
+                telemetry_error,
+            )
+            base_metadata = {
+                **base_metadata,
+                "fabric_status": result.status,
+                "recovered_from_telemetry_fault": True,
+                "telemetry_error": telemetry_error,
+            }
 
         # Fabric wraps the output in a ``RunOutput`` mapping (RunOutput response contract, #52),
         # which is not itself a JSON value; normalize it to a plain mapping so it round-trips through the
@@ -706,6 +732,33 @@ def _extract_output_text(output: object) -> str | None:
             if isinstance(value, str):
                 return value
     return json.dumps(output, default=str)
+
+
+def _telemetry_teardown_error(result: RunResult) -> str | None:
+    """Return the adapter error when a Fabric failure is only a Relay telemetry-teardown fault.
+
+    ``None`` means the failure is not recoverable here and the trial must stay failed. Recovery needs
+    both halves of the evidence, so this deliberately stays narrow:
+
+    * the adapter's own ``output.error`` carries the Relay scope-stack signature — a failure raised
+      while closing the telemetry scope, not while running the agent; and
+    * ``output.response`` holds a non-empty final assistant message, so the agent phase did reach a
+      terminal answer. A run that died mid-turn has no final response and stays failed.
+
+    Note ``output.error`` is read rather than ``result.error``: Fabric normalizes any adapter-reported
+    failure to the same top-level ``adapter_reported_failure`` code, so only the adapter's own error
+    string distinguishes a telemetry teardown from a real agent failure.
+    """
+    output = result.output
+    if not isinstance(output, Mapping):
+        return None
+    error = output.get("error")
+    if not isinstance(error, str) or _RELAY_SCOPE_STACK_ERROR not in error:
+        return None
+    response = output.get("response")
+    if not isinstance(response, str) or not response.strip():
+        return None
+    return error
 
 
 def _result_error(result: RunResult) -> Mapping[str, Any]:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

NVBug 6562846: a Fabric DeepAgents invocation completes its turn — model calls, tool calls, workspace changes, a final assistant response — and is then reported as **failed** because NeMo Relay's telemetry teardown raises `RuntimeError: invalid argument: scope handle is not at the top of the stack`. QA saw 31 such trials in the 2026-08-05 full Evaluator regression, including at `parallelism=1`, so it is not an Evaluator concurrency problem. Before: those trials score as adapter invocation failures. After: when the failure is provably telemetry-only, the trial stays `completed` with the fault recorded on it.

## Related Issue

AALGO-495. NVBug 6562846.

## Changes

- `FabricAgentRuntime._to_trial` no longer fails a trial whose only failure is a Relay telemetry-teardown fault. It falls through to the normal success path, so the recovered trial carries the same output and evidence (workspace, `fabric_result.json`, any promoted ATIF/ATOF artifacts) as any other completed trial.
- New `_telemetry_teardown_error` predicate. It requires **both** halves of the evidence before recovering: the adapter's own `output.error` carries the Relay scope-stack signature, **and** `output.response` holds a non-empty final assistant message. It reads `output.error` rather than `result.error` because Fabric normalizes every adapter-reported failure to the same top-level `adapter_reported_failure` code, so only the adapter's own error string distinguishes a telemetry teardown from a real agent failure.
- The recovery is recorded, never silent: `recovered_from_telemetry_fault`, `fabric_status`, and `telemetry_error` land on the trial metadata (and a warning is logged), so it is auditable and the possibly-truncated trajectory is not read as complete. This mirrors the existing `recovered_from_mcp_binding` path.
- Three unit tests: the recovery, plus two negative cases (no final response; a non-telemetry failure that happens to carry a response) that guard against this widening into general failure suppression.
- Regenerated the vendored SDK mirror (`make vendor`).

### Why this is a mitigation, not the fix

The root cause is upstream and not vendored in this repo:

- **`NVIDIA/NeMo-Relay`** — `nemo_relay/integrations/langchain/callbacks.py` maps every chain run onto one process-global LIFO `ScopeStack` held in a `ContextVar`. LangGraph schedules child tasks with `copy_context()`, which preserves that *same mutable* stack rather than cloning it, so overlapping chain callbacks close out of LIFO order. `_pop_scope` also drops the handle from `_scope_handles` before attempting the Relay pop, stranding an untracked live scope. Relay ships `fork_asyncio_context()` for exactly this case; the integration never uses it.
- **`NVIDIA/NeMo-Fabric`** — `adapters/deepagents/adapter.py` catches the teardown exception in the same `try` that guards the agent invocation, so an observability fault rewrites a successful functional outcome.

Verified still live on 2026-08-10 by re-running the bug's minimal repro (two overlapping async chain lifecycles inside one outer Relay scope): reproduces on `nemo-relay` 0.6.0 (the version pinned here) **and** on 0.7.2, the newest release — `callbacks.py` is byte-identical between the two. Upstream issues are being filed separately.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal trial-normalization behavior in the evaluator SDK; no user-facing surface or config changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_runtime.py -q` — **37 passed** (34 before, 3 new).
- Mutation check: stubbing `_telemetry_teardown_error` to return `None` fails `test_fabric_runtime_recovers_trial_when_only_relay_teardown_failed` — the new test genuinely exercises the new code.
- `uv run --frozen pytest packages/nemo_evaluator_sdk/tests/ -q` — **1451 passed**.
- `uv run ruff check packages/nemo_evaluator_sdk/` — clean. `uv run ruff format --check` on both changed source files — clean.
- `tools/lint/lint-python-types.sh` (the exact CI type-check entrypoint) — exit 0; no diagnostics in the changed files.
- `tools/lint/lint-sdk-vendored.sh` and `tools/lint/lint-cli.sh` — **pass** after committing the regenerated mirror.

Blocked locally, not marked as passed:

- `uv run pre-commit run -a` — all Python hooks pass (ruff, ruff format, ty, config-reference docs, uv.lock drift, copyright headers, merge conflicts, plugin-import check). Two hooks fail for local-environment reasons unrelated to this change and are left to CI: `uv-lock` requires uv 0.9.14 and this machine has 0.9.30 (no `pyproject.toml`/`uv.lock` change in this PR), and `studio-lint-staged` cannot run without `web/node_modules` (no `web/` files changed).
- `tools/lint/lint-openapi.sh` fails locally with `mapfile: command not found` (macOS bash 3.2) and `tools/lint/lint-web-sdk.sh` fails on missing `web/node_modules` — both environmental, neither touched by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fabric evaluations now recover completed trials when a known telemetry teardown fault occurs after a valid final response.
  - Telemetry and Fabric error details remain available for troubleshooting.
  - Unrelated failures, or teardown faults without a final response, continue to be reported as failed.

- **Tests**
  - Added coverage for successful recovery and safeguards against incorrect recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->