### PR TITLE
fix(evaluator): prefer sync SDK for FilesetRef dataset download

### DIFF
--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -39,7 +39,7 @@ from nemo_evaluator_sdk.values import (
 )
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.results import EvaluationResult
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, DefaultAsyncHttpxClient, NeMoPlatform
 from nemo_platform_plugin.entities import EntityClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
@@ -77,6 +77,25 @@ class EvaluationResultFiles:
     artifacts_dir: Path
 
 
+async def _download_dataset_with_cloned_async_sdk(
+    async_sdk: AsyncNeMoPlatform,
+    dataset: FilesetRef,
+    destination: str,
+) -> Path:
+    """Download via a throwaway httpx client so the injected async SDK stays reusable.
+
+    ``run_sync`` uses ``asyncio.run``, which closes its loop. Binding the shared
+    ``async_sdk`` httpx client to that loop would leave it unusable for later
+    ``run_sync`` calls (e.g. result-entity persistence).
+    """
+    async with DefaultAsyncHttpxClient() as http_client:
+        return await download_dataset(
+            sdk=async_sdk.copy(http_client=http_client),
+            dataset=dataset,
+            destination=destination,
+        )
+
+
 def _resolve_run_dataset(
     dataset: DatasetSpec,
     *,
@@ -101,10 +120,10 @@ def _resolve_run_dataset(
         )
     if async_sdk is not None:
         return run_sync(
-            lambda: download_dataset(
-                sdk=async_sdk,
-                dataset=dataset,
-                destination=destination,
+            lambda: _download_dataset_with_cloned_async_sdk(
+                async_sdk,
+                dataset,
+                destination,
             )
         )
     raise ValueError("FilesetRef datasets require an SDK client for local evaluator job execution.")

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -23,11 +23,11 @@ from nemo_evaluator.jobs.metric_resolution import (
     unresolved_model_refs,
 )
 from nemo_evaluator.jobs.result_persistence import persist_evaluate_result
+from nemo_evaluator.jobs.utils import run_with_isolated_async_sdk
 from nemo_evaluator.metric_refs import MetricRefOrInline
 from nemo_evaluator.shared.metric_bundles.bundles import unbundle_metric
 from nemo_evaluator_sdk import Evaluator
 from nemo_evaluator_sdk.execution.config import resolve_params
-from nemo_evaluator_sdk.execution.metric_execution import run_sync
 from nemo_evaluator_sdk.values import (
     Agent,
     AgentBase,
@@ -39,7 +39,7 @@ from nemo_evaluator_sdk.values import (
 )
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.results import EvaluationResult
-from nemo_platform import AsyncNeMoPlatform, DefaultAsyncHttpxClient, NeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.entities import EntityClient
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
@@ -77,25 +77,6 @@ class EvaluationResultFiles:
     artifacts_dir: Path
 
 
-async def _download_dataset_with_cloned_async_sdk(
-    async_sdk: AsyncNeMoPlatform,
-    dataset: FilesetRef,
-    destination: str,
-) -> Path:
-    """Download via a throwaway httpx client so the injected async SDK stays reusable.
-
-    ``run_sync`` uses ``asyncio.run``, which closes its loop. Binding the shared
-    ``async_sdk`` httpx client to that loop would leave it unusable for later
-    ``run_sync`` calls (e.g. result-entity persistence).
-    """
-    async with DefaultAsyncHttpxClient() as http_client:
-        return await download_dataset(
-            sdk=async_sdk.copy(http_client=http_client),
-            dataset=dataset,
-            destination=destination,
-        )
-
-
 def _resolve_run_dataset(
     dataset: DatasetSpec,
     *,
@@ -108,10 +89,8 @@ def _resolve_run_dataset(
         return dataset
 
     destination = str(ctx.storage.persistent / "dataset")
-    # Prefer the sync SDK so Files download does not bind the shared async
-    # httpx client to a short-lived asyncio.run() loop. Result persistence later
-    # reuses async_sdk via a second run_sync; reusing the same client across two
-    # closed loops raises "Event loop is closed" and silently drops the entity.
+    # Prefer sync when available; async path isolates httpx so later run_sync calls
+    # (result persistence) can reuse the injected async_sdk.
     if sdk is not None:
         return download_dataset_sync(
             sdk=sdk,
@@ -119,12 +98,9 @@ def _resolve_run_dataset(
             destination=destination,
         )
     if async_sdk is not None:
-        return run_sync(
-            lambda: _download_dataset_with_cloned_async_sdk(
-                async_sdk,
-                dataset,
-                destination,
-            )
+        return run_with_isolated_async_sdk(
+            async_sdk,
+            lambda sdk: download_dataset(sdk=sdk, dataset=dataset, destination=destination),
         )
     raise ValueError("FilesetRef datasets require an SDK client for local evaluator job execution.")
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py
@@ -89,6 +89,16 @@ def _resolve_run_dataset(
         return dataset
 
     destination = str(ctx.storage.persistent / "dataset")
+    # Prefer the sync SDK so Files download does not bind the shared async
+    # httpx client to a short-lived asyncio.run() loop. Result persistence later
+    # reuses async_sdk via a second run_sync; reusing the same client across two
+    # closed loops raises "Event loop is closed" and silently drops the entity.
+    if sdk is not None:
+        return download_dataset_sync(
+            sdk=sdk,
+            dataset=dataset,
+            destination=destination,
+        )
     if async_sdk is not None:
         return run_sync(
             lambda: download_dataset(
@@ -96,12 +106,6 @@ def _resolve_run_dataset(
                 dataset=dataset,
                 destination=destination,
             )
-        )
-    if sdk is not None:
-        return download_dataset_sync(
-            sdk=sdk,
-            dataset=dataset,
-            destination=destination,
         )
     raise ValueError("FilesetRef datasets require an SDK client for local evaluator job execution.")
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py
@@ -18,8 +18,8 @@ import logging
 
 from nemo_evaluator.intake.publish import PublishError, PublishReport, publish_to_intake
 from nemo_evaluator.jobs.agent_spec import IntakePublicationSpec, Target, target_agent_identity
+from nemo_evaluator.jobs.utils import run_with_isolated_async_sdk
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
-from nemo_evaluator_sdk.execution.metric_execution import run_sync
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform._exceptions import NeMoPlatformError, NotFoundError
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
@@ -153,15 +153,16 @@ def publish_agent_eval_result(
         workspace,
     )
     try:
-        report = run_sync(
-            lambda: _publish(
+        report = run_with_isolated_async_sdk(
+            async_sdk,
+            lambda sdk: _publish(
                 result,
-                platform=async_sdk,
+                platform=sdk,
                 spec=spec,
                 workspace=workspace,
                 agent_name=agent_name,
                 model_name=model_name,
-            )
+            ),
         )
     except PublishError as error:
         return fail(str(error), error.report)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/result_persistence.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/result_persistence.py
@@ -28,8 +28,8 @@ from nemo_evaluator.jobs.agent_spec import (
     ModelTarget,
     Target,
 )
+from nemo_evaluator.jobs.utils import run_with_isolated_async_sdk
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
-from nemo_evaluator_sdk.execution.metric_execution import run_sync
 from nemo_evaluator_sdk.values import Agent, AgentBase, Model
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult
 from nemo_evaluator_sdk.values.results import EvaluationResult
@@ -107,15 +107,20 @@ def _row_target_fields(target: Model | Agent | None) -> tuple[str | None, str | 
 
 
 def _persist(entity: EntityBase, *, async_sdk: AsyncNeMoPlatform | None) -> None:
-    client = _entity_client(async_sdk)
-    if client is None:
+    if async_sdk is None:
         logger.info("No async task SDK injected; skipping result-entity persistence (platformless local run).")
         return
     # Best-effort: the eval has already succeeded and the full bundle is saved, so a transient
     # entity-store error must not fail the job — the record is re-derivable from the bundle. Log
     # loudly and move on. (`save` is create-or-update, so a re-run of the same job id is idempotent.)
     try:
-        run_sync(lambda: client.save(entity))
+
+        async def _save(sdk: AsyncNeMoPlatform) -> EntityBase:
+            client = _entity_client(sdk)
+            assert client is not None
+            return await client.save(entity)
+
+        run_with_isolated_async_sdk(async_sdk, _save)
     except Exception:
         logger.exception(
             "Failed to persist result entity %r in workspace %r; the result bundle is still saved",

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for evaluator plugin jobs."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from nemo_evaluator_sdk.execution.metric_execution import run_sync
+from nemo_platform import AsyncNeMoPlatform, DefaultAsyncHttpxClient
+
+T = TypeVar("T")
+
+
+def run_with_isolated_async_sdk(
+    async_sdk: AsyncNeMoPlatform,
+    fn: Callable[[AsyncNeMoPlatform], Awaitable[T]],
+) -> T:
+    """Run ``fn(cloned_sdk)`` via ``run_sync`` without binding ``async_sdk``'s httpx client."""
+
+    async def _run() -> T:
+        async with DefaultAsyncHttpxClient() as http_client:
+            return await fn(async_sdk.copy(http_client=http_client))
+
+    return run_sync(_run)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py
@@ -18,7 +18,12 @@ def run_with_isolated_async_sdk(
     async_sdk: AsyncNeMoPlatform,
     fn: Callable[[AsyncNeMoPlatform], Awaitable[T]],
 ) -> T:
-    """Run ``fn(cloned_sdk)`` via ``run_sync`` without binding ``async_sdk``'s httpx client."""
+    """Run ``fn(cloned_sdk)`` via ``run_sync`` without binding ``async_sdk``'s httpx client.
+    
+         Clones ``async_sdk`` onto a throwaway httpx client for the duration of ``fn``
+         so the injected client's transport is not bound to this temporary event loop
+         (and later ``run_sync`` calls can still reuse ``async_sdk``).
+    """
 
     async def _run() -> T:
         async with DefaultAsyncHttpxClient() as http_client:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py
@@ -19,10 +19,10 @@ def run_with_isolated_async_sdk(
     fn: Callable[[AsyncNeMoPlatform], Awaitable[T]],
 ) -> T:
     """Run ``fn(cloned_sdk)`` via ``run_sync`` without binding ``async_sdk``'s httpx client.
-    
-         Clones ``async_sdk`` onto a throwaway httpx client for the duration of ``fn``
-         so the injected client's transport is not bound to this temporary event loop
-         (and later ``run_sync`` calls can still reuse ``async_sdk``).
+
+    Clones ``async_sdk`` onto a throwaway httpx client for the duration of ``fn`` so the injected
+    client's transport is not bound to this temporary event loop (and later ``run_sync`` calls can
+    still reuse ``async_sdk``).
     """
 
     async def _run() -> T:

--- a/plugins/nemo-evaluator/tests/jobs/test_publication.py
+++ b/plugins/nemo-evaluator/tests/jobs/test_publication.py
@@ -117,12 +117,18 @@ class _FakeClient:
         self.atif_calls: list[dict[str, Any]] = []
         self.eval_result_calls: list[dict[str, Any]] = []
         self.trace_calls: _SessionIds = []
+        self.copy_calls = 0
         self.evaluations = _FakeEvaluations(missing=missing_evaluation, error=preflight_error)
         self.intake = SimpleNamespace(
             ingest=SimpleNamespace(atif=_FakeIngest(self.atif_calls, error=ingest_error)),
             evaluator_results=_FakeIngest(self.eval_result_calls),
             traces=_FakeTraces(self.trace_calls),
         )
+
+    def copy(self, **kwargs: Any) -> _FakeClient:
+        del kwargs
+        self.copy_calls += 1
+        return self
 
 
 def _client(**kwargs: Any) -> AsyncNeMoPlatform:
@@ -267,6 +273,7 @@ def test_publishes_and_reports_what_landed() -> None:
     client = _FakeClient()
     outcome = _publish(cast(AsyncNeMoPlatform, client))
 
+    assert client.copy_calls == 1
     assert outcome.status == PlatformJobStatus.COMPLETED
     assert outcome.evaluation_id == "eval-1"
     assert outcome.trial_count == 1

--- a/plugins/nemo-evaluator/tests/jobs/test_utils.py
+++ b/plugins/nemo-evaluator/tests/jobs/test_utils.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for evaluator job helpers."""
+
+from __future__ import annotations
+
+from nemo_evaluator.jobs.utils import run_with_isolated_async_sdk
+from pytest_mock import MockerFixture
+
+
+def test_run_with_isolated_async_sdk_passes_cloned_client(mocker: MockerFixture) -> None:
+    cloned = mocker.Mock(name="cloned_sdk")
+    async_sdk = mocker.Mock(name="async_sdk")
+    async_sdk.copy.return_value = cloned
+    http_client = mocker.AsyncMock(name="http_client")
+    http_client.__aenter__.return_value = http_client
+    http_client.__aexit__.return_value = None
+    mocker.patch("nemo_evaluator.jobs.utils.DefaultAsyncHttpxClient", return_value=http_client)
+
+    seen: list[object] = []
+
+    async def fn(sdk: object) -> int:
+        seen.append(sdk)
+        return 42
+
+    assert run_with_isolated_async_sdk(async_sdk, fn) == 42
+    async_sdk.copy.assert_called_once_with(http_client=http_client)
+    assert seen == [cloned]

--- a/plugins/nemo-evaluator/tests/test_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/test_evaluate_job.py
@@ -1208,7 +1208,7 @@ class TestEvaluateJobRun:
         http_client = mocker.AsyncMock(name="http_client")
         http_client.__aenter__.return_value = http_client
         http_client.__aexit__.return_value = None
-        mocker.patch("nemo_evaluator.jobs.evaluate.DefaultAsyncHttpxClient", return_value=http_client)
+        mocker.patch("nemo_evaluator.jobs.utils.DefaultAsyncHttpxClient", return_value=http_client)
         ctx = _make_job_context(tmp_path)
         dataset = FilesetRef(root="default/helpsteer2#validation.jsonl")
         config = {**_exact_match_spec(), "dataset": dataset}

--- a/plugins/nemo-evaluator/tests/test_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/test_evaluate_job.py
@@ -1259,6 +1259,42 @@ class TestEvaluateJobRun:
         assert call_kwargs["target"] is None
         assert call_kwargs["prompt_template"] is None
 
+    def test_prefers_sync_sdk_for_fileset_ref_when_both_sdks_injected(
+        self, tmp_path: Path, mocker: MockerFixture
+    ) -> None:
+        """Avoid binding async_sdk's httpx client before result-entity persistence."""
+        result = _empty_evaluation_result()
+        result_payload = result.model_dump(mode="json")
+        evaluator = mocker.Mock()
+        evaluator.run_sync.return_value = result
+        mocker.patch("nemo_evaluator.jobs.evaluate.Evaluator", return_value=evaluator)
+        downloaded_path = tmp_path / "persistent" / "dataset" / "default" / "helpsteer2" / "validation.jsonl"
+        download_dataset = mocker.patch("nemo_evaluator.jobs.evaluate.download_dataset", create=True)
+        download_dataset_sync = mocker.patch(
+            "nemo_evaluator.jobs.evaluate.download_dataset_sync",
+            return_value=downloaded_path,
+            create=True,
+        )
+        persist = mocker.patch("nemo_evaluator.jobs.evaluate.persist_evaluate_result")
+        ctx = _make_job_context(tmp_path)
+        sync_sdk = mocker.Mock()
+        async_sdk = mocker.Mock()
+        dataset = FilesetRef(root="default/helpsteer2#validation.jsonl")
+        config = {**_exact_match_spec(), "dataset": dataset}
+
+        run_result = EvaluateJob().run(config, ctx=ctx, sdk=sync_sdk, async_sdk=async_sdk)
+
+        _assert_saved_result_artifact(run_result, ctx, result_payload)
+        download_dataset.assert_not_called()
+        download_dataset_sync.assert_called_once_with(
+            sdk=sync_sdk,
+            dataset=dataset,
+            destination=str(ctx.storage.persistent / "dataset"),
+        )
+        persist.assert_called_once()
+        assert persist.call_args.kwargs["async_sdk"] is async_sdk
+        assert persist.call_args.kwargs["dataset_ref"] == dataset.root
+
 
 class TestEvaluateTask:
     """Coverage for the compiled container task entrypoint."""

--- a/plugins/nemo-evaluator/tests/test_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/test_evaluate_job.py
@@ -1202,16 +1202,23 @@ class TestEvaluateJobRun:
             create=True,
         )
         download_dataset_sync = mocker.patch("nemo_evaluator.jobs.evaluate.download_dataset_sync", create=True)
+        cloned_sdk = mocker.Mock(name="cloned_async_sdk")
+        async_sdk = mocker.Mock(name="async_sdk")
+        async_sdk.copy.return_value = cloned_sdk
+        http_client = mocker.AsyncMock(name="http_client")
+        http_client.__aenter__.return_value = http_client
+        http_client.__aexit__.return_value = None
+        mocker.patch("nemo_evaluator.jobs.evaluate.DefaultAsyncHttpxClient", return_value=http_client)
         ctx = _make_job_context(tmp_path)
-        async_sdk = mocker.Mock()
         dataset = FilesetRef(root="default/helpsteer2#validation.jsonl")
         config = {**_exact_match_spec(), "dataset": dataset}
 
         run_result = EvaluateJob().run(config, ctx=ctx, async_sdk=async_sdk)
 
         _assert_saved_result_artifact(run_result, ctx, result_payload)
+        async_sdk.copy.assert_called_once_with(http_client=http_client)
         download_dataset.assert_awaited_once_with(
-            sdk=async_sdk,
+            sdk=cloned_sdk,
             dataset=dataset,
             destination=str(ctx.storage.persistent / "dataset"),
         )

--- a/plugins/nemo-evaluator/tests/test_result_persistence.py
+++ b/plugins/nemo-evaluator/tests/test_result_persistence.py
@@ -40,9 +40,22 @@ from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import LocalJobResults
 from pytest_mock import MockerFixture
 
+
 # An opaque stand-in for the async task SDK: every test that reaches the save path patches
 # `_entity_client`, so the value is never used as a real client — only its presence matters.
-_ASYNC_SDK = cast(AsyncNeMoPlatform, object())
+# ``copy`` returns self so ``run_with_isolated_async_sdk`` can isolate a throwaway httpx client.
+class _FakeAsyncSdk:
+    def __init__(self) -> None:
+        self.copy_calls = 0
+
+    def copy(self, **kwargs: object) -> _FakeAsyncSdk:
+        del kwargs
+        self.copy_calls += 1
+        return self
+
+
+_ASYNC_SDK_FAKE = _FakeAsyncSdk()
+_ASYNC_SDK = cast(AsyncNeMoPlatform, _ASYNC_SDK_FAKE)
 
 
 def test_entity_client_adapts_async_sdk(mocker: MockerFixture) -> None:
@@ -165,6 +178,7 @@ def _eval_result() -> EvaluationResult:
 def test_persist_agent_eval_result_builds_entity_and_saves(tmp_path: Path, mocker: MockerFixture) -> None:
     client = _FakeClient()
     mocker.patch.object(result_persistence, "_entity_client", return_value=client)
+    _ASYNC_SDK_FAKE.copy_calls = 0
 
     persist_agent_eval_result(
         _agent_result(),
@@ -174,6 +188,7 @@ def test_persist_agent_eval_result_builds_entity_and_saves(tmp_path: Path, mocke
         async_sdk=_ASYNC_SDK,
     )
 
+    assert _ASYNC_SDK_FAKE.copy_calls == 1
     (entity,) = client.saved
     assert isinstance(entity, AgentEvalResultEntity)
     assert entity.name == "job-1"


### PR DESCRIPTION
## Summary

**What failed?** 
- `run_sync` creates a new events loop. When async client is passed to it. It attaches client to this loop when function ends, the client is rendered unusable. Any downstream function using client runs into "Event loop closed" issue. 
- In this particular case Completed FilesetRef row evals wrote artifacts but `GET /eval-results/{job_id}` returned 404 — no `EvaluateResultEntity` was persisted. The same shared-client/`run_sync` pattern can also break Intake publication after result-entity persistence on agent-eval jobs.

**Why?** Dataset download (or entity save) and a later `run_sync` each used `asyncio.run()` on the same `AsyncNeMoPlatform` httpx client. The first loop closed after use; the next raise `Event loop is closed` was swallowed as best-effort (persist) or surfaced as a publication failure.

**What is the fix?**
1. Prefer the injected sync `NeMoPlatform` + `download_dataset_sync()` when available.
2. For async `run_sync` call sites, run work through `run_with_isolated_async_sdk()` so each call uses `async_sdk.copy(http_client=DefaultAsyncHttpxClient())`.

**What to review**
- Util: `plugins/nemo-evaluator/src/nemo_evaluator/jobs/utils.py` (`run_with_isolated_async_sdk`)
- Call sites:
  - `plugins/nemo-evaluator/src/nemo_evaluator/jobs/evaluate.py` (FilesetRef async download)
  - `plugins/nemo-evaluator/src/nemo_evaluator/jobs/result_persistence.py` (entity save)
  - `plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py` (Intake publish)

## Related Issue

https://nvbugspro.nvidia.com/bug/6563418

## Changes

- Prefer sync SDK for FilesetRef download when both SDKs are injected
- Add `jobs/utils.py` helper that clones async SDK httpx for each `run_sync`
- Use the helper for FilesetRef download, result persistence, and Intake publication
- Unit tests for the helper and call-site clone usage

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: internal job client isolation; public API unchanged

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run --files` on changed files passes
- [x] Targeted tests pass
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```text
uv run --frozen pytest \
  plugins/nemo-evaluator/tests/jobs/test_utils.py \
  plugins/nemo-evaluator/tests/test_result_persistence.py \
  plugins/nemo-evaluator/tests/jobs/test_publication.py::test_publishes_and_reports_what_landed \
  plugins/nemo-evaluator/tests/test_evaluate_job.py::TestEvaluateJobRun::test_downloads_fileset_ref_dataset_and_passes_path_to_sdk_evaluator \
  plugins/nemo-evaluator/tests/test_evaluate_job.py::TestEvaluateJobRun::test_prefers_sync_sdk_for_fileset_ref_when_both_sdks_injected -v
# passed
```

Full plugin suite for the touched files: `111 passed`.

### Live end-to-end repro

Ran the NVBug 6563418 reproduction steps against a local platform (`nemo services run` with
`entities,files,jobs,evaluator,secrets,models,inference-gateway,auth` plus the `jobs`/`entities`
controllers): created a real fileset, uploaded a JSONL dataset, submitted a row evaluation through
the public Evaluator SDK using `FilesetRef(root="default/<fileset>")`, and waited for completion.

```text
Created fileset: default/filesetref-eval-repro
Uploaded dataset.jsonl (96 bytes)
FilesetRef: root='default/filesetref-eval-repro'
Submitted job: nemo-evaluator-lblwzne1
Job finished: nemo-evaluator-lblwzne1 status=completed
Downloaded artifacts: ['aggregate-scores.json', 'row-scores.jsonl']
get_result: rows=2 aggregates=1
PASS: eval_results.retrieve OK job_id=nemo-evaluator-lblwzne1 metric_types=['exact-match'] dataset_ref=default/filesetref-eval-repro
GET /apis/evaluator/v2/workspaces/default/eval-results/nemo-evaluator-lblwzne1 -> 200
```

`evaluation-results` was also downloadable from the persisted entity's `bundle_ref`. The reported
symptom for this bug was a 404 from that final retrieve; it now returns 200 with the aggregate
scores, `dataset_ref`, and `bundle_ref` populated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dataset download reliability by prioritizing synchronous downloads when available.
  * Added a safer asynchronous fallback for more consistent evaluation runs.
  * Improved reliability when publishing evaluations and saving results asynchronously.
  * Reduced the risk of event-loop conflicts during background processing.

* **Tests**
  * Added coverage for synchronous and asynchronous download workflows.
  * Verified reliable publication and result persistence across supported processing paths.
  * Added regression checks for consistent asynchronous processing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
