### PR TITLE
fix(experimentalist): preflight the evaluator entrypoint in doctor and run

### DIFF
--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/cli.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/cli.py
@@ -270,6 +270,7 @@ class ExperimentalistCLI(NemoCLI):
                         task_template=plan.task_template,
                         agent_source=plan.agent,
                         storage=plan.config.storage.model_dump(exclude_unset=True),
+                        evaluator=plan.config.evaluator,
                         require_template=plan.insight is not None,
                         probes=_PREFLIGHT_PROBES,
                     )
@@ -412,6 +413,7 @@ class ExperimentalistCLI(NemoCLI):
                         task_template=plan.task_template,
                         agent_source=plan.agent,
                         storage=plan.config.storage.model_dump(),
+                        evaluator=plan.config.evaluator,
                         require_template=plan.insight is not None,
                         probes=_PREFLIGHT_PROBES,
                     )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/entrypoint.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/entrypoint.py
@@ -3,27 +3,25 @@
 
 """The agent entrypoint contract: one definition of what the evaluator imports.
 
-The evaluator imports ``import_path`` from the candidate agent directory and
-nothing else. Preflight resolves the same reference against the agent source so
-a missing wrapper is reported before a run instead of at the first trial. Both
-sides read this module, so they cannot disagree.
-
-Importable in the CLI hot path: standard library only, no ``harbor``.
+Preflight reports a wrapper the evaluator could not import before a run instead
+of at the first trial, so it needs this contract without importing ``harbor``:
+whether harbor is importable is itself one of the checks.
 """
 
-from importlib.machinery import ModuleSpec, PathFinder
+from importlib.machinery import PathFinder
 from pathlib import Path
 
 DEFAULT_AGENT_IMPORT_PATH = "harbor_wrapper:WrappedAgent"
 
 
 def split_import_path(import_path: str) -> tuple[str, str]:
-    """Split ``module[:attribute]`` into its normalized module and attribute."""
+    """Split ``module:attribute``, the only form the evaluator can import."""
     module_name, _, attribute = import_path.partition(":")
     module_name = module_name.strip().lstrip(".")
-    if not module_name:
-        raise ValueError("import_path module is required")
-    return module_name, attribute.strip()
+    attribute = attribute.strip()
+    if not module_name or not attribute:
+        raise ValueError("import_path must be <module>:<attribute>")
+    return module_name, attribute
 
 
 def find_entrypoint_module(agent_dir: Path, module_name: str) -> Path | None:
@@ -33,10 +31,11 @@ def find_entrypoint_module(agent_dir: Path, module_name: str) -> Path | None:
     executes agent code.
     """
     search = [str(agent_dir)]
-    spec: ModuleSpec | None = None
+    origin: str | None = None
     for part in module_name.split("."):
         spec = PathFinder.find_spec(part, search)
         if spec is None:
             return None
         search = list(spec.submodule_search_locations or ())
-    return Path(spec.origin) if spec is not None and spec.origin is not None else None
+        origin = spec.origin
+    return Path(origin) if origin is not None else None

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/entrypoint.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/entrypoint.py
@@ -15,11 +15,16 @@ DEFAULT_AGENT_IMPORT_PATH = "harbor_wrapper:WrappedAgent"
 
 
 def split_import_path(import_path: str) -> tuple[str, str]:
-    """Split ``module:attribute``, the only form the evaluator can import."""
+    """Split ``module:attribute``, the only form the evaluator can import.
+
+    The evaluator reaches the attribute with ``getattr``, so a name that is not
+    an identifier — absent, dotted, or holding a second ``:`` — can never
+    resolve.
+    """
     module_name, _, attribute = import_path.partition(":")
     module_name = module_name.strip().lstrip(".")
     attribute = attribute.strip()
-    if not module_name or not attribute:
+    if not module_name or not attribute.isidentifier():
         raise ValueError("import_path must be <module>:<attribute>")
     return module_name, attribute
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/entrypoint.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/entrypoint.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The agent entrypoint contract: one definition of what the evaluator imports.
+
+The evaluator imports ``import_path`` from the candidate agent directory and
+nothing else. Preflight resolves the same reference against the agent source so
+a missing wrapper is reported before a run instead of at the first trial. Both
+sides read this module, so they cannot disagree.
+
+Importable in the CLI hot path: standard library only, no ``harbor``.
+"""
+
+from importlib.machinery import ModuleSpec, PathFinder
+from pathlib import Path
+
+DEFAULT_AGENT_IMPORT_PATH = "harbor_wrapper:WrappedAgent"
+
+
+def split_import_path(import_path: str) -> tuple[str, str]:
+    """Split ``module[:attribute]`` into its normalized module and attribute."""
+    module_name, _, attribute = import_path.partition(":")
+    module_name = module_name.strip().lstrip(".")
+    if not module_name:
+        raise ValueError("import_path module is required")
+    return module_name, attribute.strip()
+
+
+def find_entrypoint_module(agent_dir: Path, module_name: str) -> Path | None:
+    """Return the file the evaluator would import for *module_name*, or None.
+
+    Searches *agent_dir* alone, as the evaluator's scoped import does, and never
+    executes agent code.
+    """
+    search = [str(agent_dir)]
+    spec: ModuleSpec | None = None
+    for part in module_name.split("."):
+        spec = PathFinder.find_spec(part, search)
+        if spec is None:
+            return None
+        search = list(spec.submodule_search_locations or ())
+    return Path(spec.origin) if spec is not None and spec.origin is not None else None

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/entrypoint.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/entrypoint.py
@@ -3,9 +3,9 @@
 
 """The agent entrypoint contract: one definition of what the evaluator imports.
 
-Preflight reports a wrapper the evaluator could not import before a run instead
-of at the first trial, so it needs this contract without importing ``harbor``:
-whether harbor is importable is itself one of the checks.
+Preflight resolves the same reference the evaluator imports, so it reports a
+missing wrapper before a run instead of at the first trial. It must not import
+``harbor`` to do so, because whether harbor is importable is itself a check.
 """
 
 from importlib.machinery import PathFinder

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
@@ -52,6 +52,10 @@ from nemo_experimentalist_plugin.experimentalist.components.evaluator.base impor
     EvaluatorConfig,
     EvaluatorType,
 )
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.entrypoint import (
+    DEFAULT_AGENT_IMPORT_PATH,
+    split_import_path,
+)
 from pydantic import Field
 
 
@@ -187,7 +191,7 @@ class HarborEvaluatorConfig(EvaluatorConfig):
     environment_build_timeout_multiplier: float | None = Field(default=1.0)
     artifacts: list[str] = Field(default=[])
     retry: RetryConfig = Field(default=RetryConfig(exclude_exceptions=set()))
-    import_path: str = Field(default="harbor_wrapper:WrappedAgent")
+    import_path: str = Field(default=DEFAULT_AGENT_IMPORT_PATH)
     trace_dir: str = Field(default=_TRACE_ARTIFACT_SOURCE)
     trace_format: Literal["otlp", "atif"] = Field(
         default="otlp",
@@ -392,15 +396,11 @@ def _ensure_package(name: str, search_path: Path | None = None) -> None:
 
 
 def _scoped_import_path(agent_path: Path, import_path: str) -> tuple[str, str]:
-    module_name, separator, attribute = import_path.partition(":")
-    module_name = module_name.strip().lstrip(".")
-    if not module_name:
-        raise ValueError("import_path module is required")
-
+    module_name, attribute = split_import_path(import_path)
     package_name = _agent_import_package(agent_path)
     _ensure_package(package_name, search_path=agent_path)
     scoped = f"{package_name}.{module_name}"
-    if separator:
+    if ":" in import_path:
         scoped = f"{scoped}:{attribute}"
     return scoped, package_name
 

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/components/evaluator/harbor.py
@@ -399,10 +399,7 @@ def _scoped_import_path(agent_path: Path, import_path: str) -> tuple[str, str]:
     module_name, attribute = split_import_path(import_path)
     package_name = _agent_import_package(agent_path)
     _ensure_package(package_name, search_path=agent_path)
-    scoped = f"{package_name}.{module_name}"
-    if ":" in import_path:
-        scoped = f"{scoped}:{attribute}"
-    return scoped, package_name
+    return f"{package_name}.{module_name}:{attribute}", package_name
 
 
 def _cleanup_scoped_imports(package_name: str) -> None:

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/preflight.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/preflight.py
@@ -15,6 +15,11 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 
 import httpx
+from nemo_experimentalist_plugin.experimentalist.components.evaluator.entrypoint import (
+    DEFAULT_AGENT_IMPORT_PATH,
+    find_entrypoint_module,
+    split_import_path,
+)
 from nemo_experimentalist_plugin.experimentalist.components.repository import (
     _redact_url,
     looks_like_git,
@@ -200,6 +205,7 @@ def check_artifacts(
     task_template: str | None = None,
     agent_source: str | None = None,
     storage: dict | None = None,
+    evaluator: dict | None = None,
     require_template: bool = True,
     probes: Probes | None = None,
 ) -> list[CheckResult]:
@@ -221,7 +227,7 @@ def check_artifacts(
     effective_template = task_template or (profile.task_template if profile is not None else None)
     if require_template and effective_template is not None:
         results += _check_task_template(resolve_profile_path(effective_template, base_dir))
-    results += _check_agent_source(profile, p, agent_source=agent_source, storage=storage)
+    results += _check_agent_source(profile, p, agent_source=agent_source, storage=storage, evaluator=evaluator)
     return results
 
 
@@ -334,6 +340,7 @@ def _check_agent_source(
     *,
     agent_source: str | None = None,
     storage: dict | None = None,
+    evaluator: dict | None = None,
 ) -> list[CheckResult]:
     results: list[CheckResult] = []
     source = agent_source or (profile.agent_source if profile is not None else None)
@@ -366,6 +373,8 @@ def _check_agent_source(
                 f"agent source dir missing: {path}",
             )
         )
+        if path.is_dir():
+            results.append(_check_agent_entrypoint(path, evaluator))
     # Effective storage flags from the auto path (resolved config, which may come
     # from --config); doctor falls back to reading the profile's inline dict or
     # path-form experiment_config without importing the loop chain.
@@ -449,6 +458,43 @@ def _check_agent_source(
                 )
             )
     return results
+
+
+def _check_agent_entrypoint(agent_dir: Path, evaluator: dict | None) -> CheckResult:
+    """Resolve the evaluator's entrypoint module inside a local agent directory.
+
+    The evaluator imports it from that directory alone, so a module it cannot
+    find there fails every trial of every candidate. A git source is unchecked:
+    the tree only exists after the clone. Git sources aside, this is the most
+    common first-run blocker, so it is required rather than advisory.
+    """
+    configured = (evaluator or {}).get("import_path")
+    import_path = str(configured) if configured else DEFAULT_AGENT_IMPORT_PATH
+    try:
+        module_name, attribute = split_import_path(import_path)
+    except ValueError as exc:
+        return CheckResult(
+            name="agent-entrypoint",
+            group="agent-source",
+            status="fail",
+            severity="required",
+            message=f"evaluator import_path {import_path!r} names no module: {exc}",
+            hint="set evaluator.import_path to <module>[:<attribute>] in the experiment config",
+        )
+    found = find_entrypoint_module(agent_dir, module_name)
+    expected = Path(*module_name.split("."))
+    return make_check_result(
+        "agent-entrypoint",
+        "agent-source",
+        found is not None,
+        "required",
+        f"evaluator entrypoint {import_path} at {found}",
+        f"evaluator cannot import {module_name!r} from the agent source: {agent_dir}",
+        hint=(
+            f"add {expected}.py{f' defining {attribute}' if attribute else ''} to the agent directory, "
+            "or point evaluator.import_path in the experiment config at the module you have"
+        ),
+    )
 
 
 def _check_insight_file(

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/preflight.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/preflight.py
@@ -461,24 +461,23 @@ def _check_agent_source(
 
 
 def _check_agent_entrypoint(agent_dir: Path, evaluator: dict | None) -> CheckResult:
-    """Resolve the evaluator's entrypoint module inside a local agent directory.
+    """Resolve the evaluator's entrypoint inside a local agent directory.
 
-    The evaluator imports the module from that directory alone, so a module that
-    is absent there fails every trial of every candidate. Only local sources are
-    checked, because a git tree exists after the clone.
+    The evaluator imports it from that directory alone, so an entrypoint it
+    cannot find there fails every trial of every candidate.
     """
     configured = (evaluator or {}).get("import_path")
     import_path = DEFAULT_AGENT_IMPORT_PATH if configured is None else str(configured)
     try:
         module_name, attribute = split_import_path(import_path)
-    except ValueError:
+    except ValueError as exc:
         return CheckResult(
             name="agent-entrypoint",
             group="agent-source",
             status="fail",
             severity="required",
-            message=f"evaluator import_path {import_path!r} names no module",
-            hint="set evaluator.import_path to <module>[:<attribute>] in the experiment config",
+            message=f"evaluator import_path {import_path!r} is unusable: {exc}",
+            hint="set evaluator.import_path in the experiment config to <module>:<attribute>",
         )
     found = find_entrypoint_module(agent_dir, module_name)
     expected = Path(*module_name.split("."))
@@ -490,7 +489,7 @@ def _check_agent_entrypoint(agent_dir: Path, evaluator: dict | None) -> CheckRes
         f"evaluator entrypoint {import_path} at {found}",
         f"evaluator cannot import {module_name!r} from the agent source: {agent_dir}",
         hint=(
-            f"add {expected}.py{f' defining {attribute}' if attribute else ''} to the agent directory, "
+            f"add {expected}.py defining {attribute} to the agent directory, "
             "or point evaluator.import_path in the experiment config at the module you have"
         ),
     )

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/preflight.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/preflight.py
@@ -463,22 +463,21 @@ def _check_agent_source(
 def _check_agent_entrypoint(agent_dir: Path, evaluator: dict | None) -> CheckResult:
     """Resolve the evaluator's entrypoint module inside a local agent directory.
 
-    The evaluator imports it from that directory alone, so a module it cannot
-    find there fails every trial of every candidate. A git source is unchecked:
-    the tree only exists after the clone. Git sources aside, this is the most
-    common first-run blocker, so it is required rather than advisory.
+    The evaluator imports the module from that directory alone, so a module that
+    is absent there fails every trial of every candidate. Only local sources are
+    checked, because a git tree exists after the clone.
     """
     configured = (evaluator or {}).get("import_path")
-    import_path = str(configured) if configured else DEFAULT_AGENT_IMPORT_PATH
+    import_path = DEFAULT_AGENT_IMPORT_PATH if configured is None else str(configured)
     try:
         module_name, attribute = split_import_path(import_path)
-    except ValueError as exc:
+    except ValueError:
         return CheckResult(
             name="agent-entrypoint",
             group="agent-source",
             status="fail",
             severity="required",
-            message=f"evaluator import_path {import_path!r} names no module: {exc}",
+            message=f"evaluator import_path {import_path!r} names no module",
             hint="set evaluator.import_path to <module>[:<attribute>] in the experiment config",
         )
     found = find_entrypoint_module(agent_dir, module_name)

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor.py
@@ -1292,9 +1292,10 @@ def test_safe_identifier_normal():
     assert _safe_identifier("hello world") == "hello_world"
 
 
-def test_scoped_import_path_empty_module(tmp_path):
-    with pytest.raises(ValueError, match="import_path module is required"):
-        _scoped_import_path(tmp_path, ":SomeClass")
+@pytest.mark.parametrize("import_path", [":SomeClass", "harbor_wrapper", "harbor_wrapper:"])
+def test_scoped_import_path_requires_module_and_attribute(tmp_path, import_path):
+    with pytest.raises(ValueError, match="import_path must be <module>:<attribute>"):
+        _scoped_import_path(tmp_path, import_path)
 
 
 def test_cleanup_scoped_imports_removes_parent_attr():

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor.py
@@ -1292,7 +1292,10 @@ def test_safe_identifier_normal():
     assert _safe_identifier("hello world") == "hello_world"
 
 
-@pytest.mark.parametrize("import_path", [":SomeClass", "harbor_wrapper", "harbor_wrapper:"])
+@pytest.mark.parametrize(
+    "import_path",
+    [":SomeClass", "harbor_wrapper", "harbor_wrapper:", "harbor_wrapper:WrappedAgent:extra"],
+)
 def test_scoped_import_path_requires_module_and_attribute(tmp_path, import_path):
     with pytest.raises(ValueError, match="import_path must be <module>:<attribute>"):
         _scoped_import_path(tmp_path, import_path)

--- a/plugins/nemo-experimentalist/tests/test_cli_profile.py
+++ b/plugins/nemo-experimentalist/tests/test_cli_profile.py
@@ -57,7 +57,6 @@ def app():
 
 
 def write_harbor_wrapper(agent_dir: Path) -> None:
-    """Make *agent_dir* importable by the evaluator's default entrypoint."""
     (agent_dir / "harbor_wrapper.py").write_text("class WrappedAgent:\n    pass\n", encoding="utf-8")
 
 
@@ -1063,8 +1062,7 @@ def test_missing_evaluator_entrypoint_blocks_both_commands(
     """Doctor reports the same missing wrapper that stops a run, not a clean bill."""
     write_task_toml(profile_tree)
     (profile_tree / "harbor_wrapper.py").unlink()
-    recorder = RunRecorder()
-    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.setattr(cli, "run_experimentalist", RunRecorder())
     monkeypatch.chdir(profile_tree)
     args = [command]
     if command == "run":
@@ -1073,7 +1071,6 @@ def test_missing_evaluator_entrypoint_blocks_both_commands(
     result = runner.invoke(app, args)
 
     assert result.exit_code == 1
-    assert recorder.kwargs is None
     assert "evaluator cannot import 'harbor_wrapper'" in result.output
     assert "Traceback" not in result.output
 

--- a/plugins/nemo-experimentalist/tests/test_cli_profile.py
+++ b/plugins/nemo-experimentalist/tests/test_cli_profile.py
@@ -56,10 +56,16 @@ def app():
     return cli.ExperimentalistCLI().get_cli()
 
 
+def write_harbor_wrapper(agent_dir: Path) -> None:
+    """Make *agent_dir* importable by the evaluator's default entrypoint."""
+    (agent_dir / "harbor_wrapper.py").write_text("class WrappedAgent:\n    pass\n", encoding="utf-8")
+
+
 @pytest.fixture()
 def profile_tree(tmp_path: Path) -> Path:
     for sub in ("evals/task_template", "evals/train", "evals/val"):
         (tmp_path / sub).mkdir(parents=True)
+    write_harbor_wrapper(tmp_path)
     (tmp_path / "optimizer.yaml").write_text(
         "agent: flight-planner\n"
         "task_template: ./evals/task_template\n"
@@ -134,6 +140,7 @@ def test_experiment_all_flags_no_profile_still_works(app, tmp_path: Path, monkey
     monkeypatch.setattr(cli, "_PREFLIGHT_PROBES", quiet_probes())
     for sub in ("agent", "t", "v"):
         (tmp_path / sub).mkdir()
+    write_harbor_wrapper(tmp_path / "agent")
     monkeypatch.chdir(tmp_path)
     result = runner.invoke(
         app,
@@ -246,6 +253,7 @@ def test_profileless_implicit_experiment_dirs_retry_collisions_and_stay_unique(
     monkeypatch.setattr(cli, "run_experimentalist", recorder)
     for sub in ("agent", "t", "v"):
         (tmp_path / sub).mkdir()
+    write_harbor_wrapper(tmp_path / "agent")
     monkeypatch.chdir(tmp_path)
     args = [
         "run",
@@ -1042,6 +1050,31 @@ def test_doctor_validates_full_effective_experiment_config(
 
     assert result.exit_code == 1
     assert expected in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize("command", ["run", "doctor"])
+def test_missing_evaluator_entrypoint_blocks_both_commands(
+    app,
+    profile_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+) -> None:
+    """Doctor reports the same missing wrapper that stops a run, not a clean bill."""
+    write_task_toml(profile_tree)
+    (profile_tree / "harbor_wrapper.py").unlink()
+    recorder = RunRecorder()
+    monkeypatch.setattr(cli, "run_experimentalist", recorder)
+    monkeypatch.chdir(profile_tree)
+    args = [command]
+    if command == "run":
+        args += ["--no-insight", "-o", str(profile_tree / "out")]
+
+    result = runner.invoke(app, args)
+
+    assert result.exit_code == 1
+    assert recorder.kwargs is None
+    assert "evaluator cannot import 'harbor_wrapper'" in result.output
     assert "Traceback" not in result.output
 
 

--- a/plugins/nemo-experimentalist/tests/test_experiment_cli.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_cli.py
@@ -133,12 +133,19 @@ def _make_dir(path: Path) -> Path:
     return path
 
 
+def _make_agent_dir(path: Path) -> Path:
+    """An agent directory the evaluator can import its entrypoint from."""
+    _make_dir(path)
+    (path / "harbor_wrapper.py").write_text("class WrappedAgent:\n    pass\n", encoding="utf-8")
+    return path
+
+
 def _make_paths(tmp_path: Path) -> ExperimentCliPaths:
     template = _make_dir(tmp_path / "template")
     (template / "task.toml").write_text('[task]\nname = "org/test-template"\n', encoding="utf-8")
     (template / "instruction.md").write_text("Test task instructions.\n", encoding="utf-8")
     return ExperimentCliPaths(
-        agent=_make_dir(tmp_path / "agent"),
+        agent=_make_agent_dir(tmp_path / "agent"),
         train=_make_dir(tmp_path / "train"),
         validation=_make_dir(tmp_path / "validation"),
         template=template,

--- a/plugins/nemo-experimentalist/tests/test_experiment_cli.py
+++ b/plugins/nemo-experimentalist/tests/test_experiment_cli.py
@@ -133,19 +133,14 @@ def _make_dir(path: Path) -> Path:
     return path
 
 
-def _make_agent_dir(path: Path) -> Path:
-    """An agent directory the evaluator can import its entrypoint from."""
-    _make_dir(path)
-    (path / "harbor_wrapper.py").write_text("class WrappedAgent:\n    pass\n", encoding="utf-8")
-    return path
-
-
 def _make_paths(tmp_path: Path) -> ExperimentCliPaths:
     template = _make_dir(tmp_path / "template")
     (template / "task.toml").write_text('[task]\nname = "org/test-template"\n', encoding="utf-8")
     (template / "instruction.md").write_text("Test task instructions.\n", encoding="utf-8")
+    agent = _make_dir(tmp_path / "agent")
+    (agent / "harbor_wrapper.py").write_text("class WrappedAgent:\n    pass\n", encoding="utf-8")
     return ExperimentCliPaths(
-        agent=_make_agent_dir(tmp_path / "agent"),
+        agent=agent,
         train=_make_dir(tmp_path / "train"),
         validation=_make_dir(tmp_path / "validation"),
         template=template,

--- a/plugins/nemo-experimentalist/tests/test_preflight.py
+++ b/plugins/nemo-experimentalist/tests/test_preflight.py
@@ -230,10 +230,9 @@ def test_missing_evaluator_entrypoint_is_required_failure(tmp_path: Path) -> Non
     [
         ("pkg.wrapper:Agent", "pass"),
         ("pkg.missing:Agent", "fail"),
-        (":Agent", "fail"),
-        ("", "fail"),
+        ("pkg.wrapper", "fail"),
     ],
-    ids=["configured", "configured-missing", "no-module", "empty"],
+    ids=["configured", "configured-missing", "no-attribute"],
 )
 def test_configured_entrypoint_replaces_the_default(tmp_path: Path, import_path: str, expected_status: str) -> None:
     (tmp_path / "agent" / "pkg").mkdir(parents=True)

--- a/plugins/nemo-experimentalist/tests/test_preflight.py
+++ b/plugins/nemo-experimentalist/tests/test_preflight.py
@@ -231,8 +231,9 @@ def test_missing_evaluator_entrypoint_is_required_failure(tmp_path: Path) -> Non
         ("pkg.wrapper:Agent", "pass"),
         ("pkg.missing:Agent", "fail"),
         (":Agent", "fail"),
+        ("", "fail"),
     ],
-    ids=["configured", "configured-missing", "no-module"],
+    ids=["configured", "configured-missing", "no-module", "empty"],
 )
 def test_configured_entrypoint_replaces_the_default(tmp_path: Path, import_path: str, expected_status: str) -> None:
     (tmp_path / "agent" / "pkg").mkdir(parents=True)

--- a/plugins/nemo-experimentalist/tests/test_preflight.py
+++ b/plugins/nemo-experimentalist/tests/test_preflight.py
@@ -29,6 +29,7 @@ def make_probes(*, cmd_ok: bool = True, http: bool = True) -> Probes:
 def full_profile(tmp_path: Path, *, agent_source: str | None = None):
     tt = tmp_path / "evals" / "task_template"
     tt.mkdir(parents=True)
+    (tmp_path / "harbor_wrapper.py").write_text("class WrappedAgent:\n    pass\n", encoding="utf-8")
     (tt / "task.toml").write_text('[task]\nname = "org/agent__template"\n', encoding="utf-8")
     (tt / "instruction.md").write_text("do the thing", encoding="utf-8")
     for sub in ("evals/train", "evals/val"):
@@ -210,6 +211,50 @@ def test_local_agent_source_dir_stays_required(tmp_path: Path) -> None:
     src = next(r for r in results if r.name == "agent-source-dir")
     assert src.severity == "required"
     assert src.status == "fail"
+
+
+def test_missing_evaluator_entrypoint_is_required_failure(tmp_path: Path) -> None:
+    (tmp_path / "agent").mkdir()
+
+    results = check_artifacts(full_profile(tmp_path, agent_source="./agent"), probes=make_probes())
+
+    entrypoint = next(r for r in results if r.name == "agent-entrypoint")
+    assert entrypoint.status == "fail"
+    assert entrypoint.severity == "required"
+    assert "harbor_wrapper.py" in (entrypoint.hint or "")
+    assert "WrappedAgent" in (entrypoint.hint or "")
+
+
+@pytest.mark.parametrize(
+    ("import_path", "expected_status"),
+    [
+        ("pkg.wrapper:Agent", "pass"),
+        ("pkg.missing:Agent", "fail"),
+        (":Agent", "fail"),
+    ],
+    ids=["configured", "configured-missing", "no-module"],
+)
+def test_configured_entrypoint_replaces_the_default(tmp_path: Path, import_path: str, expected_status: str) -> None:
+    (tmp_path / "agent" / "pkg").mkdir(parents=True)
+    (tmp_path / "agent" / "pkg" / "wrapper.py").write_text("class Agent:\n    pass\n", encoding="utf-8")
+
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source="./agent"),
+        probes=make_probes(),
+        evaluator={"import_path": import_path},
+    )
+
+    entrypoint = next(r for r in results if r.name == "agent-entrypoint")
+    assert entrypoint.status == expected_status
+
+
+def test_git_agent_source_has_no_entrypoint_check(tmp_path: Path) -> None:
+    results = check_artifacts(
+        full_profile(tmp_path, agent_source="https://host/g/repo.git@main"),
+        probes=make_probes(),
+    )
+
+    assert not any(r.name == "agent-entrypoint" for r in results)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes [NMP-34](https://linear.app/nvidia/issue/NMP-34/nemo-agents-experimentalist-doctor-does-not-check-for-harbor-wrapperpy)


<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`nemo agents experimentalist doctor` passed every check and exited 0 for an agent directory with no `harbor_wrapper.py`, and the following `run` failed only once Harbor tried to import the wrapper. The evaluator's entrypoint contract now lives in one module that both the Harbor evaluator and preflight read, so the shared `check_artifacts` suite resolves the effective `evaluator.import_path` against the local agent source. Doctor and run report the same required failure before anything is downloaded or evaluated.

## Related Issue

Doctor passes all checks when `harbor_wrapper.py` is missing from the agent directory.

## Changes

- New `components/evaluator/entrypoint.py` holds the contract: `DEFAULT_AGENT_IMPORT_PATH`, `split_import_path`, and `find_entrypoint_module`. It imports only the standard library, because preflight cannot import `harbor` — whether harbor is importable is itself one of its checks.
- `harbor.py` reads that contract for the `import_path` field default and in `_scoped_import_path`.
- `check_artifacts` takes the effective `evaluator` options and adds a required `agent-entrypoint` check beside `agent-source-dir`. Both call sites — run phase 2 and doctor — pass `plan.config.evaluator`, so the check is shared rather than duplicated.
- `split_import_path` enforces `<module>:<attribute>`, the only form Harbor can import. Harbor's `import_symbol` requires a separator and then reaches the attribute with `getattr`, so the attribute must also be an identifier: `harbor_wrapper` (no separator), `harbor_wrapper:` (absent), `mod:Agent:extra` and `mod:Outer.Inner` all used to pass doctor and fail at the first trial. Enforcing the whole format in the one splitter also removes the attribute branch `_scoped_import_path` carried.

`find_entrypoint_module` walks the module path with `importlib.machinery.PathFinder`, which is what the evaluator's scoped import does: `_ensure_package` gives the synthetic package a `__path__` of the agent directory and nothing else. Resolution never executes agent code. A git agent source is not checked, because its tree exists only after the clone.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no documented check list changes; the failure message and hint carry the guidance, and the smoke example already ships a wrapper.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pytest plugins/nemo-experimentalist/tests plugins/nemo-eval-author/tests packages/nemo_platform_plugin -q` → 2100 passed, 44 skipped.
- `pre-commit run --files <changed files>` → ruff, ruff format, `ty` typechecks, copyright headers, and plugin import boundary all pass. `uv run pre-commit run -a` was not run in full: the repo-wide `uv sync --frozen --all-packages` fails in this environment while building `nemo-fabric-runtime`, which needs a Cargo newer than the image ships.
- Real CLI before and after on a scratch agent directory outside the repo, with Docker up, the platform running at `localhost:8080`, and a configured model pair. On `main` doctor exits 0 for an agent with no wrapper; on this branch doctor and run both exit 1 on the same `agent-entrypoint` failure, and both go green once the wrapper is added.

```
=== BEFORE — main (0b0e4be4b) ===
    doctor exit code: 0
Agent-source
  ✓ agent source at /tmp/first-run-agent/agent

=== AFTER — this branch ===
    doctor exit code: 1
Agent-source
  ✓ agent source at /tmp/first-run-agent/agent
  ✗ evaluator cannot import 'harbor_wrapper' from the agent source: /tmp/first-run-agent/agent
      hint: add harbor_wrapper.py defining WrappedAgent to the agent directory, or point evaluator.import_path in the experiment config at the module you have
```

- Malformed `import_path` values, verified through the real CLI against the same profile:

```
--- import_path: harbor_wrapper:WrappedAgent:extra
    doctor exit code: 1
  ✗ evaluator import_path 'harbor_wrapper:WrappedAgent:extra' is unusable: import_path must be <module>:<attribute>
--- import_path: harbor_wrapper:Outer.Inner
    doctor exit code: 1
  ✗ evaluator import_path 'harbor_wrapper:Outer.Inner' is unusable: import_path must be <module>:<attribute>
--- import_path: harbor_wrapper:WrappedAgent
    doctor exit code: 0
  ✓ evaluator entrypoint harbor_wrapper:WrappedAgent at /tmp/first-run-agent/agent/harbor_wrapper.py
```

Known gaps left alone, both pre-existing and out of scope here: the check reads the agent source while the run imports from a `copytree(..., ignore=_ignore_patterns)` copy, so a module under an ignored path such as `artifacts/` would pass the check and be absent from the candidate; and doctor still cannot verify that the module defines the named attribute without importing agent code.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1222a4fd-47b2-4229-a580-8078e74bf8e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1222a4fd-47b2-4229-a580-8078e74bf8e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added preflight validation for local agent evaluator entrypoints.
  * Supports configured evaluator import paths with a default entrypoint.
  * Provides clear corrective guidance for missing or invalid entrypoints.

* **Bug Fixes**
  * `run` and `doctor` now stop cleanly when required evaluator files are missing, without starting execution or displaying a traceback.
  * Git-based agent sources are correctly excluded from local entrypoint checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->