### PR TITLE
fix: patch PyTorch header for ARM64 DeepEP

### DIFF
--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -194,12 +194,22 @@ uv sync ${UV_SYNC_MODE} --no-install-project
 # https://github.com/pytorch/pytorch/commit/c2671b853e1553b258a30c15d66f9647faae7aee.
 # Remove this when the RL dependency stack moves to PyTorch 2.13 or later.
 torch_include=/opt/nemo_rl_venv/lib/python3.13/site-packages/torch/include
-test -f "${torch_include}/ATen/core/List_inl.h"
+list_inl="${torch_include}/ATen/core/List_inl.h"
+test -f "${list_inl}"
+# UV_LINK_MODE=symlink above leaves every venv file a symlink into UV_CACHE_DIR, and `git apply`
+# rejects a symlink target with "wrong type". Swap this one header for a private copy so the patch
+# lands in the venv alone: writing through the link would edit the shared cache mount, which other
+# targets reuse and which would then fail the --check below on every subsequent build.
+if [ -L "${list_inl}" ]; then
+    cached_list_inl="$(readlink -f "${list_inl}")"
+    rm "${list_inl}"
+    cp "${cached_list_inl}" "${list_inl}"
+fi
 git -C "${torch_include}" apply --check /opt/cherry-picks/pytorch-c2671b8-list-inl.diff
 git -C "${torch_include}" apply /opt/cherry-picks/pytorch-c2671b8-list-inl.diff
 grep -Fq \
     'typename c10::detail::ListImpl::list_type::difference_type' \
-    "${torch_include}/ATen/core/List_inl.h"
+    "${list_inl}"
 
 uv sync ${UV_SYNC_MODE} --extra vllm      --no-install-project   # GRPO generation (vllm 0.20 cu130 + flashinfer + deep_gemm/deep_ep)
 uv sync ${UV_SYNC_MODE} --extra fsdp      --no-install-project   # DPO/GRPO policy training (flash-attn, mamba-ssm, causal-conv1d)

--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -166,6 +166,7 @@ COPY --from=nemo-rl nemo_rl/__init__.py nemo_rl/package_info.py ./nemo_rl/
 COPY --from=nemo-rl --exclude=TensorRT-LLM-workspace --exclude=TensorRT-LLM-workspace/** \
      --exclude=**/.git 3rdparty/ ./3rdparty/
 COPY --from=nemo-rl research/ ./research/
+COPY docker/rl/cherry-picks /opt/cherry-picks
 
 # Default --frozen (reproducible). Gym is RL's own submodule, so its pin is always in lockstep with
 # RL's uv.lock. Set to "" to relock if you bump RL to a commit whose lock has drifted.
@@ -187,6 +188,19 @@ export UV_LINK_MODE=symlink
 uv venv --seed
 
 uv sync ${UV_SYNC_MODE} --no-install-project
+
+# PyTorch 2.11's List_inl.h uses a dependent decltype expression that nvcc from CUDA 13.3 rejects
+# while compiling DeepEP on arm64. Backport the equivalent type spelling from upstream commit
+# https://github.com/pytorch/pytorch/commit/c2671b853e1553b258a30c15d66f9647faae7aee.
+# Remove this when the RL dependency stack moves to PyTorch 2.13 or later.
+torch_include=/opt/nemo_rl_venv/lib/python3.13/site-packages/torch/include
+test -f "${torch_include}/ATen/core/List_inl.h"
+git -C "${torch_include}" apply --check /opt/cherry-picks/pytorch-c2671b8-list-inl.diff
+git -C "${torch_include}" apply /opt/cherry-picks/pytorch-c2671b8-list-inl.diff
+grep -Fq \
+    'typename c10::detail::ListImpl::list_type::difference_type' \
+    "${torch_include}/ATen/core/List_inl.h"
+
 uv sync ${UV_SYNC_MODE} --extra vllm      --no-install-project   # GRPO generation (vllm 0.20 cu130 + flashinfer + deep_gemm/deep_ep)
 uv sync ${UV_SYNC_MODE} --extra fsdp      --no-install-project   # DPO/GRPO policy training (flash-attn, mamba-ssm, causal-conv1d)
 uv sync ${UV_SYNC_MODE} --extra modelopt  --no-install-project   # quantization / model-opt

--- a/docker/rl/cherry-picks/pytorch-c2671b8-list-inl.diff
+++ b/docker/rl/cherry-picks/pytorch-c2671b8-list-inl.diff
@@ -1,0 +1,11 @@
+diff --git a/ATen/core/List_inl.h b/ATen/core/List_inl.h
+index f2d86fe..3e59737 100644
+--- a/ATen/core/List_inl.h
++++ b/ATen/core/List_inl.h
+@@ -198,5 +198,5 @@ typename List<T>::internal_const_reference_type List<T>::operator[](size_type po
+ template<class T>
+ typename List<T>::internal_reference_type List<T>::operator[](size_type pos) {
+   static_cast<void>(impl_->list.at(pos)); // Throw the exception if it is out of range.
+-  return {impl_->list.begin() + static_cast<typename decltype(impl_->list)::difference_type>(pos)};
++  return {impl_->list.begin() + static_cast<typename c10::detail::ListImpl::list_type::difference_type>(pos)};
+ }


### PR DESCRIPTION
## Summary

Backport PyTorch's upstream `List_inl.h` type-spelling fix so DeepEP can compile on ARM64 with CUDA 13.3 while keeping the existing PyTorch 2.11, vLLM 0.25.1, DeepEP, and NeMo-RL pins unchanged.

## Root cause

PyTorch 2.11 spells `List<T>::operator[]`'s iterator offset type through a dependent `decltype(impl_->list)::difference_type`. CUDA 13.3's nvcc rejects that expression while DeepEP builds on ARM64.

PyTorch corrected the header upstream in [c2671b8](https://github.com/pytorch/pytorch/commit/c2671b853e1553b258a30c15d66f9647faae7aee), but the fix is not present in PyTorch 2.11.

## Changes

- add the exact upstream `List_inl.h` correction as a small cherry-pick
- apply it after the base `uv sync` installs PyTorch and before the vLLM extra builds DeepEP
- use `git apply --check` so missing headers, changed context, or an already-applied patch fail loudly
- assert the corrected expression exists after applying the patch
- document removal when the RL stack moves to PyTorch 2.13 or later

No CUDA or dependency pins and no lockfiles change.

## Validation

- `git diff --check`
- applied the patch successfully against the exact PyTorch v2.11.0 `List_inl.h`
- `make docker-print TARGET=nmp-rl-base-builder`
- `make docker-print TARGET=nmp-rl-training`

The cache-free ARM64 image build and RL smoke test are intentionally left to CI rather than completed locally. This targets the failure in [Build Automodel Docker images](https://github.com/NVIDIA-NeMo/Platform-Deploy/actions/runs/31823327198/job/94841620610).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RL container builds by applying a targeted PyTorch compatibility patch during dependency setup.
  * Fixed iterator offset type handling in PyTorch list access to improve build and runtime compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->