### PR TITLE
fix(nemo-insights): export analyst result types from package __init__ and update prompt import path

### DIFF
--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/__init__.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from nemo_insights_plugin.analyst.result import AnalystResult, InsightUpdate, NewInsight
+
+__all__ = ["AnalystResult", "InsightUpdate", "NewInsight"]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
@@ -122,7 +122,12 @@ noisy Insight burns developer trust and is worse than no Insight at all.
 ## Reporting your findings
 
 When your analysis is complete, report everything in one final
-``AnalystResult`` via ``return_result`` with your full change-set:
+``AnalystResult`` via ``return_result`` with your full change-set.
+Import the result types from ``nemo_insights_plugin.analyst``:
+
+```python
+from nemo_insights_plugin.analyst import AnalystResult, NewInsight, InsightUpdate
+```
 
 - ``new_insights``: Insights that do not already exist. Give each a
   short, human-readable title (a sentence naming the failure, e.g.


### PR DESCRIPTION
## Summary

The analyst LLM was crashing with `AttributeError: module 'nemo_insights_plugin.analyst.functions.insights' has no attribute 'NewInsight'`. The system prompt told the model to call `return_result(result=AnalystResult(...))` but gave no import path. The model guessed `NewInsight` lived in the `insights` module (the last insights-related module it had used), which was wrong — it lives in `analyst.result`.

## Related Issue

<!-- None known -->

## Changes

- Add `plugins/nemo-insights/src/nemo_insights_plugin/analyst/__init__.py`: exports `AnalystResult`, `NewInsight`, and `InsightUpdate` as the stable public API of the `analyst` package, decoupling consumers from internal module layout.
- Update the analyst system prompt in `agent.py` to show the canonical import path (`from nemo_insights_plugin.analyst import ...`) so the model no longer has to guess.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: 146 non-testbed nemo-insights tests pass; the changed modules are exercised by the existing analyst test suite.
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior — the system prompt is the user-facing documentation for the model.
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer (horde@nvidia.com)
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
# Import sanity check
python -c "from nemo_insights_plugin.analyst import AnalystResult, NewInsight, InsightUpdate; print('ok')"
# -> ok

# Non-testbed plugin tests (testbed tests require external services and fail pre-existing)
uv run --frozen pytest plugins/nemo-insights/ --ignore=plugins/nemo-insights/tests/testbed -v
# -> 146 passed, 1 skipped

# Pre-commit (all hooks pass; uv-lock hook reports version mismatch 0.9.30 vs required 0.9.14 — unrelated to this change, uv-lock-check confirms lock is in sync)
uv run pre-commit run -a
```