### PR TITLE
fix(test): give the scoped-access-key test a timeout it can actually meet

### DIFF
--- a/services/core/auth/tests/integration/test_scoped_access_keys.py
+++ b/services/core/auth/tests/integration/test_scoped_access_keys.py
@@ -19,7 +19,17 @@ from nmp.testing.client import create_test_client
 # Run on a dedicated worker so the inline create_test_client call doesn't share
 # the module-level wasmtime singleton with the module-scoped test_client fixture
 # used by sibling integration tests (which would violate wasmtime thread affinity).
-pytestmark = pytest.mark.xdist_group("auth_scoped_access_keys")
+pytestmark = [
+    pytest.mark.xdist_group("auth_scoped_access_keys"),
+    # This test stands up a full auth-enabled platform in-process and drives the whole access-key
+    # lifecycle through it, which costs around two minutes on a loaded CI worker. Measured on
+    # passing main runs: 89.47s, 108.28s, 117.81s, 119.92s — against the suite-wide `--timeout=120`.
+    # Runs that exceed it are killed by pytest-timeout's thread method, which calls os._exit(1);
+    # that is not a signal, so faulthandler writes nothing, and its own stack dump goes to the
+    # worker's captured stdout which xdist never forwards. The controller sees only
+    # `node down: Not properly terminated`, which reads as a hard crash rather than a timeout.
+    pytest.mark.timeout(600),
+]
 
 ACCESS_KEYS_PATH = "/apis/auth/v2/access-keys"
 IAM_ROLE_BINDINGS_PATH = "/apis/auth/v2/iam/role-bindings"


### PR DESCRIPTION
## Summary

`test_scoped_access_keys.py::test_scoped_access_key_created_by_auth_service_authenticates_platform_requests` fails roughly half of all integration runs, reported as `worker gwN crashed while running ...`. **It is not a crash** — it is the suite-wide `--timeout=120` firing on a test that legitimately takes about two minutes.

## Evidence

Durations from `--durations=25` on runs where it passed, against the 120s limit:

| commit | result | duration |
|---|---|---|
| `88698368` | success | **119.92s** |
| `095b1991` | success | 117.81s |
| `4c3bef54` | success | 108.28s |
| `ed68cbb1` | success | 89.47s |
| 7 others | failure | *no duration — never finished* |

Every pass is under 120s; every failure reports no duration. Whether a run passes is decided by runner load.

## Why it looked like a crash

pytest-timeout's thread method calls `os._exit(1)`. That is not a signal, so faulthandler never runs — which is why a per-worker faulthandler dump captured the test-entry trail and no traceback. Its own stack dump goes to the worker's captured stdout, which xdist does not forward. Both channels dark, for different reasons, leaving only `node down: Not properly terminated`.

## Changes

`pytest.mark.timeout(600)` on the test, alongside its existing `xdist_group`. Verified the marker overrides the command-line value by running under `--timeout=5` and watching it pass.

## Type of Change

- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Existing tests cover changed behavior — justification: the change is a timeout ceiling on one existing test; the test's assertions are untouched.
- [x] Documentation not applicable — justification: no user-visible behavior changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included
- [ ] `uv run pre-commit run -a` passes — three hooks fail on this machine (`Helm Docs`, `uv lock`, `UI lint-staged`, the last on a missing local `pnpm` shim). None touch this file.

Targeted validation: passes locally in 65.58s under `--timeout=120`, and in 18.88s under `--timeout=5`, confirming the marker takes precedence.

## Follow-up

Making the test cheaper is worth doing separately — `bundle_cache_seconds=0` forces a policy reload on every authorization call. That changes what the test exercises, so it should not ride along with stopping the bleeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated scoped access key integration tests to run in a dedicated test group.
  * Increased the test timeout to improve reliability for longer-running test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->