### PR TITLE
fix(files): keep local file blobs in the platform data directory

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/files/storage_config.py
@@ -17,6 +17,7 @@ from typing import (
     Self,
 )
 
+from nemo_platform_plugin.config import nmp_user_data_dir
 from nemo_platform_plugin.schema import SecretRef
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -91,7 +92,16 @@ class LocalStorageConfig(BaseStorageConfig):
         This allows the config to pass in absolute paths, ``~``-prefixed
         paths (expanded against the running user's home dir), or relative
         paths like ``./files_storage`` (joined against cwd).
+
+        An **empty** path means the platform's user-data directory, so blobs follow
+        ``NMP_DATA_DIR`` alongside the entity-store database.
+
+        Resolved here rather than as a field default because a machine-dependent default is
+        rendered into the committed config reference — the same reason the SQLite path is
+        computed in ``get_database_url``.
         """
+        if not v:
+            return str(nmp_user_data_dir() / "files")
         return str(Path.cwd() / Path(v).expanduser())
 
     @property

--- a/packages/nemo_platform_plugin/tests/files/test_storage_config_path.py
+++ b/packages/nemo_platform_plugin/tests/files/test_storage_config_path.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""How a local storage path is resolved, and which state it keeps together.
+
+Regression: ``NMP_DATA_DIR`` relocates the entity-store database, but the bundled local
+configurations pinned the literal blob location, so a run with it set produced a *half*
+isolated instance — database in the chosen directory, blobs in the default one. That is worse
+than an un-isolated instance: it looks isolated, and wiping the chosen directory silently
+leaves the blobs behind.
+"""
+
+import pytest
+from nemo_platform_plugin.files.storage_config import LocalStorageConfig
+
+
+def test_an_empty_path_follows_the_platform_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """The fix: blobs land under the chosen data directory, beside the entity-store database."""
+    monkeypatch.setenv("NMP_DATA_DIR", str(tmp_path))
+    assert LocalStorageConfig(path="").path == str(tmp_path / "files")
+
+
+def test_an_empty_path_without_a_data_dir_keeps_the_previous_location(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The value the bundled configs used to hard-code. Anyone who has not opted into a data
+    directory must see no change at all."""
+    monkeypatch.delenv("NMP_DATA_DIR", raising=False)
+    monkeypatch.setenv("HOME", "/home/someone")
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    assert LocalStorageConfig(path="").path == "/home/someone/.local/share/nemo/files"
+
+
+def test_an_explicit_path_is_never_overridden(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """The container image, the Helm chart and the agentic runners all set this explicitly."""
+    monkeypatch.setenv("NMP_DATA_DIR", str(tmp_path))
+    assert LocalStorageConfig(path="/data/files_storage").path == "/data/files_storage"
+
+
+def test_home_relative_paths_still_expand(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the empty path gains meaning; every other form resolves exactly as before."""
+    monkeypatch.setenv("HOME", "/home/someone")
+    assert LocalStorageConfig(path="~/blobs").path == "/home/someone/blobs"
+
+
+def test_the_data_dir_is_read_per_construction(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    """Resolution happens in the validator, not as a field default, so it tracks the
+    environment at construction — and, just as importantly, keeps a machine-dependent path out
+    of the field default that generates the committed config reference."""
+    monkeypatch.setenv("NMP_DATA_DIR", str(tmp_path / "one"))
+    assert LocalStorageConfig(path="").path == str(tmp_path / "one" / "files")
+    monkeypatch.setenv("NMP_DATA_DIR", str(tmp_path / "two"))
+    assert LocalStorageConfig(path="").path == str(tmp_path / "two" / "files")

--- a/packages/nmp_platform/config/local.yaml
+++ b/packages/nmp_platform/config/local.yaml
@@ -178,7 +178,9 @@ secrets:
 files:
   default_storage_config:
     type: local
-    path: ~/.local/share/nemo/files
+    # Empty means the platform user-data directory, so blobs follow NMP_DATA_DIR
+    # alongside the entity-store database.
+    path: ""
 
 studio:
   static_files_path: web/packages/studio/dist

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml
@@ -90,4 +90,6 @@ secrets:
 files:
   default_storage_config:
     type: local
-    path: ~/.local/share/nemo/files
+    # Empty means the platform user-data directory, so blobs follow NMP_DATA_DIR
+    # alongside the entity-store database.
+    path: ""


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`NMP_DATA_DIR` relocated the entity-store database but not the Files service, because both bundled local configurations pinned the literal `~/.local/share/nemo/files` for blob storage. Before this change, a local run with the variable set put the database in the chosen directory and the file blobs in the default one; after it, both land under the chosen directory. Behaviour is unchanged when `NMP_DATA_DIR` is unset, and an explicit path still wins.

A half-isolated instance is worse than an un-isolated one: it looks isolated, so wiping the chosen directory silently leaves the blobs behind. Three places already promised otherwise — `LocalServicesConfig.data_dir` ("SQLite DB, encryption key, files"), `SETUP.md` (the wipe warning lists files), and `packages/nmp_testing/tests/unit/test_e2e_harness.py`, which asserts the rendered path is `<data dir>/files`. Only the bundled configs disagreed.

## Changes

- `LocalStorageConfig.make_path_relative_to_program`: an empty `path` now resolves to `<platform user-data dir>/files`. Absolute, `~`-prefixed, and relative paths behave exactly as before.
- `packages/nmp_platform_runner/src/nmp/platform_runner/config/local.yaml` and `packages/nmp_platform/config/local.yaml`: use the empty sentinel instead of a hard-coded path.
- New unit tests covering the empty-path resolution, the unchanged no-`NMP_DATA_DIR` location, explicit paths winning, `~` expansion, and per-construction resolution.

Resolved in the field validator rather than as a field default on purpose: `docs/set-up/config-reference.mdx` is generated from field defaults and committed, so a default derived from the environment would bake the generating machine's home directory into the repository. This mirrors the SQLite path, computed in `get_database_url` for the same reason. `lint-config-reference-docs` passes as a result.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: this makes the code match what `SETUP.md` and `LocalServicesConfig.data_dir` already document; the generated config reference is unchanged by design.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest services/core/files/tests/ packages/nemo_platform_plugin/tests/` — **1737 passed, 51 skipped**.
- `uv run --frozen pytest packages/nemo_platform_plugin/tests/files/test_storage_config_path.py` — **5 passed** (the new tests).
- `uv run pre-commit run -a` — all substantive hooks pass: `ruff`, `ruff format`, `Run ty typechecks`, **`Check config reference doc is up to date`**, `Helm Docs Container`, `Check for uv.lock drift`, `Fix copyright headers`, `Plugins must not import from nmp-common`, `check for merge conflicts`. Two hooks could not run in my local environment, which is why the gate above is left unchecked — neither is reported as passing:
  - `Run uv lock with platform uv` — requires uv 0.9.14; local uv is 0.9.30. No `pyproject.toml` is touched by this PR, the separate `Check for uv.lock drift` hook passes, and CI's `Check uv lock` job passes on this head.
  - `Run UI lint-staged` — `pnpm` unavailable locally (untrusted `mise.toml`). No `web/` files are touched by this PR.
- `tools/lint/lint-all.sh` — passes except `lint-openapi` (fails locally on `mapfile: command not found`, macOS bash 3.2) and `lint-web-sdk` (same missing `pnpm`). Neither is affected by this change; no API surface is added.
- Manual end-to-end, `nemo services run --services entities,files`:
  - with `NMP_DATA_DIR=<tmp>`, a new fileset resolves to `<tmp>/files/filesets/default/<name>` (previously `~/.local/share/nemo/...`).
  - resolution semantics checked directly: empty path with no `NMP_DATA_DIR` → `~/.local/share/nemo/files` (identical to the value the configs used to hard-code), empty path with it set → `<dir>/files`, explicit `/data/files_storage` → unchanged, `~/somewhere` → expanded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Local file storage now automatically uses the platform’s user-data directory.
  - Storage locations can be customized through the `NMP_DATA_DIR` environment setting.
  - Explicit storage paths continue to take precedence, including home-relative paths.

- **Bug Fixes**
  - Corrected local storage path handling when no path is configured.

- **Tests**
  - Added coverage for environment-based, default, explicit, and dynamically evaluated storage paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->