### PR TITLE
build: remove additional openCV imports from automodel

### DIFF
--- a/docker/automodel/Dockerfile.nmp-automodel-base
+++ b/docker/automodel/Dockerfile.nmp-automodel-base
@@ -41,8 +41,10 @@ RUN cd /opt/Automodel && \
     bash docker/common/update_pyproject_pytorch.sh /opt/Automodel && \
     patch -p1 < /opt/cherry-picks/3d98f6e3.diff
 
-# Sync the Automodel extras used by text training. The cherry-pick removes the
-# unconditional OpenCV dependency; skipping VLM/media extras keeps FFmpeg wheels out.
+# Sync the Automodel extras used by text training. The cherry-pick removes OpenCV
+# from base deps, including mistral-common's image extra; skipping VLM/media extras
+# keeps FFmpeg wheels out. We'll need to re-examine when Customizer supports VLM
+# and FFmpeg 8.xx only releases every 6 months
 RUN --mount=type=cache,target=/root/.cache/uv \
     cd /opt/Automodel && \
     UV_HTTP_TIMEOUT=120 uv sync --locked \

--- a/docker/automodel/README.md
+++ b/docker/automodel/README.md
@@ -85,7 +85,7 @@ Override registry: `export WHEELS_REGISTRY=...` and `export IMAGE_REGISTRY=...` 
 
 | Patch | Purpose |
 |-------|---------|
-| `3d98f6e3.diff` | Drop old media deps (`decord`, `imageio-ffmpeg`) from Automodel extras and remove Automodel's unconditional `opencv-python-headless` dependency. The container skips Automodel's VLM extra, so FFmpeg-bearing `av` / `opencv-python-headless` wheels are not installed. |
+| `3d98f6e3.diff` | Drop old media deps (`decord`, `imageio-ffmpeg`) from Automodel extras, remove Automodel's unconditional `opencv-python-headless` dependency, and stop selecting `mistral-common`'s image extra for text training. The container skips Automodel's VLM extra, so FFmpeg-bearing `av` / `opencv-python-headless` wheels are not installed. |
 
 **Customizer tasks image (`nmp-customizer-tasks`):** `uv sync --package nmp-customization-common --package nmp-models --no-dev --inexact` from the customizer workspace slice (`docker/customizer/`). Hosts shared CPU steps (`file_io`, `model_entity`, `model_spec`, LoRA sidecar) for all customization backends.
 

--- a/docker/automodel/cherry-picks/3d98f6e3.diff
+++ b/docker/automodel/cherry-picks/3d98f6e3.diff
@@ -5,7 +5,8 @@ index 801ca1be..3d98f6e3 100644
 @@ -80,7 +80,6 @@ dependencies = [
      "datasets>=4.0.0",
      "megatron-fsdp>=0.2.3",
-     "mistral-common[image,audio,hf-hub,sentencepiece]",
+-    "mistral-common[image,audio,hf-hub,sentencepiece]",
++    "mistral-common[audio,hf-hub,sentencepiece]",
 -    "opencv-python-headless==4.10.0.84",
      "pybind11",
      "pyyaml",
@@ -73,7 +74,8 @@ index ad6029d3..42f67bd1 100644
  version = "1.4.1"
 @@ -3879,7 +3852,6 @@ dependencies = [
      { name = "megatron-fsdp" },
-     { name = "mistral-common", extra = ["audio", "hf-hub", "image", "sentencepiece"] },
+-    { name = "mistral-common", extra = ["audio", "hf-hub", "image", "sentencepiece"] },
++    { name = "mistral-common", extra = ["audio", "hf-hub", "sentencepiece"] },
      { name = "mlflow" },
 -    { name = "opencv-python-headless" },
      { name = "pybind11" },
@@ -125,7 +127,9 @@ index ad6029d3..42f67bd1 100644
      { name = "deep-ep", marker = "extra == 'moe'", git = "https://github.com/deepseek-ai/DeepEP.git?rev=7febc6e25660af0f54d95dd781ecdcd62265ecca" },
      { name = "deltalake", marker = "extra == 'delta-databricks'", specifier = ">=1.0.0" },
      { name = "diffusers", marker = "extra == 'diffusion'", specifier = ">=0.37.0" },
-@@ -4081,7 +4048,6 @@ requires-dist = [
+@@ -4081,9 +4048,8 @@ requires-dist = [
+     { name = "flash-attn", marker = "extra == 'fa'", specifier = "<=2.8.3" },
+     { name = "flash-linear-attention", marker = "extra == 'fla'", specifier = ">=0.4.2" },
      { name = "flashoptim", specifier = ">=0.1.3" },
      { name = "ftfy", marker = "extra == 'diffusion'" },
      { name = "imageio", marker = "extra == 'diffusion'" },
@@ -133,7 +137,15 @@ index ad6029d3..42f67bd1 100644
      { name = "kernels", marker = "extra == 'diffusion-kernels'" },
      { name = "mamba-ssm", marker = "extra == 'cuda'" },
      { name = "megatron-fsdp", specifier = ">=0.2.3" },
-@@ -4109,7 +4075,6 @@ requires-dist = [
+@@ -4086,6 +4052,6 @@ requires-dist = [
+     { name = "mamba-ssm", marker = "extra == 'cuda'" },
+     { name = "megatron-fsdp", specifier = ">=0.2.3" },
+-    { name = "mistral-common", extras = ["audio", "hf-hub", "image", "sentencepiece"] },
++    { name = "mistral-common", extras = ["audio", "hf-hub", "sentencepiece"] },
+     { name = "mistral-common", extras = ["opencv"], marker = "extra == 'vlm'", specifier = ">=1.11.0" },
+     { name = "mlflow" },
+     { name = "multi-storage-client", marker = "extra == 'msc'", specifier = ">=0.13" },
+@@ -4107,6 +4073,5 @@ requires-dist = [
      { name = "onnxscript", marker = "extra == 'cuda'", specifier = ">=0.5.6" },
      { name = "open-clip-torch", marker = "extra == 'vlm'" },
 -    { name = "opencv-python-headless", specifier = "==4.10.0.84" },


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Removes more instances of ffmpeg

## Related Issue
Also bumps the flash atention version


## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ X] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

https://github.com/NVIDIA-NeMo/Platform-Deploy/actions/runs/31431446909/job/93595664341#step:8:2

The only remaining High have vendor_vex.status = in_triage

## Verification

- [X] Pull request title follows the repository's Conventional Commit format
- [X] Every commit includes an appropriate `Signed-off-by:` trailer
- [X] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [X] No secrets, API keys, or credentials are included

Targeted validation:

0 of the prior 92 High remain.
Latest scan says:
vuln_counts.High = 0
RequiresAction = 0
There are still 21 raw JSON rows with "severity": "High", but all are vendor_vex.status = in_triage and requires_action = false, so they are not counted in vuln_counts.High.
Those 21 raw rows are:
15 GitPython
2  JupyterLab
1  flash-attn
1  wandb bundled go-git
1  wandb bundled grpc
1  wandb bundled Go stdlib
The FFmpeg/OpenCV issue is gone:
old opencv_python_headless.libs High rows: 120
new opencv_python_headless.libs High rows: 0
new av.libs High rows: 0
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary image and video dependencies in the Automodel base container.
  * Prevented OpenCV, FFmpeg-related packages, and associated media wheels from being installed for text training.
  * Updated dependency groups to maintain compatibility while keeping the base image lightweight.

* **Documentation**
  * Clarified which visual-language and media extras are intentionally excluded from the container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->