### PR TITLE
feat(studio): Create a reusable Stat Tile component

### DIFF
--- a/web/packages/common/src/components/StatTile/StatTile.stories.tsx
+++ b/web/packages/common/src/components/StatTile/StatTile.stories.tsx
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatTile, type StatTileProps } from '@nemo/common/src/components/StatTile/index';
+import { Grid } from '@nvidia/foundations-react-core';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof StatTile> = {
+  component: StatTile,
+  title: 'Studio Common/StatTile',
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StatTile>;
+
+export const Default: Story = {
+  args: {
+    label: 'Final Training Loss',
+    value: '0.6420',
+    hint: '-0.4600 from start',
+    hintStatus: 'success',
+  },
+};
+
+export const WithoutHint: Story = {
+  args: {
+    label: 'Steps Completed',
+    value: '1,240 / 2,000',
+  },
+};
+
+export const Unavailable: Story = {
+  args: {
+    label: 'Final Validation Loss',
+    value: '—',
+  },
+};
+
+export const HintStatuses: Story = {
+  render: () => (
+    <Grid cols={{ base: 1, md: 2, lg: 4 }} gap="density-xl">
+      <StatTile label="Success" value="0.6420" hint="-0.4600 from start" hintStatus="success" />
+      <StatTile label="Warning" value="4.1%" hint="hit length limit" hintStatus="warning" />
+      <StatTile label="Error" value="0.5800" hint="+0.1000 from start" hintStatus="error" />
+      <StatTile label="Neutral" value="18" hint="no change" hintStatus="neutral" />
+    </Grid>
+  ),
+};
+
+const SUMMARY_TILES: StatTileProps[] = [
+  {
+    label: 'Final Training Loss',
+    value: '0.6420',
+    hint: '-0.4600 from start',
+    hintStatus: 'success',
+  },
+  {
+    label: 'Final Validation Loss',
+    value: '0.5800',
+    hint: '+0.1000 from start',
+    hintStatus: 'error',
+  },
+  { label: 'Steps Completed', value: '1,240 / 2,000' },
+  { label: 'Epochs Completed', value: '2 / 3' },
+];
+
+export const AsARow: Story = {
+  render: () => (
+    <Grid cols={{ base: 1, md: 2, lg: 4 }} gap="density-xl">
+      {SUMMARY_TILES.map((tile) => (
+        <StatTile key={tile.label} {...tile} />
+      ))}
+    </Grid>
+  ),
+};

--- a/web/packages/common/src/components/StatTile/StatTile.stories.tsx
+++ b/web/packages/common/src/components/StatTile/StatTile.stories.tsx
@@ -37,6 +37,61 @@ export const Unavailable: Story = {
   },
 };
 
+export const WithTrailingLabel: Story = {
+  args: {
+    label: 'gen_kl_error',
+    value: '5.4e-4',
+    trailingLabel: 'ok',
+    trailingLabelStatus: 'success',
+    hint: 'flag above 1e-3',
+  },
+};
+
+export const TrailingLabelWarning: Story = {
+  args: {
+    label: 'approx_entropy',
+    value: '0.31',
+    trailingLabel: 'falling',
+    trailingLabelStatus: 'warning',
+    hint: 'entropy collapse risk',
+  },
+};
+
+export const DiagnosticsRow: Story = {
+  render: () => (
+    <Grid cols={{ base: 1, md: 2, lg: 4 }} gap="density-xl">
+      <StatTile
+        label="gen_kl_error"
+        value="5.4e-4"
+        trailingLabel="ok"
+        trailingLabelStatus="success"
+        hint="flag above 1e-3"
+      />
+      <StatTile
+        label="token_mult_prob_error"
+        value="0.4%"
+        trailingLabel="ok"
+        trailingLabelStatus="success"
+        hint="flag above 1-2%"
+      />
+      <StatTile
+        label="sampling_importance_ratio"
+        value="1.002"
+        trailingLabel="ok"
+        trailingLabelStatus="success"
+        hint="should hover near 1"
+      />
+      <StatTile
+        label="approx_entropy"
+        value="0.31"
+        trailingLabel="falling"
+        trailingLabelStatus="warning"
+        hint="entropy collapse risk"
+      />
+    </Grid>
+  ),
+};
+
 export const HintStatuses: Story = {
   render: () => (
     <Grid cols={{ base: 1, md: 2, lg: 4 }} gap="density-xl">

--- a/web/packages/common/src/components/StatTile/StatTile.test.tsx
+++ b/web/packages/common/src/components/StatTile/StatTile.test.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { StatTile } from '@nemo/common/src/components/StatTile';
+import { render, screen } from '@testing-library/react';
+
+describe('StatTile', () => {
+  it('renders the label and value', () => {
+    render(<StatTile label="Final training loss" value="0.1234" />);
+
+    expect(screen.getByText('Final training loss')).toBeInTheDocument();
+    expect(screen.getByText('0.1234')).toBeInTheDocument();
+  });
+
+  it('renders the hint only when provided', () => {
+    const { rerender } = render(
+      <StatTile label="Final training loss" value="0.1234" hint="-0.05 from start" />
+    );
+    expect(screen.getByText('-0.05 from start')).toBeInTheDocument();
+
+    rerender(<StatTile label="Final training loss" value="0.1234" />);
+    expect(screen.queryByText('-0.05 from start')).not.toBeInTheDocument();
+  });
+
+  it('applies the success hint status class when specified', () => {
+    render(
+      <StatTile label="Final training loss" value="0.1234" hint="-0.05" hintStatus="success" />
+    );
+
+    expect(screen.getByText('-0.05')).toHaveClass(
+      'text-[color:var(--text-color-feedback-success)]'
+    );
+  });
+
+  it('applies the warning hint status class when specified', () => {
+    render(
+      <StatTile label="Truncation Rate" value="4.1%" hint="hit length limit" hintStatus="warning" />
+    );
+
+    expect(screen.getByText('hit length limit')).toHaveClass(
+      'text-[color:var(--text-color-feedback-warning)]'
+    );
+  });
+
+  it('applies the error hint status class when specified', () => {
+    render(
+      <StatTile label="Final validation loss" value="0.9876" hint="+0.05" hintStatus="error" />
+    );
+
+    expect(screen.getByText('+0.05')).toHaveClass('text-[color:var(--text-color-feedback-danger)]');
+  });
+
+  it('renders the label in the same muted tone as an unstatused hint', () => {
+    render(<StatTile label="Learning Rate" value="1.00e-6" hint="at latest step" />);
+
+    expect(screen.getByText('Learning Rate')).toHaveClass('text-placeholder');
+    expect(screen.getByText('at latest step')).toHaveClass('text-placeholder');
+  });
+});

--- a/web/packages/common/src/components/StatTile/StatTile.test.tsx
+++ b/web/packages/common/src/components/StatTile/StatTile.test.tsx
@@ -12,6 +12,33 @@ describe('StatTile', () => {
     expect(screen.getByText('0.1234')).toBeInTheDocument();
   });
 
+  it('renders the trailing label only when provided', () => {
+    const { rerender } = render(
+      <StatTile label="gen_kl_error" value="5.4e-4" trailingLabel="ok" />
+    );
+    expect(screen.getByText('ok')).toBeInTheDocument();
+
+    rerender(<StatTile label="gen_kl_error" value="5.4e-4" />);
+    expect(screen.queryByText('ok')).not.toBeInTheDocument();
+  });
+
+  it('statuses the trailing label independently of the hint', () => {
+    render(
+      <StatTile
+        label="approx_entropy"
+        value="0.31"
+        trailingLabel="falling"
+        trailingLabelStatus="warning"
+        hint="entropy collapse risk"
+      />
+    );
+
+    expect(screen.getByText('falling')).toHaveClass(
+      'text-[color:var(--text-color-feedback-warning)]'
+    );
+    expect(screen.getByText('entropy collapse risk')).toHaveClass('text-placeholder');
+  });
+
   it('renders the hint only when provided', () => {
     const { rerender } = render(
       <StatTile label="Final training loss" value="0.1234" hint="-0.05 from start" />

--- a/web/packages/common/src/components/StatTile/index.tsx
+++ b/web/packages/common/src/components/StatTile/index.tsx
@@ -1,34 +1,55 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Panel, Stack, Text } from '@nvidia/foundations-react-core';
+import { Flex, Panel, Stack, Text } from '@nvidia/foundations-react-core';
 import { FC } from 'react';
+
+export type StatTileStatus = 'success' | 'warning' | 'error' | 'neutral';
 
 export interface StatTileProps {
   label: string;
   value: string;
+  trailingLabel?: string;
+  trailingLabelStatus?: StatTileStatus;
   hint?: string;
-  hintStatus?: 'success' | 'warning' | 'error' | 'neutral';
+  hintStatus?: StatTileStatus;
 }
 
 const MUTED_CLASS_NAME = 'text-placeholder';
 
-const HINT_STATUS_CLASS_NAME: Record<NonNullable<StatTileProps['hintStatus']>, string> = {
+const STATUS_CLASS_NAME: Record<StatTileStatus, string> = {
   success: 'text-[color:var(--text-color-feedback-success)]',
   warning: 'text-[color:var(--text-color-feedback-warning)]',
   error: 'text-[color:var(--text-color-feedback-danger)]',
   neutral: MUTED_CLASS_NAME,
 };
 
-export const StatTile: FC<StatTileProps> = ({ label, value, hint, hintStatus }) => (
+export const StatTile: FC<StatTileProps> = ({
+  label,
+  value,
+  trailingLabel,
+  trailingLabelStatus,
+  hint,
+  hintStatus,
+}) => (
   <Panel className="max-w-sm">
     <Stack gap="density-sm">
       <Text kind="body/regular/sm" className={MUTED_CLASS_NAME}>
         {label}
       </Text>
-      <Text kind="label/bold/2xl">{value}</Text>
+      <Flex align="baseline" gap="density-sm" wrap="wrap">
+        <Text kind="label/bold/2xl">{value}</Text>
+        {trailingLabel ? (
+          <Text
+            kind="body/regular/sm"
+            className={STATUS_CLASS_NAME[trailingLabelStatus ?? 'neutral']}
+          >
+            {trailingLabel}
+          </Text>
+        ) : null}
+      </Flex>
       {hint ? (
-        <Text kind="body/regular/sm" className={HINT_STATUS_CLASS_NAME[hintStatus ?? 'neutral']}>
+        <Text kind="body/regular/sm" className={STATUS_CLASS_NAME[hintStatus ?? 'neutral']}>
           {hint}
         </Text>
       ) : null}

--- a/web/packages/common/src/components/StatTile/index.tsx
+++ b/web/packages/common/src/components/StatTile/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Flex, Panel, Stack, Text } from '@nvidia/foundations-react-core';
-import { FC } from 'react';
+import type { FC } from 'react';
 
 export type StatTileStatus = 'success' | 'warning' | 'error' | 'neutral';
 

--- a/web/packages/common/src/components/StatTile/index.tsx
+++ b/web/packages/common/src/components/StatTile/index.tsx
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Panel, Stack, Text } from '@nvidia/foundations-react-core';
+import { FC } from 'react';
+
+export interface StatTileProps {
+  label: string;
+  value: string;
+  hint?: string;
+  hintStatus?: 'success' | 'warning' | 'error' | 'neutral';
+}
+
+const MUTED_CLASS_NAME = 'text-placeholder';
+
+const HINT_STATUS_CLASS_NAME: Record<NonNullable<StatTileProps['hintStatus']>, string> = {
+  success: 'text-[color:var(--text-color-feedback-success)]',
+  warning: 'text-[color:var(--text-color-feedback-warning)]',
+  error: 'text-[color:var(--text-color-feedback-danger)]',
+  neutral: MUTED_CLASS_NAME,
+};
+
+export const StatTile: FC<StatTileProps> = ({ label, value, hint, hintStatus }) => (
+  <Panel className="max-w-sm">
+    <Stack gap="density-sm">
+      <Text kind="body/regular/sm" className={MUTED_CLASS_NAME}>
+        {label}
+      </Text>
+      <Text kind="label/bold/2xl">{value}</Text>
+      {hint ? (
+        <Text kind="body/regular/sm" className={HINT_STATUS_CLASS_NAME[hintStatus ?? 'neutral']}>
+          {hint}
+        </Text>
+      ) : null}
+    </Stack>
+  </Panel>
+);


### PR DESCRIPTION
New component with storybook additions:
<img width="1586" height="188" alt="image" src="https://github.com/user-attachments/assets/6a19d3f5-5b06-4189-86e0-91f87f75be09" />
<img width="1590" height="165" alt="image" src="https://github.com/user-attachments/assets/1e6b3110-81fd-4c9d-b600-6e1653be7961" />














-----––––––––––––––––––––––––––-------------------------------------------------------------------------------
This is NOT used currently anywhere. The goal here is to be ready for upcoming Customizer Job Details changes and building the building blocks for that, proposed designs for reference:
 
<img width="1531" height="2290" alt="image" src="https://github.com/user-attachments/assets/d9819ed5-f09b-4350-b4fd-e11bca0ecfc4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable statistics tile for displaying labels, values, trailing labels, and optional hints.
  - Supports success, warning, error, and neutral status styling.
  - Provides responsive layouts for individual metrics and summary rows.
  - Added examples covering unavailable values, diagnostics, and hint statuses.

- **Tests**
  - Added coverage for content rendering, optional elements, status styling, and muted states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->