### PR TITLE
feat(evaluator): Update publish_to_intake to record latency + tokens

### DIFF
--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -90,6 +90,7 @@ def trial_to_atif_ingest(
     agent_version: str = DEFAULT_AGENT_VERSION,
     model_name: str | None = None,
     final_metrics: AtifFinalMetricsParam | None = None,
+    ended_at: datetime | None = None,
 ) -> AtifCreateParams:
     """Build the ATIF ingest params for a single Trial.
 
@@ -115,6 +116,16 @@ def trial_to_atif_ingest(
         "message": output_text or "",
         "timestamp": started_at,
     }
+    if ended_at is not None:
+        # Give the single-step trajectory a real duration so the root span's latency (end - start) is
+        # the trial's runtime instead of 0. Intake reads the window start/end from this NAT invocation
+        # block (epoch-second timestamps); ``started_at`` stays the start, so re-ingest is still idempotent.
+        step["extra"] = {
+            "invocation": {
+                "start_timestamp": started_at.timestamp(),
+                "end_timestamp": ended_at.timestamp(),
+            }
+        }
 
     body: AtifCreateParams = {
         "schema_version": ATIF_SCHEMA_VERSION,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
@@ -19,13 +19,16 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from datetime import timedelta
 
 from nemo_evaluator.intake import mapping
 from nemo_evaluator.sdk import http_utils
+from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
 from nemo_platform import AsyncNeMoPlatform
+from nemo_platform.types.intake.ingest.atif_final_metrics_param import AtifFinalMetricsParam
 from nemo_platform.types.intake.trace_filter_param import TraceFilterParam
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -93,6 +96,24 @@ class PublishReport(BaseModel):
         return sum(trial.evaluator_result_count for trial in self.published_trials)
 
 
+def _token_final_metrics(measurements: TrialMeasurements) -> AtifFinalMetricsParam | None:
+    """Project the trial's recorded token usage onto ATIF ``final_metrics``.
+
+    Intake promotes these root totals onto the trajectory's root span, where the evaluation rollup
+    reads them — so publishing them is what makes token counts show up under the Evaluation. Only the
+    token fields the trial actually recorded are set; a trial whose harness recorded no usage yields
+    ``None`` (no ``final_metrics`` block). Cost is not captured here.
+    """
+    final_metrics: AtifFinalMetricsParam = {}
+    if measurements.prompt_tokens is not None:
+        final_metrics["total_prompt_tokens"] = measurements.prompt_tokens
+    if measurements.completion_tokens is not None:
+        final_metrics["total_completion_tokens"] = measurements.completion_tokens
+    if measurements.cache_read_tokens is not None:
+        final_metrics["total_cached_tokens"] = measurements.cache_read_tokens
+    return final_metrics or None
+
+
 async def publish_to_intake(
     result: AgentEvalResult,
     *,
@@ -154,6 +175,14 @@ async def publish_to_intake(
 
     async def _publish_trial(trial: AgentEvalTrial) -> PublishedTrial:
         async with semaphore:
+            measurements = TrialMeasurements.from_metadata(trial.metadata)
+            # A recorded runtime gives the trajectory a real end so Intake's latency rollup sees the
+            # trial's wall-clock duration instead of 0; absent → no window, latency stays unmeasured.
+            ended_at = (
+                started_at + timedelta(seconds=measurements.runtime_sec)
+                if measurements.runtime_sec is not None
+                else None
+            )
             body = mapping.trial_to_atif_ingest(
                 trial,
                 run_id=result.run_id,
@@ -162,6 +191,8 @@ async def publish_to_intake(
                 started_at=started_at,
                 agent_version=agent_version,
                 model_name=model_name,
+                final_metrics=_token_final_metrics(measurements),
+                ended_at=ended_at,
             )
             body["workspace"] = resolved_workspace
             await platform.intake.ingest.atif.create(**body)

--- a/plugins/nemo-evaluator/tests/intake/test_mapping.py
+++ b/plugins/nemo-evaluator/tests/intake/test_mapping.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 import math
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from nemo_evaluator.intake.mapping import (
@@ -126,6 +126,26 @@ def test_trial_to_atif_ingest_includes_final_metrics_when_given() -> None:
         final_metrics={"total_prompt_tokens": 10},
     )
     assert body["final_metrics"] == {"total_prompt_tokens": 10}
+
+
+def test_trial_to_atif_ingest_adds_invocation_window_when_ended_at_given() -> None:
+    # ended_at gives the single-step trajectory a real duration (via the invocation window) so Intake's
+    # root-span latency is the trial's runtime instead of 0.
+    ended = STARTED_AT + timedelta(seconds=12.5)
+    body = trial_to_atif_ingest(
+        _trial(), run_id="run-1", experiment_id="exp-1", agent_name="a", started_at=STARTED_AT, ended_at=ended
+    )
+    (step,) = body["steps"]
+    assert step["extra"] == {
+        "invocation": {"start_timestamp": STARTED_AT.timestamp(), "end_timestamp": ended.timestamp()}
+    }
+
+
+def test_trial_to_atif_ingest_omits_invocation_window_without_ended_at() -> None:
+    body = trial_to_atif_ingest(
+        _trial(), run_id="run-1", experiment_id="exp-1", agent_name="a", started_at=STARTED_AT
+    )
+    assert "extra" not in body["steps"][0]
 
 
 # --- score_to_evaluator_results: data_type coercions ------------------------

--- a/plugins/nemo-evaluator/tests/intake/test_mapping.py
+++ b/plugins/nemo-evaluator/tests/intake/test_mapping.py
@@ -142,9 +142,7 @@ def test_trial_to_atif_ingest_adds_invocation_window_when_ended_at_given() -> No
 
 
 def test_trial_to_atif_ingest_omits_invocation_window_without_ended_at() -> None:
-    body = trial_to_atif_ingest(
-        _trial(), run_id="run-1", experiment_id="exp-1", agent_name="a", started_at=STARTED_AT
-    )
+    body = trial_to_atif_ingest(_trial(), run_id="run-1", experiment_id="exp-1", agent_name="a", started_at=STARTED_AT)
     assert "extra" not in body["steps"][0]
 
 

--- a/plugins/nemo-evaluator/tests/intake/test_publish.py
+++ b/plugins/nemo-evaluator/tests/intake/test_publish.py
@@ -12,7 +12,8 @@ from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
-from nemo_evaluator.intake.publish import PublishError, publish_to_intake
+from nemo_evaluator.intake.publish import PublishError, _token_final_metrics, publish_to_intake
+from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary, RunMetadata
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
@@ -126,6 +127,21 @@ def _result(trials: list[AgentEvalTrial], scores: list[AgentEvalTaskScore]) -> A
         summary=AgentEvalSummary(),
         metadata=RunMetadata(started_at=STARTED_AT),
     )
+
+
+def test_token_final_metrics_projects_recorded_token_usage() -> None:
+    # Recorded token usage becomes ATIF final_metrics, which Intake promotes onto the root span.
+    measurements = TrialMeasurements(prompt_tokens=120, completion_tokens=45, cache_read_tokens=30)
+    assert _token_final_metrics(measurements) == {
+        "total_prompt_tokens": 120,
+        "total_completion_tokens": 45,
+        "total_cached_tokens": 30,
+    }
+
+
+def test_token_final_metrics_is_none_without_recorded_usage() -> None:
+    # No recorded token usage → no final_metrics block (rather than zeros).
+    assert _token_final_metrics(TrialMeasurements()) is None
 
 
 # --- tests ------------------------------------------------------------------


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`publish_to_intake` previously emitted a stub single-step trajectory with no telemetry, so evaluations published from nemo-evaluator showed **no token counts** and a **`0ms` latency**. This wires each trial's recorded token usage and runtime into the ATIF payload so Intake's rollup captures them:

- **Tokens** ride along as ATIF `final_metrics`, which Intake promotes onto the trajectory's root span (`attributes_number`) — exactly what the evaluation rollup sums into `tokens`.
- **Latency** is captured by giving the trajectory a real duration: a NAT invocation window (`started_at → started_at + runtime_sec`) on the step, so the root span's `end − start` is the trial's runtime instead of `0`.

Metrics are emitted **only when the harness actually recorded them** — a trial with no usage/runtime yields no `final_metrics` and no window, so latency reads as *unmeasured* rather than a misleading `0ms`. **Cost is still not captured** (there is no per-trial cost source in the trial measurements yet).

## Related Issue

Follow-up to the evaluator → Intake publish path: closes the token/latency capture gap the initial stub deferred. (No Linear issue linked; add one if applicable.)

## Changes

- **`intake/publish.py`** — project each trial's `TrialMeasurements` (from `trial.metadata`) once: build ATIF `final_metrics` from its token fields (`_token_final_metrics`), and derive `ended_at = started_at + runtime_sec` when a runtime was recorded; pass both to `trial_to_atif_ingest`.
- **`intake/mapping.py`** — `trial_to_atif_ingest` gains an optional `ended_at`; when set, it attaches a NAT invocation window (`extra["invocation"]` with epoch-second `start_timestamp`/`end_timestamp`) to the step. Purely additive — no change when `ended_at` is absent.
- **Idempotency preserved** — `started_at` stays the window start and `runtime_sec` is a stable recorded value, so the root span's id and `start_time` don't change on re-publish.
- **Tests** — token projection (`test_publish.py`) and invocation-window presence/absence (`test_mapping.py`).

No API or schema change: `AtifFinalMetricsParam` and the step `extra` field already exist in the SDK types, so no OpenAPI/SDK regen.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: internal evaluator → Intake mapping; no user-facing surface or schema change.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation (targeted checks run locally, not the full pre-commit sweep):

- `uv run --frozen pytest plugins/nemo-evaluator/tests/intake/test_publish.py plugins/nemo-evaluator/tests/intake/test_mapping.py` → 35 passed
- `uv run --frozen ty check plugins/nemo-evaluator/src/nemo_evaluator/intake/{publish,mapping}.py` → clean
- `uv run ruff check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reporting of prompt, completion, and cached token usage for evaluation trials.
  - Added runtime-duration reporting, including invocation start and end timestamps.
  - Trials without token or runtime measurements continue to omit unavailable fields.

- **Tests**
  - Added coverage for invocation timing and token-usage metrics.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->