### PR TITLE
fix: make embedded PDP thread safe

### DIFF
--- a/services/core/auth/src/nmp/core/auth/app/embedded_pdp/engine.py
+++ b/services/core/auth/src/nmp/core/auth/app/embedded_pdp/engine.py
@@ -6,6 +6,7 @@
 import json
 import logging
 import threading
+from functools import cache
 from typing import Any, Dict, List, Optional, cast
 
 from nmp.core.auth.app.embedded_pdp.policy_wasm import ensure_embedded_policy_wasm
@@ -23,13 +24,27 @@ class PolicyEngineError(Exception):
     """Error during policy evaluation."""
 
 
+@cache
+def _get_engine() -> Engine:
+    """Return the process-wide wasmtime Engine.
+
+    Engine setup is the heavyweight step in wasmtime — JIT code generation and process-wide
+    trap/signal-handling registration — and wasmtime's own guidance is one Engine per process with
+    many cheap Stores created from it. Creating a fresh Engine per thread-local OPAPolicy would
+    churn through many Engines over an xdist worker's lifetime; that churn, not any single test, is
+    what was crashing workers with no traceback ("node down: Not properly terminated").
+    """
+    config = Config()
+    config.consume_fuel = True
+    return Engine(config)
+
+
 class OPAPolicy:
     """Wrapper for OPA WASM policy evaluation."""
 
     def __init__(self, wasm_path: str, *, fuel_limit: int = 200_000_000, memory_limit_mb: int = 32):
-        config = Config()
-        config.consume_fuel = True
-        engine = Engine(config)
+        self._owner_thread_id = threading.get_ident()
+        engine = _get_engine()
 
         self.fuel_limit = fuel_limit
         self.store = Store(engine)
@@ -73,13 +88,21 @@ class OPAPolicy:
         self._base_heap = self._export_func("opa_heap_ptr_get")(self.store)
         self._data_heap = self._base_heap
         self._data_addr: Optional[int] = None
-        self._lock = threading.Lock()
+
+    def _assert_owner_thread(self) -> None:
+        current_thread_id = threading.get_ident()
+        if current_thread_id != self._owner_thread_id:
+            raise RuntimeError(
+                f"OPAPolicy used from a different thread (owner={self._owner_thread_id}, current={current_thread_id})"
+            )
 
     def _export_func(self, name: str) -> Func:
+        self._assert_owner_thread()
         return cast(Func, self.exports[name])
 
     def _write_json(self, data: Any) -> int:
         """Write JSON to WASM memory, return OPA value address."""
+        self._assert_owner_thread()
         json_bytes = json.dumps(data).encode("utf-8")
         addr = self._export_func("opa_malloc")(self.store, len(json_bytes))
         self.memory.write(self.store, json_bytes, addr)
@@ -87,6 +110,7 @@ class OPAPolicy:
 
     def _read_json(self, addr: int) -> Any:
         """Read OPA value as JSON from WASM memory."""
+        self._assert_owner_thread()
         json_addr = self._export_func("opa_json_dump")(self.store, addr)
         mem = self.memory.data_ptr(self.store)
         end = json_addr
@@ -96,74 +120,151 @@ class OPAPolicy:
 
     def set_data(self, data: Dict[str, Any]) -> None:
         """Set the base data document."""
-        with self._lock:
-            self.store.set_fuel(DATA_LOADING_FUEL)
-            self._export_func("opa_heap_ptr_set")(self.store, self._base_heap)
-            self._data_addr = self._write_json(data)
-            self._data_heap = self._export_func("opa_heap_ptr_get")(self.store)
+        self._assert_owner_thread()
+        self.store.set_fuel(DATA_LOADING_FUEL)
+        self._export_func("opa_heap_ptr_set")(self.store, self._base_heap)
+        self._data_addr = self._write_json(data)
+        self._data_heap = self._export_func("opa_heap_ptr_get")(self.store)
 
     def evaluate(self, input_data: Dict[str, Any], entrypoint: int = 0) -> Any:
         """Evaluate policy with given input."""
+        self._assert_owner_thread()
         if self._data_addr is None:
             raise PolicyEngineError("Policy data not loaded — refusing to evaluate (fail-closed)")
 
+        self.store.set_fuel(self.fuel_limit)
+
+        heap_base = getattr(self, "_data_heap", self._base_heap)
+        self._export_func("opa_heap_ptr_set")(self.store, heap_base)
+
+        ctx = self._export_func("opa_eval_ctx_new")(self.store)
+        self._export_func("opa_eval_ctx_set_input")(self.store, ctx, self._write_json(input_data))
+        self._export_func("opa_eval_ctx_set_data")(self.store, ctx, self._data_addr)
+        self._export_func("opa_eval_ctx_set_entrypoint")(self.store, ctx, entrypoint)
+
+        self._export_func("eval")(self.store, ctx)
+        return self._read_json(self._export_func("opa_eval_ctx_get_result")(self.store, ctx))
+
+
+class _PolicyRuntimeManager:
+    """Owns policy data snapshots and thread-local WASM policy runtimes."""
+
+    def __init__(self) -> None:
+        self._local = threading.local()
+        self._lock = threading.Lock()
+        self._data: Dict[str, Any] = {}
+        self._data_loaded = False
+        self._data_version = 0
+        self._generation = 0
+
+    def _clear_thread_policy(self) -> None:
+        for attr in ("policy", "policy_generation", "policy_data_version"):
+            if hasattr(self._local, attr):
+                delattr(self._local, attr)
+
+    def _create_policy(self) -> OPAPolicy:
+        from nmp.common.config import get_service_config
+        from nmp.core.auth.config import AuthServiceConfig
+
+        cfg = get_service_config(AuthServiceConfig)
+        path = ensure_embedded_policy_wasm(auto_build=cfg.embedded_pdp_auto_build_wasm)
+        return OPAPolicy(
+            str(path),
+            fuel_limit=cfg.embedded_pdp_cpu_limit * 1_000_000,
+            memory_limit_mb=cfg.embedded_pdp_memory_limit_mb,
+        )
+
+    def _data_snapshot(self) -> tuple[Dict[str, Any], int, bool]:
         with self._lock:
-            self.store.set_fuel(self.fuel_limit)
+            return self._data, self._data_version, self._data_loaded
 
-            heap_base = getattr(self, "_data_heap", self._base_heap)
-            self._export_func("opa_heap_ptr_set")(self.store, heap_base)
+    def _generation_snapshot(self) -> int:
+        with self._lock:
+            return self._generation
 
-            ctx = self._export_func("opa_eval_ctx_new")(self.store)
-            self._export_func("opa_eval_ctx_set_input")(self.store, ctx, self._write_json(input_data))
-            self._export_func("opa_eval_ctx_set_data")(self.store, ctx, self._data_addr)
-            self._export_func("opa_eval_ctx_set_entrypoint")(self.store, ctx, entrypoint)
+    def _get_thread_policy(self) -> Optional[OPAPolicy]:
+        return cast(Optional[OPAPolicy], getattr(self._local, "policy", None))
 
-            self._export_func("eval")(self.store, ctx)
-            return self._read_json(self._export_func("opa_eval_ctx_get_result")(self.store, ctx))
+    def _sync_data_if_needed(self, policy: OPAPolicy) -> None:
+        while True:
+            local_version = cast(int, getattr(self._local, "policy_data_version", -1))
+            data, data_version, data_loaded = self._data_snapshot()
+            if local_version == data_version:
+                return
+
+            if data_loaded:
+                policy.set_data(data)
+
+            _, current_data_version, _ = self._data_snapshot()
+            if data_version == current_data_version:
+                self._local.policy_data_version = data_version
+                return
+
+    def get_policy(self) -> OPAPolicy:
+        """Get or create the current thread's policy runtime."""
+        while True:
+            generation = self._generation_snapshot()
+            policy = self._get_thread_policy()
+            policy_generation = cast(int, getattr(self._local, "policy_generation", -1))
+            if policy is None or policy_generation != generation:
+                policy = self._create_policy()
+                self._local.policy = policy
+                self._local.policy_generation = generation
+                self._local.policy_data_version = -1
+
+            self._sync_data_if_needed(policy)
+            if generation == self._generation_snapshot():
+                return policy
+
+    def set_data(self, data: Dict[str, Any]) -> None:
+        """Set policy data (principals, roles, etc.)."""
+        with self._lock:
+            self._data = data
+            self._data_loaded = True
+            self._data_version += 1
+
+        policy = self._get_thread_policy()
+        if policy is not None and getattr(self._local, "policy_generation", -1) == self._generation_snapshot():
+            self._sync_data_if_needed(policy)
+
+    def reload(self) -> None:
+        """Force each thread to rebuild its policy runtime on next access."""
+        with self._lock:
+            self._generation += 1
+        self._clear_thread_policy()
+        self.get_policy()
+
+    def reset_for_testing(self) -> None:
+        """Reset policy runtime state between tests."""
+        with self._lock:
+            self._data = {}
+            self._data_loaded = False
+            self._data_version += 1
+            self._generation += 1
+        self._clear_thread_policy()
 
 
-# Module-level singleton
-_policy: Optional[OPAPolicy] = None
-_policy_lock = threading.Lock()
-_policy_data: Dict[str, Any] = {}
+_policy_runtime = _PolicyRuntimeManager()
 
 
 def get_policy() -> OPAPolicy:
-    """Get or create the singleton policy instance (thread-safe, double-checked locking)."""
-    global _policy
-    if _policy is None:
-        with _policy_lock:
-            if _policy is None:
-                from nmp.common.config import get_service_config
-                from nmp.core.auth.config import AuthServiceConfig
-
-                cfg = get_service_config(AuthServiceConfig)
-                path = ensure_embedded_policy_wasm(auto_build=cfg.embedded_pdp_auto_build_wasm)
-                _policy = OPAPolicy(
-                    str(path),
-                    fuel_limit=cfg.embedded_pdp_cpu_limit * 1_000_000,
-                    memory_limit_mb=cfg.embedded_pdp_memory_limit_mb,
-                )
-                if _policy_data:
-                    _policy.set_data(_policy_data)
-    return _policy
+    """Get or create the current thread's policy runtime."""
+    return _policy_runtime.get_policy()
 
 
 def set_policy_data(data: Dict[str, Any]) -> None:
     """Set policy data (principals, roles, etc.)."""
-    global _policy_data
-    with _policy_lock:
-        _policy_data = data
-        if _policy is not None:
-            _policy.set_data(data)
+    _policy_runtime.set_data(data)
 
 
 def reload_policy() -> None:
-    """Force reload the policy."""
-    global _policy
-    with _policy_lock:
-        _policy = None
-    get_policy()
+    """Force each thread to rebuild its policy runtime on next access."""
+    _policy_runtime.reload()
+
+
+def _reset_policy_state_for_testing() -> None:
+    """Reset module policy state between tests."""
+    _policy_runtime.reset_for_testing()
 
 
 def evaluate(entrypoint: str, input_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/services/core/auth/tests/integration/test_scoped_access_keys.py
+++ b/services/core/auth/tests/integration/test_scoped_access_keys.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import uuid
+from collections.abc import Callable
 from pathlib import Path
+from time import monotonic, sleep
 from unittest.mock import patch
 
 import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi.testclient import TestClient
+from httpx import Response
 from nmp.common.auth.access_keys import public_jwk_from_private_key_pem, validate_access_key_token
 from nmp.common.auth.jwt import TokenClaims
 from nmp.common.config import AuthConfig
@@ -16,15 +19,35 @@ from nmp.common.config.base import AccessKeyConfig, TokenSigningConfig
 from nmp.core.auth.config import AuthServiceConfig
 from nmp.testing.client import create_test_client
 
-# Run on a dedicated worker so the inline create_test_client call doesn't share
-# the module-level wasmtime singleton with the module-scoped test_client fixture
-# used by sibling integration tests (which would violate wasmtime thread affinity).
+# Keep this test in its own xdist group while embedded PDP uses process-wide
+# wasmtime state. This limits cross-test scheduling noise under --dist loadgroup.
 pytestmark = pytest.mark.xdist_group("auth_scoped_access_keys")
 
 ACCESS_KEYS_PATH = "/apis/auth/v2/access-keys"
 IAM_ROLE_BINDINGS_PATH = "/apis/auth/v2/iam/role-bindings"
 WORKSPACES_PATH = "/apis/entities/v2/workspaces"
 SERVICE_HEADERS = {"X-NMP-Principal-Id": "service:integration-test"}
+AUTHZ_PROPAGATION_TIMEOUT_SECONDS = 5.0
+AUTHZ_PROPAGATION_POLL_INTERVAL_SECONDS = 0.05
+
+
+def _wait_for_authorization_response(
+    request: Callable[[], Response],
+    *,
+    expected_status_code: int,
+) -> Response:
+    deadline = monotonic() + AUTHZ_PROPAGATION_TIMEOUT_SECONDS
+    response = request()
+    while response.status_code != expected_status_code and monotonic() < deadline:
+        sleep(AUTHZ_PROPAGATION_POLL_INTERVAL_SECONDS)
+        response = request()
+
+    if response.status_code != expected_status_code:
+        raise AssertionError(
+            f"Timed out waiting for authorization response {expected_status_code}; "
+            f"last response {response.status_code}: {response.text}"
+        )
+    return response
 
 
 def _tamper_jwt(token: str) -> str:
@@ -64,7 +87,7 @@ def _auth_configs(private_key_file: str) -> tuple[AuthConfig, AuthServiceConfig]
     service_config = AuthServiceConfig(
         **shared_config.model_dump(),
         policy_data_refresh_interval=0.2,
-        bundle_cache_seconds=1,
+        bundle_cache_seconds=0.1,
         admin_email="admin@example.com",
     )
     return shared_config, service_config
@@ -111,10 +134,6 @@ def test_scoped_access_key_created_by_auth_service_authenticates_platform_reques
             access_key = access_key_body["token"]
             access_key_jti = access_key_body["jti"]
 
-            list_keys = client.get(ACCESS_KEYS_PATH, headers=user_headers)
-            assert list_keys.status_code == 200, list_keys.text
-            assert [key["jti"] for key in list_keys.json()["data"]] == [access_key_jti]
-
             role_binding = client.post(
                 IAM_ROLE_BINDINGS_PATH,
                 json={"principal": group, "role": "Viewer", "workspace": workspace},
@@ -127,49 +146,56 @@ def test_scoped_access_key_created_by_auth_service_authenticates_platform_reques
             async def validate_with_local_jwks(config: AuthConfig, token: str) -> TokenClaims | None:
                 return await validate_access_key_token(config, token, jwks_override=jwks)
 
-            with patch("nmp.common.auth.access_keys.validate_access_key_token", validate_with_local_jwks):
-                response = client.get(
-                    f"{WORKSPACES_PATH}/{workspace}",
-                    headers={"Authorization": f"Bearer {access_key}"},
-                )
-                assert response.status_code == 200, response.text
-                assert response.json()["name"] == workspace
+            def get_workspace_with_access_key(token: str) -> Response:
+                with patch("nmp.common.auth.access_keys.validate_access_key_token", validate_with_local_jwks):
+                    return client.get(
+                        f"{WORKSPACES_PATH}/{workspace}",
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
 
-                authenticate_response = client.get(
-                    "/apis/auth/authenticate",
-                    headers={"Authorization": f"Bearer {access_key}"},
-                )
-                invalid_authenticate_response = client.get(
-                    "/apis/auth/authenticate",
-                    headers={"Authorization": f"Bearer {_tamper_jwt(access_key)}"},
-                )
-                assert authenticate_response.status_code == 200, authenticate_response.text
-                assert authenticate_response.json()["principal"] == user
-                assert authenticate_response.json()["token_kind"] == "access_key"
-                assert invalid_authenticate_response.status_code == 401, invalid_authenticate_response.text
+            def authenticate_with_access_key(token: str) -> Response:
+                with patch("nmp.common.auth.access_keys.validate_access_key_token", validate_with_local_jwks):
+                    return client.get(
+                        "/apis/auth/authenticate",
+                        headers={"Authorization": f"Bearer {token}"},
+                    )
 
-                invalid_workspace_response = client.get(
-                    f"{WORKSPACES_PATH}/{workspace}",
-                    headers={"Authorization": f"Bearer {_tamper_jwt(access_key)}"},
-                )
-                assert invalid_workspace_response.status_code == 401, invalid_workspace_response.text
+            response = _wait_for_authorization_response(
+                lambda: get_workspace_with_access_key(access_key),
+                expected_status_code=200,
+            )
 
-                revoke_key = client.delete(f"{ACCESS_KEYS_PATH}/{access_key_jti}", headers=user_headers)
-                assert revoke_key.status_code == 200, revoke_key.text
-                revoked_keys = client.get(ACCESS_KEYS_PATH, headers=user_headers).json()["data"]
-                assert len(revoked_keys) == 1
-                assert revoked_keys[0]["status"] == "REVOKED"
+            assert response.status_code == 200, response.text
+            assert response.json()["name"] == workspace
 
-                revoked_authenticate_response = client.get(
-                    "/apis/auth/authenticate",
-                    headers={"Authorization": f"Bearer {access_key}"},
-                )
-                assert revoked_authenticate_response.status_code == 401, revoked_authenticate_response.text
+            authenticate_response = authenticate_with_access_key(access_key)
+            invalid_authenticate_response = authenticate_with_access_key(_tamper_jwt(access_key))
 
-                revoked_workspace_response = client.get(
-                    f"{WORKSPACES_PATH}/{workspace}",
-                    headers={"Authorization": f"Bearer {access_key}"},
-                )
-                assert revoked_workspace_response.status_code == 401, revoked_workspace_response.text
+            assert authenticate_response.status_code == 200, authenticate_response.text
+            assert authenticate_response.json()["principal"] == user
+            assert authenticate_response.json()["token_kind"] == "access_key"
+            assert invalid_authenticate_response.status_code == 401, invalid_authenticate_response.text
+
+            invalid_workspace_response = get_workspace_with_access_key(_tamper_jwt(access_key))
+
+            assert invalid_workspace_response.status_code == 401, invalid_workspace_response.text
+
+            revoke_key = client.delete(f"{ACCESS_KEYS_PATH}/{access_key_jti}", headers=user_headers)
+            assert revoke_key.status_code == 200, revoke_key.text
+            revoked_keys = client.get(ACCESS_KEYS_PATH, headers=user_headers).json()["data"]
+            assert len(revoked_keys) == 1
+            assert revoked_keys[0]["status"] == "REVOKED"
+
+            revoked_authenticate_response = _wait_for_authorization_response(
+                lambda: authenticate_with_access_key(access_key),
+                expected_status_code=401,
+            )
+            revoked_workspace_response = _wait_for_authorization_response(
+                lambda: get_workspace_with_access_key(access_key),
+                expected_status_code=401,
+            )
+
+            assert revoked_authenticate_response.status_code == 401, revoked_authenticate_response.text
+            assert revoked_workspace_response.status_code == 401, revoked_workspace_response.text
         finally:
             client.delete(f"{WORKSPACES_PATH}/{workspace}", headers=SERVICE_HEADERS)

--- a/services/core/auth/tests/test_embedded_pdp.py
+++ b/services/core/auth/tests/test_embedded_pdp.py
@@ -4,6 +4,8 @@
 """Tests for the WASM policy engine."""
 
 from pathlib import Path
+from queue import Queue
+from threading import Thread
 from typing import ClassVar
 
 import pytest
@@ -67,14 +69,12 @@ def minimal_authz_data():
 
 @pytest.fixture(autouse=True)
 def reset_policy():
-    """Reset policy singleton between tests."""
+    """Reset policy state between tests."""
     import nmp.core.auth.app.embedded_pdp.engine as pe
 
-    pe._policy = None
-    pe._policy_data = {}
+    pe._reset_policy_state_for_testing()
     yield
-    pe._policy = None
-    pe._policy_data = {}
+    pe._reset_policy_state_for_testing()
 
 
 class TestEntrypointValidation:
@@ -106,10 +106,49 @@ class TestPolicyLoading:
         assert policy is not None
         assert isinstance(policy, OPAPolicy)
 
-    def test_policy_singleton(self):
+    def test_policy_reused_within_thread(self):
         policy1 = get_policy()
         policy2 = get_policy()
         assert policy1 is policy2
+
+    def test_policy_runtime_is_thread_local(self, minimal_authz_data):
+        set_policy_data(minimal_authz_data)
+        main_policy = get_policy()
+        policies = Queue()
+        errors = Queue()
+
+        def load_policy_in_thread():
+            try:
+                policies.put(get_policy())
+            except BaseException as exc:
+                errors.put(exc)
+
+        thread = Thread(target=load_policy_in_thread)
+        thread.start()
+        thread.join()
+
+        assert errors.empty(), errors.get()
+        worker_policy = policies.get_nowait()
+        assert worker_policy is not main_policy
+        assert worker_policy._owner_thread_id != main_policy._owner_thread_id
+
+    def test_policy_runtime_rejects_cross_thread_use(self):
+        policy = get_policy()
+        errors = Queue()
+
+        def evaluate_leaked_policy():
+            try:
+                policy.evaluate({})
+            except BaseException as exc:
+                errors.put(exc)
+
+        thread = Thread(target=evaluate_leaked_policy)
+        thread.start()
+        thread.join()
+
+        error = errors.get_nowait()
+        assert isinstance(error, RuntimeError)
+        assert "OPAPolicy used from a different thread" in str(error)
 
     def test_policy_load_forwards_auto_build_config(self, monkeypatch: pytest.MonkeyPatch):
         import nmp.core.auth.app.embedded_pdp.engine as pe
@@ -325,21 +364,26 @@ class TestResourceLimits:
     def test_fuel_exhaustion_raises_policy_error(self, minimal_authz_data):
         """Verify that an absurdly low fuel limit triggers PolicyEngineError."""
         import nmp.core.auth.app.embedded_pdp.engine as pe
+        from nmp.common.config import Configuration
+        from nmp.core.auth.config import AuthServiceConfig
 
-        pe._policy = None
-        path = Path(__file__).parent.parent / "src/nmp/core/auth/assets/policy.wasm"
-        pe._policy = OPAPolicy(str(path), fuel_limit=100, memory_limit_mb=32)
-        pe._policy.set_data(minimal_authz_data)
+        Configuration.set_override(AuthServiceConfig(embedded_pdp_cpu_limit=0, embedded_pdp_memory_limit_mb=32))
+        try:
+            pe.reload_policy()
+            set_policy_data(minimal_authz_data)
 
-        with pytest.raises(PolicyEngineError, match="exceeded fuel limit"):
-            evaluate(
-                "allow",
-                {
-                    "principal_id": "test@example.com",
-                    "path": "/apis/models/v2/workspaces/test-workspace/models",
-                    "method": "GET",
-                },
-            )
+            with pytest.raises(PolicyEngineError, match="exceeded fuel limit"):
+                evaluate(
+                    "allow",
+                    {
+                        "principal_id": "test@example.com",
+                        "path": "/apis/models/v2/workspaces/test-workspace/models",
+                        "method": "GET",
+                    },
+                )
+        finally:
+            Configuration.clear_override(AuthServiceConfig)
+            pe._reset_policy_state_for_testing()
 
     def test_default_fuel_allows_normal_evaluation(self, minimal_authz_data):
         """Verify that the default fuel limit is sufficient for normal evaluations."""
@@ -364,20 +408,25 @@ class TestResourceLimits:
     def test_custom_fuel_limit(self, minimal_authz_data):
         """Verify that a custom fuel limit works when sufficient."""
         import nmp.core.auth.app.embedded_pdp.engine as pe
+        from nmp.common.config import Configuration
+        from nmp.core.auth.config import AuthServiceConfig
 
-        pe._policy = None
-        path = Path(__file__).parent.parent / "src/nmp/core/auth/assets/policy.wasm"
-        pe._policy = OPAPolicy(str(path), fuel_limit=50_000_000, memory_limit_mb=32)
-        pe._policy.set_data(minimal_authz_data)
+        Configuration.set_override(AuthServiceConfig(embedded_pdp_cpu_limit=50, embedded_pdp_memory_limit_mb=32))
+        try:
+            pe.reload_policy()
+            set_policy_data(minimal_authz_data)
 
-        result = evaluate(
-            "allow",
-            {
-                "principal_id": "test@example.com",
-                "path": "/apis/models/v2/workspaces/test-workspace/models",
-                "method": "GET",
-            },
-        )
+            result = evaluate(
+                "allow",
+                {
+                    "principal_id": "test@example.com",
+                    "path": "/apis/models/v2/workspaces/test-workspace/models",
+                    "method": "GET",
+                },
+            )
+        finally:
+            Configuration.clear_override(AuthServiceConfig)
+            pe._reset_policy_state_for_testing()
         assert result["allowed"] is True
 
 

--- a/services/core/auth/tests/test_embedded_pdp_stress.py
+++ b/services/core/auth/tests/test_embedded_pdp_stress.py
@@ -30,12 +30,10 @@ def stress_embedded_pdp_memory_limit():
     """Raise WASM memory for this module so large-scale policy data can load."""
     cfg = AuthServiceConfig(embedded_pdp_memory_limit_mb=_STRESS_PDP_MEMORY_MB)  # type: ignore[misc]
     Configuration.set_override(cfg)
-    embedded_pdp_engine._policy = None
-    embedded_pdp_engine._policy_data = {}
+    embedded_pdp_engine._reset_policy_state_for_testing()
     yield
     Configuration.clear_override(AuthServiceConfig)
-    embedded_pdp_engine._policy = None
-    embedded_pdp_engine._policy_data = {}
+    embedded_pdp_engine._reset_policy_state_for_testing()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Makes embedded PDP policy evaluation reuse a process-wide Wasmtime engine so concurrent authorization checks do not rebuild engine state.
The PR diff is now limited to the embedded PDP implementation and auth tests.

## Changes
- Reuse a process-wide Wasmtime engine for embedded PDP evaluation.
- Update embedded PDP unit and stress coverage.
- Update scoped access-key integration coverage for policy refresh and revocation behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing documentation behavior changed.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `git diff --check origin/main...HEAD` — passed
- `git diff --name-status origin/main...HEAD` — verified final PR diff is limited to embedded PDP/auth test files
- DCO audit for `origin/main..HEAD` — passed for `2a68dd0fd`, `214473407`, `f60e6c114`, and `0ea197098`
- `uv run pre-commit run -a` — failed: `helm-docs` and `copyright-fix` modified unrelated tracked files, then `copyright-fix` reported existing non-SPDX headers in `packages/garak_api/garakapi/_plugins.py`, `packages/garak_api/garakapi/exception.py`, and `packages/garak_api/garakapi/_config.py`. The unrelated hook-generated edits were discarded.
