### PR TITLE
fix(Studio): lowercase fileset name generated from first uploaded file

### DIFF
--- a/web/packages/common/src/components/UploadModal/utils.test.ts
+++ b/web/packages/common/src/components/UploadModal/utils.test.ts
@@ -161,11 +161,12 @@ describe('UploadModal utils', () => {
       expect(sanitizeFilenameForDatasetName('file.txt')).toBe('file');
     });
 
-    it('keeps valid characters (alphanumeric, dots, underscores, dashes)', () => {
+    it('lowercases and keeps valid characters (alphanumeric, dots, underscores, dashes)', () => {
       expect(sanitizeFilenameForDatasetName('my-dataset-123.json')).toBe('my-dataset-123');
       expect(sanitizeFilenameForDatasetName('my_dataset_v2.json')).toBe('my_dataset_v2');
       expect(sanitizeFilenameForDatasetName('dataset.v1.0.json')).toBe('dataset.v1.0');
-      expect(sanitizeFilenameForDatasetName('Dataset123.json')).toBe('Dataset123');
+      expect(sanitizeFilenameForDatasetName('Dataset123.json')).toBe('dataset123');
+      expect(sanitizeFilenameForDatasetName('MyDataset.JSON')).toBe('mydataset');
     });
 
     it('replaces invalid characters with underscores', () => {

--- a/web/packages/common/src/components/UploadModal/utils.ts
+++ b/web/packages/common/src/components/UploadModal/utils.ts
@@ -67,8 +67,8 @@ export const sanitizeFilenameForDatasetName = (filename: string): string => {
   // Remove file extension
   const nameWithoutExtension = filename.replace(/\.[^/.]+$/, '');
 
-  // Replace any character that's not alphanumeric, dot, underscore, or dash with an underscore
-  const sanitized = nameWithoutExtension.replace(/[^a-zA-Z0-9._-]/g, '_');
+  // Replace invalid chars with underscores, then lowercase for a valid name.
+  const sanitized = nameWithoutExtension.replace(/[^a-zA-Z0-9._-]/g, '_').toLowerCase();
 
   // If the result is empty or contains only underscores, return an empty name,
   // dataset names cannot be changed, so we return an empty name.


### PR DESCRIPTION
The upload modal derives a new fileset's name from the first uploaded file via sanitizeFilenameForDatasetName. Lowercase that generated name.

Resolves ASTD-313

## Changes
Adds `.toLowerCase()` to the preexisting `sanitizeFilenameForDatasetName()` to satisfy validation.
Updates tests to support change

- **Type of Change:** Code change (feature, bug fix, or refactor)
- **Quality Gates:** Tests updated for changed behavior

## Verification


https://github.com/user-attachments/assets/f9d748f0-4cdf-4284-a48b-7893daa12666



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dataset names generated from uploaded filenames are now consistently lowercase.
  - Uppercase file extensions and characters are normalized during filename sanitization.
- **Tests**
  - Added coverage to verify lowercase conversion for filenames and extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->