### PR TITLE
docs: document installing a published plugin and fix the dependency claim

### DIFF
--- a/docs/agents/plugins.mdx
+++ b/docs/agents/plugins.mdx
@@ -25,14 +25,77 @@ can contribute one or more surfaces:
 | Inference middleware | `nemo.inference_middleware` | Virtual-model request or response middleware |
 | Entity | plugin code | Entity definitions stored in Entity Store |
 
-The default first-party plugins are installed by `uv sync` and
-`make bootstrap-python` through the root workspace's `enabled-plugins` group.
-Install or remove custom plugins in the same environment as `nemo-platform`,
-then restart local services so entry points are discovered:
+## Install a Plugin
+
+First-party plugins ship with the platform. The `all` extra installs them. A
+source checkout installs them through the root workspace's `enabled-plugins`
+group, with `uv sync` or `make bootstrap-python`.
+
+To add a third-party plugin, install it into the same environment as
+`nemo-platform`.
+
+<Tabs>
+
+<Tab title="uv tool install">
+
+uv manages the tool environment. Do not install into it directly. Re-run the
+install and pass the plugin with `--with`:
 
 ```bash
-nemo services run
+uv tool install "nemo-platform[all]" --with <plugin>
 ```
+
+A re-run replaces the environment, so anything you omit is removed. Read the
+current install line first:
+
+```bash
+uv tool list --show-with --show-extras
+```
+
+`uv tool upgrade nemo-platform` keeps the extras and the `--with` packages.
+
+</Tab>
+
+<Tab title="Virtual environment">
+
+```bash
+uv pip install <plugin>
+```
+
+</Tab>
+
+</Tabs>
+
+<Warning>
+Never uninstall `nemo-platform-plugin`. Every plugin depends on it, so your
+installer adds it. The `nemo-platform` wheel also bundles the same
+`nemo_platform` and `nemo_platform_plugin` modules, so removing the
+`nemo-platform-plugin` distribution deletes files that `nemo-platform` still
+needs. To repair a broken environment, re-run the full platform install.
+</Warning>
+
+Restart local services after you install or remove a plugin. The platform reads
+entry points only at startup:
+
+```bash
+nemo services restart
+```
+
+Then list what is installed:
+
+```bash
+nemo plugins list
+```
+
+This command reads package metadata. It lists a plugin even when the platform
+failed to import it. If a listed plugin does not work, check the service log for
+an import warning.
+
+To remove a plugin, take it out of the install line and restart services. In a
+tool environment, re-run `uv tool install` without the `--with` entry. In a
+virtual environment, run `uv pip uninstall <plugin>`. The distribution name and
+the plugin name can differ: `nemo plugins list` shows plugin names, and
+`uv pip list` shows distribution names.
 
 ## First-Party Plugins
 

--- a/packages/nemo_platform_plugin/AGENTS.md
+++ b/packages/nemo_platform_plugin/AGENTS.md
@@ -7,7 +7,7 @@
 
 ## Key Concepts
 
-- **One install, everything included**: `nemo-platform-plugin` depends on `nmp-common` (the platform library) transitively. Plugin authors also need `nemo-platform` for `get_entity_client` and SDK features.
+- **One install, everything included**: `nemo-platform-plugin` provides `get_entity_client` and bundles the `nemo_platform` SDK module. It does not pull in `nmp-common` or platform internals. A plugin needs no other NeMo dependency.
 - **Four primary surfaces**: `NemoService` (HTTP routes), `NemoCLI` (CLI commands), `NemoJob` (schedulable jobs), `NemoController` (background reconcile loop).
 - **Discovery via entry-points**: Plugins register surfaces under entry-point groups (`nemo.services`, `nemo.cli`, `nemo.jobs`, `nemo.controllers`) in `pyproject.toml`. The platform scans these at startup — no code registration needed.
 - **Entities for persistent state**: Use `NemoEntity` + `NemoEntitiesClient` to store plugin data in the NeMo Platform entity store. Entity types are global — use plugin-scoped names (`"my_plugin_widget"` not `"widget"`).

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/.agents/skills/creating-a-plugin/SKILL.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/.agents/skills/creating-a-plugin/SKILL.md
@@ -26,7 +26,7 @@ my-plugin/
 [project]
 name = "nemo-my-plugin"
 version = "0.1.0"
-dependencies = ["nemo-platform-plugin", "nemo-platform"]
+dependencies = ["nemo-platform-plugin"]
 
 [project.entry-points."nemo.services"]
 my-plugin = "nemo_my_plugin.service:MyService"
@@ -89,7 +89,7 @@ name = "nemo-my-plugin"
 version = "0.1.0"
 description = "My NeMo Platform plugin."
 requires-python = ">=3.11"
-dependencies = ["nemo-platform-plugin", "nemo-platform", "pydantic>=2.0.0"]
+dependencies = ["nemo-platform-plugin", "pydantic>=2.0.0"]
 
 [project.entry-points."nemo.services"]
 my-plugin = "nemo_my_plugin.service:MyService"
@@ -259,7 +259,7 @@ from nemo_platform_plugin.discovery import discover, discover_entry_points
 # discover_entry_points() is metadata-only (no imports)
 ```
 
-A broken plugin (import error) logs a warning and is skipped — the platform continues. To disable a plugin, uninstall its package.
+A broken plugin (import error) logs a warning and is skipped — the platform continues. To disable a plugin, uninstall its package. `NEMO_PLUGIN_ALLOWLIST` and the per-surface `NEMO_PLUGIN_<SURFACE>_ALLOWLIST` suppress discovery without uninstalling. Both are allowlists keyed by entry-point name, so every plugin you leave out is also disabled. Use them for debugging, not as a per-plugin off switch.
 
 **Tests that mock entry-points must clear the cache:**
 
@@ -274,7 +274,7 @@ discover_entry_points.cache_clear()
 
 - **No `__init__.py`**: The package directory does not need one. Do not add it.
 - **`name` must match entry-point key**: For jobs, `NemoJob.name` is the suffix after the dot, not the full key.
-- **Both `nemo-platform-plugin` AND `nemo-platform` required**: `nemo-platform-plugin` provides the ABCs; `nemo-platform` provides `get_entity_client` and SDK features.
+- **`nemo-platform-plugin` is the only NeMo dependency you need**: it provides the ABCs, `get_entity_client` (import it from `nemo_platform_plugin.entity_client`), and the `nemo_platform` SDK module, which it bundles. Adding `nemo-platform` pulls every platform service and first-party plugin into your dependency closure for no gain.
 - **Install with `-e` (editable)**: `uv pip install -e .` — non-editable installs require reinstall on every change.
 - **`discover.cache_clear()` in tests**: Any test that mocks entry-points must call both `discover.cache_clear()` and `discover_entry_points.cache_clear()` to avoid stale caches between tests.
 - **`packages = ["src/nemo_my_plugin"]` in hatchling config**: Without this, the wheel will not include the `nmp` namespace package correctly.

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/QUICKSTART.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/QUICKSTART.md
@@ -34,7 +34,7 @@ name = "nemo-my-plugin"
 version = "0.1.0"
 description = "My NeMo Platform plugin."
 requires-python = ">=3.12"
-dependencies = ["nemo-platform-plugin", "nemo-platform"]
+dependencies = ["nemo-platform-plugin"]
 
 [project.entry-points."nemo.services"]
 "my-plugin" = "nemo_my_plugin.service:MyService"
@@ -305,5 +305,5 @@ Use `dependency_overrides` to inject a mock entity client — no platform requir
 ## Common pitfalls
 
 - **`name` mismatch:** `MyService.name = "my_plugin"` but entry-point key is `"my-plugin"` — routing breaks silently (only a warning is logged). They must be identical.
-- **Missing `nemo-platform`:** `get_entity_client` requires `nemo-platform` installed. Without it, entity injection at startup will fail.
+- **Do not depend on `nemo-platform`:** `nemo-platform-plugin` already provides `get_entity_client` and bundles the `nemo_platform` SDK module. Adding `nemo-platform` pulls every platform service into your dependency closure for no gain.
 - **Do not add `__init__.py`**: The package directory does not require one. Do not add it.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -22,6 +22,8 @@ uv pip install -e plugins/example-plugin/
 
 Restart `nemo services run` after installing or uninstalling plugins. Service, controller, and inference middleware entry points are discovered at platform startup.
 
+This is the local-checkout path. To install a **published** plugin, see [Plugins and Skills](https://docs.nvidia.com/nemo-platform/documentation/agents/plugins-and-skills).
+
 ## Default bootstrap behavior
 
 `make bootstrap-python` syncs the root uv workspace. Bare `uv sync` and `make bootstrap-python` include the `enabled-plugins` dependency group by default through `tool.uv.default-groups`.
@@ -80,6 +82,14 @@ uv pip uninstall nemo-example-plugin
 ## Verifying a plugin is active
 
 ```bash
+nemo plugins list
+```
+
+This scans every surface entry-point group, so it reports plugins that add no CLI command and no HTTP route — inference middleware, jobs, and Studio pages included. It reads package metadata only, so it lists a plugin that the platform failed to import.
+
+Per-surface checks, once the plugin is listed:
+
+```bash
 # CLI commands appear under the plugin name:
 nemo <plugin-name> --help
 
@@ -87,12 +97,7 @@ nemo <plugin-name> --help
 curl http://localhost:8080/apis/<plugin-name>/health
 ```
 
-Inference middleware plugins do not necessarily add CLI commands or HTTP routes. Verify they are loaded by checking platform startup logs for the middleware entry point, then reference that entry point from a VirtualModel:
-
-```bash
-# Example log text emitted during platform startup:
-# Loaded inference middleware plugin: nemo-switchyard
-```
+Inference middleware adds no CLI command and no route. To confirm that the running platform loaded it, grep the platform log for `Loaded inference middleware plugin`. See [SETUP.md](../SETUP.md) for that check and the `422 references unknown plugin` signal.
 
 ## Writing a new plugin
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Every plugin install instruction in this repo stopped at a local checkout (`uv pip install -e .`), so there was no guidance for installing a *published* third-party plugin. This documents that path on the already-published Plugins and Skills page, and corrects a dependency claim that three authoring sources repeated and that is factually wrong.

No new documents. Plugin install guidance already lived in five overlapping places, so this fills the gap in the one published page and links the others to it instead of duplicating.

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

None.

## Changes
<!-- List the concrete changes included in this pull request. -->

**`docs/agents/plugins.mdx`** — replaced a commands-free paragraph with an `Install a Plugin` section: the two install shapes (`uv tool install "nemo-platform[all]" --with <plugin>` and `uv pip install <plugin>`); that uv manages the tool environment and a re-run replaces it, so `uv tool list --show-with --show-extras` recovers the current install line first, while `uv tool upgrade` preserves extras and `--with`; `nemo services restart`, because the platform reads entry points only at startup; `nemo plugins list` for verification, with the caveat that it reads package metadata and so lists a plugin the platform failed to import; removal for both install shapes.

**`plugins/README.md`** — added `nemo plugins list` to *Verifying a plugin is active*. It is the only check that covers middleware-, job-, and Studio-only plugins, which the existing per-surface checks (`nemo <plugin> --help`, `curl /apis/<plugin>/health`) cannot. Replaced the deleted startup-log snippet, whose format was stale, with a pointer to `SETUP.md`, which owns the "did the running platform load it" check. Added a link to the published page for the published-plugin path.

**Dependency correctness fix** in `packages/nemo_platform_plugin/AGENTS.md`, `creating-a-plugin/SKILL.md`, and `nemo_platform_plugin/docs/QUICKSTART.md`. All three said a plugin needs both `nemo-platform-plugin` and `nemo-platform` "because `nemo-platform` provides `get_entity_client` and SDK features". Both halves are false:

- `get_entity_client` is defined in `nemo_platform_plugin/dependencies.py` and re-exported from `nemo_platform_plugin/entity_client.py`.
- `nemo-platform-plugin` declares `nemo-platform-sdk` and bundles it via `[tool.bundle-package]`. The published `nemo-platform-plugin` 0.3.0 wheel ships both `nemo_platform/` and `nemo_platform_plugin/`.

`nemo-platform` was dropped from the three templates. `AGENTS.md` had a second false claim corrected in the same sentence: `nemo-platform-plugin` does not depend on `nmp-common` — its `pyproject.toml` lists only `nemo-platform-sdk` among NeMo packages, and the wheel ships no `nmp` package. `plugins/README.md` already stated the dependency correctly and needed no change.

`creating-a-plugin/SKILL.md` also gained one sentence on `NEMO_PLUGIN_ALLOWLIST`, beside its existing "to disable a plugin, uninstall its package". The skill did not mention the variable, and it is an allowlist keyed by entry-point name, so it disables every plugin left out — a debugging knob, not the per-plugin off switch a reader might assume.

**On the uninstall warning.** The two published wheels overlap completely: the plugin wheel's 1053 files are a strict subset of the wrapper's, with zero plugin-only files. Installing both is silent, with no resolver warning. Uninstalling `nemo-platform-plugin` then deletes the wrapper's `nemo_platform_plugin/` tree and `nemo_platform/__init__.py`, leaving `nemo-platform` installed per its metadata but broken. Since every plugin depends on `nemo-platform-plugin`, the overlap itself is unavoidable and expected, so the warning targets uninstall rather than install.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Markdown and MDX content only, no runtime behavior change. The packaging and CLI facts asserted in the prose were verified manually against the published wheels and the source; commands and results are listed below.
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:
<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `make docs-check` — pass. `fern check` 0 errors, 218 MDX files parsed cleanly, no inbound links from published pages into gated pages. Confirms the new `<Tabs>` and `<Warning>` blocks parse.
- `make docs-broken-links` — pass, `✓ All checks passed`.
- `uv run pre-commit run --files <the 5 changed files>` — pass. `Fix copyright headers` and `check for merge conflicts` passed; every other hook reported no files to check, as expected for a Markdown-only change.
- `uv run pre-commit run -a` — **not passing on this branch, for reasons unrelated to this change**, so the box above is left unchecked rather than claimed. Two pre-existing failures: `Fix copyright headers` rewrites 36 files elsewhere in the repo that lack SPDX headers (`openapi/`, `e2e/configs/`, `skills/`, vendored lockfiles), none touched by this PR — those modifications were reverted and the branch is clean; and `Run UI lint-staged` fails with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` because the local Node is v24.15.0 while `web/package.json` wants `>=22.23.2 <23` and Studio deps are not bootstrapped in this worktree. No `web/` files are changed here.
- The `docs.nvidia.com/.../agents/plugins-and-skills` URL added to `plugins/README.md` returns HTTP 200.

Facts asserted in the docs, verified directly rather than assumed:

- `nemo-platform-plugin` 0.3.0 wheel top-level packages are `nemo_platform` and `nemo_platform_plugin`. `nemo-platform-sdk` is not published to PyPI.
- The plugin wheel's 1053 files are a strict subset of the `nemo-platform` wheel's. Installing both produces no warning. Uninstalling the plugin distribution breaks the wrapper; re-running the platform install restores all 2863 files.
- `uv tool list --show-with --show-extras` exists in uv 0.9.14, the version pinned by `pyproject.toml` (`required-version = ">=0.9.14"`) and `.github/workflows/ci.yaml`.
- `nemo plugins list` is implemented in `packages/nemo_platform_ext/.../cli/commands/plugins.py` and calls `discover_manifests()`, which scans all surface groups without loading entry-point values — hence the note that it reports installed rather than loaded plugins.
- `Loaded inference middleware plugin` is emitted by `services/core/inference-gateway/.../middleware_registry.py`, and `SETUP.md` already documents grepping for it.

## Notes for reviewers

`plugins/example-plugin/pyproject.toml` still declares both `nemo-platform-plugin` and `nemo-platform`, so the reference plugin does not yet match the corrected guidance. Deliberately out of scope: that is a dependency edit warranting a run of the plugin's test suite, not a docs change. Every other first-party plugin declares both as well, for workspace resolution reasons. Worth a follow-up.
