### PR TITLE
fix(studio): create example agents against the current workspace

### DIFF
--- a/web/packages/studio/src/api/agents/loadSampleAgentConfig.test.ts
+++ b/web/packages/studio/src/api/agents/loadSampleAgentConfig.test.ts
@@ -34,6 +34,17 @@ mcp:
       url: /workspace/.venv/bin/email-phishing-analyzer-mcp
 `;
 
+const ATIF_TELEMETRY_YAML = `telemetry:
+  enabled: true
+  provider: relay
+  atif:
+    enabled: true
+    storage:
+      - type: http
+        endpoint: http://127.0.0.1:8080/apis/intake/v2/workspaces/default/ingest/atif
+        timeout_millis: 3000
+`;
+
 const mockFetchText = (body: string, ok = true) =>
   vi.spyOn(globalThis, 'fetch').mockResolvedValue({
     ok,
@@ -46,7 +57,7 @@ describe('loadSampleAgentConfig', () => {
 
   it('parses the YAML and injects the selected model, preserving the rest', async () => {
     mockFetchText(AGENT_YAML);
-    const config = (await loadSampleAgentConfig('sample-agents/x/agent.yml', 'my-model')) as {
+    const config = (await loadSampleAgentConfig('sample-agents/x/agent.yml', 'my-model', 'ws')) as {
       functions: Record<string, { _type: string }>;
       llms: { llm: { model_name: string; _type: string } };
       workflow: { _type: string };
@@ -59,7 +70,7 @@ describe('loadSampleAgentConfig', () => {
 
   it('throws when the config is missing llms.llm', async () => {
     mockFetchText('workflow:\n  _type: react_agent\n');
-    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(
+    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm', 'ws')).rejects.toThrow(
       /missing llms\.llm/
     );
   });
@@ -68,14 +79,14 @@ describe('loadSampleAgentConfig', () => {
     // A non-object llm (here a string) would otherwise crash the model_name
     // assignment with a TypeError instead of the clean guard error.
     mockFetchText('llms:\n  llm: some-string\n');
-    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(
+    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm', 'ws')).rejects.toThrow(
       /missing llms\.llm/
     );
   });
 
   it('injects the model into models.default for a Fabric config', async () => {
     mockFetchText(FABRIC_AGENT_YAML);
-    const config = (await loadSampleAgentConfig('sample-agents/x/agent.yml', 'my-model')) as {
+    const config = (await loadSampleAgentConfig('sample-agents/x/agent.yml', 'my-model', 'ws')) as {
       config_format: string;
       default_harness: string;
       models: { default: { model: string; provider: string } };
@@ -91,22 +102,65 @@ describe('loadSampleAgentConfig', () => {
 
   it('throws when a Fabric config is missing models.default', async () => {
     mockFetchText('config_format: nemo-agents-spec-v1\ndefault_harness: deepagents\n');
-    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(
+    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm', 'ws')).rejects.toThrow(
       /missing models\.default/
     );
   });
 
   it('throws on an unsupported config_format instead of falling back to NAT', async () => {
     mockFetchText('config_format: nemo-agents-spec-v2\nworkflow:\n  _type: react_agent\n');
-    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(
+    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm', 'ws')).rejects.toThrow(
       /unsupported config_format: nemo-agents-spec-v2/
     );
   });
 
   it('throws when the fetch fails', async () => {
     mockFetchText('', false);
-    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm')).rejects.toThrow(
+    await expect(loadSampleAgentConfig('sample-agents/x/agent.yml', 'm', 'ws')).rejects.toThrow(
       /Failed to fetch/
     );
+  });
+
+  it('rebinds the ATIF ingest endpoint to the target workspace', async () => {
+    mockFetchText(`${FABRIC_AGENT_YAML}${ATIF_TELEMETRY_YAML}`);
+    const config = (await loadSampleAgentConfig(
+      'sample-agents/x/agent.yml',
+      'my-model',
+      'mschwab'
+    )) as { telemetry: { atif: { storage: { endpoint: string; timeout_millis: number }[] } } };
+
+    const [storage] = config.telemetry.atif.storage;
+    expect(storage.endpoint).toBe(
+      'http://127.0.0.1:8080/apis/intake/v2/workspaces/mschwab/ingest/atif'
+    );
+    expect(storage.timeout_millis).toBe(3000);
+  });
+
+  it('leaves non-Intake and non-http storage endpoints alone', async () => {
+    mockFetchText(`${FABRIC_AGENT_YAML}telemetry:
+  atif:
+    storage:
+      - type: http
+        endpoint: http://collector:4318/v1/traces
+      - type: file
+        endpoint: http://x/apis/intake/v2/workspaces/default/ingest/atif
+`);
+    const config = (await loadSampleAgentConfig(
+      'sample-agents/x/agent.yml',
+      'my-model',
+      'mschwab'
+    )) as { telemetry: { atif: { storage: { endpoint: string }[] } } };
+
+    const [collector, file] = config.telemetry.atif.storage;
+    expect(collector.endpoint).toBe('http://collector:4318/v1/traces');
+    expect(file.endpoint).toBe('http://x/apis/intake/v2/workspaces/default/ingest/atif');
+  });
+
+  it('leaves a config without ATIF telemetry untouched', async () => {
+    mockFetchText(AGENT_YAML);
+    const config = (await loadSampleAgentConfig('sample-agents/x/agent.yml', 'm', 'ws')) as {
+      telemetry?: unknown;
+    };
+    expect(config.telemetry).toBeUndefined();
   });
 });

--- a/web/packages/studio/src/api/agents/loadSampleAgentConfig.ts
+++ b/web/packages/studio/src/api/agents/loadSampleAgentConfig.ts
@@ -6,9 +6,10 @@ import YAML from 'yaml';
 
 /**
  * Loads a sample agent's config from a public static asset and injects the
- * selected model. Parse-then-set: the fetched YAML's model literal is
- * overwritten, so the asset can stay byte-identical to the plugin's
- * ${NEMO_DEFAULT_MODEL} version (the platform service doesn't resolve that).
+ * selected model plus the target workspace. Parse-then-set: the fetched YAML's
+ * literals are overwritten, so the asset can stay byte-identical to the
+ * plugin's ${NEMO_DEFAULT_MODEL} version (the platform service doesn't resolve
+ * that).
  *
  * Branches on the config's own `config_format`:
  * - NAT (`nat-workflow-v1`, the default when absent): model lives at
@@ -18,7 +19,8 @@ import YAML from 'yaml';
  */
 export const loadSampleAgentConfig = async (
   agentConfigPath: string,
-  modelName: string
+  modelName: string,
+  workspace: string
 ): Promise<Record<string, unknown>> => {
   const text = await fetchSampleText(agentConfigPath);
   const config = YAML.parse(text) as Record<string, unknown>;
@@ -27,11 +29,13 @@ export const loadSampleAgentConfig = async (
 
   if (configFormat === 'nemo-agents-spec-v1') {
     injectFabricModel(config, modelName, agentConfigPath);
+    injectIntakeWorkspace(config, workspace);
     return config;
   }
 
   if (configFormat === undefined || configFormat === 'nat-workflow-v1') {
     injectNatModel(config, modelName, agentConfigPath);
+    injectIntakeWorkspace(config, workspace);
     return config;
   }
 
@@ -51,6 +55,33 @@ const injectNatModel = (
     throw new Error(`Sample agent config ${agentConfigPath} is missing llms.llm`);
   }
   (llm as Record<string, unknown>).model_name = modelName;
+};
+
+const INTAKE_WORKSPACE_RE = /(\/apis\/intake\/v\d+\/workspaces\/)[^/]+(\/)/;
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+/**
+ * Point ATIF HTTP storage endpoints at the workspace the agent is created in.
+ * The sample assets ship a literal `default`, so without this the agent's
+ * traces land in the wrong workspace and never reach its own agent page.
+ */
+const injectIntakeWorkspace = (config: Record<string, unknown>, workspace: string): void => {
+  const atif = asRecord(asRecord(config.telemetry)?.atif);
+  const storage = atif?.storage;
+  if (!Array.isArray(storage)) return;
+
+  for (const entry of storage) {
+    const record = asRecord(entry);
+    if (record?.type !== 'http' || typeof record.endpoint !== 'string') continue;
+    record.endpoint = record.endpoint.replace(
+      INTAKE_WORKSPACE_RE,
+      (_match, prefix: string, suffix: string) => `${prefix}${workspace}${suffix}`
+    );
+  }
 };
 
 /** Fabric (nemo-agents-spec-v1) config: overwrite `models.default.model`. */

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/CreateExampleAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/CreateExampleAgentModal/index.tsx
@@ -40,6 +40,11 @@ import { type FC, useEffect, useMemo, useState } from 'react';
 import { type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
+const EXAMPLE_ITEMS = SAMPLE_AGENTS.map((example) => ({
+  value: example.key,
+  children: example.displayName,
+}));
+
 // Since useForm is called in the component itself, key-based remount needs a thin outer wrapper
 // otherwise there's nothing to put the key on
 export const CreateExampleAgentModal: FC<CreateExampleAgentModalProps> = (props) => (
@@ -62,11 +67,7 @@ const CreateExampleAgentModalInner: FC<CreateExampleAgentModalProps> = ({
     { query: { enabled: open && !!workspace } }
   );
   const models = useMemo(() => modelsPage?.data ?? [], [modelsPage?.data]);
-  const modelOptions = buildSuggestedModelOptions(models);
-  const exampleItems = SAMPLE_AGENTS.map((example) => ({
-    value: example.key,
-    children: example.displayName,
-  }));
+  const modelOptions = useMemo(() => buildSuggestedModelOptions(models), [models]);
 
   const {
     mutateAsync: createAgent,
@@ -145,7 +146,7 @@ const CreateExampleAgentModalInner: FC<CreateExampleAgentModalProps> = ({
     setLoadError(undefined);
     let config: Record<string, unknown>;
     try {
-      config = await loadSampleAgentConfig(example.agentConfigPath, formData.modelName);
+      config = await loadSampleAgentConfig(example.agentConfigPath, formData.modelName, workspace);
     } catch (err) {
       setLoadError(getErrorMessage(err as Error, 'Failed to load example agent config'));
       return;
@@ -186,8 +187,8 @@ const CreateExampleAgentModalInner: FC<CreateExampleAgentModalProps> = ({
     >
       <ControlledSelect
         useControllerProps={{ control, name: 'exampleKey' }}
-        items={exampleItems}
-        renderValue={(v) => exampleItems.find((item) => item.value === v)?.children}
+        items={EXAMPLE_ITEMS}
+        renderValue={(v) => EXAMPLE_ITEMS.find((item) => item.value === v)?.children}
         formFieldProps={{
           slotLabel: 'Example',
           slotError: errors.exampleKey?.message,


### PR DESCRIPTION
## Summary

Sample agent configs ship an ATIF ingest endpoint with a hardcoded `default` workspace. Creating a sample agent from any other workspace sent its trajectories to `default`, so its traces never appeared on the agent's own page — every Intake read path is workspace-scoped, leading its `ORDER BY` with `workspace`. Studio now rebinds that workspace segment when it loads the sample config, so traces land in the workspace the agent was created in.

## Related Issue

Supports ASTD-424 (agent trace aggregation). Not a full fix for it — this only covers agents created through Studio's Create Example Agent modal.

## Changes

- `loadSampleAgentConfig` takes a required `workspace` argument and rewrites the workspace segment of `telemetry.atif.storage` HTTP endpoints, alongside the existing model injection. Applies to both NAT and Fabric configs; non-Intake and non-`http` entries are left untouched.
- The argument is required rather than optional so a future caller cannot silently skip the rewrite.
- `CreateExampleAgentModal` passes the `workspace` prop it already holds.
- Perf cleanup in the same file: `modelOptions` is now memoized, and the static example-select items are hoisted to module scope. `buildSuggestedModelOptions` makes five passes over a model list fetched at `page_size: 1000` and was recomputed on every render even though its input was already memoized.

### Not covered

Agents deployed via the CLI, the deployments API directly, or the `plugins/nemo-agents/examples/*` YAMLs still carry the literal `default`. This fix is at config-authoring time in the browser, not at deploy resolution.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal config resolution; no user-facing docs describe the sample agent's telemetry endpoint.

Three tests added to `loadSampleAgentConfig.test.ts`: rebinding to the target workspace, non-Intake and non-`http` endpoints left alone, and a config without ATIF telemetry untouched.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
| --- | --- |
| `vitest --run src/api/agents/loadSampleAgentConfig.test.ts` | 10 passed |
| `vitest --run src/routes/agents/AgentsListRoute src/api/agents/loadSampleAgentConfig.test.ts` | 25 passed (3 files) |
| `tsc --noEmit --noErrorTruncation` (studio) | clean |
| `eslint . --report-unused-disable-directives --max-warnings 0` (web) | clean |

`uv run pre-commit run -a` was not run across the whole repo; the commit hooks that apply to this change (copyright headers, UI lint-staged, merge-conflict check) ran and passed on commit. The Python hooks reported no files to check, since this change is TypeScript only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Example agent configurations now automatically use the selected workspace.
  - ATIF telemetry endpoints are updated to match the active workspace when applicable.
  - Existing non-HTTP and unsupported telemetry configurations are preserved safely.

- **Bug Fixes**
  - Improved handling of missing models, unsupported configuration formats, failed configuration downloads, and agents without telemetry.
  - Example agent selection and model options now behave more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->