### PR TITLE
fix(deployments): inject PATH into openshell sandbox env so exec'd nat is found

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
@@ -341,6 +341,8 @@ class OpenShellDeploymentBackend(DeploymentBackend):
                     "backend and secret references must resolve to a value."
                 ),
             )
+        if "PATH" not in env:
+            env["PATH"] = self._executor_config.serve_path
         all_labels = {
             **labels,
             **config.labels,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/config.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/config.py
@@ -112,6 +112,15 @@ class OpenShellExecutorConfig(BaseModel):
             "per-run temp dir is written here instead. Empty string disables the chdir."
         ),
     )
+    serve_path: str = Field(
+        default="/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        description=(
+            "PATH injected into the sandbox environment so exec'd processes find "
+            "image-installed binaries. The supervisor resets PATH to a system default, so an "
+            "image's ENV PATH is not seen by exec'd children. Ignored when the deployment "
+            "config already declares PATH."
+        ),
+    )
     landlock_compatibility: Literal["best_effort", "hard_requirement"] = Field(
         default="best_effort",
         description=(

--- a/plugins/nemo-deployments/tests/integration/backends/openshell/test_openshell_backend.py
+++ b/plugins/nemo-deployments/tests/integration/backends/openshell/test_openshell_backend.py
@@ -58,7 +58,7 @@ async def _poll_until_ready(backend, *, attempts: int = 60, delay: float = 2.0):
 def _make_backend():
     mock_entities = AsyncMock()
     with (
-        patch("nemo_deployments_plugin.backends.openshell.backend.AsyncEntitiesResource"),
+        patch("nemo_deployments_plugin.backends.openshell.backend.client_from_platform"),
         patch("nemo_deployments_plugin.backends.openshell.backend.NemoEntitiesClient", return_value=mock_entities),
     ):
         from nemo_deployments_plugin.backends.openshell.backend import OpenShellDeploymentBackend

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py
@@ -406,6 +406,40 @@ async def test_create_fails_on_unresolved_value_from(
     mock_stub.CreateSandbox.assert_not_called()
 
 
+async def test_create_injects_serve_path_into_sandbox_environment(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = _config()
+    mock_stub.GetSandbox.side_effect = _not_found()
+    mock_stub.CreateSandbox.return_value = MagicMock()
+
+    update = await openshell_backend.create_deployment(
+        workspace="default", name="srv", config_name="cfg1", labels={}, backend_config={}
+    )
+
+    assert update.status == "STARTING"
+    spec = mock_stub.CreateSandbox.call_args.args[0].spec
+    expected = openshell_backend._executor_config.serve_path
+    assert spec.environment["PATH"] == expected
+    assert spec.template.environment["PATH"] == expected
+
+
+async def test_create_respects_a_container_declared_path(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = _config_with_env([EnvVar(name="PATH", value="/custom/bin")])
+    mock_stub.GetSandbox.side_effect = _not_found()
+    mock_stub.CreateSandbox.return_value = MagicMock()
+
+    update = await openshell_backend.create_deployment(
+        workspace="default", name="srv", config_name="cfg1", labels={}, backend_config={}
+    )
+
+    assert update.status == "STARTING"
+    spec = mock_stub.CreateSandbox.call_args.args[0].spec
+    assert spec.environment["PATH"] == "/custom/bin"
+
+
 async def test_create_fails_when_secret_resolution_errors(
     openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
 ) -> None:

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_executor_config.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_executor_config.py
@@ -87,3 +87,13 @@ def test_platform_egress_accepts_proto_value_sets() -> None:
 def test_platform_egress_rejects_invalid_protocol() -> None:
     with pytest.raises(ValidationError):
         OpenShellExecutorConfig.model_validate({"platform_egress": {"protocol": "ftp"}})
+
+
+def test_serve_path_defaults_to_venv_bin_prepended_to_system_path() -> None:
+    config = OpenShellExecutorConfig()
+    assert config.serve_path == "/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+
+def test_serve_path_is_overridable() -> None:
+    config = OpenShellExecutorConfig.model_validate({"serve_path": "/opt/bin:/usr/bin"})
+    assert config.serve_path == "/opt/bin:/usr/bin"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Exec'd processes inside an OpenShell sandbox get the system PATH, not the image's `/workspace/.venv/bin`, so the bare `nat start fastapi` command the agents compiler emits fails NOTFOUND. The packaged agent image bakes `ENV PATH="/workspace/.venv/bin:$PATH"`, but that only applies to the image's own entrypoint; the OpenShell supervisor never inherits it. This injects PATH into the sandbox environment from the backend so exec'd children find `nat`.

## Related Issue

AIRCORE-955

## Changes

- Add a `serve_path` knob to `OpenShellExecutorConfig` (default: `/workspace/.venv/bin` prepended to the standard system PATH).
- Inject `serve_path` into `SandboxSpec.environment` (and `SandboxTemplate.environment`) in `create_deployment` when the deployment config does not already declare PATH. A container-declared PATH wins.
- Drop the stale `AsyncEntitiesResource` patch from the openshell integration test (the backend switched to `NemoEntitiesClient` in AIRCORE-977); replace it with the `client_from_platform` patch the unit tests use.
- Add unit tests: backend injects PATH into both spec and template env; backend respects a container-declared PATH; config default and override.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: `serve_path` is an executor config knob documented by its pydantic field description; no user-facing docs surface changed.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_executor_config.py plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py -q` — 83 passed.
- `uv run --frozen pytest plugins/nemo-deployments/tests/integration/backends/openshell/test_openshell_backend.py -q` — 1 passed (against a live gateway).
- `uv run --frozen pytest plugins/nemo-deployments/tests/unit/backends/openshell/ -q` — 113 passed.
- `uv run pre-commit run --files <changed>` — ruff, ruff format, ty, copyright headers, plugins-import check, merge-conflict check all passed.
- DCO audit: 1 commit, `Signed-off-by` trailer matches author email.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable serve-path support for OpenShell deployments.
  - Automatically provides `PATH` in deployment environments when one is not already defined.
  - Defaults to a virtual-environment bin directory followed by the system path.
  - Preserves explicitly configured container `PATH` values.

- **Tests**
  - Added coverage for default, override, and environment-preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->