### PR TITLE
fix(entities): key the async engine singleton by event loop

### DIFF
--- a/services/core/entities/src/nmp/core/entities/app/repository/__init__.py
+++ b/services/core/entities/src/nmp/core/entities/app/repository/__init__.py
@@ -6,6 +6,9 @@
 Provides abstract interfaces and implementations for database operations.
 """
 
+import asyncio
+from typing import TYPE_CHECKING
+
 from nmp.core.entities.app.database import create_async_engine_for_entities
 from nmp.core.entities.app.repository.entity import EntityRepositoryInterface
 from nmp.core.entities.app.repository.sqlalchemy.entity import SQLAlchemyEntityRepository
@@ -15,44 +18,88 @@ from nmp.core.entities.config import EntitiesConfig
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-_async_engine: AsyncEngine | None = None
-_async_session_maker: async_sessionmaker[AsyncSession] | None = None
+if TYPE_CHECKING:
+    from asyncio import AbstractEventLoop
+
+# One engine/session-maker pair per event loop.
+#
+# asyncpg pools bind their internal asyncio primitives (queues, waiters) to the
+# event loop that first uses them.  The service runs at least two loops in one
+# process: the uvicorn lifespan loop (service.py) and the controller worker
+# loop (controllers/main.py, daemon thread).  A process-global singleton lets
+# whichever loop initializes first capture the pool; when the pool is saturated
+# the other loop parks on a waiter bound to the foreign loop and every acquire
+# fails with "RuntimeError: <Queue> is bound to a different event loop"
+# (intermittent: an unsaturated pool never parks, so light load hides the bug).
+# Keying the singleton by running loop gives each loop its own pool while
+# keeping the once-per-loop initialization contract.  See NVBug 6588975 /
+# GitHub issue #1230.
+_engines_by_loop: dict["AbstractEventLoop", AsyncEngine] = {}
+_session_makers_by_loop: dict["AbstractEventLoop", async_sessionmaker[AsyncSession]] = {}
 
 
 async def initialize_async_engine(config: EntitiesConfig) -> None:
-    """Initialize the async engine with the given config.
+    """Initialize the async engine for the current event loop.
 
-    This should be called once during service startup.
+    This should be called once during startup of every component that runs its
+    own event loop (service lifespan, controller worker thread).  Calling it
+    again on the same loop is a no-op; calling it from a different loop creates
+    an independent engine bound to that loop.
 
     Args:
         config: Entities service configuration
     """
-    global _async_engine, _async_session_maker
+    loop = asyncio.get_running_loop()
 
-    if _async_engine is not None:
-        return  # Already initialized
+    if loop in _engines_by_loop:
+        return  # Already initialized on this loop
 
-    _async_engine = create_async_engine_for_entities(config)
-    _async_session_maker = async_sessionmaker(bind=_async_engine, class_=AsyncSession, expire_on_commit=False)
+    engine = create_async_engine_for_entities(config)
+    _engines_by_loop[loop] = engine
+    _session_makers_by_loop[loop] = async_sessionmaker(
+        bind=engine, class_=AsyncSession, expire_on_commit=False
+    )
+
+
+async def get_async_engine() -> AsyncEngine:
+    """Get the async engine bound to the current event loop.
+
+    Returns:
+        The initialized async engine for this loop
+
+    Raises:
+        RuntimeError: If called before initialize_async_engine() on this loop
+    """
+    loop = asyncio.get_running_loop()
+    engine = _engines_by_loop.get(loop)
+    if engine is None:
+        raise RuntimeError(
+            "Async engine not initialized on this event loop. "
+            "Call initialize_async_engine(config) during startup of the component that owns this loop."
+        )
+    return engine
 
 
 async def get_async_session_maker() -> async_sessionmaker[AsyncSession]:
-    """Get async session maker for entities database.
+    """Get the async session maker bound to the current event loop.
 
-    Note: initialize_async_engine() must be called first during service startup.
+    Note: initialize_async_engine() must be called first during startup of the
+    component that owns the current event loop.
 
     Returns:
-        The initialized async session maker
+        The initialized async session maker for this loop
 
     Raises:
-        RuntimeError: If called before initialize_async_engine()
+        RuntimeError: If called before initialize_async_engine() on this loop
     """
-    global _async_session_maker
-    if _async_session_maker is None:
+    loop = asyncio.get_running_loop()
+    session_maker = _session_makers_by_loop.get(loop)
+    if session_maker is None:
         raise RuntimeError(
-            "Async session maker not initialized. Call initialize_async_engine(config) during service startup."
+            "Async session maker not initialized on this event loop. "
+            "Call initialize_async_engine(config) during startup of the component that owns this loop."
         )
-    return _async_session_maker
+    return session_maker
 
 
 async def ping_database() -> bool:
@@ -61,10 +108,12 @@ async def ping_database() -> bool:
     Returns:
         True if the database is reachable, False otherwise.
     """
-    if _async_session_maker is None:
+    loop = asyncio.get_running_loop()
+    session_maker = _session_makers_by_loop.get(loop)
+    if session_maker is None:
         return False
     try:
-        async with _async_session_maker() as session:
+        async with session_maker() as session:
             await session.execute(text("SELECT 1"))
         return True
     except Exception:
@@ -72,15 +121,18 @@ async def ping_database() -> bool:
 
 
 async def dispose_async_engine() -> None:
-    """Dispose the async engine, closing all connections.
+    """Dispose the current loop's async engine, closing all connections.
 
-    Should be called during service shutdown to properly close database connections.
+    Should be called during shutdown of the component that owns the current
+    event loop.  Engines owned by other loops are left untouched so a
+    controller shutdown cannot yank connections out from under the service
+    loop (and vice versa).
     """
-    global _async_engine, _async_session_maker
-    if _async_engine is not None:
-        await _async_engine.dispose()
-        _async_engine = None
-        _async_session_maker = None
+    loop = asyncio.get_running_loop()
+    engine = _engines_by_loop.pop(loop, None)
+    _session_makers_by_loop.pop(loop, None)
+    if engine is not None:
+        await engine.dispose()
 
 
 def dep_workspace_repository(session_maker: async_sessionmaker[AsyncSession]) -> WorkspaceRepositoryInterface:
@@ -101,6 +153,7 @@ __all__ = [
     "dep_workspace_repository",
     "dep_entity_repository",
     "dispose_async_engine",
+    "get_async_engine",
     "get_async_session_maker",
     "initialize_async_engine",
     "ping_database",

--- a/services/core/entities/src/nmp/core/entities/initialize.py
+++ b/services/core/entities/src/nmp/core/entities/initialize.py
@@ -108,19 +108,18 @@ async def initialize_database(run_migrations: bool = True) -> None:
     Args:
         run_migrations: If True, run Alembic upgrade head at startup.
     """
-    from nmp.core.entities.app.repository import _async_engine, get_async_session_maker
+    from nmp.core.entities.app.repository import get_async_engine, get_async_session_maker
 
     logger.info("Initializing entity store database...")
 
-    if _async_engine is None:
-        raise RuntimeError("Async engine not initialized. Call initialize_async_engine() before initialize_database().")
+    engine = await get_async_engine()
 
     if run_migrations:
         alembic_ini = _find_alembic_ini()
         if alembic_ini:
             logger.info("Running database migrations (alembic upgrade head)...")
             try:
-                await asyncio.to_thread(_run_alembic_upgrade, alembic_ini, _engine_url_for_alembic(_async_engine))
+                await asyncio.to_thread(_run_alembic_upgrade, alembic_ini, _engine_url_for_alembic(engine))
                 logger.info("✓ Database migrations applied")
             except Exception:
                 logger.exception("Database migrations failed")

--- a/services/core/entities/tests/repository/test_per_loop_engine.py
+++ b/services/core/entities/tests/repository/test_per_loop_engine.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for per-event-loop engine initialization (NVBug 6588975 / #1230).
+
+The service process runs at least two event loops: the uvicorn lifespan loop
+(service.py) and the controller worker loop (controllers/main.py daemon
+thread).  asyncpg pools bind their internal waiters to the loop that first
+uses them, so a process-global engine singleton makes cross-loop acquires fail
+with "RuntimeError: <Queue> is bound to a different event loop" once the pool
+saturates.  These tests pin the per-loop contract without requiring postgres:
+each loop must get its own engine/session maker, and disposal on one loop must
+not affect another.
+"""
+
+import asyncio
+import tempfile
+import threading
+
+import pytest
+from nmp.core.entities.app.repository import (
+    dispose_async_engine,
+    get_async_session_maker,
+    initialize_async_engine,
+    ping_database,
+)
+from nmp.core.entities.config import EntitiesConfig
+
+
+def _sqlite_config() -> EntitiesConfig:
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    return EntitiesConfig(database_url=f"sqlite+aiosqlite:///{db_path}")
+
+
+def _run_in_fresh_loop(coro_factory):
+    """Run a coroutine in a brand-new event loop on a separate thread.
+
+    Mirrors how controllers/main.py runs: a daemon thread with its own loop.
+    Returns the coroutine result (or raises its exception).
+    """
+    result: dict = {}
+
+    def runner():
+        loop = asyncio.new_event_loop()
+        try:
+            result["value"] = loop.run_until_complete(coro_factory())
+        except BaseException as exc:  # noqa: BLE001 - propagate to caller
+            result["error"] = exc
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join(timeout=60)
+    if "error" in result:
+        raise result["error"]
+    return result.get("value")
+
+
+@pytest.mark.asyncio
+async def test_each_loop_gets_its_own_session_maker():
+    """Two loops initializing the same config must not share a session maker."""
+    config = _sqlite_config()
+
+    await initialize_async_engine(config)
+    maker_service_loop = await get_async_session_maker()
+
+    async def controller_side():
+        await initialize_async_engine(config)
+        return await get_async_session_maker()
+
+    maker_controller_loop = _run_in_fresh_loop(controller_side)
+
+    assert maker_controller_loop is not None
+    assert maker_service_loop is not maker_controller_loop, (
+        "session maker leaked across event loops — this is the exact sharing "
+        "that produces 'Queue is bound to a different event loop' (6588975)"
+    )
+    await dispose_async_engine()
+
+
+@pytest.mark.asyncio
+async def test_second_init_on_same_loop_is_noop():
+    """The once-per-loop contract: re-initializing on one loop keeps the maker."""
+    config = _sqlite_config()
+    await initialize_async_engine(config)
+    first = await get_async_session_maker()
+    await initialize_async_engine(config)
+    second = await get_async_session_maker()
+    assert first is second
+    await dispose_async_engine()
+
+
+@pytest.mark.asyncio
+async def test_uninitialized_loop_raises_clear_error():
+    """A loop that never initialized must get the explicit RuntimeError."""
+    config = _sqlite_config()
+    await initialize_async_engine(config)
+
+    async def never_initialized():
+        try:
+            await get_async_session_maker()
+        except RuntimeError as exc:
+            return str(exc)
+        return None
+
+    message = _run_in_fresh_loop(never_initialized)
+    assert message is not None and "not initialized on this event loop" in message
+    await dispose_async_engine()
+
+
+@pytest.mark.asyncio
+async def test_dispose_only_affects_current_loop():
+    """Controller shutdown must not yank the service loop's engine."""
+    config = _sqlite_config()
+    await initialize_async_engine(config)
+    assert await ping_database() is True
+
+    async def controller_lifecycle():
+        await initialize_async_engine(config)
+        assert await ping_database() is True
+        await dispose_async_engine()  # controller shuts down its own engine
+        return await ping_database()  # controller loop: gone
+
+    controller_ping_after_dispose = _run_in_fresh_loop(controller_lifecycle)
+    assert controller_ping_after_dispose is False
+
+    # service loop unaffected
+    assert await ping_database() is True
+    await dispose_async_engine()
+
+
+@pytest.mark.asyncio
+async def test_cross_loop_usage_does_not_touch_foreign_pool():
+    """The 6588975 scenario shape: loop B working while loop A's pool exists.
+
+    With per-loop engines the controller loop's queries run on its own pool,
+    so no cross-loop waiter binding is possible by construction.
+    """
+    config = _sqlite_config()
+    await initialize_async_engine(config)
+
+    async def controller_query_burst():
+        await initialize_async_engine(config)
+        results = []
+        for _ in range(10):
+            results.append(await ping_database())
+        await dispose_async_engine()
+        return all(results)
+
+    assert _run_in_fresh_loop(controller_query_burst) is True
+    assert await ping_database() is True
+    await dispose_async_engine()


### PR DESCRIPTION
## Summary

Fixes the intermittent `workspace_cleanup` controller failure tracked in #1230 (NVBug 6588975): the entities async engine was a process-global singleton, but the process runs two event loops (uvicorn lifespan + controller worker thread). Whichever loop initialized first captured the asyncpg pool; once the pool saturated, acquires from the other loop failed with:

```
RuntimeError: <Queue at 0x... maxsize=0 _getters[N]> is bound to a different event loop
```

`workspace_cleanup` then flips `controllers.healthy` false while the API keeps serving, so health-gated consumers fail at setup. Light load never saturates the pool, which is why the failure was intermittent (see the issue for the deterministic standalone reproduction).

## Change

- `repository/__init__.py`: key engines/session makers by `asyncio.get_running_loop()`. Once-per-init becomes once-per-loop; `get_async_session_maker()` / `ping_database()` resolve the current loop's pool; `dispose_async_engine()` disposes only the current loop's engine (a controller shutdown can no longer yank connections out from under the service loop). New public `get_async_engine()` accessor.
- `initialize.py`: use `get_async_engine()` instead of importing the private `_async_engine`.
- No caller signature changes — `service.py` and `controllers/main.py` already call `initialize_async_engine()` on their own loops.

## Testing

- **New regression tests** `tests/repository/test_per_loop_engine.py` (5) pin the per-loop contract: distinct session makers per loop, per-loop no-op re-init, clear error on an uninitialized loop, dispose isolation, cross-loop burst shape. **4 of 5 fail on the previous singleton; all 5 pass with the fix** (mutation-checked both ways).
- Full entities unit suite: **305 passed**, no regressions.
- **Live verification**: full service+controller topology (19 services, `--controller-group all`) deployed from this branch; 500-request saturation burst against the entities API concurrent with cleanup controller stepping — zero cross-loop `RuntimeError`s, `workspace_cleanup` healthy throughout. The unfixed build under the same daily regression load accumulated 25 setup errors from this race (2026-08-10 evidence in the issue).

Closes #1230. NVBug 6588975.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database reliability when operations run across multiple asynchronous event loops.
  * Prevented connections and sessions from being incorrectly shared between event loops.
  * Added clearer errors when database access is attempted before initialization.
  * Ensured database cleanup affects only the active event loop.

* **Tests**
  * Added coverage for independent initialization, reuse, cleanup, and cross-loop database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->