### PR TITLE
fix(evaluator): support Gym rows that carry no prompt

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym_runtime.py
@@ -59,6 +59,11 @@ Gym runtime whose deps are installed (each Gym env ships its own
 ``requirements.txt``), and for handing a *ready-to-run* dataset file (``--no-serve
 --input`` bypasses Gym's prompt-templating/materialization). Service-side
 provisioning (docker/k8s, Ray) is out of scope here — that is the plugin's job.
+
+A consequence of that bypass: an environment whose rows carry no rendered prompt
+(``responses_create_params.input == []``, the prompt supplied by data-prep or by the
+environment's own agent) is still supported — the row travels through this runtime intact
+and the task simply has no ``inputs['instruction']``. See :func:`discover_gym_tasks`.
 """
 
 from __future__ import annotations
@@ -169,15 +174,22 @@ def _content_text(content: Any) -> str:
     return ""
 
 
-def _render_instruction(responses_create_params: Any) -> str:
-    """Derive a non-empty instruction from a row's ``responses_create_params``.
+def _render_instruction(responses_create_params: Mapping[str, Any]) -> str:
+    """Derive a task instruction from a row's ``responses_create_params``, or ``""`` when it carries none.
 
     Uses ``instructions`` (system prompt, when present) + ``input`` (a plain string
-    or an OpenAI message list). ``instruction`` is required on every task, so a row
-    that cannot produce one fails loudly rather than yielding a task with no prompt.
+    or an OpenAI message list).
+
+    An empty result is *not* an error. A whole class of Gym environments ships
+    ``"responses_create_params": {"input": []}`` and keeps the task elsewhere — ``gdpval``
+    in a top-level ``prompt``, ``legal_agent_bench`` in an ``instance_id`` its own agent
+    resolves, ``aviary``/``toolsandbox`` in nothing but a ``task_idx``. Their prompt is
+    materialized by Gym's data-preparation step or by the environment's agent, neither of
+    which this runner drives (``--no-serve --input`` hands Gym a ready-to-run dataset by
+    design). Nothing here can reconstruct it, and no single row field generalizes across
+    them, so the honest answer is no instruction rather than a guess. See
+    :func:`discover_gym_tasks` for what that means downstream.
     """
-    if not isinstance(responses_create_params, Mapping):
-        raise ValueError("row has no 'responses_create_params' mapping to render an instruction from")
     parts: list[str] = []
     instructions = responses_create_params.get("instructions")
     if isinstance(instructions, str) and instructions.strip():
@@ -191,10 +203,7 @@ def _render_instruction(responses_create_params: Any) -> str:
                 text = _content_text(item.get("content"))
                 if text:
                     parts.append(text)
-    instruction = "\n\n".join(part for part in parts if part).strip()
-    if not instruction:
-        raise ValueError("could not derive a non-empty instruction from responses_create_params.input")
-    return instruction
+    return "\n\n".join(part for part in parts if part).strip()
 
 
 def _read_jsonl(path: str | Path, *, tolerant: bool = False) -> list[dict[str, Any]]:
@@ -320,8 +329,8 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
     """Build one :class:`AgentEvalTask` per distinct row in a Gym dataset (jsonl).
 
     Each task's id is the content hash of the row; its ``instruction`` is rendered
-    from ``responses_create_params.input``; the raw params are stashed under
-    ``inputs['gym_row']`` for provenance; and it is scored by a
+    from ``responses_create_params.input`` *when the row carries one*; the raw params
+    are stashed under ``inputs['gym_row']`` for provenance; and it is scored by a
     :class:`GymRewardMetric`. The dataset path is stamped on
     ``metadata['gym_dataset_path']``, and every *other* row key (the verifier's
     ground-truth fields, ``agent_ref``, and so on) on ``metadata['gym_row_extras']``.
@@ -335,24 +344,51 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
     so they are by definition the same task) and are reported as a warning: repeated
     attempts are a run-level concern — ``GymRuntimeConfig.num_repeats`` — not something
     a dataset expresses by repeating a row, so duplicates almost always mean bad data.
+
+    **A row need not carry a prompt.** A sweep of the 106 built-in environments shipping example
+    data found 5 — ``aviary``, ``gdpval``, ``legal_agent_bench``, ``scicode`` and ``toolsandbox``
+    — whose every row ships ``responses_create_params.input == []``, letting Gym's data-prep step
+    or the environment's own agent materialize the prompt instead (see
+    :func:`_render_instruction`). Such a row yields a task with **no** ``inputs['instruction']``
+    key rather than a fabricated one, and is counted in a summary log line. This costs the
+    Gym path nothing: the runner never reads ``instruction`` — it re-materializes the source
+    row from ``inputs['gym_row']`` + ``metadata['gym_row_extras']`` and hands *that* to Gym,
+    and ``intent`` is a dataset label either way. It stays absent (not ``""``) so that
+    :meth:`AgentEvalTask.agent_prompt` still fails loudly for the runners that *do* need a
+    prompt — an instruction-less task must not reach an agent as an empty one.
+
+    ``responses_create_params`` itself remains required: Gym indexes into it unconditionally
+    (``rollout_collection._preprocess_rows_from_config``), so a row without it is rejected here
+    rather than crashing Gym mid-collection.
     """
     dataset = Path(dataset)
     tasks: list[AgentEvalTask] = []
     seen: set[str] = set()
     duplicates = 0
-    for row in _read_jsonl(dataset):
+    promptless = 0
+    for position, row in enumerate(_read_jsonl(dataset), 1):
+        params = row.get("responses_create_params")
+        if not isinstance(params, Mapping):
+            raise ValueError(
+                f"row {position} of {dataset} has no 'responses_create_params' mapping; Gym requires that key "
+                "on every dataset row"
+            )
         task_id = _canonical_row_hash(row)
         if task_id in seen:
             duplicates += 1
             continue
         seen.add(task_id)
+        instruction = _render_instruction(params)
+        if not instruction:
+            promptless += 1
         tasks.append(
             AgentEvalTask(
                 id=task_id,
                 intent=f"Gym row from {dataset.name}",
                 inputs={
-                    "instruction": _render_instruction(row.get("responses_create_params")),
-                    "gym_row": row.get("responses_create_params"),
+                    # Absent, not empty, when the row carries no prompt — see the docstring.
+                    **({"instruction": instruction} if instruction else {}),
+                    "gym_row": params,
                 },
                 metrics=list(metrics) if metrics is not None else [GymRewardMetric()],
                 metadata={
@@ -374,6 +410,16 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
             duplicates,
             dataset,
             len(tasks),
+        )
+    if promptless:
+        logger.info(
+            "%d of %d task(s) in %s carry no prompt in responses_create_params and were discovered without an "
+            "inputs['instruction']. Expected for environments whose prompt is built by Gym's data-prep step or by "
+            "their own agent (e.g. aviary, gdpval, legal_agent_bench, scicode, toolsandbox); the Gym runner does "
+            "not read the instruction. A runner that hands the task straight to an agent will reject these tasks.",
+            promptless,
+            len(tasks),
+            dataset,
         )
     if not tasks:
         raise ValueError(f"no rows found in Gym dataset {dataset}")

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_gym_runtime.py
@@ -74,11 +74,92 @@ def test_render_instruction_from_string_messages_and_parts() -> None:
     assert _render_instruction(parts) == "part"
 
 
-def test_render_instruction_fails_loudly_when_empty() -> None:
-    with pytest.raises(ValueError):
-        _render_instruction({"input": ""})
-    with pytest.raises(ValueError):
-        _render_instruction({})
+def test_render_instruction_is_empty_rather_than_fatal_when_the_row_carries_no_prompt() -> None:
+    # A whole class of Gym environments ships `{"input": []}` and materializes the prompt elsewhere.
+    # Rendering must report "no prompt", not fail the dataset.
+    assert _render_instruction({"input": ""}) == ""
+    assert _render_instruction({"input": []}) == ""
+    assert _render_instruction({}) == ""
+
+
+@pytest.mark.parametrize(
+    ("name", "row"),
+    [
+        # Shapes taken verbatim from the five affected environments' data/example.jsonl.
+        ("gdpval", {"responses_create_params": {"input": []}, "task_id": "83d10b06", "prompt": "You are an auditor…"}),
+        (
+            "legal_agent_bench",
+            {
+                "agent_ref": {"name": "legal_agent_bench_harbor_agent", "type": "responses_api_agents"},
+                "instance_id": "legal_agent_bench::corporate-ma__analyze-tsa-markup",
+                "responses_create_params": {"input": [], "temperature": 1.0, "top_p": 0.95},
+            },
+        ),
+        ("aviary", {"task_idx": 0, "responses_create_params": {"input": []}, "agent_ref": {"name": "gsm8k_aviary"}}),
+        ("scicode", {"responses_create_params": {"input": []}, "problem_id": "10", "sub_steps": [{"step": "10.1"}]}),
+        ("toolsandbox", {"task_idx": 0, "responses_create_params": {"input": []}}),
+    ],
+)
+def test_discover_gym_tasks_ingests_rows_with_no_prompt(name: str, row: dict, tmp_path: Path) -> None:
+    # AALGO-498: these environments could not be ingested at all — discovery raised before a run began.
+    dataset = tmp_path / f"{name}.jsonl"
+    dataset.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    (task,) = discover_gym_tasks(dataset)
+
+    # No instruction is *absent*, not empty: agent_prompt() must still refuse to run an agent on nothing.
+    assert "instruction" not in task.inputs
+    with pytest.raises(ValueError, match="has no instruction"):
+        task.agent_prompt()
+    # ...but everything the Gym path actually needs survives: the row round-trips whole.
+    assert task.inputs["gym_row"] == row["responses_create_params"]
+    assert task.metadata["gym_row_extras"] == {k: v for k, v in row.items() if k != "responses_create_params"}
+
+
+def test_promptless_rows_still_hash_distinctly(tmp_path: Path) -> None:
+    # Identity is the whole row, so rows differing only in a field the runner ignores (`task_idx` for
+    # aviary/toolsandbox, `instance_id` for legal_agent_bench) must remain distinct tasks — otherwise a
+    # promptless dataset would collapse into a single task.
+    dataset = tmp_path / "toolsandbox.jsonl"
+    dataset.write_text(
+        "\n".join(json.dumps({"task_idx": idx, "responses_create_params": {"input": []}}) for idx in range(5)) + "\n",
+        encoding="utf-8",
+    )
+    tasks = discover_gym_tasks(dataset)
+    assert len({task.id for task in tasks}) == 5
+    # and they re-materialize into the five rows Gym will read, each with its own index
+    index_map = _materialize_dataset(tasks, tmp_path / "gym_input.jsonl")
+    rows = _rows(tmp_path / "gym_input.jsonl")
+    assert [row["task_idx"] for row in rows] == [0, 1, 2, 3, 4]
+    assert index_map == {index: task.id for index, task in enumerate(tasks)}
+
+
+def test_discover_gym_tasks_reports_how_many_rows_had_no_prompt(tmp_path: Path, caplog) -> None:
+    dataset = tmp_path / "mixed.jsonl"
+    dataset.write_text(
+        json.dumps({"responses_create_params": {"input": "answer me"}})
+        + "\n"
+        + json.dumps({"task_idx": 0, "responses_create_params": {"input": []}})
+        + "\n",
+        encoding="utf-8",
+    )
+    with caplog.at_level(logging.INFO):
+        tasks = discover_gym_tasks(dataset)
+    assert [("instruction" in task.inputs) for task in tasks] == [True, False]
+    assert "1 of 2 task(s)" in caplog.text
+    assert "carry no prompt" in caplog.text
+
+
+@pytest.mark.parametrize("row", [{"task_idx": 0}, {"responses_create_params": None}, {"responses_create_params": []}])
+def test_discover_gym_tasks_still_requires_responses_create_params(row: dict, tmp_path: Path) -> None:
+    # Gym indexes into this key unconditionally, so a row without a usable one must be rejected at
+    # discovery rather than crashing `gym eval run` after the servers are up. All three non-mapping
+    # shapes are covered deliberately: a check of `params is None` alone would pass the missing-key
+    # case while letting a list through to fail deep inside Gym.
+    dataset = tmp_path / "bad_params.jsonl"
+    dataset.write_text(json.dumps(row) + "\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="row 1 .* has no 'responses_create_params' mapping"):
+        discover_gym_tasks(dataset)
 
 
 def test_discover_gym_tasks_from_example_fixture() -> None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/gym_runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/gym_runtime.py
@@ -59,6 +59,11 @@ Gym runtime whose deps are installed (each Gym env ships its own
 ``requirements.txt``), and for handing a *ready-to-run* dataset file (``--no-serve
 --input`` bypasses Gym's prompt-templating/materialization). Service-side
 provisioning (docker/k8s, Ray) is out of scope here — that is the plugin's job.
+
+A consequence of that bypass: an environment whose rows carry no rendered prompt
+(``responses_create_params.input == []``, the prompt supplied by data-prep or by the
+environment's own agent) is still supported — the row travels through this runtime intact
+and the task simply has no ``inputs['instruction']``. See :func:`discover_gym_tasks`.
 """
 
 from __future__ import annotations
@@ -169,15 +174,22 @@ def _content_text(content: Any) -> str:
     return ""
 
 
-def _render_instruction(responses_create_params: Any) -> str:
-    """Derive a non-empty instruction from a row's ``responses_create_params``.
+def _render_instruction(responses_create_params: Mapping[str, Any]) -> str:
+    """Derive a task instruction from a row's ``responses_create_params``, or ``""`` when it carries none.
 
     Uses ``instructions`` (system prompt, when present) + ``input`` (a plain string
-    or an OpenAI message list). ``instruction`` is required on every task, so a row
-    that cannot produce one fails loudly rather than yielding a task with no prompt.
+    or an OpenAI message list).
+
+    An empty result is *not* an error. A whole class of Gym environments ships
+    ``"responses_create_params": {"input": []}`` and keeps the task elsewhere — ``gdpval``
+    in a top-level ``prompt``, ``legal_agent_bench`` in an ``instance_id`` its own agent
+    resolves, ``aviary``/``toolsandbox`` in nothing but a ``task_idx``. Their prompt is
+    materialized by Gym's data-preparation step or by the environment's agent, neither of
+    which this runner drives (``--no-serve --input`` hands Gym a ready-to-run dataset by
+    design). Nothing here can reconstruct it, and no single row field generalizes across
+    them, so the honest answer is no instruction rather than a guess. See
+    :func:`discover_gym_tasks` for what that means downstream.
     """
-    if not isinstance(responses_create_params, Mapping):
-        raise ValueError("row has no 'responses_create_params' mapping to render an instruction from")
     parts: list[str] = []
     instructions = responses_create_params.get("instructions")
     if isinstance(instructions, str) and instructions.strip():
@@ -191,10 +203,7 @@ def _render_instruction(responses_create_params: Any) -> str:
                 text = _content_text(item.get("content"))
                 if text:
                     parts.append(text)
-    instruction = "\n\n".join(part for part in parts if part).strip()
-    if not instruction:
-        raise ValueError("could not derive a non-empty instruction from responses_create_params.input")
-    return instruction
+    return "\n\n".join(part for part in parts if part).strip()
 
 
 def _read_jsonl(path: str | Path, *, tolerant: bool = False) -> list[dict[str, Any]]:
@@ -320,8 +329,8 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
     """Build one :class:`AgentEvalTask` per distinct row in a Gym dataset (jsonl).
 
     Each task's id is the content hash of the row; its ``instruction`` is rendered
-    from ``responses_create_params.input``; the raw params are stashed under
-    ``inputs['gym_row']`` for provenance; and it is scored by a
+    from ``responses_create_params.input`` *when the row carries one*; the raw params
+    are stashed under ``inputs['gym_row']`` for provenance; and it is scored by a
     :class:`GymRewardMetric`. The dataset path is stamped on
     ``metadata['gym_dataset_path']``, and every *other* row key (the verifier's
     ground-truth fields, ``agent_ref``, and so on) on ``metadata['gym_row_extras']``.
@@ -335,24 +344,51 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
     so they are by definition the same task) and are reported as a warning: repeated
     attempts are a run-level concern — ``GymRuntimeConfig.num_repeats`` — not something
     a dataset expresses by repeating a row, so duplicates almost always mean bad data.
+
+    **A row need not carry a prompt.** A sweep of the 106 built-in environments shipping example
+    data found 5 — ``aviary``, ``gdpval``, ``legal_agent_bench``, ``scicode`` and ``toolsandbox``
+    — whose every row ships ``responses_create_params.input == []``, letting Gym's data-prep step
+    or the environment's own agent materialize the prompt instead (see
+    :func:`_render_instruction`). Such a row yields a task with **no** ``inputs['instruction']``
+    key rather than a fabricated one, and is counted in a summary log line. This costs the
+    Gym path nothing: the runner never reads ``instruction`` — it re-materializes the source
+    row from ``inputs['gym_row']`` + ``metadata['gym_row_extras']`` and hands *that* to Gym,
+    and ``intent`` is a dataset label either way. It stays absent (not ``""``) so that
+    :meth:`AgentEvalTask.agent_prompt` still fails loudly for the runners that *do* need a
+    prompt — an instruction-less task must not reach an agent as an empty one.
+
+    ``responses_create_params`` itself remains required: Gym indexes into it unconditionally
+    (``rollout_collection._preprocess_rows_from_config``), so a row without it is rejected here
+    rather than crashing Gym mid-collection.
     """
     dataset = Path(dataset)
     tasks: list[AgentEvalTask] = []
     seen: set[str] = set()
     duplicates = 0
-    for row in _read_jsonl(dataset):
+    promptless = 0
+    for position, row in enumerate(_read_jsonl(dataset), 1):
+        params = row.get("responses_create_params")
+        if not isinstance(params, Mapping):
+            raise ValueError(
+                f"row {position} of {dataset} has no 'responses_create_params' mapping; Gym requires that key "
+                "on every dataset row"
+            )
         task_id = _canonical_row_hash(row)
         if task_id in seen:
             duplicates += 1
             continue
         seen.add(task_id)
+        instruction = _render_instruction(params)
+        if not instruction:
+            promptless += 1
         tasks.append(
             AgentEvalTask(
                 id=task_id,
                 intent=f"Gym row from {dataset.name}",
                 inputs={
-                    "instruction": _render_instruction(row.get("responses_create_params")),
-                    "gym_row": row.get("responses_create_params"),
+                    # Absent, not empty, when the row carries no prompt — see the docstring.
+                    **({"instruction": instruction} if instruction else {}),
+                    "gym_row": params,
                 },
                 metrics=list(metrics) if metrics is not None else [GymRewardMetric()],
                 metadata={
@@ -374,6 +410,16 @@ def discover_gym_tasks(dataset: str | Path, *, metrics: Sequence[Any] | None = N
             duplicates,
             dataset,
             len(tasks),
+        )
+    if promptless:
+        logger.info(
+            "%d of %d task(s) in %s carry no prompt in responses_create_params and were discovered without an "
+            "inputs['instruction']. Expected for environments whose prompt is built by Gym's data-prep step or by "
+            "their own agent (e.g. aviary, gdpval, legal_agent_bench, scicode, toolsandbox); the Gym runner does "
+            "not read the instruction. A runner that hands the task straight to an agent will reject these tasks.",
+            promptless,
+            len(tasks),
+            dataset,
         )
     if not tasks:
         raise ValueError(f"no rows found in Gym dataset {dataset}")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`GymAgentTaskRunner` could not ingest a whole class of Gym environments at all — `discover_gym_tasks` raised `ValueError: could not derive a non-empty instruction from responses_create_params.input` on every row, before a run could start. Those environments ship `"responses_create_params": {"input": []}` and materialize the prompt in Gym's own data-preparation step or in the environment's agent; the runner's two-step `gym eval run --no-serve --input` path bypasses that step by design. Discovery now accepts a promptless row and yields a task with no `inputs['instruction']` instead of failing the dataset.

Before: all 5 affected environments failed at discovery. After: all 5 discover cleanly with distinct task ids, and `mcqa` (a prompt-carrying environment) is unchanged.

## Related Issue

Fixes [AALGO-498](https://linear.app/nvidia/issue/AALGO-498/support-gym-environments-whose-rows-carry-no-prompt-in-responses). Found during the [AALGO-485](https://linear.app/nvidia/issue/AALGO-485/validate-the-gym-runner-across-a-representative-sample-of-built-in) coverage sweep; unblocks the Gym side of [AALGO-434](https://linear.app/nvidia/issue/AALGO-434/evaluator-level-aggregation-meanpassk-bubble-gym-aggregates)'s heterogeneous-aggregation comparison, since `legal_agent_bench` is the one benchmark runnable through Gym, Harbor and Fabric on the same tasks.

## Changes

- `_render_instruction` returns `""` instead of raising when a row carries no prompt. Its `responses_create_params` argument is now typed `Mapping[str, Any]` rather than `Any`.
- `discover_gym_tasks` **omits** `inputs['instruction']` entirely for such a row rather than storing an empty string, and validates `responses_create_params` itself (moved out of `_render_instruction`, so a bad row is named by position: `row 3 of <path>`).
- A summary `INFO` line reports how many of a dataset's tasks were discovered without an instruction, so the condition is visible rather than silent.
- Tests: the five affected environments' real row shapes, distinct-hashing of promptless rows, the summary log, and all three non-mapping `responses_create_params` shapes.
- Docstrings at all three levels (module, `_render_instruction`, `discover_gym_tasks`) record why an empty instruction is legitimate here.
- Vendored SDK copy re-synced via `make vendor`.

### Design calls

- **Absent, not empty.** `AgentEvalTask.agent_prompt()` treats missing and `""` identically today, but the key is omitted so the distinction survives if that ever changes. A runner that hands a task straight to an agent still rejects these tasks loudly — an instruction-less task must not reach an agent as an empty prompt. This costs the Gym path nothing: it re-materializes the source row from `inputs['gym_row']` + `metadata['gym_row_extras']` and never reads the instruction.
- **No per-environment prompt fallback.** The issue floated falling back to another row field. Rejected: `gdpval` has a top-level `prompt`, `legal_agent_bench` only an `instance_id`, and `aviary`/`toolsandbox` nothing but a `task_idx`. No single field generalizes, and a partial fallback would make the instruction mean different things per environment.
- **`intent` left as `"Gym row from <file>"`.** Unchanged for all rows. It is a dataset label, not the prompt, so promptless rows need no special case.
- **`responses_create_params` stays required.** Gym indexes into that key unconditionally (`rollout_collection._preprocess_rows_from_config`), so a row without it is better rejected before the servers start than mid-collection.

### The issue's second open question, answered

The issue asked whether an empty `input` *also* breaks `gym eval run --no-serve --input`, noting it was not yet established. It does not. I fed promptless materialized datasets (source row + our `_ng_task_index`, exactly what `_materialize_dataset` writes) through Gym's own `_preprocess_rows_from_config` for all five environments: each produced the expected rollout rows with `input` untouched and our caller-supplied `_ng_task_index` honored, so discovery was the only blocker. Live end-to-end collection additionally needs servers, per-environment deps and model credentials — the `gym env start` provisioning failure is out of scope here per the issue.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the behavior lives in the SDK runtime's own docstrings, which are updated here at all three levels. No Fern/user-facing page documents Gym dataset discovery.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

The `pre-commit run -a` box is **left unchecked**: three hooks failed for host-toolchain reasons, not because of this change. Details below.

Targeted validation:

| Command | Result |
| -- | -- |
| `uv run --frozen pytest packages/nemo_evaluator_sdk/tests -q` | 1490 passed |
| `uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval -q` (after review fixes) | 586 passed |
| `uv run ruff check packages/nemo_evaluator_sdk/` | passed |
| `uv run ruff format --check <changed files>` | passed |
| `tools/lint/lint-python-types.sh` | exit 0; 9 warnings, none in changed files |
| `tools/lint/lint-sdk-vendored.sh` | exit 0 |
| `tools/lint/lint-cli.sh` | exit 0 |
| `uv run pre-commit run -a` | ruff, ruff format, ty, config-reference docs, copyright headers, merge-conflict, uv-lock **drift** all passed; 3 failures below |

Real-data check, against a local NeMo-Gym checkout at `93aeccdd`: `discover_gym_tasks` on `aviary`, `gdpval`, `legal_agent_bench`, `scicode` and `toolsandbox` each yielded 5 tasks with 5 distinct ids and 0 instructions, and each re-materialized to 5 rows with a total index map. `mcqa` still yields 5 tasks with 5 instructions.

Test quality was checked by mutation: reverting the raise, storing `""` instead of omitting the key, and weakening the params guard to `params is None` produce 8, 6 and 1 test failures respectively.

### Blocked checks (host toolchain, not this change)

| Hook / lint | Failure | Why it is not this change |
| -- | -- | -- |
| `uv-lock` (pre-commit) | requires uv 0.9.14, host has 0.9.30 | diff touches no `pyproject.toml`; the `uv-lock-check` drift hook, which would catch a real lock problem, passed |
| `Helm Docs` (pre-commit) | helm-docs container unavailable locally | diff touches no Helm chart |
| `studio-lint-staged` (pre-commit) | `mise ERROR No version is set for shim: pnpm` | diff touches no `web/` files |
| `tools/lint/lint-openapi.sh` | `mapfile: command not found` (host bash 3.2) | script cannot start; diff touches no API or datamodel file |
| `tools/lint/lint-web-sdk.sh` | node fails parsing the `mise` binary | same host-toolchain cause as `studio-lint-staged` |

Each should pass in CI, which pins these toolchains. Flagging rather than asserting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Gym task discovery now supports rows without rendered prompts.
  - Promptless tasks remain available while omitting the instruction input.
  - Discovery reports the number of promptless tasks encountered.

- **Bug Fixes**
  - Improved validation messages identify the position of rows missing response parameters.

- **Documentation**
  - Documented promptless-row behavior in Gym runtime guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->