### PR TITLE
fix(evaluator): detect structured output support from the endpoint

### DIFF
--- a/docs/evaluator/agent-eval/targets-and-runners.mdx
+++ b/docs/evaluator/agent-eval/targets-and-runners.mdx
@@ -34,15 +34,14 @@ bare model do before you wrap it in an agent?). The evaluator prompts it with ea
 |---|---|---|
 | `url` | yes | endpoint URL (e.g. `.../v1/chat/completions` or `.../v1/completions`) |
 | `name` | yes | model identifier, stamped on trials |
-| `format` | no | `ModelFormat.NVIDIA_NIM` (default), `ModelFormat.OPEN_AI`, or `ModelFormat.LLAMA_STACK` — serialized as `nim` / `openai` / `llama_stack` |
+| `format` | no | **deprecated and ignored** — structured output support is probed from the endpoint during preflight |
 | `api_key_secret` | no | credential reference — `workspace/secret_name` or `secret_name` |
 
 ```python
-from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.values import Model
 
 target = Model(url="https://integrate.api.nvidia.com/v1/chat/completions", name="meta/llama-3.1-8b-instruct",
-               format=ModelFormat.OPEN_AI, api_key_secret="NVIDIA_API_KEY")
+               api_key_secret="NVIDIA_API_KEY")
 ```
 
 For a local `run()`, `api_key_secret` names an **environment variable** in your process; for a submitted

--- a/docs/evaluator/manage-tasks-tasksets.mdx
+++ b/docs/evaluator/manage-tasks-tasksets.mdx
@@ -317,13 +317,12 @@ each run.
 from nemo_evaluator.api.schemas import TasksetRef
 from nemo_evaluator.jobs.agent_spec import AgentEvalInputSpec, ModelTarget
 from nemo_evaluator_sdk.values import Model
-from nemo_evaluator_sdk.enums import ModelFormat
 
 # Instead of inlining AgentEvalTaskInput objects, point `tasks` at a stored taskset.
 input_spec = AgentEvalInputSpec(
     tasks=TasksetRef("default/geography-suite"),
     target=ModelTarget(
-        model=Model(url="https://integrate.api.nvidia.com/v1", name="meta/llama-3.3-70b-instruct", format=ModelFormat.OPEN_AI),
+        model=Model(url="https://integrate.api.nvidia.com/v1", name="meta/llama-3.3-70b-instruct"),
     ),
 )
 ```

--- a/docs/evaluator/metrics/llm-as-a-judge.mdx
+++ b/docs/evaluator/metrics/llm-as-a-judge.mdx
@@ -71,13 +71,11 @@ from nemo_evaluator_sdk import (
     RunConfig,
     LLMJudgeMetric
 )
-from nemo_evaluator_sdk.enums import ModelFormat
 
 metric = LLMJudgeMetric(
     model=Model(
         url="<judge-nim-url>/v1",
         name="meta/llama-3.1-70b-instruct",
-        format=ModelFormat.NVIDIA_NIM,
     ),
     scores=[
         RangeScore(
@@ -169,7 +167,6 @@ Use rubric scores when you want categorical labels with explicit descriptions:
 
 ```python
 from nemo_evaluator_sdk import JSONScoreParser, Model, RubricScore, LLMJudgeMetric
-from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.values import Rubric
 from nemo_evaluator_sdk import Evaluator as LocalEvaluator
 
@@ -177,7 +174,6 @@ metric = LLMJudgeMetric(
     model=Model(
         url="<judge-nim-url>/v1",
         name="meta/llama-3.1-70b-instruct",
-        format=ModelFormat.NVIDIA_NIM,
     ),
     scores=[
         RubricScore(
@@ -279,14 +275,12 @@ For production workloads, submit the same metric and dataset as a durable platfo
 
 ```python
 from nemo_evaluator_sdk import RunConfig, JSONScoreParser, Model, RubricScore, LLMJudgeMetric
-from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.values import Rubric
 
 metric = LLMJudgeMetric(
     model=Model(
         url="<judge-nim-url>/v1",
         name="meta/llama-3.1-70b-instruct",
-        format=ModelFormat.NVIDIA_NIM,
     ),
     scores=[
         RubricScore(
@@ -552,7 +546,6 @@ metric = {
  "model": {
  "url": "<judge-url>/v1",
  "name": "meta/llama-3.1-70b-instruct",
- "format": "nim"
  },
  "scores": [
  {
@@ -599,7 +592,6 @@ metric = {
     "model": {
         "url": "https://api.example.com/v1",
         "name": "gpt-4",
-        "format": "openai",
         "api_key_secret": "judge-api-key",
     },
     # ... scores and prompt_template
@@ -638,7 +630,6 @@ metric = {
     "model": {
         "url": "<nim-url>/v1",
         "name": "nvidia/llama-3.3-nemotron-super-49b-v1",
-        "format": "nim",
     },
     # ... scores ...
     "system_prompt": "'detailed thinking on'",

--- a/docs/evaluator/metrics/model-configuration.mdx
+++ b/docs/evaluator/metrics/model-configuration.mdx
@@ -36,7 +36,6 @@ from nemo_evaluator_sdk import Model
 model = Model(
     url="https://integrate.api.nvidia.com/v1",
     name="meta/llama-3.1-70b-instruct",
-    format="nim",
     api_key_secret="nvidia-api-key",
 )
 ```
@@ -45,7 +44,7 @@ model = Model(
 |-------|----------|-------------|
 | `url` | Yes | Base URL of the inference endpoint. |
 | `name` | Yes | Model name to send in inference requests. |
-| `format` | No | API format: `"nim"`, `"openai"`, or `"llama_stack"`. Defaults to `"nim"`. |
+| `format` | No | **Deprecated and ignored.** Structured output support is detected from the endpoint during preflight rather than inferred from this label. |
 | `api_key_secret` | No | Model API key reference. See [Model API Authentication](#model-api-authentication). |
 
 <a id="model-api-authentication"></a>
@@ -80,7 +79,6 @@ from nemo_evaluator_sdk import (
 model = Model(
     url="https://integrate.api.nvidia.com/v1",
     name="meta/llama-3.1-70b-instruct",
-    format="nim",
     api_key_secret="nvidia-api-key",
 )
 
@@ -112,7 +110,6 @@ from nemo_evaluator_sdk import Model, RangeScore, LLMJudgeMetric
 judge_model = Model(
     url="https://integrate.api.nvidia.com/v1",
     name="meta/llama-3.1-70b-instruct",
-    format="nim",
     api_key_secret="nvidia-api-key",
 )
 metric = LLMJudgeMetric(

--- a/docs/notebooks/ndd_evaluator.mdx
+++ b/docs/notebooks/ndd_evaluator.mdx
@@ -574,7 +574,6 @@ def run_evaluation(
  model_kwargs = {
  "url": model_spec["url"],
  "name": model_spec["model_id"],
- "format": "openai",
  }
  if secret_key_name:
  model_kwargs["api_key_secret"] = secret_key_name

--- a/packages/nemo_evaluator_sdk/examples/agentic_eval_with_fabric.ipynb
+++ b/packages/nemo_evaluator_sdk/examples/agentic_eval_with_fabric.ipynb
@@ -411,7 +411,6 @@
     "        model=Model(\n",
     "            url=\"https://integrate.api.nvidia.com/v1/chat/completions\",\n",
     "            name=os.environ.get(\"JUDGE_MODEL\", \"nvidia/nvidia-nemotron-nano-9b-v2\"),\n",
-    "            format=\"openai\",\n",
     "            # api_key_secret names the env var to read; model.api_key resolves os.environ[JUDGE_API_KEY_ENV].\n",
     "            api_key_secret=SecretRef(JUDGE_API_KEY_ENV),\n",
     "        ),\n",

--- a/packages/nemo_evaluator_sdk/examples/profbench/profbench.py
+++ b/packages/nemo_evaluator_sdk/examples/profbench/profbench.py
@@ -20,7 +20,10 @@ from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalTask
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
-from nemo_evaluator_sdk.execution.metric_execution import generate_online_sample
+from nemo_evaluator_sdk.execution.metric_execution import (
+    generate_online_sample,
+    resolve_target_structured_output_mode,
+)
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
 from nemo_evaluator_sdk.values import InferenceParams, Model, RunConfigOnlineModel
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
@@ -246,7 +249,14 @@ class ProfBenchModelJudge:
         self.default_headers = default_headers
 
     async def judge(self, request: ProfBenchJudgeRequest) -> ProfBenchJudgeDecision:
-        preprocess_hooks, postprocess_hooks = inference.new_hooks(self.params, model_format=self.model.format)
+        preprocess_hooks, postprocess_hooks = inference.new_hooks(self.params)
+        # Hooks are rebuilt per judge call, so this relies on detection being cached per endpoint.
+        await resolve_target_structured_output_mode(
+            preprocess_hooks=preprocess_hooks,
+            model=self.model,
+            inference_fn=self.inference_fn,
+            params=self.params,
+        )
         sample = await generate_online_sample(
             target=self.model,
             row={"prompt": _render_judge_prompt(request)},

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -166,17 +166,19 @@ class AgentEvaluator:
         runtime_config = resolved_config.model_copy(update={"run_id": run_id})
         started_at = datetime.now(UTC)
 
-        if (trials is None) == (target is None):
-            raise ValueError("provide exactly one of trials or target")
+        seam_error = "provide exactly one of trials or target"
+        if trials is not None and target is not None:
+            raise ValueError(seam_error)
 
         async with begin_evaluation_session():
-            # Branch on which seam was supplied so the type checker can narrow ``target`` to a
-            # concrete ``AgentEvalTarget`` without a cast.
+            # Branch on which seam was supplied so the type checker narrows each of ``trials`` and
+            # ``target`` to a concrete type without a cast. The final arm is the "neither" case.
             if trials is not None:
                 trial_list = list(trials)
-            else:
-                assert target is not None
+            elif target is not None:
                 trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
+            else:
+                raise ValueError(seam_error)
             scores = await self._score_trials(
                 tasks=task_list,
                 trials=trial_list,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -46,10 +46,15 @@ from nemo_evaluator_sdk.agent_inference import (
     make_agent_inference_fn,
     new_agent_inference_client,
 )
-from nemo_evaluator_sdk.execution.metric_execution import generate_online_sample, run_sync
+from nemo_evaluator_sdk.execution.metric_execution import (
+    generate_online_sample,
+    resolve_target_structured_output_mode,
+    run_sync,
+)
+from nemo_evaluator_sdk.structured_output import structured_output_mode_session
 from nemo_evaluator_sdk.execution.samples import build_metric_input
 from nemo_evaluator_sdk.inference import InferenceFn
-from nemo_evaluator_sdk.metrics.protocol import Metric, validate_metric_result
+from nemo_evaluator_sdk.metrics.protocol import Metric, MetricWithPreflight, validate_metric_result
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
 from nemo_evaluator_sdk.values import (
     Agent,
@@ -161,22 +166,26 @@ class AgentEvaluator:
         runtime_config = resolved_config.model_copy(update={"run_id": run_id})
         started_at = datetime.now(UTC)
 
-        # Branch on which seam was supplied so the type checker can narrow ``target`` to a
-        # concrete ``AgentEvalTarget`` without a cast.
-        if trials is not None:
-            if target is not None:
+        # One detection session for the whole run: generation probes the target and scoring probes
+        # any judge model, and imported-trial runs still score, so scoping this to generation alone
+        # would leave judges probing per call.
+        async with structured_output_mode_session():
+            # Branch on which seam was supplied so the type checker can narrow ``target`` to a
+            # concrete ``AgentEvalTarget`` without a cast.
+            if trials is not None:
+                if target is not None:
+                    raise ValueError("provide exactly one of trials or target")
+                trial_list = list(trials)
+            elif target is not None:
+                trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
+            else:
                 raise ValueError("provide exactly one of trials or target")
-            trial_list = list(trials)
-        elif target is not None:
-            trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
-        else:
-            raise ValueError("provide exactly one of trials or target")
-        scores = await self._score_trials(
-            tasks=task_list,
-            trials=trial_list,
-            config=runtime_config,
-            run_id=run_id,
-        )
+            scores = await self._score_trials(
+                tasks=task_list,
+                trials=trial_list,
+                config=runtime_config,
+                run_id=run_id,
+            )
         runner_scores = _collect_runner_aggregate_scores(target) if target is not None else []
         finished_at = datetime.now(UTC)
         metadata = RunMetadata(
@@ -238,6 +247,19 @@ class AgentEvaluator:
         for task in tasks:
             if not task.metrics:
                 raise ValueError(f"task {task.id!r} does not declare any metrics")
+
+        # Agent-eval scores metrics directly rather than through prepare_metric_for_execution, so
+        # nothing else runs their preflight. An LLM judge detects its endpoint's structured-output
+        # encoding there; without this it would score using the provisional guess from new_hooks.
+        # Deduplicated by identity because the same metric object is scored once per trial. The run
+        # session would collapse repeat probes to one request anyway; this just avoids the repeated
+        # awaits. Identity is stable here: `tasks` holds every metric for the duration of the loop.
+        preflighted: set[int] = set()
+        for task in tasks:
+            for metric in task.metrics:
+                if isinstance(metric, MetricWithPreflight) and id(metric) not in preflighted:
+                    preflighted.add(id(metric))
+                    await metric.preflight()
 
         semaphore = asyncio.Semaphore(config.parallelism)
 
@@ -311,6 +333,8 @@ class AgentEvaluator:
         params = _resolve_live_params(config, target)
         prompt_template = config.prompt_template or _default_prompt_template(target)
         semaphore = asyncio.Semaphore(params.parallelism)
+        # Hooks are built per row below; the run-level session opened by run() is what keeps the
+        # endpoint probe to one round trip for the whole pass instead of one per row.
 
         # Use the injected transport client when provided; otherwise build a default for the
         # resolved target type and close it when generation finishes.
@@ -395,9 +419,17 @@ async def _generate_sample(
     # The transport client is a real class union, so isinstance narrowing is enough there.
     if isinstance(target, Model):
         model_params = cast(RunConfigOnlineModel, params)
-        preprocess_hooks, postprocess_hooks = inference.new_hooks(model_params, model_format=target.format)
+        preprocess_hooks, postprocess_hooks = inference.new_hooks(model_params)
         model_inference_fn = (
             cast(InferenceFn, inference_fn) if inference_fn is not None else inference.make_inference_request
+        )
+        # Hooks are built per row here, so this relies on detection being cached per endpoint:
+        # without the probe the request would carry whichever encoding new_hooks guessed.
+        await resolve_target_structured_output_mode(
+            preprocess_hooks=preprocess_hooks,
+            model=target,
+            inference_fn=model_inference_fn,
+            params=model_params,
         )
         return await generate_online_sample(
             target=target,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
@@ -245,7 +245,7 @@ class AgentEvaluator:
             if not task.metrics:
                 raise ValueError(f"task {task.id!r} does not declare any metrics")
 
-        await _preflight_task_metrics(tasks)
+        await _preflight_task_metrics(tasks, trials_by_task)
 
         semaphore = asyncio.Semaphore(config.parallelism)
 
@@ -386,14 +386,22 @@ class AgentEvaluator:
                 await close_client()
 
 
-async def _preflight_task_metrics(tasks: Sequence[AgentEvalTask]) -> None:
-    """Run each distinct metric's preflight once.
+async def _preflight_task_metrics(
+    tasks: Sequence[AgentEvalTask],
+    trials_by_task: Mapping[str, Sequence[AgentEvalTrial]],
+) -> None:
+    """Run each distinct metric's preflight once, skipping metrics with nothing to score.
 
     Agent-eval scores metrics directly rather than through ``prepare_metric_for_execution``, so
-    nothing else runs their preflight.
+    nothing else runs their preflight. Failed trials short-circuit to a failed score without
+    invoking the metric, so a task whose trials all failed must not trigger one: preflight resolves
+    the judge endpoint, making it both a wasted request and a way for the run to abort.
     """
     preflighted: set[int] = set()
     for task in tasks:
+        scoreable = any(trial.status != AgentEvalTrialStatus.FAILED for trial in trials_by_task.get(task.id, ()))
+        if not scoreable:
+            continue
         for metric in task.metrics:
             if isinstance(metric, MetricWithPreflight) and id(metric) not in preflighted:
                 preflighted.add(id(metric))

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -166,17 +166,17 @@ class AgentEvaluator:
         runtime_config = resolved_config.model_copy(update={"run_id": run_id})
         started_at = datetime.now(UTC)
 
+        if (trials is None) == (target is None):
+            raise ValueError("provide exactly one of trials or target")
+
         async with begin_evaluation_session():
             # Branch on which seam was supplied so the type checker can narrow ``target`` to a
             # concrete ``AgentEvalTarget`` without a cast.
             if trials is not None:
-                if target is not None:
-                    raise ValueError("provide exactly one of trials or target")
                 trial_list = list(trials)
-            elif target is not None:
-                trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
             else:
-                raise ValueError("provide exactly one of trials or target")
+                assert target is not None
+                trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
             scores = await self._score_trials(
                 tasks=task_list,
                 trials=trial_list,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/evaluator.py
@@ -51,7 +51,7 @@ from nemo_evaluator_sdk.execution.metric_execution import (
     resolve_target_structured_output_mode,
     run_sync,
 )
-from nemo_evaluator_sdk.structured_output import structured_output_mode_session
+from nemo_evaluator_sdk.session import begin_evaluation_session
 from nemo_evaluator_sdk.execution.samples import build_metric_input
 from nemo_evaluator_sdk.inference import InferenceFn
 from nemo_evaluator_sdk.metrics.protocol import Metric, MetricWithPreflight, validate_metric_result
@@ -166,10 +166,7 @@ class AgentEvaluator:
         runtime_config = resolved_config.model_copy(update={"run_id": run_id})
         started_at = datetime.now(UTC)
 
-        # One detection session for the whole run: generation probes the target and scoring probes
-        # any judge model, and imported-trial runs still score, so scoping this to generation alone
-        # would leave judges probing per call.
-        async with structured_output_mode_session():
+        async with begin_evaluation_session():
             # Branch on which seam was supplied so the type checker can narrow ``target`` to a
             # concrete ``AgentEvalTarget`` without a cast.
             if trials is not None:
@@ -248,18 +245,7 @@ class AgentEvaluator:
             if not task.metrics:
                 raise ValueError(f"task {task.id!r} does not declare any metrics")
 
-        # Agent-eval scores metrics directly rather than through prepare_metric_for_execution, so
-        # nothing else runs their preflight. An LLM judge detects its endpoint's structured-output
-        # encoding there; without this it would score using the provisional guess from new_hooks.
-        # Deduplicated by identity because the same metric object is scored once per trial. The run
-        # session would collapse repeat probes to one request anyway; this just avoids the repeated
-        # awaits. Identity is stable here: `tasks` holds every metric for the duration of the loop.
-        preflighted: set[int] = set()
-        for task in tasks:
-            for metric in task.metrics:
-                if isinstance(metric, MetricWithPreflight) and id(metric) not in preflighted:
-                    preflighted.add(id(metric))
-                    await metric.preflight()
+        await _preflight_task_metrics(tasks)
 
         semaphore = asyncio.Semaphore(config.parallelism)
 
@@ -333,8 +319,6 @@ class AgentEvaluator:
         params = _resolve_live_params(config, target)
         prompt_template = config.prompt_template or _default_prompt_template(target)
         semaphore = asyncio.Semaphore(params.parallelism)
-        # Hooks are built per row below; the run-level session opened by run() is what keeps the
-        # endpoint probe to one round trip for the whole pass instead of one per row.
 
         # Use the injected transport client when provided; otherwise build a default for the
         # resolved target type and close it when generation finishes.
@@ -402,6 +386,20 @@ class AgentEvaluator:
                 await close_client()
 
 
+async def _preflight_task_metrics(tasks: Sequence[AgentEvalTask]) -> None:
+    """Run each distinct metric's preflight once.
+
+    Agent-eval scores metrics directly rather than through ``prepare_metric_for_execution``, so
+    nothing else runs their preflight.
+    """
+    preflighted: set[int] = set()
+    for task in tasks:
+        for metric in task.metrics:
+            if isinstance(metric, MetricWithPreflight) and id(metric) not in preflighted:
+                preflighted.add(id(metric))
+                await metric.preflight()
+
+
 async def _generate_sample(
     *,
     target: Model | Agent,
@@ -423,8 +421,6 @@ async def _generate_sample(
         model_inference_fn = (
             cast(InferenceFn, inference_fn) if inference_fn is not None else inference.make_inference_request
         )
-        # Hooks are built per row here, so this relies on detection being cached per endpoint:
-        # without the probe the request would carry whichever encoding new_hooks guessed.
         await resolve_target_structured_output_mode(
             preprocess_hooks=preprocess_hooks,
             model=target,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/backends/local/backend.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/backends/local/backend.py
@@ -24,7 +24,7 @@ from nemo_evaluator_sdk.execution.utils import prepare_metric_for_execution, uni
 from nemo_evaluator_sdk.inference import PostprocessResponse, PreprocessRequest
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.resolvers import LocalModelResolver, LocalSecretResolver
-from nemo_evaluator_sdk.structured_output import structured_output_mode_session
+from nemo_evaluator_sdk.session import begin_evaluation_session
 from nemo_evaluator_sdk.values import Agent, DatasetInput, FieldMapping, Model
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult, namespace_result
 from nemo_evaluator_sdk.values.results import AggregateFieldName, EvaluationResult
@@ -85,10 +85,8 @@ class LocalBackend:
         Returns:
             A namespaced single-metric evaluation result.
         """
-        # Wraps preparation as well as execution: prepare_metric_for_execution runs the metric's
-        # preflight, which is where an LLM judge probes its endpoint. evaluate_metric opens a
-        # session too; the session is re-entrant, so both share this one cache.
-        async with structured_output_mode_session():
+        # Preparation runs each metric's preflight, so it belongs inside the session.
+        async with begin_evaluation_session():
             return await self._evaluate_one_in_session(
                 metric=metric,
                 metric_key=metric_key,
@@ -114,7 +112,6 @@ class LocalBackend:
         postprocess_hooks: tuple[PostprocessResponse, ...] | None,
         rows: list[dict[str, Any]],
     ) -> EvaluationResult:
-        """Body of :meth:`_evaluate_one`, inside a structured-output detection session."""
         prepared_metric = await prepare_metric_for_execution(
             metric,
             params=params,
@@ -168,10 +165,8 @@ class LocalBackend:
         """
         rows = _prepare_rows(dataset, params, field_mapping)
         metric_keys = unique_metric_keys(metrics)
-        # Opened before metric preparation on purpose: prepare_metric_for_execution runs each
-        # metric's preflight, which is where an LLM judge probes its endpoint. Starting the session
-        # later would leave those probes uncached, so two judges on one endpoint would each probe.
-        async with structured_output_mode_session():
+        # Preparation runs each metric's preflight, so it belongs inside the session.
+        async with begin_evaluation_session():
             return await self._evaluate_dataset_in_session(
                 metrics=metrics,
                 metric_keys=metric_keys,
@@ -197,7 +192,6 @@ class LocalBackend:
         preprocess_hooks: Sequence[PreprocessRequest] | None,
         postprocess_hooks: Sequence[PostprocessResponse] | None,
     ) -> BenchmarkEvaluationResult:
-        """Body of :meth:`evaluate_dataset`, inside a structured-output detection session."""
         prepared_metrics = [
             await prepare_metric_for_execution(
                 metric,
@@ -218,16 +212,13 @@ class LocalBackend:
         else:
             merged_preprocess_hooks = tuple(preprocess_hooks or ())
             merged_postprocess_hooks = tuple(postprocess_hooks or ())
-        # This multi-metric path builds target hooks itself and calls evaluate_benchmark directly,
-        # bypassing evaluate_metric, so it has to resolve the hook here or generation would send
-        # whichever encoding new_hooks guessed.
+        # This path builds target hooks itself and bypasses evaluate_metric, so it resolves here.
         if isinstance(target, Model):
             await resolve_target_structured_output_mode(
                 preprocess_hooks=merged_preprocess_hooks,
                 model=target,
-                # Resolved from the benchmark module at call time, not bound here, so the probe
-                # always travels the exact transport that evaluate_benchmark's own default uses --
-                # including when that binding is swapped.
+                # Attribute lookup, not a bound import: the probe must use the same transport
+                # evaluate_benchmark defaults to, including when that binding is swapped.
                 inference_fn=benchmark_execution.make_inference_request,
                 params=params,
             )

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/backends/local/backend.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/backends/local/backend.py
@@ -12,13 +12,19 @@ from typing import Any
 
 from nemo_evaluator_sdk.dataset_schemas.compatibility import apply_column_mapping_to_row
 from nemo_evaluator_sdk.datasets.loader import prepare_dataset_rows
+from nemo_evaluator_sdk.execution import benchmark_execution
 from nemo_evaluator_sdk.execution.backends.base import BackendParams
 from nemo_evaluator_sdk.execution.benchmark_execution import evaluate_benchmark as sdk_evaluate_benchmark
-from nemo_evaluator_sdk.execution.metric_execution import _merge_online_hooks, evaluate_metric
+from nemo_evaluator_sdk.execution.metric_execution import (
+    _merge_online_hooks,
+    evaluate_metric,
+    resolve_target_structured_output_mode,
+)
 from nemo_evaluator_sdk.execution.utils import prepare_metric_for_execution, unique_metric_keys
 from nemo_evaluator_sdk.inference import PostprocessResponse, PreprocessRequest
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.resolvers import LocalModelResolver, LocalSecretResolver
+from nemo_evaluator_sdk.structured_output import structured_output_mode_session
 from nemo_evaluator_sdk.values import Agent, DatasetInput, FieldMapping, Model
 from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationResult, namespace_result
 from nemo_evaluator_sdk.values.results import AggregateFieldName, EvaluationResult
@@ -79,6 +85,36 @@ class LocalBackend:
         Returns:
             A namespaced single-metric evaluation result.
         """
+        # Wraps preparation as well as execution: prepare_metric_for_execution runs the metric's
+        # preflight, which is where an LLM judge probes its endpoint. evaluate_metric opens a
+        # session too; the session is re-entrant, so both share this one cache.
+        async with structured_output_mode_session():
+            return await self._evaluate_one_in_session(
+                metric=metric,
+                metric_key=metric_key,
+                params=params,
+                target=target,
+                prompt_template=prompt_template,
+                aggregate_fields=aggregate_fields,
+                preprocess_hooks=preprocess_hooks,
+                postprocess_hooks=postprocess_hooks,
+                rows=rows,
+            )
+
+    async def _evaluate_one_in_session(
+        self,
+        *,
+        metric: Metric,
+        metric_key: str,
+        params: BackendParams,
+        target: Model | Agent | None,
+        prompt_template: str | dict[str, Any] | None,
+        aggregate_fields: tuple[AggregateFieldName, ...] | None,
+        preprocess_hooks: tuple[PreprocessRequest, ...] | None,
+        postprocess_hooks: tuple[PostprocessResponse, ...] | None,
+        rows: list[dict[str, Any]],
+    ) -> EvaluationResult:
+        """Body of :meth:`_evaluate_one`, inside a structured-output detection session."""
         prepared_metric = await prepare_metric_for_execution(
             metric,
             params=params,
@@ -132,6 +168,36 @@ class LocalBackend:
         """
         rows = _prepare_rows(dataset, params, field_mapping)
         metric_keys = unique_metric_keys(metrics)
+        # Opened before metric preparation on purpose: prepare_metric_for_execution runs each
+        # metric's preflight, which is where an LLM judge probes its endpoint. Starting the session
+        # later would leave those probes uncached, so two judges on one endpoint would each probe.
+        async with structured_output_mode_session():
+            return await self._evaluate_dataset_in_session(
+                metrics=metrics,
+                metric_keys=metric_keys,
+                rows=rows,
+                params=params,
+                target=target,
+                prompt_template=prompt_template,
+                aggregate_fields=aggregate_fields,
+                preprocess_hooks=preprocess_hooks,
+                postprocess_hooks=postprocess_hooks,
+            )
+
+    async def _evaluate_dataset_in_session(
+        self,
+        *,
+        metrics: Sequence[Metric],
+        metric_keys: Sequence[str],
+        rows: list[dict[str, Any]],
+        params: BackendParams,
+        target: Model | Agent | None,
+        prompt_template: str | dict[str, Any] | None,
+        aggregate_fields: Sequence[AggregateFieldName] | None,
+        preprocess_hooks: Sequence[PreprocessRequest] | None,
+        postprocess_hooks: Sequence[PostprocessResponse] | None,
+    ) -> BenchmarkEvaluationResult:
+        """Body of :meth:`evaluate_dataset`, inside a structured-output detection session."""
         prepared_metrics = [
             await prepare_metric_for_execution(
                 metric,
@@ -152,6 +218,19 @@ class LocalBackend:
         else:
             merged_preprocess_hooks = tuple(preprocess_hooks or ())
             merged_postprocess_hooks = tuple(postprocess_hooks or ())
+        # This multi-metric path builds target hooks itself and calls evaluate_benchmark directly,
+        # bypassing evaluate_metric, so it has to resolve the hook here or generation would send
+        # whichever encoding new_hooks guessed.
+        if isinstance(target, Model):
+            await resolve_target_structured_output_mode(
+                preprocess_hooks=merged_preprocess_hooks,
+                model=target,
+                # Resolved from the benchmark module at call time, not bound here, so the probe
+                # always travels the exact transport that evaluate_benchmark's own default uses --
+                # including when that binding is swapped.
+                inference_fn=benchmark_execution.make_inference_request,
+                params=params,
+            )
         return await sdk_evaluate_benchmark(
             metrics=metrics_built,
             rows=rows,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/metric_execution.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/metric_execution.py
@@ -26,7 +26,6 @@ from nemo_evaluator_sdk.agent_inference import (
     make_agent_inference_request,
     new_agent_inference_client,
 )
-from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.execution.config import fail_fast_from_params, resolve_params
 from nemo_evaluator_sdk.execution.pipeline import (
     GeneratedSampleEvent,
@@ -49,6 +48,7 @@ from nemo_evaluator_sdk.metrics.protocol import (
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
 from nemo_evaluator_sdk.resilience.api import run_indexed_tasks, use_resilience_session
 from nemo_evaluator_sdk.resilience.errors import get_evaluation_error
+from nemo_evaluator_sdk.structured_output import structured_output_mode_session
 from nemo_evaluator_sdk.templates import render_request
 from nemo_evaluator_sdk.values import (
     Agent,
@@ -231,7 +231,6 @@ def _merge_online_hooks(
     #   postprocess -> [log_hook, ...]
     built_preprocess_hooks, built_postprocess_hooks = inference.new_hooks(
         params if isinstance(params, RunConfigOnlineModel) else None,
-        model_format=target.format if isinstance(target, Model) else None,
     )
     if not built_preprocess_hooks or not built_postprocess_hooks:
         raise ValueError(
@@ -259,16 +258,63 @@ def _merge_online_hooks(
     )
 
 
-def _maybe_set_nim_default_max_tokens(
+async def resolve_target_structured_output_mode(
     *,
-    request: dict[str, Any],
+    preprocess_hooks: Sequence[inference.PreprocessRequest],
     model: Model,
-    params: RunConfigOnlineModel | None,
+    inference_fn: inference.InferenceFn,
+    params: RunConfig | RunConfigOnline | RunConfigOnlineModel | None,
 ) -> None:
-    """Apply the NIM max token default only when neither params nor request set one."""
-    if model.format != ModelFormat.NVIDIA_NIM:
+    """Probe the target endpoint so generation uses an encoding it actually honours.
+
+    The judge has its own preflight; target generation had none, and previously relied on the
+    model's ``format`` label to pick an encoding. That label is deprecated and ignored, so without
+    this probe a target that only accepts ``nvext.guided_json`` would be sent ``response_format``
+    and either reject the request or silently drop the constraint.
+
+    Only the hook built from ``params.structured_output`` is retuned. A caller that hand-builds an
+    InferenceStructuredOutput and splices it in via ``preprocess_hooks`` has chosen a mode
+    deliberately, and silently overriding that choice would be surprising; ``_merge_online_hooks``
+    places the run-level hook ahead of caller-supplied ones, so the first match is ours.
+
+    Like the judge's own preflight, this runs before ``use_resilience_session()`` opens, so probe
+    attempts use the process-global scheduler and do not appear in the session summary. Detection
+    itself is cached per endpoint for the run, so a Model used as both target and judge is probed
+    once, not once per role.
+    """
+    from nemo_evaluator_sdk.structured_output import InferenceStructuredOutput, detect_structured_output_mode
+
+    if not (isinstance(params, RunConfigOnlineModel) and params.structured_output):
         return
 
+    structured_hook = next(
+        (hook for hook in preprocess_hooks if isinstance(hook, InferenceStructuredOutput)),
+        None,
+    )
+    if structured_hook is None:
+        return
+
+    mode = await detect_structured_output_mode(
+        model=model,
+        inference_fn=inference_fn,
+        api_key=model.api_key,
+    )
+    structured_hook.set_mode(mode)
+    log.info("Structured output mode selected for target %s: %s", model.name, mode.value)
+
+
+def _maybe_set_default_max_tokens(
+    *,
+    request: dict[str, Any],
+    params: RunConfigOnlineModel | None,
+) -> None:
+    """Apply the default max token cap when neither params nor request set one.
+
+    This was previously applied only to ``nim``-format models. Model format is deprecated and no
+    longer distinguishes endpoints, so the cap is unconditional: an unbounded generation against a
+    reasoning-capable judge is a cost risk on any endpoint, and callers that want more can set
+    ``max_tokens`` or ``max_completion_tokens`` explicitly.
+    """
     inference_params = params.inference if isinstance(params, RunConfigOnlineModel) else None
     if inference_params is not None and (
         inference_params.max_tokens is not None or inference_params.max_completion_tokens is not None
@@ -350,8 +396,8 @@ async def generate_online_sample(
 
     Two valid call shapes, pinned by the ``@overload``s above:
 
-    - ``target: Model`` pairs with ``inference_fn: InferenceFn``. NIM
-      max-token defaults are applied and ``default_headers`` is forwarded
+    - ``target: Model`` pairs with ``inference_fn: InferenceFn``. Default
+      max-token caps are applied and ``default_headers`` is forwarded
       to the inference fn.
     - ``target: Agent`` pairs with ``inference_fn: AgentInferenceFn``.
       ``default_headers`` is forwarded to the inference fn.
@@ -359,7 +405,7 @@ async def generate_online_sample(
     request = render_request(prompt_template, context={**row, "item": row, **(template_context or {})})
     if isinstance(target, Model):
         model_params = params if isinstance(params, RunConfigOnlineModel) else None
-        _maybe_set_nim_default_max_tokens(request=request, model=target, params=model_params)
+        _maybe_set_default_max_tokens(request=request, params=model_params)
     request = inference.preprocess_request(request, list(preprocess_hooks or ()), id=str(index))
 
     max_retries = params.max_retries if params is not None else 3
@@ -822,6 +868,31 @@ async def evaluate_metric(
         log.warning("No rows found in dataset, returning empty evaluation result")
         return empty_evaluation_result()
 
+    # Scope endpoint structured-output detection to this run so probes are cached across rows
+    # without leaking a result (or a transient failure) into the next run.
+    async with structured_output_mode_session():
+        return await _evaluate_metric_in_session(
+            metric=metric,
+            rows=rows,
+            target=target,
+            prompt_template=prompt_template,
+            params=params,
+            preprocess_hooks=preprocess_hooks,
+            postprocess_hooks=postprocess_hooks,
+        )
+
+
+async def _evaluate_metric_in_session(
+    *,
+    metric: Metric,
+    rows: list[dict[str, Any]],
+    target: Model | Agent | None,
+    prompt_template: str | dict[str, Any] | None,
+    params: RunConfig | RunConfigOnline | RunConfigOnlineModel | None,
+    preprocess_hooks: Sequence[inference.PreprocessRequest] | None,
+    postprocess_hooks: Sequence[inference.PostprocessResponse] | None,
+) -> EvaluationResult:
+    """Body of :func:`evaluate_metric`, run inside a structured-output detection session."""
     params = resolve_params(params, target)
 
     client_close_fn = None
@@ -836,6 +907,12 @@ async def evaluate_metric(
         params = cast(RunConfigOnlineModel, params)
         inference_fn = (
             metric.inference_fn if isinstance(metric, InferenceMetricBase) else inference.make_inference_request
+        )
+        await resolve_target_structured_output_mode(
+            preprocess_hooks=merged_preprocess_hooks,
+            model=target,
+            inference_fn=inference_fn,
+            params=params,
         )
         resolved_prompt_template = _resolve_online_prompt_template(prompt_template, target, rows[0])
         client = inference.new_inference_client(target)

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/metric_execution.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/execution/metric_execution.py
@@ -48,7 +48,11 @@ from nemo_evaluator_sdk.metrics.protocol import (
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
 from nemo_evaluator_sdk.resilience.api import run_indexed_tasks, use_resilience_session
 from nemo_evaluator_sdk.resilience.errors import get_evaluation_error
-from nemo_evaluator_sdk.structured_output import structured_output_mode_session
+from nemo_evaluator_sdk.session import begin_evaluation_session
+from nemo_evaluator_sdk.structured_output import (
+    InferenceStructuredOutput,
+    detect_structured_output_mode,
+)
 from nemo_evaluator_sdk.templates import render_request
 from nemo_evaluator_sdk.values import (
     Agent,
@@ -265,25 +269,11 @@ async def resolve_target_structured_output_mode(
     inference_fn: inference.InferenceFn,
     params: RunConfig | RunConfigOnline | RunConfigOnlineModel | None,
 ) -> None:
-    """Probe the target endpoint so generation uses an encoding it actually honours.
+    """Probe the target endpoint and set the generation hook's encoding.
 
-    The judge has its own preflight; target generation had none, and previously relied on the
-    model's ``format`` label to pick an encoding. That label is deprecated and ignored, so without
-    this probe a target that only accepts ``nvext.guided_json`` would be sent ``response_format``
-    and either reject the request or silently drop the constraint.
-
-    Only the hook built from ``params.structured_output`` is retuned. A caller that hand-builds an
-    InferenceStructuredOutput and splices it in via ``preprocess_hooks`` has chosen a mode
-    deliberately, and silently overriding that choice would be surprising; ``_merge_online_hooks``
-    places the run-level hook ahead of caller-supplied ones, so the first match is ours.
-
-    Like the judge's own preflight, this runs before ``use_resilience_session()`` opens, so probe
-    attempts use the process-global scheduler and do not appear in the session summary. Detection
-    itself is cached per endpoint for the run, so a Model used as both target and judge is probed
-    once, not once per role.
+    Only the hook built from ``params.structured_output`` is retuned; a caller that supplies its own
+    InferenceStructuredOutput has chosen a mode deliberately.
     """
-    from nemo_evaluator_sdk.structured_output import InferenceStructuredOutput, detect_structured_output_mode
-
     if not (isinstance(params, RunConfigOnlineModel) and params.structured_output):
         return
 
@@ -308,13 +298,7 @@ def _maybe_set_default_max_tokens(
     request: dict[str, Any],
     params: RunConfigOnlineModel | None,
 ) -> None:
-    """Apply the default max token cap when neither params nor request set one.
-
-    This was previously applied only to ``nim``-format models. Model format is deprecated and no
-    longer distinguishes endpoints, so the cap is unconditional: an unbounded generation against a
-    reasoning-capable judge is a cost risk on any endpoint, and callers that want more can set
-    ``max_tokens`` or ``max_completion_tokens`` explicitly.
-    """
+    """Apply the default max token cap when neither params nor request set one."""
     inference_params = params.inference if isinstance(params, RunConfigOnlineModel) else None
     if inference_params is not None and (
         inference_params.max_tokens is not None or inference_params.max_completion_tokens is not None
@@ -868,9 +852,7 @@ async def evaluate_metric(
         log.warning("No rows found in dataset, returning empty evaluation result")
         return empty_evaluation_result()
 
-    # Scope endpoint structured-output detection to this run so probes are cached across rows
-    # without leaking a result (or a transient failure) into the next run.
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         return await _evaluate_metric_in_session(
             metric=metric,
             rows=rows,
@@ -892,7 +874,6 @@ async def _evaluate_metric_in_session(
     preprocess_hooks: Sequence[inference.PreprocessRequest] | None,
     postprocess_hooks: Sequence[inference.PostprocessResponse] | None,
 ) -> EvaluationResult:
-    """Body of :func:`evaluate_metric`, run inside a structured-output detection session."""
     params = resolve_params(params, target)
 
     client_close_fn = None

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/inference.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/inference.py
@@ -238,11 +238,17 @@ class TransformReasoningOutput(PostprocessResponse):
 
 def new_hooks(
     params: InferenceHookParams | None,
-    model_format: ModelFormat | None = ModelFormat.NVIDIA_NIM,
+    model_format: ModelFormat | None = None,
     logger: logging.Logger | None = None,
 ) -> tuple[list[PreprocessRequest], list[PostprocessResponse]]:
-    """Build the standard online generation hooks used by SDK and service flows."""
+    """Build the standard online generation hooks used by SDK and service flows.
+
+    ``model_format`` is deprecated and ignored. The structured output mode set here is only a
+    starting point; preflight detection replaces it with whatever the endpoint actually honours.
+    """
     from nemo_evaluator_sdk.structured_output import InferenceStructuredOutput, default_structured_output_mode
+
+    _ = model_format  # Deprecated: retained so existing callers keep working.
 
     log_hook = LogHook(logger)
     preprocess_hooks: list[PreprocessRequest] = []
@@ -258,8 +264,11 @@ def new_hooks(
     if params and params.structured_output:
         preprocess_hooks.append(
             InferenceStructuredOutput(
-                default_structured_output_mode(model_format or "nim"),
+                default_structured_output_mode(),
                 params.structured_output,
+                # Provisional: the endpoint has not been probed yet. Marking it unresolved makes a
+                # generation path that never probes warn instead of silently emitting this guess.
+                resolved=False,
             )
         )
 
@@ -306,7 +315,8 @@ async def make_inference_request(
     """
     Helper to run inference on a model with a given prompt.
 
-    Only OpenAI format is supported (nim and openai formats).
+    Requests use the OpenAI-compatible wire format. ``Model.format`` is deprecated and has no
+    effect here; structured output support is probed from the endpoint.
 
     Args:
         model: The Model to run inference on.

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/llm_judge.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/llm_judge.py
@@ -200,14 +200,8 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
         await resolve_model_refs(self, model_resolver)
         self._client = None
         self._api_key = None
-        # `_preflight_lock` is deliberately NOT reset here. Clearing it would split preflight
-        # synchronisation while a concurrent compute_scores() is mid-probe: a second scorer would
-        # build a new lock, and an in-flight scorer could then render through the freshly rebuilt
-        # unresolved hook and send a guessed encoding with only a warning. A lock retained from a
-        # previous event loop instead fails loudly on its next contended acquire, and both cases
-        # require resolving models while scoring with the same metric object, which is unsupported:
-        # resolution is preparation-time, before evaluation starts. A loud failure beats a silent
-        # unprobed request in a change whose whole purpose is removing silent degradation.
+        # `_preflight_lock` is deliberately not reset: clearing it mid-run would split preflight
+        # synchronisation and let an in-flight scorer send an unprobed request.
         self._ensure_default_prompt_template()
         preprocess_hooks, postprocess_hooks = new_hooks(self)
         self.with_hooks(preprocess=preprocess_hooks, postprocess=postprocess_hooks)
@@ -250,11 +244,7 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
         _logger.info("Structured output mode selected for %s: %s", model.name, mode.value)
 
     def _require_preflight_lock(self) -> asyncio.Lock:
-        """Return this metric's preflight lock, created on first use.
-
-        Built lazily rather than as a field default so the metric stays deep-copyable and does not
-        bind a lock to an event loop at construction time.
-        """
+        """Return this metric's preflight lock, created lazily to keep the metric deep-copyable."""
         if self._preflight_lock is None:
             self._preflight_lock = asyncio.Lock()
         return self._preflight_lock
@@ -357,13 +347,8 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
         """Compute structured score output for one item/sample pair."""
-        # Executors call preflight() before scoring, but this is public API: a caller can build the
-        # metric and score with it directly, and then nothing would have probed the endpoint. Detect
-        # on first use so the encoding is never a guess.
-        #
-        # Locked and re-checked because a direct caller may gather many compute_scores() at once
-        # with no run session to cache detection: without this, every one of them would see an
-        # unresolved hook and probe the same endpoint concurrently.
+        # Public API: a caller may score without an executor having run preflight. Locked because
+        # concurrent direct callers would otherwise each probe the same endpoint.
         if self._has_unresolved_structured_output_hook():
             async with self._require_preflight_lock():
                 if self._has_unresolved_structured_output_hook():

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/llm_judge.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/metrics/llm_judge.py
@@ -3,12 +3,12 @@
 
 """LLM judge metric runtime implementation."""
 
+import asyncio
 import logging
 from copy import copy, deepcopy
 from typing import Any, Literal, Protocol, Self
 
 import nemo_evaluator_sdk.inference as inference
-from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.inference import InferenceFn, InferenceHookParams
 from nemo_evaluator_sdk.inference import new_hooks as _new_inference_hooks
 from nemo_evaluator_sdk.metrics.hooks import HooksBase
@@ -78,6 +78,7 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
     _use_max_completion_tokens: bool = False
     _api_key: str | None = None
     _client: AsyncOpenAI | None = PrivateAttr(default=None)
+    _preflight_lock: asyncio.Lock | None = PrivateAttr(default=None)
     _inference_fn: InferenceFn | None = None
     _parsers: dict[str, ScoreParser] = PrivateAttr(default_factory=dict)
     _score_dumps: dict[str, dict[str, Any]] = PrivateAttr(default_factory=dict)
@@ -121,12 +122,13 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
                 {
                     k: v
                     for k, v in self.__pydantic_private__.items()
-                    if v is not PydanticUndefined and k not in {"_client", "_api_key"}
+                    if v is not PydanticUndefined and k not in {"_client", "_api_key", "_preflight_lock"}
                 },
                 memo=memo,
             )
             private_attrs["_client"] = None
             private_attrs["_api_key"] = None
+            private_attrs["_preflight_lock"] = None
             object.__setattr__(m, "__pydantic_private__", private_attrs)
 
         return m
@@ -198,6 +200,14 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
         await resolve_model_refs(self, model_resolver)
         self._client = None
         self._api_key = None
+        # `_preflight_lock` is deliberately NOT reset here. Clearing it would split preflight
+        # synchronisation while a concurrent compute_scores() is mid-probe: a second scorer would
+        # build a new lock, and an in-flight scorer could then render through the freshly rebuilt
+        # unresolved hook and send a guessed encoding with only a warning. A lock retained from a
+        # previous event loop instead fails loudly on its next contended acquire, and both cases
+        # require resolving models while scoring with the same metric object, which is unsupported:
+        # resolution is preparation-time, before evaluation starts. A loud failure beats a silent
+        # unprobed request in a change whose whole purpose is removing silent degradation.
         self._ensure_default_prompt_template()
         preprocess_hooks, postprocess_hooks = new_hooks(self)
         self.with_hooks(preprocess=preprocess_hooks, postprocess=postprocess_hooks)
@@ -219,7 +229,7 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
     async def preflight(self) -> None:
         """Resolve structured-output mode once before parallel inference starts."""
         model = self._require_model()
-        if model.format != ModelFormat.NVIDIA_NIM or not self.structured_output:
+        if not self.structured_output:
             return
 
         structured_hook: InferenceStructuredOutput | None = None
@@ -232,19 +242,26 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
             return
 
         mode = await detect_structured_output_mode(
-            format=model.format,
             model=model,
             inference_fn=self.inference_fn,
             api_key=self._api_key,
-            probe_schema={
-                "type": "object",
-                "properties": {"__nmp_probe_score": {"type": "integer"}},
-                "required": ["__nmp_probe_score"],
-                "additionalProperties": False,
-            },
         )
         structured_hook.set_mode(mode)
-        _logger.info("NIM structured output mode selected: %s", mode.value)
+        _logger.info("Structured output mode selected for %s: %s", model.name, mode.value)
+
+    def _require_preflight_lock(self) -> asyncio.Lock:
+        """Return this metric's preflight lock, created on first use.
+
+        Built lazily rather than as a field default so the metric stays deep-copyable and does not
+        bind a lock to an event loop at construction time.
+        """
+        if self._preflight_lock is None:
+            self._preflight_lock = asyncio.Lock()
+        return self._preflight_lock
+
+    def _has_unresolved_structured_output_hook(self) -> bool:
+        """Return whether a structured-output hook is still carrying an unprobed default."""
+        return any(isinstance(hook, InferenceStructuredOutput) and not hook.resolved for hook in self._preprocess_hooks)
 
     def secrets(self) -> dict[str, SecretRef]:
         """Return secret env mappings required by this metric."""
@@ -340,6 +357,18 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
         """Compute structured score output for one item/sample pair."""
+        # Executors call preflight() before scoring, but this is public API: a caller can build the
+        # metric and score with it directly, and then nothing would have probed the endpoint. Detect
+        # on first use so the encoding is never a guess.
+        #
+        # Locked and re-checked because a direct caller may gather many compute_scores() at once
+        # with no run session to cache detection: without this, every one of them would see an
+        # unresolved hook and probe the same endpoint concurrently.
+        if self._has_unresolved_structured_output_hook():
+            async with self._require_preflight_lock():
+                if self._has_unresolved_structured_output_hook():
+                    await self.preflight()
+
         item = input.row.data
         sample = input.candidate
         request = self._render_request(item, sample)
@@ -392,8 +421,7 @@ def _selected_rubric_label(score: MetricScore) -> str | None:
 
 def new_hooks(params: _LLMJudgeHookParams | None):
     """Initialize preprocess and postprocess hooks for the LLM judge."""
-    model_format = params.model.format if params and isinstance(params.model, Model) else ModelFormat.NVIDIA_NIM
-    return _new_inference_hooks(params, model_format=model_format)
+    return _new_inference_hooks(params)
 
 
 def generate_structured_output(params: _LLMJudgeHookParams) -> dict | None:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/session.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/session.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run-scoped cache shared by everything participating in one evaluation."""
+
+import asyncio
+from collections.abc import AsyncIterator, Hashable
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from typing import Any
+
+_CACHE: ContextVar[dict[Hashable, Any] | None] = ContextVar("evaluation_session_cache", default=None)
+_LOCK: ContextVar[asyncio.Lock | None] = ContextVar("evaluation_session_lock", default=None)
+
+
+@asynccontextmanager
+async def begin_evaluation_session() -> AsyncIterator[None]:
+    """Scope cached evaluation state to one run.
+
+    Entries live only inside this boundary, which is what makes caching a failed result safe: a
+    transient failure is retried by the next run instead of persisting for the life of the process.
+    Outside a session nothing is cached and every caller recomputes.
+
+    Re-entrant. Entry points nest -- a backend opens a session, then the metric executor opens
+    another -- and a fresh inner cache would recompute what the run already resolved.
+    """
+    if _CACHE.get() is not None:
+        yield
+        return
+
+    cache_token = _CACHE.set({})
+    lock_token = _LOCK.set(asyncio.Lock())
+    try:
+        yield
+    finally:
+        _CACHE.reset(cache_token)
+        _LOCK.reset(lock_token)
+
+
+def session_cache() -> dict[Hashable, Any] | None:
+    """Return the active run's cache, or None outside a session."""
+    return _CACHE.get()
+
+
+def session_lock() -> asyncio.Lock:
+    """Return the active run's lock, or a throwaway one outside a session."""
+    return _LOCK.get() or asyncio.Lock()

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/structured_output.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/structured_output.py
@@ -16,6 +16,10 @@ from nemo_evaluator_sdk.values import Model
 
 _logger = logging.getLogger(__name__)
 
+#: Probes must survive a reasoning model's thinking budget; too small and truncated output looks
+#: identical to an endpoint that ignored the encoding.
+_PROBE_MAX_TOKENS = 4096
+
 #: The marker name must stay unguessable: the probe never shows this schema to the model, so a
 #: mode only passes when the server actually injected the grammar.
 _DEFAULT_PROBE_SCHEMA: dict = {
@@ -165,6 +169,14 @@ def _looks_like_unsupported_guided_json_error(message: str) -> bool:
     return False
 
 
+def _probe_was_truncated(response: dict) -> bool:
+    """Return whether the probe ran out of output budget before producing content."""
+    choices = response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return False
+    return choices[0].get("finish_reason") == "length"
+
+
 def _extract_chat_content(response: dict) -> str | None:
     choices = response.get("choices")
     if not isinstance(choices, list) or not choices:
@@ -249,7 +261,9 @@ async def _probe_structured_output_mode(
     base_request = {
         "messages": [{"role": "user", "content": probe_message}],
         "temperature": 0,
-        "max_tokens": 128,
+        # Generous because reasoning models spend most of a small budget thinking and return
+        # truncated or empty content, which is indistinguishable from an unhonoured encoding.
+        "max_tokens": _PROBE_MAX_TOKENS,
     }
     # Deep-copied so `probe_schema` stays unreachable from the request: Pydantic copies only a
     # dict's top level, and `probe_schema` is what the response is validated against.
@@ -270,6 +284,14 @@ async def _probe_structured_output_mode(
             content = _extract_chat_content(response)
             if content and _is_probe_valid_json(content, probe_schema):
                 return mode
+            if _probe_was_truncated(response):
+                _logger.warning(
+                    "Structured output probe for %s hit the %d-token budget, so support for %s "
+                    "could not be determined; enforcement may be dropped for this run.",
+                    model.name,
+                    _PROBE_MAX_TOKENS,
+                    mode.value,
+                )
         except Exception as e:
             if _looks_like_unsupported_guided_json_error(str(e)):
                 continue

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/structured_output.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/structured_output.py
@@ -1,16 +1,44 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+import copy
 import json
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from enum import Enum
 
 from jsonschema.exceptions import SchemaError
 from jsonschema.validators import validator_for
 from pydantic import BaseModel, Field, field_validator
 
-from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.inference import InferenceFn, PreprocessRequest, deep_merge
 from nemo_evaluator_sdk.values import Model
+
+_logger = logging.getLogger(__name__)
+
+#: Schema used to probe an endpoint for structured output support. The marker property name is
+#: deliberately unguessable: the probe never shows the schema to the model, so a mode only passes
+#: when the server actually injected the grammar. Shared by every probing call site so that the
+#: judge path and the target-generation path agree on what a probe request looks like.
+#:
+#: Never pass this object directly into a request-building path; use :func:`_default_probe_schema`.
+#: Pydantic copies only the top level when validating, so the nested ``properties`` dict would stay
+#: shared with the request payload, and a later mutation of that payload would silently corrupt this
+#: constant for every probe in the process.
+_DEFAULT_PROBE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"__nmp_probe_score": {"type": "integer"}},
+    "required": ["__nmp_probe_score"],
+    "additionalProperties": False,
+}
+
+
+def _default_probe_schema() -> dict:
+    """Return a fresh copy of the endpoint probe schema."""
+    return copy.deepcopy(_DEFAULT_PROBE_SCHEMA)
 
 
 class StructuredOutputMode(str, Enum):
@@ -36,7 +64,16 @@ class StructuredOutput(BaseModel):
 class InferenceStructuredOutput(PreprocessRequest):
     """Format structured output request parameters based on provider mode."""
 
-    def __init__(self, mode: StructuredOutputMode, structured_output: dict):
+    def __init__(self, mode: StructuredOutputMode, structured_output: dict, *, resolved: bool = True):
+        """Build the hook.
+
+        Args:
+            mode: Structured output encoding to emit.
+            structured_output: ``{"schema": ..., "strict": ...}`` payload.
+            resolved: Whether ``mode`` reflects what the endpoint actually accepts. Callers that
+                pass a provisional default must set this False so that using the hook without
+                probing is reported instead of silently emitting a guessed encoding.
+        """
         if not structured_output:
             raise ValueError("structured_output cannot be empty")
         try:
@@ -44,6 +81,8 @@ class InferenceStructuredOutput(PreprocessRequest):
             self._json_schema = output.json_schema
             self._strict = output.strict
             self.mode = mode
+            self._resolved = resolved
+            self._warned_unresolved = False
             self.inference_param = self._build_inference_param(mode)
         except SchemaError as e:
             raise ValueError("structured output contains invalid JSON schema") from e
@@ -52,8 +91,15 @@ class InferenceStructuredOutput(PreprocessRequest):
     def json_schema(self) -> dict:
         return self._json_schema
 
+    @property
+    def resolved(self) -> bool:
+        """Whether the mode reflects a real endpoint probe rather than a provisional default."""
+        return self._resolved
+
     def set_mode(self, mode: StructuredOutputMode) -> None:
+        """Set the encoding, marking it as reflecting a real endpoint probe."""
         self.mode = mode
+        self._resolved = True
         self.inference_param = self._build_inference_param(mode)
 
     def _build_inference_param(self, mode: StructuredOutputMode) -> dict:
@@ -91,19 +137,35 @@ class InferenceStructuredOutput(PreprocessRequest):
 
     def preprocess(self, request: dict, id: str | None = None) -> dict:
         _ = id  # Required by preprocess hook interface.
+        if not self._resolved and not self._warned_unresolved:
+            # Warn once per hook rather than per row. A generation path that builds this hook and
+            # never probes sends a guessed encoding, which an endpoint may silently ignore -- the
+            # structured output constraint then disappears with no other signal. Every first-party
+            # path probes; this exists so a new or forgotten one is visible instead of silent.
+            self._warned_unresolved = True
+            _logger.warning(
+                "Structured output encoding was never resolved against the endpoint; sending %s as "
+                "a guess. Call detect_structured_output_mode() (or "
+                "resolve_target_structured_output_mode()) before generating, or the constraint may "
+                "be silently dropped.",
+                self.mode.value,
+            )
         if self.mode == StructuredOutputMode.UNSUPPORTED:
             return self._apply_fallback_instruction(request)
         # Use merge instead of update to avoid overwriting nested dicts
         return deep_merge(request, self.inference_param)
 
 
-def default_structured_output_mode(format: str) -> StructuredOutputMode:
-    if format == ModelFormat.OPEN_AI:
-        return StructuredOutputMode.OPENAI_RESPONSE_FORMAT
-    if format == ModelFormat.NVIDIA_NIM:
-        # Backward-compatible default before preflight detection overrides this.
-        return StructuredOutputMode.NVEXT_GUIDED_JSON
-    raise ValueError(f"Unsupported structured output format: {format}")
+def default_structured_output_mode(format: str | None = None) -> StructuredOutputMode:
+    """Return the pre-detection structured output mode.
+
+    ``format`` is accepted for call compatibility and ignored: which structured output mode an
+    endpoint accepts is a property of the endpoint, not of the label attached to the model. The
+    OpenAI ``response_format`` field is the broadest-support starting point, and
+    :func:`detect_structured_output_mode` refines it during preflight.
+    """
+    _ = format  # Deprecated: retained so existing callers keep working.
+    return StructuredOutputMode.OPENAI_RESPONSE_FORMAT
 
 
 def _looks_like_unsupported_guided_json_error(message: str) -> bool:
@@ -145,33 +207,154 @@ def _is_probe_valid_json(content: str, probe_schema: dict) -> bool:
         return False
 
 
+#: Detected mode per endpoint for the duration of one run, so a probe costs one round trip per
+#: endpoint instead of one per caller. Paths that build hooks per row (agent evaluation, the
+#: ProfBench judge) depend on this: without it they could not probe without a request per row.
+#:
+#: Run-scoped rather than process-global, which is what makes caching a negative result safe. A
+#: probe can fail for reasons unrelated to capability -- a rate limit, a 500, a network blip -- and
+#: a process-global negative would silently disable enforcement for that endpoint until restart.
+#: Bounded to a run, the same failure costs enforcement for one run and is re-probed by the next.
+#:
+#: Endpoint capability changing mid-process is rare and is NOT the motivation here.
+#:
+#: Entries are keyed on (url, name) only, so a session is assumed to be single-principal. The same
+#: (url, name) can route to different backends per principal through the inference gateway; a
+#: session that mixed credentials would reuse the first principal's result for the second. No
+#: first-party path does that today -- one run carries one credential -- and keying on the API key
+#: would put a secret in a cache key, so this is recorded as an assumption rather than defended
+#: against. Revisit if a run ever fans out across principals.
+_MODE_CACHE_VAR: ContextVar[dict[tuple[str, str], StructuredOutputMode] | None] = ContextVar(
+    "structured_output_mode_cache", default=None
+)
+_MODE_CACHE_LOCK_VAR: ContextVar[asyncio.Lock | None] = ContextVar("structured_output_mode_lock", default=None)
+
+
+@asynccontextmanager
+async def structured_output_mode_session() -> AsyncIterator[None]:
+    """Scope endpoint structured-output detection to one run.
+
+    Detection results are cached only inside this boundary. Outside one, every call probes, which
+    is correct but costs a round trip per caller -- open a session around a run to avoid that.
+
+    Re-entrant: opening a session inside another joins the outer one rather than shadowing it. Entry
+    points nest (a backend opens one around metric preparation, then evaluate_metric opens one of
+    its own), and a fresh inner cache would re-probe endpoints the outer run already resolved.
+    """
+    if _MODE_CACHE_VAR.get() is not None:
+        yield
+        return
+
+    cache_token = _MODE_CACHE_VAR.set({})
+    lock_token = _MODE_CACHE_LOCK_VAR.set(asyncio.Lock())
+    try:
+        yield
+    finally:
+        _MODE_CACHE_VAR.reset(cache_token)
+        _MODE_CACHE_LOCK_VAR.reset(lock_token)
+
+
 async def detect_structured_output_mode(
     *,
-    format: str,
+    format: str | None = None,
     model: Model,
     inference_fn: InferenceFn,
     api_key: str | None,
-    probe_schema: dict,
+    probe_schema: dict | None = None,
+    use_cache: bool = True,
 ) -> StructuredOutputMode:
-    """Detect working structured output mode for the given model/format."""
-    if format == ModelFormat.OPEN_AI:
-        return StructuredOutputMode.OPENAI_RESPONSE_FORMAT
-    if format != ModelFormat.NVIDIA_NIM:
-        return StructuredOutputMode.UNSUPPORTED
+    """Detect the structured output mode an endpoint actually honours.
 
+    Every endpoint is probed with the same ordered candidate list regardless of the label on the
+    model, because support is a property of the endpoint: ``integrate.api.nvidia.com`` is served
+    under the ``nim`` label yet rejects ``nvext.guided_json`` and silently ignores root
+    ``guided_json``, while honouring OpenAI ``response_format``. Branching on the label caused that
+    endpoint to resolve to UNSUPPORTED and fall back to an unenforced prompt instruction.
+
+    The OpenAI ``response_format`` field is probed first as the broadest-support option, then the
+    two legacy ``guided_json`` placements. An endpoint that accepts none of them falls back to a
+    prompt-level instruction, which is *not* enforced.
+
+    Results are cached per endpoint for the duration of the enclosing
+    :func:`structured_output_mode_session`; outside a session every call probes. Pass
+    ``use_cache=False`` to force a fresh probe inside one.
+
+    UNSUPPORTED is cached like any other result, which is only safe because the cache is
+    run-scoped: a transient probe failure costs enforcement for this run rather than until the
+    process restarts, and a genuinely unsupported endpoint costs three probes per run rather than
+    three per row.
+
+    ``format`` is accepted for call compatibility and ignored.
+    """
+    _ = format  # Deprecated: retained so existing callers keep working.
+
+    cache = _MODE_CACHE_VAR.get() if use_cache else None
+    if cache is None:
+        return await _probe_structured_output_mode(
+            model=model, inference_fn=inference_fn, api_key=api_key, probe_schema=probe_schema
+        )
+
+    cache_key = (model.url, model.name)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    lock = _MODE_CACHE_LOCK_VAR.get()
+    if lock is None:  # pragma: no cover - a session always sets both vars together
+        lock = asyncio.Lock()
+    async with lock:
+        # Re-check under the lock: concurrent rows would otherwise each probe the same endpoint.
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+        mode = await _probe_structured_output_mode(
+            model=model, inference_fn=inference_fn, api_key=api_key, probe_schema=probe_schema
+        )
+        cache[cache_key] = mode
+        return mode
+
+
+async def _probe_structured_output_mode(
+    *,
+    model: Model,
+    inference_fn: InferenceFn,
+    api_key: str | None,
+    probe_schema: dict | None,
+) -> StructuredOutputMode:
+    """Probe an endpoint for the structured output encoding it honours, without consulting cache."""
+    probe_schema = _default_probe_schema() if probe_schema is None else probe_schema
+
+    # The probe instructs the model to match "the provided schema" without ever showing it. A mode
+    # therefore only passes when the server actually injected the grammar; a capable model that is
+    # merely following the prompt cannot guess the schema's field names. Do not add the schema to
+    # probe_message -- every mode would then report success and enforcement would silently vanish.
     probe_message = "Return ONLY a JSON object that matches the provided schema exactly. No prose or code fences."
     base_request = {
         "messages": [{"role": "user", "content": probe_message}],
         "temperature": 0,
         "max_tokens": 128,
     }
-    candidates: list[tuple[StructuredOutputMode, dict]] = [
-        (StructuredOutputMode.ROOT_GUIDED_JSON, {"extra_body": {"guided_json": probe_schema}}),
-        (StructuredOutputMode.NVEXT_GUIDED_JSON, {"extra_body": {"nvext": {"guided_json": probe_schema}}}),
+    # Built through InferenceStructuredOutput so each probe sends the exact payload the hook would
+    # send in production; a divergence here would detect a mode that then fails during evaluation.
+    # A malformed probe_schema must degrade to the prompt-level fallback rather than abort startup.
+    # The hook gets its own deep copy: validation copies only the top level of a dict field, so the
+    # nested schema would otherwise stay shared with the outgoing request. `probe_schema` must stay
+    # unreachable from any request payload, since it is what the response is validated against --
+    # and it may be a caller's object, which this function has no business mutating either.
+    try:
+        probe = InferenceStructuredOutput(StructuredOutputMode.UNSUPPORTED, {"schema": copy.deepcopy(probe_schema)})
+    except ValueError:
+        return StructuredOutputMode.UNSUPPORTED
+
+    candidates: list[StructuredOutputMode] = [
+        StructuredOutputMode.OPENAI_RESPONSE_FORMAT,
+        StructuredOutputMode.ROOT_GUIDED_JSON,
+        StructuredOutputMode.NVEXT_GUIDED_JSON,
     ]
-    for mode, structured_param in candidates:
+    for mode in candidates:
+        probe.set_mode(mode)
         try:
-            response = await inference_fn(model, {**base_request, **structured_param}, 1, api_key=api_key)
+            response = await inference_fn(model, {**base_request, **probe.inference_param}, 1, api_key=api_key)
             content = _extract_chat_content(response)
             if content and _is_probe_valid_json(content, probe_schema):
                 return mode

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/structured_output.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/structured_output.py
@@ -1,13 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import copy
 import json
 import logging
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
-from contextvars import ContextVar
 from enum import Enum
 
 from jsonschema.exceptions import SchemaError
@@ -15,19 +11,13 @@ from jsonschema.validators import validator_for
 from pydantic import BaseModel, Field, field_validator
 
 from nemo_evaluator_sdk.inference import InferenceFn, PreprocessRequest, deep_merge
+from nemo_evaluator_sdk.session import session_cache, session_lock
 from nemo_evaluator_sdk.values import Model
 
 _logger = logging.getLogger(__name__)
 
-#: Schema used to probe an endpoint for structured output support. The marker property name is
-#: deliberately unguessable: the probe never shows the schema to the model, so a mode only passes
-#: when the server actually injected the grammar. Shared by every probing call site so that the
-#: judge path and the target-generation path agree on what a probe request looks like.
-#:
-#: Never pass this object directly into a request-building path; use :func:`_default_probe_schema`.
-#: Pydantic copies only the top level when validating, so the nested ``properties`` dict would stay
-#: shared with the request payload, and a later mutation of that payload would silently corrupt this
-#: constant for every probe in the process.
+#: The marker name must stay unguessable: the probe never shows this schema to the model, so a
+#: mode only passes when the server actually injected the grammar.
 _DEFAULT_PROBE_SCHEMA: dict = {
     "type": "object",
     "properties": {"__nmp_probe_score": {"type": "integer"}},
@@ -37,7 +27,7 @@ _DEFAULT_PROBE_SCHEMA: dict = {
 
 
 def _default_probe_schema() -> dict:
-    """Return a fresh copy of the endpoint probe schema."""
+    """Return a fresh copy; the constant must never reach a request payload."""
     return copy.deepcopy(_DEFAULT_PROBE_SCHEMA)
 
 
@@ -70,9 +60,8 @@ class InferenceStructuredOutput(PreprocessRequest):
         Args:
             mode: Structured output encoding to emit.
             structured_output: ``{"schema": ..., "strict": ...}`` payload.
-            resolved: Whether ``mode`` reflects what the endpoint actually accepts. Callers that
-                pass a provisional default must set this False so that using the hook without
-                probing is reported instead of silently emitting a guessed encoding.
+            resolved: Whether ``mode`` reflects a real endpoint probe. Callers passing a
+                provisional default must set this False so unprobed use is reported.
         """
         if not structured_output:
             raise ValueError("structured_output cannot be empty")
@@ -138,10 +127,7 @@ class InferenceStructuredOutput(PreprocessRequest):
     def preprocess(self, request: dict, id: str | None = None) -> dict:
         _ = id  # Required by preprocess hook interface.
         if not self._resolved and not self._warned_unresolved:
-            # Warn once per hook rather than per row. A generation path that builds this hook and
-            # never probes sends a guessed encoding, which an endpoint may silently ignore -- the
-            # structured output constraint then disappears with no other signal. Every first-party
-            # path probes; this exists so a new or forgotten one is visible instead of silent.
+            # Once per hook, not per row.
             self._warned_unresolved = True
             _logger.warning(
                 "Structured output encoding was never resolved against the endpoint; sending %s as "
@@ -157,14 +143,11 @@ class InferenceStructuredOutput(PreprocessRequest):
 
 
 def default_structured_output_mode(format: str | None = None) -> StructuredOutputMode:
-    """Return the pre-detection structured output mode.
+    """Return the provisional mode used before preflight probes the endpoint.
 
-    ``format`` is accepted for call compatibility and ignored: which structured output mode an
-    endpoint accepts is a property of the endpoint, not of the label attached to the model. The
-    OpenAI ``response_format`` field is the broadest-support starting point, and
-    :func:`detect_structured_output_mode` refines it during preflight.
+    ``format`` is accepted for compatibility and ignored.
     """
-    _ = format  # Deprecated: retained so existing callers keep working.
+    _ = format
     return StructuredOutputMode.OPENAI_RESPONSE_FORMAT
 
 
@@ -207,53 +190,6 @@ def _is_probe_valid_json(content: str, probe_schema: dict) -> bool:
         return False
 
 
-#: Detected mode per endpoint for the duration of one run, so a probe costs one round trip per
-#: endpoint instead of one per caller. Paths that build hooks per row (agent evaluation, the
-#: ProfBench judge) depend on this: without it they could not probe without a request per row.
-#:
-#: Run-scoped rather than process-global, which is what makes caching a negative result safe. A
-#: probe can fail for reasons unrelated to capability -- a rate limit, a 500, a network blip -- and
-#: a process-global negative would silently disable enforcement for that endpoint until restart.
-#: Bounded to a run, the same failure costs enforcement for one run and is re-probed by the next.
-#:
-#: Endpoint capability changing mid-process is rare and is NOT the motivation here.
-#:
-#: Entries are keyed on (url, name) only, so a session is assumed to be single-principal. The same
-#: (url, name) can route to different backends per principal through the inference gateway; a
-#: session that mixed credentials would reuse the first principal's result for the second. No
-#: first-party path does that today -- one run carries one credential -- and keying on the API key
-#: would put a secret in a cache key, so this is recorded as an assumption rather than defended
-#: against. Revisit if a run ever fans out across principals.
-_MODE_CACHE_VAR: ContextVar[dict[tuple[str, str], StructuredOutputMode] | None] = ContextVar(
-    "structured_output_mode_cache", default=None
-)
-_MODE_CACHE_LOCK_VAR: ContextVar[asyncio.Lock | None] = ContextVar("structured_output_mode_lock", default=None)
-
-
-@asynccontextmanager
-async def structured_output_mode_session() -> AsyncIterator[None]:
-    """Scope endpoint structured-output detection to one run.
-
-    Detection results are cached only inside this boundary. Outside one, every call probes, which
-    is correct but costs a round trip per caller -- open a session around a run to avoid that.
-
-    Re-entrant: opening a session inside another joins the outer one rather than shadowing it. Entry
-    points nest (a backend opens one around metric preparation, then evaluate_metric opens one of
-    its own), and a fresh inner cache would re-probe endpoints the outer run already resolved.
-    """
-    if _MODE_CACHE_VAR.get() is not None:
-        yield
-        return
-
-    cache_token = _MODE_CACHE_VAR.set({})
-    lock_token = _MODE_CACHE_LOCK_VAR.set(asyncio.Lock())
-    try:
-        yield
-    finally:
-        _MODE_CACHE_VAR.reset(cache_token)
-        _MODE_CACHE_LOCK_VAR.reset(lock_token)
-
-
 async def detect_structured_output_mode(
     *,
     format: str | None = None,
@@ -265,45 +201,29 @@ async def detect_structured_output_mode(
 ) -> StructuredOutputMode:
     """Detect the structured output mode an endpoint actually honours.
 
-    Every endpoint is probed with the same ordered candidate list regardless of the label on the
-    model, because support is a property of the endpoint: ``integrate.api.nvidia.com`` is served
-    under the ``nim`` label yet rejects ``nvext.guided_json`` and silently ignores root
-    ``guided_json``, while honouring OpenAI ``response_format``. Branching on the label caused that
-    endpoint to resolve to UNSUPPORTED and fall back to an unenforced prompt instruction.
+    Every endpoint is probed with the same ordered candidate list regardless of the model's label,
+    because support is a property of the endpoint. OpenAI ``response_format`` is tried first, then
+    the two ``guided_json`` placements. An endpoint accepting none falls back to a prompt-level
+    instruction, which is *not* enforced.
 
-    The OpenAI ``response_format`` field is probed first as the broadest-support option, then the
-    two legacy ``guided_json`` placements. An endpoint that accepts none of them falls back to a
-    prompt-level instruction, which is *not* enforced.
-
-    Results are cached per endpoint for the duration of the enclosing
-    :func:`structured_output_mode_session`; outside a session every call probes. Pass
-    ``use_cache=False`` to force a fresh probe inside one.
-
-    UNSUPPORTED is cached like any other result, which is only safe because the cache is
-    run-scoped: a transient probe failure costs enforcement for this run rather than until the
-    process restarts, and a genuinely unsupported endpoint costs three probes per run rather than
-    three per row.
-
-    ``format`` is accepted for call compatibility and ignored.
+    Results are cached for the enclosing :func:`begin_evaluation_session`. ``format`` is accepted
+    for compatibility and ignored.
     """
-    _ = format  # Deprecated: retained so existing callers keep working.
+    _ = format
 
-    cache = _MODE_CACHE_VAR.get() if use_cache else None
+    cache = session_cache() if use_cache else None
     if cache is None:
         return await _probe_structured_output_mode(
             model=model, inference_fn=inference_fn, api_key=api_key, probe_schema=probe_schema
         )
 
-    cache_key = (model.url, model.name)
+    # Keyed on the endpoint, not the credential: a session is assumed to be single-principal.
+    cache_key = ("structured_output_mode", model.url, model.name)
     cached = cache.get(cache_key)
     if cached is not None:
         return cached
 
-    lock = _MODE_CACHE_LOCK_VAR.get()
-    if lock is None:  # pragma: no cover - a session always sets both vars together
-        lock = asyncio.Lock()
-    async with lock:
-        # Re-check under the lock: concurrent rows would otherwise each probe the same endpoint.
+    async with session_lock():
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -324,23 +244,15 @@ async def _probe_structured_output_mode(
     """Probe an endpoint for the structured output encoding it honours, without consulting cache."""
     probe_schema = _default_probe_schema() if probe_schema is None else probe_schema
 
-    # The probe instructs the model to match "the provided schema" without ever showing it. A mode
-    # therefore only passes when the server actually injected the grammar; a capable model that is
-    # merely following the prompt cannot guess the schema's field names. Do not add the schema to
-    # probe_message -- every mode would then report success and enforcement would silently vanish.
+    # Must not name the schema: every mode would then pass and enforcement would silently vanish.
     probe_message = "Return ONLY a JSON object that matches the provided schema exactly. No prose or code fences."
     base_request = {
         "messages": [{"role": "user", "content": probe_message}],
         "temperature": 0,
         "max_tokens": 128,
     }
-    # Built through InferenceStructuredOutput so each probe sends the exact payload the hook would
-    # send in production; a divergence here would detect a mode that then fails during evaluation.
-    # A malformed probe_schema must degrade to the prompt-level fallback rather than abort startup.
-    # The hook gets its own deep copy: validation copies only the top level of a dict field, so the
-    # nested schema would otherwise stay shared with the outgoing request. `probe_schema` must stay
-    # unreachable from any request payload, since it is what the response is validated against --
-    # and it may be a caller's object, which this function has no business mutating either.
+    # Deep-copied so `probe_schema` stays unreachable from the request: Pydantic copies only a
+    # dict's top level, and `probe_schema` is what the response is validated against.
     try:
         probe = InferenceStructuredOutput(StructuredOutputMode.UNSUPPORTED, {"schema": copy.deepcopy(probe_schema)})
     except ValueError:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/metrics.py
@@ -178,7 +178,6 @@ class LLMJudge(MetricBase):
                 "endpoint": "https://api.openai.com/v1",
                 "name": "gpt-4o",
                 "api_key_secret": "secret/my_openai_api_key",
-                "format": "openai",
             }
         ],
     )

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/models.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/models.py
@@ -128,7 +128,16 @@ class Model(BaseModel):
         description="API key secret reference for the model. Format: workspace/secret_name or secret_name within the job workspace.",
     )
     format: Literal[ModelFormat.NVIDIA_NIM, ModelFormat.OPEN_AI, ModelFormat.LLAMA_STACK] = Field(
-        default=ModelFormat.NVIDIA_NIM, description="API format of the model."
+        default=ModelFormat.OPEN_AI,
+        deprecated=(
+            "`format` is ignored and will be removed. Structured output support is detected from "
+            "the endpoint during preflight rather than inferred from this label."
+        ),
+        description=(
+            "Deprecated and ignored. Previously selected the structured output encoding; that is "
+            "now detected per endpoint, because support is a property of the endpoint rather than "
+            "of the label attached to the model."
+        ),
     )
 
     @field_validator("default_headers")

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
@@ -296,6 +296,11 @@ def test_run_rejects_trials_and_target_together() -> None:
         )
 
 
+def test_run_rejects_neither_trials_nor_target() -> None:
+    with pytest.raises(ValueError, match="provide exactly one"):
+        AgentEvaluator().run_sync(tasks=[_task()])
+
+
 @pytest.mark.asyncio
 async def test_run_writes_nothing_until_persist_is_called(tmp_path: Path) -> None:
     # The point of the change: computing an evaluation and storing one are separate decisions, so a

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
@@ -921,3 +921,52 @@ def test_metric_row_error_is_none_for_a_trial_that_did_not_fail() -> None:
     row = _metric_row(AgentEvalTask(id="task-1", intent="Fix it.", inputs={}), _candidate_trial())
 
     assert row["trial"]["error"] is None
+class _PreflightCountingMetric(_ConstantMetric):
+    """Metric that records how many times its preflight ran."""
+
+    preflight_calls: int = 0
+
+    async def preflight(self) -> None:
+        self.preflight_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_run_preflights_metrics_before_scoring_imported_trials() -> None:
+    """Agent-eval scores metrics directly, so it must run their preflight itself.
+
+    An LLM judge detects its endpoint's structured-output encoding in preflight. Without this the
+    judge scores using the provisional encoding new_hooks guessed, silently losing enforcement on
+    an endpoint that does not honour it.
+    """
+    metric = _PreflightCountingMetric()
+
+    await AgentEvaluator().run(
+        tasks=[_task(metric)],
+        trials=[_candidate_trial()],
+        config=AgentEvalRunConfig(parallelism=1),
+    )
+
+    assert metric.preflight_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_run_preflights_each_metric_once_across_tasks() -> None:
+    """The same metric object is scored once per trial; preflight must not repeat per scoring."""
+    metric = _PreflightCountingMetric()
+
+    await AgentEvaluator().run(
+        tasks=[_task(metric, task_id="task-1"), _task(metric, task_id="task-2")],
+        trials=[
+            _candidate_trial(),
+            AgentEvalTrial(
+                id="trial-2",
+                task_id="task-2",
+                status=AgentEvalTrialStatus.COMPLETED,
+                output=AgentOutput(output_text="Candidate answer"),
+                metadata={"model_id": "candidate"},
+            ),
+        ],
+        config=AgentEvalRunConfig(parallelism=1),
+    )
+
+    assert metric.preflight_calls == 1

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
@@ -972,3 +972,65 @@ async def test_run_preflights_each_metric_once_across_tasks() -> None:
     )
 
     assert metric.preflight_calls == 1
+
+
+class _ProbingMetric(_ConstantMetric):
+    """Metric whose preflight probes a remote endpoint, as an LLM judge's does."""
+
+    preflight_calls: int = 0
+
+    async def preflight(self) -> None:
+        self.preflight_calls += 1
+        raise RuntimeError("endpoint probe failed")
+
+
+def _failed_trial(task_id: str = "task-1", trial_id: str = "trial-1") -> AgentEvalTrial:
+    return AgentEvalTrial(
+        id=trial_id,
+        task_id=task_id,
+        status=AgentEvalTrialStatus.FAILED,
+        output=AgentOutput(output_text=""),
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_trials_are_scored_without_preflighting_their_metric() -> None:
+    """A run whose trials all failed must not probe the judge endpoint.
+
+    Failed trials short-circuit to a failed score without invoking the metric, so preflighting is
+    both a wasted remote call and a new way for the run to abort: preflight resolves the judge
+    model, and that raises for an unresolved reference. Importing a batch of failed trials must
+    still yield failed scores rather than an exception.
+    """
+    metric = _ProbingMetric()
+
+    result = await AgentEvaluator().run(
+        tasks=[_task(metric)],
+        trials=[_failed_trial()],
+        config=AgentEvalRunConfig(parallelism=1),
+    )
+
+    assert metric.preflight_calls == 0
+    assert [score.status for score in result.scores] == [AgentEvalScoreStatus.FAILED]
+
+
+@pytest.mark.asyncio
+async def test_metric_is_preflighted_when_any_trial_is_scoreable() -> None:
+    """One completed trial is enough to need the endpoint resolved."""
+    metric = _PreflightCountingMetric()
+
+    await AgentEvaluator().run(
+        tasks=[_task(metric, task_id="task-1"), _task(metric, task_id="task-2")],
+        trials=[
+            _failed_trial(task_id="task-1", trial_id="trial-1"),
+            AgentEvalTrial(
+                id="trial-2",
+                task_id="task-2",
+                status=AgentEvalTrialStatus.COMPLETED,
+                output=AgentOutput(output_text="Candidate answer"),
+            ),
+        ],
+        config=AgentEvalRunConfig(parallelism=1),
+    )
+
+    assert metric.preflight_calls == 1

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evaluator.py
@@ -921,6 +921,8 @@ def test_metric_row_error_is_none_for_a_trial_that_did_not_fail() -> None:
     row = _metric_row(AgentEvalTask(id="task-1", intent="Fix it.", inputs={}), _candidate_trial())
 
     assert row["trial"]["error"] is None
+
+
 class _PreflightCountingMetric(_ConstantMetric):
     """Metric that records how many times its preflight ran."""
 

--- a/packages/nemo_evaluator_sdk/tests/execution/test_metric_execution.py
+++ b/packages/nemo_evaluator_sdk/tests/execution/test_metric_execution.py
@@ -4,6 +4,7 @@
 """Unit tests for nemo_evaluator_sdk.execution.metric_execution."""
 
 import asyncio
+import json
 import logging
 import math
 from contextlib import asynccontextmanager
@@ -23,7 +24,7 @@ from nemo_evaluator_sdk.execution.metric_execution import (
     _default_online_request_template,
     _format_exception_summary,
     _is_completions_endpoint,
-    _maybe_set_nim_default_max_tokens,
+    _maybe_set_default_max_tokens,
     _merge_online_hooks,
     _resolve_online_prompt_template,
     _score_pipeline_samples,
@@ -37,6 +38,7 @@ from nemo_evaluator_sdk.execution.pipeline import PipelineRuntime
 from nemo_evaluator_sdk.execution.samples import build_metric_input
 from nemo_evaluator_sdk.execution.scoring import empty_evaluation_result, finalize_evaluation_result
 from nemo_evaluator_sdk.execution.values import EvaluationError, EvaluationPhase
+from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.metrics.hooks import HooksBase
 from nemo_evaluator_sdk.metrics.llm_judge import LLMJudgeMetric as RuntimeLLMJudgeMetric
 from nemo_evaluator_sdk.metrics.protocol import Metric, MetricInput, MetricOutput, MetricOutputSpec, MetricResult
@@ -134,6 +136,15 @@ def _make_model(
     format: Literal[ModelFormat.NVIDIA_NIM, ModelFormat.OPEN_AI, ModelFormat.LLAMA_STACK] = ModelFormat.OPEN_AI,
 ) -> Model:
     return Model(url=url, name="test-model", format=format)
+
+
+def _is_structured_output_probe(request: dict) -> bool:
+    """Identify a preflight structured-output probe by its marker schema.
+
+    Detect on the probe's own schema marker rather than on message shape, since the probe is sent
+    under whichever placement is being tried (response_format or either guided_json position).
+    """
+    return "__nmp_probe_score" in json.dumps(request)
 
 
 def _make_agent() -> Agent:
@@ -596,7 +607,7 @@ class TestResolveOnlinePromptTemplate:
         assert getattr(warning_records[0], "prompt_template", None) == result
 
 
-class TestMaybeSetNimDefaultMaxTokens:
+class TestMaybeSetDefaultMaxTokens:
     @pytest.mark.parametrize(
         ("request_payload", "params", "expected_request"),
         [
@@ -611,13 +622,118 @@ class TestMaybeSetNimDefaultMaxTokens:
         params: RunConfigOnlineModel | None,
         expected_request: dict[str, object],
     ):
-        _maybe_set_nim_default_max_tokens(
-            request=request_payload,
-            model=_make_model(format=ModelFormat.NVIDIA_NIM),
-            params=params,
-        )
+        _maybe_set_default_max_tokens(request=request_payload, params=params)
 
         assert request_payload == expected_request
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("format", [ModelFormat.NVIDIA_NIM, ModelFormat.OPEN_AI, ModelFormat.LLAMA_STACK])
+    async def test_applies_default_through_call_path_for_every_model_format(
+        self, format: ModelFormat, mocker: MockerFixture
+    ):
+        """The cap used to be NIM-only, so flipping the default format would have silently removed it."""
+        inference_fn = mocker.AsyncMock(return_value={})
+        mocker.patch(
+            "nemo_evaluator_sdk.execution.metric_execution._process_online_response",
+            return_value=({}, None),
+        )
+
+        await generate_online_sample(
+            target=_make_model(format=format),
+            row={"prompt": "hello"},
+            index=0,
+            prompt_template={"messages": [{"role": "user", "content": "{{item.prompt}}"}]},
+            inference_fn=inference_fn,
+        )
+
+        assert inference_fn.await_args.args[1]["max_tokens"] == 4096
+
+
+class TestTargetStructuredOutputPreflight:
+    """Target generation must probe the endpoint, not assume an encoding."""
+
+    @pytest.mark.asyncio
+    async def test_target_generation_falls_back_to_nvext_when_endpoint_only_honours_it(self, mocker: MockerFixture):
+        """A target that only accepts nvext.guided_json must still get an enforced encoding.
+
+        Before target-side preflight existed this path used the model's `format` label; with the
+        label deprecated and ignored, an unprobed target would be sent response_format instead.
+        """
+        captured: list[dict] = []
+
+        async def fake_inference(model, request, max_retries, **kwargs):
+            captured.append(request)
+            if "response_format" in request or "guided_json" in request.get("extra_body", {}):
+                # Endpoint ignores both of these and answers in prose.
+                return {"choices": [{"message": {"content": "sure thing"}}]}
+            return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+        mocker.patch.object(inference, "make_inference_request", side_effect=fake_inference)
+        metric = ExactMatchMetric(reference="{{item.expected}}")
+
+        await evaluate_metric(
+            metric,
+            rows=[{"prompt": "hi", "expected": "sure thing"}],
+            target=_make_model(),
+            prompt_template={"messages": [{"role": "user", "content": "{{item.prompt}}"}]},
+            params=RunConfigOnlineModel(
+                parallelism=1,
+                structured_output={"schema": {"type": "object", "properties": {"a": {"type": "string"}}}},
+            ),
+        )
+
+        probes = [r for r in captured if _is_structured_output_probe(r)]
+        generation = [r for r in captured if not _is_structured_output_probe(r)]
+        assert len(probes) == 3, "expected all three placements to be probed"
+        assert generation, "expected a generation request"
+        assert generation[0]["extra_body"]["nvext"]["guided_json"] is not None
+
+
+class TestBenchmarkPathStructuredOutput:
+    """The multi-metric LocalBackend path bypasses evaluate_metric and must still probe."""
+
+    @pytest.mark.asyncio
+    async def test_multi_metric_benchmark_path_resolves_the_target_encoding(self, mocker: MockerFixture):
+        """Evaluator.run() with several metrics goes through evaluate_benchmark, not evaluate_metric.
+
+        Without its own session and probe this path sent whichever encoding new_hooks guessed.
+        """
+        from nemo_evaluator_sdk.execution.backends.local.backend import LocalBackend
+
+        captured: list[dict] = []
+
+        async def fake_inference(model, request, max_retries, **kwargs):
+            captured.append(request)
+            if _is_structured_output_probe(request):
+                if "response_format" in request or "guided_json" in request.get("extra_body", {}):
+                    return {"choices": [{"message": {"content": "prose, not json"}}]}
+                return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+            return {"choices": [{"message": {"content": "sure thing"}}]}
+
+        # Patch ONLY the benchmark module's binding. The probe must travel the same seam that
+        # generation does, so patching one place has to be enough; if the probe used a different
+        # binding it would escape this patch and attempt a real request.
+        mocker.patch(
+            "nemo_evaluator_sdk.execution.benchmark_execution.make_inference_request",
+            side_effect=fake_inference,
+        )
+
+        await LocalBackend().evaluate_dataset(
+            metrics=[ExactMatchMetric(reference="{{item.expected}}"), ExactMatchMetric(reference="{{item.expected}}")],
+            dataset=[{"prompt": "hi", "expected": "sure thing"}],
+            target=_make_model(),
+            prompt_template={"messages": [{"role": "user", "content": "{{item.prompt}}"}]},
+            params=RunConfigOnlineModel(
+                parallelism=1,
+                structured_output={"schema": {"type": "object", "properties": {"a": {"type": "string"}}}},
+            ),
+        )
+
+        probes = [r for r in captured if _is_structured_output_probe(r)]
+        generation = [r for r in captured if not _is_structured_output_probe(r)]
+        assert probes, "the benchmark path must probe the target endpoint"
+        assert generation, "expected a generation request"
+        assert generation[0]["extra_body"]["nvext"]["guided_json"] is not None
 
 
 class TestGenerateOnlineSample:
@@ -1773,6 +1889,7 @@ class TestEvaluateMetricOnline:
 
         assert captured["request"] == {
             "messages": [{"role": "user", "content": "What is 2 + 2?"}],
+            "max_tokens": 4096,
         }
 
     @pytest.mark.asyncio
@@ -1806,6 +1923,7 @@ class TestEvaluateMetricOnline:
 
         assert captured["request"] == {
             "prompt": "What is the capital of France?",
+            "max_tokens": 4096,
         }
 
     @pytest.mark.asyncio
@@ -1899,6 +2017,9 @@ class TestEvaluateMetricOnline:
             **kwargs,
         ) -> dict:
             captured_judge_requests.append(request)
+            if _is_structured_output_probe(request):
+                # Behave like an endpoint that honours response_format, so preflight resolves to it.
+                return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
             return {"choices": [{"message": {"role": "assistant", "content": '{"helpfulness": 4}'}}]}
 
         metric.set_inference_fn(fake_judge_inference)
@@ -1917,11 +2038,15 @@ class TestEvaluateMetricOnline:
         )
 
         assert captured_generation_requests == [
-            {"messages": [{"role": "user", "content": "What is the capital of France?"}]}
+            {"messages": [{"role": "user", "content": "What is the capital of France?"}], "max_tokens": 4096}
         ]
         assert "response_format" not in captured_generation_requests[0]
-        assert captured_judge_requests[0]["response_format"]["type"] == "json_schema"
-        assert "Assistant response: Paris" in captured_judge_requests[0]["messages"][-1]["content"]
+        # Preflight probes the endpoint before scoring, so the judge sees a probe request first.
+        probe_requests = [r for r in captured_judge_requests if _is_structured_output_probe(r)]
+        scoring_requests = [r for r in captured_judge_requests if not _is_structured_output_probe(r)]
+        assert len(probe_requests) == 1
+        assert scoring_requests[0]["response_format"]["type"] == "json_schema"
+        assert "Assistant response: Paris" in scoring_requests[0]["messages"][-1]["content"]
         assert result.row_scores[0].sample["output_text"] == "Paris"
         assert result.row_scores[0].metrics["llm-judge"][0].value == 4.0
 
@@ -2007,10 +2132,11 @@ class TestEvaluateMetricOnline:
         detect_mode.assert_awaited_once()
         assert detect_mode.await_args is not None
         detect_kwargs = detect_mode.await_args.kwargs
-        assert detect_kwargs["format"] == ModelFormat.NVIDIA_NIM
+        # Detection is endpoint-driven; the deprecated model format is deliberately not passed.
+        assert "format" not in detect_kwargs
         assert detect_kwargs["api_key"] == "secret-value"
         assert captured_generation_requests == [
-            {"messages": [{"role": "user", "content": "What is the capital of France?"}]}
+            {"messages": [{"role": "user", "content": "What is the capital of France?"}], "max_tokens": 4096}
         ]
         assert captured_judge_requests[0]["api_key"] == "secret-value"
         assert captured_judge_requests[0]["request"]["extra_body"]["guided_json"]["type"] == "object"

--- a/packages/nemo_evaluator_sdk/tests/metrics/test_llm_judge.py
+++ b/packages/nemo_evaluator_sdk/tests/metrics/test_llm_judge.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+import json
 import math
 from copy import deepcopy
 from types import SimpleNamespace
@@ -420,6 +422,11 @@ def test_json_parser_no_structured_output():
     assert score.stats.rubric_distribution[1].count == 1
 
 
+def _is_structured_output_probe(request: dict) -> bool:
+    """Identify a preflight structured-output probe by its marker schema."""
+    return "__nmp_probe_score" in json.dumps(request)
+
+
 class TestLLMJudgeMetric:
     def test_rejects_duplicate_score_names(self):
         with pytest.raises(ValueError, match="score names must be unique"):
@@ -764,6 +771,9 @@ class TestLLMJudgeMetric:
 
         async def inference_fn(*args, **kwargs):
             request = kwargs.get("request", args[1])
+            if _is_structured_output_probe(request):
+                # Preflight probes share this inference_fn; they are not scoring requests.
+                return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
             captured_requests.append(deepcopy(request))
             if len(captured_requests) == 1:
                 raise error
@@ -832,6 +842,9 @@ class TestLLMJudgeMetric:
 
         async def inference_fn(*args, **kwargs):
             request = kwargs.get("request", args[1])
+            if _is_structured_output_probe(request):
+                # Preflight probes share this inference_fn; they are not scoring requests.
+                return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
             captured_requests.append(deepcopy(request))
             if len(captured_requests) == 1:
                 raise error
@@ -875,6 +888,25 @@ class TestLLMJudgeMetric:
         assert detect.await_args.kwargs["model"].default_headers == {"X-NMP-Principal-Id": "service:evaluator"}
         structured_hook = next(hook for hook in metric._preprocess_hooks if hasattr(hook, "mode"))
         assert structured_hook.mode == StructuredOutputMode.ROOT_GUIDED_JSON
+
+    @pytest.mark.asyncio
+    async def test_preflight_selects_structured_output_mode_for_non_nim_formats(self, mocker: MockerFixture):
+        """Mode selection is driven by detection for every format, not just NIM."""
+        metric = LLMJudgeMetric(
+            model=_make_model().model_copy(update={"format": ModelFormat.OPEN_AI}),
+            scores=[_make_metric_score()],
+        )
+        detect = mocker.patch(
+            "nemo_evaluator_sdk.metrics.llm_judge.detect_structured_output_mode",
+            new_callable=mocker.AsyncMock,
+            return_value=StructuredOutputMode.OPENAI_RESPONSE_FORMAT,
+        )
+
+        await metric.preflight()
+
+        detect.assert_awaited_once()
+        structured_hook = next(hook for hook in metric._preprocess_hooks if hasattr(hook, "mode"))
+        assert structured_hook.mode == StructuredOutputMode.OPENAI_RESPONSE_FORMAT
 
     @pytest.mark.asyncio
     async def test_preflight_is_noop_without_structured_output(self, mocker: MockerFixture):
@@ -1148,15 +1180,31 @@ class TestGenerateStructuredOutput:
         assert metric.structured_output == explicit
         assert "accuracy" in metric._parsers
 
-    def test_render_request_preserves_nim_max_thinking_tokens_with_structured_output(self):
+    def test_render_request_preserves_nvext_max_thinking_tokens_with_structured_output(self):
+        """Structured output must merge into an existing extra_body.nvext, not replace it."""
         metric = LLMJudgeMetric.model_construct(
-            model=_make_model(ModelFormat.NVIDIA_NIM),
+            model=_make_model(),
             scores=[RubricScore(name="quality", rubric=[Rubric(label="good", value=1), Rubric(label="bad", value=0)])],
             inference=InferenceParams.model_validate({"extra_body": {"nvext": {"max_thinking_tokens": 256}}}),
         )
         item = {"question": "What is AI?"}
         sample = {"output_text": "AI is artificial intelligence"}
         request = metric._render_request(item, sample)
+
+        assert request["extra_body"]["nvext"]["max_thinking_tokens"] == 256
+        assert "response_format" in request
+
+    def test_render_request_merges_nvext_guided_json_beside_max_thinking_tokens(self):
+        """The nvext placement still deep-merges once preflight selects it."""
+        metric = LLMJudgeMetric.model_construct(
+            model=_make_model(),
+            scores=[RubricScore(name="quality", rubric=[Rubric(label="good", value=1), Rubric(label="bad", value=0)])],
+            inference=InferenceParams.model_validate({"extra_body": {"nvext": {"max_thinking_tokens": 256}}}),
+        )
+        for hook in metric._preprocess_hooks:
+            if isinstance(hook, InferenceStructuredOutput):
+                hook.set_mode(StructuredOutputMode.NVEXT_GUIDED_JSON)
+        request = metric._render_request({"question": "What is AI?"}, {"output_text": "AI is intelligence"})
 
         assert request["extra_body"]["nvext"]["max_thinking_tokens"] == 256
         assert "guided_json" in request["extra_body"]["nvext"]
@@ -1204,14 +1252,17 @@ def test_new_hooks_with_defaults():
     assert pre[0].params == {"temperature": 0.9}
     assert isinstance(pre[1], InferenceStructuredOutput)
     assert pre[1].inference_param == {
-        "extra_body": {
-            "nvext": {
-                "guided_json": {
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "structured_output",
+                "schema": {
                     "type": "object",
                     "properties": {"quality": {"enum": ["good", "bad"], "type": "string"}},
                     "required": ["quality"],
-                }
-            }
+                },
+                "strict": False,
+            },
         }
     }
     assert isinstance(pre[2], LogHook), "log hook"
@@ -1221,8 +1272,12 @@ def test_new_hooks_with_defaults():
     assert pre[2] == post[0], "pre and post should have the same instance of log hook"
 
 
-def test_new_hooks_openai_format_uses_response_format():
-    """Test that new_hooks uses response_format for OpenAI model format."""
+def test_new_hooks_defaults_to_response_format_before_probing():
+    """new_hooks installs response_format as the PROVISIONAL default, not because of the format.
+
+    Selection is endpoint-driven; preflight replaces this. Named away from "openai format uses
+    response_format" so it cannot be read as licence to restore format-based selection.
+    """
     metric = LLMJudgeMetric.model_validate(
         {
             "name": "test-judge",
@@ -1253,8 +1308,12 @@ def test_new_hooks_openai_format_uses_response_format():
     assert structured_output_hook.inference_param["response_format"]["type"] == "json_schema"
 
 
-def test_new_hooks_nim_format_uses_nvext():
-    """Test that new_hooks uses nvext for NIM model format."""
+def test_new_hooks_nim_format_no_longer_forces_nvext():
+    """A `nim` label must not preselect nvext: preflight decides from the endpoint.
+
+    Hardcoding nvext here is what made integrate.api.nvidia.com fall back to an unenforced prompt
+    instruction, since that endpoint rejects nvext.guided_json outright.
+    """
     metric = LLMJudgeMetric.model_validate(
         {
             "name": "test-judge",
@@ -1281,8 +1340,8 @@ def test_new_hooks_nim_format_uses_nvext():
             break
 
     assert structured_output_hook is not None, "Expected InferenceStructuredOutput hook"
-    assert "extra_body" in structured_output_hook.inference_param
-    assert "nvext" in structured_output_hook.inference_param["extra_body"]
+    assert "extra_body" not in structured_output_hook.inference_param
+    assert "response_format" in structured_output_hook.inference_param
 
 
 # =============================================================================
@@ -1487,3 +1546,102 @@ def test_llm_judge_top_level_system_prompt_and_reasoning_still_work():
     assert len(metric._postprocess_hooks) == 2
     assert isinstance(metric._postprocess_hooks[1], TransformReasoningOutput)
     assert metric._postprocess_hooks[1].end_reasoning_token == "</think>"
+
+
+@pytest.mark.asyncio
+async def test_compute_scores_probes_the_endpoint_when_called_directly(mocker: MockerFixture):
+    """compute_scores is public API: a caller can score without any executor running preflight.
+
+    Without self-preflight the judge would send the provisional encoding new_hooks guessed, and an
+    endpoint that ignores it would silently drop the constraint.
+    """
+    metric = LLMJudgeMetric(model=_make_model(), scores=[_make_metric_score()])
+    seen: list[dict] = []
+
+    async def inference_fn(*args, **kwargs):
+        request = kwargs.get("request", args[1])
+        seen.append(request)
+        if _is_structured_output_probe(request):
+            # Endpoint honours only nvext.guided_json.
+            if "nvext" in request.get("extra_body", {}):
+                return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+            return {"choices": [{"message": {"content": "prose, not json"}}]}
+        return {"choices": [{"message": {"content": '{"helpfulness": 3}'}}]}
+
+    metric.set_inference_fn(inference_fn)
+
+    await compute_scores(metric, {"prompt": "hello"}, {"output_text": "world"})
+
+    scoring = [r for r in seen if not _is_structured_output_probe(r)]
+    assert [r for r in seen if _is_structured_output_probe(r)], "expected the endpoint to be probed"
+    assert scoring[0]["extra_body"]["nvext"]["guided_json"] is not None
+
+
+@pytest.mark.asyncio
+async def test_compute_scores_self_preflight_keeps_the_unresolved_model_ref_error():
+    """Self-preflight must not change the failure a caller sees for an unresolved ModelRef.
+
+    preflight() calls _require_model(), which raises for a ModelRef. compute_scores already raised
+    the same error at its own _require_model() call, so the guard only moves it earlier -- it must
+    not turn into a different or less actionable exception.
+    """
+    metric = LLMJudgeMetric(model=ModelRef(root="workspace/judge"), scores=[_make_metric_score()])
+
+    with pytest.raises(ValueError, match="has not been resolved"):
+        await compute_scores(metric, {"prompt": "hello"}, {"output_text": "world"})
+
+
+@pytest.mark.asyncio
+async def test_concurrent_direct_compute_scores_probe_the_endpoint_once():
+    """Direct callers may gather many compute_scores() with no run session to cache detection.
+
+    Without serialising the self-preflight, every concurrent call would see an unresolved hook and
+    probe the same endpoint at once -- hundreds of extra requests before any scoring happens.
+    """
+    metric = LLMJudgeMetric(model=_make_model(), scores=[_make_metric_score()])
+    probes: list[dict] = []
+
+    async def inference_fn(*args, **kwargs):
+        request = kwargs.get("request", args[1])
+        if _is_structured_output_probe(request):
+            probes.append(request)
+            await asyncio.sleep(0.01)  # widen the stampede window
+            return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+        return {"choices": [{"message": {"content": '{"helpfulness": 3}'}}]}
+
+    metric.set_inference_fn(inference_fn)
+
+    await asyncio.gather(*(compute_scores(metric, {"prompt": "hello"}, {"output_text": "world"}) for _ in range(8)))
+
+    assert len(probes) == 1, f"expected a single probe for 8 concurrent callers, got {len(probes)}"
+
+
+class TestPreflightLockLifecycle:
+    """Pin where the preflight lock is and is not cleared.
+
+    Clearing it in resolve_models() looks tidy and is actively harmful: that method rebuilds the
+    hooks as unresolved, so dropping the lock mid-flight splits synchronisation and lets an
+    in-flight scorer render through the rebuilt hook, sending a guessed encoding with only a
+    warning. A lock retained from another event loop instead fails loudly on its next contended
+    acquire. Deep copies are a different case -- a copy is a new object and must start fresh.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolve_models_keeps_the_preflight_lock(self):
+        metric = LLMJudgeMetric(model=ModelRef(root="workspace/judge"), scores=[_make_metric_score()])
+        lock = metric._require_preflight_lock()
+
+        await metric.resolve_models(_RegisteredModelResolver())
+
+        assert metric._preflight_lock is lock, (
+            "resolve_models must not clear the preflight lock: doing so splits preflight "
+            "synchronisation while a concurrent compute_scores() is mid-probe"
+        )
+
+    def test_deepcopy_starts_with_a_fresh_preflight_lock(self):
+        metric = LLMJudgeMetric(model=_make_model(), scores=[_make_metric_score()])
+        metric._require_preflight_lock()
+
+        clone = deepcopy(metric)
+
+        assert clone._preflight_lock is None

--- a/packages/nemo_evaluator_sdk/tests/test_structured_output.py
+++ b/packages/nemo_evaluator_sdk/tests/test_structured_output.py
@@ -519,3 +519,37 @@ async def test_concurrent_runs_get_isolated_caches():
 
     assert set(modes) == {StructuredOutputMode.OPENAI_RESPONSE_FORMAT}
     assert sorted(calls) == ["a", "b"], f"each concurrent run must probe in its own cache, got {calls}"
+
+
+@pytest.mark.asyncio
+async def test_truncated_probe_is_reported_rather_than_silently_unsupported(caplog):
+    """A reasoning model can spend the whole probe budget thinking and return empty content.
+
+    Truncation is indistinguishable from an endpoint ignoring the encoding, so it must at least be
+    surfaced instead of quietly resolving to the unenforced prompt fallback.
+    """
+
+    async def truncating_inference_fn(model, request, max_retries, **kwargs):
+        return {"choices": [{"finish_reason": "length", "message": {"content": ""}}]}
+
+    with caplog.at_level(logging.WARNING):
+        mode = await detect_structured_output_mode(
+            model=_test_model(), inference_fn=truncating_inference_fn, api_key=None
+        )
+
+    assert mode == StructuredOutputMode.UNSUPPORTED
+    assert [r for r in caplog.records if "could not be determined" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_probe_budget_accommodates_a_reasoning_model():
+    """The probe must not use a budget a reasoning model burns before emitting content."""
+    seen: list[int] = []
+
+    async def inference_fn(model, request, max_retries, **kwargs):
+        seen.append(request["max_tokens"])
+        return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+    await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+
+    assert seen[0] >= 2048, f"probe budget {seen[0]} is too small for a reasoning model"

--- a/packages/nemo_evaluator_sdk/tests/test_structured_output.py
+++ b/packages/nemo_evaluator_sdk/tests/test_structured_output.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from nemo_evaluator_sdk.enums import ModelFormat
+from nemo_evaluator_sdk.session import begin_evaluation_session
 from nemo_evaluator_sdk.structured_output import (
     InferenceStructuredOutput,
     Model,
@@ -16,7 +17,6 @@ from nemo_evaluator_sdk.structured_output import (
     _looks_like_unsupported_guided_json_error,
     default_structured_output_mode,
     detect_structured_output_mode,
-    structured_output_mode_session,
 )
 from pydantic import ValidationError
 
@@ -344,7 +344,7 @@ async def test_detection_is_cached_per_endpoint_within_a_session():
         calls.append(request)
         return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
 
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         first = await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
         second = await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
 
@@ -382,14 +382,14 @@ async def test_unsupported_is_cached_within_a_run_but_re_probed_by_the_next():
             raise RuntimeError("Error code: 429 - rate limited")
         return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
 
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         first = await detect_structured_output_mode(model=_test_model(), inference_fn=flaky_inference_fn, api_key=None)
         repeat = await detect_structured_output_mode(model=_test_model(), inference_fn=flaky_inference_fn, api_key=None)
 
     assert first == repeat == StructuredOutputMode.UNSUPPORTED
     assert attempts["n"] == 3, "the negative must be cached within the run, not re-probed per caller"
 
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         later = await detect_structured_output_mode(model=_test_model(), inference_fn=flaky_inference_fn, api_key=None)
 
     assert later == StructuredOutputMode.OPENAI_RESPONSE_FORMAT, "a new run must re-probe"
@@ -445,7 +445,7 @@ async def test_concurrent_detections_in_one_session_probe_the_endpoint_once():
         await asyncio.sleep(0.01)  # widen the window for a stampede
         return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
 
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         modes = await asyncio.gather(
             *(
                 detect_structured_output_mode(model=_test_model(), inference_fn=slow_inference_fn, api_key=None)
@@ -470,9 +470,9 @@ async def test_nested_sessions_are_re_entrant_and_share_one_cache():
         calls.append(request)
         return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
 
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
-        async with structured_output_mode_session():
+        async with begin_evaluation_session():
             await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
         await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
 
@@ -488,9 +488,9 @@ async def test_separate_runs_do_not_share_a_cache():
         calls.append(request)
         return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
 
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
 
     assert len(calls) == 2
@@ -512,7 +512,7 @@ async def test_concurrent_runs_get_isolated_caches():
             await asyncio.sleep(0.01)
             return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
 
-        async with structured_output_mode_session():
+        async with begin_evaluation_session():
             return await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
 
     modes = await asyncio.gather(run_one("a"), run_one("b"))

--- a/packages/nemo_evaluator_sdk/tests/test_structured_output.py
+++ b/packages/nemo_evaluator_sdk/tests/test_structured_output.py
@@ -1,18 +1,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+import copy
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
+from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.structured_output import (
     InferenceStructuredOutput,
     Model,
-    ModelFormat,
     StructuredOutputMode,
+    _default_probe_schema,
     _looks_like_unsupported_guided_json_error,
+    default_structured_output_mode,
     detect_structured_output_mode,
+    structured_output_mode_session,
 )
 from pydantic import ValidationError
+
+_PROBE_SCHEMA = {"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}
 
 
 def _test_model() -> Model:
@@ -115,21 +123,44 @@ def test_inference_structured_output_openai_default_strict():
 
 
 @pytest.mark.asyncio
-async def test_detect_structured_output_mode_openai_skips_probe():
-    inference_fn = AsyncMock()
+@pytest.mark.parametrize("format", [ModelFormat.OPEN_AI, ModelFormat.NVIDIA_NIM, ModelFormat.LLAMA_STACK, None])
+async def test_detect_structured_output_mode_probes_regardless_of_format(format):
+    """Support is a property of the endpoint, so the label must not short-circuit detection.
+
+    Previously OPEN_AI returned without probing and every other non-NIM format returned UNSUPPORTED
+    without probing, which meant the label decided enforcement rather than the endpoint.
+    """
+    requests: list[dict] = []
+
+    async def inference_fn(model, request, max_retries, **kwargs):
+        requests.append(request)
+        return {"choices": [{"message": {"content": '{"ok":true}'}}]}
+
     mode = await detect_structured_output_mode(
-        format=ModelFormat.OPEN_AI,
+        format=format,
         model=_test_model(),
         inference_fn=inference_fn,
         api_key=None,
-        probe_schema={"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]},
+        probe_schema=_PROBE_SCHEMA,
     )
+
     assert mode == StructuredOutputMode.OPENAI_RESPONSE_FORMAT
-    inference_fn.assert_not_called()
+    assert len(requests) == 1
+
+
+def test_default_structured_output_mode_ignores_format():
+    for format in (ModelFormat.OPEN_AI, ModelFormat.NVIDIA_NIM, ModelFormat.LLAMA_STACK, None):
+        assert default_structured_output_mode(format) == StructuredOutputMode.OPENAI_RESPONSE_FORMAT
 
 
 @pytest.mark.asyncio
-async def test_detect_structured_output_mode_prefers_root_guided_json():
+async def test_detect_structured_output_mode_prefers_response_format_for_nim():
+    """NIM-labelled endpoints serving an OpenAI-compatible route must resolve to response_format.
+
+    Hosted endpoints such as integrate.api.nvidia.com reject nvext.guided_json and silently ignore
+    root guided_json, so probing the guided_json placements first yields UNSUPPORTED even though
+    response_format is enforced there.
+    """
     requests: list[dict] = []
 
     async def inference_fn(model, request, max_retries, **kwargs):
@@ -141,14 +172,42 @@ async def test_detect_structured_output_mode_prefers_root_guided_json():
         model=_test_model(),
         inference_fn=inference_fn,
         api_key="secret",
-        probe_schema={"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]},
+        probe_schema=_PROBE_SCHEMA,
+    )
+
+    assert mode == StructuredOutputMode.OPENAI_RESPONSE_FORMAT
+    assert len(requests) == 1
+    assert "extra_body" not in requests[0]
+    # The probe must send the same payload the hook sends in production, or detection can select a
+    # mode that then fails during evaluation.
+    assert requests[0]["response_format"] == {
+        "type": "json_schema",
+        "json_schema": {"name": "structured_output", "schema": _PROBE_SCHEMA, "strict": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_detect_structured_output_mode_falls_back_to_root_guided_json():
+    requests: list[dict] = []
+
+    async def inference_fn(model, request, max_retries, **kwargs):
+        requests.append(request)
+        if "response_format" in request:
+            # Endpoint ignores response_format and answers in prose.
+            return {"choices": [{"message": {"content": "Sure, the value is true."}}]}
+        return {"choices": [{"message": {"content": '{"ok":true}'}}]}
+
+    mode = await detect_structured_output_mode(
+        format=ModelFormat.NVIDIA_NIM,
+        model=_test_model(),
+        inference_fn=inference_fn,
+        api_key=None,
+        probe_schema=_PROBE_SCHEMA,
     )
 
     assert mode == StructuredOutputMode.ROOT_GUIDED_JSON
-    assert len(requests) == 1
-    assert requests[0]["extra_body"] == {
-        "guided_json": {"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}
-    }
+    assert len(requests) == 2
+    assert requests[1]["extra_body"] == {"guided_json": _PROBE_SCHEMA}
 
 
 @pytest.mark.asyncio
@@ -157,6 +216,8 @@ async def test_detect_structured_output_mode_falls_back_to_nvext_when_root_inval
 
     async def inference_fn(model, request, max_retries, **kwargs):
         requests.append(request)
+        if "response_format" in request:
+            return {"choices": [{"message": {"content": "Sure, the value is true."}}]}
         if request.get("extra_body", {}).get("guided_json") is not None:
             # Invalid for schema ("ok" must be boolean)
             return {"choices": [{"message": {"content": '{"ok":"not-bool"}'}}]}
@@ -167,15 +228,14 @@ async def test_detect_structured_output_mode_falls_back_to_nvext_when_root_inval
         model=_test_model(),
         inference_fn=inference_fn,
         api_key=None,
-        probe_schema={"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]},
+        probe_schema=_PROBE_SCHEMA,
     )
 
     assert mode == StructuredOutputMode.NVEXT_GUIDED_JSON
-    assert len(requests) == 2
-    assert "guided_json" in requests[0]["extra_body"]
-    assert requests[1]["extra_body"] == {
-        "nvext": {"guided_json": {"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}}
-    }
+    assert len(requests) == 3
+    assert "response_format" in requests[0]
+    assert "guided_json" in requests[1]["extra_body"]
+    assert requests[2]["extra_body"] == {"nvext": {"guided_json": _PROBE_SCHEMA}}
 
 
 @pytest.mark.asyncio
@@ -222,3 +282,240 @@ async def test_detect_structured_output_mode_unsupported_signature_then_unsuppor
 )
 def test_looks_like_unsupported_guided_json_error(message: str, expected: bool):
     assert _looks_like_unsupported_guided_json_error(message) is expected
+
+
+@pytest.mark.asyncio
+async def test_detect_structured_output_mode_does_not_abort_on_malformed_probe_schema():
+    """A bad probe schema must degrade to the prompt fallback, not abort evaluation startup."""
+    inference_fn = AsyncMock()
+
+    mode = await detect_structured_output_mode(
+        model=_test_model(),
+        inference_fn=inference_fn,
+        api_key=None,
+        probe_schema={"type": "not-a-real-json-schema-type"},
+    )
+
+    assert mode == StructuredOutputMode.UNSUPPORTED
+    inference_fn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_probe_schema_default_is_not_shared_between_calls():
+    """The default probe schema must not be reachable-and-mutable from a request payload.
+
+    Pydantic copies only the top level of a dict field, so a module-level constant handed straight
+    to InferenceStructuredOutput stays nested-shared with the outgoing request. One mutation of that
+    payload would corrupt the schema every later probe validates against, and a corrupted schema
+    silently mis-selects the structured output mode.
+    """
+    captured: list[dict] = []
+
+    async def inference_fn(model, request, max_retries, **kwargs):
+        # Snapshot before mutating: `request` is the live object, so reading it back afterwards
+        # would only show this function's own edit.
+        captured.append(copy.deepcopy(request))
+        # Simulate any downstream code mutating the request payload it was handed.
+        schema = request["response_format"]["json_schema"]["schema"]
+        schema["properties"]["__nmp_probe_score"]["type"] = "POISONED"
+        return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+    # use_cache=False: this exercises schema isolation between probes, not the endpoint cache.
+    first = await detect_structured_output_mode(
+        model=_test_model(), inference_fn=inference_fn, api_key=None, use_cache=False
+    )
+    second = await detect_structured_output_mode(
+        model=_test_model(), inference_fn=inference_fn, api_key=None, use_cache=False
+    )
+
+    assert first == StructuredOutputMode.OPENAI_RESPONSE_FORMAT
+    assert second == StructuredOutputMode.OPENAI_RESPONSE_FORMAT
+    assert _default_probe_schema()["properties"]["__nmp_probe_score"]["type"] == "integer"
+    assert captured[1]["response_format"]["json_schema"]["schema"]["properties"]["__nmp_probe_score"] == {
+        "type": "integer"
+    }
+
+
+@pytest.mark.asyncio
+async def test_detection_is_cached_per_endpoint_within_a_session():
+    calls: list[dict] = []
+
+    async def inference_fn(model, request, max_retries, **kwargs):
+        calls.append(request)
+        return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+    async with structured_output_mode_session():
+        first = await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+        second = await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+
+    assert first == second == StructuredOutputMode.OPENAI_RESPONSE_FORMAT
+    assert len(calls) == 1, "second call should have been served from the run cache"
+
+
+@pytest.mark.asyncio
+async def test_detection_is_not_cached_outside_a_session():
+    """Without a run boundary there is nowhere safe to cache, so every call probes."""
+    calls: list[dict] = []
+
+    async def inference_fn(model, request, max_retries, **kwargs):
+        calls.append(request)
+        return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+    await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+    await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_unsupported_is_cached_within_a_run_but_re_probed_by_the_next():
+    """Run scoping is what makes caching a negative safe.
+
+    Within a run an unsupported endpoint must not be re-probed per row. Across runs the negative
+    must not persist, so a transient failure cannot silently disable enforcement thereafter.
+    """
+    attempts = {"n": 0}
+
+    async def flaky_inference_fn(model, request, max_retries, **kwargs):
+        attempts["n"] += 1
+        if attempts["n"] <= 3:  # first run: every candidate fails transiently
+            raise RuntimeError("Error code: 429 - rate limited")
+        return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+    async with structured_output_mode_session():
+        first = await detect_structured_output_mode(model=_test_model(), inference_fn=flaky_inference_fn, api_key=None)
+        repeat = await detect_structured_output_mode(model=_test_model(), inference_fn=flaky_inference_fn, api_key=None)
+
+    assert first == repeat == StructuredOutputMode.UNSUPPORTED
+    assert attempts["n"] == 3, "the negative must be cached within the run, not re-probed per caller"
+
+    async with structured_output_mode_session():
+        later = await detect_structured_output_mode(model=_test_model(), inference_fn=flaky_inference_fn, api_key=None)
+
+    assert later == StructuredOutputMode.OPENAI_RESPONSE_FORMAT, "a new run must re-probe"
+
+
+def test_unresolved_hook_warns_once_when_used_without_probing(caplog):
+    """A generation path that never probes must be visible, not silent."""
+    hook = InferenceStructuredOutput(
+        StructuredOutputMode.OPENAI_RESPONSE_FORMAT, {"schema": _PROBE_SCHEMA}, resolved=False
+    )
+
+    with caplog.at_level(logging.WARNING):
+        hook.preprocess({"messages": []})
+        hook.preprocess({"messages": []})
+
+    warnings = [r for r in caplog.records if "never resolved against the endpoint" in r.message]
+    assert len(warnings) == 1, "warn once per hook, not per row"
+
+
+def test_resolved_hook_does_not_warn(caplog):
+    hook = InferenceStructuredOutput(
+        StructuredOutputMode.OPENAI_RESPONSE_FORMAT, {"schema": _PROBE_SCHEMA}, resolved=False
+    )
+    hook.set_mode(StructuredOutputMode.NVEXT_GUIDED_JSON)
+
+    with caplog.at_level(logging.WARNING):
+        hook.preprocess({"messages": []})
+
+    assert not [r for r in caplog.records if "never resolved against the endpoint" in r.message]
+
+
+def test_explicitly_constructed_hook_is_resolved_by_default(caplog):
+    """A caller passing a deliberate mode is not guessing, so it must not be warned at."""
+    hook = InferenceStructuredOutput(StructuredOutputMode.NVEXT_GUIDED_JSON, {"schema": _PROBE_SCHEMA})
+
+    with caplog.at_level(logging.WARNING):
+        hook.preprocess({"messages": []})
+
+    assert not [r for r in caplog.records if "never resolved against the endpoint" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_detections_in_one_session_probe_the_endpoint_once():
+    """Per-row callers must not stampede the endpoint.
+
+    Also pins that the session ContextVar is visible inside tasks created by asyncio.gather: if it
+    were not, each task would get no cache and probe independently.
+    """
+    calls: list[dict] = []
+
+    async def slow_inference_fn(model, request, max_retries, **kwargs):
+        calls.append(request)
+        await asyncio.sleep(0.01)  # widen the window for a stampede
+        return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+    async with structured_output_mode_session():
+        modes = await asyncio.gather(
+            *(
+                detect_structured_output_mode(model=_test_model(), inference_fn=slow_inference_fn, api_key=None)
+                for _ in range(8)
+            )
+        )
+
+    assert set(modes) == {StructuredOutputMode.OPENAI_RESPONSE_FORMAT}
+    assert len(calls) == 1, f"expected a single probe for 8 concurrent callers, got {len(calls)}"
+
+
+@pytest.mark.asyncio
+async def test_nested_sessions_are_re_entrant_and_share_one_cache():
+    """Entry points nest (backend opens one, evaluate_metric opens another).
+
+    A nested session must join the outer one; creating a fresh inner cache would re-probe endpoints
+    the run had already resolved.
+    """
+    calls: list[dict] = []
+
+    async def inference_fn(model, request, max_retries, **kwargs):
+        calls.append(request)
+        return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+    async with structured_output_mode_session():
+        await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+        async with structured_output_mode_session():
+            await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+        await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+
+    assert len(calls) == 1, "the nested session must join the outer cache, not start a new one"
+
+
+@pytest.mark.asyncio
+async def test_separate_runs_do_not_share_a_cache():
+    """Re-entrancy must not leak between sibling runs."""
+    calls: list[dict] = []
+
+    async def inference_fn(model, request, max_retries, **kwargs):
+        calls.append(request)
+        return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+    async with structured_output_mode_session():
+        await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+    async with structured_output_mode_session():
+        await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_runs_get_isolated_caches():
+    """Two concurrent runs must not share detection results.
+
+    A long-lived process (the evaluator service) handles jobs as sibling asyncio tasks. Each task
+    gets a copy of the context at creation, so each session must be its own cache -- otherwise one
+    job's transient failure would decide the encoding for another job's endpoint.
+    """
+    calls: list[str] = []
+
+    async def run_one(tag: str) -> StructuredOutputMode:
+        async def inference_fn(model, request, max_retries, **kwargs):
+            calls.append(tag)
+            await asyncio.sleep(0.01)
+            return {"choices": [{"message": {"content": '{"__nmp_probe_score": 1}'}}]}
+
+        async with structured_output_mode_session():
+            return await detect_structured_output_mode(model=_test_model(), inference_fn=inference_fn, api_key=None)
+
+    modes = await asyncio.gather(run_one("a"), run_one("b"))
+
+    assert set(modes) == {StructuredOutputMode.OPENAI_RESPONSE_FORMAT}
+    assert sorted(calls) == ["a", "b"], f"each concurrent run must probe in its own cache, got {calls}"

--- a/packages/nemo_evaluator_sdk/tests/values/test_model.py
+++ b/packages/nemo_evaluator_sdk/tests/values/test_model.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.values.models import (
     Model,
     filter_auth_headers,
@@ -112,3 +113,26 @@ class TestModelDefaultHeaders:
         )
 
         assert model.default_headers == {header_name: "value"}
+
+
+class TestDeprecatedFormatField:
+    """`format` is deprecated and ignored; these pin the contract API consumers see."""
+
+    def test_format_defaults_to_openai(self):
+        model = Model(url="https://judge.example.test/v1/chat/completions", name="judge-model")
+
+        assert model.format == ModelFormat.OPEN_AI
+
+    def test_format_is_marked_deprecated_in_the_json_schema(self):
+        # The published OpenAPI spec is generated from this schema, so the deprecation signal
+        # reaching API consumers depends on this flag rather than on the docstring.
+        assert Model.model_json_schema()["properties"]["format"]["deprecated"] is True
+
+    def test_format_is_still_accepted_so_existing_callers_keep_working(self):
+        model = Model(
+            url="https://judge.example.test/v1/chat/completions",
+            name="judge-model",
+            format=ModelFormat.NVIDIA_NIM,
+        )
+
+        assert model.format == ModelFormat.NVIDIA_NIM

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/sdk-execution.md
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/skills/nemo-evaluator/references/sdk-execution.md
@@ -137,7 +137,6 @@ metric = ExactMatchMetric(reference="{{item.expected}}")
 target = Model(
     url="https://provider.example/v1",
     name="<model-id>",
-    format="openai",
     api_key_secret="<secret-or-env-name>",
 )
 
@@ -153,8 +152,9 @@ result = Evaluator().run_sync(
 )
 ```
 
-In `Model(...)`, `format` selects the provider/API protocol shape, such as
-OpenAI-compatible request and response handling. `api_key_secret` is a secret
+In `Model(...)`, `format` is deprecated and ignored; do not set it. Structured
+output support is detected from the endpoint during preflight rather than
+inferred from a label. `api_key_secret` is a secret
 reference name, not a literal secret value. For local SDK runs, ensure the
 matching local environment variable exists; for remote platform jobs, create a
 platform secret with the same name in the job workspace.
@@ -173,7 +173,6 @@ from nemo_evaluator_sdk import Evaluator, JSONScoreParser, LLMJudgeMetric, Model
 judge_model = Model(
     url="https://provider.example/v1",
     name="<judge-model-id>",
-    format="openai",
     api_key_secret="<secret-or-env-name>",
 )
 

--- a/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/eval_helpers.py
+++ b/plugins/nemo-customizer/src/nemo_customizer/skills/nemo-customizer/references/eval_helpers.py
@@ -357,7 +357,6 @@ def build_platform_model_target(
     model-entity path always routes to the base VirtualModel and ignores adapter
     names in the request body.
     """
-    from nemo_evaluator_sdk.enums import ModelFormat
     from nemo_evaluator_sdk.values.models import Model
 
     resolved_provider = provider_name or find_ready_provider_for_model_entity(
@@ -379,13 +378,11 @@ def build_platform_model_target(
                 provider_name=resolved_provider,
             ),
             name=served_model_name(workspace=workspace, entity_or_adapter=adapter_name, finetuning="lora"),
-            format=ModelFormat.NVIDIA_NIM,
         )
 
     return Model(
         url=model_entity_gateway_url(base_url=base_url, workspace=workspace, model_entity=model_entity),
         name=served_model_name(workspace=workspace, entity_or_adapter=model_entity, finetuning="base"),
-        format=ModelFormat.NVIDIA_NIM,
     )
 
 

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -4436,8 +4436,11 @@ components:
           - openai
           - llama_stack
           title: Format
-          description: API format of the model.
-          default: nim
+          description: Deprecated and ignored. Previously selected the structured
+            output encoding; that is now detected per endpoint, because support is
+            a property of the endpoint rather than of the label attached to the model.
+          default: openai
+          deprecated: true
       additionalProperties: false
       type: object
       required:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/resolvers.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/resolvers.py
@@ -10,7 +10,6 @@ import logging
 from collections.abc import Awaitable
 from typing import Protocol, TypeVar, cast, runtime_checkable
 
-from nemo_evaluator_sdk.enums import ModelFormat
 from nemo_evaluator_sdk.values.models import Model, ModelRef
 from nemo_platform import NotFoundError
 from nemo_platform.types.inference import ModelProvider as PlatformModelProvider
@@ -128,6 +127,5 @@ class PlatformModelResolver:
         return Model(
             url=endpoint,
             name=name,
-            format=ModelFormat.NVIDIA_NIM,
             host_url=host_url,
         )

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
@@ -166,17 +166,19 @@ class AgentEvaluator:
         runtime_config = resolved_config.model_copy(update={"run_id": run_id})
         started_at = datetime.now(UTC)
 
-        if (trials is None) == (target is None):
-            raise ValueError("provide exactly one of trials or target")
+        seam_error = "provide exactly one of trials or target"
+        if trials is not None and target is not None:
+            raise ValueError(seam_error)
 
         async with begin_evaluation_session():
-            # Branch on which seam was supplied so the type checker can narrow ``target`` to a
-            # concrete ``AgentEvalTarget`` without a cast.
+            # Branch on which seam was supplied so the type checker narrows each of ``trials`` and
+            # ``target`` to a concrete type without a cast. The final arm is the "neither" case.
             if trials is not None:
                 trial_list = list(trials)
-            else:
-                assert target is not None
+            elif target is not None:
                 trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
+            else:
+                raise ValueError(seam_error)
             scores = await self._score_trials(
                 tasks=task_list,
                 trials=trial_list,

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import uuid
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import UTC, datetime
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as package_version
@@ -245,7 +245,7 @@ class AgentEvaluator:
             if not task.metrics:
                 raise ValueError(f"task {task.id!r} does not declare any metrics")
 
-        await _preflight_task_metrics(tasks)
+        await _preflight_task_metrics(tasks, trials_by_task)
 
         semaphore = asyncio.Semaphore(config.parallelism)
 
@@ -386,14 +386,22 @@ class AgentEvaluator:
                 await close_client()
 
 
-async def _preflight_task_metrics(tasks: Sequence[AgentEvalTask]) -> None:
-    """Run each distinct metric's preflight once.
+async def _preflight_task_metrics(
+    tasks: Sequence[AgentEvalTask],
+    trials_by_task: Mapping[str, Sequence[AgentEvalTrial]],
+) -> None:
+    """Run each distinct metric's preflight once, skipping metrics with nothing to score.
 
     Agent-eval scores metrics directly rather than through ``prepare_metric_for_execution``, so
-    nothing else runs their preflight.
+    nothing else runs their preflight. Failed trials short-circuit to a failed score without
+    invoking the metric, so a task whose trials all failed must not trigger one: preflight resolves
+    the judge endpoint, making it both a wasted request and a way for the run to abort.
     """
     preflighted: set[int] = set()
     for task in tasks:
+        scoreable = any(trial.status != AgentEvalTrialStatus.FAILED for trial in trials_by_task.get(task.id, ()))
+        if not scoreable:
+            continue
         for metric in task.metrics:
             if isinstance(metric, MetricWithPreflight) and id(metric) not in preflighted:
                 preflighted.add(id(metric))

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
@@ -166,17 +166,17 @@ class AgentEvaluator:
         runtime_config = resolved_config.model_copy(update={"run_id": run_id})
         started_at = datetime.now(UTC)
 
+        if (trials is None) == (target is None):
+            raise ValueError("provide exactly one of trials or target")
+
         async with begin_evaluation_session():
             # Branch on which seam was supplied so the type checker can narrow ``target`` to a
             # concrete ``AgentEvalTarget`` without a cast.
             if trials is not None:
-                if target is not None:
-                    raise ValueError("provide exactly one of trials or target")
                 trial_list = list(trials)
-            elif target is not None:
-                trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
             else:
-                raise ValueError("provide exactly one of trials or target")
+                assert target is not None
+                trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
             scores = await self._score_trials(
                 tasks=task_list,
                 trials=trial_list,

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
@@ -51,7 +51,7 @@ from nemo_platform.beta.evaluator.execution.metric_execution import (
     resolve_target_structured_output_mode,
     run_sync,
 )
-from nemo_platform.beta.evaluator.structured_output import structured_output_mode_session
+from nemo_platform.beta.evaluator.session import begin_evaluation_session
 from nemo_platform.beta.evaluator.execution.samples import build_metric_input
 from nemo_platform.beta.evaluator.inference import InferenceFn
 from nemo_platform.beta.evaluator.metrics.protocol import Metric, MetricWithPreflight, validate_metric_result
@@ -166,10 +166,7 @@ class AgentEvaluator:
         runtime_config = resolved_config.model_copy(update={"run_id": run_id})
         started_at = datetime.now(UTC)
 
-        # One detection session for the whole run: generation probes the target and scoring probes
-        # any judge model, and imported-trial runs still score, so scoping this to generation alone
-        # would leave judges probing per call.
-        async with structured_output_mode_session():
+        async with begin_evaluation_session():
             # Branch on which seam was supplied so the type checker can narrow ``target`` to a
             # concrete ``AgentEvalTarget`` without a cast.
             if trials is not None:
@@ -248,18 +245,7 @@ class AgentEvaluator:
             if not task.metrics:
                 raise ValueError(f"task {task.id!r} does not declare any metrics")
 
-        # Agent-eval scores metrics directly rather than through prepare_metric_for_execution, so
-        # nothing else runs their preflight. An LLM judge detects its endpoint's structured-output
-        # encoding there; without this it would score using the provisional guess from new_hooks.
-        # Deduplicated by identity because the same metric object is scored once per trial. The run
-        # session would collapse repeat probes to one request anyway; this just avoids the repeated
-        # awaits. Identity is stable here: `tasks` holds every metric for the duration of the loop.
-        preflighted: set[int] = set()
-        for task in tasks:
-            for metric in task.metrics:
-                if isinstance(metric, MetricWithPreflight) and id(metric) not in preflighted:
-                    preflighted.add(id(metric))
-                    await metric.preflight()
+        await _preflight_task_metrics(tasks)
 
         semaphore = asyncio.Semaphore(config.parallelism)
 
@@ -333,8 +319,6 @@ class AgentEvaluator:
         params = _resolve_live_params(config, target)
         prompt_template = config.prompt_template or _default_prompt_template(target)
         semaphore = asyncio.Semaphore(params.parallelism)
-        # Hooks are built per row below; the run-level session opened by run() is what keeps the
-        # endpoint probe to one round trip for the whole pass instead of one per row.
 
         # Use the injected transport client when provided; otherwise build a default for the
         # resolved target type and close it when generation finishes.
@@ -402,6 +386,20 @@ class AgentEvaluator:
                 await close_client()
 
 
+async def _preflight_task_metrics(tasks: Sequence[AgentEvalTask]) -> None:
+    """Run each distinct metric's preflight once.
+
+    Agent-eval scores metrics directly rather than through ``prepare_metric_for_execution``, so
+    nothing else runs their preflight.
+    """
+    preflighted: set[int] = set()
+    for task in tasks:
+        for metric in task.metrics:
+            if isinstance(metric, MetricWithPreflight) and id(metric) not in preflighted:
+                preflighted.add(id(metric))
+                await metric.preflight()
+
+
 async def _generate_sample(
     *,
     target: Model | Agent,
@@ -423,8 +421,6 @@ async def _generate_sample(
         model_inference_fn = (
             cast(InferenceFn, inference_fn) if inference_fn is not None else inference.make_inference_request
         )
-        # Hooks are built per row here, so this relies on detection being cached per endpoint:
-        # without the probe the request would carry whichever encoding new_hooks guessed.
         await resolve_target_structured_output_mode(
             preprocess_hooks=preprocess_hooks,
             model=target,

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/evaluator.py
@@ -46,10 +46,15 @@ from nemo_platform.beta.evaluator.agent_inference import (
     make_agent_inference_fn,
     new_agent_inference_client,
 )
-from nemo_platform.beta.evaluator.execution.metric_execution import generate_online_sample, run_sync
+from nemo_platform.beta.evaluator.execution.metric_execution import (
+    generate_online_sample,
+    resolve_target_structured_output_mode,
+    run_sync,
+)
+from nemo_platform.beta.evaluator.structured_output import structured_output_mode_session
 from nemo_platform.beta.evaluator.execution.samples import build_metric_input
 from nemo_platform.beta.evaluator.inference import InferenceFn
-from nemo_platform.beta.evaluator.metrics.protocol import Metric, validate_metric_result
+from nemo_platform.beta.evaluator.metrics.protocol import Metric, MetricWithPreflight, validate_metric_result
 from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
 from nemo_platform.beta.evaluator.values import (
     Agent,
@@ -161,22 +166,26 @@ class AgentEvaluator:
         runtime_config = resolved_config.model_copy(update={"run_id": run_id})
         started_at = datetime.now(UTC)
 
-        # Branch on which seam was supplied so the type checker can narrow ``target`` to a
-        # concrete ``AgentEvalTarget`` without a cast.
-        if trials is not None:
-            if target is not None:
+        # One detection session for the whole run: generation probes the target and scoring probes
+        # any judge model, and imported-trial runs still score, so scoping this to generation alone
+        # would leave judges probing per call.
+        async with structured_output_mode_session():
+            # Branch on which seam was supplied so the type checker can narrow ``target`` to a
+            # concrete ``AgentEvalTarget`` without a cast.
+            if trials is not None:
+                if target is not None:
+                    raise ValueError("provide exactly one of trials or target")
+                trial_list = list(trials)
+            elif target is not None:
+                trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
+            else:
                 raise ValueError("provide exactly one of trials or target")
-            trial_list = list(trials)
-        elif target is not None:
-            trial_list = await self._generate_trials(tasks=task_list, target=target, config=runtime_config)
-        else:
-            raise ValueError("provide exactly one of trials or target")
-        scores = await self._score_trials(
-            tasks=task_list,
-            trials=trial_list,
-            config=runtime_config,
-            run_id=run_id,
-        )
+            scores = await self._score_trials(
+                tasks=task_list,
+                trials=trial_list,
+                config=runtime_config,
+                run_id=run_id,
+            )
         runner_scores = _collect_runner_aggregate_scores(target) if target is not None else []
         finished_at = datetime.now(UTC)
         metadata = RunMetadata(
@@ -238,6 +247,19 @@ class AgentEvaluator:
         for task in tasks:
             if not task.metrics:
                 raise ValueError(f"task {task.id!r} does not declare any metrics")
+
+        # Agent-eval scores metrics directly rather than through prepare_metric_for_execution, so
+        # nothing else runs their preflight. An LLM judge detects its endpoint's structured-output
+        # encoding there; without this it would score using the provisional guess from new_hooks.
+        # Deduplicated by identity because the same metric object is scored once per trial. The run
+        # session would collapse repeat probes to one request anyway; this just avoids the repeated
+        # awaits. Identity is stable here: `tasks` holds every metric for the duration of the loop.
+        preflighted: set[int] = set()
+        for task in tasks:
+            for metric in task.metrics:
+                if isinstance(metric, MetricWithPreflight) and id(metric) not in preflighted:
+                    preflighted.add(id(metric))
+                    await metric.preflight()
 
         semaphore = asyncio.Semaphore(config.parallelism)
 
@@ -311,6 +333,8 @@ class AgentEvaluator:
         params = _resolve_live_params(config, target)
         prompt_template = config.prompt_template or _default_prompt_template(target)
         semaphore = asyncio.Semaphore(params.parallelism)
+        # Hooks are built per row below; the run-level session opened by run() is what keeps the
+        # endpoint probe to one round trip for the whole pass instead of one per row.
 
         # Use the injected transport client when provided; otherwise build a default for the
         # resolved target type and close it when generation finishes.
@@ -395,9 +419,17 @@ async def _generate_sample(
     # The transport client is a real class union, so isinstance narrowing is enough there.
     if isinstance(target, Model):
         model_params = cast(RunConfigOnlineModel, params)
-        preprocess_hooks, postprocess_hooks = inference.new_hooks(model_params, model_format=target.format)
+        preprocess_hooks, postprocess_hooks = inference.new_hooks(model_params)
         model_inference_fn = (
             cast(InferenceFn, inference_fn) if inference_fn is not None else inference.make_inference_request
+        )
+        # Hooks are built per row here, so this relies on detection being cached per endpoint:
+        # without the probe the request would carry whichever encoding new_hooks guessed.
+        await resolve_target_structured_output_mode(
+            preprocess_hooks=preprocess_hooks,
+            model=target,
+            inference_fn=model_inference_fn,
+            params=model_params,
         )
         return await generate_online_sample(
             target=target,

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/backends/local/backend.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/backends/local/backend.py
@@ -24,7 +24,7 @@ from nemo_platform.beta.evaluator.execution.utils import prepare_metric_for_exec
 from nemo_platform.beta.evaluator.inference import PostprocessResponse, PreprocessRequest
 from nemo_platform.beta.evaluator.metrics.protocol import Metric
 from nemo_platform.beta.evaluator.resolvers import LocalModelResolver, LocalSecretResolver
-from nemo_platform.beta.evaluator.structured_output import structured_output_mode_session
+from nemo_platform.beta.evaluator.session import begin_evaluation_session
 from nemo_platform.beta.evaluator.values import Agent, DatasetInput, FieldMapping, Model
 from nemo_platform.beta.evaluator.values.multi_metric_results import BenchmarkEvaluationResult, namespace_result
 from nemo_platform.beta.evaluator.values.results import AggregateFieldName, EvaluationResult
@@ -85,10 +85,8 @@ class LocalBackend:
         Returns:
             A namespaced single-metric evaluation result.
         """
-        # Wraps preparation as well as execution: prepare_metric_for_execution runs the metric's
-        # preflight, which is where an LLM judge probes its endpoint. evaluate_metric opens a
-        # session too; the session is re-entrant, so both share this one cache.
-        async with structured_output_mode_session():
+        # Preparation runs each metric's preflight, so it belongs inside the session.
+        async with begin_evaluation_session():
             return await self._evaluate_one_in_session(
                 metric=metric,
                 metric_key=metric_key,
@@ -114,7 +112,6 @@ class LocalBackend:
         postprocess_hooks: tuple[PostprocessResponse, ...] | None,
         rows: list[dict[str, Any]],
     ) -> EvaluationResult:
-        """Body of :meth:`_evaluate_one`, inside a structured-output detection session."""
         prepared_metric = await prepare_metric_for_execution(
             metric,
             params=params,
@@ -168,10 +165,8 @@ class LocalBackend:
         """
         rows = _prepare_rows(dataset, params, field_mapping)
         metric_keys = unique_metric_keys(metrics)
-        # Opened before metric preparation on purpose: prepare_metric_for_execution runs each
-        # metric's preflight, which is where an LLM judge probes its endpoint. Starting the session
-        # later would leave those probes uncached, so two judges on one endpoint would each probe.
-        async with structured_output_mode_session():
+        # Preparation runs each metric's preflight, so it belongs inside the session.
+        async with begin_evaluation_session():
             return await self._evaluate_dataset_in_session(
                 metrics=metrics,
                 metric_keys=metric_keys,
@@ -197,7 +192,6 @@ class LocalBackend:
         preprocess_hooks: Sequence[PreprocessRequest] | None,
         postprocess_hooks: Sequence[PostprocessResponse] | None,
     ) -> BenchmarkEvaluationResult:
-        """Body of :meth:`evaluate_dataset`, inside a structured-output detection session."""
         prepared_metrics = [
             await prepare_metric_for_execution(
                 metric,
@@ -218,16 +212,13 @@ class LocalBackend:
         else:
             merged_preprocess_hooks = tuple(preprocess_hooks or ())
             merged_postprocess_hooks = tuple(postprocess_hooks or ())
-        # This multi-metric path builds target hooks itself and calls evaluate_benchmark directly,
-        # bypassing evaluate_metric, so it has to resolve the hook here or generation would send
-        # whichever encoding new_hooks guessed.
+        # This path builds target hooks itself and bypasses evaluate_metric, so it resolves here.
         if isinstance(target, Model):
             await resolve_target_structured_output_mode(
                 preprocess_hooks=merged_preprocess_hooks,
                 model=target,
-                # Resolved from the benchmark module at call time, not bound here, so the probe
-                # always travels the exact transport that evaluate_benchmark's own default uses --
-                # including when that binding is swapped.
+                # Attribute lookup, not a bound import: the probe must use the same transport
+                # evaluate_benchmark defaults to, including when that binding is swapped.
                 inference_fn=benchmark_execution.make_inference_request,
                 params=params,
             )

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/backends/local/backend.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/backends/local/backend.py
@@ -12,13 +12,19 @@ from typing import Any
 
 from nemo_platform.beta.evaluator.dataset_schemas.compatibility import apply_column_mapping_to_row
 from nemo_platform.beta.evaluator.datasets.loader import prepare_dataset_rows
+from nemo_platform.beta.evaluator.execution import benchmark_execution
 from nemo_platform.beta.evaluator.execution.backends.base import BackendParams
 from nemo_platform.beta.evaluator.execution.benchmark_execution import evaluate_benchmark as sdk_evaluate_benchmark
-from nemo_platform.beta.evaluator.execution.metric_execution import _merge_online_hooks, evaluate_metric
+from nemo_platform.beta.evaluator.execution.metric_execution import (
+    _merge_online_hooks,
+    evaluate_metric,
+    resolve_target_structured_output_mode,
+)
 from nemo_platform.beta.evaluator.execution.utils import prepare_metric_for_execution, unique_metric_keys
 from nemo_platform.beta.evaluator.inference import PostprocessResponse, PreprocessRequest
 from nemo_platform.beta.evaluator.metrics.protocol import Metric
 from nemo_platform.beta.evaluator.resolvers import LocalModelResolver, LocalSecretResolver
+from nemo_platform.beta.evaluator.structured_output import structured_output_mode_session
 from nemo_platform.beta.evaluator.values import Agent, DatasetInput, FieldMapping, Model
 from nemo_platform.beta.evaluator.values.multi_metric_results import BenchmarkEvaluationResult, namespace_result
 from nemo_platform.beta.evaluator.values.results import AggregateFieldName, EvaluationResult
@@ -79,6 +85,36 @@ class LocalBackend:
         Returns:
             A namespaced single-metric evaluation result.
         """
+        # Wraps preparation as well as execution: prepare_metric_for_execution runs the metric's
+        # preflight, which is where an LLM judge probes its endpoint. evaluate_metric opens a
+        # session too; the session is re-entrant, so both share this one cache.
+        async with structured_output_mode_session():
+            return await self._evaluate_one_in_session(
+                metric=metric,
+                metric_key=metric_key,
+                params=params,
+                target=target,
+                prompt_template=prompt_template,
+                aggregate_fields=aggregate_fields,
+                preprocess_hooks=preprocess_hooks,
+                postprocess_hooks=postprocess_hooks,
+                rows=rows,
+            )
+
+    async def _evaluate_one_in_session(
+        self,
+        *,
+        metric: Metric,
+        metric_key: str,
+        params: BackendParams,
+        target: Model | Agent | None,
+        prompt_template: str | dict[str, Any] | None,
+        aggregate_fields: tuple[AggregateFieldName, ...] | None,
+        preprocess_hooks: tuple[PreprocessRequest, ...] | None,
+        postprocess_hooks: tuple[PostprocessResponse, ...] | None,
+        rows: list[dict[str, Any]],
+    ) -> EvaluationResult:
+        """Body of :meth:`_evaluate_one`, inside a structured-output detection session."""
         prepared_metric = await prepare_metric_for_execution(
             metric,
             params=params,
@@ -132,6 +168,36 @@ class LocalBackend:
         """
         rows = _prepare_rows(dataset, params, field_mapping)
         metric_keys = unique_metric_keys(metrics)
+        # Opened before metric preparation on purpose: prepare_metric_for_execution runs each
+        # metric's preflight, which is where an LLM judge probes its endpoint. Starting the session
+        # later would leave those probes uncached, so two judges on one endpoint would each probe.
+        async with structured_output_mode_session():
+            return await self._evaluate_dataset_in_session(
+                metrics=metrics,
+                metric_keys=metric_keys,
+                rows=rows,
+                params=params,
+                target=target,
+                prompt_template=prompt_template,
+                aggregate_fields=aggregate_fields,
+                preprocess_hooks=preprocess_hooks,
+                postprocess_hooks=postprocess_hooks,
+            )
+
+    async def _evaluate_dataset_in_session(
+        self,
+        *,
+        metrics: Sequence[Metric],
+        metric_keys: Sequence[str],
+        rows: list[dict[str, Any]],
+        params: BackendParams,
+        target: Model | Agent | None,
+        prompt_template: str | dict[str, Any] | None,
+        aggregate_fields: Sequence[AggregateFieldName] | None,
+        preprocess_hooks: Sequence[PreprocessRequest] | None,
+        postprocess_hooks: Sequence[PostprocessResponse] | None,
+    ) -> BenchmarkEvaluationResult:
+        """Body of :meth:`evaluate_dataset`, inside a structured-output detection session."""
         prepared_metrics = [
             await prepare_metric_for_execution(
                 metric,
@@ -152,6 +218,19 @@ class LocalBackend:
         else:
             merged_preprocess_hooks = tuple(preprocess_hooks or ())
             merged_postprocess_hooks = tuple(postprocess_hooks or ())
+        # This multi-metric path builds target hooks itself and calls evaluate_benchmark directly,
+        # bypassing evaluate_metric, so it has to resolve the hook here or generation would send
+        # whichever encoding new_hooks guessed.
+        if isinstance(target, Model):
+            await resolve_target_structured_output_mode(
+                preprocess_hooks=merged_preprocess_hooks,
+                model=target,
+                # Resolved from the benchmark module at call time, not bound here, so the probe
+                # always travels the exact transport that evaluate_benchmark's own default uses --
+                # including when that binding is swapped.
+                inference_fn=benchmark_execution.make_inference_request,
+                params=params,
+            )
         return await sdk_evaluate_benchmark(
             metrics=metrics_built,
             rows=rows,

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/metric_execution.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/metric_execution.py
@@ -26,7 +26,6 @@ from nemo_platform.beta.evaluator.agent_inference import (
     make_agent_inference_request,
     new_agent_inference_client,
 )
-from nemo_platform.beta.evaluator.enums import ModelFormat
 from nemo_platform.beta.evaluator.execution.config import fail_fast_from_params, resolve_params
 from nemo_platform.beta.evaluator.execution.pipeline import (
     GeneratedSampleEvent,
@@ -49,6 +48,7 @@ from nemo_platform.beta.evaluator.metrics.protocol import (
 from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
 from nemo_platform.beta.evaluator.resilience.api import run_indexed_tasks, use_resilience_session
 from nemo_platform.beta.evaluator.resilience.errors import get_evaluation_error
+from nemo_platform.beta.evaluator.structured_output import structured_output_mode_session
 from nemo_platform.beta.evaluator.templates import render_request
 from nemo_platform.beta.evaluator.values import (
     Agent,
@@ -231,7 +231,6 @@ def _merge_online_hooks(
     #   postprocess -> [log_hook, ...]
     built_preprocess_hooks, built_postprocess_hooks = inference.new_hooks(
         params if isinstance(params, RunConfigOnlineModel) else None,
-        model_format=target.format if isinstance(target, Model) else None,
     )
     if not built_preprocess_hooks or not built_postprocess_hooks:
         raise ValueError(
@@ -259,16 +258,63 @@ def _merge_online_hooks(
     )
 
 
-def _maybe_set_nim_default_max_tokens(
+async def resolve_target_structured_output_mode(
     *,
-    request: dict[str, Any],
+    preprocess_hooks: Sequence[inference.PreprocessRequest],
     model: Model,
-    params: RunConfigOnlineModel | None,
+    inference_fn: inference.InferenceFn,
+    params: RunConfig | RunConfigOnline | RunConfigOnlineModel | None,
 ) -> None:
-    """Apply the NIM max token default only when neither params nor request set one."""
-    if model.format != ModelFormat.NVIDIA_NIM:
+    """Probe the target endpoint so generation uses an encoding it actually honours.
+
+    The judge has its own preflight; target generation had none, and previously relied on the
+    model's ``format`` label to pick an encoding. That label is deprecated and ignored, so without
+    this probe a target that only accepts ``nvext.guided_json`` would be sent ``response_format``
+    and either reject the request or silently drop the constraint.
+
+    Only the hook built from ``params.structured_output`` is retuned. A caller that hand-builds an
+    InferenceStructuredOutput and splices it in via ``preprocess_hooks`` has chosen a mode
+    deliberately, and silently overriding that choice would be surprising; ``_merge_online_hooks``
+    places the run-level hook ahead of caller-supplied ones, so the first match is ours.
+
+    Like the judge's own preflight, this runs before ``use_resilience_session()`` opens, so probe
+    attempts use the process-global scheduler and do not appear in the session summary. Detection
+    itself is cached per endpoint for the run, so a Model used as both target and judge is probed
+    once, not once per role.
+    """
+    from nemo_platform.beta.evaluator.structured_output import InferenceStructuredOutput, detect_structured_output_mode
+
+    if not (isinstance(params, RunConfigOnlineModel) and params.structured_output):
         return
 
+    structured_hook = next(
+        (hook for hook in preprocess_hooks if isinstance(hook, InferenceStructuredOutput)),
+        None,
+    )
+    if structured_hook is None:
+        return
+
+    mode = await detect_structured_output_mode(
+        model=model,
+        inference_fn=inference_fn,
+        api_key=model.api_key,
+    )
+    structured_hook.set_mode(mode)
+    log.info("Structured output mode selected for target %s: %s", model.name, mode.value)
+
+
+def _maybe_set_default_max_tokens(
+    *,
+    request: dict[str, Any],
+    params: RunConfigOnlineModel | None,
+) -> None:
+    """Apply the default max token cap when neither params nor request set one.
+
+    This was previously applied only to ``nim``-format models. Model format is deprecated and no
+    longer distinguishes endpoints, so the cap is unconditional: an unbounded generation against a
+    reasoning-capable judge is a cost risk on any endpoint, and callers that want more can set
+    ``max_tokens`` or ``max_completion_tokens`` explicitly.
+    """
     inference_params = params.inference if isinstance(params, RunConfigOnlineModel) else None
     if inference_params is not None and (
         inference_params.max_tokens is not None or inference_params.max_completion_tokens is not None
@@ -350,8 +396,8 @@ async def generate_online_sample(
 
     Two valid call shapes, pinned by the ``@overload``s above:
 
-    - ``target: Model`` pairs with ``inference_fn: InferenceFn``. NIM
-      max-token defaults are applied and ``default_headers`` is forwarded
+    - ``target: Model`` pairs with ``inference_fn: InferenceFn``. Default
+      max-token caps are applied and ``default_headers`` is forwarded
       to the inference fn.
     - ``target: Agent`` pairs with ``inference_fn: AgentInferenceFn``.
       ``default_headers`` is forwarded to the inference fn.
@@ -359,7 +405,7 @@ async def generate_online_sample(
     request = render_request(prompt_template, context={**row, "item": row, **(template_context or {})})
     if isinstance(target, Model):
         model_params = params if isinstance(params, RunConfigOnlineModel) else None
-        _maybe_set_nim_default_max_tokens(request=request, model=target, params=model_params)
+        _maybe_set_default_max_tokens(request=request, params=model_params)
     request = inference.preprocess_request(request, list(preprocess_hooks or ()), id=str(index))
 
     max_retries = params.max_retries if params is not None else 3
@@ -822,6 +868,31 @@ async def evaluate_metric(
         log.warning("No rows found in dataset, returning empty evaluation result")
         return empty_evaluation_result()
 
+    # Scope endpoint structured-output detection to this run so probes are cached across rows
+    # without leaking a result (or a transient failure) into the next run.
+    async with structured_output_mode_session():
+        return await _evaluate_metric_in_session(
+            metric=metric,
+            rows=rows,
+            target=target,
+            prompt_template=prompt_template,
+            params=params,
+            preprocess_hooks=preprocess_hooks,
+            postprocess_hooks=postprocess_hooks,
+        )
+
+
+async def _evaluate_metric_in_session(
+    *,
+    metric: Metric,
+    rows: list[dict[str, Any]],
+    target: Model | Agent | None,
+    prompt_template: str | dict[str, Any] | None,
+    params: RunConfig | RunConfigOnline | RunConfigOnlineModel | None,
+    preprocess_hooks: Sequence[inference.PreprocessRequest] | None,
+    postprocess_hooks: Sequence[inference.PostprocessResponse] | None,
+) -> EvaluationResult:
+    """Body of :func:`evaluate_metric`, run inside a structured-output detection session."""
     params = resolve_params(params, target)
 
     client_close_fn = None
@@ -836,6 +907,12 @@ async def evaluate_metric(
         params = cast(RunConfigOnlineModel, params)
         inference_fn = (
             metric.inference_fn if isinstance(metric, InferenceMetricBase) else inference.make_inference_request
+        )
+        await resolve_target_structured_output_mode(
+            preprocess_hooks=merged_preprocess_hooks,
+            model=target,
+            inference_fn=inference_fn,
+            params=params,
         )
         resolved_prompt_template = _resolve_online_prompt_template(prompt_template, target, rows[0])
         client = inference.new_inference_client(target)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/metric_execution.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/execution/metric_execution.py
@@ -48,7 +48,11 @@ from nemo_platform.beta.evaluator.metrics.protocol import (
 from nemo_platform.beta.evaluator.metrics.utils import metric_type_name
 from nemo_platform.beta.evaluator.resilience.api import run_indexed_tasks, use_resilience_session
 from nemo_platform.beta.evaluator.resilience.errors import get_evaluation_error
-from nemo_platform.beta.evaluator.structured_output import structured_output_mode_session
+from nemo_platform.beta.evaluator.session import begin_evaluation_session
+from nemo_platform.beta.evaluator.structured_output import (
+    InferenceStructuredOutput,
+    detect_structured_output_mode,
+)
 from nemo_platform.beta.evaluator.templates import render_request
 from nemo_platform.beta.evaluator.values import (
     Agent,
@@ -265,25 +269,11 @@ async def resolve_target_structured_output_mode(
     inference_fn: inference.InferenceFn,
     params: RunConfig | RunConfigOnline | RunConfigOnlineModel | None,
 ) -> None:
-    """Probe the target endpoint so generation uses an encoding it actually honours.
+    """Probe the target endpoint and set the generation hook's encoding.
 
-    The judge has its own preflight; target generation had none, and previously relied on the
-    model's ``format`` label to pick an encoding. That label is deprecated and ignored, so without
-    this probe a target that only accepts ``nvext.guided_json`` would be sent ``response_format``
-    and either reject the request or silently drop the constraint.
-
-    Only the hook built from ``params.structured_output`` is retuned. A caller that hand-builds an
-    InferenceStructuredOutput and splices it in via ``preprocess_hooks`` has chosen a mode
-    deliberately, and silently overriding that choice would be surprising; ``_merge_online_hooks``
-    places the run-level hook ahead of caller-supplied ones, so the first match is ours.
-
-    Like the judge's own preflight, this runs before ``use_resilience_session()`` opens, so probe
-    attempts use the process-global scheduler and do not appear in the session summary. Detection
-    itself is cached per endpoint for the run, so a Model used as both target and judge is probed
-    once, not once per role.
+    Only the hook built from ``params.structured_output`` is retuned; a caller that supplies its own
+    InferenceStructuredOutput has chosen a mode deliberately.
     """
-    from nemo_platform.beta.evaluator.structured_output import InferenceStructuredOutput, detect_structured_output_mode
-
     if not (isinstance(params, RunConfigOnlineModel) and params.structured_output):
         return
 
@@ -308,13 +298,7 @@ def _maybe_set_default_max_tokens(
     request: dict[str, Any],
     params: RunConfigOnlineModel | None,
 ) -> None:
-    """Apply the default max token cap when neither params nor request set one.
-
-    This was previously applied only to ``nim``-format models. Model format is deprecated and no
-    longer distinguishes endpoints, so the cap is unconditional: an unbounded generation against a
-    reasoning-capable judge is a cost risk on any endpoint, and callers that want more can set
-    ``max_tokens`` or ``max_completion_tokens`` explicitly.
-    """
+    """Apply the default max token cap when neither params nor request set one."""
     inference_params = params.inference if isinstance(params, RunConfigOnlineModel) else None
     if inference_params is not None and (
         inference_params.max_tokens is not None or inference_params.max_completion_tokens is not None
@@ -868,9 +852,7 @@ async def evaluate_metric(
         log.warning("No rows found in dataset, returning empty evaluation result")
         return empty_evaluation_result()
 
-    # Scope endpoint structured-output detection to this run so probes are cached across rows
-    # without leaking a result (or a transient failure) into the next run.
-    async with structured_output_mode_session():
+    async with begin_evaluation_session():
         return await _evaluate_metric_in_session(
             metric=metric,
             rows=rows,
@@ -892,7 +874,6 @@ async def _evaluate_metric_in_session(
     preprocess_hooks: Sequence[inference.PreprocessRequest] | None,
     postprocess_hooks: Sequence[inference.PostprocessResponse] | None,
 ) -> EvaluationResult:
-    """Body of :func:`evaluate_metric`, run inside a structured-output detection session."""
     params = resolve_params(params, target)
 
     client_close_fn = None

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/inference.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/inference.py
@@ -238,11 +238,17 @@ class TransformReasoningOutput(PostprocessResponse):
 
 def new_hooks(
     params: InferenceHookParams | None,
-    model_format: ModelFormat | None = ModelFormat.NVIDIA_NIM,
+    model_format: ModelFormat | None = None,
     logger: logging.Logger | None = None,
 ) -> tuple[list[PreprocessRequest], list[PostprocessResponse]]:
-    """Build the standard online generation hooks used by SDK and service flows."""
+    """Build the standard online generation hooks used by SDK and service flows.
+
+    ``model_format`` is deprecated and ignored. The structured output mode set here is only a
+    starting point; preflight detection replaces it with whatever the endpoint actually honours.
+    """
     from nemo_platform.beta.evaluator.structured_output import InferenceStructuredOutput, default_structured_output_mode
+
+    _ = model_format  # Deprecated: retained so existing callers keep working.
 
     log_hook = LogHook(logger)
     preprocess_hooks: list[PreprocessRequest] = []
@@ -258,8 +264,11 @@ def new_hooks(
     if params and params.structured_output:
         preprocess_hooks.append(
             InferenceStructuredOutput(
-                default_structured_output_mode(model_format or "nim"),
+                default_structured_output_mode(),
                 params.structured_output,
+                # Provisional: the endpoint has not been probed yet. Marking it unresolved makes a
+                # generation path that never probes warn instead of silently emitting this guess.
+                resolved=False,
             )
         )
 
@@ -306,7 +315,8 @@ async def make_inference_request(
     """
     Helper to run inference on a model with a given prompt.
 
-    Only OpenAI format is supported (nim and openai formats).
+    Requests use the OpenAI-compatible wire format. ``Model.format`` is deprecated and has no
+    effect here; structured output support is probed from the endpoint.
 
     Args:
         model: The Model to run inference on.

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/llm_judge.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/llm_judge.py
@@ -3,12 +3,12 @@
 
 """LLM judge metric runtime implementation."""
 
+import asyncio
 import logging
 from copy import copy, deepcopy
 from typing import Any, Literal, Protocol, Self
 
 import nemo_platform.beta.evaluator.inference as inference
-from nemo_platform.beta.evaluator.enums import ModelFormat
 from nemo_platform.beta.evaluator.inference import InferenceFn, InferenceHookParams
 from nemo_platform.beta.evaluator.inference import new_hooks as _new_inference_hooks
 from nemo_platform.beta.evaluator.metrics.hooks import HooksBase
@@ -78,6 +78,7 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
     _use_max_completion_tokens: bool = False
     _api_key: str | None = None
     _client: AsyncOpenAI | None = PrivateAttr(default=None)
+    _preflight_lock: asyncio.Lock | None = PrivateAttr(default=None)
     _inference_fn: InferenceFn | None = None
     _parsers: dict[str, ScoreParser] = PrivateAttr(default_factory=dict)
     _score_dumps: dict[str, dict[str, Any]] = PrivateAttr(default_factory=dict)
@@ -121,12 +122,13 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
                 {
                     k: v
                     for k, v in self.__pydantic_private__.items()
-                    if v is not PydanticUndefined and k not in {"_client", "_api_key"}
+                    if v is not PydanticUndefined and k not in {"_client", "_api_key", "_preflight_lock"}
                 },
                 memo=memo,
             )
             private_attrs["_client"] = None
             private_attrs["_api_key"] = None
+            private_attrs["_preflight_lock"] = None
             object.__setattr__(m, "__pydantic_private__", private_attrs)
 
         return m
@@ -198,6 +200,14 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
         await resolve_model_refs(self, model_resolver)
         self._client = None
         self._api_key = None
+        # `_preflight_lock` is deliberately NOT reset here. Clearing it would split preflight
+        # synchronisation while a concurrent compute_scores() is mid-probe: a second scorer would
+        # build a new lock, and an in-flight scorer could then render through the freshly rebuilt
+        # unresolved hook and send a guessed encoding with only a warning. A lock retained from a
+        # previous event loop instead fails loudly on its next contended acquire, and both cases
+        # require resolving models while scoring with the same metric object, which is unsupported:
+        # resolution is preparation-time, before evaluation starts. A loud failure beats a silent
+        # unprobed request in a change whose whole purpose is removing silent degradation.
         self._ensure_default_prompt_template()
         preprocess_hooks, postprocess_hooks = new_hooks(self)
         self.with_hooks(preprocess=preprocess_hooks, postprocess=postprocess_hooks)
@@ -219,7 +229,7 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
     async def preflight(self) -> None:
         """Resolve structured-output mode once before parallel inference starts."""
         model = self._require_model()
-        if model.format != ModelFormat.NVIDIA_NIM or not self.structured_output:
+        if not self.structured_output:
             return
 
         structured_hook: InferenceStructuredOutput | None = None
@@ -232,19 +242,26 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
             return
 
         mode = await detect_structured_output_mode(
-            format=model.format,
             model=model,
             inference_fn=self.inference_fn,
             api_key=self._api_key,
-            probe_schema={
-                "type": "object",
-                "properties": {"__nmp_probe_score": {"type": "integer"}},
-                "required": ["__nmp_probe_score"],
-                "additionalProperties": False,
-            },
         )
         structured_hook.set_mode(mode)
-        _logger.info("NIM structured output mode selected: %s", mode.value)
+        _logger.info("Structured output mode selected for %s: %s", model.name, mode.value)
+
+    def _require_preflight_lock(self) -> asyncio.Lock:
+        """Return this metric's preflight lock, created on first use.
+
+        Built lazily rather than as a field default so the metric stays deep-copyable and does not
+        bind a lock to an event loop at construction time.
+        """
+        if self._preflight_lock is None:
+            self._preflight_lock = asyncio.Lock()
+        return self._preflight_lock
+
+    def _has_unresolved_structured_output_hook(self) -> bool:
+        """Return whether a structured-output hook is still carrying an unprobed default."""
+        return any(isinstance(hook, InferenceStructuredOutput) and not hook.resolved for hook in self._preprocess_hooks)
 
     def secrets(self) -> dict[str, SecretRef]:
         """Return secret env mappings required by this metric."""
@@ -340,6 +357,18 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
         """Compute structured score output for one item/sample pair."""
+        # Executors call preflight() before scoring, but this is public API: a caller can build the
+        # metric and score with it directly, and then nothing would have probed the endpoint. Detect
+        # on first use so the encoding is never a guess.
+        #
+        # Locked and re-checked because a direct caller may gather many compute_scores() at once
+        # with no run session to cache detection: without this, every one of them would see an
+        # unresolved hook and probe the same endpoint concurrently.
+        if self._has_unresolved_structured_output_hook():
+            async with self._require_preflight_lock():
+                if self._has_unresolved_structured_output_hook():
+                    await self.preflight()
+
         item = input.row.data
         sample = input.candidate
         request = self._render_request(item, sample)
@@ -392,8 +421,7 @@ def _selected_rubric_label(score: MetricScore) -> str | None:
 
 def new_hooks(params: _LLMJudgeHookParams | None):
     """Initialize preprocess and postprocess hooks for the LLM judge."""
-    model_format = params.model.format if params and isinstance(params.model, Model) else ModelFormat.NVIDIA_NIM
-    return _new_inference_hooks(params, model_format=model_format)
+    return _new_inference_hooks(params)
 
 
 def generate_structured_output(params: _LLMJudgeHookParams) -> dict | None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/llm_judge.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/metrics/llm_judge.py
@@ -200,14 +200,8 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
         await resolve_model_refs(self, model_resolver)
         self._client = None
         self._api_key = None
-        # `_preflight_lock` is deliberately NOT reset here. Clearing it would split preflight
-        # synchronisation while a concurrent compute_scores() is mid-probe: a second scorer would
-        # build a new lock, and an in-flight scorer could then render through the freshly rebuilt
-        # unresolved hook and send a guessed encoding with only a warning. A lock retained from a
-        # previous event loop instead fails loudly on its next contended acquire, and both cases
-        # require resolving models while scoring with the same metric object, which is unsupported:
-        # resolution is preparation-time, before evaluation starts. A loud failure beats a silent
-        # unprobed request in a change whose whole purpose is removing silent degradation.
+        # `_preflight_lock` is deliberately not reset: clearing it mid-run would split preflight
+        # synchronisation and let an in-flight scorer send an unprobed request.
         self._ensure_default_prompt_template()
         preprocess_hooks, postprocess_hooks = new_hooks(self)
         self.with_hooks(preprocess=preprocess_hooks, postprocess=postprocess_hooks)
@@ -250,11 +244,7 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
         _logger.info("Structured output mode selected for %s: %s", model.name, mode.value)
 
     def _require_preflight_lock(self) -> asyncio.Lock:
-        """Return this metric's preflight lock, created on first use.
-
-        Built lazily rather than as a field default so the metric stays deep-copyable and does not
-        bind a lock to an event loop at construction time.
-        """
+        """Return this metric's preflight lock, created lazily to keep the metric deep-copyable."""
         if self._preflight_lock is None:
             self._preflight_lock = asyncio.Lock()
         return self._preflight_lock
@@ -357,13 +347,8 @@ class LLMJudgeMetric(HooksBase, LLMJudge):
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
         """Compute structured score output for one item/sample pair."""
-        # Executors call preflight() before scoring, but this is public API: a caller can build the
-        # metric and score with it directly, and then nothing would have probed the endpoint. Detect
-        # on first use so the encoding is never a guess.
-        #
-        # Locked and re-checked because a direct caller may gather many compute_scores() at once
-        # with no run session to cache detection: without this, every one of them would see an
-        # unresolved hook and probe the same endpoint concurrently.
+        # Public API: a caller may score without an executor having run preflight. Locked because
+        # concurrent direct callers would otherwise each probe the same endpoint.
         if self._has_unresolved_structured_output_hook():
             async with self._require_preflight_lock():
                 if self._has_unresolved_structured_output_hook():

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/session.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/session.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run-scoped cache shared by everything participating in one evaluation."""
+
+import asyncio
+from collections.abc import AsyncIterator, Hashable
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+from typing import Any
+
+_CACHE: ContextVar[dict[Hashable, Any] | None] = ContextVar("evaluation_session_cache", default=None)
+_LOCK: ContextVar[asyncio.Lock | None] = ContextVar("evaluation_session_lock", default=None)
+
+
+@asynccontextmanager
+async def begin_evaluation_session() -> AsyncIterator[None]:
+    """Scope cached evaluation state to one run.
+
+    Entries live only inside this boundary, which is what makes caching a failed result safe: a
+    transient failure is retried by the next run instead of persisting for the life of the process.
+    Outside a session nothing is cached and every caller recomputes.
+
+    Re-entrant. Entry points nest -- a backend opens a session, then the metric executor opens
+    another -- and a fresh inner cache would recompute what the run already resolved.
+    """
+    if _CACHE.get() is not None:
+        yield
+        return
+
+    cache_token = _CACHE.set({})
+    lock_token = _LOCK.set(asyncio.Lock())
+    try:
+        yield
+    finally:
+        _CACHE.reset(cache_token)
+        _LOCK.reset(lock_token)
+
+
+def session_cache() -> dict[Hashable, Any] | None:
+    """Return the active run's cache, or None outside a session."""
+    return _CACHE.get()
+
+
+def session_lock() -> asyncio.Lock:
+    """Return the active run's lock, or a throwaway one outside a session."""
+    return _LOCK.get() or asyncio.Lock()

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/structured_output.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/structured_output.py
@@ -1,13 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import copy
 import json
 import logging
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
-from contextvars import ContextVar
 from enum import Enum
 
 from jsonschema.exceptions import SchemaError
@@ -15,19 +11,13 @@ from jsonschema.validators import validator_for
 from pydantic import BaseModel, Field, field_validator
 
 from nemo_platform.beta.evaluator.inference import InferenceFn, PreprocessRequest, deep_merge
+from nemo_platform.beta.evaluator.session import session_cache, session_lock
 from nemo_platform.beta.evaluator.values import Model
 
 _logger = logging.getLogger(__name__)
 
-#: Schema used to probe an endpoint for structured output support. The marker property name is
-#: deliberately unguessable: the probe never shows the schema to the model, so a mode only passes
-#: when the server actually injected the grammar. Shared by every probing call site so that the
-#: judge path and the target-generation path agree on what a probe request looks like.
-#:
-#: Never pass this object directly into a request-building path; use :func:`_default_probe_schema`.
-#: Pydantic copies only the top level when validating, so the nested ``properties`` dict would stay
-#: shared with the request payload, and a later mutation of that payload would silently corrupt this
-#: constant for every probe in the process.
+#: The marker name must stay unguessable: the probe never shows this schema to the model, so a
+#: mode only passes when the server actually injected the grammar.
 _DEFAULT_PROBE_SCHEMA: dict = {
     "type": "object",
     "properties": {"__nmp_probe_score": {"type": "integer"}},
@@ -37,7 +27,7 @@ _DEFAULT_PROBE_SCHEMA: dict = {
 
 
 def _default_probe_schema() -> dict:
-    """Return a fresh copy of the endpoint probe schema."""
+    """Return a fresh copy; the constant must never reach a request payload."""
     return copy.deepcopy(_DEFAULT_PROBE_SCHEMA)
 
 
@@ -70,9 +60,8 @@ class InferenceStructuredOutput(PreprocessRequest):
         Args:
             mode: Structured output encoding to emit.
             structured_output: ``{"schema": ..., "strict": ...}`` payload.
-            resolved: Whether ``mode`` reflects what the endpoint actually accepts. Callers that
-                pass a provisional default must set this False so that using the hook without
-                probing is reported instead of silently emitting a guessed encoding.
+            resolved: Whether ``mode`` reflects a real endpoint probe. Callers passing a
+                provisional default must set this False so unprobed use is reported.
         """
         if not structured_output:
             raise ValueError("structured_output cannot be empty")
@@ -138,10 +127,7 @@ class InferenceStructuredOutput(PreprocessRequest):
     def preprocess(self, request: dict, id: str | None = None) -> dict:
         _ = id  # Required by preprocess hook interface.
         if not self._resolved and not self._warned_unresolved:
-            # Warn once per hook rather than per row. A generation path that builds this hook and
-            # never probes sends a guessed encoding, which an endpoint may silently ignore -- the
-            # structured output constraint then disappears with no other signal. Every first-party
-            # path probes; this exists so a new or forgotten one is visible instead of silent.
+            # Once per hook, not per row.
             self._warned_unresolved = True
             _logger.warning(
                 "Structured output encoding was never resolved against the endpoint; sending %s as "
@@ -157,14 +143,11 @@ class InferenceStructuredOutput(PreprocessRequest):
 
 
 def default_structured_output_mode(format: str | None = None) -> StructuredOutputMode:
-    """Return the pre-detection structured output mode.
+    """Return the provisional mode used before preflight probes the endpoint.
 
-    ``format`` is accepted for call compatibility and ignored: which structured output mode an
-    endpoint accepts is a property of the endpoint, not of the label attached to the model. The
-    OpenAI ``response_format`` field is the broadest-support starting point, and
-    :func:`detect_structured_output_mode` refines it during preflight.
+    ``format`` is accepted for compatibility and ignored.
     """
-    _ = format  # Deprecated: retained so existing callers keep working.
+    _ = format
     return StructuredOutputMode.OPENAI_RESPONSE_FORMAT
 
 
@@ -207,53 +190,6 @@ def _is_probe_valid_json(content: str, probe_schema: dict) -> bool:
         return False
 
 
-#: Detected mode per endpoint for the duration of one run, so a probe costs one round trip per
-#: endpoint instead of one per caller. Paths that build hooks per row (agent evaluation, the
-#: ProfBench judge) depend on this: without it they could not probe without a request per row.
-#:
-#: Run-scoped rather than process-global, which is what makes caching a negative result safe. A
-#: probe can fail for reasons unrelated to capability -- a rate limit, a 500, a network blip -- and
-#: a process-global negative would silently disable enforcement for that endpoint until restart.
-#: Bounded to a run, the same failure costs enforcement for one run and is re-probed by the next.
-#:
-#: Endpoint capability changing mid-process is rare and is NOT the motivation here.
-#:
-#: Entries are keyed on (url, name) only, so a session is assumed to be single-principal. The same
-#: (url, name) can route to different backends per principal through the inference gateway; a
-#: session that mixed credentials would reuse the first principal's result for the second. No
-#: first-party path does that today -- one run carries one credential -- and keying on the API key
-#: would put a secret in a cache key, so this is recorded as an assumption rather than defended
-#: against. Revisit if a run ever fans out across principals.
-_MODE_CACHE_VAR: ContextVar[dict[tuple[str, str], StructuredOutputMode] | None] = ContextVar(
-    "structured_output_mode_cache", default=None
-)
-_MODE_CACHE_LOCK_VAR: ContextVar[asyncio.Lock | None] = ContextVar("structured_output_mode_lock", default=None)
-
-
-@asynccontextmanager
-async def structured_output_mode_session() -> AsyncIterator[None]:
-    """Scope endpoint structured-output detection to one run.
-
-    Detection results are cached only inside this boundary. Outside one, every call probes, which
-    is correct but costs a round trip per caller -- open a session around a run to avoid that.
-
-    Re-entrant: opening a session inside another joins the outer one rather than shadowing it. Entry
-    points nest (a backend opens one around metric preparation, then evaluate_metric opens one of
-    its own), and a fresh inner cache would re-probe endpoints the outer run already resolved.
-    """
-    if _MODE_CACHE_VAR.get() is not None:
-        yield
-        return
-
-    cache_token = _MODE_CACHE_VAR.set({})
-    lock_token = _MODE_CACHE_LOCK_VAR.set(asyncio.Lock())
-    try:
-        yield
-    finally:
-        _MODE_CACHE_VAR.reset(cache_token)
-        _MODE_CACHE_LOCK_VAR.reset(lock_token)
-
-
 async def detect_structured_output_mode(
     *,
     format: str | None = None,
@@ -265,45 +201,29 @@ async def detect_structured_output_mode(
 ) -> StructuredOutputMode:
     """Detect the structured output mode an endpoint actually honours.
 
-    Every endpoint is probed with the same ordered candidate list regardless of the label on the
-    model, because support is a property of the endpoint: ``integrate.api.nvidia.com`` is served
-    under the ``nim`` label yet rejects ``nvext.guided_json`` and silently ignores root
-    ``guided_json``, while honouring OpenAI ``response_format``. Branching on the label caused that
-    endpoint to resolve to UNSUPPORTED and fall back to an unenforced prompt instruction.
+    Every endpoint is probed with the same ordered candidate list regardless of the model's label,
+    because support is a property of the endpoint. OpenAI ``response_format`` is tried first, then
+    the two ``guided_json`` placements. An endpoint accepting none falls back to a prompt-level
+    instruction, which is *not* enforced.
 
-    The OpenAI ``response_format`` field is probed first as the broadest-support option, then the
-    two legacy ``guided_json`` placements. An endpoint that accepts none of them falls back to a
-    prompt-level instruction, which is *not* enforced.
-
-    Results are cached per endpoint for the duration of the enclosing
-    :func:`structured_output_mode_session`; outside a session every call probes. Pass
-    ``use_cache=False`` to force a fresh probe inside one.
-
-    UNSUPPORTED is cached like any other result, which is only safe because the cache is
-    run-scoped: a transient probe failure costs enforcement for this run rather than until the
-    process restarts, and a genuinely unsupported endpoint costs three probes per run rather than
-    three per row.
-
-    ``format`` is accepted for call compatibility and ignored.
+    Results are cached for the enclosing :func:`begin_evaluation_session`. ``format`` is accepted
+    for compatibility and ignored.
     """
-    _ = format  # Deprecated: retained so existing callers keep working.
+    _ = format
 
-    cache = _MODE_CACHE_VAR.get() if use_cache else None
+    cache = session_cache() if use_cache else None
     if cache is None:
         return await _probe_structured_output_mode(
             model=model, inference_fn=inference_fn, api_key=api_key, probe_schema=probe_schema
         )
 
-    cache_key = (model.url, model.name)
+    # Keyed on the endpoint, not the credential: a session is assumed to be single-principal.
+    cache_key = ("structured_output_mode", model.url, model.name)
     cached = cache.get(cache_key)
     if cached is not None:
         return cached
 
-    lock = _MODE_CACHE_LOCK_VAR.get()
-    if lock is None:  # pragma: no cover - a session always sets both vars together
-        lock = asyncio.Lock()
-    async with lock:
-        # Re-check under the lock: concurrent rows would otherwise each probe the same endpoint.
+    async with session_lock():
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -324,23 +244,15 @@ async def _probe_structured_output_mode(
     """Probe an endpoint for the structured output encoding it honours, without consulting cache."""
     probe_schema = _default_probe_schema() if probe_schema is None else probe_schema
 
-    # The probe instructs the model to match "the provided schema" without ever showing it. A mode
-    # therefore only passes when the server actually injected the grammar; a capable model that is
-    # merely following the prompt cannot guess the schema's field names. Do not add the schema to
-    # probe_message -- every mode would then report success and enforcement would silently vanish.
+    # Must not name the schema: every mode would then pass and enforcement would silently vanish.
     probe_message = "Return ONLY a JSON object that matches the provided schema exactly. No prose or code fences."
     base_request = {
         "messages": [{"role": "user", "content": probe_message}],
         "temperature": 0,
         "max_tokens": 128,
     }
-    # Built through InferenceStructuredOutput so each probe sends the exact payload the hook would
-    # send in production; a divergence here would detect a mode that then fails during evaluation.
-    # A malformed probe_schema must degrade to the prompt-level fallback rather than abort startup.
-    # The hook gets its own deep copy: validation copies only the top level of a dict field, so the
-    # nested schema would otherwise stay shared with the outgoing request. `probe_schema` must stay
-    # unreachable from any request payload, since it is what the response is validated against --
-    # and it may be a caller's object, which this function has no business mutating either.
+    # Deep-copied so `probe_schema` stays unreachable from the request: Pydantic copies only a
+    # dict's top level, and `probe_schema` is what the response is validated against.
     try:
         probe = InferenceStructuredOutput(StructuredOutputMode.UNSUPPORTED, {"schema": copy.deepcopy(probe_schema)})
     except ValueError:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/structured_output.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/structured_output.py
@@ -16,6 +16,10 @@ from nemo_platform.beta.evaluator.values import Model
 
 _logger = logging.getLogger(__name__)
 
+#: Probes must survive a reasoning model's thinking budget; too small and truncated output looks
+#: identical to an endpoint that ignored the encoding.
+_PROBE_MAX_TOKENS = 4096
+
 #: The marker name must stay unguessable: the probe never shows this schema to the model, so a
 #: mode only passes when the server actually injected the grammar.
 _DEFAULT_PROBE_SCHEMA: dict = {
@@ -165,6 +169,14 @@ def _looks_like_unsupported_guided_json_error(message: str) -> bool:
     return False
 
 
+def _probe_was_truncated(response: dict) -> bool:
+    """Return whether the probe ran out of output budget before producing content."""
+    choices = response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return False
+    return choices[0].get("finish_reason") == "length"
+
+
 def _extract_chat_content(response: dict) -> str | None:
     choices = response.get("choices")
     if not isinstance(choices, list) or not choices:
@@ -249,7 +261,9 @@ async def _probe_structured_output_mode(
     base_request = {
         "messages": [{"role": "user", "content": probe_message}],
         "temperature": 0,
-        "max_tokens": 128,
+        # Generous because reasoning models spend most of a small budget thinking and return
+        # truncated or empty content, which is indistinguishable from an unhonoured encoding.
+        "max_tokens": _PROBE_MAX_TOKENS,
     }
     # Deep-copied so `probe_schema` stays unreachable from the request: Pydantic copies only a
     # dict's top level, and `probe_schema` is what the response is validated against.
@@ -270,6 +284,14 @@ async def _probe_structured_output_mode(
             content = _extract_chat_content(response)
             if content and _is_probe_valid_json(content, probe_schema):
                 return mode
+            if _probe_was_truncated(response):
+                _logger.warning(
+                    "Structured output probe for %s hit the %d-token budget, so support for %s "
+                    "could not be determined; enforcement may be dropped for this run.",
+                    model.name,
+                    _PROBE_MAX_TOKENS,
+                    mode.value,
+                )
         except Exception as e:
             if _looks_like_unsupported_guided_json_error(str(e)):
                 continue

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/structured_output.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/structured_output.py
@@ -1,16 +1,44 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+import copy
 import json
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from enum import Enum
 
 from jsonschema.exceptions import SchemaError
 from jsonschema.validators import validator_for
 from pydantic import BaseModel, Field, field_validator
 
-from nemo_platform.beta.evaluator.enums import ModelFormat
 from nemo_platform.beta.evaluator.inference import InferenceFn, PreprocessRequest, deep_merge
 from nemo_platform.beta.evaluator.values import Model
+
+_logger = logging.getLogger(__name__)
+
+#: Schema used to probe an endpoint for structured output support. The marker property name is
+#: deliberately unguessable: the probe never shows the schema to the model, so a mode only passes
+#: when the server actually injected the grammar. Shared by every probing call site so that the
+#: judge path and the target-generation path agree on what a probe request looks like.
+#:
+#: Never pass this object directly into a request-building path; use :func:`_default_probe_schema`.
+#: Pydantic copies only the top level when validating, so the nested ``properties`` dict would stay
+#: shared with the request payload, and a later mutation of that payload would silently corrupt this
+#: constant for every probe in the process.
+_DEFAULT_PROBE_SCHEMA: dict = {
+    "type": "object",
+    "properties": {"__nmp_probe_score": {"type": "integer"}},
+    "required": ["__nmp_probe_score"],
+    "additionalProperties": False,
+}
+
+
+def _default_probe_schema() -> dict:
+    """Return a fresh copy of the endpoint probe schema."""
+    return copy.deepcopy(_DEFAULT_PROBE_SCHEMA)
 
 
 class StructuredOutputMode(str, Enum):
@@ -36,7 +64,16 @@ class StructuredOutput(BaseModel):
 class InferenceStructuredOutput(PreprocessRequest):
     """Format structured output request parameters based on provider mode."""
 
-    def __init__(self, mode: StructuredOutputMode, structured_output: dict):
+    def __init__(self, mode: StructuredOutputMode, structured_output: dict, *, resolved: bool = True):
+        """Build the hook.
+
+        Args:
+            mode: Structured output encoding to emit.
+            structured_output: ``{"schema": ..., "strict": ...}`` payload.
+            resolved: Whether ``mode`` reflects what the endpoint actually accepts. Callers that
+                pass a provisional default must set this False so that using the hook without
+                probing is reported instead of silently emitting a guessed encoding.
+        """
         if not structured_output:
             raise ValueError("structured_output cannot be empty")
         try:
@@ -44,6 +81,8 @@ class InferenceStructuredOutput(PreprocessRequest):
             self._json_schema = output.json_schema
             self._strict = output.strict
             self.mode = mode
+            self._resolved = resolved
+            self._warned_unresolved = False
             self.inference_param = self._build_inference_param(mode)
         except SchemaError as e:
             raise ValueError("structured output contains invalid JSON schema") from e
@@ -52,8 +91,15 @@ class InferenceStructuredOutput(PreprocessRequest):
     def json_schema(self) -> dict:
         return self._json_schema
 
+    @property
+    def resolved(self) -> bool:
+        """Whether the mode reflects a real endpoint probe rather than a provisional default."""
+        return self._resolved
+
     def set_mode(self, mode: StructuredOutputMode) -> None:
+        """Set the encoding, marking it as reflecting a real endpoint probe."""
         self.mode = mode
+        self._resolved = True
         self.inference_param = self._build_inference_param(mode)
 
     def _build_inference_param(self, mode: StructuredOutputMode) -> dict:
@@ -91,19 +137,35 @@ class InferenceStructuredOutput(PreprocessRequest):
 
     def preprocess(self, request: dict, id: str | None = None) -> dict:
         _ = id  # Required by preprocess hook interface.
+        if not self._resolved and not self._warned_unresolved:
+            # Warn once per hook rather than per row. A generation path that builds this hook and
+            # never probes sends a guessed encoding, which an endpoint may silently ignore -- the
+            # structured output constraint then disappears with no other signal. Every first-party
+            # path probes; this exists so a new or forgotten one is visible instead of silent.
+            self._warned_unresolved = True
+            _logger.warning(
+                "Structured output encoding was never resolved against the endpoint; sending %s as "
+                "a guess. Call detect_structured_output_mode() (or "
+                "resolve_target_structured_output_mode()) before generating, or the constraint may "
+                "be silently dropped.",
+                self.mode.value,
+            )
         if self.mode == StructuredOutputMode.UNSUPPORTED:
             return self._apply_fallback_instruction(request)
         # Use merge instead of update to avoid overwriting nested dicts
         return deep_merge(request, self.inference_param)
 
 
-def default_structured_output_mode(format: str) -> StructuredOutputMode:
-    if format == ModelFormat.OPEN_AI:
-        return StructuredOutputMode.OPENAI_RESPONSE_FORMAT
-    if format == ModelFormat.NVIDIA_NIM:
-        # Backward-compatible default before preflight detection overrides this.
-        return StructuredOutputMode.NVEXT_GUIDED_JSON
-    raise ValueError(f"Unsupported structured output format: {format}")
+def default_structured_output_mode(format: str | None = None) -> StructuredOutputMode:
+    """Return the pre-detection structured output mode.
+
+    ``format`` is accepted for call compatibility and ignored: which structured output mode an
+    endpoint accepts is a property of the endpoint, not of the label attached to the model. The
+    OpenAI ``response_format`` field is the broadest-support starting point, and
+    :func:`detect_structured_output_mode` refines it during preflight.
+    """
+    _ = format  # Deprecated: retained so existing callers keep working.
+    return StructuredOutputMode.OPENAI_RESPONSE_FORMAT
 
 
 def _looks_like_unsupported_guided_json_error(message: str) -> bool:
@@ -145,33 +207,154 @@ def _is_probe_valid_json(content: str, probe_schema: dict) -> bool:
         return False
 
 
+#: Detected mode per endpoint for the duration of one run, so a probe costs one round trip per
+#: endpoint instead of one per caller. Paths that build hooks per row (agent evaluation, the
+#: ProfBench judge) depend on this: without it they could not probe without a request per row.
+#:
+#: Run-scoped rather than process-global, which is what makes caching a negative result safe. A
+#: probe can fail for reasons unrelated to capability -- a rate limit, a 500, a network blip -- and
+#: a process-global negative would silently disable enforcement for that endpoint until restart.
+#: Bounded to a run, the same failure costs enforcement for one run and is re-probed by the next.
+#:
+#: Endpoint capability changing mid-process is rare and is NOT the motivation here.
+#:
+#: Entries are keyed on (url, name) only, so a session is assumed to be single-principal. The same
+#: (url, name) can route to different backends per principal through the inference gateway; a
+#: session that mixed credentials would reuse the first principal's result for the second. No
+#: first-party path does that today -- one run carries one credential -- and keying on the API key
+#: would put a secret in a cache key, so this is recorded as an assumption rather than defended
+#: against. Revisit if a run ever fans out across principals.
+_MODE_CACHE_VAR: ContextVar[dict[tuple[str, str], StructuredOutputMode] | None] = ContextVar(
+    "structured_output_mode_cache", default=None
+)
+_MODE_CACHE_LOCK_VAR: ContextVar[asyncio.Lock | None] = ContextVar("structured_output_mode_lock", default=None)
+
+
+@asynccontextmanager
+async def structured_output_mode_session() -> AsyncIterator[None]:
+    """Scope endpoint structured-output detection to one run.
+
+    Detection results are cached only inside this boundary. Outside one, every call probes, which
+    is correct but costs a round trip per caller -- open a session around a run to avoid that.
+
+    Re-entrant: opening a session inside another joins the outer one rather than shadowing it. Entry
+    points nest (a backend opens one around metric preparation, then evaluate_metric opens one of
+    its own), and a fresh inner cache would re-probe endpoints the outer run already resolved.
+    """
+    if _MODE_CACHE_VAR.get() is not None:
+        yield
+        return
+
+    cache_token = _MODE_CACHE_VAR.set({})
+    lock_token = _MODE_CACHE_LOCK_VAR.set(asyncio.Lock())
+    try:
+        yield
+    finally:
+        _MODE_CACHE_VAR.reset(cache_token)
+        _MODE_CACHE_LOCK_VAR.reset(lock_token)
+
+
 async def detect_structured_output_mode(
     *,
-    format: str,
+    format: str | None = None,
     model: Model,
     inference_fn: InferenceFn,
     api_key: str | None,
-    probe_schema: dict,
+    probe_schema: dict | None = None,
+    use_cache: bool = True,
 ) -> StructuredOutputMode:
-    """Detect working structured output mode for the given model/format."""
-    if format == ModelFormat.OPEN_AI:
-        return StructuredOutputMode.OPENAI_RESPONSE_FORMAT
-    if format != ModelFormat.NVIDIA_NIM:
-        return StructuredOutputMode.UNSUPPORTED
+    """Detect the structured output mode an endpoint actually honours.
 
+    Every endpoint is probed with the same ordered candidate list regardless of the label on the
+    model, because support is a property of the endpoint: ``integrate.api.nvidia.com`` is served
+    under the ``nim`` label yet rejects ``nvext.guided_json`` and silently ignores root
+    ``guided_json``, while honouring OpenAI ``response_format``. Branching on the label caused that
+    endpoint to resolve to UNSUPPORTED and fall back to an unenforced prompt instruction.
+
+    The OpenAI ``response_format`` field is probed first as the broadest-support option, then the
+    two legacy ``guided_json`` placements. An endpoint that accepts none of them falls back to a
+    prompt-level instruction, which is *not* enforced.
+
+    Results are cached per endpoint for the duration of the enclosing
+    :func:`structured_output_mode_session`; outside a session every call probes. Pass
+    ``use_cache=False`` to force a fresh probe inside one.
+
+    UNSUPPORTED is cached like any other result, which is only safe because the cache is
+    run-scoped: a transient probe failure costs enforcement for this run rather than until the
+    process restarts, and a genuinely unsupported endpoint costs three probes per run rather than
+    three per row.
+
+    ``format`` is accepted for call compatibility and ignored.
+    """
+    _ = format  # Deprecated: retained so existing callers keep working.
+
+    cache = _MODE_CACHE_VAR.get() if use_cache else None
+    if cache is None:
+        return await _probe_structured_output_mode(
+            model=model, inference_fn=inference_fn, api_key=api_key, probe_schema=probe_schema
+        )
+
+    cache_key = (model.url, model.name)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    lock = _MODE_CACHE_LOCK_VAR.get()
+    if lock is None:  # pragma: no cover - a session always sets both vars together
+        lock = asyncio.Lock()
+    async with lock:
+        # Re-check under the lock: concurrent rows would otherwise each probe the same endpoint.
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+        mode = await _probe_structured_output_mode(
+            model=model, inference_fn=inference_fn, api_key=api_key, probe_schema=probe_schema
+        )
+        cache[cache_key] = mode
+        return mode
+
+
+async def _probe_structured_output_mode(
+    *,
+    model: Model,
+    inference_fn: InferenceFn,
+    api_key: str | None,
+    probe_schema: dict | None,
+) -> StructuredOutputMode:
+    """Probe an endpoint for the structured output encoding it honours, without consulting cache."""
+    probe_schema = _default_probe_schema() if probe_schema is None else probe_schema
+
+    # The probe instructs the model to match "the provided schema" without ever showing it. A mode
+    # therefore only passes when the server actually injected the grammar; a capable model that is
+    # merely following the prompt cannot guess the schema's field names. Do not add the schema to
+    # probe_message -- every mode would then report success and enforcement would silently vanish.
     probe_message = "Return ONLY a JSON object that matches the provided schema exactly. No prose or code fences."
     base_request = {
         "messages": [{"role": "user", "content": probe_message}],
         "temperature": 0,
         "max_tokens": 128,
     }
-    candidates: list[tuple[StructuredOutputMode, dict]] = [
-        (StructuredOutputMode.ROOT_GUIDED_JSON, {"extra_body": {"guided_json": probe_schema}}),
-        (StructuredOutputMode.NVEXT_GUIDED_JSON, {"extra_body": {"nvext": {"guided_json": probe_schema}}}),
+    # Built through InferenceStructuredOutput so each probe sends the exact payload the hook would
+    # send in production; a divergence here would detect a mode that then fails during evaluation.
+    # A malformed probe_schema must degrade to the prompt-level fallback rather than abort startup.
+    # The hook gets its own deep copy: validation copies only the top level of a dict field, so the
+    # nested schema would otherwise stay shared with the outgoing request. `probe_schema` must stay
+    # unreachable from any request payload, since it is what the response is validated against --
+    # and it may be a caller's object, which this function has no business mutating either.
+    try:
+        probe = InferenceStructuredOutput(StructuredOutputMode.UNSUPPORTED, {"schema": copy.deepcopy(probe_schema)})
+    except ValueError:
+        return StructuredOutputMode.UNSUPPORTED
+
+    candidates: list[StructuredOutputMode] = [
+        StructuredOutputMode.OPENAI_RESPONSE_FORMAT,
+        StructuredOutputMode.ROOT_GUIDED_JSON,
+        StructuredOutputMode.NVEXT_GUIDED_JSON,
     ]
-    for mode, structured_param in candidates:
+    for mode in candidates:
+        probe.set_mode(mode)
         try:
-            response = await inference_fn(model, {**base_request, **structured_param}, 1, api_key=api_key)
+            response = await inference_fn(model, {**base_request, **probe.inference_param}, 1, api_key=api_key)
             content = _extract_chat_content(response)
             if content and _is_probe_valid_json(content, probe_schema):
                 return mode

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/metrics.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/metrics.py
@@ -178,7 +178,6 @@ class LLMJudge(MetricBase):
                 "endpoint": "https://api.openai.com/v1",
                 "name": "gpt-4o",
                 "api_key_secret": "secret/my_openai_api_key",
-                "format": "openai",
             }
         ],
     )

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/models.py
@@ -128,7 +128,16 @@ class Model(BaseModel):
         description="API key secret reference for the model. Format: workspace/secret_name or secret_name within the job workspace.",
     )
     format: Literal[ModelFormat.NVIDIA_NIM, ModelFormat.OPEN_AI, ModelFormat.LLAMA_STACK] = Field(
-        default=ModelFormat.NVIDIA_NIM, description="API format of the model."
+        default=ModelFormat.OPEN_AI,
+        deprecated=(
+            "`format` is ignored and will be removed. Structured output support is detected from "
+            "the endpoint during preflight rather than inferred from this label."
+        ),
+        description=(
+            "Deprecated and ignored. Previously selected the structured output encoding; that is "
+            "now detected per endpoint, because support is a property of the endpoint rather than "
+            "of the label attached to the model."
+        ),
     )
 
     @field_validator("default_headers")

--- a/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/sdk-execution.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/skills/nemo-evaluator/references/sdk-execution.md
@@ -137,7 +137,6 @@ metric = ExactMatchMetric(reference="{{item.expected}}")
 target = Model(
     url="https://provider.example/v1",
     name="<model-id>",
-    format="openai",
     api_key_secret="<secret-or-env-name>",
 )
 
@@ -153,8 +152,9 @@ result = Evaluator().run_sync(
 )
 ```
 
-In `Model(...)`, `format` selects the provider/API protocol shape, such as
-OpenAI-compatible request and response handling. `api_key_secret` is a secret
+In `Model(...)`, `format` is deprecated and ignored; do not set it. Structured
+output support is detected from the endpoint during preflight rather than
+inferred from a label. `api_key_secret` is a secret
 reference name, not a literal secret value. For local SDK runs, ensure the
 matching local environment variable exists; for remote platform jobs, create a
 platform secret with the same name in the job workspace.
@@ -173,7 +173,6 @@ from nemo_evaluator_sdk import Evaluator, JSONScoreParser, LLMJudgeMetric, Model
 judge_model = Model(
     url="https://provider.example/v1",
     name="<judge-model-id>",
-    format="openai",
     api_key_secret="<secret-or-env-name>",
 )
 

--- a/skills/nemo-evaluator-plugin/assets/specs/llm_as_judge.json
+++ b/skills/nemo-evaluator-plugin/assets/specs/llm_as_judge.json
@@ -36,7 +36,7 @@
             "name": "nvidia/nemotron-3-super-120b-a12b",
             "host_url": null,
             "api_key_secret": "NVIDIA_API_KEY",
-            "format": "nim"
+            "format": "openai"
           },
           "scores": [
             {
@@ -84,7 +84,7 @@
           "ignore_request_failure": false,
           "job_type": "online"
         },
-        "digest": "f06c95859ec1b45d596a29b92a81e85c9b585fb850a42a26e2cd7fa9adb4003f",
+        "digest": "521535470f2c5cce64c4936a1bfcca39e5554e80e926f75cb6dbbcc9c8cd5d9c",
         "kind": "inline"
       }
     }
@@ -108,7 +108,7 @@
     "name": "nvidia/nemotron-3-super-120b-a12b",
     "host_url": null,
     "api_key_secret": "NVIDIA_API_KEY",
-    "format": "nim"
+    "format": "openai"
   },
   "prompt_template": {
     "messages": [

--- a/skills/nemo-evaluator-plugin/references/execution.md
+++ b/skills/nemo-evaluator-plugin/references/execution.md
@@ -104,7 +104,6 @@ from nemo_evaluator_sdk import (
 target = Model(
     url="https://provider.example/v1/chat/completions",
     name="<model-id>",
-    format="openai",
     api_key_secret=SecretRef(root="nvidia-api-key"),
 )
 

--- a/skills/nemo-evaluator-plugin/references/llm-judge.md
+++ b/skills/nemo-evaluator-plugin/references/llm-judge.md
@@ -21,7 +21,6 @@ judge = LLMJudgeMetric(
     model=Model(
         url="https://provider.example/v1/chat/completions",
         name="<judge-model-id>",
-        format="openai",
         api_key_secret=SecretRef(root="NVIDIA_API_KEY"),
     ),
     scores=[

--- a/skills/nemo-evaluator-plugin/scripts/generate_example_specs.py
+++ b/skills/nemo-evaluator-plugin/scripts/generate_example_specs.py
@@ -43,7 +43,6 @@ from nemo_evaluator_sdk import (
     RangeScore,
     SecretRef,
 )
-from nemo_evaluator_sdk.enums import ModelFormat
 
 SKILL_DIR = Path(__file__).resolve().parents[1]
 SPEC_DIR = SKILL_DIR / "assets" / "specs"
@@ -88,7 +87,6 @@ def build_llm_as_judge_spec() -> dict[str, Any]:
         url="https://integrate.api.nvidia.com/v1/chat/completions",
         name="nvidia/nemotron-3-super-120b-a12b",
         api_key_secret=SecretRef(root="NVIDIA_API_KEY"),
-        format=ModelFormat.NVIDIA_NIM,
     )
     judge = LLMJudgeMetric(
         model=model,


### PR DESCRIPTION
## Summary

Structured output mode was selected from `Model.format`, but support is a property of the endpoint, not of the label on the model. `integrate.api.nvidia.com` is served under the `nim` label yet rejects `nvext.guided_json` (400) and silently ignores root `guided_json`, while honouring OpenAI `response_format`. Preflight probed only the two `guided_json` placements for `nim`, resolved to `UNSUPPORTED`, and fell back to an unenforced "return JSON" prompt instruction. Judges kept scoring; nothing surfaced the downgrade.

Detection now probes every endpoint with the same ordered candidate list, `response_format` first. `Model.format` is deprecated, ignored, and defaults to `openai`.

## Changes

- `detect_structured_output_mode` probes all endpoints identically. Probe payloads are built through `InferenceStructuredOutput`, so a probe sends exactly what production sends.
- `Model.format` marked `deprecated`, default `nim` → `openai`; internal reads removed. Plugin `openapi.yaml` regenerated.
- New `session.py`: `begin_evaluation_session()`, a re-entrant run-scoped cache. Run scoping is what makes caching a *failed* probe safe — a transient failure dies with the run instead of persisting for the process.
- Five generation paths built a structured-output hook and issued requests without probing (target generation, agent evaluation, the multi-metric benchmark path, ProfBench, direct `compute_scores()`). All resolve first, and a hook used unresolved warns once so a future path is visible rather than silent.
- Probe budget raised from 128 tokens; a truncated probe now warns. See below — this was a live-only bug.
- The default `max_tokens=4096` cap was NIM-only; flipping the default format would have silently removed it. Now unconditional.
- Docs, skill references, the fabric notebook and the example-spec generator no longer instruct users to set `format`.

## Type of Change

- [x] Code change with documentation updates

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation updated for user-visible behavior

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation (rebased onto `main`, re-run after the rebase):

| Command | Result |
|---|---|
| `pytest packages/nemo_evaluator_sdk/tests` | 1674 passed, 10 skipped |
| `pytest plugins/nemo-evaluator/tests` (unit) | 837 passed |
| `pytest plugins/nemo-optimization/tests plugins/nemo-customizer/tests` | 105 passed |
| `uv run ruff check` / `ruff format --check` | clean |
| `tools/lint/lint-python-types.sh` | exit 0 |
| `make vendor` + `make refresh-openapi` | no drift against the rebased base |

New behavioural tests are mutation-verified: each was confirmed to fail with its corresponding fix removed.

`pre-commit run -a` is **not** fully green and the box is left unchecked. Three hooks fail for missing local toolchain, none governing a file in this diff: `Helm Docs` (binary absent; no `k8s/helm` changes), `uv-lock` (pins uv 0.9.14, local 0.9.30; no `pyproject.toml`/`uv.lock` changes, and the separate lock-drift check passes), `studio-lint-staged` (no pnpm shim; no `web/` changes). `tools/lint/lint-openapi.sh` needs `mapfile` (bash 4) on a bash 3.2 host; its check was reproduced portably — no drift across the committed specs.

### Live verification

Run against `integrate.api.nvidia.com`. Which encodings each model actually honours:

| Model | `response_format` | root `guided_json` | `nvext` |
|---|---|---|---|
| `meta/llama-3.3-70b-instruct` | yes | yes | ignored |
| `meta/llama-3.1-8b-instruct` | yes | yes | ignored |
| `nvidia/nemotron-3-nano-30b-a3b` | yes | ignored | ignored |
| `nvidia/llama-3.3-nemotron-super-49b-v1.5` | yes | ignored | ignored |

No model honoured `nvext.guided_json`, which is the encoding the old code chose for every `nim`-labelled model.

End-to-end judge with `format="nim"` explicitly set, confirming the label is ignored:

```
nvidia/nemotron-3-nano-30b-a3b  ->  openai_response_format   scores [4.0, 0.0]
meta/llama-3.1-8b-instruct      ->  openai_response_format   scores [nan, nan]
```

**Live testing found a bug that the unit tests could not.** The probe capped output at 128 tokens. Reasoning models spend that budget thinking and return truncated or empty content, which is indistinguishable from an endpoint ignoring the encoding — so every reasoning model resolved to `UNSUPPORTED` and silently lost enforcement:

```
nemotron-3-nano-30b-a3b       max_tokens=128   finish=length  reasoning=610ch  content='We need to output only a JSON…'
nemotron-3-nano-30b-a3b       max_tokens=2048  finish=stop    reasoning=2072ch content='{"__nmp_probe_score": 0}'
llama-3.3-nemotron-super-49b  max_tokens=128   finish=length  reasoning=592ch  content=''
llama-3.3-nemotron-super-49b  max_tokens=2048  finish=stop    reasoning=8281ch content='{"__nmp_probe_score": 0}'
```

A mocked probe always answers instantly, so no hermetic test could have caught this.

### Reviewer notes

1. **`RangeScore` produces NaN on `meta/llama-3.1-8b-instruct`.** Not this change: `RangeScore` derives an `integer` schema with `minimum`/`maximum`, and that model's grammar backend degenerates on it — emitting `{` followed by an unbounded run of tabs until it hits the token cap. The same schema typed as `number` returns `{"helpfulness": 4}`. Worth deciding whether `RangeScore` should derive `number`. Incidentally, the unconditional `max_tokens` cap is what bounds that runaway.
2. **`nvidia/nemotron-3-super-120b-a12b` is listed by `/v1/models` but 404s on chat completions.** Listed is not served — an argument for probing over any static capability table.
3. **The endpoint was unstable during testing** (404s, 500s, 504s, per-model timeouts). `meta/llama-3.3-70b-instruct` timed out at every budget including 128, so the raised probe budget is not the cause.
4. **`max_tokens`** — openai-format models that never set it now get a 4096 cap. Deliberate; may warrant a release note.
5. **Cache key is `(url, name)`**, so a session is assumed single-principal. No first-party path mixes credentials within a run, and keying on the API key would put a secret in a cache key. Recorded as an assumption in code.

### Deferred

- `new_hooks()` still returns a hook pre-set to a provisional encoding, with probing as a separate step each call site must remember — that shape is why five paths were missed. Making the hook unusable until probed is the structural fix; the warning is the interim mitigation.
- `nemo-optimization` still maps a user-facing `provider` onto `ModelFormat`, now a dead path.
- Probes run before `use_resilience_session()` opens, so they use the global scheduler and are absent from the session summary. Pre-existing; the judge's own preflight has always behaved this way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured-output support is detected directly from model endpoints during preflight.
  * Endpoint capabilities are cached during evaluations to reduce repeated probing.
  * Evaluation workflows now run preflight checks before scoring.

* **Bug Fixes**
  * Improved structured-output compatibility, including fallback handling.
  * Applied default token limits consistently across model types.
  * Prevented duplicate concurrent capability probes.

* **Documentation**
  * Updated examples to remove explicit model format configuration.
  * Marked the model format setting as deprecated and ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->