### PR TITLE
fix(studio): clarify anonymizer entity mode copy [ASTD-416]

### DIFF
--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.test.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.test.tsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EntitiesSection } from '@studio/routes/AnonymizerBuilderRoute/components/EntitiesSection';
+import { ENTITY_MODE_AUTO } from '@studio/routes/AnonymizerBuilderRoute/constants';
+import {
+  AnonymizerFormData,
+  getAnonymizerFormDefaults,
+} from '@studio/routes/AnonymizerBuilderRoute/schema';
+import { render, screen } from '@testing-library/react';
+import { FC, ReactNode } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+vi.mock('@nemo/sdk/generated/anonymizer/api', () => ({
+  useAnonymizerListEntityLabels: () => ({
+    data: { data: ['email', 'ssn', 'first_name'] },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@studio/hooks/useWorkspaceFromPath', () => ({
+  useWorkspaceFromPath: () => 'default',
+}));
+
+const TestWrapper: FC<{ defaultValues?: Partial<AnonymizerFormData>; children: ReactNode }> = ({
+  defaultValues,
+  children,
+}) => {
+  const methods = useForm<AnonymizerFormData>({
+    defaultValues: { ...getAnonymizerFormDefaults(), ...defaultValues },
+  });
+  return <FormProvider {...methods}>{children}</FormProvider>;
+};
+
+describe('EntitiesSection', () => {
+  it('states that auto-detect includes the defaults and hides the defaults checkbox', async () => {
+    render(
+      <TestWrapper defaultValues={{ entityMode: ENTITY_MODE_AUTO }}>
+        <EntitiesSection />
+      </TestWrapper>
+    );
+
+    expect(
+      await screen.findByText(/Auto-detect includes all 3 default entities/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Also include all 3 default entities/)).not.toBeInTheDocument();
+  });
+
+  it('offers the defaults checkbox in custom mode', async () => {
+    render(
+      <TestWrapper>
+        <EntitiesSection />
+      </TestWrapper>
+    );
+
+    expect(
+      await screen.findByText(/Custom mode only outputs the labels selected below/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('Also include all 3 default entities')).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.test.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.test.tsx
@@ -4,11 +4,11 @@
 import { EntitiesSection } from '@studio/routes/AnonymizerBuilderRoute/components/EntitiesSection';
 import { ENTITY_MODE_AUTO } from '@studio/routes/AnonymizerBuilderRoute/constants';
 import {
-  AnonymizerFormData,
+  type AnonymizerFormData,
   getAnonymizerFormDefaults,
 } from '@studio/routes/AnonymizerBuilderRoute/schema';
 import { render, screen } from '@testing-library/react';
-import { FC, ReactNode } from 'react';
+import type { FC, ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 vi.mock('@nemo/sdk/generated/anonymizer/api', () => ({

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.tsx
@@ -34,7 +34,11 @@ export const EntitiesSection: FC = () => {
   const available = useMemo(() => data?.data ?? [], [data?.data]);
 
   const isCustom = entityMode === ENTITY_MODE_CUSTOM;
+  const isAuto = entityMode === ENTITY_MODE_AUTO;
   const selected = useMemo(() => selectedLabels ?? [], [selectedLabels]);
+  const defaultEntitiesLabel = available.length
+    ? `all ${available.length} default entities`
+    : 'all default entities';
 
   const items = useMemo(() => {
     const sections = buildEntitySections([...available]).map((section) => ({
@@ -65,9 +69,9 @@ export const EntitiesSection: FC = () => {
         useControllerProps={{ name: 'entityMode', control }}
       />
       <Text kind="body/regular/md">
-        {entityMode === ENTITY_MODE_AUTO
-          ? 'Auto-detect mode allows the augmenter to create additional labels beyond the defaults. To restrict the output entities to a defined list, use Custom.'
-          : 'Custom mode only outputs entities defined by you. To allow the augmenter to create additional labels beyond the defaults, use Auto-detect mode.'}
+        {isAuto
+          ? `Auto-detect includes ${defaultEntitiesLabel} and lets the augmenter add more labels it finds. To restrict the output to a defined list, use Custom.`
+          : 'Custom mode only outputs the labels selected below. Auto-detect cannot be combined with custom labels.'}
       </Text>
       {isCustom && (
         <Stack gap="density-md">
@@ -107,11 +111,13 @@ export const EntitiesSection: FC = () => {
           )}
         </Stack>
       )}
-      <ControlledCheckbox
-        slotLabel={`Include all ${available.length} default entities`}
-        disabled={isLoading}
-        useControllerProps={{ name: 'includeDefaultEntities', control }}
-      />
+      {isCustom && (
+        <ControlledCheckbox
+          slotLabel={`Also include ${defaultEntitiesLabel}`}
+          disabled={isLoading}
+          useControllerProps={{ name: 'includeDefaultEntities', control }}
+        />
+      )}
     </Stack>
   );
 };

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.tsx
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/components/EntitiesSection.tsx
@@ -8,8 +8,9 @@ import { useAnonymizerListEntityLabels } from '@nemo/sdk/generated/anonymizer/ap
 import { Flex, Stack, Tag, Text } from '@nvidia/foundations-react-core';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import {
-  ENTITY_MODE_AUTO,
+  defaultEntitiesLabel,
   ENTITY_MODE_CUSTOM,
+  ENTITY_MODE_DESCRIPTIONS,
   ENTITY_MODE_OPTIONS,
   entityTagColor,
 } from '@studio/routes/AnonymizerBuilderRoute/constants';
@@ -34,11 +35,8 @@ export const EntitiesSection: FC = () => {
   const available = useMemo(() => data?.data ?? [], [data?.data]);
 
   const isCustom = entityMode === ENTITY_MODE_CUSTOM;
-  const isAuto = entityMode === ENTITY_MODE_AUTO;
   const selected = useMemo(() => selectedLabels ?? [], [selectedLabels]);
-  const defaultEntitiesLabel = available.length
-    ? `all ${available.length} default entities`
-    : 'all default entities';
+  const defaultsLabel = defaultEntitiesLabel(available.length);
 
   const items = useMemo(() => {
     const sections = buildEntitySections([...available]).map((section) => ({
@@ -68,11 +66,7 @@ export const EntitiesSection: FC = () => {
         items={ENTITY_MODE_OPTIONS}
         useControllerProps={{ name: 'entityMode', control }}
       />
-      <Text kind="body/regular/md">
-        {isAuto
-          ? `Auto-detect includes ${defaultEntitiesLabel} and lets the augmenter add more labels it finds. To restrict the output to a defined list, use Custom.`
-          : 'Custom mode only outputs the labels selected below. Auto-detect cannot be combined with custom labels.'}
-      </Text>
+      <Text kind="body/regular/md">{ENTITY_MODE_DESCRIPTIONS[entityMode](defaultsLabel)}</Text>
       {isCustom && (
         <Stack gap="density-md">
           <ControlledCombobox
@@ -113,7 +107,7 @@ export const EntitiesSection: FC = () => {
       )}
       {isCustom && (
         <ControlledCheckbox
-          slotLabel={`Also include ${defaultEntitiesLabel}`}
+          slotLabel={`Also include ${defaultsLabel}`}
           disabled={isLoading}
           useControllerProps={{ name: 'includeDefaultEntities', control }}
         />

--- a/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
+++ b/web/packages/studio/src/routes/AnonymizerBuilderRoute/constants.ts
@@ -105,6 +105,17 @@ export const ENTITY_MODE_OPTIONS: { value: EntityMode; children: string }[] = [
   { value: ENTITY_MODE_AUTO, children: 'Auto-detect' },
 ];
 
+/** The count comes from the entity-labels endpoint, so it is unknown until that call lands. */
+export const defaultEntitiesLabel = (count: number): string =>
+  count ? `all ${count} default entities` : 'all default entities';
+
+export const ENTITY_MODE_DESCRIPTIONS: Record<EntityMode, (defaults: string) => string> = {
+  [ENTITY_MODE_AUTO]: (defaults) =>
+    `Auto-detect includes ${defaults} and lets the augmenter add more labels it finds. To restrict the output to a defined list, use Custom.`,
+  [ENTITY_MODE_CUSTOM]: () =>
+    'Custom mode only outputs the labels selected below. Auto-detect cannot be combined with custom labels.',
+};
+
 export type EntityTagColor = NonNullable<ComponentProps<typeof Tag>['color']>;
 
 interface EntityCategory {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The Anonymizer builder showed a single "Include all N default entities" checkbox in both entity modes, which implied custom labels and Auto-detect could be combined. They cannot: Auto-detect always runs the full default entity set, and when custom labels are supplied only those labels are used. The Auto-detect view now states the default set inline instead of offering a checkbox that has no effect there.

## Related Issue

ASTD-416

## Changes

- `EntitiesSection`: the "include defaults" checkbox renders only in Custom mode, relabelled `Also include all N default entities`.
- Auto-detect description now reads `Auto-detect includes all N default entities and lets the augmenter add more labels it finds. To restrict the output to a defined list, use Custom.`
- Custom description now reads `Custom mode only outputs the labels selected below. Auto-detect cannot be combined with custom labels.`
- Entity count falls back to "all default entities" while the label list is still loading, so the copy never reads "all 0 default entities".
- New `EntitiesSection.test.tsx` covering both modes.

No request-building behavior changed — `buildDetectConfig` already ignored `includeDefaultEntities` outside Custom mode.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: in-product copy only; no docs page describes these controls.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below — not run repo-wide; the commit-stage hooks ran and passed on the changed files.
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/routes/AnonymizerBuilderRoute` — 7 files, 54 tests passed
- `pnpm --filter nemo-studio-ui typecheck` — clean
- `pnpm lint:fix` (from `web/`) — clean, no changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated anonymizer entity settings with clearer guidance for Auto-detect and Custom modes.
  * Displayed the number of available default entities in relevant instructions and controls.
  * Limited the default-entities checkbox to Custom mode for a more focused configuration experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->