### PR TITLE
docs: address nvbugs 6581813 and 6581793

### DIFF
--- a/docs/customizer/index.mdx
+++ b/docs/customizer/index.mdx
@@ -31,6 +31,7 @@ Fine-tuning jobs run in container images published to NVIDIA NGC. Use the image 
 | `nvcr.io/nvidia/nemo-platform/nmp-customizer-tasks:<image-tag>` | Shared CPU task steps (file I/O, model entity, model spec) for all customization backends |
 | `nvcr.io/nvidia/nemo-platform/nmp-automodel-training:<image-tag>` | Automodel GPU training step |
 | `nvcr.io/nvidia/nemo-platform/nmp-unsloth-training:<image-tag>` | Unsloth GPU training step |
+| `nvcr.io/nvidia/nemo-platform/nmp-rl-training:<image-tag>` | RL/DPO GPU training step |
 
 These public images can be pulled directly from `nvcr.io`:
 
@@ -38,6 +39,7 @@ These public images can be pulled directly from `nvcr.io`:
 docker pull nvcr.io/nvidia/nemo-platform/nmp-customizer-tasks:<image-tag>
 docker pull nvcr.io/nvidia/nemo-platform/nmp-automodel-training:<image-tag>
 docker pull nvcr.io/nvidia/nemo-platform/nmp-unsloth-training:<image-tag>
+docker pull nvcr.io/nvidia/nemo-platform/nmp-rl-training:<image-tag>
 ```
 
 Most users do not need to pull these images manually. NeMo Platform resolves them from the configured platform image registry and tag. Pull or mirror them when you are operating a self-managed deployment, preloading an air-gapped environment, or validating registry access. If your environment requires authenticated registry pulls, authenticate to `nvcr.io` with an NGC API key before pulling or mirroring the images.

--- a/docs/customizer/tutorials/distillation-customization-job.ipynb
+++ b/docs/customizer/tutorials/distillation-customization-job.ipynb
@@ -922,7 +922,7 @@
         "\n",
         "**Deployment fails:**\n",
         "- Verify output model exists: `client.models.retrieve(name=DISTILLED_STUDENT_NAME, workspace=\"default\")`\n",
-        "- Check deployment logs: `client.inference.deployments.get_logs(name=deployment.name, workspace=\"default\")`\n",
+        "- Check deployment status: `deployment_status = client.inference.deployments.retrieve(name=student_deployment.name, workspace=\"default\")`. The returned deployment's `status` should be `READY` when it is available for inference.\n",
         "- The distilled model has the same size as the student, so GPU requirements match the student model\n",
         "\n",
         "\n",

--- a/docs/customizer/tutorials/distillation-customization-job.mdx
+++ b/docs/customizer/tutorials/distillation-customization-job.mdx
@@ -747,7 +747,7 @@ KD loads both models, so OOM is more likely than with SFT:
 
 **Deployment fails:**
 - Verify output model exists: `client.models.retrieve(name=DISTILLED_STUDENT_NAME, workspace="default")`
-- Check deployment logs: `client.inference.deployments.get_logs(name=deployment.name, workspace="default")`
+- Check deployment status: `deployment_status = client.inference.deployments.retrieve(name=student_deployment.name, workspace="default")`. The returned deployment's `status` should be `READY` when it is available for inference.
 - The distilled model has the same size as the student, so GPU requirements match the student model
 
 

--- a/docs/customizer/tutorials/embedding-customization-job.ipynb
+++ b/docs/customizer/tutorials/embedding-customization-job.ipynb
@@ -955,7 +955,7 @@
         "**Deployment fails:**\n",
         "- Ensure you use the correct NIM image for embedding models\n",
         "- Verify sufficient GPU memory for the model size\n",
-        "- Check deployment status: `client.inference.deployments.retrieve(name=deployment.name, workspace=\"default\")` and refer to platform logs for debugging\n",
+        "- Check deployment status: `deployment_status = client.inference.deployments.retrieve(name=deployment.name, workspace=\"default\")`. The returned deployment's `status` should be `READY` when it is available for inference.\n",
         "\n",
         "## Next Steps\n",
         "\n",

--- a/docs/customizer/tutorials/embedding-customization-job.mdx
+++ b/docs/customizer/tutorials/embedding-customization-job.mdx
@@ -793,7 +793,7 @@ For detailed information on all available hyperparameters, recommended values, a
 **Deployment fails:**
 - Ensure you use the correct NIM image for embedding models
 - Verify sufficient GPU memory for the model size
-- Check deployment status: `client.inference.deployments.retrieve(name=deployment.name, workspace="default")` and refer to platform logs for debugging
+- Check deployment status: `deployment_status = client.inference.deployments.retrieve(name=deployment.name, workspace="default")`. The returned deployment's `status` should be `READY` when it is available for inference.
 
 ## Next Steps
 

--- a/docs/customizer/tutorials/sft-customization-job.ipynb
+++ b/docs/customizer/tutorials/sft-customization-job.ipynb
@@ -863,7 +863,7 @@
         "\n",
         "**Deployment fails:**\n",
         "- Verify output model exists: `client.models.retrieve(name=OUTPUT_NAME, workspace=\"default\")`\n",
-        "- Check deployment logs: `client.inference.deployments.get_logs(name=deployment.name, workspace=\"default\")`\n",
+        "- Check deployment status: `deployment_status = client.inference.deployments.retrieve(name=deployment.name, workspace=\"default\")`. The returned deployment's `status` should be `READY` when it is available for inference.\n",
         "- Ensure sufficient GPU resources for `executor_config={\"gpu\": 1, ...}`\n",
         "- Verify the deployment config matches this tutorial: `engine=\"vllm\"` with `vllm/vllm-openai:v0.22.1`\n",
         "\n",

--- a/docs/customizer/tutorials/sft-customization-job.mdx
+++ b/docs/customizer/tutorials/sft-customization-job.mdx
@@ -690,7 +690,7 @@ For detailed information on all available hyperparameters, recommended values, a
 
 **Deployment fails:**
 - Verify output model exists: `client.models.retrieve(name=OUTPUT_NAME, workspace="default")`
-- Check deployment logs: `client.inference.deployments.get_logs(name=deployment.name, workspace="default")`
+- Check deployment status: `deployment_status = client.inference.deployments.retrieve(name=deployment.name, workspace="default")`. The returned deployment's `status` should be `READY` when it is available for inference.
 - Ensure sufficient GPU resources for `executor_config={"gpu": 1, ...}`
 - Verify the deployment config matches this tutorial: `engine="vllm"` with `vllm/vllm-openai:v0.22.1`
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Address to lower priority docs issues:
nvbugs 6581813 and  nvbugs 6581793. One was we simply weren't referencing the new nemo-rl training image in our listed images. The other was we had multiple references to the deprecated get_logs call.


## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [X] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [X] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ X] Pull request title follows the repository's Conventional Commit format
- [ X] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ X] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the reinforcement learning training container image and its `docker pull` command to the available container images table.
  - Updated customization tutorials for distillation, embedding, and supervised fine-tuning to provide clearer deployment troubleshooting guidance.
  - Troubleshooting instructions now recommend checking deployment status and confirming it reaches `READY` before using the deployment for inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->