### PR TITLE
chore(experiments): enable experiments studio view by default

### DIFF
--- a/web/packages/studio/src/constants/featureFlags/featureFlags.ts
+++ b/web/packages/studio/src/constants/featureFlags/featureFlags.ts
@@ -65,7 +65,7 @@ export const flagDefinitions = {
   deploymentsEnabled: previewFlag('VITE_FF_DEPLOYMENTS_ENABLED'),
   evaluatorBenchmarksEnabled: previewFlag('VITE_FF_EVALUATOR_BENCHMARKS_ENABLED', false),
   evaluatorEnabled: previewFlag('VITE_FF_EVALUATOR_ENABLED', true),
-  experiment: previewFlag('VITE_FF_EXPERIMENT', false),
+  experiment: previewFlag('VITE_FF_EXPERIMENT', true),
   filesetDetailsEnabled: previewFlag('VITE_FF_FILESET_DETAILS_ENABLED'),
   guardrailsEnabled: previewFlag('VITE_FF_GUARDRAILS_ENABLED', true),
   inferenceProviderEnabled: previewFlag('VITE_FF_INFERENCE_PROVIDER_ENABLED'),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Enables the Experiments Studio view by default while preserving the `VITE_FF_EXPERIMENT` override.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Change the Experiments preview flag default from disabled to enabled.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: Studio navigation tests exercise feature-flagged routes.
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: The existing preview flag and override remain unchanged.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `uv run pre-commit run -a` — passed.
- `pnpm --filter="...[origin/main]" run --parallel --if-present typecheck` — failed on unrelated generated SDK and icon exports in the local unsynchronized Studio environment.
- `pnpm --filter nemo-studio-ui test` — stopped after failures in existing Safe Synthesizer and workspace navigation tests; CI will run the suite in a clean environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the experiment preview feature by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->