### PR TITLE
fix(studio): point agent Open traces button to Intake traces

### DIFF
--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/index.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 vi.hoisted(() => {
-  vi.stubEnv('VITE_FF_MONITOR_ENABLED', 'true');
+  vi.stubEnv('VITE_FF_INTAKE_ENABLED', 'true');
 });
 
 import { ROUTES } from '@studio/constants/routes';
@@ -18,7 +18,10 @@ const workspace = workspace1.workspace;
 const renderDetail = () =>
   renderRoute(undefined, {
     history: getAgentDetailRoute(workspace, agentName),
-    routes: [{ path: ROUTES.workspace.agentDetail, element: <AgentDetailRoute /> }],
+    routes: [
+      { path: ROUTES.workspace.agentDetail, element: <AgentDetailRoute /> },
+      { path: ROUTES.workspace.intakeTraces, element: <div>intake-traces-page</div> },
+    ],
   });
 
 describe('AgentDetailRoute', () => {
@@ -40,6 +43,15 @@ describe('AgentDetailRoute', () => {
     expect(screen.getByRole('button', { name: 'Run evaluation' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Deploy' })).toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('navigates to intake traces when Open traces is clicked', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+
+    await user.click(await screen.findByRole('button', { name: 'Open traces' }));
+
+    expect(await screen.findByText('intake-traces-page')).toBeInTheDocument();
   });
 
   it('switches to the chat tab', async () => {

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
@@ -36,7 +36,7 @@ import {
   isAgentWalkthroughPending,
 } from '@studio/routes/agents/AgentDetailRoute/walkthroughStorage';
 import { getAgentsListRoute, getIntakeTracesRoute } from '@studio/routes/utils';
-import { Activity, ClipboardCheck, Dot, Rocket } from 'lucide-react';
+import { ClipboardCheck, Dot, ListTree, Rocket } from 'lucide-react';
 import { type FC, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 
@@ -166,7 +166,7 @@ export const AgentDetailRoute: FC = () => {
             <Flex gap="2" wrap="wrap" justify="end">
               {INTAKE_ENABLED && (
                 <Button kind="secondary" onClick={() => navigate(getIntakeTracesRoute(workspace))}>
-                  <Activity className="size-4" aria-hidden />
+                  <ListTree className="size-4" aria-hidden />
                   Open traces
                 </Button>
               )}

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
@@ -18,7 +18,7 @@ import {
 } from '@nvidia/foundations-react-core';
 import { getAgentModelNames } from '@studio/components/dataViews/AgentsDataView/utils';
 import { SubmitEvaluationModal } from '@studio/components/evaluation/SubmitEvaluationModal';
-import { MONITOR_ENABLED } from '@studio/constants/environment';
+import { INTAKE_ENABLED } from '@studio/constants/environment';
 import { ROUTE_PARAMS } from '@studio/constants/routes';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
@@ -35,7 +35,7 @@ import {
   clearAgentWalkthroughPending,
   isAgentWalkthroughPending,
 } from '@studio/routes/agents/AgentDetailRoute/walkthroughStorage';
-import { getAgentMonitorRoute, getAgentsListRoute } from '@studio/routes/utils';
+import { getAgentsListRoute, getIntakeTracesRoute } from '@studio/routes/utils';
 import { Activity, ClipboardCheck, Dot, Rocket } from 'lucide-react';
 import { type FC, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
@@ -164,8 +164,8 @@ export const AgentDetailRoute: FC = () => {
           }
           slotActions={
             <Flex gap="2" wrap="wrap" justify="end">
-              {MONITOR_ENABLED && (
-                <Button kind="secondary" onClick={() => navigate(getAgentMonitorRoute(workspace))}>
+              {INTAKE_ENABLED && (
+                <Button kind="secondary" onClick={() => navigate(getIntakeTracesRoute(workspace))}>
                   <Activity className="size-4" aria-hidden />
                   Open traces
                 </Button>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The "Open traces" button on the agent detail page navigated to the Monitor tab (`/agents/monitor`) and was gated behind `MONITOR_ENABLED`, so with Monitor disabled it was hidden entirely. It now navigates to the Intake **Traces** route (`/intake/traces`) and is gated behind `INTAKE_ENABLED`, so it renders and links to Traces as intended.

## Related Issue

ASTD-402: https://linear.app/nvidia/issue/ASTD-402

## Changes

- `AgentDetailRoute/index.tsx`: swap `getAgentMonitorRoute` → `getIntakeTracesRoute` and `MONITOR_ENABLED` → `INTAKE_ENABLED` for the "Open traces" button, and use the `ListTree` icon to match the AppBar Traces nav item (was `Activity`).
- `AgentDetailRoute/index.test.tsx`: stub `VITE_FF_INTAKE_ENABLED`, and add a test asserting the button navigates to the Intake traces route.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal navigation link fix; no user-facing docs describe this button target.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui exec vitest run src/routes/agents/AgentDetailRoute/index.test.tsx` → 4 passed (incl. new navigation guard).
- `pnpm exec prettier --check` on changed files → clean.
- `pnpm exec eslint` on changed files → clean.
- `pnpm --filter nemo-studio-ui run typecheck` → clean.
- Commit-time pre-commit hooks (incl. DCO) passed on the changed files. Full `uv run pre-commit run -a` not run; change is web-only, and CI runs the full gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Updated the agent details page’s **Open traces** action to open the intake traces view.
- Refreshed the traces icon to better represent the available trace hierarchy.
- Enabled the intake experience for this workflow.

## Tests

- Added coverage confirming that **Open traces** navigates to the correct intake traces page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->