### PR TITLE
fix(intake): honor explicit ATIF per-result tool status

### DIFF
--- a/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
+++ b/services/intake/src/nmp/intake/spans/ingest/atif_mapping.py
@@ -981,7 +981,11 @@ def _datetime_from_value(value: Any) -> datetime | None:
 def _tool_result_is_error(step: AtifStep, result: AtifObservationResult | None) -> bool:
     """Recognize supported ATIF producer error markers."""
     # These markers are emitted by the Claude-Code Harbor trajectories we ingest today.
-    # ATIF itself does not define a normalized tool-result error field.
+    # ATIF itself does not define a normalized tool-result error field, so the text marker
+    # below cannot tell a failure from a success that quotes one.
+    explicit_result_status = _result_extra_bool(result, "is_error")
+    if explicit_result_status is not None:
+        return explicit_result_status
     metadata = _matched_tool_result_metadata(step, result)
     if metadata.get("is_error") is True:
         return True
@@ -1038,6 +1042,13 @@ def _result_text(result: AtifObservationResult | None) -> str | None:
 def _step_extra_bool(step: AtifStep, key: str) -> bool:
     """Read a strictly true boolean from step extras."""
     return step.extra is not None and step.extra.get(key) is True
+
+
+def _result_extra_bool(result: AtifObservationResult | None, key: str) -> bool | None:
+    """Read an explicit boolean from observation-result extras."""
+    extra = result.extra if result is not None else None
+    value = extra.get(key) if extra is not None else None
+    return value if isinstance(value, bool) else None
 
 
 def _step_extra_dict(step: AtifStep, key: str) -> dict[str, Any]:

--- a/services/intake/tests/test_atif_v17.py
+++ b/services/intake/tests/test_atif_v17.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 from nmp.intake.spans.api.spans_schemas import Span
-from nmp.intake.spans.domain import SpanKind, SpanStatus
+from nmp.intake.spans.domain import IntakeSpan, SpanKind, SpanStatus
 from nmp.intake.spans.ingest.atif import AtifIngestRequest
 from nmp.intake.spans.ingest.atif_domain import (
     AtifAgent,
@@ -702,6 +702,91 @@ def test_atif_mapping_keeps_tool_error_on_tool_span() -> None:
     assert root.status == SpanStatus.SUCCESS
     assert llm.status == SpanStatus.SUCCESS
     assert tool.status == SpanStatus.ERROR
+
+
+QUOTED_ERROR_CONTENT = '{"success":true,"snippet":"[ERROR] Failed to download package"}'
+
+
+def _tool_result_spans(results: list[dict[str, Any]]) -> list[IntakeSpan]:
+    """Map a single tool-using step whose observation carries the given results."""
+    step: dict[str, Any] = {
+        "step_id": 2,
+        "source": "agent",
+        "message": "using a tool",
+        "tool_calls": [
+            {"tool_call_id": result["source_call_id"], "function_name": f"tool_{index}"}
+            for index, result in enumerate(results)
+        ],
+        "observation": {"results": results},
+    }
+    trajectory = AtifTrajectory.model_validate(
+        {
+            "schema_version": "ATIF-v1.7",
+            "session_id": "trace-session-id",
+            "agent": {"name": "sample-agent", "version": "1.0.0"},
+            "steps": [{"step_id": 1, "source": "user", "message": "search the incident archive"}, step],
+        }
+    )
+    return trajectory_to_spans(
+        workspace="default",
+        trajectory=trajectory,
+        ingested_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+    )
+
+
+def test_atif_mapping_keeps_successful_tool_result_that_quotes_an_error() -> None:
+    spans = _tool_result_spans(
+        [{"source_call_id": "call-1", "content": QUOTED_ERROR_CONTENT, "extra": {"is_error": False}}]
+    )
+
+    tool = next(span for span in spans if span.kind == SpanKind.TOOL)
+    assert tool.status == SpanStatus.SUCCESS
+    assert Span.from_domain(tool).error_message is None
+    assert all(span.status == SpanStatus.SUCCESS for span in spans)
+
+
+def test_atif_mapping_marks_tool_error_from_explicit_result_extra() -> None:
+    spans = _tool_result_spans([{"source_call_id": "call-1", "content": "all good", "extra": {"is_error": True}}])
+
+    tool = next(span for span in spans if span.kind == SpanKind.TOOL)
+    assert tool.status == SpanStatus.ERROR
+    assert Span.from_domain(tool).error_message == "all good"
+
+
+def test_atif_mapping_resolves_parallel_tool_results_independently() -> None:
+    spans = _tool_result_spans(
+        [
+            {"source_call_id": "call-1", "content": QUOTED_ERROR_CONTENT, "extra": {"is_error": False}},
+            {"source_call_id": "call-2", "content": "tool crashed", "extra": {"is_error": True}},
+        ]
+    )
+
+    tools = {span.name: span for span in spans if span.kind == SpanKind.TOOL}
+    assert tools["tool_0"].status == SpanStatus.SUCCESS
+    assert tools["tool_1"].status == SpanStatus.ERROR
+
+
+def test_atif_mapping_keeps_legacy_text_marker_without_explicit_status() -> None:
+    spans = _tool_result_spans([{"source_call_id": "call-1", "content": QUOTED_ERROR_CONTENT}])
+
+    tool = next(span for span in spans if span.kind == SpanKind.TOOL)
+    assert tool.status == SpanStatus.ERROR
+
+
+def test_atif_mapping_keeps_successful_subagent_result_that_quotes_an_error() -> None:
+    spans = _tool_result_spans(
+        [
+            {
+                "source_call_id": "call-1",
+                "content": QUOTED_ERROR_CONTENT,
+                "extra": {"is_error": False},
+                "subagent_trajectory_ref": [{"trajectory_id": "subagent-trajectory-1"}],
+            }
+        ]
+    )
+
+    subagent = next(span for span in spans if span.name.startswith("subagent-"))
+    assert subagent.status == SpanStatus.SUCCESS
 
 
 def test_atif_mapping_span_ids_are_trace_native_and_ignore_evaluation_run_id() -> None:


### PR DESCRIPTION
## Problem

Intake marks a successful ATIF tool call as failed when the tool's returned text contains the case-insensitive substring `[error]` anywhere in the payload.

`_tool_result_is_error()` ended with:

```python
content = _result_text(result)
return content is not None and "[error]" in content.lower()
```

This treats arbitrary returned content as a status channel, which is unsafe for search, retrieval, log-reading, and ticket-reading tools — successful results routinely quote error messages from other systems.

Observed in a production `qa-copilot` trace (`efdefb9d-94e2-4051-9839-c5b9caef03ea`): a successful `glean_search` returned results containing the log line `[ERROR] Failed to download package`. The producer reported success (`isError: false`, `"success": true`), but Intake stored the tool span with `status: "error"` and copied the successful search response into `error_message`. Since `repository/clickhouse/trace.py` computes `countIf(status = 'error') AS error_count`, the span also inflated the trace's error count.

Reproduced on `main` before the fix; the mapper produced `status=error` with `error_message` set to the full successful payload.

## Fix

Consume `AtifObservationResult.extra.is_error` as an authoritative per-result signal, in both directions, ahead of the existing markers. The field is already accepted by the schema but was never read.

Per-result rather than step-level is deliberate: `_matched_tool_result_metadata()` and `_step_extra_bool()` are both gated on `_is_only_observation_result()`, so neither can express status for parallel tool calls. That gap is why producers resorted to text sentinels. Note also that a step-level `is_error: false` would not have helped — the existing branches only short-circuit on exactly `True`, so `False` fell through to the substring check.

The three existing branches are unchanged. Source diff is 13 lines.

## Why the text fallback is retained

It cannot be safely removed yet:

- **Deleting it** would flip real failures to `success`. Claude Code trajectories already send both step-level markers (see `tests/integration/spans/test_atif_ingest.py`), so they do not depend on it — but producers that signal secondary parallel-call failures only in text do, and the step-level markers structurally cannot express those.
- **Anchoring it** (e.g. to line starts) would fix this specific case, since `[ERROR]` here is mid-line inside JSON, but would still misfire on log-reading tools where `[ERROR]` legitimately begins lines. That trades one silent wrong answer for a narrower one.

The intended sequencing is: land this, migrate producers to emit `extra.is_error`, then remove the fallback. Sanitizing or escaping `[ERROR]` in tool content is explicitly not proposed — it would alter source evidence and only move the ambiguity to another string.

## Producer contract

```json
{
  "source_call_id": "call-1",
  "content": "...",
  "extra": { "is_error": false }
}
```

Backward compatible: trajectories without `result.extra.is_error` continue through the existing paths unchanged.

## Tests

Six new tests in `services/intake/tests/test_atif_v17.py`:

- `extra.is_error: false` with content containing `[ERROR]` produces a successful span with no `error_message`
- `extra.is_error: true` produces an error span even when content has no marker
- two parallel results with differing explicit statuses map to differing span statuses
- a legacy result with no explicit status and `[error]` content remains an error
- the subagent-span path (`_subagent_ref_to_span`) honors explicit status — this is a second call site of `_tool_result_is_error()`, so the false positive was not limited to tool spans

## Verification

- 307 intake unit tests pass, including the pre-existing `test_atif_mapping_keeps_tool_error_on_tool_span`
- `pre-commit run --files` clean on both changed files (ruff, ruff format, ty, copyright headers)
- Full `services/intake` suite green on this branch: 455 passed, 0 skipped (~12 min). The integration tests self-provision ClickHouse and were included in that run.

Validated against: https://docs.nvidia.com/nemo/relay/configure-plugins/observability/atif as a valid path
<img width="556" height="388" alt="image" src="https://github.com/user-attachments/assets/ab375510-14fe-4772-ad76-21b86122da5a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-result error detection by prioritizing explicit error status information.
  * Prevented successful results from being incorrectly marked as errors when their content only mentions error text.
  * Improved handling of parallel tool results and subagent results.
  * Preserved compatibility with existing metadata and legacy text-based error indicators.

* **Tests**
  * Added coverage for explicit error flags, quoted error text, parallel results, legacy markers, and subagent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
