### PR TITLE
docs: record the Fabric agent-eval false-failure known issue

### DIFF
--- a/docs/about/release-notes/current-release.mdx
+++ b/docs/about/release-notes/current-release.mdx
@@ -207,21 +207,9 @@ workflows against the upgraded checkout.
 
 ## Known issues
 
-- **Fabric agent-eval trials can be scored as failures after successful runs.**
-  An agent-eval trial run through a NeMo Fabric adapter can be recorded as an
-  adapter failure even though the agent completed its work and produced the
-  expected output. It affects agents whose graph runs nodes concurrently, and
-  it can occur at any parallelism, including one. NeMo Relay closes telemetry
-  scopes in strict last-in-first-out order, but concurrent LangGraph sibling
-  runs finish in an order that can leave a scope open; the enclosing request
-  scope then fails to close with `scope handle is not at the top of the stack`,
-  and the Fabric adapter reports that teardown error as an invocation failure.
-  Affected trials are scored as failures, so evaluation results can understate
-  an agent's accuracy. There is no workaround in this release. The underlying
-  defect is fixed upstream in
-  [NeMo-Relay #755](https://github.com/NVIDIA/NeMo-Relay/pull/755); the fix
-  reaches NeMo Platform once NeMo Relay publishes a release containing it and
-  NeMo Fabric updates its NeMo Relay dependency.
+- **Deep Agents trials can be scored as failures.** Agent-eval trials run
+  through the NeMo Fabric Deep Agents adapter can be recorded as failures even
+  when the agent completed successfully. Fixed in a future release.
 
 ## Links
 

--- a/docs/about/release-notes/current-release.mdx
+++ b/docs/about/release-notes/current-release.mdx
@@ -209,7 +209,7 @@ workflows against the upgraded checkout.
 
 - **Deep Agents trials can be scored as failures.** Agent-eval trials run
   through the NeMo Fabric Deep Agents adapter can be recorded as failures even
-  when the agent completed successfully. Fixed in a future release.
+  when the agent completed successfully. This will be fixed in the next release.
 
 ## Links
 

--- a/docs/about/release-notes/current-release.mdx
+++ b/docs/about/release-notes/current-release.mdx
@@ -205,6 +205,24 @@ workflows against the upgraded checkout.
 - **Python support.** Python 3.11 is no longer part of the supported source
   checkout or `nemo-platform` distribution matrix.
 
+## Known issues
+
+- **Fabric agent-eval trials can be scored as failures after successful runs.**
+  An agent-eval trial run through a NeMo Fabric adapter can be recorded as an
+  adapter failure even though the agent completed its work and produced the
+  expected output. It affects agents whose graph runs nodes concurrently, and
+  it can occur at any parallelism, including one. NeMo Relay closes telemetry
+  scopes in strict last-in-first-out order, but concurrent LangGraph sibling
+  runs finish in an order that can leave a scope open; the enclosing request
+  scope then fails to close with `scope handle is not at the top of the stack`,
+  and the Fabric adapter reports that teardown error as an invocation failure.
+  Affected trials are scored as failures, so evaluation results can understate
+  an agent's accuracy. There is no workaround in this release. The underlying
+  defect is fixed upstream in
+  [NeMo-Relay #755](https://github.com/NVIDIA/NeMo-Relay/pull/755); the fix
+  reaches NeMo Platform once NeMo Relay publishes a release containing it and
+  NeMo Fabric updates its NeMo Relay dependency.
+
 ## Links
 
 - Repository: [https://github.com/NVIDIA-NeMo/nemo-platform](https://github.com/NVIDIA-NeMo/nemo-platform)


### PR DESCRIPTION
#### Overview

**What.** Documents the Fabric agent-eval false-failure as a known issue in the current release notes.

**Why.** A trial run through a NeMo Fabric adapter can be scored as an adapter failure even though the agent completed its work and produced the expected output, so evaluation results can understate an agent's accuracy. Users have no workaround in this release, and the fix cannot ship here yet, so the behaviour needs to be stated rather than left to be rediscovered.

#### Details

The root cause is upstream, not in the evaluator: NeMo Relay closes telemetry scopes strictly LIFO, but LangGraph schedules concurrent sibling chain runs that finish in an order the stack rejects. Relay's LangChain callback handler dropped the rejected close and left the scope live, so the enclosing request scope failed with `scope handle is not at the top of the stack`, and the Fabric adapter reported that teardown error as an invocation failure. It reproduces at any parallelism, including one.

Fixed upstream in [NeMo-Relay #755](https://github.com/NVIDIA/NeMo-Relay/pull/755), merged to `release/0.7`. It cannot reach NeMo Platform yet: Relay has not cut a release containing it, and NeMo Fabric pins `nemo-relay>=0.6.0,<0.7`, which excludes the whole 0.7 line. So the chain is a Relay 0.7.x release, then a Fabric dependency update, then a Fabric rev bump here.

This supersedes #1205, an evaluator-side mitigation that treated the teardown error as non-fatal. That worked around the symptom rather than fixing it, so it is closed in favour of the upstream fix plus this disclosure.

Placed under a new `## Known issues` heading rather than in `## Current constraints`, since that section lists intentional scope limits and this is a defect.

**Testing.** Docs-only change; no code paths affected. `pre-commit` passes on the changed file.

**Breaking changes.** None.

#### Where should the reviewer start?

`docs/about/release-notes/current-release.mdx` — the new `## Known issues` section. Worth checking the impact wording is right for a public docs surface.

#### Related Issues:

- Relates to AALGO-495
- Relates to NVBug 6562846


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Known Issues section documenting that Deep Agents trials using the NeMo Fabric adapter may be recorded as failures even when agent execution completes successfully.
  * Noted that this issue is fixed in a future release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->