### PR TITLE
ci: fix the flaky integration failure, and make the next one diagnosable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1072,10 +1072,8 @@ jobs:
           NMP_FILES_HF_RETRY_MAX_DELAY_SECONDS: "30"
           PYTEST_WORKERS: "4"
           _TYPER_FORCE_DISABLE_TERMINAL: "1"
-          # Fatal-signal tracebacks, one file per worker. pytest's own faulthandler plugin
-          # points at the worker's captured stderr, which xdist never forwards, so a worker
-          # that dies of a signal reports only "node down". Disabling it lets ours write
-          # files that outlive the process and name the test it was running.
+          # Per-worker crash dumps; pytest's own faulthandler would point them at stderr, which
+          # xdist never forwards. See conftest.py.
           PYTEST_CRASH_DUMP_DIR: crash-dumps
           PYTEST_EXTRA: -p no:faulthandler
       - name: Upload test artifacts
@@ -1089,8 +1087,7 @@ jobs:
             coverage.xml
             coverage.json
       - name: Upload worker crash dumps
-        # Separate artifact: the coverage-comment job consumes the results artifact above and
-        # should keep receiving exactly the coverage files it expects.
+        # Separate artifact so coverage-comment keeps receiving exactly the files it expects.
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1072,6 +1072,12 @@ jobs:
           NMP_FILES_HF_RETRY_MAX_DELAY_SECONDS: "30"
           PYTEST_WORKERS: "4"
           _TYPER_FORCE_DISABLE_TERMINAL: "1"
+          # Fatal-signal tracebacks, one file per worker. pytest's own faulthandler plugin
+          # points at the worker's captured stderr, which xdist never forwards, so a worker
+          # that dies of a signal reports only "node down". Disabling it lets ours write
+          # files that outlive the process and name the test it was running.
+          PYTEST_CRASH_DUMP_DIR: crash-dumps
+          PYTEST_EXTRA: -p no:faulthandler
       - name: Upload test artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1082,6 +1088,16 @@ jobs:
             report.xml
             coverage.xml
             coverage.json
+      - name: Upload worker crash dumps
+        # Separate artifact: the coverage-comment job consumes the results artifact above and
+        # should keep receiving exactly the coverage files it expects.
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-integration-crash-dumps
+          retention-days: 30
+          if-no-files-found: ignore
+          path: crash-dumps/
 
   python-auth-idp-static-test:
     name: Python auth-idp static tests

--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,6 @@ docs/helm/index.mdx
 # nektos/act files commonly used
 .act-variables
 .act-secrets
+
+# Per-worker fatal-signal tracebacks (PYTEST_CRASH_DUMP_DIR)
+crash-dumps/

--- a/Makefile
+++ b/Makefile
@@ -378,9 +378,11 @@ PYTEST_VERBOSITY := $(if $(filter true,$(CI)),-q,-v)
 PYTEST_WORKERS ?= auto
 PYTEST_MAX_WORKERS ?= 16
 PYTEST_DIST ?= loadscope
+PYTEST_MAX_WORKER_RESTART ?= 2
 PYTEST_CMD = env PYTHONWARNINGS="ignore::UserWarning:pytest_only.version" $(UV) run --frozen \
 	pytest \
-	-n $(PYTEST_WORKERS) --maxprocesses=$(PYTEST_MAX_WORKERS) --max-worker-restart=2 \
+	-n $(PYTEST_WORKERS) --maxprocesses=$(PYTEST_MAX_WORKERS) \
+	--max-worker-restart=$(PYTEST_MAX_WORKER_RESTART) \
 	--dist $(PYTEST_DIST) --timeout=120 $(PYTEST_VERBOSITY) $(PYTEST_EXTRA)
 
 PYTEST_CI_OPTS := --cov=src --cov=packages \
@@ -403,6 +405,14 @@ PYTEST_CI_CMD = timeout --kill-after=60s $(PYTEST_CI_TIMEOUT)s $(PYTEST_CMD)
 # CI integration runs therefore use ``loadgroup`` while unit runs keep
 # ``loadscope``.
 test-integration test-integration-ci: PYTEST_DIST := loadgroup
+
+# Integration workers own external resources (Docker containers, service ports, spawned `nemo`
+# processes) through session-scoped fixtures. A killed worker never runs its teardown, so replacing
+# it re-runs the same group against resources the dead worker still owns — which fails, and can
+# leave the controller waiting until the outer wall-clock timeout. Not replacing a crashed
+# integration worker ends the run instead, with xdist naming the test it died on. Unit workers own
+# nothing external, so they keep the restart budget.
+test-integration test-integration-ci: PYTEST_MAX_WORKER_RESTART := 0
 
 .PHONY: test-unit
 test-unit: ## Run Python unit tests across all packages and services

--- a/Makefile
+++ b/Makefile
@@ -406,12 +406,8 @@ PYTEST_CI_CMD = timeout --kill-after=60s $(PYTEST_CI_TIMEOUT)s $(PYTEST_CMD)
 # ``loadscope``.
 test-integration test-integration-ci: PYTEST_DIST := loadgroup
 
-# Integration workers own external resources (Docker containers, service ports, spawned `nemo`
-# processes) through session-scoped fixtures. A killed worker never runs its teardown, so replacing
-# it re-runs the same group against resources the dead worker still owns — which fails, and can
-# leave the controller waiting until the outer wall-clock timeout. Not replacing a crashed
-# integration worker ends the run instead, with xdist naming the test it died on. Unit workers own
-# nothing external, so they keep the restart budget.
+# A killed integration worker never tears down its containers and ports, so replacing it re-runs
+# the group against resources the dead worker still holds. Unit workers own nothing external.
 test-integration test-integration-ci: PYTEST_MAX_WORKER_RESTART := 0
 
 .PHONY: test-unit

--- a/conftest.py
+++ b/conftest.py
@@ -205,6 +205,51 @@ def pytest_configure(config):
     This runs once at the start of the test session.
     """
     config.option.importmode = "importlib"
+    _enable_crash_dumps(config)
+
+
+def _enable_crash_dumps(config) -> None:
+    """Route fatal-signal tracebacks to a per-worker file when asked to.
+
+    An xdist worker that dies of a fatal signal reports only ``node down: Not properly terminated``
+    on the controller: xdist does not forward worker stdout/stderr live, so anything the dying
+    process writes to its own streams is lost. A file survives, which is the only way to learn what
+    the worker was doing when it aborted.
+
+    Off unless ``PYTEST_CRASH_DUMP_DIR`` is set, so ordinary runs are untouched.
+    """
+    dump_dir = os.environ.get("PYTEST_CRASH_DUMP_DIR")
+    if not dump_dir:
+        return
+
+    import faulthandler
+
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "controller")
+    directory = Path(dump_dir)
+    directory.mkdir(parents=True, exist_ok=True)
+    # Line buffered: a fatal signal gives no chance to flush.
+    handle = (directory / f"crash-{worker}-{os.getpid()}.log").open("w", buffering=1)
+    faulthandler.enable(file=handle, all_threads=True)
+    # Held module-level so the file object outlives this function; closing it would disable the
+    # handler, and `pytest_runtest_logstart` below needs the same handle.
+    global _CRASH_DUMP_FILE
+    _CRASH_DUMP_FILE = handle
+    handle.write(f"--- worker {worker} pid {os.getpid()}\n")
+
+
+#: Open crash-dump file for this process, or None when crash dumps are disabled.
+_CRASH_DUMP_FILE = None
+
+
+def pytest_runtest_logstart(nodeid, location):
+    """Record which test this process entered, so a crash dump can be attributed to it.
+
+    The controller only learns that a worker died, never which test it was on when the signal
+    arrived. Writing the nodeid on entry means the tail of the file names it.
+    """
+    del location
+    if _CRASH_DUMP_FILE is not None:
+        _CRASH_DUMP_FILE.write(f"--- entering {nodeid}\n")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/conftest.py
+++ b/conftest.py
@@ -212,14 +212,9 @@ def pytest_configure(config):
 
 
 def _enable_crash_dumps(config) -> None:
-    """Route fatal-signal tracebacks to a per-worker file when asked to.
+    """Route fatal-signal tracebacks to a per-worker file when ``PYTEST_CRASH_DUMP_DIR`` is set.
 
-    An xdist worker that dies of a fatal signal reports only ``node down: Not properly terminated``
-    on the controller: xdist does not forward worker stdout/stderr live, so anything the dying
-    process writes to its own streams is lost. A file survives, which is the only way to learn what
-    the worker was doing when it aborted.
-
-    Off unless ``PYTEST_CRASH_DUMP_DIR`` is set, so ordinary runs are untouched.
+    xdist does not forward worker streams, so a signal death otherwise reports only ``node down``.
     """
     dump_dir = os.environ.get("PYTEST_CRASH_DUMP_DIR")
     if not dump_dir:
@@ -233,8 +228,7 @@ def _enable_crash_dumps(config) -> None:
     # Line buffered: a fatal signal gives no chance to flush.
     handle = (directory / f"crash-{worker}-{os.getpid()}.log").open("w", buffering=1)
     faulthandler.enable(file=handle, all_threads=True)
-    # Held module-level so the file object outlives this function; closing it would disable the
-    # handler, and `pytest_runtest_logstart` below needs the same handle.
+    # Module-level so the handle outlives this function; closing it would disable the handler.
     global _CRASH_DUMP_FILE
     _CRASH_DUMP_FILE = handle
     handle.write(f"--- worker {worker} pid {os.getpid()}\n")
@@ -243,22 +237,16 @@ def _enable_crash_dumps(config) -> None:
 #: Open crash-dump file for this process, or None when crash dumps are disabled.
 _CRASH_DUMP_FILE = None
 
-#: Session-wide per-test timeout, so a lost worker's elapsed time can be judged against it.
+#: Session-wide per-test timeout, to judge a lost worker's elapsed time against.
 _SESSION_TIMEOUT_SECONDS = None
 
-
-#: When each in-flight test started, by nodeid. Populated on the controller as well as in workers,
-#: because xdist forwards `logstart` to the controller — which is what lets a lost worker's test be
-#: timed from the outside, where the process that was running it no longer exists to report.
+#: Start time of each in-flight test, by nodeid. xdist forwards `logstart` to the controller, so a
+#: lost worker's test can still be timed from there.
 _TEST_START_TIMES: dict[str, float] = {}
 
 
 def pytest_runtest_logstart(nodeid, location):
-    """Record which test this process entered, so a crash dump can be attributed to it.
-
-    The controller only learns that a worker died, never which test it was on when the signal
-    arrived. Writing the nodeid on entry means the tail of the file names it.
-    """
+    """Record the test being entered, so the tail of a crash dump names it."""
     del location
     _TEST_START_TIMES[nodeid] = time.monotonic()
     if _CRASH_DUMP_FILE is not None:
@@ -272,17 +260,10 @@ def pytest_runtest_logfinish(nodeid, location):
 
 
 def pytest_handlecrashitem(crashitem, report, sched):
-    """Say how long a lost worker's test had been running, and name a timeout when it looks like one.
+    """Say how long a lost worker's test ran, and name a timeout when it looks like one.
 
-    xdist can only report ``worker 'gwN' crashed while running <nodeid>``, because from the
-    controller a lost worker is indistinguishable from any other. A timeout reads as a crash: with
-    ``timeout_method = thread``, pytest-timeout calls ``os._exit(1)``, which is not a signal — so
-    faulthandler never runs — and its own stack dump goes to the worker's captured stdout, which
-    xdist does not forward. Both channels are dark and the operator is left to guess.
-
-    The controller does know when the test started, so it can supply the one number that
-    distinguishes the cases. Appending it turns "crashed" into "ran 121.4s against a 120s timeout",
-    which is the difference between a five-minute diagnosis and a five-day one.
+    pytest-timeout's thread method ``os._exit(1)``s the worker, which the controller cannot tell
+    from a crash. Elapsed time is the one number that distinguishes them.
     """
     del sched
     started = _TEST_START_TIMES.pop(crashitem, None)

--- a/conftest.py
+++ b/conftest.py
@@ -12,6 +12,7 @@ files for more specific fixtures.
 import logging
 import os
 import tempfile
+import time
 from collections.abc import Generator
 from pathlib import Path
 
@@ -206,6 +207,8 @@ def pytest_configure(config):
     """
     config.option.importmode = "importlib"
     _enable_crash_dumps(config)
+    global _SESSION_TIMEOUT_SECONDS
+    _SESSION_TIMEOUT_SECONDS = getattr(config.option, "timeout", None)
 
 
 def _enable_crash_dumps(config) -> None:
@@ -240,6 +243,15 @@ def _enable_crash_dumps(config) -> None:
 #: Open crash-dump file for this process, or None when crash dumps are disabled.
 _CRASH_DUMP_FILE = None
 
+#: Session-wide per-test timeout, so a lost worker's elapsed time can be judged against it.
+_SESSION_TIMEOUT_SECONDS = None
+
+
+#: When each in-flight test started, by nodeid. Populated on the controller as well as in workers,
+#: because xdist forwards `logstart` to the controller — which is what lets a lost worker's test be
+#: timed from the outside, where the process that was running it no longer exists to report.
+_TEST_START_TIMES: dict[str, float] = {}
+
 
 def pytest_runtest_logstart(nodeid, location):
     """Record which test this process entered, so a crash dump can be attributed to it.
@@ -248,8 +260,44 @@ def pytest_runtest_logstart(nodeid, location):
     arrived. Writing the nodeid on entry means the tail of the file names it.
     """
     del location
+    _TEST_START_TIMES[nodeid] = time.monotonic()
     if _CRASH_DUMP_FILE is not None:
         _CRASH_DUMP_FILE.write(f"--- entering {nodeid}\n")
+
+
+def pytest_runtest_logfinish(nodeid, location):
+    """Forget a test that finished, so only genuinely in-flight tests are timed."""
+    del location
+    _TEST_START_TIMES.pop(nodeid, None)
+
+
+def pytest_handlecrashitem(crashitem, report, sched):
+    """Say how long a lost worker's test had been running, and name a timeout when it looks like one.
+
+    xdist can only report ``worker 'gwN' crashed while running <nodeid>``, because from the
+    controller a lost worker is indistinguishable from any other. A timeout reads as a crash: with
+    ``timeout_method = thread``, pytest-timeout calls ``os._exit(1)``, which is not a signal — so
+    faulthandler never runs — and its own stack dump goes to the worker's captured stdout, which
+    xdist does not forward. Both channels are dark and the operator is left to guess.
+
+    The controller does know when the test started, so it can supply the one number that
+    distinguishes the cases. Appending it turns "crashed" into "ran 121.4s against a 120s timeout",
+    which is the difference between a five-minute diagnosis and a five-day one.
+    """
+    del sched
+    started = _TEST_START_TIMES.pop(crashitem, None)
+    if started is None:
+        return None
+    elapsed = time.monotonic() - started
+    if _SESSION_TIMEOUT_SECONDS and elapsed >= _SESSION_TIMEOUT_SECONDS * 0.9:
+        note = (
+            f"ran {elapsed:.1f}s against --timeout={_SESSION_TIMEOUT_SECONDS:g}s "
+            f"— likely a TIMEOUT, not a crash (pytest-timeout os._exit()s the worker)"
+        )
+    else:
+        note = f"ran {elapsed:.1f}s before the worker was lost"
+    report.longrepr = f"{report.longrepr}\n  {note}"
+    return None
 
 
 def pytest_collection_modifyitems(config, items):

--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -105,39 +105,17 @@ def _wait_for_ready(base_url: str, *, timeout: float) -> None:
     raise RuntimeError(f"platform at {base_url} not ready within {timeout}s")
 
 
-#: Stable data directory for this suite's ClickHouse container.
-#
-# Deliberately not a per-session temp directory. The provisioner names the container from a fixed
-# legacy name but validates it against the data directory it was created with, so a per-session
-# path means every new session presents a *different* directory under the *same* container name.
-# One container that outlives its session — which is exactly what happens when an xdist worker is
-# killed before its teardown runs — then makes every later session fail to provision with
-# "does not use the expected data directory", and `--remove` cannot clear it because removal only
-# matches containers whose data directory equals the one being asked for.
-#
-# With a stable path, a stranded container is reclaimable: `--remove` below matches it, so the
-# next session cleans it up instead of colliding with it.
+#: Stable, not per-session: `--remove` only matches containers whose data directory equals the one
+#: being asked for, so a per-session path leaves a stranded container unremovable.
 _CLICKHOUSE_DATA_DIR = REPO_ROOT / "tmp" / "evaluator-intake-clickhouse"
 
 
-#: Ceiling for a single provisioner invocation. Generous enough to cover a cold image pull, short
-#: enough that a wedged Docker fails this fixture rather than the whole worker: an unbounded wait
-#: inside session-fixture setup is charged to whichever test triggered it, and pytest-timeout's
-#: thread method answers that by killing the process outright, which the controller reports as a
-#: bare `node down` with no cause.
+#: Bounds one provisioner call, so a wedged Docker fails this fixture instead of the worker.
 _CLICKHOUSE_SCRIPT_TIMEOUT_ENV = "NMP_EVALUATOR_CLICKHOUSE_SCRIPT_TIMEOUT"
 
 
 def _script_timeout_seconds() -> float:
-    """Resolve the provisioner timeout, rejecting values `subprocess.run` would misread.
-
-    Parsed here rather than inline so a bad value fails with a message that names the variable.
-    A bare ``float()`` at module scope would abort collection of this file with a stray
-    ``ValueError`` and no indication of which setting caused it. Zero and negative are rejected
-    because ``subprocess.run`` treats them as an immediate timeout, silently turning every
-    invocation into a failure, and non-finite values because ``inf`` disables the bound that this
-    setting exists to impose.
-    """
+    """Resolve the provisioner timeout. Zero and negative time out immediately; ``inf`` never."""
     raw = os.getenv(_CLICKHOUSE_SCRIPT_TIMEOUT_ENV)
     if raw is None:
         return 300.0
@@ -169,21 +147,17 @@ def _clickhouse() -> Iterator[None]:
     if not _docker_available():
         pytest.skip("Docker not available; required for ClickHouse-backed Intake")
     clickhouse_env = {**os.environ, "CLICKHOUSE_DATA_DIR": str(_CLICKHOUSE_DATA_DIR)}
-    # Reclaim anything a previous session left behind before provisioning. Not check=True: there is
-    # usually nothing to remove, and a failure here must not mask the provisioning error below. A
-    # timeout counts as a failure, so the wipe below is skipped and provisioning reports the real
-    # problem.
+    # Reclaim anything a previous session left behind. Not check=True: usually there is nothing to
+    # remove, and a failure here must not mask the provisioning error below.
     try:
         reclaimed = _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
     except subprocess.TimeoutExpired:
         reclaimed = -1
-    # Only wipe once removal reported success — including the "nothing to remove" case, which also
-    # exits 0. The directory is bind-mounted read-write into the container, so deleting it after a
-    # failed removal would pull the data out from under a ClickHouse that is still running.
-    # Provisioning below fails loudly on a container it cannot reconcile, which is the better error.
+    # The directory is bind-mounted read-write, so only wipe it once removal succeeded — otherwise
+    # a still-running ClickHouse loses its data underneath it.
     if reclaimed == 0:
-        # Not ignore_errors: a partially deleted data directory would leave the session running
-        # against state it believes is empty. Only absence is tolerable.
+        # Not ignore_errors: a partial delete leaves the session running against state it believes
+        # is empty.
         try:
             shutil.rmtree(_CLICKHOUSE_DATA_DIR)
         except FileNotFoundError:
@@ -193,9 +167,7 @@ def _clickhouse() -> Iterator[None]:
         _wait_for_tcp("localhost", 8123, timeout=60)
         yield
     finally:
-        # Best effort: teardown must not turn a test failure into a fixture error, and the setup
-        # above no longer depends on this having run. A hung Docker would otherwise replace the
-        # real failure with a teardown error.
+        # Best effort: setup reclaims on its own, so this must not mask a real test failure.
         try:
             _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
         except subprocess.TimeoutExpired:

--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -120,14 +120,48 @@ def _wait_for_ready(base_url: str, *, timeout: float) -> None:
 _CLICKHOUSE_DATA_DIR = REPO_ROOT / "tmp" / "evaluator-intake-clickhouse"
 
 
-def _run_clickhouse_script(*args: str, env: dict[str, str], check: bool) -> None:
-    """Invoke the local ClickHouse provisioner script."""
-    subprocess.run(
+#: Ceiling for a single provisioner invocation. Generous enough to cover a cold image pull, short
+#: enough that a wedged Docker fails this fixture rather than the whole worker: an unbounded wait
+#: inside session-fixture setup is charged to whichever test triggered it, and pytest-timeout's
+#: thread method answers that by killing the process outright, which the controller reports as a
+#: bare `node down` with no cause.
+_CLICKHOUSE_SCRIPT_TIMEOUT_ENV = "NMP_EVALUATOR_CLICKHOUSE_SCRIPT_TIMEOUT"
+
+
+def _script_timeout_seconds() -> float:
+    """Resolve the provisioner timeout, rejecting values `subprocess.run` would misread.
+
+    Parsed here rather than inline so a bad value fails with a message that names the variable.
+    A bare ``float()`` at module scope would abort collection of this file with a stray
+    ``ValueError`` and no indication of which setting caused it. Zero and negative are rejected
+    because ``subprocess.run`` treats them as an immediate timeout, silently turning every
+    invocation into a failure, and non-finite values because ``inf`` disables the bound that this
+    setting exists to impose.
+    """
+    raw = os.getenv(_CLICKHOUSE_SCRIPT_TIMEOUT_ENV)
+    if raw is None:
+        return 300.0
+    try:
+        seconds = float(raw)
+    except ValueError:
+        raise ValueError(f"{_CLICKHOUSE_SCRIPT_TIMEOUT_ENV} must be a number of seconds, got {raw!r}") from None
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError(f"{_CLICKHOUSE_SCRIPT_TIMEOUT_ENV} must be a positive, finite number of seconds, got {raw!r}")
+    return seconds
+
+
+_CLICKHOUSE_SCRIPT_TIMEOUT_SECONDS = _script_timeout_seconds()
+
+
+def _run_clickhouse_script(*args: str, env: dict[str, str], check: bool) -> int:
+    """Invoke the local ClickHouse provisioner script and return its exit status."""
+    return subprocess.run(
         ["bash", str(REPO_ROOT / "services/intake/scripts/spans/run_clickhouse.sh"), *args],
         check=check,
         cwd=REPO_ROOT,
         env=env,
-    )
+        timeout=_CLICKHOUSE_SCRIPT_TIMEOUT_SECONDS,
+    ).returncode
 
 
 @pytest.fixture(scope="session")
@@ -136,17 +170,36 @@ def _clickhouse() -> Iterator[None]:
         pytest.skip("Docker not available; required for ClickHouse-backed Intake")
     clickhouse_env = {**os.environ, "CLICKHOUSE_DATA_DIR": str(_CLICKHOUSE_DATA_DIR)}
     # Reclaim anything a previous session left behind before provisioning. Not check=True: there is
-    # usually nothing to remove, and a failure here must not mask the provisioning error below.
-    _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
-    shutil.rmtree(_CLICKHOUSE_DATA_DIR, ignore_errors=True)
+    # usually nothing to remove, and a failure here must not mask the provisioning error below. A
+    # timeout counts as a failure, so the wipe below is skipped and provisioning reports the real
+    # problem.
+    try:
+        reclaimed = _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
+    except subprocess.TimeoutExpired:
+        reclaimed = -1
+    # Only wipe once removal reported success — including the "nothing to remove" case, which also
+    # exits 0. The directory is bind-mounted read-write into the container, so deleting it after a
+    # failed removal would pull the data out from under a ClickHouse that is still running.
+    # Provisioning below fails loudly on a container it cannot reconcile, which is the better error.
+    if reclaimed == 0:
+        # Not ignore_errors: a partially deleted data directory would leave the session running
+        # against state it believes is empty. Only absence is tolerable.
+        try:
+            shutil.rmtree(_CLICKHOUSE_DATA_DIR)
+        except FileNotFoundError:
+            pass
     try:
         _run_clickhouse_script(env=clickhouse_env, check=True)
         _wait_for_tcp("localhost", 8123, timeout=60)
         yield
     finally:
         # Best effort: teardown must not turn a test failure into a fixture error, and the setup
-        # above no longer depends on this having run.
-        _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
+        # above no longer depends on this having run. A hung Docker would otherwise replace the
+        # real failure with a teardown error.
+        try:
+            _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
+        except subprocess.TimeoutExpired:
+            pass
 
 
 @pytest.fixture(scope="session")

--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import math
 import os
+import shutil
 import socket
 import subprocess
 import time
@@ -104,30 +105,48 @@ def _wait_for_ready(base_url: str, *, timeout: float) -> None:
     raise RuntimeError(f"platform at {base_url} not ready within {timeout}s")
 
 
+#: Stable data directory for this suite's ClickHouse container.
+#
+# Deliberately not a per-session temp directory. The provisioner names the container from a fixed
+# legacy name but validates it against the data directory it was created with, so a per-session
+# path means every new session presents a *different* directory under the *same* container name.
+# One container that outlives its session — which is exactly what happens when an xdist worker is
+# killed before its teardown runs — then makes every later session fail to provision with
+# "does not use the expected data directory", and `--remove` cannot clear it because removal only
+# matches containers whose data directory equals the one being asked for.
+#
+# With a stable path, a stranded container is reclaimable: `--remove` below matches it, so the
+# next session cleans it up instead of colliding with it.
+_CLICKHOUSE_DATA_DIR = REPO_ROOT / "tmp" / "evaluator-intake-clickhouse"
+
+
+def _run_clickhouse_script(*args: str, env: dict[str, str], check: bool) -> None:
+    """Invoke the local ClickHouse provisioner script."""
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "services/intake/scripts/spans/run_clickhouse.sh"), *args],
+        check=check,
+        cwd=REPO_ROOT,
+        env=env,
+    )
+
+
 @pytest.fixture(scope="session")
-def _clickhouse(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+def _clickhouse() -> Iterator[None]:
     if not _docker_available():
         pytest.skip("Docker not available; required for ClickHouse-backed Intake")
-    clickhouse_env = {
-        **os.environ,
-        "CLICKHOUSE_DATA_DIR": str(tmp_path_factory.mktemp("evaluator-intake-clickhouse")),
-    }
+    clickhouse_env = {**os.environ, "CLICKHOUSE_DATA_DIR": str(_CLICKHOUSE_DATA_DIR)}
+    # Reclaim anything a previous session left behind before provisioning. Not check=True: there is
+    # usually nothing to remove, and a failure here must not mask the provisioning error below.
+    _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
+    shutil.rmtree(_CLICKHOUSE_DATA_DIR, ignore_errors=True)
     try:
-        subprocess.run(
-            ["bash", str(REPO_ROOT / "services/intake/scripts/spans/run_clickhouse.sh")],
-            check=True,
-            cwd=REPO_ROOT,
-            env=clickhouse_env,
-        )
+        _run_clickhouse_script(env=clickhouse_env, check=True)
         _wait_for_tcp("localhost", 8123, timeout=60)
         yield
     finally:
-        subprocess.run(
-            ["bash", str(REPO_ROOT / "services/intake/scripts/spans/run_clickhouse.sh"), "--remove"],
-            check=True,
-            cwd=REPO_ROOT,
-            env=clickhouse_env,
-        )
+        # Best effort: teardown must not turn a test failure into a fixture error, and the setup
+        # above no longer depends on this having run.
+        _run_clickhouse_script("--remove", env=clickhouse_env, check=False)
 
 
 @pytest.fixture(scope="session")

--- a/services/core/auth/tests/integration/test_scoped_access_keys.py
+++ b/services/core/auth/tests/integration/test_scoped_access_keys.py
@@ -64,7 +64,7 @@ def _auth_configs(private_key_file: str) -> tuple[AuthConfig, AuthServiceConfig]
     service_config = AuthServiceConfig(
         **shared_config.model_dump(),
         policy_data_refresh_interval=0.2,
-        bundle_cache_seconds=0,
+        bundle_cache_seconds=1,
         admin_email="admin@example.com",
     )
     return shared_config, service_config


### PR DESCRIPTION
## Summary

`Python integration tests` has been failing roughly half of all runs — on `main` as well — reported as `worker gwN crashed while running ...` after ~31 minutes with no test named. **It was never a crash.** It was the suite-wide `--timeout=120` firing on one test that takes about two minutes. This fixes that test, and fixes the two things that made the failure impossible to diagnose for days.

## The actual bug

`test_scoped_access_keys` sets `bundle_cache_seconds=0`, which makes the authz endpoint call `load_policy_data` before **every** PDP evaluation. The test drives a full access-key lifecycle — create workspace, create key, list, authenticate, revoke, re-authenticate — through an in-process platform, so each request reloaded the entire policy document.

Durations from `--durations=25` on runs where it passed, against the 120s limit:

| commit | result | duration |
|---|---|---|
| `88698368` | success | **119.92s** |
| `095b1991` | success | 117.81s |
| `4c3bef54` | success | 108.28s |
| `ed68cbb1` | success | 89.47s |
| 7 others | failure | *no duration — never finished* |

Every pass under 120s, every failure with no duration. Runner load decided the outcome.

A one-second cache takes it to **12.96s in CI**, verified on a green run. Ran locally eight times consecutively to confirm the cache does not trade a timeout for a staleness flake: 8 passes.

An alternative fix that only raised the ceiling was tested separately and gave the causal proof: that run took **129.26s** — over the old limit — and passed solely because the ceiling was higher. Same diagnosis confirmed from both directions.

## Why it took days to find

Two independent things hid it, and both are fixed here.

**pytest-timeout's thread method calls `os._exit(1)`.** Not a signal, so faulthandler never runs. Its own stack dump goes to the worker's captured stdout, which xdist does not forward. Both diagnostic channels dark, for different reasons, leaving the controller with only `node down: Not properly terminated`.

**GNU `timeout` sends SIGTERM at the 1800s wall clock**, killing pytest before it writes `report.xml`, so the summary that names the test never printed.

## Changes

- **`test_scoped_access_keys.py`** — `bundle_cache_seconds=1`. The fix.
- **`Makefile`** — `--max-worker-restart=0` for integration targets only. A killed worker never runs its session-fixture teardown, so replacing it re-runs the group against resources the dead worker still holds. Measured on a synthetic crashing test: with restarts, 57s and 9 failures as it retried on each replacement; without, 7s, one failure, the test named, `report.xml` written. Unit workers own nothing external and keep the budget.
- **`conftest.py`** — fatal-signal tracebacks to a per-worker file when `PYTEST_CRASH_DUMP_DIR` is set, plus a nodeid trail so the tail of the file names the test. Unset, none of it runs.
- **`.github/workflows/ci.yaml`** — sets that directory for the integration job, passes `-p no:faulthandler` (pytest's plugin otherwise re-enables faulthandler against captured stderr and wins), and uploads dumps as their own artifact so `coverage-comment` keeps receiving exactly the coverage files it expects.
- **`test_publish_to_intake.py`** — stable ClickHouse data directory, so a container stranded by a killed worker is reclaimable instead of blocking every later session with "does not use the expected data directory". Setup reclaims first and wipes only once that reports success — the directory is bind-mounted read-write, so wiping after a failed removal would pull data out from under a running ClickHouse — and the wipe does not ignore errors, since a partial delete would leave the session running against state it believes is empty. Provisioner invocations are bounded by a validated timeout, because an unbounded wait in session-fixture setup is charged to whichever test triggered it and produces exactly the undebuggable `node down` this PR exists to eliminate.
- **`.gitignore`** — `crash-dumps/`.

## Effect

The failure stops. Wall clock is unchanged — ~918s either way, since the 116s came off a worker that was not the critical path — so this is a reliability fix, not a speed one.

## Type of Change

- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Existing tests cover changed behavior — justification: test and CI infrastructure. The ClickHouse fixture is exercised by the four tests in its module; the timeout fix is one existing test's config with its assertions untouched; the restart and crash-dump changes alter how pytest is invoked and were validated against synthetic crashing workers.
- [x] Documentation not applicable — justification: no user-visible behavior changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included
- [ ] `uv run pre-commit run -a` passes — three hooks fail on this machine (`Helm Docs`, `uv lock`, `UI lint-staged`, the last on a missing local `pnpm` shim). None touch this PR's files.

Targeted validation:

- The fix, in CI: `1322 passed` with the test at **12.96s**, down from 129.26s.
- The fix, locally: 8 consecutive passes at 5.7–6.8s.
- Restart behaviour: synthetic crashing test under `-n 2 --dist loadgroup` — 57s/9 failures with restarts, 7s/1 named failure without.
- Crash dumps: SIGABRT to a worker — without `-p no:faulthandler` the file holds only the nodeid trail; with it, `Fatal Python error: Aborted` plus every thread's stack. Confirmed reaching pytest via `make -n`.
- ClickHouse fixture against a deliberately stranded container: before, `--remove` no-ops and provisioning exits 1; after, it removes cleanly and provisioning succeeds with nothing surviving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)