### PR TITLE
fix(auth): document access-key pagination params at the source

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -227,8 +227,10 @@ paths:
         schema:
           type: integer
           minimum: 1
+          description: Page number to retrieve.
           default: 1
           title: Page
+        description: Page number to retrieve.
       - name: page_size
         in: query
         required: false
@@ -236,8 +238,10 @@ paths:
           type: integer
           maximum: 100
           minimum: 1
+          description: Number of keys to retrieve per page.
           default: 100
           title: Page Size
+        description: Number of keys to retrieve per page.
       responses:
         '200':
           description: Successful Response

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -227,8 +227,10 @@ paths:
         schema:
           type: integer
           minimum: 1
+          description: Page number to retrieve.
           default: 1
           title: Page
+        description: Page number to retrieve.
       - name: page_size
         in: query
         required: false
@@ -236,8 +238,10 @@ paths:
           type: integer
           maximum: 100
           minimum: 1
+          description: Number of keys to retrieve per page.
           default: 100
           title: Page Size
+        description: Number of keys to retrieve per page.
       responses:
         '200':
           description: Successful Response

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -227,8 +227,10 @@ paths:
         schema:
           type: integer
           minimum: 1
+          description: Page number to retrieve.
           default: 1
           title: Page
+        description: Page number to retrieve.
       - name: page_size
         in: query
         required: false
@@ -236,8 +238,10 @@ paths:
           type: integer
           maximum: 100
           minimum: 1
+          description: Number of keys to retrieve per page.
           default: 100
           title: Page Size
+        description: Number of keys to retrieve per page.
       responses:
         '200':
           description: Successful Response

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -227,8 +227,10 @@ paths:
         schema:
           type: integer
           minimum: 1
+          description: Page number to retrieve.
           default: 1
           title: Page
+        description: Page number to retrieve.
       - name: page_size
         in: query
         required: false
@@ -236,8 +238,10 @@ paths:
           type: integer
           maximum: 100
           minimum: 1
+          description: Number of keys to retrieve per page.
           default: 100
           title: Page Size
+        description: Number of keys to retrieve per page.
       responses:
         '200':
           description: Successful Response
@@ -273,12 +277,12 @@ paths:
       - name: jti
         in: path
         required: true
-        description: Stable JWT ID of the Scoped Access Key to revoke.
         schema:
           type: string
           pattern: ^ak_[0-9a-f]{32}$
           description: Stable JWT ID of the Scoped Access Key to revoke.
           title: Jti
+        description: Stable JWT ID of the Scoped Access Key to revoke.
       responses:
         '200':
           description: Successful Response

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/access_keys/access_keys.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/access_keys/access_keys.py
@@ -32,7 +32,7 @@ from ..._response import (
     async_to_streamed_response_wrapper,
 )
 from ..._base_client import make_request_options
-from ...types.access_keys import access_key_create_params, access_key_list_params
+from ...types.access_keys import access_key_list_params, access_key_create_params
 from ...types.access_keys.access_key_list_response import AccessKeyListResponse
 from ...types.access_keys.access_key_create_response import AccessKeyCreateResponse
 from ...types.access_keys.access_key_revoke_response import AccessKeyRevokeResponse
@@ -147,7 +147,11 @@ class AccessKeysResource(SyncAPIResource):
                 extra_body=extra_body,
                 timeout=timeout,
                 query=maybe_transform(
-                    {"page": page, "page_size": page_size}, access_key_list_params.AccessKeyListParams
+                    {
+                        "page": page,
+                        "page_size": page_size,
+                    },
+                    access_key_list_params.AccessKeyListParams,
                 ),
             ),
             cast_to=AccessKeyListResponse,
@@ -296,7 +300,11 @@ class AsyncAccessKeysResource(AsyncAPIResource):
                 extra_body=extra_body,
                 timeout=timeout,
                 query=await async_maybe_transform(
-                    {"page": page, "page_size": page_size}, access_key_list_params.AccessKeyListParams
+                    {
+                        "page": page,
+                        "page_size": page_size,
+                    },
+                    access_key_list_params.AccessKeyListParams,
                 ),
             ),
             cast_to=AccessKeyListResponse,

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/__init__.py
@@ -17,8 +17,8 @@
 
 from __future__ import annotations
 
-from .access_key_create_params import AccessKeyCreateParams as AccessKeyCreateParams
 from .access_key_list_params import AccessKeyListParams as AccessKeyListParams
+from .access_key_create_params import AccessKeyCreateParams as AccessKeyCreateParams
 from .access_key_list_response import AccessKeyListResponse as AccessKeyListResponse
 from .access_key_create_response import AccessKeyCreateResponse as AccessKeyCreateResponse
 from .access_key_revoke_response import AccessKeyRevokeResponse as AccessKeyRevokeResponse

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_list_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_list_params.py
@@ -24,5 +24,7 @@ __all__ = ["AccessKeyListParams"]
 
 class AccessKeyListParams(TypedDict, total=False):
     page: int
+    """Page number to retrieve."""
 
     page_size: int
+    """Number of keys to retrieve per page."""

--- a/sdk/python/nemo-platform/tests/api_resources/test_access_keys.py
+++ b/sdk/python/nemo-platform/tests/api_resources/test_access_keys.py
@@ -83,7 +83,10 @@ class TestAccessKeys:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     def test_method_list_with_all_params(self, client: NeMoPlatform) -> None:
-        access_key = client.access_keys.list(page=2, page_size=25)
+        access_key = client.access_keys.list(
+            page=1,
+            page_size=1,
+        )
         assert_matches_type(AccessKeyListResponse, access_key, path=["response"])
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -112,7 +115,7 @@ class TestAccessKeys:
     @parametrize
     def test_method_delete(self, client: NeMoPlatform) -> None:
         access_key = client.access_keys.delete(
-            "jti",
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
         )
         assert_matches_type(AccessKeyRevokeResponse, access_key, path=["response"])
 
@@ -120,7 +123,7 @@ class TestAccessKeys:
     @parametrize
     def test_raw_response_delete(self, client: NeMoPlatform) -> None:
         response = client.access_keys.with_raw_response.delete(
-            "jti",
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
         )
 
         assert response.is_closed is True
@@ -132,7 +135,7 @@ class TestAccessKeys:
     @parametrize
     def test_streaming_response_delete(self, client: NeMoPlatform) -> None:
         with client.access_keys.with_streaming_response.delete(
-            "jti",
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -203,7 +206,10 @@ class TestAsyncAccessKeys:
     @pytest.mark.skip(reason="Mock server tests are disabled")
     @parametrize
     async def test_method_list_with_all_params(self, async_client: AsyncNeMoPlatform) -> None:
-        access_key = await async_client.access_keys.list(page=2, page_size=25)
+        access_key = await async_client.access_keys.list(
+            page=1,
+            page_size=1,
+        )
         assert_matches_type(AccessKeyListResponse, access_key, path=["response"])
 
     @pytest.mark.skip(reason="Mock server tests are disabled")
@@ -232,7 +238,7 @@ class TestAsyncAccessKeys:
     @parametrize
     async def test_method_delete(self, async_client: AsyncNeMoPlatform) -> None:
         access_key = await async_client.access_keys.delete(
-            "jti",
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
         )
         assert_matches_type(AccessKeyRevokeResponse, access_key, path=["response"])
 
@@ -240,7 +246,7 @@ class TestAsyncAccessKeys:
     @parametrize
     async def test_raw_response_delete(self, async_client: AsyncNeMoPlatform) -> None:
         response = await async_client.access_keys.with_raw_response.delete(
-            "jti",
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
         )
 
         assert response.is_closed is True
@@ -252,7 +258,7 @@ class TestAsyncAccessKeys:
     @parametrize
     async def test_streaming_response_delete(self, async_client: AsyncNeMoPlatform) -> None:
         async with async_client.access_keys.with_streaming_response.delete(
-            "jti",
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"

--- a/services/core/auth/src/nmp/core/auth/api/v2/access_keys/endpoints.py
+++ b/services/core/auth/src/nmp/core/auth/api/v2/access_keys/endpoints.py
@@ -117,8 +117,8 @@ async def create_access_key(
     responses=_ACCESS_KEY_LIFECYCLE_ERROR_RESPONSES,
 )
 async def list_access_keys(
-    page: int = Query(default=1, ge=1),
-    page_size: int = Query(default=100, ge=1, le=100),
+    page: int = Query(default=1, ge=1, description="Page number to retrieve."),
+    page_size: int = Query(default=100, ge=1, le=100, description="Number of keys to retrieve per page."),
     issuer: PersistentAccessKeyIssuer = Depends(get_access_key_issuer),
 ) -> schemas.AccessKeyListResponse | JSONResponse:
     try:

--- a/services/core/auth/tests/test_access_keys.py
+++ b/services/core/auth/tests/test_access_keys.py
@@ -348,13 +348,20 @@ def test_access_key_lifecycle_openapi_documents_error_responses(client):
 
     list_operation = openapi["paths"]["/v2/access-keys"]["get"]
     list_parameters = {parameter["name"]: parameter for parameter in list_operation["parameters"]}
-    assert list_parameters["page"]["schema"] == {"type": "integer", "minimum": 1, "default": 1, "title": "Page"}
+    assert list_parameters["page"]["schema"] == {
+        "type": "integer",
+        "minimum": 1,
+        "default": 1,
+        "title": "Page",
+        "description": "Page number to retrieve.",
+    }
     assert list_parameters["page_size"]["schema"] == {
         "type": "integer",
         "maximum": 100,
         "minimum": 1,
         "default": 100,
         "title": "Page Size",
+        "description": "Number of keys to retrieve per page.",
     }
     list_responses = list_operation["responses"]
     assert list_responses["200"]["content"]["application/json"]["schema"] == {


### PR DESCRIPTION
## Summary

The committed Stainless-generated Python SDK for `access_keys` did not match what Stainless produces from the current OpenAPI spec and config, so running `make update-sdk` on any unrelated branch silently rewrote three SDK files. The generated SDK had been hand-edited: `AccessKeysResource.list()` carried `Args:` docstrings for `page`/`page_size`, and the generated tests used example values (`page=2`, `page_size=25`, `"jti"`) that Stainless never emits for these schemas.

Stainless derives parameter documentation from the OpenAPI parameter `description`, and the route declared `Query(default=1, ge=1)` with no description — so regeneration was correctly dropping documentation the spec never carried. This adds the descriptions at the FastAPI route so they reach the spec and the SDK legitimately, then commits the true Stainless output.

**No behavioural regression existed.** `page` and `page_size` were always real parameters and always passed in the query; only the docstrings were at risk. The remaining SDK churn (multi-line dict formatting, import ordering, generated example values) is genuine Stainless output.

## Related Issue

AALGO-499

## Changes

- `services/core/auth/.../access_keys/endpoints.py` — add `description=` to the `page` and `page_size` `Query()` declarations on `list_access_keys`, using the wording the SDK previously documented so no user-visible docs are lost.
- `services/core/auth/tests/test_access_keys.py` — extend the OpenAPI contract assertions to pin the new parameter descriptions.
- `openapi/openapi.yaml`, `openapi/ga/openapi.yaml`, `openapi/ga/individual/platform.openapi.yaml` — regenerated.
- `sdk/python/nemo-platform/**` — regenerated via `sdk/stainless.sh sync`; the committed SDK is now byte-identical to Stainless output, and `.nmpcontext/openapi.yaml` matches the platform spec.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the user-visible documentation change is the SDK docstring itself, which is generated from the spec; there is no prose doc describing access-key pagination.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest services/core/auth/tests packages/nemo_platform_plugin/tests/auth packages/nmp_common/tests/auth -q` → **601 passed, 4 skipped**. The updated assertion was confirmed to fail before the fix and pass after.
- `(cd sdk/python/nemo-platform && uv run --frozen pytest tests/api_resources/test_access_keys.py -q)` → **48 skipped** (mock-server tests are disabled repo-wide).
- `tools/lint/lint-all.sh` → **15 passed, 2 failed**; both failures are local-toolchain only and were verified another way (see below).
- `tools/lint/lint-sdk-vendored.sh`, `tools/lint/lint-cli.sh`, `tools/lint/lint-python-sdk.sh` → all exit 0 against the committed tree.
- `sdk/stainless.sh sync` re-run against the updated spec leaves no further drift.

### Checks blocked locally (not marked as passed)

These fail on missing/mismatched local tooling, not on this change. None of them governs a file in this diff, and each underlying invariant was verified directly:

| Check | Why it failed here | How the invariant was verified instead |
|---|---|---|
| `lint-openapi` | `mapfile` is a bash 4+ builtin; macOS ships bash 3.2, so the script aborts at line 12 before doing any work | Ran `script/generate-openapi-spec.sh` directly — `git status` clean afterwards, so every spec is regen-stable |
| `lint-web-sdk` | local `pnpm` resolves to a broken `mise` shim, so `node "$(command -v pnpm)"` throws a `SyntaxError` | Ran `pnpm gen:check` inside the Flox Node env — "✅ All generated files are up to date" |
| `pre-commit: helm-docs` | `helm-docs` not installed locally | No Helm chart in this diff |
| `pre-commit: uv-lock` | pins uv 0.9.14; local uv is 0.9.30 | No `pyproject.toml` in this diff; the separate `uv-lock-check` drift hook passes |
| `pre-commit: studio-lint-staged` | same broken `mise`/`pnpm` shim | No web files in this diff |

All other `uv run pre-commit run -a` hooks pass, including `ruff`, `ruff format`, `ty`, config-reference-docs, and copyright headers.

## Follow-up worth considering (not in this PR)

The ticket suggested CI lacks a regenerate-and-diff drift check. Two already exist and both pass here — `lint-openapi` regenerates and diffs every spec, and `lint-python-sdk` diffs `.nmpcontext/{openapi,stainless}.yaml` against the platform sources. The real gap is narrower: `lint-python-sdk` compares only the generation **inputs**, and normalizes YAML with `sort_keys=True`, so a hand-edit to generated SDK **output** — exactly what happened here — is invisible to CI. Closing that needs a Stainless API key and a real build per PR, so it is a separate piece of work rather than a rider on this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear descriptions for the `page` and `page_size` pagination parameters when listing access keys.
  * Updated API documentation consistently across available specifications.

* **Tests**
  * Updated API documentation checks to verify pagination parameter descriptions.

* **Bug Fixes**
  * Improved clarity of access-key listing parameters without changing defaults or validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->