### PR TITLE
fix(guardrails): Surface 500 when guardrail result cannot be parsed

### DIFF
--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -383,7 +383,17 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         logger.debug("Storing process_request GenerationResponse for %s", provenance.label)
         plugin_state.set(STATE_KEY_INPUT_GENERATION_RESPONSE, generation_response)
 
-        if is_blocked_generation_response(generation_response):
+        if generation_response.log is None:
+            logger.warning(
+                "Guardrail %s returned no activation log after input rails; cannot determine rail result",
+                provenance.label,
+            )
+            raise InferenceMiddlewareError(
+                "Unable to determine guardrail result for the request",
+                status_code=500,
+            )
+
+        if is_blocked_generation_response(generation_response.log):
             return build_immediate_response(
                 response_body=build_blocked_immediate_response_body(
                     config_id,
@@ -574,10 +584,20 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
             error_msg="Failed to run output rails",
         )
 
+        if generation_response.log is None:
+            logger.warning(
+                "Guardrail %s returned no activation log after output rails; cannot determine rail result",
+                provenance.label,
+            )
+            raise InferenceMiddlewareError(
+                "Unable to determine guardrail result for the request",
+                status_code=500,
+            )
+
         # Both branches share the same kwargs; only the builder differs.
         response_body_builder = (
             build_blocked_output_response_body
-            if is_blocked_generation_response(generation_response)
+            if is_blocked_generation_response(generation_response.log)
             else build_output_response_body
         )
         return build_inference_response(

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
@@ -18,7 +18,7 @@ from nemo_platform_plugin.inference_middleware import (
     ResponseResult,
 )
 from nemoguardrails.exceptions import LLMCallException
-from nemoguardrails.rails.llm.options import GenerationResponse
+from nemoguardrails.rails.llm.options import GenerationLog, GenerationResponse
 
 logger = logging.getLogger(__name__)
 
@@ -128,19 +128,9 @@ def build_chat_completion_response_id() -> str:
     return f"chatcmpl-{uuid.uuid4()}"
 
 
-def is_blocked_generation_response(generation_response: GenerationResponse) -> bool:
-    """
-    Returns True if the GenerationResponse indicates the request was blocked by a guardrail.
-    """
-    log = generation_response.log
-
-    if not log:
-        logger.debug("Received GenerationResponse with empty log. ")
-        return True
-
-    activated_rails = log.activated_rails or []
-
-    return any(rail.stop is True for rail in activated_rails)
+def is_blocked_generation_response(log: GenerationLog) -> bool:
+    """Return True if the activation log indicates the request was blocked by a guardrail."""
+    return any(rail.stop is True for rail in log.activated_rails)
 
 
 def extract_response_content(generation_response: GenerationResponse) -> str:

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -853,6 +853,22 @@ class TestProcessRequest:
             with pytest.raises(InferenceMiddlewareUnavailableError, match="Failed to run input rails"):
                 await _process_request(middleware, request_body, {}, _entity_source())
 
+    async def test_missing_activation_log_raises_500(self, middleware: GuardrailsMiddleware) -> None:
+        """When NeMo Guardrails returns a ``GenerationResponse`` without a log,
+        ``process_request`` must surface a 500 rather than silently treating
+        the request as blocked (the old fail-closed behaviour that produced a
+        200 ``content_filter`` response indistinguishable from a genuine block).
+        """
+        request_body = {"model": "ws/llama", "messages": [{"role": "user", "content": "Hello"}]}
+        no_log_response = GenerationResponse(response="ok", log=None)
+
+        with patch.object(middleware, "_run_rails", new=AsyncMock(return_value=no_log_response)):
+            with pytest.raises(InferenceMiddlewareError) as exc_info:
+                await _process_request(middleware, request_body, {}, _entity_source())
+
+        assert exc_info.value.status_code == 500
+        assert "Unable to determine guardrail result" in exc_info.value.detail
+
 
 # ---------------------------------------------------------------------------
 # process_response
@@ -1366,6 +1382,33 @@ class TestProcessResponse:
                     {},
                     _entity_source(output_flows=["self check output"]),
                 )
+
+    async def test_missing_activation_log_raises_500(self, middleware: GuardrailsMiddleware) -> None:
+        """Companion to ``TestProcessRequest.test_missing_activation_log_raises_500``:
+        output rails must also surface a 500 when NeMo Guardrails returns a
+        ``GenerationResponse`` with no log, rather than silently treating the
+        response as blocked.
+        """
+        request_body = {"model": "ws/llama", "messages": [{"role": "user", "content": "Hello"}]}
+        response_result = {
+            "id": "chatcmpl-123",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi"}, "finish_reason": "stop"}],
+        }
+        no_log_response = GenerationResponse(response="ok", log=None)
+
+        with patch.object(middleware, "_run_rails", new=AsyncMock(return_value=no_log_response)):
+            with pytest.raises(InferenceMiddlewareError) as exc_info:
+                await _process_response(
+                    middleware,
+                    response_result,
+                    request_body,
+                    {},
+                    {},
+                    _entity_source(output_flows=["self check output"]),
+                )
+
+        assert exc_info.value.status_code == 500
+        assert "Unable to determine guardrail result" in exc_info.value.detail
 
     async def test_blocked_output_rail(self, middleware: GuardrailsMiddleware) -> None:
         request_body = {"model": "ws/llama", "messages": [{"role": "user", "content": "Hello"}]}

--- a/plugins/nemo-guardrails/tests/unit/test_responses.py
+++ b/plugins/nemo-guardrails/tests/unit/test_responses.py
@@ -17,6 +17,7 @@ from nemo_guardrails_plugin.responses import (
     build_inference_response,
     build_output_response_body,
     extract_upstream_error,
+    is_blocked_generation_response,
 )
 from nemo_platform_plugin.inference_middleware import InferenceMiddlewareError, InferenceResponse
 from nemoguardrails.exceptions import LLMCallException
@@ -56,6 +57,35 @@ def _make_response_result(content: str = "Hello!") -> dict[str, Any]:
         ],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     }
+
+
+# ---------------------------------------------------------------------------
+# is_blocked_generation_response
+# ---------------------------------------------------------------------------
+
+
+class TestIsBlockedGenerationResponse:
+    def test_returns_true_when_a_rail_stopped(self) -> None:
+        log = GenerationLog(
+            activated_rails=[ActivatedRail(type="input", name="self check input", stop=True)],
+        )
+        assert is_blocked_generation_response(log) is True
+
+    def test_returns_false_when_no_rail_stopped(self) -> None:
+        log = GenerationLog(
+            activated_rails=[ActivatedRail(type="input", name="self check input", stop=False)],
+        )
+        assert is_blocked_generation_response(log) is False
+
+    def test_returns_false_when_activated_rails_empty(self) -> None:
+        assert is_blocked_generation_response(GenerationLog(activated_rails=[])) is False
+
+    def test_returns_false_when_activated_rails_none_set_via_stop_false(self) -> None:
+        """Rail present but stop=False is not a block."""
+        log = GenerationLog(
+            activated_rails=[ActivatedRail(type="output", name="self check output", stop=False)],
+        )
+        assert is_blocked_generation_response(log) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Addresses edge case where a rail result cannot be parsed from the underlying `GenerationResponse`. Previously, we blocked the request and `DEBUG` logged the error. This PR updates the plugin to return an explicit `500` with a `WARNING` log.

## Changes
- `responses.py`: Refactored `is_blocked_generation_response` to accept `GenerationLog` directly instead of `GenerationResponse`. The caller (i.e. the plugin middleware) returns early if there is no `GenerationLog`.
- `middleware.py`: Added a `log is None` guard in both `process_request` (input rails) and `process_response` (output rails) that raises `InferenceMiddlewareError(status_code=500)` and logs at `WARNING` before the blocked/unblocked branch is evaluated.
- Updated tests

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

`uv run --frozen pytest plugins/nemo-guardrails/ -x -q`
412 passed, 292 warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing generation logs during input and output guardrail processing.
  * Requests now return a clear HTTP 500 error when guardrail results cannot be determined.
  * Blocked responses are detected more reliably based on activated rail results.

* **Tests**
  * Added coverage for missing logs and blocked, allowed, empty, and non-stopping rail outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->