### PR TITLE
fix: add needed param for wheels and fix automodel build

### DIFF
--- a/.github/actions/build-policy-wasm/action.yaml
+++ b/.github/actions/build-policy-wasm/action.yaml
@@ -3,7 +3,13 @@ description: >
   Installs Flox, activates the OPA environment, and builds the authorization
   policy WASM asset at
   services/core/auth/src/nmp/core/auth/assets/policy.wasm. Assumes the
-  repository has already been checked out.
+  repository has already been checked out to `inputs.source-root`.
+
+inputs:
+  source-root:
+    description: Path to the checked-out NeMo Platform repository.
+    required: false
+    default: "."
 
 runs:
   using: composite
@@ -15,5 +21,5 @@ runs:
     - name: Build policy WASM
       uses: flox/activate-action@410568008895a0f2e09a34bbd9523f8ef1f2d292 # v1.1.0
       with:
-        dir: ./tools/open-policy-agent
+        dir: ${{ inputs.source-root }}/tools/open-policy-agent
         command: ./script/build_policy_wasm.sh

--- a/docker/automodel/Dockerfile.nmp-automodel-base
+++ b/docker/automodel/Dockerfile.nmp-automodel-base
@@ -75,7 +75,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     git checkout v1.1.4 && \
     git submodule update --init --recursive && \
     mkdir -p /source-distributions/nmp-automodel-base/git && \
-    git archive --format=tar.gz --output /source-distributions/nmp-automodel-base/git/grouped_gemm-v1.1.4.tar.gz HEAD && \
+    tar --exclude-vcs --create --gzip \
+      --file /source-distributions/nmp-automodel-base/git/grouped_gemm-v1.1.4.tar.gz . && \
     uv pip install --no-build-isolation --no-deps . && \
     rm -rf /tmp/grouped_gemm
 

--- a/docker/automodel/Dockerfile.nmp-automodel-base
+++ b/docker/automodel/Dockerfile.nmp-automodel-base
@@ -73,6 +73,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     git clone https://github.com/fanshiqing/grouped_gemm.git /tmp/grouped_gemm && \
     cd /tmp/grouped_gemm && \
     git checkout v1.1.4 && \
+    git submodule update --init --recursive && \
     mkdir -p /source-distributions/nmp-automodel-base/git && \
     git archive --format=tar.gz --output /source-distributions/nmp-automodel-base/git/grouped_gemm-v1.1.4.tar.gz HEAD && \
     uv pip install --no-build-isolation --no-deps . && \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
This adds an input for the source repo in the wheel build composite action. This is necessary to use the composite action in an external checkout. Additionally, a compilation failure from missing headers in the automodel container build is likely fixed with submodule checkout.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional source directory setting for policy builds, supporting repositories checked out in custom locations.

* **Bug Fixes**
  * Improved package setup by initializing required Git submodules before building and installing the component.
  * Updated source package creation to reliably include the required files without relying on repository archive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->