### PR TITLE
build(rl): avoid recursive chmod in base image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -123,7 +123,7 @@ variable "RL_BASE_CONTEXT" {
 
 # The tag for base images if needed
 variable "WHEELS_TAG" {
-  default = "2c1a9ef2535a6648a272d9b74dae97fb672b8234"
+  default = "54ae40bf653127f1300399912e6c1083f0b96771"
 }
 
 variable "BAKE_CACHE_SOURCE_BRANCH" {

--- a/docker/Dockerfile.nmp-customizer-tasks
+++ b/docker/Dockerfile.nmp-customizer-tasks
@@ -56,13 +56,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     "transformers==${TRANSFORMERS_VERSION}" \
     "accelerate>=1.0.0"
 
-# Nemotron/Mamba CUDA wheels — compiled against NGC 26.05 torch; install --no-deps
+# Nemotron/Mamba CUDA wheels — compiled against NGC 26.07 torch; install --no-deps
 # after the HF stack so a PyPI torch never lands in the venv first.
 RUN --mount=from=causal-conv1d-wheel-src,target=/tmp/causal-conv1d-wheel-src,readonly \
     --mount=from=mamba-ssm-wheel-src,target=/tmp/mamba-ssm-wheel-src,readonly \
     uv pip install --python ${VIRTUAL_ENV}/bin/python --no-cache-dir --no-deps \
-    /tmp/causal-conv1d-wheel-src/wheels/cu13.2/causal_conv1d-*cp312*.whl \
-    /tmp/mamba-ssm-wheel-src/wheels/cu13.2/mamba_ssm-2.3.0-cp312*.whl
+    /tmp/causal-conv1d-wheel-src/wheels/cu13.3/causal_conv1d-*cp312*.whl \
+    /tmp/mamba-ssm-wheel-src/wheels/cu13.3/mamba_ssm-2.3.0-cp312*.whl
 
 # Platform glue — no_override_requirements.txt keeps uv from clobbering NGC torch
 # or re-resolving the HF stack (same pattern as nmp-automodel-training).

--- a/docker/Dockerfile.nmp-unsloth-training
+++ b/docker/Dockerfile.nmp-unsloth-training
@@ -19,7 +19,7 @@
 #   1b. bitsandbytes — compiled from source against the NGC base CUDA (same pattern
 #       as docker/automodel/Dockerfile.nmp-automodel-base). PyPI wheels only ship through
 #       cuda130; source build replaces the wheel from step 1.
-#   1c. mamba-ssm + causal-conv1d — prebuilt cu13.2 / cp312 wheels (shared with
+#   1c. mamba-ssm + causal-conv1d — prebuilt cu13.3 / cp312 wheels (shared with
 #       docker/automodel/Dockerfile.nmp-automodel-base).
 #   1d. flash-attn — optional for unsloth and currently NOT installed (see the
 #       commented TODO below). Without it Unsloth falls back when xformers is
@@ -127,12 +127,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip uninstall --python ${VIRTUAL_ENV}/bin/python scikit-build-core && \
     rm -rf /tmp/bitsandbytes
 
-# Step 1c: mamba-ssm + causal-conv1d — cu13.2 / cp312 wheels shared with automodel base.
+# Step 1c: mamba-ssm + causal-conv1d — cu13.3 / cp312 wheels shared with automodel base.
 RUN --mount=from=causal-conv1d-wheel-src,target=/tmp/causal-conv1d-wheel-src,readonly \
     --mount=from=mamba-ssm-wheel-src,target=/tmp/mamba-ssm-wheel-src,readonly \
     uv pip install --python ${VIRTUAL_ENV}/bin/python --no-cache --no-deps \
-    /tmp/causal-conv1d-wheel-src/wheels/cu13.2/causal_conv1d-*cp312*.whl \
-    /tmp/mamba-ssm-wheel-src/wheels/cu13.2/mamba_ssm-2.3.0-cp312*.whl
+    /tmp/causal-conv1d-wheel-src/wheels/cu13.3/causal_conv1d-*cp312*.whl \
+    /tmp/mamba-ssm-wheel-src/wheels/cu13.3/mamba_ssm-2.3.0-cp312*.whl
 
 # TODO: Step 1d: Flash Attention 2 — compiled from source against the NGC 26.02 torch.
 # /usr/local/cuda symlinks to an older toolkit; use /usr/local/cuda-13.1 instead.

--- a/docker/automodel/Dockerfile.nmp-automodel-base
+++ b/docker/automodel/Dockerfile.nmp-automodel-base
@@ -69,8 +69,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN --mount=from=causal-conv1d-wheel-src,target=/tmp/causal-conv1d-wheel-src,readonly \
     --mount=from=mamba-ssm-wheel-src,target=/tmp/mamba-ssm-wheel-src,readonly \
     uv pip install --no-cache-dir --no-deps \
-    /tmp/causal-conv1d-wheel-src/wheels/cu13.2/causal_conv1d-*cp312*.whl \
-    /tmp/mamba-ssm-wheel-src/wheels/cu13.2/mamba_ssm-2.3.0-cp312*.whl
+    /tmp/causal-conv1d-wheel-src/wheels/cu13.3/causal_conv1d-*cp312*.whl \
+    /tmp/mamba-ssm-wheel-src/wheels/cu13.3/mamba_ssm-2.3.0-cp312*.whl
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     git clone https://github.com/fanshiqing/grouped_gemm.git /tmp/grouped_gemm && \

--- a/docker/base/Dockerfile.python-wheels
+++ b/docker/base/Dockerfile.python-wheels
@@ -103,8 +103,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends software-proper
 
 COPY --from=ghcr.io/astral-sh/uv:0.9.14 /uv /usr/local/bin/uv
 
-# special builder for 13.2 cuda (automodel on NGC 26.05)
-FROM nvcr.io/nvidia/pytorch:26.05-py3 AS mamba-wheel-base-py312-cu13.2
+# special builder for CUDA 13.3 (Automodel/Customizer/Unsloth on NGC 26.07)
+FROM nvcr.io/nvidia/pytorch:26.07-py3 AS mamba-wheel-base-py312-cu13.3
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -158,9 +158,9 @@ RUN mkdir -p /wheels && \
     rm -rf /src/causal-conv1d
 
 # =============================================================================
-# causal-conv1d wheel — Python 3.12 (for Python 3.12 consumers) - Using CUDA 13.2
+# causal-conv1d wheel — Python 3.12 (for Python 3.12 consumers) - Using CUDA 13.3
 # =============================================================================
-FROM  mamba-wheel-base-py312-cu13.2 AS causal-conv1d-wheel-builder-py312-cu13.2
+FROM  mamba-wheel-base-py312-cu13.3 AS causal-conv1d-wheel-builder-py312-cu13.3
 
 ARG CAUSAL_CONV1D_VERSION=v1.5.3
 
@@ -179,7 +179,7 @@ FROM scratch AS causal-conv1d-wheel
 COPY --from=causal-conv1d-wheel-builder /wheels /wheels
 COPY --from=causal-conv1d-wheel-builder-py312 /wheels /wheels
 COPY --from=causal-conv1d-wheel-builder-py312-cu13.1.1 /wheels /wheels/cu13.1.1
-COPY --from=causal-conv1d-wheel-builder-py312-cu13.2 /wheels /wheels/cu13.2
+COPY --from=causal-conv1d-wheel-builder-py312-cu13.3 /wheels /wheels/cu13.3
 
 # =============================================================================
 # mamba-ssm 2.2.5 wheel — Python 3.11 (for safe-synthesizer-tasks)
@@ -250,9 +250,9 @@ RUN mkdir -p /wheels && \
 
 
 # =============================================================================
-# mamba-ssm 2.3.0 wheel — Python 3.12 (for Python 3.12 consumers) - Using CUDA 13.2
+# mamba-ssm 2.3.0 wheel — Python 3.12 (for Python 3.12 consumers) - Using CUDA 13.3
 # =============================================================================
-FROM mamba-wheel-base-py312-cu13.2 AS mamba-ssm-23-wheel-builder-py312-cu13.2
+FROM mamba-wheel-base-py312-cu13.3 AS mamba-ssm-23-wheel-builder-py312-cu13.3
 
 ARG MAMBA_23_COMMIT=v2.3.0
 
@@ -271,14 +271,14 @@ RUN mkdir -p /wheels && \
 #   - mamba_ssm-2.2.5-cp312-*.whl  (from MAMBA_22_COMMIT=6b32be06, for Python 3.12 consumers)
 #   - mamba_ssm-2.3.0-cp312-*.whl  (from v2.3.0, for Python 3.12 consumers)
 #   - cu13.1.1/mamba_ssm-2.3.0-cp312-*.whl  (from v2.3.0, for Unsloth on CUDA 13.1.1)
-#   - cu13.2/mamba_ssm-2.3.0-cp312-*.whl  (from v2.3.0, for Automodel on CUDA 13.2)
+#   - cu13.3/mamba_ssm-2.3.0-cp312-*.whl  (from v2.3.0, for Automodel/Customizer/Unsloth on CUDA 13.3)
 # Consumers must pin both version AND Python tag glob to select the correct wheel.
 FROM scratch AS mamba-ssm-wheel
 COPY --from=mamba-ssm-wheel-builder /wheels /wheels
 COPY --from=mamba-ssm-25-wheel-builder-py312 /wheels /wheels
 COPY --from=mamba-ssm-23-wheel-builder-py312 /wheels /wheels
 COPY --from=mamba-ssm-23-wheel-builder-py312-cu13.1.1 /wheels /wheels/cu13.1.1
-COPY --from=mamba-ssm-23-wheel-builder-py312-cu13.2 /wheels /wheels/cu13.2
+COPY --from=mamba-ssm-23-wheel-builder-py312-cu13.3 /wheels /wheels/cu13.3
 
 # =============================================================================
 # FFmpeg / VLM wheels (manylinux_2_28) — av + opencv-python-headless + decord2

--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -48,6 +48,8 @@ ADD ${NEMO_RL_REPO}#${NEMO_RL_REF} /
 
 # ---- base: cuda-dl-base + system deps + cmake + uv + python 3.13 (mirrors RL's own base stage) ----
 FROM ${BASE_IMAGE} AS base
+ARG BUILD_UID=2000
+ARG BUILD_GID=2000
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
 RUN dpkg-query -W -f='${binary:Package}\t${Version}\n' > /tmp/base-dpkg-packages.txt
@@ -86,12 +88,22 @@ ARG PYTHON_VERSION
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
     UV_PYTHON=${PYTHON_VERSION} \
     PATH="/usr/local/bin:/root/.local/bin:${PATH}"
-RUN curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh && \
+RUN umask 022 && \
+    curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh && \
     cp /root/.local/bin/uv /usr/local/bin/uv && \
     uv python install "${PYTHON_VERSION}"
 COPY docker/scripts/collect-apt-sources.sh \
     docker/scripts/collect-python-sdists.py \
     /usr/local/bin/
+
+# Heavy Python artifacts are built by a non-runtime user. The runtime UID can read them via
+# umask 022, but cannot rewrite the shared uv cache that the symlinked venvs execute from.
+RUN groupadd --gid "${BUILD_GID}" nmp-build && \
+    useradd --uid "${BUILD_UID}" --gid "${BUILD_GID}" --home-dir /home/nmp-build \
+        --create-home --shell /bin/bash nmp-build && \
+    mkdir -p /opt/nemo-rl /opt/nemo_rl_venv /opt/uv_cache /opt/ray_venvs /opt/gym_venvs && \
+    chown -R "${BUILD_UID}:${BUILD_GID}" \
+        /home/nmp-build /opt/nemo-rl /opt/nemo_rl_venv /opt/uv_cache /opt/ray_venvs /opt/gym_venvs
 
 # Ray / NeMo-RL runtime behavior (affects the running container, not the build):
 #   RAY_USAGE_STATS_ENABLED=0        - no telemetry phone-home.
@@ -112,6 +124,8 @@ ENV RAY_USAGE_STATS_ENABLED=0 \
 # and automodel extras are deliberately EXCLUDED: alternative training backends the customizer does
 # not use, and the only source of Transformer-Engine (the longest CUDA compile).
 FROM base AS builder
+ARG BUILD_UID=2000
+ARG BUILD_GID=2000
 WORKDIR /opt/nemo-rl
 
 # Arch knobs + cuDNN wiring (mirrors RL's own hermetic stage). The arch flags only affect the
@@ -151,6 +165,7 @@ ENV NVTE_BUILD_MAX_JOBS=${NVTE_BUILD_MAX_JOBS} \
     TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST} \
     CUDA_HOME=/usr/local/cuda \
     CPLUS_INCLUDE_PATH=/usr/local/cuda/include/cccl \
+    HOME=/home/nmp-build \
     UV_PROJECT_ENVIRONMENT=/opt/nemo_rl_venv \
     UV_CACHE_DIR=/opt/uv_cache \
     CUDNN_HOME=/opt/nemo_rl_venv/lib/python3.13/site-packages/nvidia/cudnn \
@@ -164,11 +179,13 @@ ENV NVTE_BUILD_MAX_JOBS=${NVTE_BUILD_MAX_JOBS} \
 # TensorRT-LLM is excluded (we never build the trtllm extra). Megatron-Bridge must stay, even though
 # the mcore extra is not built: `uv run` validates the lock, which needs metadata for every path
 # source, so removing it fails the prefetch step below.
-COPY --from=nemo-rl pyproject.toml uv.lock ./
-COPY --from=nemo-rl nemo_rl/__init__.py nemo_rl/package_info.py ./nemo_rl/
-COPY --from=nemo-rl --exclude=TensorRT-LLM-workspace --exclude=TensorRT-LLM-workspace/** \
+COPY --from=nemo-rl --chown=${BUILD_UID}:${BUILD_GID} pyproject.toml uv.lock ./
+COPY --from=nemo-rl --chown=${BUILD_UID}:${BUILD_GID} nemo_rl/__init__.py nemo_rl/package_info.py ./nemo_rl/
+COPY --from=nemo-rl --chown=${BUILD_UID}:${BUILD_GID} --exclude=TensorRT-LLM-workspace --exclude=TensorRT-LLM-workspace/** \
      --exclude=**/.git 3rdparty/ ./3rdparty/
-COPY --from=nemo-rl research/ ./research/
+COPY --from=nemo-rl --chown=${BUILD_UID}:${BUILD_GID} research/ ./research/
+
+USER ${BUILD_UID}:${BUILD_GID}
 
 # Default --frozen (reproducible). Gym is RL's own submodule, so its pin is always in lockstep with
 # RL's uv.lock. Set to "" to relock if you bump RL to a commit whose lock has drifted.
@@ -184,6 +201,7 @@ ARG UV_SYNC_MODE=--frozen
 # --no-install-project installs dependencies but not nemo-rl itself; the root package is added
 # editable in a cheap step after the full-source COPY.
 RUN <<"EOF" bash -exu
+umask 022
 # Symlink the base venv into the uv cache (see UV_CACHE_DIR/UV_LINK_MODE note above). Scoped to
 # this command rather than the image ENV so downstream `--no-cache` installs are unaffected.
 export UV_LINK_MODE=symlink
@@ -225,12 +243,12 @@ EOF
 #
 # --exclude=**/.git: the ADD drops only the top-level .git, so each submodule still carries its own.
 # Excluding here keeps them out of this layer - removing them later would leave them extractable.
-COPY --from=nemo-rl --exclude=**/.git . /opt/nemo-rl
+COPY --from=nemo-rl --chown=${BUILD_UID}:${BUILD_GID} --exclude=**/.git . /opt/nemo-rl
 
 # Install the workspace ROOT (nemo-rl) editable. --no-install-project above installed every
 # DEPENDENCY and workspace MEMBER (incl. nemo-gym) but skipped the root; this adds it with --no-deps
 # (deps already present). .git is on disk now, so nemo_rl.__version__ picks up its +<sha> suffix.
-RUN uv pip install --python /opt/nemo_rl_venv/bin/python --no-deps -e /opt/nemo-rl
+RUN umask 022 && uv pip install --python /opt/nemo_rl_venv/bin/python --no-deps -e /opt/nemo-rl
 
 # ---- Per-worker Ray venvs (the venvs training actually runs in) ----
 # Workers do not run in the base venv - each Ray actor gets its own venv under /opt/ray_venvs.
@@ -251,6 +269,7 @@ RUN uv pip install --python /opt/nemo_rl_venv/bin/python --no-deps -e /opt/nemo-
 # NOT prefetched: automodel, mcore, sglang, trtllm, modelopt-quant
 # and the async-GRPO bookkeeping actors; those build on the node if a config selects them.
 RUN <<"EOF" bash -exu
+umask 022
 export UV_LINK_MODE=symlink
 uv run nemo_rl/utils/prefetch_venvs.py \
     dtensor_policy_worker.DTensorPolicyWorker \
@@ -296,6 +315,7 @@ ARG NEMO_GYM_CUDA=cu130
 ARG NEMO_GYM_VLLM_VERSION=0.20.0
 ARG TARGETARCH
 RUN <<"EOF" bash -exu
+umask 022
 export UV_LINK_MODE=symlink
 mkdir -p /opt/gym_venvs
 if [ -n "${NEMO_GYM_PREFETCH_CONFIGS:-}" ]; then
@@ -334,6 +354,8 @@ if [ -d "${GYM_CACHE}" ]; then
 fi
 EOF
 
+USER root
+
 # Container fingerprint (matches NeMo-RL's release stage). With NRL_CONTAINER=1 set, nemo_rl's
 # import-time check compares this against the current source to detect drift between the baked
 # venvs and the code; without the file it logs a warning on every import instead.
@@ -345,6 +367,8 @@ RUN /opt/nemo_rl_venv/bin/python tools/generate_fingerprint.py \
 
 # ---- publish base (inherits builder FS; keeps the uv-managed python valid - see header NOTE) ----
 FROM builder AS nmp-rl-base
+ARG RUNTIME_UID=1000
+ARG RUNTIME_GID=1000
 
 # setuptools CVEs (GHSA-58pv-8j8x-9vj2, GHSA-8rrh-rw8j-w5fx, in its vendored jaraco.context/wheel):
 # Megatron-Bridge pins `setuptools<80.0.0` for its build, and PEP 517 build environments resolve
@@ -390,27 +414,37 @@ ENV VIRTUAL_ENV=/opt/nemo_rl_venv \
 
 # The venv's python symlinks to the uv-managed interpreter under /opt/uv, nemo_rl is installed
 # editable from /opt/nemo-rl, and the worker/Gym venvs symlink their packages into /opt/uv_cache.
-# Make all of it world-readable/traversable so the non-root runtime (training image drops to UID
-# 1000) can load Python's stdlib, import nemo_rl / nemo_gym, and resolve those package symlinks.
-RUN chmod -R a+rX /opt/uv /opt/uv_cache /opt/nemo_rl_venv /opt/nemo-rl /opt/gym_venvs /opt/ray_venvs
+# Build steps create these trees with umask 022 so the non-root runtime can load Python's stdlib,
+# import nemo_rl / nemo_gym, and resolve package symlinks without a late recursive chmod layer.
+RUN <<"EOF" bash -eu
+for path in /opt/uv /opt/uv_cache /opt/nemo_rl_venv /opt/nemo-rl /opt/gym_venvs /opt/ray_venvs; do
+    blocked="$(find "${path}" \
+        \( -type d ! -perm -005 -o -type f ! -perm -004 -o -type f -perm /111 ! -perm -001 \) \
+        -print -quit)"
+    if [ -n "${blocked}" ]; then
+        echo "ERROR: ${blocked} is not readable/traversable by the runtime UID." >&2
+        echo "       Ensure build steps create Python artifacts with umask 022." >&2
+        exit 1
+    fi
+done
+EOF
 
 # Runtime writability, deliberately minimal. NeMo-RL and Gym create ADDITIONAL venvs at runtime
 # (user Gym FileSet environments; any actor that was not prefetched), so the two venv PARENT
-# directories must be writable by the non-root runtime user. Only the top-level directories are
-# chowned - NOT -R - so the layer stays tiny and the prefetched venvs underneath stay root-owned.
+# directories must be writable by the non-root runtime user. Only the top-level directories get group
+# write + sticky mode, so the layer stays tiny and prefetched venvs stay build-owned/read-only.
 #
 # /opt/uv_cache is deliberately left read-only: it holds the actual code the trainer executes, and
 # this container also runs user-authored Gym environment code, which must not be able to rewrite
 # it. Downstream images point uv at a writable per-user cache (see Dockerfile.nmp-rl-training).
-ARG RUNTIME_UID=1000
-ARG RUNTIME_GID=1000
-RUN chown ${RUNTIME_UID}:${RUNTIME_GID} /opt/ray_venvs /opt/gym_venvs
+RUN chown root:${RUNTIME_GID} /opt/ray_venvs /opt/gym_venvs && \
+    chmod 1775 /opt/ray_venvs /opt/gym_venvs
 
 # NeMo-RL patches vLLM in place at worker startup (models/generation/vllm/patches.py), which
-# symlinking breaks two ways: the venvs are root-owned so the patch lock fails with EACCES as UID
-# 1000, and every vLLM venv symlinks to ONE copy in /opt/uv_cache while the patch writes a per-venv
-# py_executable into it. Giving each venv a private vllm/ fixes both. Scoped to vllm/ (~506 MB x 3)
-# rather than UV_LINK_MODE=copy globally (~56 GB) - see README.md, "Link mode".
+# symlinking breaks two ways: the venvs are build-owned/read-only for the runtime UID, so the patch
+# lock fails with EACCES, and every vLLM venv symlinks to ONE copy in /opt/uv_cache while the patch
+# writes a per-venv py_executable into it. Giving each venv a private vllm/ fixes both. Scoped to vllm/
+# (~506 MB x 3) rather than UV_LINK_MODE=copy globally (~56 GB) - see README.md, "Link mode".
 RUN <<"EOF" bash -exu
 privatized=0
 for sp in /opt/ray_venvs/*/lib/python*/site-packages; do
@@ -457,7 +491,7 @@ done
 EOF
 
 # Gym falls back to this in-tree cache when a process does not inherit NRL_CONTAINER / UV_CACHE_DIR
-# (the sandboxed Gym host's per-app servers), and fails with EACCES on a root-owned tree. Keeping
+# (the sandboxed Gym host's per-app servers), and fails with EACCES on the build-owned tree. Keeping
 # the fallback writable is the safety net; the real fix is env propagation, which lives in NeMo-RL.
 RUN mkdir -p /opt/nemo-rl/3rdparty/Gym-workspace/Gym/cache && \
     chown ${RUNTIME_UID}:${RUNTIME_GID} /opt/nemo-rl/3rdparty/Gym-workspace/Gym/cache

--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -184,6 +184,7 @@ COPY --from=nemo-rl --chown=${BUILD_UID}:${BUILD_GID} nemo_rl/__init__.py nemo_r
 COPY --from=nemo-rl --chown=${BUILD_UID}:${BUILD_GID} --exclude=TensorRT-LLM-workspace --exclude=TensorRT-LLM-workspace/** \
      --exclude=**/.git 3rdparty/ ./3rdparty/
 COPY --from=nemo-rl --chown=${BUILD_UID}:${BUILD_GID} research/ ./research/
+COPY docker/rl/cherry-picks /opt/cherry-picks
 
 USER ${BUILD_UID}:${BUILD_GID}
 
@@ -208,6 +209,29 @@ export UV_LINK_MODE=symlink
 uv venv --seed
 
 uv sync ${UV_SYNC_MODE} --no-install-project
+
+# PyTorch 2.11's List_inl.h uses a dependent decltype expression that nvcc from CUDA 13.3 rejects
+# while compiling DeepEP on arm64. Backport the equivalent type spelling from upstream commit
+# https://github.com/pytorch/pytorch/commit/c2671b853e1553b258a30c15d66f9647faae7aee.
+# Remove this when the RL dependency stack moves to PyTorch 2.13 or later.
+torch_include=/opt/nemo_rl_venv/lib/python3.13/site-packages/torch/include
+list_inl="${torch_include}/ATen/core/List_inl.h"
+test -f "${list_inl}"
+# UV_LINK_MODE=symlink above leaves every venv file a symlink into UV_CACHE_DIR, and `git apply`
+# rejects a symlink target with "wrong type". Swap this one header for a private copy so the patch
+# lands in the venv alone: writing through the link would edit the shared cache mount, which other
+# targets reuse and which would then fail the --check below on every subsequent build.
+if [ -L "${list_inl}" ]; then
+    cached_list_inl="$(readlink -f "${list_inl}")"
+    rm "${list_inl}"
+    cp "${cached_list_inl}" "${list_inl}"
+fi
+git -C "${torch_include}" apply --check /opt/cherry-picks/pytorch-c2671b8-list-inl.diff
+git -C "${torch_include}" apply /opt/cherry-picks/pytorch-c2671b8-list-inl.diff
+grep -Fq \
+    'typename c10::detail::ListImpl::list_type::difference_type' \
+    "${list_inl}"
+
 uv sync ${UV_SYNC_MODE} --extra vllm      --no-install-project   # GRPO generation (vllm 0.20 cu130 + flashinfer + deep_gemm/deep_ep)
 uv sync ${UV_SYNC_MODE} --extra fsdp      --no-install-project   # DPO/GRPO policy training (flash-attn, mamba-ssm, causal-conv1d)
 uv sync ${UV_SYNC_MODE} --extra modelopt  --no-install-project   # quantization / model-opt

--- a/docker/rl/Dockerfile.nmp-rl-training
+++ b/docker/rl/Dockerfile.nmp-rl-training
@@ -53,6 +53,7 @@ RUN UV_CACHE_DIR=/root/.cache/uv \
 # UV_CACHE_DIR is overridden to the build-only mount here: the base sets it to /opt/uv_cache, which
 # this step must not write into (that cache is shipped read-only, see below).
 RUN --mount=type=cache,target=/root/.cache/uv \
+    umask 022 && \
     UV_CACHE_DIR=/root/.cache/uv \
     uv-glue pip freeze --python /opt/nemo_rl_venv/bin/python --exclude-editable \
         | grep -E '^[A-Za-z0-9._-]+==' > /tmp/base-overrides.txt && \

--- a/docker/rl/README.md
+++ b/docker/rl/README.md
@@ -433,7 +433,8 @@ readable by the non-root user. Hence `UV_CACHE_DIR=/opt/uv_cache`:
 - It cannot be a BuildKit `--mount=type=cache` — those never enter the image, so every
   symlink would dangle.
 - It cannot sit at uv's default `~/.cache/uv`, because `/root` is mode `700` and the
-  training image runs as UID 1000 (the same reason the managed Python lives under `/opt`).
+  training image runs as a configured non-root UID (1000 by default, the same reason the
+  managed Python lives under `/opt`).
 - **`/opt/uv_cache` must never be deleted** — pruning it breaks every venv that points into
   it. The prune step in the publish stage deliberately leaves it alone.
 
@@ -456,15 +457,15 @@ rewrites `v1/executor/ray_executor.py`, `model_executor/models/llama_eagle3.py` 
 `tool_parsers/hermes_tool_parser.py`, taking a `<file>.patch_lock` beside each). Symlinking breaks
 that in two independent ways, both observed on the shipped image:
 
-1. **Permission** — the prefetched venvs are root-owned and the runtime is UID 1000, so creating
-   `ray_executor.py.patch_lock` fails with `EACCES` and the `VllmAsyncGenerationWorker` actor dies
-   in its creation task.
+1. **Permission** — the prefetched venvs are build-owned/read-only for the configured runtime UID
+   (1000 by default), so creating `ray_executor.py.patch_lock` fails with `EACCES` and the
+   `VllmAsyncGenerationWorker` actor dies in its creation task.
 2. **Sharing** — every vLLM-tier venv symlinks that file to *one* physical copy in `/opt/uv_cache`.
    The patch writes a **per-venv `py_executable`** into it, so two venvs cannot share it. No amount
    of `chown` fixes this; the file must not be shared at all.
 
-So the publish stage replaces `site-packages/vllm/` with a real, private, UID-1000-owned copy in
-each vLLM-tier venv.
+So the publish stage replaces `site-packages/vllm/` with a real, private, runtime-owned copy in each
+vLLM-tier venv.
 
 The two need separate fixes: **ownership** solves (1), **private copies** solve (2). Running as root
 would silence the `EACCES` but leaves the sharing intact — the first venv to patch wins and the next
@@ -535,4 +536,5 @@ every import.
 | `NVTE_CUDA_ARCHS` | `90;100` | Archs for Transformer-Engine. Inert today (TE is only in the unused `automodel`/`mcore` extras); kept for when either is enabled. |
 | `UV_SYNC_MODE` | `--frozen` | Reproducible sync. Set to empty to relock if a bumped RL commit's lock has drifted. |
 | `NEMO_GYM_PREFETCH_CONFIGS` | *(empty — prefetch off)* | Space-separated Gym config paths whose environment venvs are baked into `/opt/gym_venvs`. Empty means every environment installs at runtime on first use. Set to `examples/nemo_gym/prefetch_super_all_envs.yaml` to bake NeMo-RL's curated set back in. |
-
+| `BUILD_UID` / `BUILD_GID` | `2000` / `2000` | Non-runtime owner for `/opt/uv_cache`, `/opt/nemo_rl_venv`, `/opt/nemo-rl`, and prefetched venvs. Build steps use `umask 022` so the configured runtime UID can read/traverse these trees without a late recursive chmod layer. |
+| `RUNTIME_UID` / `RUNTIME_GID` | `1000` / `1000` | Non-root identity for published `nmp-rl-base`. `RUNTIME_UID` owns the private vLLM copies; `/opt/ray_venvs` and `/opt/gym_venvs` are owned by root with `RUNTIME_GID` as the writable group. Keep `nmp-rl-training`'s `USER_UID` / `USER_GID` aligned if overriding the defaults. |

--- a/docker/rl/cherry-picks/pytorch-c2671b8-list-inl.diff
+++ b/docker/rl/cherry-picks/pytorch-c2671b8-list-inl.diff
@@ -1,0 +1,11 @@
+diff --git a/ATen/core/List_inl.h b/ATen/core/List_inl.h
+index f2d86fe..3e59737 100644
+--- a/ATen/core/List_inl.h
++++ b/ATen/core/List_inl.h
+@@ -198,5 +198,5 @@ typename List<T>::internal_const_reference_type List<T>::operator[](size_type po
+ template<class T>
+ typename List<T>::internal_reference_type List<T>::operator[](size_type pos) {
+   static_cast<void>(impl_->list.at(pos)); // Throw the exception if it is out of range.
+-  return {impl_->list.begin() + static_cast<typename decltype(impl_->list)::difference_type>(pos)};
++  return {impl_->list.begin() + static_cast<typename c10::detail::ListImpl::list_type::difference_type>(pos)};
+ }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Avoid a late recursive `chmod -R` over the RL base image's large venv/source/cache trees by creating build artifacts with runtime-readable permissions up front. The heavy RL build now runs as a build-only UID/GID, leaves prefetched venvs read-only for the runtime user, and audits permissions instead of mutating the inherited layer. This also rebuilds the shared Mamba/causal-conv1d CUDA 13.3 wheels against NGC PyTorch 26.07 and pins `WHEELS_TAG` to `54ae40bf653127f1300399912e6c1083f0b96771` for Automodel, Customizer, and Unsloth consumers.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Add a build-only `nmp-build` user/group to `Dockerfile.nmp-rl-base` and make NeMo-RL source, uv cache, and venv directories build-owned from creation.
- Set `umask 022` around uv Python/venv/install steps so runtime-readable permissions are produced during artifact creation.
- Replace the broad late `chmod -R a+rX` over RL artifacts with a non-mutating permission audit.
- Keep runtime-created Ray/Gym venv parent directories writable via `root:${RUNTIME_GID}` and sticky group-write mode while leaving prefetched venv contents build-owned/read-only.
- Keep private runtime-owned `vllm/` copies only where NeMo-RL patches vLLM in place.
- Set `umask 022` for the RL training image's platform-glue install into the inherited venv.
- Update the RL Docker README to document build/run UID ownership, configurable runtime identity, and the retained writable vLLM copy path.
- Cherry-pick Swarom's signed PyTorch `List_inl.h` compatibility patch from #1321 / `8f27105b5107a940f6ec60a5b04a182cf8ba656b`.
- Build the Python 3.12 Mamba/causal-conv1d CUDA extension wheel stages from `nvcr.io/nvidia/pytorch:26.07-py3` and publish them under `/wheels/cu13.3`.
- Update Automodel, Customizer, and Unsloth Dockerfiles to install the CUDA 13.3 wheel paths.
- Pin `WHEELS_TAG` to the Platform-Deploy wheel build's resolved nemo-platform SHA: `54ae40bf653127f1300399912e6c1083f0b96771`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Docker image ownership/layering and container-build fixes with no unit-test surface; verified with diff checks, DCO audit, and Docker bake graph parsing below. Full image builds were not run locally.
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `git diff --check origin/main...HEAD` - passed after rebasing the PR branch onto `origin/main`.
- `git diff --check` - passed.
- `git diff --cached --check` - passed.
- `docker buildx bake --file docker-bake.hcl --print causal-conv1d-wheel mamba-ssm-wheel nmp-customizer-tasks nmp-automodel-base-builder nmp-unsloth-training` - passed; wheel targets and consumers resolve to tag `54ae40bf653127f1300399912e6c1083f0b96771`.
- DCO audit over `origin/main..HEAD` - passed for `63957f1b0437cff25e1d1aad05520f28c7854bfe`, `07f96536518b69c96400e6652b243ba689db933f`, `abf10302740eef088c9ad00a31b3647c9c53a50a`, and `8839bb90e740d1d2bb5ad62f41460173f05a2984`.
- `uv run pre-commit run -a` - blocked locally: the repo hook requires uv `0.9.14` but the host has uv `0.9.18`; `helm-docs` and `copyright-fix` also modified unrelated files, and `copyright-fix` reported unrelated existing non-standard headers under `packages/garak_api/garakapi/`. Hook-generated unrelated changes were restored.
- Platform-Deploy wheel build run `31855503699` - resolved nemo-platform ref `54ae40bf653127f1300399912e6c1083f0b96771`; amd64 wheel image job succeeded; arm64 wheel image job was still in progress at the last check, so the final unsuffixed GHCR wheel manifests were not available yet.
- Full RL/Automodel/Customizer/Unsloth image builds - not run locally.
