### PR TITLE
feat(evaluator): stage Fabric skills from Filesets

### DIFF
--- a/plugins/nemo-evaluator/README.md
+++ b/plugins/nemo-evaluator/README.md
@@ -140,6 +140,10 @@ uv run nemo evaluator agent-evaluate submit \
 Ensure the job environment includes the Fabric Codex adapter, Codex CLI, and
 its provider credentials. Set
 `capture_trajectory` to `true` only when NeMo Relay is also available.
+To evaluate a Platform-managed Skill, add a `target.skills` entry with its
+agentskills.io name, Fileset reference, and the relative bundle directory that
+contains `SKILL.md`. The job stages the Fileset into its own runtime and Fabric
+records the injected Skill provenance on each trial.
 For repository setup, follow
 [Prepare Fabric in a repository checkout](../../skills/nemo-evaluator-plugin/SKILL.md#prepare-fabric-in-a-repository-checkout).
 

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -2099,7 +2099,7 @@ components:
           - $ref: '#/components/schemas/ModelTarget'
           - $ref: '#/components/schemas/AgentTarget'
           - $ref: '#/components/schemas/CodexRunnerTarget'
-          - $ref: '#/components/schemas/FabricRunnerTarget'
+          - $ref: '#/components/schemas/FabricRunnerTargetInput'
           - $ref: '#/components/schemas/GymRunnerTarget'
           - $ref: '#/components/schemas/HarborRunnerTarget'
           title: Target
@@ -2271,7 +2271,7 @@ components:
           - $ref: '#/components/schemas/ModelTarget'
           - $ref: '#/components/schemas/AgentTarget'
           - $ref: '#/components/schemas/CodexRunnerTarget'
-          - $ref: '#/components/schemas/FabricRunnerTarget'
+          - $ref: '#/components/schemas/FabricRunnerTargetOutput'
           - $ref: '#/components/schemas/GymRunnerTarget'
           - $ref: '#/components/schemas/HarborRunnerTarget'
           title: Target
@@ -3567,7 +3567,7 @@ components:
       - kind
       title: EvidenceDescriptor
       description: Descriptor for a candidate trace, source, or artifact.
-    FabricRunnerTarget:
+    FabricRunnerTargetInput:
       properties:
         kind:
           type: string
@@ -3598,11 +3598,18 @@ components:
           description: Capture the agent trajectory as ATIF via NeMo Relay and attach
             it to trial evidence. Requires the NeMo Relay gateway in the run environment.
           default: true
+        skills:
+          items:
+            $ref: '#/components/schemas/FabricSkillFilesetInput'
+          type: array
+          title: Skills
+          description: agentskills.io bundles staged from Platform Filesets and injected
+            into the Fabric harness.
       additionalProperties: false
       type: object
       required:
       - config
-      title: FabricRunnerTarget
+      title: FabricRunnerTargetInput
       description: "Generate trials by driving an agent harness through the NeMo Fabric\
         \ runtime.\n\nFabric is harness-agnostic: the harness (Codex, Hermes, ...)\
         \ is selected by the supplied\nconfig's ``harness.adapter_id`` and is never\
@@ -3610,6 +3617,115 @@ components:
         \ when given.\n\nA run is described by exactly one complete ``config``. Fabric\
         \ 0.1.0rc2 removed profile overlays,\nso the former ``profiles`` field is\
         \ gone \u2014 fold any overlay you were passing into ``config``."
+    FabricRunnerTargetOutput:
+      properties:
+        kind:
+          type: string
+          const: fabric
+          title: Kind
+          default: fabric
+        config:
+          additionalProperties: true
+          type: object
+          title: Config
+          description: Inline NeMo Fabric agent config (an ``agent.yaml`` as a JSON-shaped
+            mapping). Its ``harness.adapter_id`` selects the harness, e.g. ``nvidia.fabric.codex``
+            for Codex.
+        model:
+          title: Model
+          description: Optional ``provider/model`` slug applied as the config's default
+            model; the harness default is used when omitted.
+          type: string
+        timeout_s:
+          type: integer
+          minimum: 1.0
+          title: Timeout S
+          description: Per-task timeout for the Fabric run, in seconds.
+          default: 600
+        capture_trajectory:
+          type: boolean
+          title: Capture Trajectory
+          description: Capture the agent trajectory as ATIF via NeMo Relay and attach
+            it to trial evidence. Requires the NeMo Relay gateway in the run environment.
+          default: true
+        skills:
+          items:
+            $ref: '#/components/schemas/FabricSkillFilesetOutput'
+          type: array
+          title: Skills
+          description: agentskills.io bundles staged from Platform Filesets and injected
+            into the Fabric harness.
+      additionalProperties: false
+      type: object
+      required:
+      - config
+      title: FabricRunnerTargetOutput
+      description: "Generate trials by driving an agent harness through the NeMo Fabric\
+        \ runtime.\n\nFabric is harness-agnostic: the harness (Codex, Hermes, ...)\
+        \ is selected by the supplied\nconfig's ``harness.adapter_id`` and is never\
+        \ inferred from ``model``. ``model`` is applied as the\nconfig's default model\
+        \ when given.\n\nA run is described by exactly one complete ``config``. Fabric\
+        \ 0.1.0rc2 removed profile overlays,\nso the former ``profiles`` field is\
+        \ gone \u2014 fold any overlay you were passing into ``config``."
+    FabricSkillFilesetInput:
+      properties:
+        name:
+          type: string
+          maxLength: 64
+          minLength: 1
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          title: Name
+          description: agentskills.io skill name used for runtime injection and trial
+            provenance.
+        fileset:
+          type: string
+          title: Fileset
+          description: Platform Fileset containing the skill bundle, as 'name' or
+            'workspace/name'.
+        path:
+          type: string
+          minLength: 1
+          title: Path
+          description: Relative directory inside the Fileset whose root contains SKILL.md.
+          default: .
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      - fileset
+      title: FabricSkillFilesetInput
+      description: An agentskills.io bundle staged from a Platform Fileset for a Fabric
+        run.
+    FabricSkillFilesetOutput:
+      properties:
+        name:
+          type: string
+          maxLength: 64
+          minLength: 1
+          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+          title: Name
+          description: agentskills.io skill name used for runtime injection and trial
+            provenance.
+        fileset:
+          type: string
+          pattern: ^[\w\-.]+(/[\w\-.]+)?$
+          title: Fileset
+          description: Platform Fileset containing the skill bundle, as 'name' or
+            'workspace/name'.
+        path:
+          type: string
+          minLength: 1
+          title: Path
+          description: Relative directory inside the Fileset whose root contains SKILL.md.
+          default: .
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      - fileset
+      title: FabricSkillFilesetOutput
+      description: An agentskills.io bundle staged from a Platform Fileset for a Fabric
+        run.
     FieldMapping:
       properties:
         input:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_evaluate.py
@@ -18,6 +18,7 @@ is written via :func:`~nemo_evaluator.jobs.result_persistence.persist_agent_eval
 from __future__ import annotations
 
 import logging
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Literal, cast
@@ -33,6 +34,7 @@ from nemo_evaluator.jobs.agent_spec import (
     AgentTarget,
     CodexRunnerTarget,
     FabricRunnerTarget,
+    FabricSkillFileset,
     GymRunnerTarget,
     HarborRunnerTarget,
     ModelTarget,
@@ -47,6 +49,7 @@ from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.runtimes.codex.runtime import CodexCliAgentRuntime
 from nemo_evaluator_sdk.agent_eval.runtimes.fabric.runtime import FabricAgentRuntime
+from nemo_evaluator_sdk.agent_eval.runtimes.fabric.skills import AgentSkill
 from nemo_evaluator_sdk.agent_eval.runtimes.gym_runtime import GymAgentTaskRunner, GymRuntimeConfig
 from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import HarborAgentTaskRunner, HarborRuntimeConfig
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
@@ -63,6 +66,8 @@ from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec, SubprocessExe
 from nemo_platform_plugin.jobs.client import AsyncJobsClient
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError, PlatformJobDependencyUnavailableError
 from nemo_platform_plugin.jobs.execution_profiles import SubprocessJobExecutionProfile
+from nemo_platform_plugin.refs import parse_entity_ref
+from nemo_platform_plugin.run_dependencies import LocalRunError
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -324,8 +329,49 @@ class AgentEvalJob(NemoJob):
         return AgentEvaluator(default_headers=identity_headers or None)
 
     @staticmethod
+    def _materialize_fabric_skills(
+        skills: list[FabricSkillFileset], *, ctx: JobContext, sdk: NeMoPlatform | None
+    ) -> list[AgentSkill]:
+        """Download Fileset-backed skill bundles into job-local storage."""
+        if not skills:
+            return []
+        if sdk is None:
+            raise LocalRunError(
+                "Staging Fabric skills from Filesets requires a 'sdk: NeMoPlatform', but no platform SDK was "
+                "available. Set NMP_BASE_URL or pass sdk via NemoJobScheduler.run_local(sdk=...)."
+            )
+
+        stage_root = ctx.storage.ephemeral / "fabric-skills"
+        stage_root.mkdir(parents=True, exist_ok=True)
+        materialized: list[AgentSkill] = []
+        for index, skill_ref in enumerate(skills):
+            parsed = parse_entity_ref(str(skill_ref.fileset), default_workspace=ctx.workspace)
+            download_root = Path(
+                tempfile.mkdtemp(prefix=f"{index:02d}-{skill_ref.name}-", dir=str(stage_root))
+            ).resolve()
+            logger.info(
+                "Downloading Fabric skill %s from Fileset %s/%s into %s",
+                skill_ref.name,
+                parsed.workspace,
+                parsed.name,
+                download_root,
+            )
+            sdk.files.download(
+                local_path=str(download_root),
+                fileset=parsed.name,
+                workspace=parsed.workspace,
+            )
+            skill_dir = (download_root / skill_ref.path).resolve()
+            if not skill_dir.is_relative_to(download_root):
+                raise ValueError(
+                    f"Fabric skill path {skill_ref.path!r} resolves outside Fileset '{parsed.workspace}/{parsed.name}'"
+                )
+            materialized.append(AgentSkill.from_directory(skill_dir, name=skill_ref.name))
+        return materialized
+
+    @staticmethod
     def _resolve_target(
-        target: Target | None, ctx: JobContext
+        target: Target | None, ctx: JobContext, sdk: NeMoPlatform | None = None
     ) -> tuple[AgentEvalTarget | None, str | dict[str, Any] | None, RunConfigOnline | RunConfigOnlineModel | None]:
         """Resolve a target spec to ``(runtime target, prompt_template, params)`` for the SDK run config.
 
@@ -344,12 +390,14 @@ class AgentEvalJob(NemoJob):
             )
             return runtime, None, None
         if isinstance(target, FabricRunnerTarget):
+            skills = AgentEvalJob._materialize_fabric_skills(target.skills, ctx=ctx, sdk=sdk)
             fabric_runtime = FabricAgentRuntime(
                 config=target.config,
                 model=target.model,
                 timeout_s=target.timeout_s,
                 capture_trajectory=target.capture_trajectory,
                 work_root=ctx.storage.persistent / "fabric",
+                skills=skills,
             )
             return fabric_runtime, None, None
         if isinstance(target, GymRunnerTarget):
@@ -408,7 +456,7 @@ class AgentEvalJob(NemoJob):
         """Run the agent evaluation locally and persist its result bundle as artifacts."""
         spec = AgentEvalSpec.model_validate(config)
         tasks = [_to_runtime_task(task) for task in spec.tasks]
-        target, prompt_template, params = self._resolve_target(spec.target, ctx)
+        target, prompt_template, params = self._resolve_target(spec.target, ctx, sdk=sdk)
         run_config = AgentEvalRunConfig(
             params=params,
             prompt_template=prompt_template,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
@@ -27,7 +27,8 @@ from nemo_evaluator_sdk.agent_eval.tasks import SemanticView
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
 from nemo_evaluator_sdk.values import Agent, Model, RunConfigOnline, RunConfigOnlineModel
 from nemo_evaluator_sdk.values.agents import AgentBase
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from nemo_platform_plugin.refs import ENTITY_REF_PATTERN, FilesetRef
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ModelTarget(BaseModel):
@@ -78,6 +79,41 @@ class CodexRunnerTarget(BaseModel):
     timeout_s: int = Field(default=600, ge=1, description="Per-task timeout for the Codex CLI, in seconds.")
 
 
+class FabricSkillFileset(BaseModel):
+    """An agentskills.io bundle staged from a Platform Fileset for a Fabric run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[a-z0-9]+(-[a-z0-9]+)*$",
+        description="agentskills.io skill name used for runtime injection and trial provenance.",
+    )
+    fileset: FilesetRef = Field(
+        pattern=ENTITY_REF_PATTERN,
+        description="Platform Fileset containing the skill bundle, as 'name' or 'workspace/name'.",
+    )
+    path: str = Field(
+        default=".",
+        min_length=1,
+        description="Relative directory inside the Fileset whose root contains SKILL.md.",
+    )
+
+    @field_validator("path")
+    @classmethod
+    def _relative_bundle_path(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("skill path must not be empty")
+        if "\\" in normalized:
+            raise ValueError("skill path must use forward slashes")
+        parts = normalized.split("/")
+        if normalized.startswith("/") or ".." in parts:
+            raise ValueError("skill path must stay inside the downloaded Fileset")
+        return normalized
+
+
 class FabricRunnerTarget(BaseModel):
     """Generate trials by driving an agent harness through the NeMo Fabric runtime.
 
@@ -107,6 +143,18 @@ class FabricRunnerTarget(BaseModel):
         description="Capture the agent trajectory as ATIF via NeMo Relay and attach it to trial evidence. "
         "Requires the NeMo Relay gateway in the run environment.",
     )
+    skills: list[FabricSkillFileset] = Field(
+        default_factory=list,
+        description="agentskills.io bundles staged from Platform Filesets and injected into the Fabric harness.",
+    )
+
+    @model_validator(mode="after")
+    def _unique_skill_names(self) -> Self:
+        names = [skill.name for skill in self.skills]
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise ValueError(f"Fabric skill names must be unique; duplicates: {duplicates}")
+        return self
 
 
 class HarborRunnerTarget(BaseModel):

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -28,6 +28,7 @@ from nemo_evaluator.jobs.agent_spec import (
     AgentTarget,
     CodexRunnerTarget,
     FabricRunnerTarget,
+    FabricSkillFileset,
     GymRunnerTarget,
     HarborRunnerTarget,
     ModelTarget,
@@ -71,6 +72,7 @@ from nemo_platform_plugin.jobs.execution_profiles import (
     VolcanoJobExecutionProfileConfig,
 )
 from nemo_platform_plugin.jobs.spec import BaseExecutionProfile
+from nemo_platform_plugin.run_dependencies import LocalRunError
 from nemo_platform_plugin.scheduler import NemoJobScheduler
 from pytest_mock import MockerFixture
 
@@ -253,6 +255,80 @@ def test_resolve_target_builds_fabric_runtime_from_runner_target(tmp_path: Path)
     # A runner shapes its own request, so it contributes no prompt template or inference params.
     assert prompt_template is None
     assert params is None
+
+
+def test_resolve_target_stages_fileset_skills_for_fabric_runtime(tmp_path: Path, mocker: MockerFixture) -> None:
+    ctx = _job_context(tmp_path)
+    sdk = mocker.MagicMock(spec=NeMoPlatform)
+
+    def _download(*, local_path: str, fileset: str, workspace: str) -> None:
+        assert fileset == "skill-bundles"
+        assert workspace == "shared"
+        skill_dir = Path(local_path) / "skills" / "lta-analysis"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: lta-analysis\ndescription: Analyze LTA failures.\n---\nAnalyze the supplied logs.\n"
+        )
+
+    sdk.files.download.side_effect = _download
+    fabric_target = FabricRunnerTarget(
+        config={"metadata": {"name": "a"}, "harness": {"adapter_id": "nvidia.fabric.codex"}},
+        skills=[
+            FabricSkillFileset(
+                name="lta-analysis",
+                fileset="shared/skill-bundles",
+                path="skills/lta-analysis",
+            )
+        ],
+    )
+
+    target, _, _ = AgentEvalJob._resolve_target(fabric_target, ctx, sdk=sdk)
+
+    assert isinstance(target, FabricAgentRuntime)
+    assert [skill.name for skill in target._skill_set.skills] == ["lta-analysis"]
+    assert target._skill_set.skills[0].directory.joinpath("SKILL.md").is_file()
+    sdk.files.download.assert_called_once()
+
+
+def test_resolve_target_requires_sdk_for_fileset_skills(tmp_path: Path) -> None:
+    ctx = _job_context(tmp_path)
+    fabric_target = FabricRunnerTarget(
+        config={"metadata": {"name": "a"}, "harness": {"adapter_id": "nvidia.fabric.codex"}},
+        skills=[FabricSkillFileset(name="lta-analysis", fileset="skill-bundles")],
+    )
+
+    with pytest.raises(LocalRunError, match="requires a 'sdk: NeMoPlatform'"):
+        AgentEvalJob._resolve_target(fabric_target, ctx)
+
+
+def test_resolve_target_rejects_fileset_without_skill_document(tmp_path: Path, mocker: MockerFixture) -> None:
+    ctx = _job_context(tmp_path)
+    sdk = mocker.MagicMock(spec=NeMoPlatform)
+    sdk.files.download.side_effect = lambda **_: None
+    fabric_target = FabricRunnerTarget(
+        config={"metadata": {"name": "a"}, "harness": {"adapter_id": "nvidia.fabric.codex"}},
+        skills=[FabricSkillFileset(name="lta-analysis", fileset="skill-bundles")],
+    )
+
+    with pytest.raises(ValueError, match="has no SKILL.md"):
+        AgentEvalJob._resolve_target(fabric_target, ctx, sdk=sdk)
+
+
+@pytest.mark.parametrize("path", ["../escape", "/absolute", "nested\\windows"])
+def test_fabric_skill_fileset_rejects_unsafe_paths(path: str) -> None:
+    with pytest.raises(ValueError, match="skill path"):
+        FabricSkillFileset(name="lta-analysis", fileset="skill-bundles", path=path)
+
+
+def test_fabric_target_rejects_duplicate_skill_names() -> None:
+    with pytest.raises(ValueError, match="skill names must be unique"):
+        FabricRunnerTarget(
+            config={"metadata": {"name": "a"}, "harness": {"adapter_id": "nvidia.fabric.codex"}},
+            skills=[
+                FabricSkillFileset(name="lta-analysis", fileset="skill-v1"),
+                FabricSkillFileset(name="lta-analysis", fileset="skill-v2"),
+            ],
+        )
 
 
 def test_resolve_target_builds_harbor_runtime_from_runner_target(tmp_path: Path) -> None:

--- a/skills/nemo-evaluator-plugin/references/agent-evaluation.md
+++ b/skills/nemo-evaluator-plugin/references/agent-evaluation.md
@@ -120,8 +120,21 @@ target = FabricRunnerTarget(
         "harness": {"adapter_id": "nvidia.fabric.codex"},
     },
     model="<provider>/<model>",
+    skills=[
+        {
+            "name": "lta-analysis",
+            "fileset": "default/lta-analysis-v1",
+            "path": ".",
+        }
+    ],
 )
 ```
+
+Each optional `skills` entry points to an agentskills.io bundle in a Platform
+Fileset. `path` is relative to the Fileset root and must contain `SKILL.md`.
+The job downloads the bundle at run time, injects it through Fabric, and records
+the effective bundle digest in trial Skill provenance. Use a versioned Fileset
+name when reproducibility matters. Omit `skills` for the baseline arm.
 
 Do not use profile overlays. Fold the complete configuration into `config`.
 


### PR DESCRIPTION
## Summary

- add a Fileset-backed `skills` input to Fabric Agent Eval targets
- download each Skill bundle into job-local ephemeral storage and construct the SDK `AgentSkill`
- validate Skill names, relative bundle paths, duplicate names, and the required `SKILL.md`
- pass the materialized Skills to `FabricAgentRuntime`, which already owns harness routing, content hashing, injection, and trial provenance
- update the Evaluator OpenAPI schema and operator documentation

## Why

The Agent Eval SDK already supports single- and multi-Skill injection for Fabric runtimes, but that capability was not expressible through the Platform `agent-evaluate` job API. A remote job cannot access a caller-local Skill directory, even when the same bundle is stored in Platform Files.

This change closes that API/runtime bridge: callers can reference a Platform Fileset in `target.skills`, and Evaluator materializes it inside the scheduled job before creating the Fabric runtime.

## User impact

A remote Platform job can now submit a target such as:

```yaml
target:
  kind: fabric
  config: ...
  skills:
    - name: lta-analysis
      fileset: default/lta-analysis-skill
      path: skills/lta-analysis
```

Jobs without `skills` are unchanged. Existing SDK behavior records the exact Skill content hash, selected adapter, injection mode, and staged location in each trial.

## Scope

This PR intentionally does not add:

- a first-class Skill catalog/entity
- automatic baseline/treated A/B scheduling
- Fabric repeat/attempt semantics
- Fabric adapter or Relay packaging in the default CPU task image

Those are independent product/runtime concerns.

## Validation

- `uv run --frozen pytest -q plugins/nemo-evaluator/tests/test_agent_evaluate.py packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_skills.py packages/nemo_evaluator_sdk/tests/agent_eval/test_fabric_surface.py` — **97 passed**
- Ruff check and format check — passed
- `tools/lint/lint-openapi.sh` — passed
- `git diff --check origin/main...HEAD` — passed
- Live Dev Astra validation — a real Fabric/Codex job downloaded a marker Skill from a Platform Fileset, read its `SKILL.md`, returned the required marker, scored exact-match `1.0`, and persisted Skill hash provenance plus Relay ATIF/ATOF artifacts:
  - https://platform-pmeng-deploy-api.stg.astra.nvidia.com/apis/evaluator/v2/workspaces/default/agent-evaluate/jobs/qa-fabric-skill-fileset-gpt56-sol-r10

Closes #1305
