### PR TITLE
fix(ci): Copyright thrashing on OpenAPI spec

### DIFF
--- a/script/copyright_fixer.py
+++ b/script/copyright_fixer.py
@@ -733,7 +733,39 @@ def _resolve_targets(paths: list[Path], include: list[str] | None = None) -> tup
         return _collect_files_from_dir(root, include=include), root
 
     files = [str(p.resolve()) for p in paths if p.is_file() and _is_supported_file(str(p.resolve()))]
+    files = _filter_copyright_excluded(files, include=include)
     return files, None
+
+
+def _filter_copyright_excluded(files: list[str], include: list[str] | None = None) -> list[str]:
+    """Drop files matched by .copyrightignore, unless explicitly --include'd.
+
+    Mirrors the exclusion applied by ``_collect_files_from_dir`` for
+    directory scans, but for an explicit file list (e.g. filenames passed
+    by pre-commit).
+    """
+    if not files:
+        return files
+
+    repo = _get_repo(files[0])
+    if repo is None:
+        return files
+
+    repo_root = str(repo.working_tree_dir)
+    copyright_excludes = _load_copyright_excludes(repo_root)
+    if not copyright_excludes:
+        return files
+
+    include = include or []
+    kept = []
+    for filepath in files:
+        relpath = os.path.relpath(filepath, repo_root)
+        if _is_copyright_excluded(relpath, copyright_excludes) and not _is_explicitly_included(
+            relpath, relpath, include
+        ):
+            continue
+        kept.append(filepath)
+    return kept
 
 
 # --- CLI ---


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Explicitly specified files now respect `.copyrightignore` rules.
  * Added an `--include` option to override exclusions and process selected files.
  * Files outside Git repositories or without ignore patterns continue to be processed without filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->