### PR TITLE
docs: use 127.0.0.1 for the local base URL in the optimization guide

### DIFF
--- a/docs/agents/insight-driven-optimization.mdx
+++ b/docs/agents/insight-driven-optimization.mdx
@@ -296,7 +296,7 @@ agents. The examples use a local platform; replace the base URL for a remote
 deployment.
 
 ```bash
-export NMP_BASE_URL=http://localhost:8080
+export NMP_BASE_URL=http://127.0.0.1:8080
 export WORKSPACE=default
 export NMP_STUDIO_URL="$NMP_BASE_URL/studio"
 export NMP_ACCESS_TOKEN="$(nemo auth token)"


### PR DESCRIPTION
## Summary
Standardize the local base URL in the insight-driven optimization guide to `http://127.0.0.1:8080`, matching the observability and experiments guides (which already use it). This makes the derived Studio links (`$NMP_STUDIO_URL/workspaces/$WORKSPACE/...`) consistent across all three guides.

## Why
The guide's setup binds the platform with `nemo services run --host 127.0.0.1` (IPv4-only). Using `localhost` in the base URL can resolve to IPv6 (`::1`) and fail to connect to an IPv4-only server. `127.0.0.1` is unambiguous and matches the bind address.

## Scope
Only the setup instruction (`NMP_BASE_URL`) changes. The command-reference tables intentionally keep `http://localhost:8080` because that is the CLI's actual `--base-url` default (`DEFAULT_BASE_URL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the local platform setup example to use `127.0.0.1` for the `NMP_BASE_URL` value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->