### PR TITLE
feat(intake): sort span groups by time

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -6955,7 +6955,7 @@ nemo intake spans groups list [OPTIONS]
 * `--by`: Comma-separated span fields to group by, e.g.
 * `--page <INTEGER>`: Page number.
 * `--page-size <INTEGER>`: Page size.
-* `--sort <CHOICE>`: [possible values: span_count, -span_count]
+* `--sort <CHOICE>`: Sort groups by size or by time. Use -started_at to get the most recent traces or sessions first, which answers 'what ran lately' in one call instead of paging through spans. [possible values: span_count, -span_count, started_at, -started_at]
 * `--all-pages`: Fetch all pages
 
 **Filter Options:**

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -6955,7 +6955,7 @@ nemo intake spans groups list [OPTIONS]
 * `--by`: Comma-separated span fields to group by, e.g.
 * `--page <INTEGER>`: Page number.
 * `--page-size <INTEGER>`: Page size.
-* `--sort <CHOICE>`: Sort groups by size or by time. Use -started_at to get the most recent traces or sessions first, which answers 'what ran lately' in one call instead of paging through spans. [possible values: span_count, -span_count, started_at, -started_at]
+* `--sort <CHOICE>`: Sort groups by size or by start time. Use -started_at for the traces or sessions that began most recently, which answers 'what ran lately' in one call instead of paging through spans. A group's time is its earliest matching span, so this orders by when work started and not by when it was last active. [possible values: span_count, -span_count, started_at, -started_at]
 * `--all-pages`: Fetch all pages
 
 **Filter Options:**

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -4671,7 +4671,13 @@ paths:
         schema:
           allOf:
           - $ref: '#/components/schemas/SpanGroupSortField'
+          description: Sort groups by size or by time. Use -started_at to get the
+            most recent traces or sessions first, which answers 'what ran lately'
+            in one call instead of paging through spans.
           default: -span_count
+        description: Sort groups by size or by time. Use -started_at to get the most
+          recent traces or sessions first, which answers 'what ran lately' in one
+          call instead of paging through spans.
       - in: query
         name: filter
         style: deepObject
@@ -18082,10 +18088,18 @@ components:
           minimum: 0.0
           title: Span Count
           description: Number of matching spans in this group.
+        started_at:
+          type: string
+          format: date-time
+          title: Started At
+          description: Start time of the earliest matching span in this group. Only
+            matching spans count, so a filter narrows this to when the filtered work
+            began rather than when the whole trace or session began.
       type: object
       required:
       - group
       - span_count
+      - started_at
       title: SpanGroup
     SpanGroupBy:
       type: string
@@ -18098,6 +18112,8 @@ components:
       enum:
       - span_count
       - -span_count
+      - started_at
+      - -started_at
       title: SpanGroupSortField
     SpanGroupsPage:
       properties:

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -4671,13 +4671,17 @@ paths:
         schema:
           allOf:
           - $ref: '#/components/schemas/SpanGroupSortField'
-          description: Sort groups by size or by time. Use -started_at to get the
-            most recent traces or sessions first, which answers 'what ran lately'
-            in one call instead of paging through spans.
+          description: Sort groups by size or by start time. Use -started_at for the
+            traces or sessions that began most recently, which answers 'what ran lately'
+            in one call instead of paging through spans. A group's time is its earliest
+            matching span, so this orders by when work started and not by when it
+            was last active.
           default: -span_count
-        description: Sort groups by size or by time. Use -started_at to get the most
-          recent traces or sessions first, which answers 'what ran lately' in one
-          call instead of paging through spans.
+        description: Sort groups by size or by start time. Use -started_at for the
+          traces or sessions that began most recently, which answers 'what ran lately'
+          in one call instead of paging through spans. A group's time is its earliest
+          matching span, so this orders by when work started and not by when it was
+          last active.
       - in: query
         name: filter
         style: deepObject

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -4671,7 +4671,13 @@ paths:
         schema:
           allOf:
           - $ref: '#/components/schemas/SpanGroupSortField'
+          description: Sort groups by size or by time. Use -started_at to get the
+            most recent traces or sessions first, which answers 'what ran lately'
+            in one call instead of paging through spans.
           default: -span_count
+        description: Sort groups by size or by time. Use -started_at to get the most
+          recent traces or sessions first, which answers 'what ran lately' in one
+          call instead of paging through spans.
       - in: query
         name: filter
         style: deepObject
@@ -18082,10 +18088,18 @@ components:
           minimum: 0.0
           title: Span Count
           description: Number of matching spans in this group.
+        started_at:
+          type: string
+          format: date-time
+          title: Started At
+          description: Start time of the earliest matching span in this group. Only
+            matching spans count, so a filter narrows this to when the filtered work
+            began rather than when the whole trace or session began.
       type: object
       required:
       - group
       - span_count
+      - started_at
       title: SpanGroup
     SpanGroupBy:
       type: string
@@ -18098,6 +18112,8 @@ components:
       enum:
       - span_count
       - -span_count
+      - started_at
+      - -started_at
       title: SpanGroupSortField
     SpanGroupsPage:
       properties:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -4671,13 +4671,17 @@ paths:
         schema:
           allOf:
           - $ref: '#/components/schemas/SpanGroupSortField'
-          description: Sort groups by size or by time. Use -started_at to get the
-            most recent traces or sessions first, which answers 'what ran lately'
-            in one call instead of paging through spans.
+          description: Sort groups by size or by start time. Use -started_at for the
+            traces or sessions that began most recently, which answers 'what ran lately'
+            in one call instead of paging through spans. A group's time is its earliest
+            matching span, so this orders by when work started and not by when it
+            was last active.
           default: -span_count
-        description: Sort groups by size or by time. Use -started_at to get the most
-          recent traces or sessions first, which answers 'what ran lately' in one
-          call instead of paging through spans.
+        description: Sort groups by size or by start time. Use -started_at for the
+          traces or sessions that began most recently, which answers 'what ran lately'
+          in one call instead of paging through spans. A group's time is its earliest
+          matching span, so this orders by when work started and not by when it was
+          last active.
       - in: query
         name: filter
         style: deepObject

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4671,7 +4671,13 @@ paths:
         schema:
           allOf:
           - $ref: '#/components/schemas/SpanGroupSortField'
+          description: Sort groups by size or by time. Use -started_at to get the
+            most recent traces or sessions first, which answers 'what ran lately'
+            in one call instead of paging through spans.
           default: -span_count
+        description: Sort groups by size or by time. Use -started_at to get the most
+          recent traces or sessions first, which answers 'what ran lately' in one
+          call instead of paging through spans.
       - in: query
         name: filter
         style: deepObject
@@ -18082,10 +18088,18 @@ components:
           minimum: 0.0
           title: Span Count
           description: Number of matching spans in this group.
+        started_at:
+          type: string
+          format: date-time
+          title: Started At
+          description: Start time of the earliest matching span in this group. Only
+            matching spans count, so a filter narrows this to when the filtered work
+            began rather than when the whole trace or session began.
       type: object
       required:
       - group
       - span_count
+      - started_at
       title: SpanGroup
     SpanGroupBy:
       type: string
@@ -18098,6 +18112,8 @@ components:
       enum:
       - span_count
       - -span_count
+      - started_at
+      - -started_at
       title: SpanGroupSortField
     SpanGroupsPage:
       properties:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4671,13 +4671,17 @@ paths:
         schema:
           allOf:
           - $ref: '#/components/schemas/SpanGroupSortField'
-          description: Sort groups by size or by time. Use -started_at to get the
-            most recent traces or sessions first, which answers 'what ran lately'
-            in one call instead of paging through spans.
+          description: Sort groups by size or by start time. Use -started_at for the
+            traces or sessions that began most recently, which answers 'what ran lately'
+            in one call instead of paging through spans. A group's time is its earliest
+            matching span, so this orders by when work started and not by when it
+            was last active.
           default: -span_count
-        description: Sort groups by size or by time. Use -started_at to get the most
-          recent traces or sessions first, which answers 'what ran lately' in one
-          call instead of paging through spans.
+        description: Sort groups by size or by start time. Use -started_at for the
+          traces or sessions that began most recently, which answers 'what ran lately'
+          in one call instead of paging through spans. A group's time is its earliest
+          matching span, so this orders by when work started and not by when it was
+          last active.
       - in: query
         name: filter
         style: deepObject

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/groups.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/groups.py
@@ -93,7 +93,7 @@ def list_groups(
         Literal["span_count", "-span_count", "started_at", "-started_at"] | None,
         typer.Option(
             "--sort",
-            help="Sort groups by size or by time. Use -started_at to get the most recent traces or sessions first, which answers 'what ran lately' in one call instead of paging through spans.",
+            help="Sort groups by size or by start time. Use -started_at for the traces or sessions that began most recently, which answers 'what ran lately' in one call instead of paging through spans. A group's time is its earliest matching span, so this orders by when work started and not by when it was last active.",
         ),
     ] = None,
     output_format: ListOutputFormatOption = None,

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/groups.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/intake/spans/groups.py
@@ -89,7 +89,13 @@ def list_groups(
     filter_trace_id: Annotated[str | None, typer.Option("--filter.trace-id", rich_help_panel="Filter Options")] = None,
     page: Annotated[int | None, typer.Option("--page", help="Page number.")] = None,
     page_size: Annotated[int | None, typer.Option("--page-size", help="Page size.")] = None,
-    sort: Annotated[Literal["span_count", "-span_count"] | None, typer.Option("--sort")] = None,
+    sort: Annotated[
+        Literal["span_count", "-span_count", "started_at", "-started_at"] | None,
+        typer.Option(
+            "--sort",
+            help="Sort groups by size or by time. Use -started_at to get the most recent traces or sessions first, which answers 'what ran lately' in one call instead of paging through spans.",
+        ),
+    ] = None,
     output_format: ListOutputFormatOption = None,
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,

--- a/plugins/nemo-insights/tests/test_periodic_analysis.py
+++ b/plugins/nemo-insights/tests/test_periodic_analysis.py
@@ -322,7 +322,7 @@ class _SpanGroups:
     async def list(self, **kwargs: object) -> SimpleNamespace:
         self.calls.append(kwargs)
         return SimpleNamespace(
-            data=[SpanGroup(group={"session_id": "session-1"}, span_count=3)],
+            data=[SpanGroup(group={"session_id": "session-1"}, span_count=3, started_at=_STAMP)],
             pagination=SimpleNamespace(total_results=7),
         )
 
@@ -371,8 +371,8 @@ class _SpanGroupsPaged:
         self.calls.append(kwargs)
         return SimpleNamespace(
             data=[
-                SpanGroup(group={"session_id": "session-1"}, span_count=12),
-                SpanGroup(group={"session_id": "session-2"}, span_count=5),
+                SpanGroup(group={"session_id": "session-1"}, span_count=12, started_at=_STAMP),
+                SpanGroup(group={"session_id": "session-2"}, span_count=5, started_at=_STAMP),
             ],
             pagination=SimpleNamespace(total_results=37),
         )
@@ -397,10 +397,11 @@ async def test_list_span_groups_fans_out_over_sessions() -> None:
         since=since,
     )
 
+    stamp = _STAMP.isoformat().replace("+00:00", "Z")
     assert result == {
         "groups": [
-            {"group": {"session_id": "session-1"}, "span_count": 12},
-            {"group": {"session_id": "session-2"}, "span_count": 5},
+            {"group": {"session_id": "session-1"}, "span_count": 12, "started_at": stamp},
+            {"group": {"session_id": "session-2"}, "span_count": 5, "started_at": stamp},
         ],
         "grouped_by": "session_id",
         "count": 2,

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -4671,7 +4671,13 @@ paths:
         schema:
           allOf:
           - $ref: '#/components/schemas/SpanGroupSortField'
+          description: Sort groups by size or by time. Use -started_at to get the
+            most recent traces or sessions first, which answers 'what ran lately'
+            in one call instead of paging through spans.
           default: -span_count
+        description: Sort groups by size or by time. Use -started_at to get the most
+          recent traces or sessions first, which answers 'what ran lately' in one
+          call instead of paging through spans.
       - in: query
         name: filter
         style: deepObject
@@ -18082,10 +18088,18 @@ components:
           minimum: 0.0
           title: Span Count
           description: Number of matching spans in this group.
+        started_at:
+          type: string
+          format: date-time
+          title: Started At
+          description: Start time of the earliest matching span in this group. Only
+            matching spans count, so a filter narrows this to when the filtered work
+            began rather than when the whole trace or session began.
       type: object
       required:
       - group
       - span_count
+      - started_at
       title: SpanGroup
     SpanGroupBy:
       type: string
@@ -18098,6 +18112,8 @@ components:
       enum:
       - span_count
       - -span_count
+      - started_at
+      - -started_at
       title: SpanGroupSortField
     SpanGroupsPage:
       properties:

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -4671,13 +4671,17 @@ paths:
         schema:
           allOf:
           - $ref: '#/components/schemas/SpanGroupSortField'
-          description: Sort groups by size or by time. Use -started_at to get the
-            most recent traces or sessions first, which answers 'what ran lately'
-            in one call instead of paging through spans.
+          description: Sort groups by size or by start time. Use -started_at for the
+            traces or sessions that began most recently, which answers 'what ran lately'
+            in one call instead of paging through spans. A group's time is its earliest
+            matching span, so this orders by when work started and not by when it
+            was last active.
           default: -span_count
-        description: Sort groups by size or by time. Use -started_at to get the most
-          recent traces or sessions first, which answers 'what ran lately' in one
-          call instead of paging through spans.
+        description: Sort groups by size or by start time. Use -started_at for the
+          traces or sessions that began most recently, which answers 'what ran lately'
+          in one call instead of paging through spans. A group's time is its earliest
+          matching span, so this orders by when work started and not by when it was
+          last active.
       - in: query
         name: filter
         style: deepObject

--- a/sdk/python/nemo-platform/pyproject.toml
+++ b/sdk/python/nemo-platform/pyproject.toml
@@ -55,6 +55,7 @@ nemo-evaluator-sdk = [
   "pyarrow>=19.0.1",
   "pandas>=1.5.3",
   "openai>=1.61.0",
+  "httpx>=0.27.0,<1",
   "sacrebleu>=2.5.1",
   "rouge_score==0.1.2",
   "ragas==0.4.3",
@@ -62,7 +63,6 @@ nemo-evaluator-sdk = [
   "langchain-nvidia-ai-endpoints>=1.4.3,<2.0.0",
   "nemo-relay>=0.6.0,<0.7",
   "nemo-fabric>=0.1.1,<0.3.0",
-  "httpx>=0.27.0,<1",
 ]
 
 [project.entry-points."nemo.skills"]

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/groups.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/groups.py
@@ -93,7 +93,7 @@ def list_groups(
         Literal["span_count", "-span_count", "started_at", "-started_at"] | None,
         typer.Option(
             "--sort",
-            help="Sort groups by size or by time. Use -started_at to get the most recent traces or sessions first, which answers 'what ran lately' in one call instead of paging through spans.",
+            help="Sort groups by size or by start time. Use -started_at for the traces or sessions that began most recently, which answers 'what ran lately' in one call instead of paging through spans. A group's time is its earliest matching span, so this orders by when work started and not by when it was last active.",
         ),
     ] = None,
     output_format: ListOutputFormatOption = None,

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/groups.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/api/intake/spans/groups.py
@@ -89,7 +89,13 @@ def list_groups(
     filter_trace_id: Annotated[str | None, typer.Option("--filter.trace-id", rich_help_panel="Filter Options")] = None,
     page: Annotated[int | None, typer.Option("--page", help="Page number.")] = None,
     page_size: Annotated[int | None, typer.Option("--page-size", help="Page size.")] = None,
-    sort: Annotated[Literal["span_count", "-span_count"] | None, typer.Option("--sort")] = None,
+    sort: Annotated[
+        Literal["span_count", "-span_count", "started_at", "-started_at"] | None,
+        typer.Option(
+            "--sort",
+            help="Sort groups by size or by time. Use -started_at to get the most recent traces or sessions first, which answers 'what ran lately' in one call instead of paging through spans.",
+        ),
+    ] = None,
     output_format: ListOutputFormatOption = None,
     no_truncate: NoTruncateOption = None,
     columns: OutputColumnsOption = None,

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/groups.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/groups.py
@@ -89,9 +89,10 @@ class GroupsResource(SyncAPIResource):
 
           page_size: Page size.
 
-          sort: Sort groups by size or by time. Use -started_at to get the most recent traces or
-              sessions first, which answers 'what ran lately' in one call instead of paging
-              through spans.
+          sort: Sort groups by size or by start time. Use -started_at for the traces or sessions
+              that began most recently, which answers 'what ran lately' in one call instead of
+              paging through spans. A group's time is its earliest matching span, so this
+              orders by when work started and not by when it was last active.
 
           extra_headers: Send extra headers
 
@@ -178,9 +179,10 @@ class AsyncGroupsResource(AsyncAPIResource):
 
           page_size: Page size.
 
-          sort: Sort groups by size or by time. Use -started_at to get the most recent traces or
-              sessions first, which answers 'what ran lately' in one call instead of paging
-              through spans.
+          sort: Sort groups by size or by start time. Use -started_at for the traces or sessions
+              that began most recently, which answers 'what ran lately' in one call instead of
+              paging through spans. A group's time is its earliest matching span, so this
+              orders by when work started and not by when it was last active.
 
           extra_headers: Send extra headers
 

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/groups.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/intake/spans/groups.py
@@ -89,6 +89,10 @@ class GroupsResource(SyncAPIResource):
 
           page_size: Page size.
 
+          sort: Sort groups by size or by time. Use -started_at to get the most recent traces or
+              sessions first, which answers 'what ran lately' in one call instead of paging
+              through spans.
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -173,6 +177,10 @@ class AsyncGroupsResource(AsyncAPIResource):
           page: Page number.
 
           page_size: Page size.
+
+          sort: Sort groups by size or by time. Use -started_at to get the most recent traces or
+              sessions first, which answers 'what ran lately' in one call instead of paging
+              through spans.
 
           extra_headers: Send extra headers
 

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/spans/group_list_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/spans/group_list_params.py
@@ -44,3 +44,8 @@ class GroupListParams(TypedDict, total=False):
     """Page size."""
 
     sort: SpanGroupSortField
+    """Sort groups by size or by time.
+
+    Use -started_at to get the most recent traces or sessions first, which answers
+    'what ran lately' in one call instead of paging through spans.
+    """

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/spans/group_list_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/spans/group_list_params.py
@@ -44,8 +44,10 @@ class GroupListParams(TypedDict, total=False):
     """Page size."""
 
     sort: SpanGroupSortField
-    """Sort groups by size or by time.
+    """Sort groups by size or by start time.
 
-    Use -started_at to get the most recent traces or sessions first, which answers
-    'what ran lately' in one call instead of paging through spans.
+    Use -started_at for the traces or sessions that began most recently, which
+    answers 'what ran lately' in one call instead of paging through spans. A group's
+    time is its earliest matching span, so this orders by when work started and not
+    by when it was last active.
     """

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/spans/span_group.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/spans/span_group.py
@@ -16,6 +16,7 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import Dict
+from datetime import datetime
 
 from ...._models import BaseModel
 
@@ -28,3 +29,10 @@ class SpanGroup(BaseModel):
 
     span_count: int
     """Number of matching spans in this group."""
+
+    started_at: datetime
+    """Start time of the earliest matching span in this group.
+
+    Only matching spans count, so a filter narrows this to when the filtered work
+    began rather than when the whole trace or session began.
+    """

--- a/sdk/python/nemo-platform/src/nemo_platform/types/intake/spans/span_group_sort_field.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/intake/spans/span_group_sort_field.py
@@ -19,4 +19,4 @@ from typing_extensions import Literal, TypeAlias
 
 __all__ = ["SpanGroupSortField"]
 
-SpanGroupSortField: TypeAlias = Literal["span_count", "-span_count"]
+SpanGroupSortField: TypeAlias = Literal["span_count", "-span_count", "started_at", "-started_at"]

--- a/services/intake/src/nmp/intake/repository/clickhouse/span.py
+++ b/services/intake/src/nmp/intake/repository/clickhouse/span.py
@@ -56,6 +56,9 @@ SPAN_GROUP_COLUMN_FIELDS = {
     "session_id": "session_id",
 }
 
+# Selected by the grouped query itself, so the outer ORDER BY can name them directly.
+SPAN_GROUP_SORT_FIELDS = frozenset({"span_count", "started_at"})
+
 _ZERO_DATETIME = datetime.fromtimestamp(0, tz=timezone.utc)
 
 
@@ -168,7 +171,7 @@ class ClickHouseSpanRepository(SpanRepository):
         select_sql = ", ".join(expression.select_sql for expression in group_expressions)
         group_sql = ", ".join(expression.group_sql for expression in group_expressions)
         grouped_sql = f"""
-            SELECT {select_sql}, count() AS span_count
+            SELECT {select_sql}, count() AS span_count, min(start_time) AS started_at
             FROM {table} FINAL
             WHERE {where_sql}
             GROUP BY {group_sql}
@@ -351,12 +354,12 @@ def _order_by(sort: str) -> str:
 def _group_order_by(sort: str, group_by: list[str]) -> str:
     direction = "DESC" if sort.startswith("-") else "ASC"
     field = sort.removeprefix("-")
-    if field != "span_count":
+    if field not in SPAN_GROUP_SORT_FIELDS:
         raise ValueError(f"Unsupported span group sort field: {field}")
-    group_sort = ", ".join(f"{field} ASC" for field in group_by)
-    if group_sort:
-        return f"span_count {direction}, {group_sort}"
-    return f"span_count {direction}"
+    tie_break = ", ".join(f"{key} ASC" for key in group_by)
+    if tie_break:
+        return f"{field} {direction}, {tie_break}"
+    return f"{field} {direction}"
 
 
 def _span_to_row(span: IntakeSpan) -> dict[str, Any]:
@@ -396,6 +399,7 @@ def _row_to_group(row: dict[str, Any], *, group_by: list[str]) -> SpanGroup:
     return SpanGroup(
         group={field: str(row[field]) for field in group_by},
         span_count=int(row["span_count"]),
+        started_at=row["started_at"],
     )
 
 

--- a/services/intake/src/nmp/intake/spans/api/spans.py
+++ b/services/intake/src/nmp/intake/spans/api/spans.py
@@ -138,8 +138,10 @@ async def list_span_groups(
     sort: SpanGroupSortField = Query(
         default=SpanGroupSortField.SPAN_COUNT_DESC,
         description=(
-            "Sort groups by size or by time. Use -started_at to get the most recent traces or sessions "
-            "first, which answers 'what ran lately' in one call instead of paging through spans."
+            "Sort groups by size or by start time. Use -started_at for the traces or sessions that began "
+            "most recently, which answers 'what ran lately' in one call instead of paging through spans. "
+            "A group's time is its earliest matching span, so this orders by when work started and not by "
+            "when it was last active."
         ),
     ),
     parsed: ParsedFilter = Depends(make_filter_dep(SpanFilter)),

--- a/services/intake/src/nmp/intake/spans/api/spans.py
+++ b/services/intake/src/nmp/intake/spans/api/spans.py
@@ -135,7 +135,13 @@ async def list_span_groups(
     by: str = Query(description="Comma-separated span fields to group by, e.g. trace_id or session_id,trace_id."),
     page: int = Query(default=1, ge=1, description="Page number."),
     page_size: int = Query(default=10, ge=1, le=1000, description="Page size."),
-    sort: SpanGroupSortField = Query(default=SpanGroupSortField.SPAN_COUNT_DESC),
+    sort: SpanGroupSortField = Query(
+        default=SpanGroupSortField.SPAN_COUNT_DESC,
+        description=(
+            "Sort groups by size or by time. Use -started_at to get the most recent traces or sessions "
+            "first, which answers 'what ran lately' in one call instead of paging through spans."
+        ),
+    ),
     parsed: ParsedFilter = Depends(make_filter_dep(SpanFilter)),
 ) -> SpanGroupsPage:
     validate_list_query_params(request, additional_params={"by"})

--- a/services/intake/src/nmp/intake/spans/api/spans_schemas.py
+++ b/services/intake/src/nmp/intake/spans/api/spans_schemas.py
@@ -34,6 +34,8 @@ class SpanSortField(StrEnum):
 class SpanGroupSortField(StrEnum):
     SPAN_COUNT_ASC = "span_count"
     SPAN_COUNT_DESC = "-span_count"
+    STARTED_AT_ASC = "started_at"
+    STARTED_AT_DESC = "-started_at"
 
 
 class SpanGroupBy(StrEnum):
@@ -206,10 +208,16 @@ class Span(BaseModel):
 class SpanGroup(BaseModel):
     group: dict[str, str] = Field(description="Group key values, keyed by the requested group-by fields.")
     span_count: int = Field(ge=0, description="Number of matching spans in this group.")
+    started_at: datetime = Field(
+        description=(
+            "Start time of the earliest matching span in this group. Only matching spans count, so a filter "
+            "narrows this to when the filtered work began rather than when the whole trace or session began."
+        )
+    )
 
     @classmethod
     def from_domain(cls, group: IntakeSpanGroup) -> Self:
-        return cls(group=group.group, span_count=group.span_count)
+        return cls(group=group.group, span_count=group.span_count, started_at=group.started_at)
 
 
 class SpanGroupsPage(Page[SpanGroup]):

--- a/services/intake/src/nmp/intake/spans/domain.py
+++ b/services/intake/src/nmp/intake/spans/domain.py
@@ -85,6 +85,7 @@ class SpanListFilter(BaseModel):
 class SpanGroup(BaseModel):
     group: dict[str, str]
     span_count: int = Field(ge=0)
+    started_at: datetime
 
 
 class TraceListFilter(BaseModel):

--- a/services/intake/tests/integration/spans/test_spans_read_filters.py
+++ b/services/intake/tests/integration/spans/test_spans_read_filters.py
@@ -3,9 +3,15 @@
 
 """Span read filter tests."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi.testclient import TestClient
+
+
+def _group_started_at(group: dict) -> datetime:
+    """Read a group start time, which ClickHouse returns without a zone."""
+    parsed = datetime.fromisoformat(group["started_at"])
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 
 
 def test_spans_read_filters(client: TestClient, make_otlp_request):
@@ -170,10 +176,32 @@ def test_spans_read_filters(client: TestClient, make_otlp_request):
     group_payload = group_response.json()
     assert group_payload["grouped_by"] == ["session_id", "trace_id"]
     assert group_payload["pagination"]["total_results"] == 2
-    assert group_payload["data"] == [
+    assert [{"group": group["group"], "span_count": group["span_count"]} for group in group_payload["data"]] == [
         {"group": {"session_id": "conv-a", "trace_id": "0" * 31 + "1"}, "span_count": 2},
         {"group": {"session_id": "conv-b", "trace_id": "0" * 31 + "1"}, "span_count": 2},
     ]
+
+    # Every span here shares one trace, so a group time taken from the whole trace would
+    # read base for both. The LLM spans of conv-b start at base + 5s, which is what makes
+    # these two groups distinguishable in time.
+    base = datetime.fromtimestamp(base_ns // 1_000_000_000, tz=timezone.utc)
+    assert [_group_started_at(group) for group in group_payload["data"]] == [
+        base,
+        base + timedelta(seconds=5),
+    ]
+
+    recent_response = client.get(
+        "/apis/intake/v2/workspaces/default/spans/groups",
+        params={
+            "by": "session_id,trace_id",
+            "filter[kind]": "LLM",
+            "sort": "-started_at",
+            "page_size": 20,
+        },
+    )
+    assert recent_response.status_code == 200, recent_response.text
+    # Newest first has to reverse the default order, or the sort is not being applied.
+    assert [group["group"]["session_id"] for group in recent_response.json()["data"]] == ["conv-b", "conv-a"]
 
     unsupported_response = client.get("/apis/intake/v2/workspaces/default/spans", params={"session_id": "conv-a"})
     assert unsupported_response.status_code == 400

--- a/services/intake/tests/test_spans_clickhouse_repository.py
+++ b/services/intake/tests/test_spans_clickhouse_repository.py
@@ -10,11 +10,13 @@ from nmp.intake.repository.clickhouse.executor import ClickHouseExecutor, ClickH
 from nmp.intake.repository.clickhouse.span import (
     SPAN_COLUMNS,
     SPAN_GROUP_COLUMN_FIELDS,
+    SPAN_GROUP_SORT_FIELDS,
     ClickHouseSpanRepository,
+    _group_order_by,
     _order_by,
 )
 from nmp.intake.repository.clickhouse.tables import ClickHouseTable
-from nmp.intake.spans.api.spans_schemas import SpanGroupBy
+from nmp.intake.spans.api.spans_schemas import SpanGroupBy, SpanGroupSortField
 from nmp.intake.spans.domain import SpanListFilter, SpanStatus
 from nmp.intake.spans.storage import make_pagination
 
@@ -44,6 +46,9 @@ class _Client(ClickHouseExecutor):
         else:
             result = _QueryResult([])
         return [dict(zip(result.column_names, row, strict=True)) for row in result.result_rows]
+
+
+_GROUP_STARTED_AT = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
 
 
 def _repository(client: _Client) -> ClickHouseSpanRepository:
@@ -173,10 +178,10 @@ async def test_list_span_groups_groups_by_columns():
             _QueryResult([(2,)]),
             _QueryResult(
                 [
-                    ("session-a", "trace-a", 3),
-                    ("session-b", "trace-b", 1),
+                    ("session-a", "trace-a", 3, _GROUP_STARTED_AT),
+                    ("session-b", "trace-b", 1, _GROUP_STARTED_AT),
                 ],
-                ["session_id", "trace_id", "span_count"],
+                ["session_id", "trace_id", "span_count", "started_at"],
             ),
         ]
     )
@@ -193,9 +198,60 @@ async def test_list_span_groups_groups_by_columns():
     assert result.pagination.total_results == 2
     assert result.data[0].group == {"session_id": "session-a", "trace_id": "trace-a"}
     assert result.data[0].span_count == 3
+    assert result.data[0].started_at == _GROUP_STARTED_AT
     assert "FROM spans FINAL" in client.queries[0]
     assert "GROUP BY session_id, trace_id" in client.queries[0]
     assert "ORDER BY span_count DESC, session_id ASC, trace_id ASC" in client.queries[1]
+
+
+@pytest.mark.asyncio
+async def test_list_span_groups_sorts_by_time_so_recent_work_is_one_call():
+    """Newest first over groups is what makes 'what did this agent run lately' cheap.
+
+    Without it a caller has to page spans newest first and collect distinct ids, which
+    only ever gives the traces that fit inside the scanned window.
+    """
+    client = _Client(
+        query_results=[
+            _QueryResult([(2,)]),
+            _QueryResult(
+                [
+                    ("trace-new", 1, _GROUP_STARTED_AT),
+                    ("trace-old", 9, datetime(2026, 1, 1, tzinfo=timezone.utc)),
+                ],
+                ["trace_id", "span_count", "started_at"],
+            ),
+        ]
+    )
+    repository = _repository(client)
+
+    result = await repository.list_span_groups(
+        filters=SpanListFilter(workspace="workspace-a"),
+        group_by=["trace_id"],
+        page=1,
+        page_size=10,
+        sort="-started_at",
+    )
+
+    assert "min(start_time) AS started_at" in client.queries[0]
+    assert "ORDER BY started_at DESC, trace_id ASC" in client.queries[1]
+    # The newest group leads even though it is the smallest.
+    assert [group.group["trace_id"] for group in result.data] == ["trace-new", "trace-old"]
+
+
+def test_group_order_by_whitelists_supported_group_sort_keys():
+    assert _group_order_by("started_at", ["trace_id"]) == "started_at ASC, trace_id ASC"
+    assert _group_order_by("-started_at", ["trace_id"]) == "started_at DESC, trace_id ASC"
+    assert _group_order_by("-span_count", ["trace_id"]) == "span_count DESC, trace_id ASC"
+
+
+def test_group_order_by_rejects_unsupported_group_sort_keys():
+    with pytest.raises(ValueError, match="Unsupported span group sort field"):
+        _group_order_by("started_at DESC; DROP TABLE spans", ["trace_id"])
+
+
+def test_group_sort_enum_matches_repository_sort_fields():
+    assert {field.value.removeprefix("-") for field in SpanGroupSortField} == SPAN_GROUP_SORT_FIELDS
 
 
 @pytest.mark.asyncio

--- a/services/intake/tests/test_spans_schemas.py
+++ b/services/intake/tests/test_spans_schemas.py
@@ -103,12 +103,18 @@ def test_span_summary_omits_payloads_and_raw_attributes():
 
 
 def test_span_group_response_maps_group_values():
+    started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     response = SpanGroup.from_domain(
-        IntakeSpanGroup(group={"session_id": "session-a", "trace_id": "trace-a"}, span_count=3)
+        IntakeSpanGroup(
+            group={"session_id": "session-a", "trace_id": "trace-a"},
+            span_count=3,
+            started_at=started_at,
+        )
     )
 
     assert response.group == {"session_id": "session-a", "trace_id": "trace-a"}
     assert response.span_count == 3
+    assert response.started_at == started_at
 
 
 def test_trace_response_maps_core_trace_fields():


### PR DESCRIPTION
## Summary

Span groups could only be sorted by size, and carried no timestamp at all. That left a common question unanswerable in one call: *which traces did this agent run lately?*

Callers had to work around it by paging spans newest first and collecting distinct trace ids. That is slower, and it is not even correct: it only ever finds the traces that happen to fit inside the scanned window.

This adds:

- `started_at` on each group row, the earliest matching span in the group.
- `started_at` and `-started_at` as sort options.

Only matching spans count toward the time, so a filter reports when the *filtered* work began rather than when the whole trace or session began.

## Why this came up

Raised by @BrianNewsom while reviewing #1212, on a helper that had to drain spans to find an agent's recent traces:

> I would have expected to do the grouped find here - sounds like this is maybe missing a sort?

He was right. Once this lands, that helper collapses to a single grouped call.

## Validation against a running instance

Ran a second Intake on port 8081 against the shared ClickHouse holding real trace data, and compared it with an unpatched instance on 8080.

Patched, `sort=-started_at`, newest first:

```
d9f4ca364185803593a6  spans=16   started_at=2026-08-06T21:03:05.958510
55da0f83996415c4005a  spans=18   started_at=2026-08-06T21:03:04.669397
856fc7e9f3f8325f698f  spans=10   started_at=2026-08-06T21:03:01.848539
```

The span counts are unordered, so time is genuinely driving the sort. The default `-span_count` still returns biggest first (64, 45, 45, 43, 41) and picks an entirely different set of traces, so the two orders are not accidentally the same.

Unpatched, same request:

```
HTTP 422  Input should be 'span_count' or '-span_count'
```

## Generated clients

`make update-sdk` carries the change into the checked-in SDK and CLI, which CI's sync check requires. `SpanGroup` gains `started_at`, `SpanGroupSortField` widens to the four values, and the sort guidance reaches both CLIs and `docs/cli/reference.mdx`.

`started_at` is required rather than optional, because every group of spans has an earliest one and an optional field would push a case that cannot happen onto every caller. That does make it a breaking change for anyone constructing a `SpanGroup` by hand, which in this repo is the Analyst's test fakes. They now pass a stamp, and the Analyst's `list_span_groups` output carries the new field through to its model.

## Test plan

- [x] `test_list_span_groups_sorts_by_time_so_recent_work_is_one_call` pins the SQL and the resulting order.
- [x] `test_group_order_by_*` pin the whitelist and the rejection of an injected sort key.
- [x] `test_group_sort_enum_matches_repository_sort_fields` keeps the API enum and the repository whitelist from drifting.
- [x] The integration test runs against real ClickHouse. Every span in it shares one trace, yet the two session groups report different start times, which pins the "only matching spans count" semantics.
- [x] Full `services/intake` suite passes: 276 unit, 108 spans integration.
- [x] `plugins/nemo-insights`: 146 passed. The `testbed` failures are `tar --zstd` on macOS, identical on `main`.
- [x] `tools/lint/lint-python-types.sh`, the exact script CI runs: no errors, only pre-existing warnings.
- [x] `ruff check`, `ruff format --check` clean.
- [x] OpenAPI spec regenerated; the diff is purely additive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added span-group sorting by earliest matching span start time.
  * Added ascending (`started_at`) and descending (`-started_at`) sort options.
  * Span-group results now include the earliest matching span’s start timestamp.
  * Updated CLI support and guidance for time-based sorting.

* **Documentation**
  * Updated API and CLI documentation with the new timestamp field and sorting behavior.

* **Tests**
  * Added coverage for timestamp values, ordering, filtering, and invalid sort options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->