### PR TITLE
fix(guardrails): Fix benchmark failure condition

### DIFF
--- a/plugins/nemo-guardrails/benchmarks/README.md
+++ b/plugins/nemo-guardrails/benchmarks/README.md
@@ -220,8 +220,9 @@ the tolerances also account for inter-runner variance.
   Other levels still appear in the analyzer's output tables, but pass/fail
   is decided only by these.
 - `DEFAULT_DELTA_P50_TOLERANCE_MS: int` — default tolerance (in ms) applied
-  to every validated concurrency. A check fails when
-  `|observed - baseline| > tolerance`.
+  to every validated concurrency. A check fails only on a regression, when
+  `observed - baseline > tolerance`. Faster results pass regardless of how
+  far below the baseline they are.
 - `DELTA_P50_TOLERANCE_OVERRIDES_MS: dict[int, int]` — per-concurrency
   tolerance overrides (in ms). Levels without an override fall back to the
   default.
@@ -229,9 +230,9 @@ the tolerances also account for inter-runner variance.
   (in ms) per concurrency level. Edit by hand when a real change shifts
   the numbers.
 
-Worked example: at c=16 the override is 200 ms, so a run with observed
-delta_p50 = 1589 (diff +199 from baseline 1390) passes; observed
-delta_p50 = 1591 (diff +201) fails.
+Worked example: at c=16 the override is 200 ms, so runs with observed
+delta_p50 = 1190 (diff -200) or 1589 (diff +199 from baseline 1390) pass;
+observed delta_p50 = 1591 (diff +201) fails.
 
 Notes on the current values:
 

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/benchmarks/analyze.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/benchmarks/analyze.py
@@ -30,8 +30,8 @@ VARIANT_WITHOUT_GUARDRAILS = "without-guardrails"
 # For each concurrency level we list:
 #   - The expected p50 latency delta between requests with guardrails vs.
 #     without guardrails.
-#   - The allowed plus/minus tolerance in CI. Benchmark jobs whose p50
-#     latency exceeds this tolerance will fail.
+#   - The allowed regression tolerance in CI. Benchmark jobs whose p50
+#     latency exceeds the baseline by more than this tolerance will fail.
 
 # Concurrency levels we check in CI.
 CONCURRENCIES_TO_VALIDATE: list[int] = [1, 2, 4, 8, 16, 32]
@@ -293,9 +293,10 @@ class LatencyReport:
 
     Each instance represents a single concurrency level from the benchmark
     run: what we measured (observed_ms), what we expected from the
-    baseline (baseline_ms), and how much they're allowed to differ
+    baseline (baseline_ms), and how much slower it is allowed to be
     (tolerance_ms).
-    The check passes when |observed_ms - baseline_ms| <= tolerance_ms.
+    The check passes when observed_ms - baseline_ms <= tolerance_ms, so
+    improvements over the baseline do not fail the regression gate.
     """
 
     concurrency: int
@@ -310,7 +311,7 @@ class LatencyReport:
 
     @property
     def passed(self) -> bool:
-        return abs(self.diff_ms) <= self.tolerance_ms
+        return self.diff_ms <= self.tolerance_ms
 
 
 def check_against_baseline(rows: list[ComparisonRow]) -> tuple[str, int]:
@@ -357,7 +358,7 @@ def check_against_baseline(rows: list[ComparisonRow]) -> tuple[str, int]:
                 f"{report.baseline_ms:.0f}",
                 f"{report.observed_ms:.0f}",
                 f"{report.diff_ms:+.0f}",
-                f"±{report.tolerance_ms:.0f}ms",
+                f"+{report.tolerance_ms:.0f}ms",
                 status,
             )
         )
@@ -366,7 +367,7 @@ def check_against_baseline(rows: list[ComparisonRow]) -> tuple[str, int]:
         lines.append(f"Skipped (missing from results or baseline): {skipped_concurrencies}")
     if failed_count:
         lines.append("")
-        lines.append(f"FAIL: {failed_count} of {len(latency_reports)} check(s) exceeded tolerance.")
+        lines.append(f"FAIL: {failed_count} of {len(latency_reports)} check(s) exceeded regression tolerance.")
 
     return "\n".join(lines), failed_count
 

--- a/plugins/nemo-guardrails/tests/unit/test_benchmark_analyze.py
+++ b/plugins/nemo-guardrails/tests/unit/test_benchmark_analyze.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from nemo_guardrails_plugin.benchmarks.analyze import LatencyReport
+
+
+@pytest.mark.parametrize(
+    ("observed_ms", "expected"),
+    [
+        (890.0, True),
+        (1390.0, True),
+        (1590.0, True),
+        (1591.0, False),
+    ],
+)
+def test_latency_report_only_fails_regressions_beyond_tolerance(observed_ms: float, expected: bool) -> None:
+    report = LatencyReport(
+        concurrency=16,
+        metric="delta_p50",
+        baseline_ms=1390.0,
+        observed_ms=observed_ms,
+        tolerance_ms=200.0,
+    )
+
+    assert report.passed is expected


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Currently, the nemo-guardrails plugin benchmark CI step fails if the observed latency is above or below the configured threshold (ex. 150 ms). This means a benchmark run that is _faster_ than the configured baseline would fail. This shouldn't be the case - only runs slower than the allowed diff should trigger a failure. 

## Changes
- Updated failure condition in `plugins/nemo-guardrails/src/nemo_guardrails_plugin/benchmarks/analyze.py`

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates
- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated benchmark gating to fail only when latency exceeds the baseline by more than the allowed tolerance.
  * Faster-than-baseline results now pass regardless of the size of the improvement.
  * Improved tolerance output and failure messages to clearly describe latency regressions.

* **Tests**
  * Added coverage for passing results within tolerance and failing results beyond tolerance.

* **Documentation**
  * Updated benchmark guidance and examples to reflect the one-sided latency regression rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->