### PR TITLE
feat(insights): give the analyst durable memory across runs

### DIFF
--- a/docs/agents/insight-driven-optimization.mdx
+++ b/docs/agents/insight-driven-optimization.mdx
@@ -214,6 +214,62 @@ Insights and evidence appended to existing ones. Give the Analyst an optional
 agent spec (`--agent-spec AGENT-SPEC.md`) so it can flag divergence from
 intended behavior.
 
+#### Analyst Memory
+
+Apart from its incremental cursor, an Analyst run carries nothing forward, so
+it re-derives an agent's telemetry conventions every time. Memory is a small
+Markdown document per agent that closes that gap and doubles as the way to give
+*scheduled* analysis standing context, which it otherwise has no channel for:
+the periodic controller cannot pass `AGENT-SPEC.md`, because that file lives on
+your machine.
+
+The document has two halves, and the split is the point:
+
+- Everything before the `nemo:auto:start` marker is yours. The Analyst never
+  rewrites it. Put durable context here: what is deliberate rather than broken,
+  domain vocabulary, caveats about a data source.
+- The section between the markers belongs to the Analyst. It replaces that
+  section wholesale on each run that returns notes, which is how the document
+  stays de-duplicated and current without a separate cleanup pass.
+
+```markdown
+# Agent memory: research-agent
+
+## Context from the developer
+- `search_web` times out at 30s deliberately. Not a bug.
+
+<!-- nemo:auto:start -->
+- Spans with `source=eval` are synthetic replay traffic, not production. (2026-08-03; traces: abc123)
+<!-- nemo:auto:end -->
+```
+
+Memory lives at `<agent>/AGENT-MEMORY.md` on the workspace fileset
+`nemo-agent-memory`, so manual and scheduled runs read and write the same
+document. Nothing else writes to it: memory changes only at the end of an
+Analyst run, and resolving or deleting an Insight in Studio does not touch it.
+The Analyst creates the fileset on the first run that returns notes, and a run
+that returns none leaves the document alone rather than clearing it. If the
+fileset cannot be written, the run reports a warning instead of failing, since
+the Insights have already been stored by that point.
+
+Read or edit it from Studio under **Filesets**, which previews the document and
+accepts a replacement upload, or from the command line:
+
+```bash
+nemo files download nemo-agent-memory \
+  --remote-path "$AGENT/AGENT-MEMORY.md" -o AGENT-MEMORY.md --workspace "$WORKSPACE"
+
+# edit AGENT-MEMORY.md, keeping your notes above the nemo:auto:start marker
+
+nemo files upload AGENT-MEMORY.md nemo-agent-memory \
+  --remote-path "$AGENT/" --workspace "$WORKSPACE"
+```
+
+Only the first 40 notes are kept, and the maintained section is capped at 8,000
+bytes; the run reports anything it dropped. The whole document is loaded into
+the Analyst's context on every run, so that ceiling is a budget you pay
+continuously rather than a storage limit.
+
 ### Experimenter
 
 The Experimenter turns an Insight into an empirically validated candidate.

--- a/docs/agents/insight-driven-optimization.mdx
+++ b/docs/agents/insight-driven-optimization.mdx
@@ -265,10 +265,13 @@ nemo files upload AGENT-MEMORY.md nemo-agent-memory \
   --remote-path "$AGENT/" --workspace "$WORKSPACE"
 ```
 
-Only the first 40 notes are kept, and the maintained section is capped at 8,000
-bytes; the run reports anything it dropped. The whole document is loaded into
-the Analyst's context on every run, so that ceiling is a budget you pay
-continuously rather than a storage limit.
+The maintained section is capped at 2,200 characters — roughly 800 tokens, or
+8 to 15 notes — and it does not grow. That ceiling is deliberate: the section
+enters the Analyst's context on every run, so it is a cost you pay
+continuously rather than a storage limit. The Analyst is shown how full memory
+is and is expected to consolidate to fit; if it overruns anyway, the lowest
+ranked notes are dropped and the run reports a warning, which is a signal to
+read the document rather than a routine statistic.
 
 ### Experimenter
 

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
@@ -19,8 +19,10 @@ The result is delivered through Nooa's ``return_result`` helper and validated
 against the ``AnalystResult`` schema.
 
 The analyst's persona, task, the agent-under-test name, and the optional AUT
-spec are all formatted into the instructions by ``build_analyst_agent``; the
-run is seeded with only the minimal ``KICKOFF`` request. The per-run config the
+spec and memory document are all formatted into the instructions by
+``build_analyst_agent``; the run is seeded with only the minimal ``KICKOFF``
+request. Memory rides the same one-shot channel as the insights: the analyst
+never edits it mid-run, it just returns the notes it wants kept. The per-run config the
 methods need is carried in :class:`~nemo_insights_plugin.analyst.deps.AnalystDeps`.
 Workspace and base URL aren't in the instructions because the methods are already
 scoped to them via ``AnalystDeps``.
@@ -30,6 +32,7 @@ from typing import Annotated, Any
 
 from nemo_insights_plugin.analyst.deps import AnalystDeps
 from nemo_insights_plugin.analyst.functions import annotations, insights, spans
+from nemo_insights_plugin.analyst.memory import MAX_NOTES
 from nemo_insights_plugin.analyst.result import AnalystResult
 from nemo_platform_plugin.nooa_model_client import get_default_model, get_fast_model
 from nooa import Agent, CodeActStrategy, hidden, strategy
@@ -119,6 +122,29 @@ noisy Insight burns developer trust and is worse than no Insight at all.
 4. Check the existing Insights for the agent so you know which of your
    findings are new and which extend an Insight that already exists.
 
+## Memory
+
+You may be given a memory document for this agent below. It holds context
+established on earlier runs and anything the developer wrote by hand: how to
+read this agent's telemetry, what is deliberate rather than broken, domain
+vocabulary. Treat it as established and do not spend budget rediscovering it.
+Where this run's evidence contradicts it, trust the evidence and say so in
+your summary.
+
+Keep it current through the ``memory`` field of your result. What you return
+is the memory that should *exist* from now on, not a log of this run, because
+it replaces the maintained section of the document wholesale. Start from the
+notes you were given, drop the ones this run contradicted, and add what you
+newly learned. This matters most on scheduled runs, which only look at traces
+newer than the previous run: a still-true note you leave out because this
+window did not happen to re-prove it is a note you have deleted.
+
+A note earns its place only if it would save work on a future run. Do not
+record findings that belong in an Insight, anything true of a single trace, or
+anything already covered by the agent spec. Order the list most important
+first; only the first {max_notes} are kept. Returning an empty list leaves the
+document untouched rather than clearing it.
+
 ## Reporting your findings
 
 When your analysis is complete, report everything in one final
@@ -136,6 +162,8 @@ When your analysis is complete, report everything in one final
   is the only change allowed on an existing Insight (you cannot rename,
   re-describe, or restatus it). Use this instead of re-filing a
   near-duplicate of an existing Insight.
+- ``memory``: the complete set of notes this agent's memory should hold from
+  now on, as described under Memory above.
 
 Producing the result ends the run, so gather all your evidence first
 and emit one complete, well-evidenced change-set. If you found
@@ -155,6 +183,14 @@ Flag agent divergence from the spec. The spec was authored by the
 developer of the application and should be considered the purpose and goals.
 """
 
+AGENT_MEMORY_HEADER = """
+## Agent Memory
+
+The current memory document for this agent. Everything outside the
+``nemo:auto`` markers was written by the developer and is authoritative; the
+section between them is what you maintain.
+"""
+
 KICKOFF = (
     "Analyze recent traces for the agent under test and file Insights for the highest-impact failure patterns you find."
 )
@@ -171,6 +207,7 @@ class Analyst(Agent):
         deps: AnalystDeps,
         agent: str,
         agent_spec: str | None = None,
+        agent_memory: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(llm=kwargs.pop("llm", None) or get_default_model(), **kwargs)
@@ -182,9 +219,11 @@ class Analyst(Agent):
             config=TokenBudgetConfig(max_tokens=MAX_SUMMARY_TOKENS),
         )
 
-        instructions = INSTRUCTIONS.format(agent=agent)
+        instructions = INSTRUCTIONS.format(agent=agent, max_notes=MAX_NOTES)
         if agent_spec and agent_spec.strip():
             instructions = f"{instructions}\n{AGENT_SPEC_HEADER}\n\n{agent_spec.strip()}\n"
+        if agent_memory and agent_memory.strip():
+            instructions = f"{instructions}\n{AGENT_MEMORY_HEADER}\n\n{agent_memory.strip()}\n"
         self.context["analyst_instructions"] = instructions
 
     async def fetch_spans(
@@ -358,6 +397,7 @@ def build_analyst_agent(
     deps: AnalystDeps,
     agent: str,
     agent_spec: str | None = None,
+    agent_memory: str | None = None,
     llm: UnifiedLLM | None = None,
     **kwargs: Any,
 ) -> Analyst:
@@ -366,6 +406,7 @@ def build_analyst_agent(
         deps=deps,
         agent=agent,
         agent_spec=agent_spec,
+        agent_memory=agent_memory,
         llm=llm,
         **kwargs,
     )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/agent.py
@@ -32,7 +32,7 @@ from typing import Annotated, Any
 
 from nemo_insights_plugin.analyst.deps import AnalystDeps
 from nemo_insights_plugin.analyst.functions import annotations, insights, spans
-from nemo_insights_plugin.analyst.memory import MAX_NOTES
+from nemo_insights_plugin.analyst.memory import MAX_MEMORY_CHARS, render_usage
 from nemo_insights_plugin.analyst.result import AnalystResult
 from nemo_platform_plugin.nooa_model_client import get_default_model, get_fast_model
 from nooa import Agent, CodeActStrategy, hidden, strategy
@@ -139,11 +139,24 @@ newly learned. This matters most on scheduled runs, which only look at traces
 newer than the previous run: a still-true note you leave out because this
 window did not happen to re-prove it is a note you have deleted.
 
-A note earns its place only if it would save work on a future run. Do not
-record findings that belong in an Insight, anything true of a single trace, or
-anything already covered by the agent spec. Order the list most important
-first; only the first {max_notes} are kept. Returning an empty list leaves the
-document untouched rather than clearing it.
+Memory is bounded at {max_chars} characters and does not grow: the header
+above shows how full it is. Consolidate to fit rather than letting notes fall
+off the end — merge overlapping notes into one denser note, and drop the ones
+that have stopped earning their place. Order what you return most important
+first; anything past the limit is dropped and reported as a problem with the
+run. Returning an empty list leaves the document untouched rather than
+clearing it.
+
+Save environment and telemetry facts, conventions, tool quirks, and
+corrections. Do not save findings that belong in an Insight, anything true of
+a single trace, a log of what this run did, facts already in the agent spec,
+or anything you could rediscover in one query. Pack related facts into one
+compact note:
+
+- Good: "Sessions hold one trace each; agent_name is only on the AGENT span,
+  so tool and LLM children must be reached via parent_span_id."
+- Bad: "The agent had an error." Too vague to act on, and no future run is
+  helped by it.
 
 ## Reporting your findings
 
@@ -184,11 +197,12 @@ developer of the application and should be considered the purpose and goals.
 """
 
 AGENT_MEMORY_HEADER = """
-## Agent Memory
+## Agent Memory [{usage}]
 
 The current memory document for this agent. Everything outside the
 ``nemo:auto`` markers was written by the developer and is authoritative; the
-section between them is what you maintain.
+section between them is what you maintain. The gauge above is how full that
+section is — plan the set you return against the space that is left.
 """
 
 KICKOFF = (
@@ -219,11 +233,12 @@ class Analyst(Agent):
             config=TokenBudgetConfig(max_tokens=MAX_SUMMARY_TOKENS),
         )
 
-        instructions = INSTRUCTIONS.format(agent=agent, max_notes=MAX_NOTES)
+        instructions = INSTRUCTIONS.format(agent=agent, max_chars=f"{MAX_MEMORY_CHARS:,}")
         if agent_spec and agent_spec.strip():
             instructions = f"{instructions}\n{AGENT_SPEC_HEADER}\n\n{agent_spec.strip()}\n"
         if agent_memory and agent_memory.strip():
-            instructions = f"{instructions}\n{AGENT_MEMORY_HEADER}\n\n{agent_memory.strip()}\n"
+            header = AGENT_MEMORY_HEADER.format(usage=render_usage(agent_memory))
+            instructions = f"{instructions}\n{header}\n\n{agent_memory.strip()}\n"
         self.context["analyst_instructions"] = instructions
 
     async def fetch_spans(

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/memory.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/memory.py
@@ -1,0 +1,243 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The analyst's memory document: durable context that survives across runs.
+
+An analyst run is otherwise stateless. Its only carry-over is
+``AnalysisRunStatus.last_successful_run_at``, a cursor that narrows which
+traces to read, so everything the analyst works out about an agent's telemetry
+is rediscovered from scratch on the next run. Memory is a small markdown
+document that closes that gap, and — because it lives in the platform rather
+than on a developer's disk — it is also the only way to hand standing context
+to *scheduled* analysis, which never sees ``AGENT-SPEC.md``.
+
+The document has two zones:
+
+- Everything before ``AUTO_START`` belongs to the developer. Nothing here ever
+  rewrites it, which is what makes a document that is both auto-maintained and
+  hand-editable safe without version history or a review queue.
+- The span between ``AUTO_START`` and ``AUTO_END`` belongs to the analyst and
+  is replaced wholesale on each run that returns notes.
+
+Replacing rather than appending means de-duplication and pruning are ordinary
+consequences of writing, with no separate consolidation pass. The cost is that
+the analyst must treat its returned notes as the memory it wants to *exist*
+rather than a log of the current run — see ``AnalystResult.memory``. It is told
+so in its instructions, and :func:`write` refuses to act on an empty list so a
+model that simply omits the field cannot erase the document.
+
+Storage is the ``nemo-agent-memory`` fileset rather than a file beside
+``optimizer.yaml``, because the scheduled job runs in a container with no
+checkout and no durable local path: ``ctx.storage.persistent`` is scoped to one
+job id and deleted once the job succeeds. A fileset is the one store that is
+durable, workspace-scoped, writable from inside a job, and visible to a human
+in Studio.
+"""
+
+import re
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from typing import Protocol
+
+import httpx
+from nemo_insights_plugin.analyst.result import MemoryNote
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatformError
+from nemo_platform_plugin.client.errors import NemoClientError
+
+MEMORY_FILESET = "nemo-agent-memory"
+MEMORY_FILENAME = "AGENT-MEMORY.md"
+
+AUTO_START = "<!-- nemo:auto:start -->"
+AUTO_END = "<!-- nemo:auto:end -->"
+AUTO_BANNER = "<!-- Observed by `nemo agents analyst run`. Edits between these markers are replaced. -->"
+EMPTY_ZONE = "_No observations recorded yet._"
+
+# The whole document is injected into the analyst's instructions on every run,
+# so the budget is a context cost paid forever, not a storage limit. It is
+# enforced here rather than merely requested in the prompt: an advisory limit
+# on a machine-written file is how context windows quietly fill up.
+MAX_NOTES = 40
+MAX_AUTO_BYTES = 8_000
+
+_HUMAN_ZONE_HINT = (
+    "Context the optimization loop keeps about this agent. Anything you write\n"
+    "above the marker below is yours and is never rewritten; the analyst only\n"
+    "replaces the section between the markers."
+)
+
+_UNSAFE_PATH_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
+
+# Read failures are normal on a first run (no document, no fileset yet) and are
+# reported by the write instead, which is the operation whose loss matters.
+# NemoClientError covers transport failures and is deliberately not a
+# NeMoPlatformError, so it has to be named: without it a network blip while
+# fetching memory would abort an otherwise healthy analysis.
+_STORE_ERRORS = (NeMoPlatformError, NemoClientError, httpx.HTTPError, OSError, ValueError, RuntimeError)
+
+
+def scaffold(agent: str) -> str:
+    """Return a fresh document with a header and an empty developer zone."""
+    return f"# Agent memory: {agent}\n\n{_HUMAN_ZONE_HINT}\n"
+
+
+def render_note(note: MemoryNote, *, stamp: str) -> str:
+    """Render one note as a single bullet.
+
+    Interior whitespace is collapsed so that a multi-line note cannot break the
+    bullet list or the marker arithmetic that :func:`replace_auto_zone` relies
+    on. The stamp records when the note was last affirmed, not when it was first
+    observed: a full rewrite re-states everything still true, so "as of" is the
+    honest reading of the date.
+    """
+    text = " ".join(note.note.split())
+    detail = f"{stamp}; {' '.join(note.source.split())}" if note.source.strip() else stamp
+    return f"- {text} ({detail})"
+
+
+def render_auto_zone(notes: Sequence[MemoryNote], *, stamp: str) -> tuple[str, int]:
+    """Render the maintained zone, returning it with the number of notes dropped.
+
+    Notes arrive most important first, so the budget is applied by stopping at
+    the first note that does not fit rather than skipping it and continuing —
+    keeping a later short note over an earlier important one would silently
+    invert the analyst's own ranking.
+    """
+    lines: list[str] = []
+    used = 0
+    dropped = 0
+    for index, note in enumerate(notes):
+        line = render_note(note, stamp=stamp)
+        size = len(line.encode("utf-8")) + 1
+        if len(lines) >= MAX_NOTES or used + size > MAX_AUTO_BYTES:
+            dropped = len(notes) - index
+            break
+        lines.append(line)
+        used += size
+    body = "\n".join(lines) if lines else EMPTY_ZONE
+    return f"{AUTO_START}\n{AUTO_BANNER}\n\n{body}\n\n{AUTO_END}", dropped
+
+
+def replace_auto_zone(
+    document: str,
+    notes: Sequence[MemoryNote],
+    *,
+    agent: str,
+    stamp: str,
+) -> tuple[str, int]:
+    """Return *document* with its maintained zone replaced, plus notes dropped.
+
+    A document with no markers keeps all of its content and gains a zone at the
+    end, so a developer can hand-write memory without knowing the format and
+    have the analyst adopt it on the next run.
+    """
+    block, dropped = render_auto_zone(notes, stamp=stamp)
+    base = document if document.strip() else scaffold(agent)
+
+    start = base.find(AUTO_START)
+    end = base.find(AUTO_END, start + len(AUTO_START)) if start != -1 else -1
+    if start == -1 or end == -1:
+        head, tail = base, ""
+    else:
+        head, tail = base[:start], base[end + len(AUTO_END) :]
+
+    sections = [section for section in (head.rstrip(), block, tail.strip()) if section]
+    return "\n\n".join(sections) + "\n", dropped
+
+
+def memory_remote_path(agent: str) -> str:
+    """Return the fileset-relative path holding *agent*'s memory document.
+
+    The agent identifier doubles as a directory name, and it is a local
+    filesystem path rather than a registered name when the loop runs offline,
+    so it is reduced to one safe segment.
+    """
+    segment = _UNSAFE_PATH_CHARS.sub("-", agent).strip("-") or "agent"
+    return f"{segment}/{MEMORY_FILENAME}"
+
+
+class MemoryStore(Protocol):
+    """Where the analyst's memory document is read from and written back to."""
+
+    async def read(self) -> str:
+        """Return the current document, or an empty string when there is none."""
+        ...
+
+    async def write(self, notes: Sequence[MemoryNote]) -> str:
+        """Persist *notes* as the maintained zone and return one report line."""
+        ...
+
+
+class FilesetMemoryStore:
+    """Memory held at ``<agent>/AGENT-MEMORY.md`` on the ``nemo-agent-memory`` fileset.
+
+    Reachable identically from a developer's laptop and from the scheduled
+    analysis job, which is the whole point of not using a local file.
+    """
+
+    def __init__(self, *, client: AsyncNeMoPlatform, workspace: str, agent: str) -> None:
+        self._client = client
+        self._workspace = workspace
+        self._agent = agent
+        self.remote_path = memory_remote_path(agent)
+
+    async def read(self) -> str:
+        """Return the stored document, or an empty string if it cannot be read.
+
+        A missing document is the ordinary first-run state and must not be
+        noisy. A genuine outage is not swallowed in practice, because the write
+        at the end of the run reports its own failure.
+        """
+        try:
+            raw = await self._client.files.download_content(
+                remote_path=self.remote_path,
+                fileset=MEMORY_FILESET,
+                workspace=self._workspace,
+            )
+        except _STORE_ERRORS:
+            return ""
+        return raw.decode("utf-8", errors="replace")
+
+    async def write(self, notes: Sequence[MemoryNote]) -> str:
+        """Replace the maintained zone with *notes* and report what happened.
+
+        An empty *notes* leaves the document alone. The analyst is asked for the
+        memory that should exist, so an empty list is indistinguishable from a
+        model that skipped the field, and wiping a developer's accumulated
+        context on that ambiguity is the worse failure. Clearing memory is a
+        deliberate hand edit.
+
+        Storage failures are reported rather than raised: by the time this runs
+        the insights have already landed, and failing the run would misreport a
+        successful analysis.
+        """
+        if not notes:
+            return "- memory: unchanged (no notes returned)"
+
+        document, dropped = replace_auto_zone(
+            await self.read(),
+            notes,
+            agent=self._agent,
+            stamp=_today(),
+        )
+        try:
+            await self._client.files.upload_content(
+                content=document,
+                remote_path=self.remote_path,
+                fileset=MEMORY_FILESET,
+                workspace=self._workspace,
+                fileset_auto_create=True,
+            )
+        except _STORE_ERRORS as exc:
+            detail = " ".join(str(exc).split())
+            return f"- warning: memory could not be written to {MEMORY_FILESET}#{self.remote_path}: {detail}"
+
+        kept = len(notes) - dropped
+        line = f"- memory: wrote {kept} note(s) to {MEMORY_FILESET}#{self.remote_path}"
+        if dropped:
+            line += f", dropped {dropped} over the {MAX_NOTES}-note / {MAX_AUTO_BYTES}-byte budget"
+        return line
+
+
+def _today() -> str:
+    """Today's date in UTC, as an absolute stamp rather than a relative one."""
+    return datetime.now(timezone.utc).date().isoformat()

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/memory.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/memory.py
@@ -52,12 +52,12 @@ AUTO_END = "<!-- nemo:auto:end -->"
 AUTO_BANNER = "<!-- Observed by `nemo agents analyst run`. Edits between these markers are replaced. -->"
 EMPTY_ZONE = "_No observations recorded yet._"
 
-# The whole document is injected into the analyst's instructions on every run,
+# The maintained zone is injected into the analyst's instructions on every run,
 # so the budget is a context cost paid forever, not a storage limit. It is
 # enforced here rather than merely requested in the prompt: an advisory limit
-# on a machine-written file is how context windows quietly fill up.
-MAX_NOTES = 40
-MAX_AUTO_BYTES = 8_000
+# on a machine-written file is how context windows quietly fill up. 2,200
+# characters is roughly 800 tokens, or 8-15 notes.
+MAX_MEMORY_CHARS = 2_200
 
 _HUMAN_ZONE_HINT = (
     "Context the optimization loop keeps about this agent. Anything you write\n"
@@ -101,20 +101,50 @@ def render_auto_zone(notes: Sequence[MemoryNote], *, stamp: str) -> tuple[str, i
     the first note that does not fit rather than skipping it and continuing —
     keeping a later short note over an earlier important one would silently
     invert the analyst's own ranking.
+
+    Dropping is a backstop, not the mechanism. The analyst is shown how full
+    memory is and told to consolidate, so overflow means it did not; the run
+    reports that as a warning rather than as a routine statistic.
     """
     lines: list[str] = []
     used = 0
     dropped = 0
     for index, note in enumerate(notes):
         line = render_note(note, stamp=stamp)
-        size = len(line.encode("utf-8")) + 1
-        if len(lines) >= MAX_NOTES or used + size > MAX_AUTO_BYTES:
+        projected = used + len(line) + (1 if lines else 0)
+        if projected > MAX_MEMORY_CHARS:
             dropped = len(notes) - index
             break
         lines.append(line)
-        used += size
+        used = projected
     body = "\n".join(lines) if lines else EMPTY_ZONE
     return f"{AUTO_START}\n{AUTO_BANNER}\n\n{body}\n\n{AUTO_END}", dropped
+
+
+def auto_zone_entries(document: str) -> str:
+    """The maintained zone's notes, without the markers, banner, or placeholder."""
+    start = document.find(AUTO_START)
+    end = document.find(AUTO_END, start + len(AUTO_START)) if start != -1 else -1
+    if start == -1 or end == -1:
+        return ""
+    lines = [
+        line
+        for line in document[start + len(AUTO_START) : end].splitlines()
+        if line.strip() and not line.lstrip().startswith("<!--") and line.strip() != EMPTY_ZONE
+    ]
+    return "\n".join(lines)
+
+
+def render_usage(document: str) -> str:
+    """A capacity gauge for the maintained zone, such as ``67% — 1,474/2,200 chars``.
+
+    Shown to the analyst alongside the document so remaining capacity is
+    something it can plan against, rather than a wall it discovers by being
+    truncated after the fact.
+    """
+    used = len(auto_zone_entries(document))
+    percent = round(100 * used / MAX_MEMORY_CHARS)
+    return f"{percent}% — {used:,}/{MAX_MEMORY_CHARS:,} chars"
 
 
 def replace_auto_zone(
@@ -232,10 +262,13 @@ class FilesetMemoryStore:
             return f"- warning: memory could not be written to {MEMORY_FILESET}#{self.remote_path}: {detail}"
 
         kept = len(notes) - dropped
-        line = f"- memory: wrote {kept} note(s) to {MEMORY_FILESET}#{self.remote_path}"
         if dropped:
-            line += f", dropped {dropped} over the {MAX_NOTES}-note / {MAX_AUTO_BYTES}-byte budget"
-        return line
+            return (
+                f"- warning: memory over budget — kept {kept} note(s), dropped {dropped} past "
+                f"{MAX_MEMORY_CHARS:,} chars. The analyst should have consolidated instead; "
+                f"review {MEMORY_FILESET}#{self.remote_path}"
+            )
+        return f"- memory: wrote {kept} note(s) to {MEMORY_FILESET}#{self.remote_path} ({render_usage(document)})"
 
 
 def _today() -> str:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/result.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/result.py
@@ -73,6 +73,26 @@ class InsightUpdate(BaseModel):
     )
 
 
+class MemoryNote(BaseModel):
+    """One durable fact about the agent, for the analyst's memory document."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    note: str = Field(
+        min_length=1,
+        description=(
+            "A single stable fact about this agent's telemetry, tooling, or "
+            "domain that would save work on a future run (e.g. 'spans with "
+            "source=eval are synthetic replay traffic, not production'). One "
+            "sentence; it is rendered as one bullet."
+        ),
+    )
+    source: str = Field(
+        default="",
+        description="Optional short evidence for the note, such as the trace ids it was observed on.",
+    )
+
+
 class AnalystResult(BaseModel):
     """The analyst's complete, final change-set for one run.
 
@@ -100,5 +120,16 @@ class AnalystResult(BaseModel):
             "New evidence (trace refs) for insights that already exist for "
             "the agent. Only evidence can be added to an existing insight — to "
             "record anything else, file a new insight."
+        ),
+    )
+    memory: list[MemoryNote] = Field(
+        default_factory=list,
+        description=(
+            "The complete set of notes the agent's memory should hold from now "
+            "on, most important first. This replaces the maintained section of "
+            "the memory document wholesale, so carry forward every note that is "
+            "still true — not just what this run discovered — and leave out "
+            "what this run contradicted. An empty list leaves memory untouched "
+            "rather than clearing it."
         ),
     )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
@@ -15,6 +15,7 @@ from nemo_insights_plugin.analyst.agent import (
 )
 from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
 from nemo_insights_plugin.analyst.deps import AnalystDeps
+from nemo_insights_plugin.analyst.memory import FilesetMemoryStore, MemoryStore
 from nemo_insights_plugin.analyst.observability import (
     ANALYST_OBSERVABILITY_ENV,
     setup_analyst_observability,
@@ -52,6 +53,7 @@ async def run_analyst(
     since: datetime | None = None,
     evaluation_id: str | None = None,
     model_refs: ConfiguredModelRefs | None = None,
+    memory_store: MemoryStore | None = None,
 ) -> str:
     """Build and run the analyst agent against an agent's telemetry.
 
@@ -74,6 +76,11 @@ async def run_analyst(
         evaluation_id: Optional run scope; AND-pinned onto every span read.
         model_refs: Optional explicit default/fast Model Entity IDs. Unset uses
             the active Platform CLI context.
+        memory_store: Optional override for where the memory document lives.
+            Unset uses the ``nemo-agent-memory`` fileset on *client*, which is
+            reachable identically from the CLI and the scheduled job. Memory is
+            skipped entirely under *local_only*, whose testbed subjects expose
+            Intake but not the rest of the platform.
     """
     observability = None
     model_clients: ConfiguredModelClients | None = None
@@ -100,14 +107,23 @@ async def run_analyst(
                 workspace=workspace,
                 target_agent=agent,
             )
+        if memory_store is None and not local_only:
+            memory_store = FilesetMemoryStore(client=client, workspace=workspace, agent=agent)
+        agent_memory = await memory_store.read() if memory_store is not None else None
         with activate_model_clients(model_clients):
             analyst = build_analyst_agent(
                 deps=deps,
                 agent=agent,
                 agent_spec=agent_spec,
+                agent_memory=agent_memory,
             )
             result = await _run_agent(analyst, verbose=verbose)
-        return await backend.persist_result(workspace=workspace, agent=agent, result=result)
+        report = await backend.persist_result(workspace=workspace, agent=agent, result=result)
+        if memory_store is None:
+            return report
+        # Runs after the insights land, so a memory failure is reported on the
+        # run rather than raised — the analysis itself already succeeded.
+        return f"{report}\n{await memory_store.write(result.memory)}"
     finally:
         try:
             if observability is not None:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/preflight.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/preflight.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import httpx
 from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
+from nemo_insights_plugin.analyst.memory import MEMORY_FILESET, memory_remote_path
 from nemo_insights_plugin.client import make_client
 from nemo_insights_plugin.contracts.checks import CheckResult, make_check_result
 from nemo_insights_plugin.profile import AnalysisProfile
@@ -219,4 +220,22 @@ async def check_environment(
                 hint="check the workspace, authentication context, and Intake availability",
             )
         )
+        results.append(_memory_location(agent))
     return results
+
+
+def _memory_location(agent: str) -> CheckResult:
+    """Point at the agent's memory document.
+
+    Deliberately does not fetch it: whether the document exists yet says little
+    (an absent one is the normal first-run state), and the useful thing to tell
+    someone running ``doctor`` is where to look and what to edit.
+    """
+    return CheckResult(
+        name="agent-memory",
+        group="artifacts",
+        status="pass",
+        severity="advisory",
+        message=f"memory at {MEMORY_FILESET}#{memory_remote_path(agent)}",
+        hint=f"read or replace it with `nemo files download/upload {MEMORY_FILESET}`",
+    )

--- a/plugins/nemo-insights/src/nemo_insights_plugin/skills/nemo-analyst/SKILL.md
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/skills/nemo-analyst/SKILL.md
@@ -118,6 +118,33 @@ nemo agents analyst run --agent <agent-name> --insights-file-output .nemo-optimi
 That path is what the Experimentalist reads by default, so it is the
 conventional choice when handing off locally.
 
+## Standing context: agent memory
+
+Alongside the Insights it files, each run reads and updates a per-agent
+`AGENT-MEMORY.md` on the `nemo-agent-memory` fileset. Everything above its
+`nemo:auto:start` marker is yours and is never rewritten; the Analyst replaces
+only the section between the markers, with what it has learned about the
+agent's telemetry.
+
+Reach for it when someone wants the Analyst to stop rediscovering something, or
+to know something that is nowhere in the traces — "the 30s `search_web` timeout
+is deliberate", "`source=eval` traffic is synthetic". Unlike `AGENT-SPEC.md`,
+which is local and therefore invisible to scheduled runs, memory reaches
+periodic analysis too, so it is the only way to give the background Analyst
+context.
+
+```bash
+nemo files download nemo-agent-memory \
+  --remote-path <agent-name>/AGENT-MEMORY.md -o AGENT-MEMORY.md --workspace <workspace>
+
+nemo files upload AGENT-MEMORY.md nemo-agent-memory \
+  --remote-path <agent-name>/ --workspace <workspace>
+```
+
+Do not use it as a place to record failures — those are Insights. A run prints
+`- memory: wrote <n> note(s) ...`, `- memory: unchanged (no notes returned)`, or
+a warning when the fileset could not be written, which never fails the run.
+
 ## Verify
 
 Do not report success on an exit code. The run prints a line per operation —

--- a/plugins/nemo-insights/src/nemo_insights_plugin/skills/nemo-analyst/SKILL.md
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/skills/nemo-analyst/SKILL.md
@@ -141,9 +141,13 @@ nemo files upload AGENT-MEMORY.md nemo-agent-memory \
   --remote-path <agent-name>/ --workspace <workspace>
 ```
 
-Do not use it as a place to record failures — those are Insights. A run prints
-`- memory: wrote <n> note(s) ...`, `- memory: unchanged (no notes returned)`, or
-a warning when the fileset could not be written, which never fails the run.
+Memory is capped at 2,200 characters and does not grow, so it holds durable
+facts, conventions, and corrections — not failures, which are Insights, and not
+a log of what a run did. A run prints `- memory: wrote <n> note(s) ... (41% —
+902/2,200 chars)`, `- memory: unchanged (no notes returned)`, or a warning: the
+fileset could not be written, or the Analyst overran the budget instead of
+consolidating. Neither warning fails the run, but the second one means the
+document is worth reading.
 
 ## Verify
 

--- a/plugins/nemo-insights/tests/test_analyst_memory.py
+++ b/plugins/nemo-insights/tests/test_analyst_memory.py
@@ -12,9 +12,10 @@ from nemo_insights_plugin.analyst.memory import (
     AUTO_END,
     AUTO_START,
     EMPTY_ZONE,
-    MAX_NOTES,
+    MAX_MEMORY_CHARS,
     FilesetMemoryStore,
     memory_remote_path,
+    render_usage,
     replace_auto_zone,
 )
 from nemo_insights_plugin.analyst.result import MemoryNote
@@ -71,14 +72,28 @@ def test_content_after_the_maintained_zone_survives_a_rewrite() -> None:
     assert document.rstrip().endswith("## Appendix\n- mine")
 
 
-def test_over_budget_notes_are_dropped_in_rank_order_and_counted() -> None:
-    notes = [MemoryNote(note=f"note {index}") for index in range(MAX_NOTES + 5)]
+def test_maintained_zone_is_capped_at_the_character_budget_in_rank_order() -> None:
+    note = "x" * 200
+    notes = [MemoryNote(note=f"{index:03d} {note}") for index in range(20)]
 
     document, dropped = replace_auto_zone("", notes, agent="research-agent", stamp=STAMP)
 
-    assert dropped == 5
-    assert "- note 0 (2026-08-10)" in document
-    assert f"- note {MAX_NOTES} " not in document
+    entries = memory_module.auto_zone_entries(document)
+    assert len(entries) <= MAX_MEMORY_CHARS
+    assert dropped == 20 - len(entries.splitlines())
+    assert dropped > 0
+    assert "- 000 " in document, "highest-ranked note must survive"
+    assert "- 019 " not in document, "lowest-ranked note must be the one dropped"
+
+
+def test_usage_gauge_reports_maintained_zone_occupancy() -> None:
+    assert render_usage("") == f"0% — 0/{MAX_MEMORY_CHARS:,} chars"
+
+    document = _document([MemoryNote(note="a fact")])
+
+    used = len(memory_module.auto_zone_entries(document))
+    assert used == len("- a fact (2026-08-10)")
+    assert render_usage(document) == f"{round(100 * used / MAX_MEMORY_CHARS)}% — {used}/{MAX_MEMORY_CHARS:,} chars"
 
 
 def test_note_is_flattened_to_one_bullet_so_it_cannot_break_the_markers() -> None:
@@ -128,19 +143,30 @@ async def test_empty_note_list_leaves_the_document_untouched() -> None:
     assert "unchanged" in line
 
 
-async def test_write_uploads_to_the_agent_path_and_reports_the_budget() -> None:
+async def test_write_uploads_to_the_agent_path_and_reports_usage() -> None:
     files = FakeFiles(stored=HUMAN_ZONE)
-    notes = [MemoryNote(note=f"note {index}") for index in range(MAX_NOTES + 2)]
 
-    line = await _store(files).write(notes)
+    line = await _store(files).write([MemoryNote(note="a fact")])
 
     upload = files.uploads[0]
     assert upload["remote_path"] == "research-agent/AGENT-MEMORY.md"
     assert upload["fileset"] == memory_module.MEMORY_FILESET
     assert upload["fileset_auto_create"] is True
     assert "search_web" in upload["content"]
-    assert f"wrote {MAX_NOTES} note(s)" in line
-    assert "dropped 2" in line
+    assert line == (
+        f"- memory: wrote 1 note(s) to nemo-agent-memory#research-agent/AGENT-MEMORY.md "
+        f"(1% — 21/{MAX_MEMORY_CHARS:,} chars)"
+    )
+
+
+async def test_overflow_is_reported_as_a_warning_not_a_routine_statistic() -> None:
+    files = FakeFiles(stored=HUMAN_ZONE)
+    notes = [MemoryNote(note=f"{index:03d} " + "x" * 300) for index in range(20)]
+
+    line = await _store(files).write(notes)
+
+    assert line.startswith("- warning: memory over budget")
+    assert "should have consolidated" in line
 
 
 async def test_unwritable_fileset_warns_instead_of_failing_the_run() -> None:

--- a/plugins/nemo-insights/tests/test_analyst_memory.py
+++ b/plugins/nemo-insights/tests/test_analyst_memory.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The memory document format and the fileset store's failure behaviour."""
+
+from typing import Any, cast
+
+import httpx
+import pytest
+from nemo_insights_plugin.analyst import memory as memory_module
+from nemo_insights_plugin.analyst.memory import (
+    AUTO_END,
+    AUTO_START,
+    EMPTY_ZONE,
+    MAX_NOTES,
+    FilesetMemoryStore,
+    memory_remote_path,
+    replace_auto_zone,
+)
+from nemo_insights_plugin.analyst.result import MemoryNote
+from nemo_platform import AsyncNeMoPlatform
+
+STAMP = "2026-08-10"
+
+HUMAN_ZONE = """# Agent memory: research-agent
+
+## Context from the developer
+- `search_web` times out at 30s deliberately. Not a bug.
+"""
+
+
+def _document(notes: list[MemoryNote], *, existing: str = "") -> str:
+    return replace_auto_zone(existing, notes, agent="research-agent", stamp=STAMP)[0]
+
+
+def _auto_zone(document: str) -> str:
+    return document[document.index(AUTO_START) : document.index(AUTO_END) + len(AUTO_END)]
+
+
+def test_rewrite_preserves_the_developer_zone_and_replaces_only_the_maintained_one() -> None:
+    first = _document([MemoryNote(note="eval spans are synthetic", source="t1")], existing=HUMAN_ZONE)
+    second = _document([MemoryNote(note="sessions carry one trace")], existing=first)
+
+    assert second.startswith(HUMAN_ZONE.rstrip())
+    assert "search_web" in second
+    assert "eval spans are synthetic" not in second
+    assert "- sessions carry one trace (2026-08-10)" in _auto_zone(second)
+    assert second.count(AUTO_START) == 1
+
+
+def test_missing_document_gets_a_scaffold_and_an_empty_list_renders_a_placeholder() -> None:
+    document = _document([])
+
+    assert document.startswith("# Agent memory: research-agent")
+    assert EMPTY_ZONE in _auto_zone(document)
+
+
+def test_hand_written_document_without_markers_keeps_its_content_and_gains_a_zone() -> None:
+    document = _document([MemoryNote(note="a fact")], existing="# Notes\n\nkeep me\n")
+
+    assert document.startswith("# Notes\n\nkeep me")
+    assert "- a fact (2026-08-10)" in _auto_zone(document)
+
+
+def test_content_after_the_maintained_zone_survives_a_rewrite() -> None:
+    existing = f"{HUMAN_ZONE}\n{AUTO_START}\nold\n{AUTO_END}\n\n## Appendix\n- mine\n"
+
+    document = _document([MemoryNote(note="fresh")], existing=existing)
+
+    assert "old" not in document
+    assert document.rstrip().endswith("## Appendix\n- mine")
+
+
+def test_over_budget_notes_are_dropped_in_rank_order_and_counted() -> None:
+    notes = [MemoryNote(note=f"note {index}") for index in range(MAX_NOTES + 5)]
+
+    document, dropped = replace_auto_zone("", notes, agent="research-agent", stamp=STAMP)
+
+    assert dropped == 5
+    assert "- note 0 (2026-08-10)" in document
+    assert f"- note {MAX_NOTES} " not in document
+
+
+def test_note_is_flattened_to_one_bullet_so_it_cannot_break_the_markers() -> None:
+    document = _document([MemoryNote(note="first line\nsecond line", source="t1\nt2")])
+
+    assert "- first line second line (2026-08-10; t1 t2)" in document
+
+
+def test_remote_path_reduces_an_offline_agent_directory_to_one_safe_segment() -> None:
+    assert memory_remote_path("research-agent") == "research-agent/AGENT-MEMORY.md"
+    assert memory_remote_path("/home/me/agents/bot") == "home-me-agents-bot/AGENT-MEMORY.md"
+
+
+class FakeFiles:
+    def __init__(self, *, stored: str | None = None, upload_error: Exception | None = None) -> None:
+        self.stored = stored
+        self.upload_error = upload_error
+        self.uploads: list[dict[str, Any]] = []
+
+    async def download_content(self, *, remote_path: str, fileset: str, workspace: str) -> bytes:
+        if self.stored is None:
+            raise FileNotFoundError(remote_path)
+        return self.stored.encode("utf-8")
+
+    async def upload_content(self, *, content: str, **kwargs: Any) -> None:
+        if self.upload_error is not None:
+            raise self.upload_error
+        self.uploads.append({"content": content, **kwargs})
+        self.stored = content
+
+
+def _store(files: FakeFiles) -> FilesetMemoryStore:
+    client = cast(AsyncNeMoPlatform, type("FakeClient", (), {"files": files})())
+    return FilesetMemoryStore(client=client, workspace="default", agent="research-agent")
+
+
+async def test_absent_document_reads_as_empty_rather_than_raising() -> None:
+    assert await _store(FakeFiles()).read() == ""
+
+
+async def test_empty_note_list_leaves_the_document_untouched() -> None:
+    files = FakeFiles(stored=HUMAN_ZONE)
+
+    line = await _store(files).write([])
+
+    assert files.uploads == []
+    assert "unchanged" in line
+
+
+async def test_write_uploads_to_the_agent_path_and_reports_the_budget() -> None:
+    files = FakeFiles(stored=HUMAN_ZONE)
+    notes = [MemoryNote(note=f"note {index}") for index in range(MAX_NOTES + 2)]
+
+    line = await _store(files).write(notes)
+
+    upload = files.uploads[0]
+    assert upload["remote_path"] == "research-agent/AGENT-MEMORY.md"
+    assert upload["fileset"] == memory_module.MEMORY_FILESET
+    assert upload["fileset_auto_create"] is True
+    assert "search_web" in upload["content"]
+    assert f"wrote {MAX_NOTES} note(s)" in line
+    assert "dropped 2" in line
+
+
+async def test_unwritable_fileset_warns_instead_of_failing_the_run() -> None:
+    files = FakeFiles(stored=HUMAN_ZONE, upload_error=httpx.ConnectError("no route"))
+
+    line = await _store(files).write([MemoryNote(note="a fact")])
+
+    assert line.startswith("- warning: memory could not be written")
+    assert "no route" in line
+
+
+@pytest.mark.parametrize("failure", [httpx.ConnectError("down"), ValueError("bad fileset")])
+async def test_unreadable_document_degrades_to_empty(failure: Exception) -> None:
+    files = FakeFiles()
+
+    async def failing_download(**kwargs: Any) -> bytes:
+        raise failure
+
+    files.download_content = failing_download  # ty: ignore[invalid-assignment]
+
+    assert await _store(files).read() == ""

--- a/plugins/nemo-insights/tests/test_analyst_run.py
+++ b/plugins/nemo-insights/tests/test_analyst_run.py
@@ -1,13 +1,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""The ``run_analyst`` client injection contract."""
+"""The ``run_analyst`` client injection and memory round-trip contracts."""
 
+from collections.abc import Sequence
 from typing import Any, cast
 
 import pytest
 from nemo_insights_plugin.analyst import run as run_module
 from nemo_insights_plugin.analyst.deps import AnalystDeps
+from nemo_insights_plugin.analyst.memory import AUTO_START, replace_auto_zone
+from nemo_insights_plugin.analyst.result import AnalystResult, MemoryNote
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.nooa_model_client import ConfiguredModelClients
 from nooa.context_blocks import ResultStatus
@@ -20,6 +23,27 @@ class FakeClient:
 
     async def close(self) -> None:
         self.closed = True
+
+
+class InMemoryStore:
+    """A ``MemoryStore`` over a string, using the real document format.
+
+    Fileset transport is covered in ``test_analyst_memory``; this double exists
+    so the run-level tests exercise the wiring and the round trip without a
+    platform.
+    """
+
+    def __init__(self, document: str = "") -> None:
+        self.document = document
+
+    async def read(self) -> str:
+        return self.document
+
+    async def write(self, notes: Sequence[MemoryNote]) -> str:
+        if not notes:
+            return "- memory: unchanged (no notes returned)"
+        self.document, _ = replace_auto_zone(self.document, notes, agent="agent", stamp="2026-08-10")
+        return f"- memory: wrote {len(notes)} note(s)"
 
 
 class FakeModelClient:
@@ -35,7 +59,11 @@ class FakeBackend:
         return "REPORT"
 
 
-def _stub_pipeline(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> None:
+def _stub_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+    seen: dict[str, object],
+    result: AnalystResult | None = None,
+) -> None:
     default = FakeModelClient()
     fast = FakeModelClient()
     model_clients = ConfiguredModelClients(
@@ -54,8 +82,8 @@ def _stub_pipeline(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> 
         seen["local_only"] = local_only
         return FakeBackend()
 
-    async def fake_run_agent(analyst: object, *, verbose: bool) -> object:
-        return object()
+    async def fake_run_agent(analyst: object, *, verbose: bool) -> AnalystResult:
+        return result if result is not None else AnalystResult(summary="nothing worth filing")
 
     monkeypatch.setattr(run_module, "make_analyst_backend", fake_make_backend)
     monkeypatch.setattr(run_module, "resolve_model_clients", fake_resolve_model_clients)
@@ -79,9 +107,10 @@ async def test_injected_client_is_used_and_closed(monkeypatch: pytest.MonkeyPatc
         workspace="workspace",
         base_url="https://platform",
         client=cast(AsyncNeMoPlatform, client),
+        memory_store=InMemoryStore(),
     )
 
-    assert report == "REPORT"
+    assert report.startswith("REPORT")
     assert seen["backend_client"] is client
     build_kwargs = cast(dict[str, object], seen["build_kwargs"])
     assert cast(AnalystDeps, build_kwargs["deps"]).backend is not None
@@ -171,6 +200,102 @@ def test_verbose_echo_maps_nooa_reasoning_tools_and_execution(capsys: pytest.Cap
     ]
 
 
+HUMAN_ZONE = """# Agent memory: agent
+
+## Context from the developer
+- `search_web` times out at 30s deliberately. Not a bug.
+"""
+
+
+async def test_memory_round_trips_from_one_run_into_the_next(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A run replaces only the maintained zone, and the next run reads it back."""
+    seen: dict[str, object] = {}
+    _stub_pipeline(
+        monkeypatch,
+        seen,
+        AnalystResult(summary="s", memory=[MemoryNote(note="eval spans are synthetic", source="t1")]),
+    )
+    store = InMemoryStore(HUMAN_ZONE)
+
+    report = await run_module.run_analyst(
+        agent="agent",
+        agent_spec=None,
+        workspace="workspace",
+        base_url="https://platform",
+        client=cast(AsyncNeMoPlatform, FakeClient()),
+        memory_store=store,
+    )
+
+    assert cast(dict[str, object], seen["build_kwargs"])["agent_memory"] == HUMAN_ZONE
+    assert store.document.startswith(HUMAN_ZONE.rstrip())
+    assert "- eval spans are synthetic (2026-08-10; t1)" in store.document
+    assert report.endswith("- memory: wrote 1 note(s)")
+
+    _stub_pipeline(monkeypatch, seen, AnalystResult(summary="s"))
+    await run_module.run_analyst(
+        agent="agent",
+        agent_spec=None,
+        workspace="workspace",
+        base_url="https://platform",
+        client=cast(AsyncNeMoPlatform, FakeClient()),
+        memory_store=store,
+    )
+
+    carried = cast(str, cast(dict[str, object], seen["build_kwargs"])["agent_memory"])
+    assert "eval spans are synthetic" in carried
+    assert AUTO_START in carried
+
+
+async def test_store_is_derived_from_the_run_client_so_scheduled_runs_need_no_extra_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The job passes no memory config; the store comes from client/workspace/agent."""
+    seen: dict[str, object] = {}
+    _stub_pipeline(monkeypatch, seen)
+    built: dict[str, object] = {}
+
+    class RecordingStore(InMemoryStore):
+        def __init__(self, *, client: object, workspace: str, agent: str) -> None:
+            super().__init__()
+            built.update(client=client, workspace=workspace, agent=agent)
+
+    monkeypatch.setattr(run_module, "FilesetMemoryStore", RecordingStore)
+    client = FakeClient()
+
+    await run_module.run_analyst(
+        agent="research-agent",
+        agent_spec=None,
+        workspace="prod",
+        base_url="https://platform",
+        client=cast(AsyncNeMoPlatform, client),
+    )
+
+    assert built == {"client": client, "workspace": "prod", "agent": "research-agent"}
+
+
+async def test_local_only_testbed_runs_skip_memory_entirely(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, object] = {}
+    _stub_pipeline(monkeypatch, seen)
+
+    def unreachable(**kwargs: object) -> object:
+        raise AssertionError("local-only runs must not touch the platform for memory")
+
+    monkeypatch.setattr(run_module, "FilesetMemoryStore", unreachable)
+
+    report = await run_module.run_analyst(
+        agent="agent",
+        agent_spec=None,
+        workspace="workspace",
+        base_url="https://platform",
+        client=cast(AsyncNeMoPlatform, FakeClient()),
+        insights_output="insights.yaml",
+        local_only=True,
+    )
+
+    assert report == "REPORT"
+    assert cast(dict[str, object], seen["build_kwargs"])["agent_memory"] is None
+
+
 async def test_client_closed_when_observability_shutdown_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     client = FakeClient()
     seen: dict[str, object] = {}
@@ -194,6 +319,7 @@ async def test_client_closed_when_observability_shutdown_raises(monkeypatch: pyt
             workspace="workspace",
             base_url="https://platform",
             client=cast(AsyncNeMoPlatform, client),
+            memory_store=InMemoryStore(),
         )
 
     assert client.closed

--- a/plugins/nemo-insights/tests/test_preflight.py
+++ b/plugins/nemo-insights/tests/test_preflight.py
@@ -182,4 +182,5 @@ def test_healthy_setup_formats_grouped_report(tmp_path: Path) -> None:
     assert "Profile\n  ✓ profile for agent 'a'" in report
     assert "Models\n  ✓ default=default/gpt-5; fast=default/gpt-5-mini" in report
     assert "Platform\n  ✓ http://localhost:8080 reachable" in report
+    assert "memory at nemo-agent-memory#a/AGENT-MEMORY.md" in report
     assert not required_failures(results)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

An Analyst run carries nothing between invocations but a trace cursor, so it re-derives an agent's telemetry conventions on every run against a 50-request ceiling. Scheduled analysis is worse off: it has no context channel at all, because the periodic controller cannot supply `AGENT-SPEC.md` — that file lives on a developer's disk. This adds `AGENT-MEMORY.md`, a per-agent markdown document on the `nemo-agent-memory` fileset that both manual and scheduled runs read, the developer can edit, and the Analyst keeps current.

The document has two zones. Everything before the `nemo:auto:start` marker belongs to the developer and is never rewritten; the span between the markers belongs to the Analyst and is replaced wholesale on each run that returns notes. That split is what lets the document be auto-maintained and hand-editable at once, without version history or a review queue.

Memory is bounded at **2,200 characters** (~800 tokens, 8–15 notes) and does not grow.

## Changes

- `analyst/memory.py` (new): the document format (markers, note rendering, zone replacement, scaffold, enforced budget, usage gauge) plus `FilesetMemoryStore` over `sdk.files` `upload_content`/`download_content` with `fileset_auto_create`.
- `analyst/result.py`: `MemoryNote` and `AnalystResult.memory`, described as the complete replacement set so memory rides the existing single terminal change-set rather than becoming a write tool.
- `analyst/run.py`: derives the store from the `client`, `workspace`, and `agent` that `run_analyst` already receives, reads memory before building the agent, writes after `persist_result`. **No controller or `AnalyzeSpec` change** — scheduled runs pick memory up for free.
- `analyst/agent.py`: `AGENT_MEMORY_HEADER` injection plus a memory section in `INSTRUCTIONS`.
- `preflight.py`: `analyst doctor` now points at the agent's memory location.
- Docs and the `nemo-analyst` skill.

### Capacity, following the Hermes agent memory design

Two ideas adopted from [Hermes](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) beyond the number itself:

- **The analyst is shown how full memory is.** The injected header carries a gauge — `## Agent Memory [41% — 902/2,200 chars]` — so remaining capacity is something it can plan against rather than a wall it discovers by being truncated after the fact.
- **Memory must not silently drop entries.** Hermes errors and lets the agent consolidate mid-turn; this Analyst emits one terminal result and has no retry, so the prompt does that work instead (consolidate to fit, merge overlapping notes, drop what stopped earning its place). Truncation remains only as a backstop, and when it fires the run says so as a warning naming the document to review, not as a routine statistic.

Its guidance on note content is reflected in the instructions too: save environment and telemetry facts, conventions, tool quirks, and corrections; pack related facts densely; do not save a log of the run, anything true of one trace, or anything already in the spec.

### Other deliberate safety properties

- **An empty `memory` list leaves the document alone** rather than clearing it. A model that omits the field is indistinguishable from one that means "empty", and wiping accumulated developer context on that ambiguity is the worse failure. Clearing is a hand edit.
- **Notes must carry forward.** Full rewrite combined with the incremental `since` cursor would otherwise erode memory silently: a scheduled run sees only new traces, so "write what you observed" deletes every fact learned from traces outside the window. The instructions frame the returned list as the memory that should *exist*.

Explicitly out of scope: the Analyst refiling Insights a developer rejected. That needs a rejection reason on the Insight entity, not a free-text document, and the instructions deliberately do not lean on `status="deleted"`.

## Type of Change

- [x] Code change with documentation updates

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation updated for user-visible behavior

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest plugins/nemo-insights/tests --ignore=tests/testbed` — **164 passed** (146 before this change, 18 new). `tests/testbed` is excluded because its 56 failures reproduce unchanged on `main` in this environment.
- `ruff check plugins/nemo-insights/` — clean. `ruff format --check` — 92 files already formatted.
- `ty check` — 1 diagnostic, reproducing identically on stashed baseline, in a file this PR does not touch (`analyst_backend.py:649`). Zero on the changed files.
- `npm run validate-mdx` — 218 files parsed cleanly; `check:gated-links` clean.
- **Live platform** (`nemo services run --services entities,files`): drove the real `FilesetMemoryStore` end to end — fileset auto-created on first write, developer zone preserved byte for byte across an Analyst rewrite, stale auto notes removed, empty write left the document untouched. Then ran the exact `nemo files download` / `nemo files upload` commands from the docs, hand-edited the developer zone, and confirmed a subsequent Analyst write preserved that edit. Three realistic notes measure 374 chars (17% of budget), so 2,200 comfortably holds the 8–15 notes it is sized for. Forcing an overflow kept the six highest-ranked notes at 1,919 chars, dropped the rest, emitted the warning line, and left the developer zone intact.

`uv run pre-commit run -a` could not run: `uv` cannot resolve this workspace because `nemo-fabric-runtime` fails to build (`feature 'edition2024' is required`, Cargo 1.83 on this image). Pinned `ruff` and `ty` were run directly instead, as above.

## Notes for reviewers

One bug worth flagging: `NemoClientError` is not a subclass of `NeMoPlatformError`, so it had to be named explicitly in the store's error tuple. Without it, a transport blip while fetching memory would have aborted an otherwise healthy analysis.

Editing is download / edit / upload — Studio's fileset UI previews and accepts a replacement upload but has no in-place markdown editor. If that proves awkward, a thin `nemo agents analyst memory show|pull|push` wrapper is the natural follow-up; it was left out here to avoid a new CLI surface for something `nemo files` already does.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d5a6fed-4a47-467c-96ac-3d020ee90003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d5a6fed-4a47-467c-96ac-3d020ee90003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

