### PR TITLE
chore: remove hardcoded parameters from nooa client

### DIFF
--- a/docs/run-inference/about.mdx
+++ b/docs/run-inference/about.mdx
@@ -292,6 +292,33 @@ working as designed — use `/health/ready` instead.
 
 ---
 
+## Troubleshooting
+
+### Function tools require disabled reasoning
+
+If an OpenAI-compatible Chat Completions request using function tools fails
+with an error like this:
+
+```text
+Function tools with reasoning_effort are not supported for <model> in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.
+```
+
+set `reasoning_effort` in the affected provider's default request body. Replace
+`<provider_name>` and `<workspace>` with the provider and workspace used for
+the request:
+
+```bash
+nemo inference providers update <provider_name> \
+  --workspace <workspace> \
+  --default-extra-body '{"reasoning_effort":"none"}'
+```
+
+Provider requirements differ. Configure only the parameters required by the
+provider and model you use; `--default-extra-body` applies them to requests
+routed through that provider and can be overridden by an individual request.
+
+---
+
 ## API Reference
 
 For complete API details, refer to the [Inference Gateway API Reference](/documentation/reference/api-reference) and [SDK Reference](/documentation/reference/python-sdk).

--- a/docs/run-inference/about.mdx
+++ b/docs/run-inference/about.mdx
@@ -316,6 +316,9 @@ nemo inference providers update <provider_name> \
 Provider requirements differ. Configure only the parameters required by the
 provider and model you use; `--default-extra-body` applies them to requests
 routed through that provider and can be overridden by an individual request.
+For function-tool requests to Chat Completions, any per-request
+`reasoning_effort` override must remain `"none"`; another value causes the
+error described above.
 
 ---
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
@@ -14,7 +14,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 
-from litellm import get_model_info
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform.config import get_context
 from nemo_platform.types.inference import ModelProvider
@@ -24,25 +23,9 @@ from nooa.unifiedllm import CompletionClient, UnifiedLLM
 _PLACEHOLDER_API_KEY = "not-needed"
 _OPENAI_FORMAT = "OPENAI_CHAT"
 _ANTHROPIC_FORMAT = "ANTHROPIC_MESSAGES"
-_OPENAI_CHAT_REASONING_EFFORT = "none"
+_OPENAI_CHAT_REASONING_EFFORT: str | None = None
 _ACCEPT_ENCODING_HEADER = "accept-encoding"
 _IDENTITY_ENCODING = "identity"
-
-
-def _openai_chat_reasoning_effort(model: str) -> str | None:
-    """Disable reasoning unless LiteLLM explicitly says this value is unsupported."""
-    try:
-        model_info = get_model_info(model)
-    except Exception as exc:
-        # Custom provider registrations need not appear in LiteLLM's model map.
-        # Preserve the value that makes frontier Chat Completions tool calls work.
-        if "This model isn't mapped yet" not in str(exc):
-            raise
-        return _OPENAI_CHAT_REASONING_EFFORT
-    if model_info.get("supports_none_reasoning_effort") is False:
-        return None
-    return _OPENAI_CHAT_REASONING_EFFORT
-
 
 @dataclass(frozen=True)
 class ConfiguredModelRefs:
@@ -119,6 +102,7 @@ def _completion_client(
         litellm_model = f"openai/{served_model_name}"
         return CompletionClient(
             litellm_model,
+            **({"reasoning_effort": _OPENAI_CHAT_REASONING_EFFORT} if _OPENAI_CHAT_REASONING_EFFORT else {}),
             api_base=api_base,
             api_key=_PLACEHOLDER_API_KEY,
             # Platform rewrites the response model to the Model Entity ID. Keep
@@ -131,10 +115,6 @@ def _completion_client(
             # LiteLLM versions otherwise bridge GPT-5.4+ tool calls with any
             # reasoning_effort value (including "none") to /responses.
             _skip_responses_api_bridge=True,
-            # Chat Completions tool calls on current OpenAI frontier models
-            # require reasoning to be disabled. Use LiteLLM's capability map to
-            # omit that value only when the served model explicitly rejects it.
-            reasoning_effort=_openai_chat_reasoning_effort(litellm_model),
         )
     elif model_entity.backend_format == _ANTHROPIC_FORMAT:
         api_base = api_base.removesuffix("/v1")

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
@@ -27,6 +27,7 @@ _OPENAI_CHAT_REASONING_EFFORT: str | None = None
 _ACCEPT_ENCODING_HEADER = "accept-encoding"
 _IDENTITY_ENCODING = "identity"
 
+
 @dataclass(frozen=True)
 class ConfiguredModelRefs:
     """Workspace-qualified Model Entity IDs for default and fast agent work."""

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/nooa_model_client.py
@@ -23,7 +23,6 @@ from nooa.unifiedllm import CompletionClient, UnifiedLLM
 _PLACEHOLDER_API_KEY = "not-needed"
 _OPENAI_FORMAT = "OPENAI_CHAT"
 _ANTHROPIC_FORMAT = "ANTHROPIC_MESSAGES"
-_OPENAI_CHAT_REASONING_EFFORT: str | None = None
 _ACCEPT_ENCODING_HEADER = "accept-encoding"
 _IDENTITY_ENCODING = "identity"
 
@@ -103,7 +102,6 @@ def _completion_client(
         litellm_model = f"openai/{served_model_name}"
         return CompletionClient(
             litellm_model,
-            **({"reasoning_effort": _OPENAI_CHAT_REASONING_EFFORT} if _OPENAI_CHAT_REASONING_EFFORT else {}),
             api_base=api_base,
             api_key=_PLACEHOLDER_API_KEY,
             # Platform rewrites the response model to the Model Entity ID. Keep

--- a/packages/nemo_platform_plugin/tests/test_nooa_model_client.py
+++ b/packages/nemo_platform_plugin/tests/test_nooa_model_client.py
@@ -9,7 +9,6 @@ from nemo_platform_plugin import nooa_model_client
 from nemo_platform_plugin.nooa_model_client import (
     ConfiguredModelClients,
     ConfiguredModelRefs,
-    _openai_chat_reasoning_effort,
     activate_model_clients,
     configured_model_refs,
     get_configured_model_refs,
@@ -76,7 +75,6 @@ async def test_resolve_model_clients_deduplicates_same_model(monkeypatch):
         extra_headers={"x-test": "value", "accept-encoding": "identity"},
         drop_params=True,
         _skip_responses_api_bridge=True,
-        reasoning_effort="none",
     )
     assert default_headers == {"x-test": "value"}
 
@@ -177,7 +175,6 @@ async def test_resolve_model_clients_uses_provider_served_name(monkeypatch):
         extra_headers={"accept-encoding": "identity"},
         drop_params=True,
         _skip_responses_api_bridge=True,
-        reasoning_effort="none",
     )
 
 
@@ -251,32 +248,3 @@ async def test_resolve_model_clients_closes_constructed_client_after_failure(mon
         )
 
     constructed.aclose.assert_awaited_once()
-
-
-def test_openai_chat_reasoning_effort_uses_litellm_capability(monkeypatch):
-    monkeypatch.setattr(
-        nooa_model_client,
-        "get_model_info",
-        lambda model: {"supports_none_reasoning_effort": False},
-    )
-
-    assert _openai_chat_reasoning_effort("openai/gpt-5-mini") is None
-
-
-def test_openai_chat_reasoning_effort_preserves_none_for_unmapped_models(monkeypatch):
-    def unmapped(model: str):
-        raise Exception("This model isn't mapped yet")
-
-    monkeypatch.setattr(nooa_model_client, "get_model_info", unmapped)
-
-    assert _openai_chat_reasoning_effort("openai/custom-model") == "none"
-
-
-def test_openai_chat_reasoning_effort_does_not_hide_lookup_failures(monkeypatch):
-    def failed(model: str):
-        raise RuntimeError("model registry failed")
-
-    monkeypatch.setattr(nooa_model_client, "get_model_info", failed)
-
-    with pytest.raises(RuntimeError, match="model registry failed"):
-        _openai_chat_reasoning_effort("openai/gpt-5-mini")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Remove hardcoded parameters from nooa client. 

*Why?* Parameter "none" in reasoning was refused and raised an error.

## Related Issue

There is currently no way to pass parameters configurations to the client model.

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [x] Bug fix
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [] Documentation not applicable — justification: internal change

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified OpenAI request configuration for more predictable handling.
  * Preserved compatibility for supported request flows.

* **Documentation**
  * Added troubleshooting guidance for function-tool errors related to `reasoning_effort`.
  * Explained how to set `reasoning_effort` to `none` for a provider and how request-level settings interact with provider defaults.

* **Tests**
  * Updated validation coverage to reflect the streamlined configuration and preserve existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->