### PR TITLE
feat(common): expose plugin chat surface

### DIFF
--- a/plugins/example-plugin/web/AGENTS.md
+++ b/plugins/example-plugin/web/AGENTS.md
@@ -74,7 +74,7 @@ instance Studio renders — same behavior, same styles, no second copy in the
 bundle. See `src/SharedUiPage.tsx`.
 
 ```ts
-import { StudioDataView, useStudioDataViewState } from '@nemo/common';
+import { AssistantChat, StudioDataView, useStudioDataViewState } from '@nemo/common';
 ```
 
 - **Bare specifier only.** A deep `@nemo/common/src/...` import is not
@@ -92,6 +92,11 @@ import { StudioDataView, useStudioDataViewState } from '@nemo/common';
   fine (they erase). A shared component that needs data takes it as a prop or
   callback and the caller supplies it from `host.sdk`; `CreateSecretModal`'s
   `onCreate` and `fetchAllPages`' page fetcher are the pattern.
+- **`AssistantChat` is shared.** A plugin can point it at an authenticated,
+  OpenAI-compatible `baseURL`; Studio supplies its current access token and
+  chat runtime. Use `messageContentProps.markdownLinkComponent` when a plugin
+  owns trusted, in-app citation targets. The plugin should still own the panel,
+  prompts, endpoint, and citation behavior specific to its feature.
 - **Types come from source**, via `paths` in `tsconfig.json`; `@nemo/common` is
   unpublished, so there is nothing to install. `src/env.d.ts` declares the `*.css`
   side-effect imports those sources carry.

--- a/web/packages/common/src/components/AssistantChat/index.test.tsx
+++ b/web/packages/common/src/components/AssistantChat/index.test.tsx
@@ -195,6 +195,29 @@ describe('AssistantChat', () => {
     interactionTimeoutMs
   );
 
+  it('allows a caller to render trusted Markdown links in messages', async () => {
+    mocks.createChatCompletion.mockResolvedValueOnce(
+      createCompletion('[Trace source](#zoomer-node=summary-1)')
+    );
+    renderAssistantChat(
+      <AssistantChat
+        model="test-model"
+        workspace="default"
+        messageContentProps={{
+          markdownLinkComponent: ({ href, children }) => <a href={href}>{children}</a>,
+        }}
+      />
+    );
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Task prompt/i }), 'Show evidence');
+    await userEvent.click(screen.getByRole('button', { name: /Submit/i }));
+
+    expect(await screen.findByRole('link', { name: 'Trace source' })).toHaveAttribute(
+      'href',
+      '#zoomer-node=summary-1'
+    );
+  });
+
   it('renders base64 images returned by an image model stream', async () => {
     const imageUrl = 'data:image/png;base64,iVBORw0KGgo=';
     const stream = {

--- a/web/packages/common/src/components/AssistantChat/index.tsx
+++ b/web/packages/common/src/components/AssistantChat/index.tsx
@@ -35,6 +35,7 @@ export const AssistantChat: FC<AssistantChatProps> = ({
   stopCount,
   slotComposerStart,
   emptyState,
+  messageContentProps,
   composerOverride,
   enableImageAttachments = true,
 }) => {
@@ -76,6 +77,7 @@ export const AssistantChat: FC<AssistantChatProps> = ({
           composerMode={composerMode}
           slotComposerStart={slotComposerStart}
           emptyState={emptyState}
+          messageContentProps={messageContentProps}
           composerOverride={composerOverride}
           enableImageAttachments={imageAttachmentsEnabled}
         />

--- a/web/packages/common/src/components/AssistantChat/types.ts
+++ b/web/packages/common/src/components/AssistantChat/types.ts
@@ -132,6 +132,8 @@ export interface AssistantChatProps {
     slotHeading?: string;
     slotSubheading?: string;
   };
+  /** Overrides used when rendering Markdown inside chat messages. */
+  messageContentProps?: AssistantChatMessageContentProps;
   composerOverride?: ReactNode;
   /**
    * @default true

--- a/web/packages/common/src/plugin.ts
+++ b/web/packages/common/src/plugin.ts
@@ -5,6 +5,11 @@
 // Removals are breaking. Explicit exports, not `export *`.
 
 export { AccessibleTitle } from '@nemo/common/src/components/AccessibleTitle';
+export { AssistantChat } from '@nemo/common/src/components/AssistantChat';
+export type {
+  AssistantChatMessageContentProps,
+  AssistantChatProps,
+} from '@nemo/common/src/components/AssistantChat/types';
 export { AccordionSection } from '@nemo/common/src/components/AccordionSection';
 // CancelJobButton is deliberately NOT exported
 export { ConfirmationModal } from '@nemo/common/src/components/ConfirmationModal';


### PR DESCRIPTION
## Summary

Adds `AssistantChat` to the curated `@nemo/common` plugin surface so a Studio plugin can render Studio's own chat component instead of bundling a second copy, and threads a `messageContentProps` override through it so a plugin can control how Markdown inside chat messages renders — specifically the link component, for plugins that own trusted in-app citation targets.

Split out of the Zoomer trace-view branch: it is a generic addition to the shared UI barrel, in the same class as `StudioDataView`, and stands on its own regardless of what consumes it.

## Related Issue

None.

## Changes

- `packages/common/src/plugin.ts` — export `AssistantChat` plus the `AssistantChatProps` / `AssistantChatMessageContentProps` types. Additions to this barrel are cheap; removals are breaking, which is why it stays an explicit export list rather than `export *`.
- `packages/common/src/components/AssistantChat/types.ts` — new optional `messageContentProps` on `AssistantChatProps`.
- `packages/common/src/components/AssistantChat/index.tsx` — pass it through to the thread.
- Test coverage for the new prop in `AssistantChat/index.test.tsx`.
- `plugins/example-plugin/web/AGENTS.md` — document the shared component and when to reach for `markdownLinkComponent`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter @nemo/common test src/components/AssistantChat/index.test.tsx` — see CI; this branch is the commit as authored, unmodified.
- Full `uv run pre-commit run -a` was not run; the commit-time hooks (copyright headers, UI lint-staged, merge conflicts) passed.

Note: the commit is authored by @rangilly and carries their sign-off — this PR only relocates it onto `main` so it can land independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing Markdown rendering in assistant chat messages, including citation links.
  * Made the Assistant Chat component and its public types available through the plugin API.
  * Updated plugin guidance with setup details for authenticated, OpenAI-compatible chat endpoints and plugin-owned conversations.

* **Tests**
  * Added coverage confirming custom link rendering preserves displayed text and destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->