### PR TITLE
docs: record Rust and test prerequisites for cloud bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,7 @@ Ensure all pre-commit hooks pass by running `uv run pre-commit run -a`. A clean 
 - **Toolchain:** Install Flox before running `make bootstrap`; Make activates it as needed. For a preinstalled host toolchain, install the versions printed by `make toolchain-versions` and use `TOOLCHAIN=system`.
 - **uv version:** Root `pyproject.toml` specifies the supported minimum for source checkout bootstrap. `make toolchain-versions` reports the exact version used for `uv.lock` updates, Flox, platform containers, and CI.
 - **Native build deps:** `make bootstrap-python` builds `annoy` (via `nemoguardrails`). Install system headers once per VM image: `sudo apt-get install -y python3-dev build-essential`.
+- **Rust toolchain:** `nemo-fabric-runtime` installs from a Git source and compiles Rust crates that use edition 2024, so Cargo 1.85 or newer is a prerequisite. A VM image that ships an older Cargo (for example 1.83) makes `uv sync` fail with a Cargo `edition2024` error. Install a newer toolchain once per VM image: `rustup toolchain install stable --profile minimal && rustup default stable`.
 - **Python bootstrap:** Run `make bootstrap-python` from repo root (creates `.venv`, runs `uv sync --frozen --all-packages`). See [SETUP.md](SETUP.md) for the full playbook.
 - **Studio (optional):** `make bootstrap-studio` uses the Node.js/pnpm versions pinned in the Flox environment, so a VM shipping an older Node does not need upgrading. API services still run without Studio assets. For a preinstalled host toolchain, install the versions printed by `make toolchain-versions` and use `TOOLCHAIN=system`.
 - **Docker:** Not needed for dependency bootstrap. It is required before running `nemo setup` or local services.
@@ -278,6 +279,10 @@ Minimal subset for inference-focused work (documented in SETUP.md): `uv run nemo
 
 Standard commands from repo root (see sections above): `uv run ruff check`, `uv run --frozen ty check`, `make test-unit`, `make test-package PACKAGE=<name>`.
 
+- **Toolchain:** `make` targets call their tools through Flox. On a VM image without Flox, add `TOOLCHAIN=system` (for example, `make test-unit TOOLCHAIN=system`), or the target stops with `flox: command not found`.
+- **Terminal:** Set `TERM=dumb` when you run the tests from tmux. A colour-capable terminal makes Rich add style codes to CLI output, and the CLI assertions then fail.
+- **Full-suite prerequisites:** The Insights testbed tests need the `zstd` CLI (`sudo apt-get install -y zstd`), and the embedded auth PDP tests build `policy.wasm` with the OPA binary. `openpolicyagent.org` is outside the Cursor Cloud allowlist, so take OPA from its GitHub mirror: `OPA_DOWNLOAD_BASE_URL=https://github.com/open-policy-agent/opa/releases/download bash script/build_policy_wasm.sh`.
+- **Live Docker tests:** The `*_live.py` tests in `packages/nemo_evaluator_sdk/tests/agent_eval/` pull images from Docker Hub. Docker Hub serves blobs from `docker-images-prod.s3.dualstack.us-east-1.amazonaws.com`, which is outside the allowlist, so these tests fail until that domain is added.
 - **Docker:** Not required for core platform smoke tests. One `nmp_common` config test expects Docker and sets runtime to `none` when Docker is unavailable.
 - **Inference providers:** `nemo setup`, `nemo chat`, and agent invoke require an API key (`NVIDIA_API_KEY`, `OPENAI_API_KEY`, etc.). Core APIs (workspaces, secrets, hello-world, entities) work without provider credentials.
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -140,6 +140,8 @@ flox -q activate
 
 Without Flox, install the versions printed by `make toolchain-versions` and a C compiler, then run `make TOOLCHAIN=system bootstrap`. Docker is required when starting local services, but not for dependency bootstrap.
 
+Flox does not pin Rust. `nemo-fabric-runtime` currently installs from a Git source and compiles a Rust extension, so Cargo 1.85 or newer must also be on your PATH — an older Cargo stops the bootstrap with a Cargo `edition2024` error. `rustup toolchain install stable --profile minimal && rustup default stable` installs a new enough toolchain. This prerequisite ends when the Fabric wheels return to PyPI (see the `nemo-fabric` comment in the root `pyproject.toml`).
+
 If `nemo setup` is too high-level for the task (e.g. debugging startup, custom service set, custom plugin install after bootstrap), use the manual sections below.
 
 ### Default and fast model selection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -398,6 +398,8 @@ nooa = { git = "https://github.com/NVIDIA-NeMo/labs-OO-Agents.git", rev = "6e027
 # and the metapackage pins runtime/adapters to ==0.2.0.
 # Declared dep floors stay >=0.1.0 so wheelcheck / PyPI installs of the published
 # wheel still resolve (uv.sources do not apply outside this workspace).
+# While these git sources are in place, nemo-fabric-runtime builds its Rust extension
+# from source, so bootstrap needs Cargo 1.85+ (Fabric's crates use edition 2024).
 # Remove these entries once PyPI has 0.2.0.
 nemo-fabric = { git = "https://github.com/NVIDIA/NeMo-Fabric.git", rev = "e7353383024523179be6a009ef16dea223bea8c0" }
 nemo-fabric-runtime = { git = "https://github.com/NVIDIA/NeMo-Fabric.git", rev = "e7353383024523179be6a009ef16dea223bea8c0", subdirectory = "python" }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`nemo-fabric-runtime` is pinned to a Git source whose crates use Rust edition 2024, so `uv sync --frozen --all-packages` fails on any host with Cargo older than 1.85 — including the Cursor Cloud VM image, which ships Cargo 1.83. This documents the prerequisite where bootstrap is described, and records the toolchain, terminal, and egress conditions the test suite needs on a cloud VM.

This is documentation only; no bootstrap behavior changes. The matching environment install script change (install a stable Rust toolchain before `uv sync`) is proposed separately in the Cloud Agent environment configuration.

## Related Issue

None. Found while investigating environment build `bld-20260814-23b4fa79-8e18-4009-8d5e-6eeb5ac8bbf4`, which failed with `feature 'edition2024' is required ... this version of Cargo (1.83.0)`.

## Changes

- `AGENTS.md`: add a Rust toolchain bullet to the Cursor Cloud bootstrap prerequisites, and add lint/test bullets for `TOOLCHAIN=system`, `TERM=dumb`, the `zstd` and `policy.wasm` prerequisites of the full suite, and the Docker Hub blob host that live Docker tests need.
- `SETUP.md`: note in the toolchain section that Flox does not pin Rust, and that Cargo 1.85 or newer must be on PATH while Fabric installs from a Git source.
- `pyproject.toml`: note the Cargo requirement inside the existing temporary `nemo-fabric` Git-source comment, so it is removed together with those entries.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: documentation only; no code paths change.
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Root cause reproduced both ways on the same NeMo-Fabric checkout: `rustup run 1.83.0 cargo metadata` → exit 101, `feature 'edition2024' is required`; `cargo metadata` on stable 1.97.1 → exit 0.
- `rustup toolchain install stable --profile minimal && rustup default stable` → Cargo 1.97.1, then `uv sync --frozen --all-packages` → exit 0 in 31s, producing `nemo_fabric/_native.abi3.so` (the wheel whose build failed in `bld-20260814-23b4fa79-8e18-4009-8d5e-6eeb5ac8bbf4`).
- `make bootstrap-python TOOLCHAIN=system` → exit 0.
- `TERM=dumb make test-unit TOOLCHAIN=system` → 13420 passed, 7 failed. The 7 failures are live Docker sandbox tests that cannot pull Docker Hub blobs from `docker-images-prod.s3.dualstack.us-east-1.amazonaws.com`, which is outside this environment's egress allowlist.
- Environment build `bld-20260814-d7a5ce1f-eb2f-4aed-bf6b-884b4cdb9ba0`, running the proposed install script, succeeded in 95s and installed `nemo-fabric-runtime==0.1.1` from the Git source. A fresh cloud agent booted from that build confirmed Cargo 1.97.1, uv 0.9.14, yq-go v4.53.3, zstd 1.5.5, an importable native extension, a built `policy.wasm`, `uv lock --check` clean, `make bootstrap-python TOOLCHAIN=system` exit 0, and 302 passed on the targeted Fabric, PDP, testbed, and CLI tests.
- `uv run pre-commit run -a` → all hooks pass except `helm-docs` and `studio-lint-staged`. Both are blocked, not failing on this change: `helm-docs` and the copyright fixer disagree about the SPDX header in the generated `k8s/helm/README.md` (the `nemo-helm-readme.md.gotmpl` template omits it), and `studio-lint-staged` needs `make bootstrap-studio` plus Node 22.23.2, while the VM image has Node 22.14.0.
- `uv lock --check` → no drift, using the repo-pinned uv 0.9.14.

Note on the `ty` gate: `uv run --frozen ty check` reports 769 diagnostics on a clean `main` checkout, so the whole-repo form is not a passing gate today. The `ty` pre-commit hook (`tools/lint/run-ty-check.sh`, changed files only) passes on this branch. That inaccuracy in the AGENTS.md lint section is pre-existing and left untouched here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e68d290d-3a93-4318-833d-f8691ed387e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e68d290d-3a93-4318-833d-f8691ed387e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

