### PR TITLE
ci: stop one crashed integration worker from poisoning the whole run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,9 +378,11 @@ PYTEST_VERBOSITY := $(if $(filter true,$(CI)),-q,-v)
 PYTEST_WORKERS ?= auto
 PYTEST_MAX_WORKERS ?= 16
 PYTEST_DIST ?= loadscope
+PYTEST_MAX_WORKER_RESTART ?= 2
 PYTEST_CMD = env PYTHONWARNINGS="ignore::UserWarning:pytest_only.version" $(UV) run --frozen \
 	pytest \
-	-n $(PYTEST_WORKERS) --maxprocesses=$(PYTEST_MAX_WORKERS) --max-worker-restart=2 \
+	-n $(PYTEST_WORKERS) --maxprocesses=$(PYTEST_MAX_WORKERS) \
+	--max-worker-restart=$(PYTEST_MAX_WORKER_RESTART) \
 	--dist $(PYTEST_DIST) --timeout=120 $(PYTEST_VERBOSITY) $(PYTEST_EXTRA)
 
 PYTEST_CI_OPTS := --cov=src --cov=packages \
@@ -403,6 +405,14 @@ PYTEST_CI_CMD = timeout --kill-after=60s $(PYTEST_CI_TIMEOUT)s $(PYTEST_CMD)
 # CI integration runs therefore use ``loadgroup`` while unit runs keep
 # ``loadscope``.
 test-integration test-integration-ci: PYTEST_DIST := loadgroup
+
+# Integration workers own external resources (Docker containers, service ports, spawned `nemo`
+# processes) through session-scoped fixtures. A killed worker never runs its teardown, so replacing
+# it re-runs the same group against resources the dead worker still owns — which fails, and can
+# leave the controller waiting until the outer wall-clock timeout. Not replacing a crashed
+# integration worker ends the run instead, with xdist naming the test it died on. Unit workers own
+# nothing external, so they keep the restart budget.
+test-integration test-integration-ci: PYTEST_MAX_WORKER_RESTART := 0
 
 .PHONY: test-unit
 test-unit: ## Run Python unit tests across all packages and services

--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import math
 import os
+import shutil
 import socket
 import subprocess
 import time
@@ -104,30 +105,48 @@ def _wait_for_ready(base_url: str, *, timeout: float) -> None:
     raise RuntimeError(f"platform at {base_url} not ready within {timeout}s")
 
 
+#: Stable data directory for this suite's ClickHouse container.
+#
+# Deliberately not a per-session temp directory. The provisioner names the container from a fixed
+# legacy name but validates it against the data directory it was created with, so a per-session
+# path means every new session presents a *different* directory under the *same* container name.
+# One container that outlives its session — which is exactly what happens when an xdist worker is
+# killed before its teardown runs — then makes every later session fail to provision with
+# "does not use the expected data directory", and `--remove` cannot clear it because removal only
+# matches containers whose data directory equals the one being asked for.
+#
+# With a stable path, a stranded container is reclaimable: `--remove` below matches it, so the
+# next session cleans it up instead of colliding with it.
+_CLICKHOUSE_DATA_DIR = REPO_ROOT / "tmp" / "evaluator-intake-clickhouse"
+
+
+def _run_clickhouse_script(*args: str, env: dict[str, str], check: bool) -> None:
+    """Invoke the local ClickHouse provisioner script."""
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "services/intake/scripts/spans/run_clickhouse.sh"), *args],
+        check=check,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+
 @pytest.fixture(scope="session")
-def _clickhouse(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+def _clickhouse() -> Iterator[None]:
     if not _docker_available():
         pytest.skip("Docker not available; required for ClickHouse-backed Intake")
-    clickhouse_env = {
-        **os.environ,
-        "CLICKHOUSE_DATA_DIR": str(tmp_path_factory.mktemp("evaluator-intake-clickhouse")),
-    }
+    clickhouse_env = {**os.environ, "CLICKHOUSE_DATA_DIR": str(_CLICKHOUSE_DATA_DIR)}
+    # Reclaim anything a previous session left behind before provisioning. Not check=True: there is
+    # usually nothing to remove, and a failure here must not mask the provisioning error below.
+    _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
+    shutil.rmtree(_CLICKHOUSE_DATA_DIR, ignore_errors=True)
     try:
-        subprocess.run(
-            ["bash", str(REPO_ROOT / "services/intake/scripts/spans/run_clickhouse.sh")],
-            check=True,
-            cwd=REPO_ROOT,
-            env=clickhouse_env,
-        )
+        _run_clickhouse_script(env=clickhouse_env, check=True)
         _wait_for_tcp("localhost", 8123, timeout=60)
         yield
     finally:
-        subprocess.run(
-            ["bash", str(REPO_ROOT / "services/intake/scripts/spans/run_clickhouse.sh"), "--remove"],
-            check=True,
-            cwd=REPO_ROOT,
-            env=clickhouse_env,
-        )
+        # Best effort: teardown must not turn a test failure into a fixture error, and the setup
+        # above no longer depends on this having run.
+        _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
`Python integration tests` intermittently fails after ~31 minutes with no test named — including on `main`, where 4 of the last 8 commits hit it. This makes that failure contained and legible. It does **not** fix whatever kills the worker in the first place; see *What this doesn't do*.

## What actually happens

```
4 workers [1415 items]
[gw0] node down: Not properly terminated
F
replacing crashed worker gw0
… stalls at 97% … killed by `timeout` at 1800s
```

`report.xml` is never written, so the summary that would name the crashed test never prints. An orphan `nemo` process is reported at job cleanup.

Successful runs take **11–20 min**; every failure sits at **~31 min**. It's a hang, not a suite that outgrew its budget. No successful run contains a worker crash, and every failure does.

## The cascade

Container identity comes from the data directory, but `run_clickhouse.sh` runs in legacy-script mode and always names the container `nmp-intake-clickhouse`. The fixture asked for a fresh `tmp_path_factory.mktemp()` directory per session — fixed name, varying directory.

1. Worker running the `nmp_intake_clickhouse` group is killed → teardown skipped → container survives with data dir **A**
2. Replacement worker re-runs the group with a new temp dir **B**
3. Same container name, different directory → provisioning fails closed
4. `--remove` can't clear it either: removal only matches containers whose directory equals **B**

Verified against a deliberately stranded container:

| | `--remove` | provision |
|---|---|---|
| before | `No managed local ClickHouse container found` (exit 0, no-op) | **exit 1**, `does not use the expected data directory` |
| after | `Removed managed local ClickHouse container` | **exit 0**, ready |

## Changes

**`test_publish_to_intake.py`** — stable data directory so a stranded container is reclaimable. Setup reclaims first and wipes the directory so sessions still start empty; teardown drops `check=True` so cleanup can't mask a real error.

**`Makefile`** — `--max-worker-restart=0` for integration targets only, alongside the existing `loadgroup` override. Measured on a synthetic crashing test: with restarts, **57s and 9 failures** as the test is retried on each replacement worker; without, **7s, one failure, the test named, and `report.xml` written**. Unit workers own nothing external and keep the restart budget.

## What this doesn't do

It doesn't explain why a worker dies. It makes the next occurrence fail in minutes with the test named, which is what identifying that needs.

## Rejected along the way

`timeout -s INT` instead of SIGTERM, to let pytest write its summary. **Tested and rejected** — under xdist with a stuck worker, SIGINT left pytest *running* past 20s and still produced no `report.xml`, where SIGTERM at least exited. It would have made things worse.

Also worth recording: a pytest-timeout thread-method timeout in a worker is indistinguishable from a hard crash in the log (`worker 'gwN' crashed while running …`, no stack dump), because xdist doesn't forward worker output live. So the crash may be something mundane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Test worker restart limits are now configurable, with a default of two retries.
  * Integration test runs disable automatic worker restarts for more predictable execution.

* **Bug Fixes**
  * Integration testing now better handles stale test environments and performs cleanup after runs.
  * ClickHouse test setup and teardown are more reliable, reducing failures caused by leftover containers or data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->