### PR TITLE
fix: correct permissions after using root to activate

### DIFF
--- a/.github/actions/build-policy-wasm/action.yaml
+++ b/.github/actions/build-policy-wasm/action.yaml
@@ -39,6 +39,10 @@ runs:
         SOURCE_ROOT: ${{ inputs.source-root }}
       run: |
         source_root="$(cd "${SOURCE_ROOT}" && pwd -P)"
+        owner_uid="$(id -u)"
+        owner_gid="$(id -g)"
+        policy_wasm="${source_root}/services/core/auth/src/nmp/core/auth/assets/policy.wasm"
         sudo git config --global --add safe.directory "${source_root}"
         sudo -E flox -q activate --dir="${source_root}/tools/open-policy-agent" -- \
           bash -c 'cd "$1" && ./script/build_policy_wasm.sh' _ "${source_root}"
+        sudo chown "${owner_uid}:${owner_gid}" "${policy_wasm}"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved root-mode policy builds by preserving the invoking user and group ownership of generated files.
  * Ensured the generated policy artifact is consistently available at its expected path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->