### PR TITLE
fix(studio): make the shared vendor bundle browser-safe

### DIFF
--- a/web/packages/studio/vite.config.ts
+++ b/web/packages/studio/vite.config.ts
@@ -116,7 +116,11 @@ const workspaceSourcePlugin = (): RolldownPlugin => ({
       const rest = id.slice(alias.length).replace(/^\//, '');
       return resolveSourceFile(path.join(WORKSPACE_ALIASES[alias], rest));
     }
-    if (importer && (id.startsWith('./') || id.startsWith('../'))) {
+    if (
+      importer &&
+      !importer.includes('node_modules') &&
+      (id.startsWith('./') || id.startsWith('../'))
+    ) {
       return resolveSourceFile(path.resolve(path.dirname(importer), id));
     }
     return null;
@@ -164,7 +168,8 @@ function buildRequireShim(externals: readonly string[]): string {
 async function buildVendorBundles(
   outdir: string,
   projectRoot: string,
-  dev: boolean
+  dev: boolean,
+  env: Record<string, string>
 ): Promise<void> {
   // Load React modules from studio's node_modules and enumerate their real
   // runtime exports so we can generate explicit named re-exports.
@@ -260,7 +265,13 @@ async function buildVendorBundles(
         // Dev needs React's development build: Fast Refresh's scheduleRefresh
         // hook and dev warnings only exist in the development renderer.
         transform: {
-          define: { 'process.env.NODE_ENV': dev ? '"development"' : '"production"' },
+          define: {
+            'process.env.NODE_ENV': dev ? '"development"' : '"production"',
+            // Rolldown leaves `import.meta.env` undefined, so shared code
+            // reading env vars (PLATFORM_BASE_URL) throws when a plugin loads
+            // this bundle. Inline Vite's resolved env instead.
+            'import.meta.env': JSON.stringify(env),
+          },
         },
         external,
         plugins: [virtualShimPlugin(shims), ...plugins],
@@ -291,13 +302,14 @@ function vendorPlugin(): Plugin {
   let projectRoot = '';
   let isServe = false;
   let isPreview = false;
+  let viteEnv: Record<string, string> = {};
   let pending: Promise<void> | null = null;
 
   // buildVendorBundles wipes outdir and rebuilds on every vite process start,
   // so dev and build never serve bundles left over from the other mode.
   const ensureBuilt = () => {
     if (!pending) {
-      pending = buildVendorBundles(outdir, projectRoot, isServe);
+      pending = buildVendorBundles(outdir, projectRoot, isServe, viteEnv);
     }
     return pending;
   };
@@ -331,6 +343,7 @@ function vendorPlugin(): Plugin {
       base = config.base;
       isServe = config.command === 'serve' && !isPreview;
       projectRoot = config.root;
+      viteEnv = config.env as Record<string, string>;
       outdir = isServe
         ? path.resolve(projectRoot, DEV_VENDOR_DIR)
         : path.resolve(projectRoot, 'public', 'vendor');

--- a/web/packages/studio/vite.config.ts
+++ b/web/packages/studio/vite.config.ts
@@ -92,6 +92,8 @@ const WORKSPACE_ALIASES: Record<string, string> = {
 
 const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
 
+const IN_NODE_MODULES = /(^|[\\/])node_modules([\\/]|$)/;
+
 const resolveSourceFile = (base: string): string | null => {
   if (fs.existsSync(base) && fs.statSync(base).isFile()) return base;
   for (const ext of SOURCE_EXTENSIONS) {
@@ -118,7 +120,7 @@ const workspaceSourcePlugin = (): RolldownPlugin => ({
     }
     if (
       importer &&
-      !importer.includes('node_modules') &&
+      !IN_NODE_MODULES.test(importer) &&
       (id.startsWith('./') || id.startsWith('../'))
     ) {
       return resolveSourceFile(path.resolve(path.dirname(importer), id));
@@ -169,7 +171,7 @@ async function buildVendorBundles(
   outdir: string,
   projectRoot: string,
   dev: boolean,
-  env: Record<string, string>
+  env: Readonly<Record<string, unknown>>
 ): Promise<void> {
   // Load React modules from studio's node_modules and enumerate their real
   // runtime exports so we can generate explicit named re-exports.
@@ -302,7 +304,7 @@ function vendorPlugin(): Plugin {
   let projectRoot = '';
   let isServe = false;
   let isPreview = false;
-  let viteEnv: Record<string, string> = {};
+  let viteEnv: Readonly<Record<string, unknown>> = {};
   let pending: Promise<void> | null = null;
 
   // buildVendorBundles wipes outdir and rebuilds on every vite process start,
@@ -343,7 +345,7 @@ function vendorPlugin(): Plugin {
       base = config.base;
       isServe = config.command === 'serve' && !isPreview;
       projectRoot = config.root;
-      viteEnv = config.env as Record<string, string>;
+      viteEnv = config.env;
       outdir = isServe
         ? path.resolve(projectRoot, DEV_VENDOR_DIR)
         : path.resolve(projectRoot, 'public', 'vendor');


### PR DESCRIPTION
## Summary

The `@nemo/common` vendor bundle Studio serves to plugins is produced by a raw rolldown pass, not by Vite, so it silently misses two things Vite normally guarantees for browser output: `browser`-field module resolution and a defined `import.meta.env`. Neither shows up until a plugin imports a shared component whose import graph reaches them, at which point the plugin fails to load with `Failed to resolve module specifier "crypto"` and then `Cannot read properties of undefined (reading 'VITE_PLATFORM_BASE_URL')`.

## Related Issue

None.

## Changes

- `workspaceSourcePlugin` claimed *every* relative specifier from *every* importer, including files inside `node_modules`. That short-circuited rolldown's `browser` field remapping, which is how axios swaps its Node implementation out (`./lib/adapters/http.js` → `./lib/helpers/null.js`, `./lib/platform/node/index.js` → the browser variant). The Node build got bundled instead, emitting bare `crypto` / `url` / `events` / `http` / `https` / `http2` / `util` / `path` / `stream` / `zlib` imports into `vendor/common.js`. The relative branch is now restricted to workspace source.
- Rolldown leaves `import.meta.env` undefined, so shared code that reads env vars (`PLATFORM_BASE_URL` via `getEnvVar`) threw on property access. Vite's resolved `config.env` is now threaded into `buildVendorBundles` and inlined through `transform.define`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: build-config only; the vendor bundle is generated by `vite.config.ts` and is not exercised by the unit test suite (`vendorPlugin` is disabled under `inTestMode`).
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-visible behavior change; this restores the intended browser output.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `npm run typecheck --prefix web/packages/studio` — passed (exit 0).
- Pre-commit hooks ran on commit and push (`Fix copyright headers`, `Run UI lint-staged`, `check for merge conflicts` — all passed). A full `uv run pre-commit run -a` was not run.
- Reproduced the vendor build directly with rolldown, using the same entry (`export * from '@nemo/common/src/plugin'`), externals, `platform: 'browser'`, and plugin set as `buildVendorBundles`:

  | | node builtin resolutions | bare builtin imports in output | `import.meta.env` left |
  | --- | --- | --- | --- |
  | before | 25 (`crypto`, `http`, `http2`, `tls`, `net`, …) | 10 | 4 |
  | after | 0 | 0 | 0 (only a code comment) |

  Importer traced to `axios/lib/platform/node/index.js` and `axios/lib/adapters/http.js`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace import resolution to avoid incorrectly processing third-party packages.
  * Ensured vendor bundles correctly include configured environment variables.
  * Improved handling of build-time environment settings for more reliable production builds.
  * Reduced the risk of missing configuration during bundled application builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->