### PR TITLE
fix(inference-gateway): decode compressed middleware responses

### DIFF
--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -2,16 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import gzip
 import json
 import logging
 import uuid
+import zlib
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, Union
 
 import aiohttp
-from aiohttp import ClientSession
-from aiohttp.compression_utils import BrotliDecompressor, ZLibDecompressor, ZSTDDecompressor
+from aiohttp import ClientSession, compression_utils
 from fastapi import HTTPException, Request
 from fastapi import status as http_status
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -452,76 +453,100 @@ class UpstreamContentDecodingError(Exception):
         super().__init__(f"Could not decode upstream Content-Encoding {content_encoding!r}")
 
 
-ContentDecoder = ZLibDecompressor | BrotliDecompressor | ZSTDDecompressor
+def _parse_content_codings(content_encoding: str) -> tuple[str, ...]:
+    """Parse the ordered content codings from a ``Content-Encoding`` value."""
+    if not content_encoding.strip():
+        return ()
+
+    codings = tuple(part.strip().lower() for part in content_encoding.split(","))
+    if any(not coding for coding in codings):
+        raise UpstreamContentDecodingError(content_encoding)
+    return tuple(coding for coding in codings if coding != "identity")
 
 
-def _build_content_decoder(content_encoding: str) -> ContentDecoder | None:
-    """Build a streaming decoder for an upstream ``Content-Encoding`` value."""
-    normalized = content_encoding.strip().lower()
-    if not normalized or normalized == "identity":
-        return None
-    if normalized == "gzip":
-        return ZLibDecompressor(encoding="gzip")
-    if normalized == "deflate":
-        return ZLibDecompressor(encoding="deflate")
-    if normalized == "br":
-        return BrotliDecompressor()
-    if normalized == "zstd":
-        return ZSTDDecompressor()
-    raise UpstreamContentDecodingError(content_encoding)
+def _decode_zstd_body(body: bytes, content_encoding: str) -> bytes:
+    """Decode one or more complete Zstandard frames."""
+    decompressor_type = getattr(compression_utils, "ZstdDecompressor", None)
+    if decompressor_type is None or not body:
+        raise UpstreamContentDecodingError(content_encoding)
+
+    decoded = bytearray()
+    remaining = body
+    while remaining:
+        decompressor = decompressor_type()
+        decoded.extend(decompressor.decompress(remaining))
+        if not decompressor.eof:
+            raise UpstreamContentDecodingError(content_encoding)
+        remaining = decompressor.unused_data
+    return bytes(decoded)
 
 
-async def _decode_content_chunks(chunks: AsyncIterable[bytes], content_encoding: str) -> AsyncIterator[bytes]:
-    """Decode an upstream response body incrementally from its content coding."""
+def _decode_content_body_sync(body: bytes, content_encoding: str) -> bytes:
+    """Decode a complete body by applying content codings in reverse order."""
     try:
-        decoder = _build_content_decoder(content_encoding)
-    except (RuntimeError, UpstreamContentDecodingError) as exc:
-        raise UpstreamContentDecodingError(content_encoding) from exc
-
-    if decoder is None:
-        async for chunk in chunks:
-            yield chunk
-        return
-
-    async for chunk in chunks:
-        try:
-            decoded = await decoder.decompress(chunk)
-        except Exception as exc:
-            raise UpstreamContentDecodingError(content_encoding) from exc
-        if decoded:
-            yield decoded
-
-    try:
-        trailing = decoder.flush()
+        decoded = body
+        for coding in reversed(_parse_content_codings(content_encoding)):
+            if coding == "gzip":
+                decoded = gzip.decompress(decoded)
+            elif coding == "deflate":
+                decoded = zlib.decompress(decoded)
+            elif coding == "br":
+                brotli = getattr(compression_utils, "brotli", None)
+                if brotli is None:
+                    raise UpstreamContentDecodingError(content_encoding)
+                decoded = brotli.decompress(decoded)
+            elif coding == "zstd":
+                decoded = _decode_zstd_body(decoded, content_encoding)
+            else:
+                raise UpstreamContentDecodingError(content_encoding)
+        return decoded
+    except UpstreamContentDecodingError:
+        raise
     except Exception as exc:
         raise UpstreamContentDecodingError(content_encoding) from exc
-    if trailing:
-        yield trailing
 
 
 async def _decode_content_body(body: bytes, content_encoding: str) -> bytes:
-    """Decode a buffered upstream response body from its content coding."""
+    """Decode and validate a complete upstream response body."""
+    return await asyncio.to_thread(_decode_content_body_sync, body, content_encoding)
 
-    async def _body_chunks() -> AsyncIterator[bytes]:
-        yield body
 
-    return b"".join([chunk async for chunk in _decode_content_chunks(_body_chunks(), content_encoding)])
+async def _decode_upstream_body(body: bytes, content_encoding: str, upstream_url: str) -> bytes:
+    """Decode an upstream body or raise the gateway's public 502 error."""
+    try:
+        return await _decode_content_body(body, content_encoding)
+    except UpstreamContentDecodingError as exc:
+        logger.warning(
+            "Inference Gateway failed to decode upstream response from %s with Content-Encoding %r",
+            upstream_url,
+            content_encoding,
+            exc_info=exc,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"Inference Gateway could not decode the upstream response with Content-Encoding {content_encoding!r}."
+            ),
+        ) from exc
+
+
+async def _iter_response_chunks(chunks: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
+    """Yield already parsed response chunks through the streaming middleware API."""
+    for chunk in chunks:
+        yield chunk
 
 
 async def _parse_sse_stream(response: aiohttp.ClientResponse) -> AsyncIterator[dict[str, Any]]:
     """Yield parsed JSON objects from an SSE (text/event-stream) response.
 
-    The response body is decoded according to ``Content-Encoding`` before each
-    ``data:`` line is parsed and yielded as a dict. ``data: [DONE]`` terminates
-    the stream. Malformed or non-JSON data lines are silently skipped. The
-    underlying aiohttp response is always closed when the generator exits.
+    Each ``data:`` line is parsed and yielded as a dict. ``data: [DONE]``
+    terminates the stream. Malformed or non-JSON data lines are silently skipped.
+    Compressed SSE responses are decoded eagerly by :func:`fetch_proxy_response`
+    instead so decoding failures can become a 502 before response output starts.
+    The underlying aiohttp response is always closed when the generator exits.
     """
     try:
-        decoded_chunks = _decode_content_chunks(
-            response.content.iter_any(),
-            response.headers.get("content-encoding", ""),
-        )
-        async for parsed in _parse_sse_chunks(decoded_chunks):
+        async for parsed in _parse_sse_chunks(response.content.iter_any()):
             yield parsed
     finally:
         _close_response(response)
@@ -538,11 +563,12 @@ async def fetch_proxy_response(
     responsible for applying response middleware and then streaming via
     :func:`stream_response_result`.
 
-    For ``Content-Type: text/event-stream`` responses the decoded result is an
-    ``AsyncIterator[dict]`` backed by the live aiohttp response — the iterator
-    **must** be fully consumed or the underlying connection will leak. For all
-    other responses the body is buffered, decoded according to
-    ``Content-Encoding``, and parsed as a JSON object.
+    Unencoded ``Content-Type: text/event-stream`` responses remain backed by the
+    live aiohttp response, so the iterator **must** be fully consumed or the
+    underlying connection will leak. Compressed SSE responses are buffered and
+    validated before an iterator is returned, allowing decoding failures to be
+    reported as a 502 before response output begins. All other responses are
+    buffered, decoded according to ``Content-Encoding``, and parsed as JSON.
 
     Returns:
         A ``(response_result, headers, status_code)`` tuple.
@@ -586,30 +612,32 @@ async def fetch_proxy_response(
         content_type = response.headers.get("content-type", "")
 
         if "text/event-stream" in content_type:
-            # Streaming — return a live async generator; ownership of the
-            # aiohttp response is transferred to the generator.
-            result: ResponseResult = _parse_sse_stream(response)
+            content_encoding = response.headers.get("content-encoding", "")
+            if content_encoding.strip().lower() not in {"", "identity"}:
+                # A compressed stream must be complete before its checksum and
+                # framing can be validated. Buffer it so a corrupt stream becomes
+                # a 502 instead of failing after successful headers were sent.
+                try:
+                    raw = b"".join([chunk async for chunk in response.content.iter_any()])
+                finally:
+                    _close_response(response)
+                decoded = await _decode_upstream_body(raw, content_encoding, next_request_info.url)
+
+                async def _decoded_body() -> AsyncIterator[bytes]:
+                    yield decoded
+
+                parsed_chunks = [chunk async for chunk in _parse_sse_chunks(_decoded_body())]
+                result: ResponseResult = _iter_response_chunks(parsed_chunks)
+            else:
+                # Ownership of the live aiohttp response is transferred to the
+                # generator for unencoded streaming responses.
+                result = _parse_sse_stream(response)
         else:
             # Non-streaming — buffer and decode the full body before parsing it.
             raw = await response.read()
             _close_response(response)
             content_encoding = response.headers.get("content-encoding", "")
-            try:
-                decoded = await _decode_content_body(raw, content_encoding)
-            except UpstreamContentDecodingError as exc:
-                logger.warning(
-                    "Inference Gateway failed to decode upstream response from %s with Content-Encoding %r",
-                    next_request_info.url,
-                    content_encoding,
-                    exc_info=exc,
-                )
-                raise HTTPException(
-                    status_code=502,
-                    detail=(
-                        "Inference Gateway could not decode the upstream response "
-                        f"with Content-Encoding {content_encoding!r}."
-                    ),
-                ) from exc
+            decoded = await _decode_upstream_body(raw, content_encoding, next_request_info.url)
             try:
                 result = json.loads(decoded)
             except (json.JSONDecodeError, ValueError) as exc:

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, AsyncIterator, Union
 
 import aiohttp
 from aiohttp import ClientSession
+from aiohttp.compression_utils import BrotliDecompressor, ZLibDecompressor, ZSTDDecompressor
 from fastapi import HTTPException, Request
 from fastapi import status as http_status
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -443,15 +444,84 @@ async def _parse_sse_chunks(
                 yield parsed
 
 
+class UpstreamContentDecodingError(Exception):
+    """Raised when IGW cannot decode an upstream response body."""
+
+    def __init__(self, content_encoding: str):
+        self.content_encoding = content_encoding
+        super().__init__(f"Could not decode upstream Content-Encoding {content_encoding!r}")
+
+
+ContentDecoder = ZLibDecompressor | BrotliDecompressor | ZSTDDecompressor
+
+
+def _build_content_decoder(content_encoding: str) -> ContentDecoder | None:
+    """Build a streaming decoder for an upstream ``Content-Encoding`` value."""
+    normalized = content_encoding.strip().lower()
+    if not normalized or normalized == "identity":
+        return None
+    if normalized == "gzip":
+        return ZLibDecompressor(encoding="gzip")
+    if normalized == "deflate":
+        return ZLibDecompressor(encoding="deflate")
+    if normalized == "br":
+        return BrotliDecompressor()
+    if normalized == "zstd":
+        return ZSTDDecompressor()
+    raise UpstreamContentDecodingError(content_encoding)
+
+
+async def _decode_content_chunks(chunks: AsyncIterable[bytes], content_encoding: str) -> AsyncIterator[bytes]:
+    """Decode an upstream response body incrementally from its content coding."""
+    try:
+        decoder = _build_content_decoder(content_encoding)
+    except (RuntimeError, UpstreamContentDecodingError) as exc:
+        raise UpstreamContentDecodingError(content_encoding) from exc
+
+    if decoder is None:
+        async for chunk in chunks:
+            yield chunk
+        return
+
+    async for chunk in chunks:
+        try:
+            decoded = await decoder.decompress(chunk)
+        except Exception as exc:
+            raise UpstreamContentDecodingError(content_encoding) from exc
+        if decoded:
+            yield decoded
+
+    try:
+        trailing = decoder.flush()
+    except Exception as exc:
+        raise UpstreamContentDecodingError(content_encoding) from exc
+    if trailing:
+        yield trailing
+
+
+async def _decode_content_body(body: bytes, content_encoding: str) -> bytes:
+    """Decode a buffered upstream response body from its content coding."""
+
+    async def _body_chunks() -> AsyncIterator[bytes]:
+        yield body
+
+    return b"".join([chunk async for chunk in _decode_content_chunks(_body_chunks(), content_encoding)])
+
+
 async def _parse_sse_stream(response: aiohttp.ClientResponse) -> AsyncIterator[dict[str, Any]]:
     """Yield parsed JSON objects from an SSE (text/event-stream) response.
 
-    Each ``data:`` line is decoded and yielded as a dict.  ``data: [DONE]``
-    terminates the stream.  Malformed or non-JSON data lines are silently skipped.
-    The underlying aiohttp response is always closed when the generator exits.
+    The response body is decoded according to ``Content-Encoding`` before each
+    ``data:`` line is parsed and yielded as a dict. ``data: [DONE]`` terminates
+    the stream. Malformed or non-JSON data lines are silently skipped. The
+    underlying aiohttp response is always closed when the generator exits.
     """
     try:
-        async for parsed in _parse_sse_chunks(response.content.iter_any()):
+        decoded_chunks = _decode_content_chunks(
+            response.content.iter_any(),
+            response.headers.get("content-encoding", ""),
+        )
+        async for parsed in _parse_sse_chunks(decoded_chunks):
             yield parsed
     finally:
         _close_response(response)
@@ -468,11 +538,11 @@ async def fetch_proxy_response(
     responsible for applying response middleware and then streaming via
     :func:`stream_response_result`.
 
-    For ``Content-Type: text/event-stream`` responses the result is an
+    For ``Content-Type: text/event-stream`` responses the decoded result is an
     ``AsyncIterator[dict]`` backed by the live aiohttp response — the iterator
-    **must** be fully consumed or the underlying connection will leak.  For all
-    other responses the body is buffered and parsed as JSON (falling back to an
-    empty dict for non-JSON bodies).
+    **must** be fully consumed or the underlying connection will leak. For all
+    other responses the body is buffered, decoded according to
+    ``Content-Encoding``, and parsed as a JSON object.
 
     Returns:
         A ``(response_result, headers, status_code)`` tuple.
@@ -520,20 +590,48 @@ async def fetch_proxy_response(
             # aiohttp response is transferred to the generator.
             result: ResponseResult = _parse_sse_stream(response)
         else:
-            # Non-streaming — buffer the full body and parse as a JSON object.
+            # Non-streaming — buffer and decode the full body before parsing it.
             raw = await response.read()
             _close_response(response)
+            content_encoding = response.headers.get("content-encoding", "")
             try:
-                result = json.loads(raw)
-            except (json.JSONDecodeError, ValueError) as exc:
+                decoded = await _decode_content_body(raw, content_encoding)
+            except UpstreamContentDecodingError as exc:
+                logger.warning(
+                    "Inference Gateway failed to decode upstream response from %s with Content-Encoding %r",
+                    next_request_info.url,
+                    content_encoding,
+                    exc_info=exc,
+                )
                 raise HTTPException(
                     status_code=502,
-                    detail="Inference middleware requires JSON upstream responses; backend returned non-JSON.",
+                    detail=(
+                        "Inference Gateway could not decode the upstream response "
+                        f"with Content-Encoding {content_encoding!r}."
+                    ),
+                ) from exc
+            try:
+                result = json.loads(decoded)
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.warning(
+                    "Inference Gateway could not parse upstream response from %s as JSON",
+                    next_request_info.url,
+                    exc_info=exc,
+                )
+                raise HTTPException(
+                    status_code=502,
+                    detail=(
+                        "Inference Gateway could not parse the upstream response as JSON "
+                        "for inference middleware processing."
+                    ),
                 ) from exc
             if not isinstance(result, dict):
                 raise HTTPException(
                     status_code=502,
-                    detail="Inference middleware requires JSON object upstream responses; backend returned a non-object.",
+                    detail=(
+                        "Inference Gateway received an upstream JSON response that is not an object, "
+                        "which inference middleware cannot process."
+                    ),
                 )
 
         return result, response_headers, status_code

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -2,17 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import gzip
 import json
 import logging
 import uuid
-import zlib
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, Union
 
 import aiohttp
-from aiohttp import ClientSession, compression_utils
+from aiohttp import ClientSession
 from fastapi import HTTPException, Request
 from fastapi import status as http_status
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -445,105 +443,13 @@ async def _parse_sse_chunks(
                 yield parsed
 
 
-class UpstreamContentDecodingError(Exception):
-    """Raised when IGW cannot decode an upstream response body."""
-
-    def __init__(self, content_encoding: str):
-        self.content_encoding = content_encoding
-        super().__init__(f"Could not decode upstream Content-Encoding {content_encoding!r}")
-
-
-def _parse_content_codings(content_encoding: str) -> tuple[str, ...]:
-    """Parse the ordered content codings from a ``Content-Encoding`` value."""
-    if not content_encoding.strip():
-        return ()
-
-    codings = tuple(part.strip().lower() for part in content_encoding.split(","))
-    if any(not coding for coding in codings):
-        raise UpstreamContentDecodingError(content_encoding)
-    return tuple(coding for coding in codings if coding != "identity")
-
-
-def _decode_zstd_body(body: bytes, content_encoding: str) -> bytes:
-    """Decode one or more complete Zstandard frames."""
-    decompressor_type = getattr(compression_utils, "ZstdDecompressor", None)
-    if decompressor_type is None or not body:
-        raise UpstreamContentDecodingError(content_encoding)
-
-    decoded = bytearray()
-    remaining = body
-    while remaining:
-        decompressor = decompressor_type()
-        decoded.extend(decompressor.decompress(remaining))
-        if not decompressor.eof:
-            raise UpstreamContentDecodingError(content_encoding)
-        remaining = decompressor.unused_data
-    return bytes(decoded)
-
-
-def _decode_content_body_sync(body: bytes, content_encoding: str) -> bytes:
-    """Decode a complete body by applying content codings in reverse order."""
-    try:
-        decoded = body
-        for coding in reversed(_parse_content_codings(content_encoding)):
-            if coding == "gzip":
-                decoded = gzip.decompress(decoded)
-            elif coding == "deflate":
-                decoded = zlib.decompress(decoded)
-            elif coding == "br":
-                brotli = getattr(compression_utils, "brotli", None)
-                if brotli is None:
-                    raise UpstreamContentDecodingError(content_encoding)
-                decoded = brotli.decompress(decoded)
-            elif coding == "zstd":
-                decoded = _decode_zstd_body(decoded, content_encoding)
-            else:
-                raise UpstreamContentDecodingError(content_encoding)
-        return decoded
-    except UpstreamContentDecodingError:
-        raise
-    except Exception as exc:
-        raise UpstreamContentDecodingError(content_encoding) from exc
-
-
-async def _decode_content_body(body: bytes, content_encoding: str) -> bytes:
-    """Decode and validate a complete upstream response body."""
-    return await asyncio.to_thread(_decode_content_body_sync, body, content_encoding)
-
-
-async def _decode_upstream_body(body: bytes, content_encoding: str, upstream_url: str) -> bytes:
-    """Decode an upstream body or raise the gateway's public 502 error."""
-    try:
-        return await _decode_content_body(body, content_encoding)
-    except UpstreamContentDecodingError as exc:
-        logger.warning(
-            "Inference Gateway failed to decode upstream response from %s with Content-Encoding %r",
-            upstream_url,
-            content_encoding,
-            exc_info=exc,
-        )
-        raise HTTPException(
-            status_code=502,
-            detail=(
-                f"Inference Gateway could not decode the upstream response with Content-Encoding {content_encoding!r}."
-            ),
-        ) from exc
-
-
-async def _iter_response_chunks(chunks: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
-    """Yield already parsed response chunks through the streaming middleware API."""
-    for chunk in chunks:
-        yield chunk
-
-
 async def _parse_sse_stream(response: aiohttp.ClientResponse) -> AsyncIterator[dict[str, Any]]:
     """Yield parsed JSON objects from an SSE (text/event-stream) response.
 
-    Each ``data:`` line is parsed and yielded as a dict. ``data: [DONE]``
+    Each ``data:`` line is decoded and yielded as a dict. ``data: [DONE]``
     terminates the stream. Malformed or non-JSON data lines are silently skipped.
-    Compressed SSE responses are decoded eagerly by :func:`fetch_proxy_response`
-    instead so decoding failures can become a 502 before response output starts.
-    The underlying aiohttp response is always closed when the generator exits.
+    aiohttp decodes compressed response chunks before they reach this parser.
+    The underlying response is always closed when the generator exits.
     """
     try:
         async for parsed in _parse_sse_chunks(response.content.iter_any()):
@@ -563,12 +469,10 @@ async def fetch_proxy_response(
     responsible for applying response middleware and then streaming via
     :func:`stream_response_result`.
 
-    Unencoded ``Content-Type: text/event-stream`` responses remain backed by the
-    live aiohttp response, so the iterator **must** be fully consumed or the
-    underlying connection will leak. Compressed SSE responses are buffered and
-    validated before an iterator is returned, allowing decoding failures to be
-    reported as a 502 before response output begins. All other responses are
-    buffered, decoded according to ``Content-Encoding``, and parsed as JSON.
+    aiohttp decodes the upstream ``Content-Encoding`` for this middleware-aware
+    path. ``Content-Type: text/event-stream`` responses remain backed by the live
+    response, so the iterator **must** be fully consumed or the connection will
+    leak. Other responses are buffered and parsed as JSON.
 
     Returns:
         A ``(response_result, headers, status_code)`` tuple.
@@ -585,6 +489,7 @@ async def fetch_proxy_response(
             params=next_request_info.query_params,
             data=next_request_info.body,
             timeout=None,
+            auto_decompress=True,
         )
 
         if response.status >= 400:
@@ -612,34 +517,15 @@ async def fetch_proxy_response(
         content_type = response.headers.get("content-type", "")
 
         if "text/event-stream" in content_type:
-            content_encoding = response.headers.get("content-encoding", "")
-            if content_encoding.strip().lower() not in {"", "identity"}:
-                # A compressed stream must be complete before its checksum and
-                # framing can be validated. Buffer it so a corrupt stream becomes
-                # a 502 instead of failing after successful headers were sent.
-                try:
-                    raw = b"".join([chunk async for chunk in response.content.iter_any()])
-                finally:
-                    _close_response(response)
-                decoded = await _decode_upstream_body(raw, content_encoding, next_request_info.url)
-
-                async def _decoded_body() -> AsyncIterator[bytes]:
-                    yield decoded
-
-                parsed_chunks = [chunk async for chunk in _parse_sse_chunks(_decoded_body())]
-                result: ResponseResult = _iter_response_chunks(parsed_chunks)
-            else:
-                # Ownership of the live aiohttp response is transferred to the
-                # generator for unencoded streaming responses.
-                result = _parse_sse_stream(response)
+            # Ownership of the live aiohttp response is transferred to the
+            # generator for streaming responses.
+            result: ResponseResult = _parse_sse_stream(response)
         else:
-            # Non-streaming — buffer and decode the full body before parsing it.
+            # aiohttp has already decoded Content-Encoding for this request.
             raw = await response.read()
             _close_response(response)
-            content_encoding = response.headers.get("content-encoding", "")
-            decoded = await _decode_upstream_body(raw, content_encoding, next_request_info.url)
             try:
-                result = json.loads(decoded)
+                result = json.loads(raw)
             except (json.JSONDecodeError, ValueError) as exc:
                 logger.warning(
                     "Inference Gateway could not parse upstream response from %s as JSON",
@@ -666,6 +552,17 @@ async def fetch_proxy_response(
 
     except HTTPException:
         raise
+    except aiohttp.ClientPayloadError as exc:
+        _close_response(response)
+        logger.warning(
+            "Inference Gateway could not decode upstream response from %s",
+            next_request_info.url,
+            exc_info=exc,
+        )
+        raise HTTPException(
+            status_code=502,
+            detail="Inference Gateway could not decode the upstream response body.",
+        ) from exc
     except aiohttp.ClientError as exc:
         _close_response(response)
         raise HTTPException(status_code=502, detail=f"Backend networking error: {exc}")

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/service.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/service.py
@@ -144,8 +144,9 @@ class InferenceGatewayService(Service):
         #
         # - DummyCookieJar: this client session will be used across different
         #   domains, so we don't want to mix cookies between providers.
-        # - auto_decompress=False: compressed responses pass through
-        #   transparently to clients.
+        # - auto_decompress=False: direct proxy responses pass through
+        #   transparently. The inference-middleware path decodes upstream
+        #   Content-Encoding itself before parsing and re-serializing bodies.
         # - skip_auto_headers=["Accept-Encoding"]: pass through the client's
         #   encoding preferences instead of advertising our own.
         # - Explicit TCPConnector: aiohttp's default ClientSession connector

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/service.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/service.py
@@ -145,8 +145,8 @@ class InferenceGatewayService(Service):
         # - DummyCookieJar: this client session will be used across different
         #   domains, so we don't want to mix cookies between providers.
         # - auto_decompress=False: direct proxy responses pass through
-        #   transparently. The inference-middleware path decodes upstream
-        #   Content-Encoding itself before parsing and re-serializing bodies.
+        #   transparently. The inference-middleware request overrides this
+        #   setting so aiohttp decodes before JSON or SSE parsing.
         # - skip_auto_headers=["Accept-Encoding"]: pass through the client's
         #   encoding preferences instead of advertising our own.
         # - Explicit TCPConnector: aiohttp's default ClientSession connector

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/_loopback.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/_loopback.py
@@ -132,9 +132,9 @@ async def per_request_http_client() -> AsyncGenerator[aiohttp.ClientSession, Non
 
     Constructor flags mirror the production client so headers and
     decompression behave identically: ``DummyCookieJar`` (no cross-domain
-    cookie persistence), ``auto_decompress=False`` (the relevant proxy path
-    decides whether to pass through or decode), and ``Accept-Encoding`` left
-    to the inbound request.
+    cookie persistence), ``auto_decompress=False`` (middleware requests
+    override it per request), and ``Accept-Encoding`` left to the inbound
+    request.
     """
     session = aiohttp.ClientSession(
         cookie_jar=aiohttp.DummyCookieJar(),

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/_loopback.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/_loopback.py
@@ -132,8 +132,9 @@ async def per_request_http_client() -> AsyncGenerator[aiohttp.ClientSession, Non
 
     Constructor flags mirror the production client so headers and
     decompression behave identically: ``DummyCookieJar`` (no cross-domain
-    cookie persistence), ``auto_decompress=False`` (compressed responses
-    pass through), and ``Accept-Encoding`` left to the inbound request.
+    cookie persistence), ``auto_decompress=False`` (the relevant proxy path
+    decides whether to pass through or decode), and ``Accept-Encoding`` left
+    to the inbound request.
     """
     session = aiohttp.ClientSession(
         cookie_jar=aiohttp.DummyCookieJar(),

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -128,6 +128,28 @@ async def test_stream_response_result_prefers_typed_non_streaming_payload():
     assert json.loads(body)["id"] == "typed"
 
 
+@pytest.mark.asyncio
+async def test_stream_response_result_strips_stale_upstream_body_headers():
+    """Re-serialized middleware output does not retain upstream body framing."""
+    response = await stream_response_result(
+        {"id": "decoded"},
+        200,
+        {
+            "content-length": "123",
+            "content-encoding": "gzip",
+            "transfer-encoding": "chunked",
+            "x-upstream-header": "preserved",
+        },
+    )
+
+    assert "content-length" not in response.headers
+    assert "content-encoding" not in response.headers
+    assert "transfer-encoding" not in response.headers
+    assert response.headers["content-type"] == "application/json"
+    assert response.headers["x-upstream-header"] == "preserved"
+    assert json.loads(await _read_streaming_response(response)) == {"id": "decoded"}
+
+
 def test_response_annotations_do_not_overwrite_typed_body_fields():
     typed = openai_chat_types.ChatCompletion.model_validate(
         {

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -6,12 +6,12 @@
 import asyncio
 import gzip
 import json
-import zlib
 from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
+import aiohttp
 import anthropic.types as anthropic_types
 import openai.types.chat as openai_chat_types
 import pytest
@@ -49,6 +49,7 @@ from nmp.core.inference_gateway.api.proxy import (
     stream_response_result,
     virtual_model_proxy,
 )
+from pytest_httpserver import HTTPServer
 
 
 @pytest.fixture
@@ -1494,111 +1495,41 @@ async def test_compressed_response_bytes_passed_through(mock_proxy_client, mock_
 
 
 @pytest.mark.asyncio
-async def test_fetch_proxy_response_decodes_gzip_json(mock_proxy_client, mock_proxy_response, next_request_info):
-    """Middleware processing receives decoded JSON when the upstream uses gzip."""
+async def test_fetch_proxy_response_decodes_gzip_json(httpserver: HTTPServer):
+    """The middleware request overrides a non-decompressing session for gzip JSON."""
     expected = {"id": "response", "choices": [{"message": {"content": "ok"}}]}
-    mock_proxy_response.headers = CIMultiDictProxy(
-        CIMultiDict(
-            [
-                ("content-type", "application/json"),
-                ("content-encoding", "gzip"),
-            ]
-        )
+    httpserver.expect_request("/gzip-json").respond_with_data(
+        gzip.compress(json.dumps(expected).encode()),
+        headers={"content-encoding": "gzip"},
+        content_type="application/json",
     )
-    mock_proxy_response.read = AsyncMock(return_value=gzip.compress(json.dumps(expected).encode()))
+    request_info = NextRequestInfo(
+        url=httpserver.url_for("/gzip-json"),
+        body=None,
+        headers=CIMultiDict({"accept-encoding": "gzip"}),
+        method="GET",
+        query_params={},
+    )
 
-    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
+    async with aiohttp.ClientSession(auto_decompress=False) as http_client:
+        result, _, status_code = await fetch_proxy_response(http_client, request_info)
 
     assert status_code == 200
     assert result == expected
 
 
 @pytest.mark.asyncio
-async def test_fetch_proxy_response_decodes_deflate_json(mock_proxy_client, mock_proxy_response, next_request_info):
-    """The middleware path supports the other baseline HTTP compression coding."""
-    expected = {"id": "response", "choices": [{"message": {"content": "ok"}}]}
-    mock_proxy_response.headers = CIMultiDictProxy(
-        CIMultiDict(
-            [
-                ("content-type", "application/json"),
-                ("content-encoding", "deflate"),
-            ]
-        )
-    )
-    mock_proxy_response.read = AsyncMock(return_value=zlib.compress(json.dumps(expected).encode()))
-
-    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
-
-    assert status_code == 200
-    assert result == expected
-
-
-@pytest.mark.asyncio
-async def test_fetch_proxy_response_decodes_chained_json(mock_proxy_client, mock_proxy_response, next_request_info):
-    """Content codings are decoded in reverse application order."""
-    expected = {"id": "response", "choices": [{"message": {"content": "ok"}}]}
-    encoded = zlib.compress(gzip.compress(json.dumps(expected).encode()))
-    mock_proxy_response.headers = CIMultiDictProxy(
-        CIMultiDict(
-            [
-                ("content-type", "application/json"),
-                ("content-encoding", " gzip, deflate "),
-            ]
-        )
-    )
-    mock_proxy_response.read = AsyncMock(return_value=encoded)
-
-    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
-
-    assert status_code == 200
-    assert result == expected
-
-
-@pytest.mark.asyncio
-async def test_fetch_proxy_response_reports_content_decoding_failure(
+async def test_fetch_proxy_response_reports_payload_decoding_failure(
     mock_proxy_client, mock_proxy_response, next_request_info
 ):
-    """A corrupt compressed body is reported as a gateway decoding failure."""
-    mock_proxy_response.headers = CIMultiDictProxy(
-        CIMultiDict(
-            [
-                ("content-type", "application/json"),
-                ("content-encoding", "gzip"),
-            ]
-        )
-    )
-    mock_proxy_response.read = AsyncMock(return_value=b"not-gzip")
+    """aiohttp payload decoding failures are reported as gateway processing errors."""
+    mock_proxy_response.read = AsyncMock(side_effect=aiohttp.ClientPayloadError("invalid gzip body"))
 
     with pytest.raises(HTTPException) as exc_info:
         await fetch_proxy_response(mock_proxy_client, next_request_info)
 
     assert exc_info.value.status_code == 502
-    assert exc_info.value.detail == (
-        "Inference Gateway could not decode the upstream response with Content-Encoding 'gzip'."
-    )
-
-
-@pytest.mark.asyncio
-async def test_fetch_proxy_response_rejects_truncated_gzip(mock_proxy_client, mock_proxy_response, next_request_info):
-    """A gzip body without its checksum trailer is not accepted as valid JSON."""
-    encoded = gzip.compress(b'{"id":"response"}')
-    mock_proxy_response.headers = CIMultiDictProxy(
-        CIMultiDict(
-            [
-                ("content-type", "application/json"),
-                ("content-encoding", "gzip"),
-            ]
-        )
-    )
-    mock_proxy_response.read = AsyncMock(return_value=encoded[:-8])
-
-    with pytest.raises(HTTPException) as exc_info:
-        await fetch_proxy_response(mock_proxy_client, next_request_info)
-
-    assert exc_info.value.status_code == 502
-    assert exc_info.value.detail == (
-        "Inference Gateway could not decode the upstream response with Content-Encoding 'gzip'."
-    )
+    assert exc_info.value.detail == "Inference Gateway could not decode the upstream response body."
 
 
 @pytest.mark.asyncio
@@ -1619,8 +1550,8 @@ async def test_fetch_proxy_response_reports_json_processing_failure(
 
 
 @pytest.mark.asyncio
-async def test_fetch_proxy_response_decodes_gzip_sse(mock_proxy_client, mock_proxy_response, next_request_info):
-    """Streaming middleware receives decoded SSE chunks when the upstream uses gzip."""
+async def test_fetch_proxy_response_decodes_gzip_sse(httpserver: HTTPServer):
+    """The middleware path keeps streaming while aiohttp decodes gzip SSE."""
     expected = [
         {"id": "chunk-1", "choices": [{"delta": {"content": "hello"}}]},
         {"id": "chunk-2", "choices": [{"delta": {"content": " world"}}]},
@@ -1628,89 +1559,26 @@ async def test_fetch_proxy_response_decodes_gzip_sse(mock_proxy_client, mock_pro
     encoded = gzip.compress(
         ("\n".join(f"data: {json.dumps(chunk)}" for chunk in expected) + "\ndata: [DONE]\n").encode()
     )
-
-    async def _iter_compressed_fragments():
-        midpoint = len(encoded) // 2
-        yield encoded[:midpoint]
-        yield encoded[midpoint:]
-
-    mock_proxy_response.headers = CIMultiDictProxy(
-        CIMultiDict(
-            [
-                ("content-type", "text/event-stream"),
-                ("content-encoding", "gzip"),
-            ]
-        )
+    httpserver.expect_request("/gzip-sse").respond_with_data(
+        encoded,
+        headers={"content-encoding": "gzip"},
+        content_type="text/event-stream",
     )
-    mock_proxy_response.content.iter_any = Mock(return_value=_iter_compressed_fragments())
-
-    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
-
-    assert status_code == 200
-    assert not isinstance(result, dict)
-    assert [chunk async for chunk in result] == expected
-
-
-@pytest.mark.asyncio
-async def test_fetch_proxy_response_decodes_chained_fragmented_sse(
-    mock_proxy_client, mock_proxy_response, next_request_info
-):
-    """Fragmented SSE supports multiple content codings in application order."""
-    expected = [
-        {"id": "chunk-1", "choices": [{"delta": {"content": "hello"}}]},
-        {"id": "chunk-2", "choices": [{"delta": {"content": " world"}}]},
-    ]
-    body = ("\n".join(f"data: {json.dumps(chunk)}" for chunk in expected) + "\ndata: [DONE]\n").encode()
-    encoded = zlib.compress(gzip.compress(body))
-
-    async def _iter_compressed_fragments():
-        for offset in range(0, len(encoded), 7):
-            yield encoded[offset : offset + 7]
-
-    mock_proxy_response.headers = CIMultiDictProxy(
-        CIMultiDict(
-            [
-                ("content-type", "text/event-stream"),
-                ("content-encoding", "gzip, deflate"),
-            ]
-        )
+    request_info = NextRequestInfo(
+        url=httpserver.url_for("/gzip-sse"),
+        body=None,
+        headers=CIMultiDict({"accept-encoding": "gzip"}),
+        method="GET",
+        query_params={},
     )
-    mock_proxy_response.content.iter_any = Mock(return_value=_iter_compressed_fragments())
 
-    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
+    async with aiohttp.ClientSession(auto_decompress=False) as http_client:
+        result, _, status_code = await fetch_proxy_response(http_client, request_info)
+        assert status_code == 200
+        assert not isinstance(result, dict)
+        parsed = [chunk async for chunk in result]
 
-    assert status_code == 200
-    assert not isinstance(result, dict)
-    assert [chunk async for chunk in result] == expected
-
-
-@pytest.mark.asyncio
-async def test_fetch_proxy_response_rejects_corrupt_gzip_sse_before_returning_response(
-    mock_proxy_client, mock_proxy_response, next_request_info
-):
-    """A compressed SSE decoding error becomes a 502 before any stream is returned."""
-
-    async def _iter_corrupt_body():
-        yield b"not-gzip"
-
-    mock_proxy_response.headers = CIMultiDictProxy(
-        CIMultiDict(
-            [
-                ("content-type", "text/event-stream"),
-                ("content-encoding", "gzip"),
-            ]
-        )
-    )
-    mock_proxy_response.content.iter_any = Mock(return_value=_iter_corrupt_body())
-
-    with pytest.raises(HTTPException) as exc_info:
-        await fetch_proxy_response(mock_proxy_client, next_request_info)
-
-    assert exc_info.value.status_code == 502
-    assert exc_info.value.detail == (
-        "Inference Gateway could not decode the upstream response with Content-Encoding 'gzip'."
-    )
-    mock_proxy_response.close.assert_called_once()
+    assert parsed == expected
 
 
 # ---------------------------------------------------------------------------
@@ -1733,7 +1601,6 @@ def _make_sse_response(*lines: str, encoding: str = "utf-8") -> Mock:
             yield chunk
 
     response = Mock()
-    response.headers = CIMultiDictProxy(CIMultiDict())
     response.content = Mock()
     response.content.iter_any = Mock(return_value=_iter_any())
     response.close = Mock()
@@ -1751,7 +1618,6 @@ def _make_sse_response_fragmented(*lines: str) -> Mock:
             yield bytes([byte])
 
     response = Mock()
-    response.headers = CIMultiDictProxy(CIMultiDict())
     response.content = Mock()
     response.content.iter_any = Mock(return_value=_iter_any())
     response.close = Mock()
@@ -1826,7 +1692,6 @@ async def test_parse_sse_handles_crlf_line_endings():
         yield raw.encode()
 
     response = Mock()
-    response.headers = CIMultiDictProxy(CIMultiDict())
     response.content = Mock()
     response.content.iter_any = Mock(return_value=_iter_any())
     response.close = Mock()

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -4,7 +4,9 @@
 """Tests for proxy functionality."""
 
 import asyncio
+import gzip
 import json
+import zlib
 from collections.abc import AsyncIterator
 from datetime import datetime
 from typing import Any, cast
@@ -41,6 +43,7 @@ from nmp.core.inference_gateway.api.proxy import (
     _rewrite_model_field,
     _rewrite_model_field_in_stream,
     build_next_request,
+    fetch_proxy_response,
     normalize_proxy_url,
     proxy_request,
     stream_response_result,
@@ -1433,8 +1436,6 @@ async def test_compressed_response_bytes_passed_through(mock_proxy_client, mock_
     This verifies the gateway doesn't decompress responses, allowing compressed
     data to flow transparently from upstream to client.
     """
-    import gzip
-
     from multidict import CIMultiDict, CIMultiDictProxy
 
     # Simulate a gzip-compressed response from upstream
@@ -1470,6 +1471,120 @@ async def test_compressed_response_bytes_passed_through(mock_proxy_client, mock_
     assert gzip.decompress(received_data) == original_data
 
 
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_decodes_gzip_json(mock_proxy_client, mock_proxy_response, next_request_info):
+    """Middleware processing receives decoded JSON when the upstream uses gzip."""
+    expected = {"id": "response", "choices": [{"message": {"content": "ok"}}]}
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/json"),
+                ("content-encoding", "gzip"),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=gzip.compress(json.dumps(expected).encode()))
+
+    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert status_code == 200
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_decodes_deflate_json(mock_proxy_client, mock_proxy_response, next_request_info):
+    """The middleware path supports the other baseline HTTP compression coding."""
+    expected = {"id": "response", "choices": [{"message": {"content": "ok"}}]}
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/json"),
+                ("content-encoding", "deflate"),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=zlib.compress(json.dumps(expected).encode()))
+
+    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert status_code == 200
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_reports_content_decoding_failure(
+    mock_proxy_client, mock_proxy_response, next_request_info
+):
+    """A corrupt compressed body is reported as a gateway decoding failure."""
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/json"),
+                ("content-encoding", "gzip"),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=b"not-gzip")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == (
+        "Inference Gateway could not decode the upstream response with Content-Encoding 'gzip'."
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_reports_json_processing_failure(
+    mock_proxy_client, mock_proxy_response, next_request_info
+):
+    """A JSON parsing failure describes gateway processing instead of blaming the backend."""
+    mock_proxy_response.read = AsyncMock(return_value=b"not-json")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == (
+        "Inference Gateway could not parse the upstream response as JSON for inference middleware processing."
+    )
+    assert "backend returned" not in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_decodes_gzip_sse(mock_proxy_client, mock_proxy_response, next_request_info):
+    """Streaming middleware receives decoded SSE chunks when the upstream uses gzip."""
+    expected = [
+        {"id": "chunk-1", "choices": [{"delta": {"content": "hello"}}]},
+        {"id": "chunk-2", "choices": [{"delta": {"content": " world"}}]},
+    ]
+    encoded = gzip.compress(
+        ("\n".join(f"data: {json.dumps(chunk)}" for chunk in expected) + "\ndata: [DONE]\n").encode()
+    )
+
+    async def _iter_compressed_fragments():
+        midpoint = len(encoded) // 2
+        yield encoded[:midpoint]
+        yield encoded[midpoint:]
+
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "text/event-stream"),
+                ("content-encoding", "gzip"),
+            ]
+        )
+    )
+    mock_proxy_response.content.iter_any = Mock(return_value=_iter_compressed_fragments())
+
+    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert status_code == 200
+    assert not isinstance(result, dict)
+    assert [chunk async for chunk in result] == expected
+
+
 # ---------------------------------------------------------------------------
 # _parse_sse_stream tests
 # ---------------------------------------------------------------------------
@@ -1490,6 +1605,7 @@ def _make_sse_response(*lines: str, encoding: str = "utf-8") -> Mock:
             yield chunk
 
     response = Mock()
+    response.headers = CIMultiDictProxy(CIMultiDict())
     response.content = Mock()
     response.content.iter_any = Mock(return_value=_iter_any())
     response.close = Mock()
@@ -1507,6 +1623,7 @@ def _make_sse_response_fragmented(*lines: str) -> Mock:
             yield bytes([byte])
 
     response = Mock()
+    response.headers = CIMultiDictProxy(CIMultiDict())
     response.content = Mock()
     response.content.iter_any = Mock(return_value=_iter_any())
     response.close = Mock()
@@ -1581,6 +1698,7 @@ async def test_parse_sse_handles_crlf_line_endings():
         yield raw.encode()
 
     response = Mock()
+    response.headers = CIMultiDictProxy(CIMultiDict())
     response.content = Mock()
     response.content.iter_any = Mock(return_value=_iter_any())
     response.close = Mock()

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -1512,6 +1512,27 @@ async def test_fetch_proxy_response_decodes_deflate_json(mock_proxy_client, mock
 
 
 @pytest.mark.asyncio
+async def test_fetch_proxy_response_decodes_chained_json(mock_proxy_client, mock_proxy_response, next_request_info):
+    """Content codings are decoded in reverse application order."""
+    expected = {"id": "response", "choices": [{"message": {"content": "ok"}}]}
+    encoded = zlib.compress(gzip.compress(json.dumps(expected).encode()))
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/json"),
+                ("content-encoding", " gzip, deflate "),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=encoded)
+
+    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert status_code == 200
+    assert result == expected
+
+
+@pytest.mark.asyncio
 async def test_fetch_proxy_response_reports_content_decoding_failure(
     mock_proxy_client, mock_proxy_response, next_request_info
 ):
@@ -1525,6 +1546,29 @@ async def test_fetch_proxy_response_reports_content_decoding_failure(
         )
     )
     mock_proxy_response.read = AsyncMock(return_value=b"not-gzip")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == (
+        "Inference Gateway could not decode the upstream response with Content-Encoding 'gzip'."
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_rejects_truncated_gzip(mock_proxy_client, mock_proxy_response, next_request_info):
+    """A gzip body without its checksum trailer is not accepted as valid JSON."""
+    encoded = gzip.compress(b'{"id":"response"}')
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "application/json"),
+                ("content-encoding", "gzip"),
+            ]
+        )
+    )
+    mock_proxy_response.read = AsyncMock(return_value=encoded[:-8])
 
     with pytest.raises(HTTPException) as exc_info:
         await fetch_proxy_response(mock_proxy_client, next_request_info)
@@ -1583,6 +1627,68 @@ async def test_fetch_proxy_response_decodes_gzip_sse(mock_proxy_client, mock_pro
     assert status_code == 200
     assert not isinstance(result, dict)
     assert [chunk async for chunk in result] == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_decodes_chained_fragmented_sse(
+    mock_proxy_client, mock_proxy_response, next_request_info
+):
+    """Fragmented SSE supports multiple content codings in application order."""
+    expected = [
+        {"id": "chunk-1", "choices": [{"delta": {"content": "hello"}}]},
+        {"id": "chunk-2", "choices": [{"delta": {"content": " world"}}]},
+    ]
+    body = ("\n".join(f"data: {json.dumps(chunk)}" for chunk in expected) + "\ndata: [DONE]\n").encode()
+    encoded = zlib.compress(gzip.compress(body))
+
+    async def _iter_compressed_fragments():
+        for offset in range(0, len(encoded), 7):
+            yield encoded[offset : offset + 7]
+
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "text/event-stream"),
+                ("content-encoding", "gzip, deflate"),
+            ]
+        )
+    )
+    mock_proxy_response.content.iter_any = Mock(return_value=_iter_compressed_fragments())
+
+    result, _, status_code = await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert status_code == 200
+    assert not isinstance(result, dict)
+    assert [chunk async for chunk in result] == expected
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_rejects_corrupt_gzip_sse_before_returning_response(
+    mock_proxy_client, mock_proxy_response, next_request_info
+):
+    """A compressed SSE decoding error becomes a 502 before any stream is returned."""
+
+    async def _iter_corrupt_body():
+        yield b"not-gzip"
+
+    mock_proxy_response.headers = CIMultiDictProxy(
+        CIMultiDict(
+            [
+                ("content-type", "text/event-stream"),
+                ("content-encoding", "gzip"),
+            ]
+        )
+    )
+    mock_proxy_response.content.iter_any = Mock(return_value=_iter_corrupt_body())
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail == (
+        "Inference Gateway could not decode the upstream response with Content-Encoding 'gzip'."
+    )
+    mock_proxy_response.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Inference middleware uses the gateway's non-decompressing HTTP session but then parses upstream bytes as JSON or SSE. When a sandbox egress proxy negotiates gzip, that path sees compressed bytes and returns a misleading JSON 502 or an empty event stream. Enable aiohttp decompression only for middleware-aware requests while leaving direct proxy responses byte-transparent.

## Changes

- Set `auto_decompress=True` on the middleware-aware upstream request; keep the shared session default disabled for direct proxying.
- Keep SSE responses live-streaming while aiohttp decodes chunks before the existing parser.
- Report gateway decode/JSON-processing failures without blaming the model backend.
- Cover real gzip JSON and SSE responses, payload decode errors, middleware response header sanitization, and unchanged direct compressed pass-through.

### Scope boundary

- Delegate supported `Content-Encoding` handling to aiohttp instead of maintaining gateway-specific codecs.
- Do not add custom support for chained content encodings or stricter validation beyond aiohttp's behavior.
- Do not buffer compressed SSE before returning it. A decode failure after streaming begins terminates that stream; guaranteeing a pre-header 502 would require buffering and is intentionally out of scope.
- Do not change forwarded `Accept-Encoding` headers or sandbox proxy configuration; the gateway now handles compression negotiated anywhere on the upstream path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: This corrects internal gateway response handling without changing a public API or user workflow.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Pre-fix reproduction: `uv run --frozen pytest services/core/inference-gateway/tests/unit/test_proxy.py -k 'fetch_proxy_response_decodes_gzip' -v` failed both regression cases with the reported JSON 502 and an empty SSE event list.
- `uv run --frozen pytest services/core/inference-gateway/tests/unit -v` — 463 passed, 5 skipped.
- `uv run --frozen pre-commit run -a` — all hooks passed.
- `make refresh-openapi` — passed with no generated changes.
- Ticket-path E2E: ran the Experimentalist smoke optimizer in an `external-only` sbx sandbox against this branch's local gateway. `HTTP_PROXY`/`HTTPS_PROXY` were set, `host.docker.internal` was absent from both `NO_PROXY` and `no_proxy`, and the run command did not override either bypass list. Gateway chat-completion requests returned 200 rather than the reported non-JSON 502.
- The E2E reached `run.json.status=completed` with `winner_agent=agent-1` and validation `reward=1.0`, `shape_ok=1.0`. One unrelated upstream request stalled with the gateway's existing unbounded timeout; interrupting and rerunning the documented command with the same experiment directory resumed successfully from persisted state.
- Post-run Experimentalist guard suite: `uv run --frozen pytest plugins/nemo-experimentalist/tests/experimentalist/ -k smoke -q` — 76 passed, 15 skipped, 321 deselected.
