### PR TITLE
fix(test): stop reloading the whole policy on every authz call in this test

### DIFF
--- a/services/core/auth/tests/integration/test_scoped_access_keys.py
+++ b/services/core/auth/tests/integration/test_scoped_access_keys.py
@@ -64,7 +64,7 @@ def _auth_configs(private_key_file: str) -> tuple[AuthConfig, AuthServiceConfig]
     service_config = AuthServiceConfig(
         **shared_config.model_dump(),
         policy_data_refresh_interval=0.2,
-        bundle_cache_seconds=0,
+        bundle_cache_seconds=1,
         admin_email="admin@example.com",
     )
     return shared_config, service_config


### PR DESCRIPTION
## Summary

Alternative to #1311 — same diagnosis, better fix. `test_scoped_access_keys` fails roughly half of all integration runs as `worker gwN crashed while running ...`. **It is not a crash**: it is `--timeout=120` firing on a test that takes about two minutes. Rather than raise the ceiling, this removes the cost.

**65.58s → 5.88s locally, an 11× reduction.**

## Evidence for the diagnosis

Durations from `--durations=25` on runs where it passed, against the 120s limit:

| commit | result | duration |
|---|---|---|
| `88698368` | success | **119.92s** |
| `095b1991` | success | 117.81s |
| `4c3bef54` | success | 108.28s |
| `ed68cbb1` | success | 89.47s |
| 7 others | failure | *no duration — never finished* |

It reads as a crash because pytest-timeout's thread method calls `os._exit(1)` — not a signal, so faulthandler never runs, and its own dump goes to the worker's captured stdout which xdist never forwards.

## The cost

`bundle_cache_seconds=0` makes the authz endpoint call `load_policy_data` before **every** PDP evaluation ([endpoints.py:86-89](services/core/auth/src/nmp/core/auth/api/v2/authz/endpoints.py)). This test drives a full access-key lifecycle — create workspace, create key, list, authenticate, revoke, re-authenticate — through an in-process platform, so each request reloads the entire policy document.

## Why this is safe

The test still exercises the same lifecycle with the same assertions. Its config already sets `propagation_poll_interval_seconds=0.05`, so assertions that depend on role propagation wait for it rather than assuming it.

A cache could trade a timeout for a staleness flake, so I ran it **eight times consecutively: 8 passed, 0 failed.**

## Choosing between this and #1311

#1311 raises the ceiling to 600s. It is lower-risk but leaves a two-minute test dominating the suite's time budget. This one removes the cost instead. They are mutually exclusive; merge whichever you prefer and close the other.

## Type of Change

- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Existing tests cover changed behavior — justification: one existing test's fixture config; its assertions are untouched.
- [x] Documentation not applicable — justification: no user-visible behavior changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included
- [ ] `uv run pre-commit run -a` passes — three hooks fail on this machine (`Helm Docs`, `uv lock`, `UI lint-staged`, the last on a missing local `pnpm` shim). None touch this file.

Targeted validation: 8 consecutive passes, 5.7–5.9s each, versus 65.58s before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test reliability by allowing a brief cache interval for scoped access key authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->