### PR TITLE
refactor(studio): share CreateSecretModal and page draining via @nemo/common

### DIFF
--- a/plugins/example-plugin/web/AGENTS.md
+++ b/plugins/example-plugin/web/AGENTS.md
@@ -112,7 +112,10 @@ import { StudioDataView, useStudioDataViewState } from '@nemo/common';
   host: {
     workspaceId: string;
     auth: { accessToken: string; getAccessToken: () => string };
-    sdk: { platform: /* @nemo/sdk platform hooks */ };
+    sdk: {
+      platform: /* @nemo/sdk platform hooks */;
+      agents: /* @nemo/sdk agents hooks and functions */;
+    };
     navigation: { navigate: (to: string) => void; back: () => void };
     notifications: {
       notify: (

--- a/plugins/example-plugin/web/AGENTS.md
+++ b/plugins/example-plugin/web/AGENTS.md
@@ -45,8 +45,9 @@ clears it, or the trail follows you to the next page. See `src/SharedUiPage.tsx`
 Studio's `QueryClientProvider` (one cache across Studio and every plugin). Put the
 `host.auth.getAccessToken()` Bearer token in your `queryFn`.
 
-Studio's **SDK** arrives on `host.sdk`, not via an import. `host.sdk.platform` is
-the platform service's generated hooks; call them at the top level like any hook
+Studio's **SDK** arrives on `host.sdk`, not via an import. `host.sdk.platform` and
+`host.sdk.agents` are those services' generated hooks and functions; call the hooks
+at the top level like any hook
 (e.g. `host.sdk.platform.useEntitiesListWorkspaces({ page: 1, page_size: 100 })`,
 see `src/Root.tsx`). They run on Studio's one configured axios instance (base URL +
 OIDC interceptor) and the shared QueryClient — a plugin never bundles or
@@ -78,6 +79,13 @@ import { StudioDataView, useStudioDataViewState } from '@nemo/common';
   export is already a tsc error, so `pnpm typecheck` covers that half.
 - **`plugin.ts` is the API.** Need something Studio has but the barrel doesn't
   export? Add it there — additions are cheap, removals are breaking.
+- **Nothing in the barrel may call the API.** The vendor build resolves
+  `@nemo/sdk` to source rather than externalizing it, and defines only
+  `process.env.NODE_ENV` — so a bundled fetcher would read an undefined
+  `import.meta.env` for its base URL and OIDC keys. Type-only SDK imports are
+  fine (they erase). A shared component that needs data takes it as a prop or
+  callback and the caller supplies it from `host.sdk`; `CreateSecretModal`'s
+  `onCreate` and `fetchAllPages`' page fetcher are the pattern.
 - **Types come from source**, via `paths` in `tsconfig.json`; `@nemo/common` is
   unpublished, so there is nothing to install. `src/env.d.ts` declares the `*.css`
   side-effect imports those sources carry.
@@ -87,10 +95,10 @@ import { StudioDataView, useStudioDataViewState } from '@nemo/common';
   router — two DataViews on one route will fight over them.
 - **Toasts need `onNotify`.** `ToastProvider` is *not* shared: Studio mounts it
   by deep import, so this bundle carries its own `ToastContext` with nothing in
-  it. `ConfirmationModal`, `DeleteConfirmationModal` and `LogViewer` therefore
-  take an `onNotify` prop — pass `host.notifications.notify` and the message
-  lands in Studio's toaster. Omit it and the message is dropped with a
-  `logger.warn`; nothing throws, so the miss is silent in the UI.
+  it. `ConfirmationModal`, `DeleteConfirmationModal`, `CreateSecretModal` and
+  `LogViewer` therefore take an `onNotify` prop — pass `host.notifications.notify`
+  and the message lands in Studio's toaster. Omit it and the message is dropped
+  with a `logger.warn`; nothing throws, so the miss is silent in the UI.
 
   ```tsx
   <DeleteConfirmationModal onNotify={host.notifications.notify} ... />

--- a/web/packages/common/package.json
+++ b/web/packages/common/package.json
@@ -38,6 +38,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@hookform/resolvers": "^4.1.3",
     "@nemo/testing": "workspace:*",
     "@storybook/react": "catalog:",
     "@testing-library/dom": "catalog:",

--- a/web/packages/common/src/api/fetchAllPages.test.ts
+++ b/web/packages/common/src/api/fetchAllPages.test.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { fetchAllPages, type PaginatedResponse } from '@nemo/common/src/api/fetchAllPages';
+
+const page = (data: number[], totalPages?: number): PaginatedResponse<number> => ({
+  data,
+  pagination: totalPages === undefined ? undefined : { total_pages: totalPages },
+});
+
+describe('fetchAllPages', () => {
+  it('concatenates every page up to total_pages', async () => {
+    const fetchPage = vi
+      .fn<(p: number, size: number) => Promise<PaginatedResponse<number>>>()
+      .mockResolvedValueOnce(page([1, 2], 3))
+      .mockResolvedValueOnce(page([3, 4], 3))
+      .mockResolvedValueOnce(page([5], 3));
+
+    await expect(fetchAllPages(fetchPage, { pageSize: 2 })).resolves.toEqual([1, 2, 3, 4, 5]);
+    expect(fetchPage.mock.calls).toEqual([
+      [1, 2],
+      [2, 2],
+      [3, 2],
+    ]);
+  });
+
+  it('stops on a short page when the response omits total_pages', async () => {
+    const fetchPage = vi
+      .fn<(p: number, size: number) => Promise<PaginatedResponse<number>>>()
+      .mockResolvedValueOnce(page([1, 2]))
+      .mockResolvedValueOnce(page([3]));
+
+    await expect(fetchAllPages(fetchPage, { pageSize: 2 })).resolves.toEqual([1, 2, 3]);
+    expect(fetchPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a missing data array as an empty page', async () => {
+    const fetchPage = vi.fn().mockResolvedValue({});
+
+    await expect(fetchAllPages(fetchPage)).resolves.toEqual([]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('truncates at maxPages rather than looping forever', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchPage = vi.fn().mockResolvedValue(page([1, 2]));
+
+    await expect(fetchAllPages(fetchPage, { pageSize: 2, maxPages: 3 })).resolves.toEqual([
+      1, 2, 1, 2, 1, 2,
+    ]);
+    expect(fetchPage).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('truncated'));
+    warn.mockRestore();
+  });
+});

--- a/web/packages/common/src/api/fetchAllPages.ts
+++ b/web/packages/common/src/api/fetchAllPages.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { logger } from '@nemo/common/src/utils/logger';
+
+export const DEFAULT_FETCH_ALL_PAGE_SIZE = 100;
+export const DEFAULT_FETCH_ALL_MAX_PAGES = 1000;
+
+export interface PaginatedResponse<T> {
+  data?: T[];
+  pagination?: { total_pages?: number };
+}
+
+export interface FetchAllPagesOptions {
+  pageSize?: number;
+  maxPages?: number;
+}
+
+/**
+ * Drains a page-numbered list endpoint. Takes the fetcher rather than the SDK
+ * function so it stays free of `@nemo/sdk` and can ship in the plugin surface.
+ */
+export const fetchAllPages = async <T>(
+  fetchPage: (page: number, pageSize: number) => Promise<PaginatedResponse<T>>,
+  {
+    pageSize = DEFAULT_FETCH_ALL_PAGE_SIZE,
+    maxPages = DEFAULT_FETCH_ALL_MAX_PAGES,
+  }: FetchAllPagesOptions = {}
+): Promise<T[]> => {
+  const all: T[] = [];
+
+  for (let page = 1; page <= maxPages; page += 1) {
+    const response = await fetchPage(page, pageSize);
+    const batch = response.data ?? [];
+    all.push(...batch);
+
+    const totalPages = response.pagination?.total_pages;
+    if (totalPages ? page >= totalPages : batch.length < pageSize) return all;
+
+    if (page === maxPages) {
+      logger.warn(`[fetchAllPages] stopped at the ${maxPages}-page cap; results are truncated`);
+    }
+  }
+
+  return all;
+};

--- a/web/packages/common/src/components/CreateSecretModal/index.test.tsx
+++ b/web/packages/common/src/components/CreateSecretModal/index.test.tsx
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { CreateSecretModal } from '@nemo/common/src/components/CreateSecretModal';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// KUI's FormField root carries the same aria-label as the input, so scope to the input.
+const field = (label: string): HTMLElement => screen.getByLabelText(label, { selector: 'input' });
+
+const fillForm = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(field('Name'), 'my-secret');
+  await user.type(field('Value'), 'hunter2');
+};
+
+describe('CreateSecretModal', () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits the form values, notifies, and closes', async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    const onNotify = vi.fn();
+
+    render(<CreateSecretModal open onClose={onClose} onCreate={onCreate} onNotify={onNotify} />);
+
+    await fillForm(user);
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith({
+        name: 'my-secret',
+        description: '',
+        value: 'hunter2',
+      })
+    );
+    expect(onNotify).toHaveBeenCalledWith('Secret created successfully', 'success', undefined);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('stays open when onCreate rejects', async () => {
+    const onCreate = vi.fn().mockRejectedValue(new Error('boom'));
+    const onClose = vi.fn();
+    const onNotify = vi.fn();
+
+    render(
+      <CreateSecretModal
+        open
+        onClose={onClose}
+        onCreate={onCreate}
+        onNotify={onNotify}
+        errorText="Secret already exists"
+      />
+    );
+
+    await fillForm(user);
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onNotify).not.toHaveBeenCalled();
+    expect(screen.getByText('Secret already exists')).toBeInTheDocument();
+  });
+
+  it('does not submit without a value', async () => {
+    const onCreate = vi.fn();
+
+    render(<CreateSecretModal open onClose={vi.fn()} onCreate={onCreate} onNotify={vi.fn()} />);
+
+    await user.type(field('Name'), 'my-secret');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await screen.findByText('Secret value is required');
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/common/src/components/CreateSecretModal/index.tsx
+++ b/web/packages/common/src/components/CreateSecretModal/index.tsx
@@ -1,0 +1,132 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { FormModal, FormModalProps } from '@nemo/common/src/components/FormModal';
+import type { NotifyFn } from '@nemo/common/src/providers/toast/types';
+import { useNotify } from '@nemo/common/src/providers/toast/useNotify';
+import { ENTITY_NAME_HELP, entityNameSchema } from '@nemo/common/src/utils/entityName';
+import { Stack } from '@nvidia/foundations-react-core';
+import { FC } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+const secretFormSchema = z.object({
+  name: entityNameSchema('Name'),
+  description: z.string().optional(),
+  value: z.string().min(1, 'Secret value is required'),
+});
+
+export type CreateSecretFormData = z.infer<typeof secretFormSchema>;
+
+const defaultValues: CreateSecretFormData = {
+  name: '',
+  description: '',
+  value: '',
+};
+
+export interface CreateSecretModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
+  /** Performs the create. Rejecting leaves the modal open; the caller surfaces the reason via `errorText`. */
+  onCreate: (data: CreateSecretFormData) => Promise<void>;
+  pending?: boolean;
+  errorText?: string;
+  /** Where result messages go. Defaults to the surrounding ToastProvider; plugins pass `host.notifications.notify`. */
+  onNotify?: NotifyFn;
+}
+
+export const CreateSecretModal: FC<CreateSecretModalProps> = ({
+  onCreate,
+  pending = false,
+  errorText,
+  onNotify,
+  open,
+  onClose,
+}) => {
+  const notify = useNotify(onNotify);
+
+  const {
+    control,
+    reset: resetForm,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(secretFormSchema),
+    defaultValues,
+    disabled: pending,
+    mode: 'onChange',
+  });
+
+  const resetAndClose = () => {
+    resetForm(defaultValues);
+    onClose();
+  };
+
+  const onSubmit: SubmitHandler<CreateSecretFormData> = async (formData) => {
+    try {
+      await onCreate(formData);
+      notify('Secret created successfully', 'success');
+      resetAndClose();
+    } catch {
+      // Reported through errorText; the modal stays open so the value isn't lost.
+    }
+  };
+
+  return (
+    <FormModal
+      open={open}
+      onClose={resetAndClose}
+      title="Create Secret"
+      instruction="To create a new secret, provide a name, description, and value. "
+      submitButtonText="Create"
+      onSubmit={handleSubmit(onSubmit)}
+      disabled={pending}
+      loading={pending}
+      errorText={errorText}
+    >
+      <Stack gap="density-xl">
+        <ControlledTextInput
+          useControllerProps={{ control, name: 'name' }}
+          name="name"
+          label="Name"
+          formFieldProps={{
+            slotInfo:
+              'Best practice: Use lowercase letters, numbers, and hyphens only to ensure compatibility with Kubernetes naming conventions.',
+            slotHelp: ENTITY_NAME_HELP,
+            slotError: errors.name?.message,
+          }}
+        />
+        <ControlledTextArea
+          useControllerProps={{ control, name: 'description' }}
+          name="description"
+          label="Description (optional)"
+          formFieldProps={{
+            slotError: errors.description?.message,
+          }}
+          rows={2}
+        />
+        <ControlledTextInput
+          masked
+          useControllerProps={{ control, name: 'value' }}
+          name="value"
+          label="Value"
+          formFieldProps={{
+            slotInfo:
+              'For security, the secret value will be encrypted and not displayed after creation.',
+            slotError: errors.value?.message,
+          }}
+        />
+      </Stack>
+    </FormModal>
+  );
+};

--- a/web/packages/common/src/components/CreateSecretModal/index.tsx
+++ b/web/packages/common/src/components/CreateSecretModal/index.tsx
@@ -13,13 +13,13 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
 import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
-import { FormModal, FormModalProps } from '@nemo/common/src/components/FormModal';
+import { FormModal, type FormModalProps } from '@nemo/common/src/components/FormModal';
 import type { NotifyFn } from '@nemo/common/src/providers/toast/types';
 import { useNotify } from '@nemo/common/src/providers/toast/useNotify';
 import { ENTITY_NAME_HELP, entityNameSchema } from '@nemo/common/src/utils/entityName';
 import { Stack } from '@nvidia/foundations-react-core';
-import { FC } from 'react';
-import { SubmitHandler, useForm } from 'react-hook-form';
+import type { FC } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 const secretFormSchema = z.object({
@@ -75,11 +75,12 @@ export const CreateSecretModal: FC<CreateSecretModalProps> = ({
   const onSubmit: SubmitHandler<CreateSecretFormData> = async (formData) => {
     try {
       await onCreate(formData);
-      notify('Secret created successfully', 'success');
-      resetAndClose();
     } catch {
       // Reported through errorText; the modal stays open so the value isn't lost.
+      return;
     }
+    notify('Secret created successfully', 'success');
+    resetAndClose();
   };
 
   return (

--- a/web/packages/common/src/plugin.ts
+++ b/web/packages/common/src/plugin.ts
@@ -7,6 +7,11 @@
 export { AccessibleTitle } from '@nemo/common/src/components/AccessibleTitle';
 export { AccordionSection } from '@nemo/common/src/components/AccordionSection';
 export { ConfirmationModal } from '@nemo/common/src/components/ConfirmationModal';
+export { CreateSecretModal } from '@nemo/common/src/components/CreateSecretModal';
+export type {
+  CreateSecretFormData,
+  CreateSecretModalProps,
+} from '@nemo/common/src/components/CreateSecretModal';
 export { DeleteConfirmationModal } from '@nemo/common/src/components/DeleteConfirmationModal';
 export type { AccordionSectionProps } from '@nemo/common/src/components/AccordionSection';
 export { ExpandableMessage } from '@nemo/common/src/components/ExpandableMessage';
@@ -52,6 +57,9 @@ export type {
 
 export { withOperators } from '@nemo/common/src/api/filterOperators';
 export type { FilterOperators, WithFilterOperators } from '@nemo/common/src/api/filterOperators';
+
+export { fetchAllPages } from '@nemo/common/src/api/fetchAllPages';
+export type { FetchAllPagesOptions, PaginatedResponse } from '@nemo/common/src/api/fetchAllPages';
 
 export {
   getJobRefetchInterval,

--- a/web/packages/studio/src/components/agents/AgentBlockingInput/agentQueries.ts
+++ b/web/packages/studio/src/components/agents/AgentBlockingInput/agentQueries.ts
@@ -1,31 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { fetchAllPages } from '@nemo/common/src/api/fetchAllPages';
 import { agentsListAgents } from '@nemo/sdk/generated/agents/api';
 import type { Agent } from '@nemo/sdk/generated/agents/schema';
 
-const AGENTS_PAGE_SIZE = 100;
-
-export const fetchAgentsForSelect = async (
-  workspace: string,
-  signal: AbortSignal
-): Promise<Agent[]> => {
-  const allAgents: Agent[] = [];
-  let page = 1;
-
-  while (true) {
-    const response = await agentsListAgents(
-      workspace,
-      { page, page_size: AGENTS_PAGE_SIZE, sort: 'name' },
-      signal
-    );
-    const batch = response.data ?? [];
-    allAgents.push(...batch);
-
-    const totalPages = response.pagination?.total_pages;
-    if (totalPages ? page >= totalPages : batch.length < AGENTS_PAGE_SIZE) break;
-    page += 1;
-  }
-
-  return allAgents;
-};
+export const fetchAgentsForSelect = (workspace: string, signal: AbortSignal): Promise<Agent[]> =>
+  fetchAllPages((page, pageSize) =>
+    agentsListAgents(workspace, { page, page_size: pageSize, sort: 'name' }, signal)
+  );

--- a/web/packages/studio/src/plugins/PluginRenderer.test.tsx
+++ b/web/packages/studio/src/plugins/PluginRenderer.test.tsx
@@ -105,6 +105,7 @@ describe('PluginRenderer', () => {
     expect(capturedProps?.host.auth.accessToken).toBe('test-token');
     expect(capturedProps?.host.auth.getAccessToken()).toBe('test-token');
     expect(typeof capturedProps?.host.sdk.platform.useEntitiesListWorkspaces).toBe('function');
+    expect(typeof capturedProps?.host.sdk.agents.agentsListAgents).toBe('function');
     expect(typeof capturedProps?.host.navigation.navigate).toBe('function');
     expect(typeof capturedProps?.host.notifications.notify).toBe('function');
     expect(typeof capturedProps?.host.telemetry.event).toBe('function');

--- a/web/packages/studio/src/plugins/PluginRenderer.tsx
+++ b/web/packages/studio/src/plugins/PluginRenderer.tsx
@@ -3,6 +3,7 @@
 
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { logger } from '@nemo/common/src/utils/logger';
+import * as agentsSdk from '@nemo/sdk/generated/agents/api';
 import * as platformSdk from '@nemo/sdk/generated/platform/api';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { usePlugins, usePluginsLoaded } from '@studio/plugins/PluginContext';
@@ -19,7 +20,7 @@ import { useAuth } from 'react-oidc-context';
 import { useNavigate, useParams } from 'react-router';
 
 // Module-scope for stable identity; plugins run these on Studio's axios + cache.
-const STUDIO_SDK: PluginSdk = { platform: platformSdk };
+const STUDIO_SDK: PluginSdk = { platform: platformSdk, agents: agentsSdk };
 
 const makeTelemetry = (name: string): PluginTelemetry => ({
   info: (message, cause) => logger.info(`[plugin:${name}] ${message}`, cause),

--- a/web/packages/studio/src/plugins/types.ts
+++ b/web/packages/studio/src/plugins/types.ts
@@ -10,6 +10,7 @@ import type { ComponentType, ReactNode } from 'react';
  */
 export interface PluginSdk {
   platform: typeof import('@nemo/sdk/generated/platform/api');
+  agents: typeof import('@nemo/sdk/generated/agents/api');
 }
 
 /** Navigate Studio's shared router; paths are absolute Studio routes. */

--- a/web/packages/studio/src/routes/SecretsListRoute/CreateSecretModal/index.tsx
+++ b/web/packages/studio/src/routes/SecretsListRoute/CreateSecretModal/index.tsx
@@ -21,7 +21,7 @@ import {
   useSecretsCreateSecret,
 } from '@nemo/sdk/generated/platform/api';
 import { useQueryClient } from '@tanstack/react-query';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 interface CreateSecretModalProps extends Pick<BaseProps, 'open' | 'onClose'> {
   workspace: string;

--- a/web/packages/studio/src/routes/SecretsListRoute/CreateSecretModal/index.tsx
+++ b/web/packages/studio/src/routes/SecretsListRoute/CreateSecretModal/index.tsx
@@ -10,38 +10,20 @@
  * its affiliates is strictly prohibited.
  */
 
-import { zodResolver } from '@hookform/resolvers/zod';
 import { getErrorMessage } from '@nemo/common/src/api/common/utils';
-import { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
-import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
-import { FormModal, FormModalProps } from '@nemo/common/src/components/FormModal';
-import { useToast } from '@nemo/common/src/providers/toast/useToast';
-import { ENTITY_NAME_HELP, entityNameSchema } from '@nemo/common/src/utils/entityName';
+import {
+  CreateSecretModal as CreateSecretModalBase,
+  type CreateSecretFormData,
+  type CreateSecretModalProps as BaseProps,
+} from '@nemo/common/src/components/CreateSecretModal';
 import {
   getSecretsListSecretsQueryKey,
   useSecretsCreateSecret,
 } from '@nemo/sdk/generated/platform/api';
-import { Stack } from '@nvidia/foundations-react-core';
 import { useQueryClient } from '@tanstack/react-query';
 import { FC } from 'react';
-import { SubmitHandler, useForm } from 'react-hook-form';
-import { z } from 'zod';
 
-const secretFormSchema = z.object({
-  name: entityNameSchema('Name'),
-  description: z.string().optional(),
-  value: z.string().min(1, 'Secret value is required'),
-});
-
-type SecretFormData = z.infer<typeof secretFormSchema>;
-
-const defaultValues: SecretFormData = {
-  name: '',
-  description: '',
-  value: '',
-};
-
-interface CreateSecretModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
+interface CreateSecretModalProps extends Pick<BaseProps, 'open' | 'onClose'> {
   workspace: string;
   /** Optional. After create, called with the new secret name (e.g. create-dataset flow sets the Secret Key field). */
   onSecretCreated?: (secretName: string) => void;
@@ -53,7 +35,6 @@ export const CreateSecretModal: FC<CreateSecretModalProps> = ({
   onClose,
   onSecretCreated,
 }) => {
-  const toast = useToast();
   const queryClient = useQueryClient();
 
   const {
@@ -61,99 +42,26 @@ export const CreateSecretModal: FC<CreateSecretModalProps> = ({
     error: createError,
     isPending,
     reset: resetCreateMutation,
-  } = useSecretsCreateSecret({
-    mutation: {
-      onSuccess: (data) => {
-        onSecretCreated?.(data.name);
-        toast.success('Secret created successfully');
-        queryClient.invalidateQueries({ queryKey: getSecretsListSecretsQueryKey(workspace) });
-        resetAndClose();
-      },
-    },
-  });
+  } = useSecretsCreateSecret();
 
-  const {
-    control,
-    reset: resetForm,
-    handleSubmit,
-    formState: { errors },
-  } = useForm({
-    resolver: zodResolver(secretFormSchema),
-    defaultValues,
-    disabled: isPending,
-    mode: 'onChange',
-  });
-
-  const reset = () => {
-    resetCreateMutation();
-    resetForm(defaultValues);
+  const handleCreate = async (data: CreateSecretFormData): Promise<void> => {
+    const secret = await createSecret({ workspace, data });
+    onSecretCreated?.(secret.name);
+    queryClient.invalidateQueries({ queryKey: getSecretsListSecretsQueryKey(workspace) });
   };
 
-  const resetAndClose = () => {
-    reset();
+  const handleClose = () => {
+    resetCreateMutation();
     onClose();
   };
 
-  const onSubmit: SubmitHandler<SecretFormData> = async (formData) => {
-    try {
-      await createSecret({
-        workspace,
-        data: {
-          name: formData.name,
-          description: formData.description,
-          value: formData.value,
-        },
-      });
-    } catch {
-      // Error handling is done via toast in mutation onError
-    }
-  };
-
   return (
-    <FormModal
+    <CreateSecretModalBase
       open={open}
-      onClose={resetAndClose}
-      title="Create Secret"
-      instruction="To create a new secret, provide a name, description, and value. "
-      submitButtonText="Create"
-      onSubmit={handleSubmit(onSubmit)}
-      disabled={isPending}
-      loading={isPending}
+      onClose={handleClose}
+      onCreate={handleCreate}
+      pending={isPending}
       errorText={createError ? getErrorMessage(createError) : undefined}
-    >
-      <Stack gap="density-xl">
-        <ControlledTextInput
-          useControllerProps={{ control, name: 'name' }}
-          name="name"
-          label="Name"
-          formFieldProps={{
-            slotInfo:
-              'Best practice: Use lowercase letters, numbers, and hyphens only to ensure compatibility with Kubernetes naming conventions.',
-            slotHelp: ENTITY_NAME_HELP,
-            slotError: errors.name?.message,
-          }}
-        />
-        <ControlledTextArea
-          useControllerProps={{ control, name: 'description' }}
-          name="description"
-          label="Description (optional)"
-          formFieldProps={{
-            slotError: errors.description?.message,
-          }}
-          rows={2}
-        />
-        <ControlledTextInput
-          masked
-          useControllerProps={{ control, name: 'value' }}
-          name="value"
-          label="Value"
-          formFieldProps={{
-            slotInfo:
-              'For security, the secret value will be encrypted and not displayed after creation.',
-            slotError: errors.value?.message,
-          }}
-        />
-      </Stack>
-    </FormModal>
+    />
   );
 };

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -401,6 +401,9 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@hookform/resolvers':
+        specifier: ^4.1.3
+        version: 4.1.3(react-hook-form@7.71.2(react@19.2.7))
       '@nemo/testing':
         specifier: workspace:*
         version: link:../testing
@@ -11472,7 +11475,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(msw@2.13.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(vite@8.0.16(@types/node@24.12.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(msw@2.13.3(@types/node@25.5.0)(typescript@7.0.2))(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
 
   '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(@typescript/typescript6@6.0.2)(eslint@10.2.1(jiti@2.6.1)))(@typescript/typescript6@6.0.2)(eslint@10.2.1(jiti@2.6.1)))(@typescript/typescript6@6.0.2)(eslint@10.2.1(jiti@2.6.1))(vitest@4.1.10)':
     dependencies:
@@ -11511,6 +11514,7 @@ snapshots:
     optionalDependencies:
       msw: 2.13.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2)
       vite: 8.0.16(@types/node@24.12.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3)
+    optional: true
 
   '@vitest/mocker@4.1.10(msw@2.13.3(@types/node@24.12.0)(typescript@7.0.2))(vite@8.0.16(@types/node@24.12.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
@@ -11565,7 +11569,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(msw@2.13.3(@types/node@24.12.0)(@typescript/typescript6@6.0.2))(vite@8.0.16(@types/node@24.12.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(msw@2.13.3(@types/node@25.5.0)(typescript@7.0.2))(vite@8.0.16(@types/node@25.5.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -15501,6 +15505,7 @@ snapshots:
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
+    optional: true
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@29.1.1)(msw@2.13.3(@types/node@24.12.0)(typescript@7.0.2))(vite@8.0.16(@types/node@24.12.0)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

`CreateSecretModal` and `fetchAgentsForSelect` were Studio-internal with no shared equivalent, so a Studio plugin could not reuse either. Both called the generated SDK directly, which is what blocked the move: the plugin vendor build resolves `@nemo/sdk` to source instead of externalizing it and defines only `process.env.NODE_ENV`, so a fetcher bundled into `common.js` would read an undefined `import.meta.env` for its base URL and OIDC keys. Each piece is now split along that line — the presentational/generic half moves to `@nemo/common` and onto the plugin surface, the SDK-bound half stays with the caller — so behavior in Studio is unchanged and plugins can now use both.

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

None.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Add `@nemo/common/src/components/CreateSecretModal` — the form schema, fields and `FormModal` shell, taking `onCreate` / `pending` / `errorText` / `onNotify`. It uses `useNotify(onNotify)` rather than `useToast`, matching `ConfirmationModal` and `DeleteConfirmationModal`, because `ToastProvider` is not shared across the plugin boundary.
- Add `@nemo/common/src/api/fetchAllPages` — a generic page-drainer that takes the page fetcher as an argument, so it carries no `@nemo/sdk` import. It replaces the previous `while (true)` with a `maxPages` cap that `logger.warn`s when it truncates.
- Export both (and their types) from `web/packages/common/src/plugin.ts`.
- Reduce `web/packages/studio/src/routes/SecretsListRoute/CreateSecretModal` to a wrapper owning the `useSecretsCreateSecret` mutation, `onSecretCreated`, and the `getSecretsListSecretsQueryKey` invalidation. Its props are unchanged, so all six existing call sites are untouched.
- Rewrite `agentQueries.ts`'s `fetchAgentsForSelect` on `fetchAllPages` (31 → 11 lines), signature unchanged.
- Add `agents` to `PluginSdk` and supply it from `PluginRenderer`, so a plugin can provide its own page fetcher for the agents service the same way `platform` is already provided.
- Add `@hookform/resolvers@^4.1.3` to `@nemo/common` devDependencies, alongside the existing `react-hook-form` and `zod` entries.
- Document in `plugins/example-plugin/web/AGENTS.md`: `host.sdk.agents`, `CreateSecretModal` in the `onNotify` list, and a new bullet stating that nothing in the `@nemo/common` barrel may call the API, with the reason and the injection pattern to use instead.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

New tests

- `pnpm --filter @nemo/common test src/api/fetchAllPages.test.ts` — 4 passed. Covers multi-page concatenation, the short-page stop when `total_pages` is absent, a missing `data` array, and `maxPages` truncation.
- `pnpm --filter @nemo/common test src/components/CreateSecretModal/index.test.tsx` — 3 passed. Covers submit → notify → close, staying open when `onCreate` rejects, and blocking submit on a missing value.

Existing suites

- `pnpm --filter nemo-studio-ui test` — all passed.
- `pnpm --filter nemo-studio-ui test src/plugins/PluginRenderer.test.tsx` — 7 passed, extended to assert `host.sdk.agents.agentsListAgents`.
- `pnpm --filter nemo-studio-ui test src/components/FilesetCreateModal/index.test.tsx` — 9 passed (the one existing test that mocks `CreateSecretModal`).
- `pnpm --filter @nemo/common test` — 1458 passed, **1 pre-existing failure unrelated to this PR**: `src/components/DataView/StudioAppliedFilters.test.tsx > renders a tag for a datetime filter with formatted date range` expects `1/1/2024` but the component renders `2024-01-01`. That file is not touched by this branch.

Typecheck and lint

- `pnpm --filter @nemo/common typecheck`, `pnpm --filter nemo-studio-ui typecheck` — both clean.
- `pnpm --filter @nemo/common lint`, `pnpm --filter nemo-studio-ui lint` — both clean at `--max-warnings 0`.

Vendor-bundle check (the invariant this change depends on)

- `pnpm --filter nemo-studio-ui build` — succeeds. The resulting `dist/vendor/common.js` exports both `CreateSecretModal` and `fetchAllPages` and contains **zero** occurrences of `import.meta.env`, confirming the shared surface pulled in no SDK fetcher.

Blocked or not resolved locally

- `uv run pre-commit run -a` — all hooks passed except two, both environmental and unrelated to this web-only change:
  - `Helm Docs` — fails with `Please install helm-docs to run the pre-commit hook!`; the binary is not installed locally.
  - `Run uv lock with platform uv` — fails because the local uv is 0.9.30 and the repo requires 0.9.14 to run the lock. `Check for uv.lock drift` passed, and this branch does not touch any `pyproject.toml`.
- `pnpm --filter="...[origin/main]" run --parallel --if-present typecheck` / `test:ci` — both report `No projects matched the filters` in this checkout, so the per-package commands above were run directly instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable secret creation modal with validation, optional descriptions, submission states, error messages, and notifications.
  * Plugins can now access agent APIs and the shared secret creation experience.
  * Added a reusable API for retrieving complete results across paginated responses.

* **Bug Fixes**
  * Improved secret creation error handling so forms remain open for corrections.
  * Agent listings now reliably retrieve results across multiple pages, with safeguards for incomplete pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->