### PR TITLE
feat(studio): add host.apiBaseUrl and keep axios off the plugin surface

### DIFF
--- a/plugins/example-plugin/web/AGENTS.md
+++ b/plugins/example-plugin/web/AGENTS.md
@@ -30,7 +30,7 @@ Runtime contract: `../../../web/packages/studio/src/plugins/types.ts`.
 | Deps | externalize the shared set in `vite.config.ts`; bundle the rest | bundle react / react-dom / react-router / foundations |
 
 Studio injects everything a plugin needs through a **single `host` prop**
-(`host.workspaceId`, `host.auth`, `host.sdk`, `host.navigation`,
+(`host.workspaceId`, `host.apiBaseUrl`, `host.auth`, `host.sdk`, `host.navigation`,
 `host.notifications`, `host.telemetry`, `host.breadcrumbs`) — grouped so new capabilities extend the
 handle without changing `Root`'s signature. Destructure what you use. All are
 backed by Studio's own singletons: `notifications` fires into Studio's shared
@@ -56,6 +56,12 @@ a private, unpublished package, so it is **not** a dependency here: `src/types.t
 declares a minimal structural `PluginSdk` covering only the hooks this example
 calls. A real plugin either mirrors the calls it needs the same way or, if it can
 resolve the SDK's types, types `host.sdk` as Studio does.
+
+`host.sdk` covers **platform** services only. A plugin that calls *its own*
+service ships its own client, and must prefix every request with
+`host.apiBaseUrl` — Studio's dev-server `/apis` proxy is opt-in, so a bare
+`/apis/...` request hits the dev server rather than the platform whenever
+`VITE_PLATFORM_BASE_URL` is set.
 
 ## Shared UI (`@nemo/common`)
 
@@ -103,6 +109,7 @@ import { StudioDataView, useStudioDataViewState } from '@nemo/common';
 {
   host: {
     workspaceId: string;
+    apiBaseUrl: string;
     auth: { accessToken: string; getAccessToken: () => string };
     sdk: { platform: /* @nemo/sdk platform hooks */ };
     navigation: { navigate: (to: string) => void; back: () => void };

--- a/plugins/example-plugin/web/src/types.ts
+++ b/plugins/example-plugin/web/src/types.ts
@@ -61,6 +61,8 @@ export interface PluginTelemetry {
 
 export interface PluginHost {
   workspaceId: string;
+  /** Origin the platform API is served from; empty when same-origin. */
+  apiBaseUrl: string;
   auth: {
     accessToken: string;
     getAccessToken: () => string;

--- a/web/packages/common/src/plugin.ts
+++ b/web/packages/common/src/plugin.ts
@@ -6,9 +6,19 @@
 
 export { AccessibleTitle } from '@nemo/common/src/components/AccessibleTitle';
 export { AccordionSection } from '@nemo/common/src/components/AccordionSection';
+// CancelJobButton is deliberately NOT exported: it imports
+// @nemo/sdk/generated/platform/api, whose fetcher pulls axios and
+// oidc-client-ts — and those resolve Node builtins (crypto, http, url) in the
+// vendor build, which the browser cannot resolve. Adding it here breaks *every*
+// plugin's dynamic import, not just the one using it. A plugin that needs it
+// builds its own on host.sdk.platform.
 export { ConfirmationModal } from '@nemo/common/src/components/ConfirmationModal';
 export { DeleteConfirmationModal } from '@nemo/common/src/components/DeleteConfirmationModal';
 export type { AccordionSectionProps } from '@nemo/common/src/components/AccordionSection';
+// ErrorPanel is deliberately NOT exported: it reaches axios through
+// api/common/utils, and axios resolves Node builtins (crypto, http, url) in the
+// vendor build — which the browser cannot resolve, breaking the dynamic import
+// of *every* plugin, not just one that uses it.
 export { ExpandableMessage } from '@nemo/common/src/components/ExpandableMessage';
 export { FileTag } from '@nemo/common/src/components/FileTag';
 export type { FileTagProps, FileTagStatus } from '@nemo/common/src/components/FileTag';
@@ -41,6 +51,7 @@ export type { BadgeStatus, StatusConfigEntry } from '@nemo/common/src/components
 export { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
 
 export { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+export { ControlledTextArea } from '@nemo/common/src/components/form/ControlledTextArea';
 export { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
 
 export { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
@@ -59,6 +70,8 @@ export {
   getSortParamWithWhitelist,
 } from '@nemo/common/src/utils/query';
 export { triggerDownload } from '@nemo/common/src/utils/file';
+
+export { ENTITY_NAME_HELP, entityNameSchema } from '@nemo/common/src/utils/entityName';
 
 export { getErrorMessage } from '@nemo/common/src/utils/error';
 export { handleFormErrorsGeneric } from '@nemo/common/src/utils/forms/error';

--- a/web/packages/common/src/plugin.ts
+++ b/web/packages/common/src/plugin.ts
@@ -6,19 +6,11 @@
 
 export { AccessibleTitle } from '@nemo/common/src/components/AccessibleTitle';
 export { AccordionSection } from '@nemo/common/src/components/AccordionSection';
-// CancelJobButton is deliberately NOT exported: it imports
-// @nemo/sdk/generated/platform/api, whose fetcher pulls axios and
-// oidc-client-ts — and those resolve Node builtins (crypto, http, url) in the
-// vendor build, which the browser cannot resolve. Adding it here breaks *every*
-// plugin's dynamic import, not just the one using it. A plugin that needs it
-// builds its own on host.sdk.platform.
+// CancelJobButton is deliberately NOT exported
 export { ConfirmationModal } from '@nemo/common/src/components/ConfirmationModal';
 export { DeleteConfirmationModal } from '@nemo/common/src/components/DeleteConfirmationModal';
 export type { AccordionSectionProps } from '@nemo/common/src/components/AccordionSection';
-// ErrorPanel is deliberately NOT exported: it reaches axios through
-// api/common/utils, and axios resolves Node builtins (crypto, http, url) in the
-// vendor build — which the browser cannot resolve, breaking the dynamic import
-// of *every* plugin, not just one that uses it.
+// ErrorPanel is deliberately NOT exported
 export { ExpandableMessage } from '@nemo/common/src/components/ExpandableMessage';
 export { FileTag } from '@nemo/common/src/components/FileTag';
 export type { FileTagProps, FileTagStatus } from '@nemo/common/src/components/FileTag';

--- a/web/packages/studio/src/plugins/PluginRenderer.test.tsx
+++ b/web/packages/studio/src/plugins/PluginRenderer.test.tsx
@@ -108,6 +108,9 @@ describe('PluginRenderer', () => {
     expect(typeof capturedProps?.host.navigation.navigate).toBe('function');
     expect(typeof capturedProps?.host.notifications.notify).toBe('function');
     expect(typeof capturedProps?.host.telemetry.event).toBe('function');
+    // A plugin calling its own service prefixes requests with this; it must be a
+    // string even when unset, so `${apiBaseUrl}${path}` never yields "undefined/...".
+    expect(typeof capturedProps?.host.apiBaseUrl).toBe('string');
   });
 
   it('does not remount on token renewal and getAccessToken returns the new token', () => {

--- a/web/packages/studio/src/plugins/PluginRenderer.tsx
+++ b/web/packages/studio/src/plugins/PluginRenderer.tsx
@@ -4,6 +4,7 @@
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { logger } from '@nemo/common/src/utils/logger';
 import * as platformSdk from '@nemo/sdk/generated/platform/api';
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { usePlugins, usePluginsLoaded } from '@studio/plugins/PluginContext';
 import { PluginErrorBoundary } from '@studio/plugins/PluginErrorBoundary';
@@ -61,6 +62,7 @@ export const PluginRenderer = (): ReactElement => {
   const host = useMemo<PluginHost>(
     () => ({
       workspaceId: workspace,
+      apiBaseUrl: PLATFORM_BASE_URL ?? '',
       auth: { accessToken, getAccessToken },
       sdk: STUDIO_SDK,
       navigation: { navigate: (to) => navigate(to), back: () => navigate(-1) },

--- a/web/packages/studio/src/plugins/types.ts
+++ b/web/packages/studio/src/plugins/types.ts
@@ -56,6 +56,13 @@ export interface PluginTelemetry {
 /** The host handle Studio injects into every plugin; extend it to add capabilities. */
 export interface PluginHost {
   workspaceId: string;
+  /**
+   * Origin the platform API is served from; empty when same-origin. A plugin
+   * that calls its own service needs this: Studio's dev-server `/apis` proxy is
+   * opt-in, so a relative request would otherwise hit the dev server whenever
+   * VITE_PLATFORM_BASE_URL is set.
+   */
+  apiBaseUrl: string;
   // Access tokens only — refresh tokens must not cross the boundary.
   auth: {
     accessToken: string;


### PR DESCRIPTION
## Summary

Two fixes to the Studio plugin system, both found while building the first plugin that calls its own backend service rather than only platform services.

A plugin shipping its own API client previously had no supported way to reach the platform, and two entries on the `@nemo/common` plugin surface silently broke *every* plugin's bundle.

## Related Issue

<!-- none -->

## Changes

**`host.apiBaseUrl`** — new field on the plugin host handle.

`host.sdk` covers platform services only. A plugin that ships its own generated client has to build its own URLs, and a relative `/apis/...` request does not work: Studio's dev-server `/apis` proxy is opt-in (gated on `VITE_PLATFORM_PROXY_DOMAIN` *and* an empty base URL, `web/packages/studio/vite.config.ts:501`), so whenever `VITE_PLATFORM_BASE_URL` is set the request hits the Vite dev server instead of the platform. There was no workaround short of reaching into Studio's internals, which the plugin contract forbids.

`PluginRenderer` populates it from `PLATFORM_BASE_URL`, defaulting to `''` for the same-origin case.

**Keeping axios off the `@nemo/common` plugin surface.**

Everything exported from `web/packages/common/src/plugin.ts` is bundled into `public/vendor/common.js`, which every plugin resolves through Studio's import map. Two components reach axios — `ErrorPanel` via `api/common/utils`, `CancelJobButton` via `@nemo/sdk/generated/platform/api` — and in the vendor build axios resolves to its **Node** build, so `common.js` emits bare imports of `crypto`, `http`, `https`, `url`, `events`, `stream` and `zlib`.

The browser cannot resolve those, so the dynamic `import()` of any plugin throws:

```
[plugins] Failed to load plugin "…": TypeError: Failed to resolve module specifier "crypto".
```

`loadPlugin` catches that, logs `logger.warn` and returns `null` (`web/packages/studio/src/plugins/utils.ts`), so the only user-visible symptom is a plugin quietly not appearing — no error surface at all. Because `common.js` is shared, one bad export breaks every installed plugin, not just the one using it.

Neither is exported. Both now carry a comment explaining why, since nothing about the failure points back to the cause.

**Surface additions** — `ControlledTextArea`, `ENTITY_NAME_HELP`, `entityNameSchema`. All verified free of any transitive reach to `@nemo/sdk`'s axios-bearing client.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

`PluginRenderer.test.tsx` asserts `host.apiBaseUrl` is a string — the case that matters is `PLATFORM_BASE_URL` being unset, where every plugin request would otherwise be prefixed with the literal `"undefined"`. `plugins/example-plugin/web/AGENTS.md` is the canonical template plugins copy, so it carries the contract change and the rule about prefixing requests.

The axios guard is enforced by comment rather than by a test. A lint rule or a build assertion that fails when `vendor/common.js` emits an unmapped bare specifier would be the durable fix; I did not add one here to keep this change small, and it is worth doing separately.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
| --- | --- |
| `pnpm --filter nemo-studio-ui typecheck` | 0 errors |
| `pnpm --filter @nemo/common typecheck` | 0 errors |
| `pnpm --filter nemo-studio-ui test src/plugins` | 27 passed |
| `eslint packages/studio/src/plugins packages/common/src/plugin.ts` | clean |
| `tsc --noEmit` in `plugins/example-plugin/web` | 0 errors |
| `uv run pre-commit run -a` | 2 failures, both environmental — see below |

`pre-commit run -a` is **not** fully green on my machine:

- `helm-docs` — the binary is not installed locally. Touches no file in this change.
- `uv-lock` — the hook requires uv `0.9.14`; this machine has `0.9.30`. The separate `Check for uv.lock drift` hook **passes**, so the lockfile is in sync; only the version guard fails. `uv.lock` is untouched by this PR.

Every other hook passes, including `ruff`, `ty`, copyright headers, `Run UI lint-staged`, and `Plugins must not import from nmp-common`.

Manually verified against a running platform that `vendor/common.js` and the other vendor bundles now emit **only** import-map specifiers, with no unmapped bare imports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can access the platform API base URL through their host configuration.
  * Added plugin API exports for controlled text input and entity-name validation utilities.
* **Documentation**
  * Documented how plugins should use the platform API base URL when calling services.
  * Clarified which components are intentionally excluded from the plugin API.
* **Tests**
  * Added coverage confirming the API base URL is provided, including same-origin deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->