### PR TITLE
chore: more SPDX header cleanup for helm/ gotmpl

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
                                  Apache License
                            Version 2.0, January 2004

--- a/contrib/auth/authentik/helm/templates/_envoy-config.tpl
+++ b/contrib/auth/authentik/helm/templates/_envoy-config.tpl
@@ -1,5 +1,7 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- define "nemo-platform-authentik.envoyConfig" -}}
 {{- $authentik := required "nemo-platform.authentikEnvoy is required" .Values.authentikEnvoy -}}

--- a/contrib/auth/authentik/helm/templates/_helpers.tpl
+++ b/contrib/auth/authentik/helm/templates/_helpers.tpl
@@ -1,5 +1,7 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- define "nemo-platform-authentik.namespace" -}}
 {{- .Release.Namespace -}}

--- a/contrib/auth/authentik/helm/templates/blueprint-apply-job.yaml
+++ b/contrib/auth/authentik/helm/templates/blueprint-apply-job.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.blueprintApplyJob.enabled }}
 {{- $authentikValues := index .Values "authentik" | default dict -}}

--- a/contrib/auth/authentik/helm/templates/blueprint-apply-job.yaml
+++ b/contrib/auth/authentik/helm/templates/blueprint-apply-job.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.blueprintApplyJob.enabled }}
 {{- $authentikValues := index .Values "authentik" | default dict -}}

--- a/contrib/auth/authentik/helm/templates/blueprint-configmap.yaml
+++ b/contrib/auth/authentik/helm/templates/blueprint-configmap.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/contrib/auth/authentik/helm/templates/blueprint-configmap.yaml
+++ b/contrib/auth/authentik/helm/templates/blueprint-configmap.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v1
 kind: ConfigMap

--- a/contrib/auth/authentik/helm/templates/shared-postgres-initdb-configmap.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-initdb-configmap.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.sharedPostgresql.enabled }}
 apiVersion: v1

--- a/contrib/auth/authentik/helm/templates/shared-postgres-initdb-configmap.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-initdb-configmap.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.sharedPostgresql.enabled }}
 apiVersion: v1

--- a/contrib/auth/authentik/helm/templates/shared-postgres-nemo-secret.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-nemo-secret.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.sharedPostgresql.enabled }}
 {{- $nemoPassword := include "nemo-platform-authentik.sharedPostgresql.password" (dict "root" . "secretName" .Values.sharedPostgresql.serviceName "secretKey" "nemo-password" "value" .Values.sharedPostgresql.nemo.password) -}}

--- a/contrib/auth/authentik/helm/templates/shared-postgres-nemo-secret.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-nemo-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.sharedPostgresql.enabled }}
 {{- $nemoPassword := include "nemo-platform-authentik.sharedPostgresql.password" (dict "root" . "secretName" .Values.sharedPostgresql.serviceName "secretKey" "nemo-password" "value" .Values.sharedPostgresql.nemo.password) -}}

--- a/contrib/auth/authentik/helm/templates/shared-postgres-secret.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-secret.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.sharedPostgresql.enabled }}
 {{- $secretName := .Values.sharedPostgresql.serviceName -}}

--- a/contrib/auth/authentik/helm/templates/shared-postgres-secret.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.sharedPostgresql.enabled }}
 {{- $secretName := .Values.sharedPostgresql.serviceName -}}

--- a/contrib/auth/authentik/helm/templates/shared-postgres-service.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.sharedPostgresql.enabled }}
 apiVersion: v1

--- a/contrib/auth/authentik/helm/templates/shared-postgres-service.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-service.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.sharedPostgresql.enabled }}
 apiVersion: v1

--- a/contrib/auth/authentik/helm/templates/shared-postgres-serviceaccount.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and .Values.sharedPostgresql.enabled .Values.sharedPostgresql.serviceAccount.create }}
 apiVersion: v1

--- a/contrib/auth/authentik/helm/templates/shared-postgres-serviceaccount.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-serviceaccount.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.sharedPostgresql.enabled .Values.sharedPostgresql.serviceAccount.create }}
 apiVersion: v1

--- a/contrib/auth/authentik/helm/templates/shared-postgres-statefulset.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-statefulset.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.sharedPostgresql.enabled }}
 apiVersion: apps/v1

--- a/contrib/auth/authentik/helm/templates/shared-postgres-statefulset.yaml
+++ b/contrib/auth/authentik/helm/templates/shared-postgres-statefulset.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.sharedPostgresql.enabled }}
 apiVersion: apps/v1

--- a/contrib/auth/authentik/helm/templates/tokenreview-rbac.yaml
+++ b/contrib/auth/authentik/helm/templates/tokenreview-rbac.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/contrib/auth/authentik/helm/templates/tokenreview-rbac.yaml
+++ b/contrib/auth/authentik/helm/templates/tokenreview-rbac.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/contrib/auth/authentik/helm/templates/workload-token-signing-key-secret.yaml
+++ b/contrib/auth/authentik/helm/templates/workload-token-signing-key-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.workloadTokenSigningKey.create }}
 apiVersion: v1

--- a/contrib/auth/authentik/helm/templates/workload-token-signing-key-secret.yaml
+++ b/contrib/auth/authentik/helm/templates/workload-token-signing-key-secret.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.workloadTokenSigningKey.create }}
 apiVersion: v1

--- a/contrib/auth/authentik/helm/templates/workload-token-tls.yaml
+++ b/contrib/auth/authentik/helm/templates/workload-token-tls.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.workloadTokenTls.create }}
 {{- $secretName := required "workloadTokenTls.secretName is required" .Values.workloadTokenTls.secretName -}}

--- a/contrib/auth/authentik/helm/templates/workload-token-tls.yaml
+++ b/contrib/auth/authentik/helm/templates/workload-token-tls.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.workloadTokenTls.create }}
 {{- $secretName := required "workloadTokenTls.secretName is required" .Values.workloadTokenTls.secretName -}}

--- a/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
+++ b/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
@@ -1,5 +1,7 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 # {{ template "chart.description" . }}
 

--- a/k8s/helm/templates/_config-render.tpl
+++ b/k8s/helm/templates/_config-render.tpl
@@ -1,4 +1,6 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- tpl .Values.basePlatformConfig . -}}

--- a/k8s/helm/templates/_helpers.tpl
+++ b/k8s/helm/templates/_helpers.tpl
@@ -1,5 +1,7 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{/*
 Expand the name of the chart.

--- a/k8s/helm/templates/api-env-secret-generator.yaml
+++ b/k8s/helm/templates/api-env-secret-generator.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if include "nemo-platform.generateDefaultEncryptionKey" . }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/api-env-secret-generator.yaml
+++ b/k8s/helm/templates/api-env-secret-generator.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if include "nemo-platform.generateDefaultEncryptionKey" . }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/api-env-secret-upgrade-check.yaml
+++ b/k8s/helm/templates/api-env-secret-upgrade-check.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if include "nemo-platform.requireExistingGeneratedDefaultEncryptionKey" . }}
 {{- $secretName := include "nemo-platform.apiEnvSecretName" . -}}

--- a/k8s/helm/templates/api-env-secret-upgrade-check.yaml
+++ b/k8s/helm/templates/api-env-secret-upgrade-check.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if include "nemo-platform.requireExistingGeneratedDefaultEncryptionKey" . }}
 {{- $secretName := include "nemo-platform.apiEnvSecretName" . -}}

--- a/k8s/helm/templates/api-env-secret-validation.yaml
+++ b/k8s/helm/templates/api-env-secret-validation.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- $existingSecretName := include "nemo-platform.defaultEncryptionKeyExistingSecretName" . -}}
 {{- if and .Values.envFromSecret $existingSecretName -}}

--- a/k8s/helm/templates/api-env-secret-validation.yaml
+++ b/k8s/helm/templates/api-env-secret-validation.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- $existingSecretName := include "nemo-platform.defaultEncryptionKeyExistingSecretName" . -}}
 {{- if and .Values.envFromSecret $existingSecretName -}}

--- a/k8s/helm/templates/api-env-secret.yaml
+++ b/k8s/helm/templates/api-env-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if not .Values.envFromSecret }}
 {{- if include "nemo-platform.defaultEncryptionKeyExistingSecretName" . }}

--- a/k8s/helm/templates/api-env-secret.yaml
+++ b/k8s/helm/templates/api-env-secret.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if not .Values.envFromSecret }}
 {{- if include "nemo-platform.defaultEncryptionKeyExistingSecretName" . }}

--- a/k8s/helm/templates/api/_helpers.tpl
+++ b/k8s/helm/templates/api/_helpers.tpl
@@ -1,5 +1,7 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{/*
 Image Definition Parsing

--- a/k8s/helm/templates/api/api-deployment.yaml
+++ b/k8s/helm/templates/api/api-deployment.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.api.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/api/api-deployment.yaml
+++ b/k8s/helm/templates/api/api-deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.api.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/api/api-hpa.yaml
+++ b/k8s/helm/templates/api/api-hpa.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.api.enabled }}
 {{- if .Values.api.autoscaling.enabled }}

--- a/k8s/helm/templates/api/api-hpa.yaml
+++ b/k8s/helm/templates/api/api-hpa.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.api.enabled }}
 {{- if .Values.api.autoscaling.enabled }}

--- a/k8s/helm/templates/api/api-pdb.yaml
+++ b/k8s/helm/templates/api/api-pdb.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.api.enabled }}
 {{- if .Values.api.podDisruptionBudget.enabled }}

--- a/k8s/helm/templates/api/api-pdb.yaml
+++ b/k8s/helm/templates/api/api-pdb.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.api.enabled }}
 {{- if .Values.api.podDisruptionBudget.enabled }}

--- a/k8s/helm/templates/api/api-service.yaml
+++ b/k8s/helm/templates/api/api-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.api.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/api/api-service.yaml
+++ b/k8s/helm/templates/api/api-service.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.api.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/api/api-serviceaccount.yaml
+++ b/k8s/helm/templates/api/api-serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.api.enabled }}
 {{- if .Values.api.serviceAccount.create -}}

--- a/k8s/helm/templates/api/api-serviceaccount.yaml
+++ b/k8s/helm/templates/api/api-serviceaccount.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.api.enabled }}
 {{- if .Values.api.serviceAccount.create -}}

--- a/k8s/helm/templates/api/api-servicemonitor.yaml
+++ b/k8s/helm/templates/api/api-servicemonitor.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.api.enabled }}
 {{- if .Values.api.serviceMonitor.enabled }}

--- a/k8s/helm/templates/api/api-servicemonitor.yaml
+++ b/k8s/helm/templates/api/api-servicemonitor.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.api.enabled }}
 {{- if .Values.api.serviceMonitor.enabled }}

--- a/k8s/helm/templates/clickhouse/clickhouse-secret.yaml
+++ b/k8s/helm/templates/clickhouse/clickhouse-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and .Values.clickhouse.enabled (not .Values.clickhouse.auth.existingSecret) }}
 {{- $secretName := include "nemo-common.clickhouse.fullname" . }}

--- a/k8s/helm/templates/clickhouse/clickhouse-secret.yaml
+++ b/k8s/helm/templates/clickhouse/clickhouse-secret.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.clickhouse.enabled (not .Values.clickhouse.auth.existingSecret) }}
 {{- $secretName := include "nemo-common.clickhouse.fullname" . }}

--- a/k8s/helm/templates/clickhouse/clickhouse-service.yaml
+++ b/k8s/helm/templates/clickhouse/clickhouse-service.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if include "nemo-common.clickhouse.enabled" . }}
 apiVersion: v1

--- a/k8s/helm/templates/clickhouse/clickhouse-service.yaml
+++ b/k8s/helm/templates/clickhouse/clickhouse-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if include "nemo-common.clickhouse.enabled" . }}
 apiVersion: v1

--- a/k8s/helm/templates/clickhouse/clickhouse-serviceaccount.yaml
+++ b/k8s/helm/templates/clickhouse/clickhouse-serviceaccount.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and (include "nemo-common.clickhouse.enabled" .) .Values.clickhouse.serviceAccount.create }}
 apiVersion: v1

--- a/k8s/helm/templates/clickhouse/clickhouse-serviceaccount.yaml
+++ b/k8s/helm/templates/clickhouse/clickhouse-serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and (include "nemo-common.clickhouse.enabled" .) .Values.clickhouse.serviceAccount.create }}
 apiVersion: v1

--- a/k8s/helm/templates/clickhouse/clickhouse-statefulset.yaml
+++ b/k8s/helm/templates/clickhouse/clickhouse-statefulset.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if include "nemo-common.clickhouse.enabled" . }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/clickhouse/clickhouse-statefulset.yaml
+++ b/k8s/helm/templates/clickhouse/clickhouse-statefulset.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if include "nemo-common.clickhouse.enabled" . }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/core/_helpers.tpl
+++ b/k8s/helm/templates/core/_helpers.tpl
@@ -1,5 +1,7 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{/*
 Image Definition Parsing

--- a/k8s/helm/templates/core/controller-deployment.yaml
+++ b/k8s/helm/templates/core/controller-deployment.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.core.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/core/controller-deployment.yaml
+++ b/k8s/helm/templates/core/controller-deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.core.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/core/controller-role.yaml
+++ b/k8s/helm/templates/core/controller-role.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.core.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/k8s/helm/templates/core/controller-role.yaml
+++ b/k8s/helm/templates/core/controller-role.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.core.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/k8s/helm/templates/core/controller-service-headless.yaml
+++ b/k8s/helm/templates/core/controller-service-headless.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.core.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/core/controller-service-headless.yaml
+++ b/k8s/helm/templates/core/controller-service-headless.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.core.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/core/controller-serviceaccount.yaml
+++ b/k8s/helm/templates/core/controller-serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.core.enabled }}
 {{- if .Values.core.controller.serviceAccount.create -}}

--- a/k8s/helm/templates/core/controller-serviceaccount.yaml
+++ b/k8s/helm/templates/core/controller-serviceaccount.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.core.enabled }}
 {{- if .Values.core.controller.serviceAccount.create -}}

--- a/k8s/helm/templates/core/controller-servicemonitor.yaml
+++ b/k8s/helm/templates/core/controller-servicemonitor.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.core.enabled }}
 {{- if .Values.core.serviceMonitor.enabled }}

--- a/k8s/helm/templates/core/controller-servicemonitor.yaml
+++ b/k8s/helm/templates/core/controller-servicemonitor.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.core.enabled }}
 {{- if .Values.core.serviceMonitor.enabled }}

--- a/k8s/helm/templates/core/jobs-serviceaccount.yaml
+++ b/k8s/helm/templates/core/jobs-serviceaccount.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.core.enabled }}
 {{- if .Values.core.jobs.serviceAccount.create -}}

--- a/k8s/helm/templates/core/jobs-serviceaccount.yaml
+++ b/k8s/helm/templates/core/jobs-serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.core.enabled }}
 {{- if .Values.core.jobs.serviceAccount.create -}}

--- a/k8s/helm/templates/core/shared-pvc.yaml
+++ b/k8s/helm/templates/core/shared-pvc.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.core.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/core/shared-pvc.yaml
+++ b/k8s/helm/templates/core/shared-pvc.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.core.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/httproute.yaml
+++ b/k8s/helm/templates/httproute.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1

--- a/k8s/helm/templates/httproute.yaml
+++ b/k8s/helm/templates/httproute.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1

--- a/k8s/helm/templates/ingress.yaml
+++ b/k8s/helm/templates/ingress.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1

--- a/k8s/helm/templates/ingress.yaml
+++ b/k8s/helm/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1

--- a/k8s/helm/templates/models-files-auth-secret.yaml
+++ b/k8s/helm/templates/models-files-auth-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 ---
 apiVersion: v1

--- a/k8s/helm/templates/models-files-auth-secret.yaml
+++ b/k8s/helm/templates/models-files-auth-secret.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 ---
 apiVersion: v1

--- a/k8s/helm/templates/networking/kyverno-policy.yaml
+++ b/k8s/helm/templates/networking/kyverno-policy.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- /*
 These Kyverno policies inject cloud-specific networking and NCCL configurations

--- a/k8s/helm/templates/networking/kyverno-policy.yaml
+++ b/k8s/helm/templates/networking/kyverno-policy.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- /*
 These Kyverno policies inject cloud-specific networking and NCCL configurations

--- a/k8s/helm/templates/networking/nccl-topology-configmap.yaml
+++ b/k8s/helm/templates/networking/nccl-topology-configmap.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.multinodeNetworking.azure.enabled }}
 ---

--- a/k8s/helm/templates/networking/nccl-topology-configmap.yaml
+++ b/k8s/helm/templates/networking/nccl-topology-configmap.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.multinodeNetworking.azure.enabled }}
 ---

--- a/k8s/helm/templates/ngc-api-secret.yaml
+++ b/k8s/helm/templates/ngc-api-secret.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if not .Values.existingSecret }}
 ---

--- a/k8s/helm/templates/ngc-api-secret.yaml
+++ b/k8s/helm/templates/ngc-api-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if not .Values.existingSecret }}
 ---

--- a/k8s/helm/templates/openshift-route.yaml
+++ b/k8s/helm/templates/openshift-route.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.openshiftRoute.enabled -}}
 apiVersion: route.openshift.io/v1

--- a/k8s/helm/templates/openshift-route.yaml
+++ b/k8s/helm/templates/openshift-route.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.openshiftRoute.enabled -}}
 apiVersion: route.openshift.io/v1

--- a/k8s/helm/templates/platform-configmap.yaml
+++ b/k8s/helm/templates/platform-configmap.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/helm/templates/platform-configmap.yaml
+++ b/k8s/helm/templates/platform-configmap.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v1
 kind: ConfigMap

--- a/k8s/helm/templates/platform-seed-job.yaml
+++ b/k8s/helm/templates/platform-seed-job.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and .Values.api.enabled .Values.platformSeedJob.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/platform-seed-job.yaml
+++ b/k8s/helm/templates/platform-seed-job.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.api.enabled .Values.platformSeedJob.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/postgres/postgres-secret.yaml
+++ b/k8s/helm/templates/postgres/postgres-secret.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.postgresql.enabled (not .Values.postgresql.auth.existingSecret) }}
 apiVersion: v1

--- a/k8s/helm/templates/postgres/postgres-secret.yaml
+++ b/k8s/helm/templates/postgres/postgres-secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and .Values.postgresql.enabled (not .Values.postgresql.auth.existingSecret) }}
 apiVersion: v1

--- a/k8s/helm/templates/postgres/postgres-service.yaml
+++ b/k8s/helm/templates/postgres/postgres-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.postgresql.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/postgres/postgres-service.yaml
+++ b/k8s/helm/templates/postgres/postgres-service.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.postgresql.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/postgres/postgres-serviceaccount.yaml
+++ b/k8s/helm/templates/postgres/postgres-serviceaccount.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and .Values.postgresql.enabled .Values.postgresql.serviceAccount.create }}
 apiVersion: v1

--- a/k8s/helm/templates/postgres/postgres-serviceaccount.yaml
+++ b/k8s/helm/templates/postgres/postgres-serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and .Values.postgresql.enabled .Values.postgresql.serviceAccount.create }}
 apiVersion: v1

--- a/k8s/helm/templates/postgres/postgres-statefulset.yaml
+++ b/k8s/helm/templates/postgres/postgres-statefulset.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.postgresql.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/postgres/postgres-statefulset.yaml
+++ b/k8s/helm/templates/postgres/postgres-statefulset.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.postgresql.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/proxy/_helpers.tpl
+++ b/k8s/helm/templates/proxy/_helpers.tpl
@@ -1,5 +1,7 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{/*
 Create a named Envoy service name which can be included from parent chart

--- a/k8s/helm/templates/proxy/envoy-configmap.yaml
+++ b/k8s/helm/templates/proxy/envoy-configmap.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- include "nemo-platform.validateEnvoyKeepAliveTimeouts" . }}
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}

--- a/k8s/helm/templates/proxy/envoy-configmap.yaml
+++ b/k8s/helm/templates/proxy/envoy-configmap.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- include "nemo-platform.validateEnvoyKeepAliveTimeouts" . }}
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}

--- a/k8s/helm/templates/proxy/envoy-deployment.yaml
+++ b/k8s/helm/templates/proxy/envoy-deployment.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/proxy/envoy-deployment.yaml
+++ b/k8s/helm/templates/proxy/envoy-deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- $imagePullSecrets := include "nemo-common.imagepullsecrets" . }}

--- a/k8s/helm/templates/proxy/envoy-hpa.yaml
+++ b/k8s/helm/templates/proxy/envoy-hpa.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- if .Values.envoyProxy.autoscaling.enabled }}

--- a/k8s/helm/templates/proxy/envoy-hpa.yaml
+++ b/k8s/helm/templates/proxy/envoy-hpa.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- if .Values.envoyProxy.autoscaling.enabled }}

--- a/k8s/helm/templates/proxy/envoy-service.yaml
+++ b/k8s/helm/templates/proxy/envoy-service.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/proxy/envoy-service.yaml
+++ b/k8s/helm/templates/proxy/envoy-service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 apiVersion: v1

--- a/k8s/helm/templates/proxy/envoy-serviceaccount.yaml
+++ b/k8s/helm/templates/proxy/envoy-serviceaccount.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- if .Values.envoyProxy.serviceAccount.create -}}

--- a/k8s/helm/templates/proxy/envoy-serviceaccount.yaml
+++ b/k8s/helm/templates/proxy/envoy-serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- if .Values.envoyProxy.serviceAccount.create -}}

--- a/k8s/helm/templates/proxy/envoy-servicemonitor.yaml
+++ b/k8s/helm/templates/proxy/envoy-servicemonitor.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- if .Values.envoyProxy.serviceMonitor.enabled }}

--- a/k8s/helm/templates/proxy/envoy-servicemonitor.yaml
+++ b/k8s/helm/templates/proxy/envoy-servicemonitor.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- if and (include "nemo-platform.authEnabled" .) .Values.envoyProxy.enabled }}
 {{- if .Values.envoyProxy.serviceMonitor.enabled }}

--- a/k8s/helm/templates/tests/nccl-test.yaml
+++ b/k8s/helm/templates/tests/nccl-test.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
+{{/*
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- /* Chart test (helm test only): resources use helm.sh/hook: test and are not applied on install/upgrade. See https://helm.sh/docs/topics/chart_tests/ */ -}}
 {{- /* kyverno-policy.yaml: only one multinodeNetworking.<cloud>.enabled; $cloud is the active profile. */ -}}

--- a/k8s/helm/templates/tests/nccl-test.yaml
+++ b/k8s/helm/templates/tests/nccl-test.yaml
@@ -1,5 +1,5 @@
-{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 {{- /* Chart test (helm test only): resources use helm.sh/hook: test and are not applied on install/upgrade. See https://helm.sh/docs/topics/chart_tests/ */ -}}
 {{- /* kyverno-policy.yaml: only one multinodeNetworking.<cloud>.enabled; $cloud is the active profile. */ -}}

--- a/script/copyright_fixer.py
+++ b/script/copyright_fixer.py
@@ -114,8 +114,10 @@ _JINJA_HEADER = (
 )
 
 _HELM_TEMPLATE_HEADER = (
-    f"{{{{/* SPDX-FileCopyrightText: Copyright (c) 2025-{_CURRENT_YEAR} NVIDIA CORPORATION & AFFILIATES. All rights reserved. */}}}}\n"
-    "{{/* SPDX-License-Identifier: Apache-2.0 */}}\n"
+    "{{/*\n"
+    f"SPDX-FileCopyrightText: Copyright (c) 2025-{_CURRENT_YEAR} NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
+    "SPDX-License-Identifier: Apache-2.0\n"
+    "*/}}\n"
 )
 
 # Cheap substring checks — no regex needed
@@ -180,8 +182,10 @@ _CORRECT_SPDX_JINJA_RE = re.compile(
     rf"{{# SPDX-License-Identifier: {_APACHE_2} #}}\n"
 )
 _CORRECT_SPDX_HELM_RE = re.compile(
-    rf"{{{{/\* SPDX-FileCopyrightText: {_NVIDIA_COPYRIGHT} \*/}}}}\n"
-    rf"{{{{/\* SPDX-License-Identifier: {_APACHE_2} \*/}}}}\n"
+    rf"{{{{/\*\n"
+    rf"\s*SPDX-FileCopyrightText: {_NVIDIA_COPYRIGHT}\n"
+    rf"\s*SPDX-License-Identifier: {_APACHE_2}\n"
+    rf"\s*\*/}}}}\n"
 )
 
 _CORRECT_SPDX_PATTERNS = (
@@ -233,8 +237,10 @@ _ANY_SPDX_JINJA_RE = re.compile(
     r"{# SPDX-License-Identifier:[^\n]* #}\n"
 )
 _ANY_SPDX_HELM_RE = re.compile(
-    r"{{/\* SPDX-FileCopyrightText:[^\n]* \*/}}\n"
-    r"{{/\* SPDX-License-Identifier:[^\n]* \*/}}\n"
+    r"{{/\*\n"
+    r"\s*SPDX-FileCopyrightText:[^\n]*\n"
+    r"\s*SPDX-License-Identifier:[^\n]*\n"
+    r"\s*\*/}}\n"
 )
 
 # -- legacy / proprietary patterns (not SPDX at all) --
@@ -462,11 +468,6 @@ def _has_frontmatter(content: str) -> bool:
     return content.startswith("---\n") or content.startswith("---\r\n")
 
 
-def _is_helm_template_file(path: Path) -> bool:
-    parts = path.parts
-    return path.suffix in {".yaml", ".yml"} and "helm" in parts and "templates" in parts
-
-
 def _get_header_for_ext(ext: str) -> str:
     """Return the appropriate copyright header for the given file extension."""
     if ext in _SLASH_EXTENSIONS:
@@ -491,9 +492,6 @@ def _get_header_for_file(filepath: str, content: str) -> str:
     path = Path(filepath)
     name = path.name
     ext = path.suffix
-
-    if _is_helm_template_file(path):
-        return _HELM_TEMPLATE_HEADER + "\n"
 
     if name in _HTML_FILENAMES:
         return _HTML_HEADER + "\n"

--- a/script/copyright_fixer.py
+++ b/script/copyright_fixer.py
@@ -468,6 +468,23 @@ def _has_frontmatter(content: str) -> bool:
     return content.startswith("---\n") or content.startswith("---\r\n")
 
 
+def _is_helm_template_yaml(path: Path) -> bool:
+    """Return True for YAML files under a Helm chart templates directory."""
+    if path.suffix not in {".yaml", ".yml"}:
+        return False
+
+    parts = path.parts
+    for index, part in enumerate(parts):
+        if part != "templates":
+            continue
+
+        chart_dir = Path(*parts[:index])
+        if (chart_dir / "Chart.yaml").is_file():
+            return True
+
+    return False
+
+
 def _get_header_for_ext(ext: str) -> str:
     """Return the appropriate copyright header for the given file extension."""
     if ext in _SLASH_EXTENSIONS:
@@ -501,6 +518,9 @@ def _get_header_for_file(filepath: str, content: str) -> str:
 
     if ext in {".md", ".mdx"} and _has_frontmatter(content):
         return _HASH_HEADER
+
+    if _is_helm_template_yaml(path):
+        return _HELM_TEMPLATE_HEADER + "\n"
 
     # Check shebang for tsx/node — these files need // style comments
     if content.startswith("#!"):

--- a/tests/auth_idp/static/test_authentik_kubernetes_demo.py
+++ b/tests/auth_idp/static/test_authentik_kubernetes_demo.py
@@ -33,8 +33,21 @@ PUBLIC_GATEWAY_URL_TEMPLATE = '{{ include "nemo-platform-authentik.publicGateway
 def _strip_leading_helm_spdx_comments(template: str) -> str:
     lines = template.splitlines(keepends=True)
     idx = 0
-    while idx < len(lines) and lines[idx].startswith("{{/* SPDX-"):
-        idx += 1
+    while idx < len(lines):
+        if lines[idx].startswith("{{/* SPDX-"):
+            idx += 1
+            continue
+        if lines[idx].strip() == "{{/*":
+            block_start = idx
+            idx += 1
+            while idx < len(lines) and lines[idx].strip() != "*/}}":
+                idx += 1
+            if idx < len(lines):
+                idx += 1
+                if any("SPDX-" in line for line in lines[block_start:idx]):
+                    continue
+            idx = block_start
+        break
     while idx < len(lines) and not lines[idx].strip():
         idx += 1
     return "".join(lines[idx:])

--- a/tests/test_copyright_fixer.py
+++ b/tests/test_copyright_fixer.py
@@ -46,10 +46,18 @@ def test_supported_file_does_not_treat_shebang_as_universal_override(tmp_path: P
 
 
 def test_add_header_uses_syntax_safe_styles_for_missing_osrb_file_types(tmp_path: Path) -> None:
+    chart_template = tmp_path / "chart" / "templates" / "serviceaccount.yaml"
+    chart_template.parent.mkdir(parents=True)
+    (tmp_path / "chart" / "Chart.yaml").write_text("apiVersion: v2\nname: test\nversion: 0.1.0\n", encoding="utf-8")
+
     files = {
         "test_case.py": ('print("ok")\n', copyright_fixer._HASH_HEADER + "\n"),
         "nemo-helm-readme.md.gotmpl": ("# title\n", copyright_fixer._HELM_TEMPLATE_HEADER + "\n"),
-        "helm-template.yaml": ("apiVersion: v1\n", copyright_fixer._HASH_HEADER + "\n"),
+        "values.yaml": ("apiVersion: v1\n", copyright_fixer._HASH_HEADER + "\n"),
+        "chart/templates/serviceaccount.yaml": (
+            "{{- if .Values.enabled -}}\napiVersion: v1\n{{- end }}\n",
+            copyright_fixer._HELM_TEMPLATE_HEADER + "\n",
+        ),
         "Brewfile": ('brew "uv"\n', copyright_fixer._HASH_HEADER + "\n"),
         "publish-pypi": (
             "#!/usr/bin/env bash\nset -e\n",
@@ -66,6 +74,31 @@ def test_add_header_uses_syntax_safe_styles_for_missing_osrb_file_types(tmp_path
 
         assert copyright_fixer._add_header(str(path))
         assert path.read_text(encoding="utf-8").startswith(expected_prefix)
+
+
+def test_fix_style_converts_helm_template_yaml_to_non_rendering_comment(tmp_path: Path) -> None:
+    chart_template = tmp_path / "chart" / "templates" / "serviceaccount.yaml"
+    chart_template.parent.mkdir(parents=True)
+    (tmp_path / "chart" / "Chart.yaml").write_text("apiVersion: v2\nname: test\nversion: 0.1.0\n", encoding="utf-8")
+    chart_template.write_text(
+        copyright_fixer._HASH_HEADER
+        + "\n{{- if .Values.enabled -}}\napiVersion: v1\nkind: ServiceAccount\n{{- end }}\n",
+        encoding="utf-8",
+    )
+
+    assert copyright_fixer._needs_style_fix(str(chart_template))
+    assert copyright_fixer._fix_header_style(str(chart_template))
+    assert chart_template.read_text(encoding="utf-8").startswith(copyright_fixer._HELM_TEMPLATE_HEADER + "\n")
+
+
+def test_plain_yaml_keeps_hash_comment_header(tmp_path: Path) -> None:
+    values = tmp_path / "chart" / "values.yaml"
+    values.parent.mkdir()
+    (tmp_path / "chart" / "Chart.yaml").write_text("apiVersion: v2\nname: test\nversion: 0.1.0\n", encoding="utf-8")
+    values.write_text("enabled: true\n", encoding="utf-8")
+
+    assert copyright_fixer._add_header(str(values))
+    assert values.read_text(encoding="utf-8").startswith(copyright_fixer._HASH_HEADER + "\n")
 
 
 def test_helm_template_header_keeps_spdx_identifier_on_own_line() -> None:

--- a/tests/test_copyright_fixer.py
+++ b/tests/test_copyright_fixer.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_copyright_fixer() -> ModuleType:
+    path = Path(__file__).resolve().parents[1] / "script" / "copyright_fixer.py"
+    spec = importlib.util.spec_from_file_location("copyright_fixer", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+copyright_fixer = _load_copyright_fixer()
+
+
+def test_supported_file_includes_missing_osrb_file_types(tmp_path: Path) -> None:
+    files = {
+        "e2e/conftest.py": 'print("ok")\n',
+        "k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl": "# title\n",
+        "sdk/python/nemo-platform/Brewfile": 'brew "uv"\n',
+        "sdk/python/nemo-platform/bin/publish-pypi": "#!/usr/bin/env bash\n",
+        "services/core/entities/alembic/README": "Generic single-database configuration.\n",
+        "services/core/entities/alembic/script.py.mako": '"""${message}"""\n',
+        "services/core/entities/src/nmp/core/entities/api/v2/entities/entities.http": "// Example\n",
+    }
+
+    for relpath, content in files.items():
+        path = tmp_path / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+        assert copyright_fixer._is_supported_file(str(path))
+
+
+def test_supported_file_does_not_treat_shebang_as_universal_override(tmp_path: Path) -> None:
+    patch_file = tmp_path / "tarfile.py.fix"
+    patch_file.write_text("#!/usr/bin/env python3\n", encoding="utf-8")
+
+    assert not copyright_fixer._is_supported_file(str(patch_file))
+
+
+def test_add_header_uses_syntax_safe_styles_for_missing_osrb_file_types(tmp_path: Path) -> None:
+    files = {
+        "test_case.py": ('print("ok")\n', copyright_fixer._HASH_HEADER + "\n"),
+        "nemo-helm-readme.md.gotmpl": ("# title\n", copyright_fixer._HELM_TEMPLATE_HEADER + "\n"),
+        "helm-template.yaml": ("apiVersion: v1\n", copyright_fixer._HASH_HEADER + "\n"),
+        "Brewfile": ('brew "uv"\n', copyright_fixer._HASH_HEADER + "\n"),
+        "publish-pypi": (
+            "#!/usr/bin/env bash\nset -e\n",
+            "#!/usr/bin/env bash\n" + copyright_fixer._HASH_HEADER + "\n",
+        ),
+        "README": ("Generic single-database configuration.\n", copyright_fixer._HTML_HEADER + "\n"),
+        "script.py.mako": ('"""${message}"""\n', copyright_fixer._HASH_HEADER + "\n"),
+        "entities.http": ("// Example\n", copyright_fixer._SLASH_HEADER + "\n"),
+    }
+
+    for filename, (content, expected_prefix) in files.items():
+        path = tmp_path / filename
+        path.write_text(content, encoding="utf-8")
+
+        assert copyright_fixer._add_header(str(path))
+        assert path.read_text(encoding="utf-8").startswith(expected_prefix)
+
+
+def test_helm_template_header_keeps_spdx_identifier_on_own_line() -> None:
+    assert "\nSPDX-License-Identifier: Apache-2.0\n*/}}\n" in copyright_fixer._HELM_TEMPLATE_HEADER
+    assert "SPDX-License-Identifier: Apache-2.0 */}}" not in copyright_fixer._HELM_TEMPLATE_HEADER
+
+
+def test_inline_helm_template_header_is_not_accepted() -> None:
+    inline_header = (
+        "{{/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. "
+        "All rights reserved. */}}\n"
+        "{{/* SPDX-License-Identifier: Apache-2.0 */}}\n"
+    )
+
+    assert not copyright_fixer._has_correct_spdx_header(inline_header)
+
+
+def test_include_can_target_files_under_copyrightignore_excluded_directories(tmp_path: Path) -> None:
+    repo = copyright_fixer.Repo.init(tmp_path)
+    ignored_file = tmp_path / "e2e" / "conftest.py"
+    ignored_file.parent.mkdir()
+    ignored_file.write_text('print("ok")\n', encoding="utf-8")
+    (tmp_path / ".copyrightignore").write_text("e2e/\n", encoding="utf-8")
+    repo.index.add([".copyrightignore", "e2e/conftest.py"])
+
+    default_files = copyright_fixer._collect_files_from_dir(str(tmp_path))
+    included_files = copyright_fixer._collect_files_from_dir(str(tmp_path), include=["e2e/conftest.py"])
+
+    assert str(ignored_file) not in default_files
+    assert str(ignored_file) in included_files
+
+
+def test_proprietary_license_detection_ignores_fixer_source_literals() -> None:
+    source = Path(copyright_fixer.__file__).read_text(encoding="utf-8")[:4096]
+
+    assert not copyright_fixer._has_proprietary_license(source)
+    assert copyright_fixer._has_proprietary_license(
+        "# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
+        "# SPDX-License-Identifier: LicenseRef-NvidiaProprietary\n"
+    )

--- a/third_party/licenses.jsonl
+++ b/third_party/licenses.jsonl
@@ -231,6 +231,7 @@
 {"name": "numpy", "license": "BSD-3-CLAUSE", "compatible": true}
 {"name": "nvidia-ml-py", "license": "BSD-3-CLAUSE", "compatible": true}
 {"name": "nvidia-nat-atif", "license": "APACHE-2.0", "compatible": true}
+{"name": "nvidia-nat-config-optimizer", "license": "APACHE-2.0", "compatible": true}
 {"name": "nvidia-nat-core", "license": "APACHE-2.0", "compatible": true}
 {"name": "nvidia-nat-eval", "license": "APACHE-2.0", "compatible": true}
 {"name": "nvidia-nat-langchain", "license": "APACHE-2.0", "compatible": true}

--- a/third_party/licenses.jsonl
+++ b/third_party/licenses.jsonl
@@ -231,7 +231,6 @@
 {"name": "numpy", "license": "BSD-3-CLAUSE", "compatible": true}
 {"name": "nvidia-ml-py", "license": "BSD-3-CLAUSE", "compatible": true}
 {"name": "nvidia-nat-atif", "license": "APACHE-2.0", "compatible": true}
-{"name": "nvidia-nat-config-optimizer", "license": "APACHE-2.0", "compatible": true}
 {"name": "nvidia-nat-core", "license": "APACHE-2.0", "compatible": true}
 {"name": "nvidia-nat-eval", "license": "APACHE-2.0", "compatible": true}
 {"name": "nvidia-nat-langchain", "license": "APACHE-2.0", "compatible": true}

--- a/third_party/osv-licenses.json
+++ b/third_party/osv-licenses.json
@@ -7100,6 +7100,3367 @@
           ]
         }
       ]
+    },
+    {
+      "source": {
+        "type": "lockfile"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "github.com/cenkalti/backoff/v5",
+            "version": "5.0.3",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/cespare/xxhash/v2",
+            "version": "2.3.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/go-logr/logr",
+            "version": "1.4.3",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/go-logr/stdr",
+            "version": "1.2.2",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/google/uuid",
+            "version": "1.6.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/grpc-ecosystem/grpc-gateway/v2",
+            "version": "2.29.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/inconshreveable/mousetrap",
+            "version": "1.1.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/spf13/cobra",
+            "version": "1.10.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/spf13/pflag",
+            "version": "1.0.9",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/auto/sdk",
+            "version": "1.2.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/contrib/bridges/otelslog",
+            "version": "0.19.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp",
+            "version": "0.20.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/exporters/stdout/stdoutlog",
+            "version": "0.20.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/log",
+            "version": "0.20.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/metric",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/sdk",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/sdk/log",
+            "version": "0.20.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/trace",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/proto/otlp",
+            "version": "1.10.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "golang.org/x/net",
+            "version": "0.56.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "golang.org/x/sys",
+            "version": "0.46.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "golang.org/x/text",
+            "version": "0.39.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "google.golang.org/genproto/googleapis/api",
+            "version": "0.0.0-20260526163538-3dc84a4a5aaa",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "google.golang.org/genproto/googleapis/rpc",
+            "version": "0.0.0-20260526163538-3dc84a4a5aaa",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "google.golang.org/grpc",
+            "version": "1.83.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "google.golang.org/protobuf",
+            "version": "1.36.11",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "stdlib",
+            "version": "1.25.12",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "UNKNOWN"
+          ]
+        }
+      ]
+    },
+    {
+      "source": {
+        "type": "lockfile"
+      },
+      "packages": [
+        {
+          "package": {
+            "name": "github.com/cenkalti/backoff/v5",
+            "version": "5.0.3",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/cespare/xxhash/v2",
+            "version": "2.3.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/cncf/xds/go",
+            "version": "0.0.0-20260202195803-dba9d589def2",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/davecgh/go-spew",
+            "version": "1.1.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "ISC"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/envoyproxy/go-control-plane/envoy",
+            "version": "1.37.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/envoyproxy/protoc-gen-validate",
+            "version": "1.3.3",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/felixge/httpsnoop",
+            "version": "1.0.4",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/go-logr/logr",
+            "version": "1.4.3",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/go-logr/stdr",
+            "version": "1.2.2",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/google/go-cmp",
+            "version": "0.7.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/google/uuid",
+            "version": "1.6.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/grpc-ecosystem/grpc-gateway/v2",
+            "version": "2.29.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/openai/openai-go/v2",
+            "version": "2.1.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/planetscale/vtprotobuf",
+            "version": "0.6.1-0.20240319094008-0393e58bdf10",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause",
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/pmezard/go-difflib",
+            "version": "1.0.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/stretchr/objx",
+            "version": "0.5.2",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/stretchr/testify",
+            "version": "1.11.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/tidwall/gjson",
+            "version": "1.14.4",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/tidwall/match",
+            "version": "1.1.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/tidwall/pretty",
+            "version": "1.2.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "github.com/tidwall/sjson",
+            "version": "1.2.5",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/auto/sdk",
+            "version": "1.2.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc",
+            "version": "0.69.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+            "version": "0.69.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/exporters/otlp/otlptrace",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/exporters/stdout/stdoutmetric",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/exporters/stdout/stdouttrace",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/metric",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/sdk",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/sdk/metric",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/otel/trace",
+            "version": "1.44.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0",
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.opentelemetry.io/proto/otlp",
+            "version": "1.10.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "go.yaml.in/yaml/v2",
+            "version": "2.4.2",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "golang.org/x/net",
+            "version": "0.56.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "golang.org/x/sys",
+            "version": "0.46.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "golang.org/x/text",
+            "version": "0.38.0",
+            "ecosystem": "Go"
+          },
+          "vulnerabilities": [
+            {
+              "modified": "2026-08-07T10:42:58Z",
+              "published": "2026-07-14T17:29:56Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-5970",
+              "aliases": [
+                "CVE-2026-56852"
+              ],
+              "related": [
+                "CGA-jjqc-qfr4-frh9",
+                "RHSA-2026:40964",
+                "RHSA-2026:41020",
+                "RHSA-2026:42083",
+                "RHSA-2026:42230",
+                "RHSA-2026:42241",
+                "RHSA-2026:43015",
+                "RHSA-2026:43119",
+                "RHSA-2026:43311",
+                "RHSA-2026:43554",
+                "RHSA-2026:43581",
+                "RHSA-2026:43716",
+                "RHSA-2026:43797",
+                "RHSA-2026:43799",
+                "RHSA-2026:43801",
+                "RHSA-2026:43803",
+                "RHSA-2026:43852",
+                "RHSA-2026:43866",
+                "RHSA-2026:43873",
+                "RHSA-2026:43906",
+                "RHSA-2026:44151",
+                "RHSA-2026:44152",
+                "RHSA-2026:44162",
+                "RHSA-2026:44430",
+                "RHSA-2026:44451",
+                "RHSA-2026:44479",
+                "RHSA-2026:46953",
+                "RHSA-2026:46960",
+                "RHSA-2026:46988",
+                "RHSA-2026:48306",
+                "RHSA-2026:49317",
+                "RHSA-2026:49360",
+                "RHSA-2026:51065"
+              ],
+              "summary": "Infinite loop on invalid input in golang.org/x/text",
+              "details": "A norm.Iter can enter an infinite loop when handling input containing invalid UTF-8 bytes.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "golang.org/x/text",
+                    "purl": "pkg:golang/golang.org/x/text"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "0.39.0"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-5970.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "golang.org/x/text/unicode/norm",
+                        "symbols": [
+                          "Form.Append",
+                          "Form.AppendString",
+                          "Form.Bytes",
+                          "Form.FirstBoundary",
+                          "Form.FirstBoundaryInString",
+                          "Form.IsNormal",
+                          "Form.IsNormalString",
+                          "Form.LastBoundary",
+                          "Form.NextBoundary",
+                          "Form.NextBoundaryInString",
+                          "Form.Properties",
+                          "Form.PropertiesString",
+                          "Form.QuickSpan",
+                          "Form.QuickSpanString",
+                          "Form.Span",
+                          "Form.SpanString",
+                          "Form.String",
+                          "Form.Transform",
+                          "Iter.Init",
+                          "Iter.InitString",
+                          "Iter.Next",
+                          "Iter.Seek",
+                          "nextComposed",
+                          "normReader.Read",
+                          "normWriter.Write"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/80142"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/794100"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-5970"
+              }
+            }
+          ],
+          "groups": [
+            {
+              "ids": [
+                "GO-2026-5970"
+              ],
+              "aliases": [
+                "CVE-2026-56852",
+                "GO-2026-5970"
+              ],
+              "experimental_analysis": {
+                "GO-2026-5970": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            }
+          ],
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "google.golang.org/genproto/googleapis/api",
+            "version": "0.0.0-20260526163538-3dc84a4a5aaa",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "google.golang.org/genproto/googleapis/rpc",
+            "version": "0.0.0-20260526163538-3dc84a4a5aaa",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "google.golang.org/grpc",
+            "version": "1.83.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "google.golang.org/protobuf",
+            "version": "1.36.11",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "BSD-3-Clause"
+          ]
+        },
+        {
+          "package": {
+            "name": "gopkg.in/yaml.v3",
+            "version": "3.0.1",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT",
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "sigs.k8s.io/yaml",
+            "version": "1.6.0",
+            "ecosystem": "Go"
+          },
+          "licenses": [
+            "MIT",
+            "BSD-3-Clause",
+            "Apache-2.0"
+          ]
+        },
+        {
+          "package": {
+            "name": "stdlib",
+            "version": "1.25.8",
+            "ecosystem": "Go"
+          },
+          "vulnerabilities": [
+            {
+              "modified": "2026-08-03T10:45:58Z",
+              "published": "2026-04-07T22:53:49Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4864",
+              "aliases": [
+                "BIT-golang-2026-32282",
+                "CVE-2026-32282"
+              ],
+              "related": [
+                "CGA-3x3m-j3x7-3f6w",
+                "RHSA-2026:10217",
+                "RHSA-2026:10219",
+                "RHSA-2026:10704",
+                "RHSA-2026:11507",
+                "RHSA-2026:11514",
+                "RHSA-2026:11704",
+                "RHSA-2026:11711",
+                "RHSA-2026:11712",
+                "RHSA-2026:11863",
+                "RHSA-2026:14200",
+                "RHSA-2026:15980",
+                "RHSA-2026:16021",
+                "RHSA-2026:16024",
+                "RHSA-2026:16101",
+                "RHSA-2026:16875",
+                "RHSA-2026:17075",
+                "RHSA-2026:17084",
+                "RHSA-2026:18027",
+                "RHSA-2026:18032",
+                "RHSA-2026:19132",
+                "RHSA-2026:19133",
+                "RHSA-2026:19134",
+                "RHSA-2026:19135",
+                "RHSA-2026:19136",
+                "RHSA-2026:19144",
+                "RHSA-2026:19156",
+                "RHSA-2026:19350",
+                "RHSA-2026:19351",
+                "RHSA-2026:19352",
+                "RHSA-2026:19353",
+                "RHSA-2026:19369",
+                "RHSA-2026:19450",
+                "RHSA-2026:19550",
+                "RHSA-2026:19714",
+                "RHSA-2026:19715",
+                "RHSA-2026:19719",
+                "RHSA-2026:19720",
+                "RHSA-2026:19721",
+                "RHSA-2026:19722",
+                "RHSA-2026:19750",
+                "RHSA-2026:19839",
+                "RHSA-2026:20556",
+                "RHSA-2026:22141",
+                "RHSA-2026:22326",
+                "RHSA-2026:22450",
+                "RHSA-2026:22709",
+                "RHSA-2026:22713",
+                "RHSA-2026:22714",
+                "RHSA-2026:22937",
+                "RHSA-2026:23228",
+                "RHSA-2026:24337",
+                "RHSA-2026:24716",
+                "RHSA-2026:24761",
+                "RHSA-2026:24762",
+                "RHSA-2026:25999",
+                "RHSA-2026:27076",
+                "RHSA-2026:27732",
+                "RHSA-2026:28038",
+                "RHSA-2026:28046",
+                "RHSA-2026:28047",
+                "RHSA-2026:28385",
+                "RHSA-2026:34365",
+                "RHSA-2026:34366",
+                "RHSA-2026:34368",
+                "RHSA-2026:36796",
+                "RHSA-2026:39810",
+                "RHSA-2026:41019",
+                "RHSA-2026:47712",
+                "RHSA-2026:47714",
+                "RHSA-2026:47716",
+                "RHSA-2026:47719",
+                "RHSA-2026:47721",
+                "RHSA-2026:47722",
+                "RHSA-2026:47910",
+                "RHSA-2026:48036",
+                "RHSA-2026:48790",
+                "RHSA-2026:49509",
+                "RHSA-2026:49600",
+                "RHSA-2026:7291",
+                "RHSA-2026:7385"
+              ],
+              "summary": "TOCTOU permits root escape on Linux via Root.Chmod in os in internal/syscall/unix",
+              "details": "On Linux, if the target of Root.Chmod is replaced with a symlink while the chmod operation is in progress, Chmod can operate on the target of the symlink, even when the target lies outside the root.\n\nThe Linux fchmodat syscall silently ignores the AT_SYMLINK_NOFOLLOW flag, which Root.Chmod uses to avoid symlink traversal. Root.Chmod checks its target before acting and returns an error if the target is a symlink lying outside the root, so the impact is limited to cases where the target is replaced with a symlink between the check and operation.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.9"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.2"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4864.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "goos": [
+                          "linux"
+                        ],
+                        "path": "internal/syscall/unix",
+                        "symbols": [
+                          "Fchmodat"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/763761"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78293"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Uuganbayar Lkhamsuren (https://github.com/uug4na)"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4864"
+              }
+            },
+            {
+              "modified": "2026-07-10T10:44:23Z",
+              "published": "2026-04-07T22:53:49Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4865",
+              "aliases": [
+                "BIT-golang-2026-32289",
+                "CVE-2026-32289"
+              ],
+              "related": [
+                "CGA-w5jp-g3cv-wvfm",
+                "RHSA-2026:19181",
+                "RHSA-2026:7291",
+                "RHSA-2026:7385"
+              ],
+              "summary": "JsBraceDepth Context Tracking Bugs (XSS) in html/template",
+              "details": "Context was not properly tracked across template branches for JS template literals, leading to possibly incorrect escaping of content when branches were used. Additionally template actions within JS template literals did not properly track the brace depth, leading to incorrect escaping being applied.\n\nThese issues could cause actions within JS template literals to be incorrectly or improperly escaped, leading to XSS vulnerabilities.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.9"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.2"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4865.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "html/template",
+                        "symbols": [
+                          "Error.Error",
+                          "HTMLEscaper",
+                          "JSEscape",
+                          "JSEscapeString",
+                          "JSEscaper",
+                          "ParseFS",
+                          "ParseFiles",
+                          "ParseGlob",
+                          "Template.AddParseTree",
+                          "Template.Clone",
+                          "Template.DefinedTemplates",
+                          "Template.Execute",
+                          "Template.ExecuteTemplate",
+                          "Template.Funcs",
+                          "Template.Parse",
+                          "Template.ParseFS",
+                          "Template.ParseFiles",
+                          "Template.ParseGlob",
+                          "URLQueryEscaper",
+                          "context.String",
+                          "context.mangle",
+                          "escaper.escapeBranch"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/763762"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78331"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4865"
+              }
+            },
+            {
+              "modified": "2026-05-15T10:59:23Z",
+              "published": "2026-04-07T22:53:49Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4869",
+              "aliases": [
+                "BIT-golang-2026-32288",
+                "CVE-2026-32288"
+              ],
+              "related": [
+                "CGA-6f85-jvrm-qq3w",
+                "RHSA-2026:7291",
+                "RHSA-2026:7385"
+              ],
+              "summary": "Unbounded allocation for old GNU sparse in archive/tar",
+              "details": "tar.Reader can allocate an unbounded amount of memory when reading a maliciously-crafted archive containing a large number of sparse regions encoded in the \"old GNU sparse map\" format.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.9"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.2"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4869.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "archive/tar",
+                        "symbols": [
+                          "Reader.Next",
+                          "Reader.readOldGNUSparseMap",
+                          "readGNUSparseMap1x0"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/763766"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78301"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Colin Walters (walters@verbum.org)"
+                },
+                {
+                  "name": "Uuganbayar Lkhamsuren (https://github.com/uug4na)"
+                },
+                {
+                  "name": "Jakub Ciolek"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4869"
+              }
+            },
+            {
+              "modified": "2026-08-07T10:42:58Z",
+              "published": "2026-04-07T22:53:49Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4870",
+              "aliases": [
+                "BIT-golang-2026-32283",
+                "CVE-2026-32283"
+              ],
+              "related": [
+                "CGA-w7vv-7vph-696h",
+                "RHSA-2026:10217",
+                "RHSA-2026:10219",
+                "RHSA-2026:10704",
+                "RHSA-2026:11507",
+                "RHSA-2026:11514",
+                "RHSA-2026:11704",
+                "RHSA-2026:11711",
+                "RHSA-2026:11712",
+                "RHSA-2026:11863",
+                "RHSA-2026:11881",
+                "RHSA-2026:14200",
+                "RHSA-2026:15980",
+                "RHSA-2026:16021",
+                "RHSA-2026:16024",
+                "RHSA-2026:16101",
+                "RHSA-2026:16102",
+                "RHSA-2026:16875",
+                "RHSA-2026:17075",
+                "RHSA-2026:17084",
+                "RHSA-2026:17287",
+                "RHSA-2026:18027",
+                "RHSA-2026:18032",
+                "RHSA-2026:19126",
+                "RHSA-2026:19132",
+                "RHSA-2026:19133",
+                "RHSA-2026:19134",
+                "RHSA-2026:19135",
+                "RHSA-2026:19136",
+                "RHSA-2026:19137",
+                "RHSA-2026:19139",
+                "RHSA-2026:19144",
+                "RHSA-2026:19156",
+                "RHSA-2026:19350",
+                "RHSA-2026:19351",
+                "RHSA-2026:19352",
+                "RHSA-2026:19353",
+                "RHSA-2026:19369",
+                "RHSA-2026:19450",
+                "RHSA-2026:19550",
+                "RHSA-2026:19634",
+                "RHSA-2026:19714",
+                "RHSA-2026:19715",
+                "RHSA-2026:19719",
+                "RHSA-2026:19720",
+                "RHSA-2026:19721",
+                "RHSA-2026:19722",
+                "RHSA-2026:19750",
+                "RHSA-2026:19839",
+                "RHSA-2026:20556",
+                "RHSA-2026:20569",
+                "RHSA-2026:20570",
+                "RHSA-2026:20571",
+                "RHSA-2026:20607",
+                "RHSA-2026:20608",
+                "RHSA-2026:20609",
+                "RHSA-2026:22450",
+                "RHSA-2026:22709",
+                "RHSA-2026:22713",
+                "RHSA-2026:22714",
+                "RHSA-2026:22937",
+                "RHSA-2026:23102",
+                "RHSA-2026:23103",
+                "RHSA-2026:23228",
+                "RHSA-2026:24337",
+                "RHSA-2026:24470",
+                "RHSA-2026:24761",
+                "RHSA-2026:24762",
+                "RHSA-2026:26447",
+                "RHSA-2026:27076",
+                "RHSA-2026:28038",
+                "RHSA-2026:28047",
+                "RHSA-2026:28074",
+                "RHSA-2026:29035",
+                "RHSA-2026:29195",
+                "RHSA-2026:29455",
+                "RHSA-2026:29703",
+                "RHSA-2026:33722",
+                "RHSA-2026:34192",
+                "RHSA-2026:34196",
+                "RHSA-2026:34197",
+                "RHSA-2026:34365",
+                "RHSA-2026:36796",
+                "RHSA-2026:39810",
+                "RHSA-2026:41019",
+                "RHSA-2026:47712",
+                "RHSA-2026:47714",
+                "RHSA-2026:47716",
+                "RHSA-2026:47719",
+                "RHSA-2026:47721",
+                "RHSA-2026:47722",
+                "RHSA-2026:47910",
+                "RHSA-2026:48036",
+                "RHSA-2026:48790",
+                "RHSA-2026:49509",
+                "RHSA-2026:49600",
+                "RHSA-2026:49944",
+                "RHSA-2026:51288",
+                "RHSA-2026:7291",
+                "RHSA-2026:7385"
+              ],
+              "summary": "Unauthenticated TLS 1.3 KeyUpdate record can cause persistent connection retention and DoS in crypto/tls",
+              "details": "If one side of the TLS connection sends multiple key update messages post-handshake in a single record, the connection can deadlock, causing uncontrolled consumption of resources. This can lead to a denial of service.\n\nThis only affects TLS 1.3.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.9"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.2"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4870.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "crypto/tls",
+                        "symbols": [
+                          "Conn.Handshake",
+                          "Conn.HandshakeContext",
+                          "Conn.Read",
+                          "Conn.Write",
+                          "Conn.handleKeyUpdate",
+                          "Dial",
+                          "DialWithDialer",
+                          "Dialer.Dial",
+                          "Dialer.DialContext",
+                          "QUICConn.HandleData",
+                          "QUICConn.Start",
+                          "clientHandshakeStateTLS13.establishHandshakeKeys",
+                          "clientHandshakeStateTLS13.readServerFinished",
+                          "serverHandshakeStateTLS13.readClientFinished",
+                          "serverHandshakeStateTLS13.sendServerParameters"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/763767"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78334"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Jakub Ciolek - https://ciolek.dev/"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4870"
+              }
+            },
+            {
+              "modified": "2026-06-27T10:44:20Z",
+              "published": "2026-05-07T19:21:40Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4918",
+              "aliases": [
+                "BIT-golang-2026-33814",
+                "CVE-2026-33814"
+              ],
+              "related": [
+                "CGA-v7v4-9r6p-x7fc",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264"
+              ],
+              "summary": "Infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE in net/http/internal/http2 in golang.org/x/net",
+              "details": "When processing HTTP/2 SETTINGS frames, transport will enter an infinite loop of writing CONTINUATION frames if it receives a SETTINGS_MAX_FRAME_SIZE with a value of 0.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "golang.org/x/net",
+                    "purl": "pkg:golang/golang.org/x/net"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "0.53.0"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4918.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "golang.org/x/net/http2",
+                        "symbols": [
+                          "Transport.NewClientConn",
+                          "Transport.RoundTrip",
+                          "Transport.RoundTripOpt",
+                          "clientConnPool.GetClientConn",
+                          "clientConnReadLoop.processSettingsNoWrite",
+                          "noDialClientConnPool.GetClientConn",
+                          "noDialH2RoundTripper.NewClientConn",
+                          "noDialH2RoundTripper.RoundTrip",
+                          "unencryptedTransport.RoundTrip"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.10"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.3"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4918.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "net/http",
+                        "symbols": [
+                          "Client.CloseIdleConnections",
+                          "Client.Do",
+                          "Client.Get",
+                          "Client.Head",
+                          "Client.Post",
+                          "Client.PostForm",
+                          "ClientConn.Close",
+                          "ClientConn.RoundTrip",
+                          "Get",
+                          "Head",
+                          "Post",
+                          "PostForm",
+                          "Transport.CloseIdleConnections",
+                          "Transport.NewClientConn",
+                          "Transport.RoundTrip",
+                          "http1ClientConn.Close",
+                          "http1ClientConn.RoundTrip",
+                          "http2Transport.NewClientConn",
+                          "http2Transport.RoundTrip",
+                          "http2Transport.RoundTripOpt",
+                          "http2clientConnPool.GetClientConn",
+                          "http2clientConnReadLoop.processSettingsNoWrite",
+                          "http2noDialClientConnPool.GetClientConn",
+                          "http2noDialH2RoundTripper.NewClientConn",
+                          "http2noDialH2RoundTripper.RoundTrip",
+                          "http2unencryptedTransport.RoundTrip"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/761581"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/761640"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78476"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/qcCIEXso47M"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Marwan Atia (marwansamir688@gmail.com)"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4918"
+              }
+            },
+            {
+              "modified": "2026-08-07T10:42:58Z",
+              "published": "2026-04-07T22:53:49Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4946",
+              "aliases": [
+                "BIT-golang-2026-32281",
+                "CVE-2026-32281"
+              ],
+              "related": [
+                "CGA-mhq6-cw97-rcc6",
+                "RHSA-2026:10217",
+                "RHSA-2026:10219",
+                "RHSA-2026:16021",
+                "RHSA-2026:16024",
+                "RHSA-2026:16101",
+                "RHSA-2026:18027",
+                "RHSA-2026:18032",
+                "RHSA-2026:19135",
+                "RHSA-2026:19353",
+                "RHSA-2026:19450",
+                "RHSA-2026:19719",
+                "RHSA-2026:19720",
+                "RHSA-2026:19721",
+                "RHSA-2026:19839",
+                "RHSA-2026:20556",
+                "RHSA-2026:20569",
+                "RHSA-2026:20570",
+                "RHSA-2026:20571",
+                "RHSA-2026:22141",
+                "RHSA-2026:22309",
+                "RHSA-2026:22713",
+                "RHSA-2026:23102",
+                "RHSA-2026:23103",
+                "RHSA-2026:24337",
+                "RHSA-2026:24470",
+                "RHSA-2026:24716",
+                "RHSA-2026:26054",
+                "RHSA-2026:26447",
+                "RHSA-2026:27076",
+                "RHSA-2026:27711",
+                "RHSA-2026:27740",
+                "RHSA-2026:28074",
+                "RHSA-2026:29035",
+                "RHSA-2026:29195",
+                "RHSA-2026:29455",
+                "RHSA-2026:29702",
+                "RHSA-2026:29703",
+                "RHSA-2026:33722",
+                "RHSA-2026:34192",
+                "RHSA-2026:34196",
+                "RHSA-2026:34197",
+                "RHSA-2026:34365",
+                "RHSA-2026:36796",
+                "RHSA-2026:39810",
+                "RHSA-2026:41019",
+                "RHSA-2026:42078",
+                "RHSA-2026:42079",
+                "RHSA-2026:47712",
+                "RHSA-2026:47714",
+                "RHSA-2026:47716",
+                "RHSA-2026:47719",
+                "RHSA-2026:47721",
+                "RHSA-2026:47722",
+                "RHSA-2026:47910",
+                "RHSA-2026:48036",
+                "RHSA-2026:49509",
+                "RHSA-2026:49526",
+                "RHSA-2026:49600",
+                "RHSA-2026:49838",
+                "RHSA-2026:49944",
+                "RHSA-2026:51288",
+                "RHSA-2026:7291",
+                "RHSA-2026:7385"
+              ],
+              "summary": "Inefficient policy validation in crypto/x509",
+              "details": "Validating certificate chains which use policies is unexpectedly inefficient when certificates in the chain contain a very large number of policy mappings, possibly causing denial of service.\n\nThis only affects validation of otherwise trusted certificate chains, issued by a root CA in the VerifyOptions.Roots CertPool, or in the system certificate pool.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.9"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.2"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4946.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "crypto/x509",
+                        "symbols": [
+                          "Certificate.Verify",
+                          "policiesValid"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/758061"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78281"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Jakub Ciolek - https://ciolek.dev"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4946"
+              }
+            },
+            {
+              "modified": "2026-08-07T10:42:57Z",
+              "published": "2026-04-07T22:53:49Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4947",
+              "aliases": [
+                "BIT-golang-2026-32280",
+                "CVE-2026-32280"
+              ],
+              "related": [
+                "CGA-crmm-287q-6v8j",
+                "RHSA-2026:10217",
+                "RHSA-2026:10219",
+                "RHSA-2026:10704",
+                "RHSA-2026:11507",
+                "RHSA-2026:11514",
+                "RHSA-2026:14200",
+                "RHSA-2026:15980",
+                "RHSA-2026:16021",
+                "RHSA-2026:16024",
+                "RHSA-2026:16101",
+                "RHSA-2026:16875",
+                "RHSA-2026:17084",
+                "RHSA-2026:17287",
+                "RHSA-2026:18027",
+                "RHSA-2026:18032",
+                "RHSA-2026:19133",
+                "RHSA-2026:19135",
+                "RHSA-2026:19144",
+                "RHSA-2026:19350",
+                "RHSA-2026:19353",
+                "RHSA-2026:19450",
+                "RHSA-2026:19550",
+                "RHSA-2026:19634",
+                "RHSA-2026:19714",
+                "RHSA-2026:19715",
+                "RHSA-2026:19719",
+                "RHSA-2026:19720",
+                "RHSA-2026:19721",
+                "RHSA-2026:19722",
+                "RHSA-2026:19750",
+                "RHSA-2026:19839",
+                "RHSA-2026:20556",
+                "RHSA-2026:20569",
+                "RHSA-2026:20570",
+                "RHSA-2026:20571",
+                "RHSA-2026:20607",
+                "RHSA-2026:20608",
+                "RHSA-2026:20609",
+                "RHSA-2026:21655",
+                "RHSA-2026:22130",
+                "RHSA-2026:22141",
+                "RHSA-2026:22309",
+                "RHSA-2026:22709",
+                "RHSA-2026:22713",
+                "RHSA-2026:23102",
+                "RHSA-2026:23103",
+                "RHSA-2026:23244",
+                "RHSA-2026:24337",
+                "RHSA-2026:24470",
+                "RHSA-2026:24716",
+                "RHSA-2026:24761",
+                "RHSA-2026:24762",
+                "RHSA-2026:25180",
+                "RHSA-2026:26447",
+                "RHSA-2026:27076",
+                "RHSA-2026:28038",
+                "RHSA-2026:28047",
+                "RHSA-2026:28074",
+                "RHSA-2026:28886",
+                "RHSA-2026:28961",
+                "RHSA-2026:29035",
+                "RHSA-2026:29195",
+                "RHSA-2026:29455",
+                "RHSA-2026:29702",
+                "RHSA-2026:29703",
+                "RHSA-2026:33722",
+                "RHSA-2026:34097",
+                "RHSA-2026:34192",
+                "RHSA-2026:34196",
+                "RHSA-2026:34197",
+                "RHSA-2026:34365",
+                "RHSA-2026:36796",
+                "RHSA-2026:39810",
+                "RHSA-2026:41019",
+                "RHSA-2026:47712",
+                "RHSA-2026:47714",
+                "RHSA-2026:47716",
+                "RHSA-2026:47719",
+                "RHSA-2026:47721",
+                "RHSA-2026:47722",
+                "RHSA-2026:47910",
+                "RHSA-2026:48036",
+                "RHSA-2026:48790",
+                "RHSA-2026:49509",
+                "RHSA-2026:49526",
+                "RHSA-2026:49600",
+                "RHSA-2026:49838",
+                "RHSA-2026:49944",
+                "RHSA-2026:51288"
+              ],
+              "summary": "Unexpected work during chain building in crypto/x509",
+              "details": "During chain building, the amount of work that is done is not correctly limited when a large number of intermediate certificates are passed in VerifyOptions.Intermediates, which can lead to a denial of service. This affects both direct users of crypto/x509 and users of crypto/tls.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.9"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.2"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4947.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "crypto/x509",
+                        "symbols": [
+                          "Certificate.Verify",
+                          "Certificate.buildChains"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/758320"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78282"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Jakub Ciolek - https://ciolek.dev"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4947"
+              }
+            },
+            {
+              "modified": "2026-07-16T10:29:37Z",
+              "published": "2026-07-07T21:34:47Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4970",
+              "aliases": [
+                "BIT-golang-2026-39822",
+                "CVE-2026-39822"
+              ],
+              "related": [
+                "CGA-8r5h-83c2-4rxw",
+                "RHSA-2026:36477",
+                "RHSA-2026:36510",
+                "RHSA-2026:37435",
+                "RHSA-2026:37436",
+                "RHSA-2026:38493",
+                "RHSA-2026:38494",
+                "RHSA-2026:38495",
+                "RHSA-2026:38878",
+                "RHSA-2026:38995"
+              ],
+              "summary": "Root escape via symlink plus trailing slash in os",
+              "details": "On Unix systems, opening a file in an os.Root improperly follows symlinks to locations outside of the Root when the final path component of the a path is a symbolic link and the path ends in /.\n\nFor example, 'root.Open(\"symlink/\")' will open \"symlink\" even when \"symlink\" is a symbolic link pointing outside of the root.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.12"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.5"
+                        },
+                        {
+                          "introduced": "1.27.0-0"
+                        },
+                        {
+                          "fixed": "1.27.0-rc.2"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4970.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "os",
+                        "symbols": [
+                          "OpenInRoot",
+                          "Root.Create",
+                          "Root.Open",
+                          "Root.OpenFile",
+                          "Root.OpenRoot",
+                          "Root.ReadFile",
+                          "Root.WriteFile",
+                          "openRootInRoot",
+                          "rootFS.Open",
+                          "rootFS.ReadDir",
+                          "rootFS.ReadFile",
+                          "rootOpenFileNolog"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/79005"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/OrmQE_Yp5Sc"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/797880"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Mundur (https://github.com/M0nd0R)"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4970"
+              }
+            },
+            {
+              "modified": "2026-08-01T10:44:51Z",
+              "published": "2026-05-07T19:21:40Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4971",
+              "aliases": [
+                "BIT-golang-2026-39836",
+                "CVE-2026-39836"
+              ],
+              "related": [
+                "CGA-g4vf-wmcj-mwwf",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264"
+              ],
+              "summary": "Panic in Dial and LookupPort when handling NUL byte on Windows in net",
+              "details": "The Dial and LookupPort functions panic on Windows when provided with an input containing a NUL (0).",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.10"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.3"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4971.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "net",
+                        "symbols": [
+                          "Dial",
+                          "DialTimeout",
+                          "Dialer.Dial",
+                          "Dialer.DialContext",
+                          "Listen",
+                          "ListenConfig.Listen",
+                          "ListenConfig.ListenPacket",
+                          "ListenPacket",
+                          "LookupAddr",
+                          "LookupCNAME",
+                          "LookupHost",
+                          "LookupIP",
+                          "LookupMX",
+                          "LookupNS",
+                          "LookupPort",
+                          "LookupSRV",
+                          "LookupTXT",
+                          "ResolveIPAddr",
+                          "ResolveTCPAddr",
+                          "ResolveUDPAddr",
+                          "Resolver.LookupAddr",
+                          "Resolver.LookupCNAME",
+                          "Resolver.LookupHost",
+                          "Resolver.LookupIP",
+                          "Resolver.LookupIPAddr",
+                          "Resolver.LookupMX",
+                          "Resolver.LookupNS",
+                          "Resolver.LookupNetIP",
+                          "Resolver.LookupPort",
+                          "Resolver.LookupSRV",
+                          "Resolver.LookupTXT",
+                          "Resolver.lookupAddr",
+                          "Resolver.lookupMX",
+                          "Resolver.lookupNS",
+                          "Resolver.lookupPort",
+                          "Resolver.lookupSRV",
+                          "Resolver.lookupTXT"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/79006"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/qcCIEXso47M"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/775320"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4971"
+              }
+            },
+            {
+              "modified": "2026-06-27T10:44:21Z",
+              "published": "2026-05-07T19:21:40Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4976",
+              "aliases": [
+                "BIT-golang-2026-39825",
+                "CVE-2026-39825"
+              ],
+              "related": [
+                "CGA-hgj8-xv45-c75x",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264"
+              ],
+              "summary": "ReverseProxy forwards queries with more than urlmaxqueryparams parameters in net/http/httputil",
+              "details": "ReverseProxy can forward queries containing parameters not visible to Rewrite functions.\n\nWhen used with a Rewrite function, or a Director function which parses query parameters, ReverseProxy sanitizes the forwarded request to remove query parameters which are not parsed by url.ParseQuery. ReverseProxy does not take ParseQuery's limit on the total number of query parameters (controlled by GODEBUG=urlmaxqueryparams=N) into account. This can permit ReverseProxy to forward a request containing a query parameter that is not visible to the Rewrite function.\n\nFor example, the query \"a1=x&a2=x&...&a10000=x&hidden=y\" can forward the parameter \"hidden=y\" while hiding it from the proxy's Rewrite function.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.10"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.3"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4976.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "net/http/httputil",
+                        "symbols": [
+                          "ReverseProxy.ServeHTTP",
+                          "cleanQueryParams"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/770541"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78948"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/qcCIEXso47M"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4976"
+              }
+            },
+            {
+              "modified": "2026-07-16T10:29:36Z",
+              "published": "2026-05-07T19:21:40Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4977",
+              "aliases": [
+                "BIT-golang-2026-42499",
+                "CVE-2026-42499"
+              ],
+              "related": [
+                "CGA-m28j-j59g-3rp3",
+                "RHSA-2026:17713",
+                "RHSA-2026:17714"
+              ],
+              "summary": "Quadratic string concatenation in consumePhrase in net/mail",
+              "details": "Pathological inputs could cause DoS through consumePhrase when parsing an email address according to RFC 5322.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.10"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.3"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4977.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "net/mail",
+                        "symbols": [
+                          "AddressParser.Parse",
+                          "AddressParser.ParseList",
+                          "Header.AddressList",
+                          "ParseAddress",
+                          "ParseAddressList",
+                          "addrParser.consumePhrase"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78987"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/771520"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/qcCIEXso47M"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4977"
+              }
+            },
+            {
+              "modified": "2026-06-10T10:29:24Z",
+              "published": "2026-05-07T19:21:40Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4980",
+              "aliases": [
+                "BIT-golang-2026-39826",
+                "CVE-2026-39826"
+              ],
+              "related": [
+                "CGA-4mcr-6mw7-3w72",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264"
+              ],
+              "summary": "Escaper bypass leads to XSS in html/template",
+              "details": "If a trusted template author were to write a <script> tag containing an empty 'type' attribute or a 'type' attribute with an ASCII whitespace, the execution of the template would incorrectly escape any data passed into the <script> block.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.10"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.3"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4980.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "html/template",
+                        "symbols": [
+                          "Template.Execute",
+                          "Template.ExecuteTemplate",
+                          "isJSType"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78981"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/771180"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/qcCIEXso47M"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Mundur (https://github.com/M0nd0R)"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4980"
+              }
+            },
+            {
+              "modified": "2026-08-07T10:42:57Z",
+              "published": "2026-05-07T19:21:40Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4981",
+              "aliases": [
+                "BIT-golang-2026-33811",
+                "CVE-2026-33811"
+              ],
+              "related": [
+                "CGA-xr8m-473w-fvfq",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264",
+                "RHSA-2026:34357",
+                "RHSA-2026:34359",
+                "RHSA-2026:35832",
+                "RHSA-2026:36617",
+                "RHSA-2026:36776",
+                "RHSA-2026:36796",
+                "RHSA-2026:38504",
+                "RHSA-2026:39266",
+                "RHSA-2026:39272",
+                "RHSA-2026:39319",
+                "RHSA-2026:39573",
+                "RHSA-2026:39810",
+                "RHSA-2026:41019",
+                "RHSA-2026:42078",
+                "RHSA-2026:42079",
+                "RHSA-2026:42082",
+                "RHSA-2026:42150",
+                "RHSA-2026:42151",
+                "RHSA-2026:42240",
+                "RHSA-2026:42946",
+                "RHSA-2026:49703",
+                "RHSA-2026:50319",
+                "RHSA-2026:50336",
+                "RHSA-2026:51187"
+              ],
+              "summary": "Crash when handling long CNAME response in net",
+              "details": "When using LookupCNAME with the cgo DNS resolver, a very long CNAME response can trigger a double-free of C memory and a crash.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.10"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.3"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4981.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "net",
+                        "symbols": [
+                          "LookupCNAME",
+                          "Resolver.LookupCNAME",
+                          "cgoResSearch"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78803"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/767860"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/qcCIEXso47M"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "hamayanhamayan"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4981"
+              }
+            },
+            {
+              "modified": "2026-06-27T10:44:21Z",
+              "published": "2026-05-07T19:21:40Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4982",
+              "aliases": [
+                "BIT-golang-2026-39823",
+                "CVE-2026-39823"
+              ],
+              "related": [
+                "CGA-x3r8-cgg4-9q3g",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264"
+              ],
+              "summary": "Bypass of meta content URL escaping causes XSS in html/template",
+              "details": "CVE-2026-27142 fixed a vulnerability in which URLs were not correctly escaped inside of a <meta> tag's <content> attribute. If the URL content were to insert ASCII whitespaces around the '=' rune inside of the <content> attribute, the escaper would fail to similarly escape it, leading to XSS.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.10"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.3"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4982.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "html/template",
+                        "symbols": [
+                          "Template.Execute",
+                          "Template.ExecuteTemplate",
+                          "tMetaContent"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78913"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/769920"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/qcCIEXso47M"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Samy Ghannad"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4982"
+              }
+            },
+            {
+              "modified": "2026-07-16T10:29:37Z",
+              "published": "2026-05-07T19:21:40Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-4986",
+              "aliases": [
+                "BIT-golang-2026-39820",
+                "CVE-2026-39820"
+              ],
+              "related": [
+                "CGA-h3rh-hg4q-4x4p",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264"
+              ],
+              "summary": "Quadratic string concatentation in consumeComment in net/mail",
+              "details": "Well-crafted inputs reaching ParseAddress, ParseAddressList, and ParseDate were able to trigger excessive CPU exhaustion and memory allocations.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.10"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.3"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-4986.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "net/mail",
+                        "symbols": [
+                          "AddressParser.Parse",
+                          "AddressParser.ParseList",
+                          "Header.AddressList",
+                          "Header.Date",
+                          "ParseAddress",
+                          "ParseAddressList",
+                          "ParseDate",
+                          "addrParser.consumeComment"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/78566"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/759940"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/qcCIEXso47M"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "thatnealpatel"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-4986"
+              }
+            },
+            {
+              "modified": "2026-08-07T10:42:57Z",
+              "published": "2026-06-02T21:39:47Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-5037",
+              "aliases": [
+                "BIT-golang-2026-27145",
+                "CVE-2026-27145"
+              ],
+              "related": [
+                "CGA-53j8-hw46-jfhx",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264",
+                "RHSA-2026:29980",
+                "RHSA-2026:29981",
+                "RHSA-2026:34357",
+                "RHSA-2026:34359",
+                "RHSA-2026:35832",
+                "RHSA-2026:36317",
+                "RHSA-2026:38995",
+                "RHSA-2026:39005",
+                "RHSA-2026:39573",
+                "RHSA-2026:39879",
+                "RHSA-2026:41930",
+                "RHSA-2026:42079",
+                "RHSA-2026:42080",
+                "RHSA-2026:42082",
+                "RHSA-2026:42150",
+                "RHSA-2026:42151",
+                "RHSA-2026:42240",
+                "RHSA-2026:42946",
+                "RHSA-2026:46394",
+                "RHSA-2026:46395",
+                "RHSA-2026:49703",
+                "RHSA-2026:50319",
+                "RHSA-2026:51187"
+              ],
+              "summary": "Inefficient candidate hostname parsing in crypto/x509",
+              "details": "(*x509.Certificate).VerifyHostname previously called matchHostnames in a loop over all DNS Subject Alternative Name (SAN) entries. This caused strings.Split(host, \".\") to execute repeatedly on the same input hostname.\n\nWith a large DNS SAN list, verification costs scaled quadratically based on the number of SAN entries multiplied by the hostname's label count. Because x509.Verify validates hostnames before building the certificate chain, this overhead occurred even for untrusted certificates.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.11"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.4"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-5037.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "crypto/x509",
+                        "symbols": [
+                          "Certificate.Verify",
+                          "Certificate.VerifyHostname",
+                          "HostnameError.Error",
+                          "matchHostnames"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/783621"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/79694"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/tKs3rmcBcKw"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Jakub Ciolek - https://ciolek.dev/"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-5037"
+              }
+            },
+            {
+              "modified": "2026-07-31T10:44:48Z",
+              "published": "2026-06-02T21:39:47Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-5038",
+              "aliases": [
+                "BIT-golang-2026-42504",
+                "CVE-2026-42504"
+              ],
+              "related": [
+                "CGA-434v-wc8g-cmvq",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264",
+                "RHSA-2026:29980",
+                "RHSA-2026:29981",
+                "RHSA-2026:38995"
+              ],
+              "summary": "Quadratic complexity in WordDecoder.DecodeHeader in mime",
+              "details": "Decoding a maliciously-crafted MIME header containing many invalid encoded-words can consume excessive CPU.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.11"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.4"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-5038.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "mime",
+                        "symbols": [
+                          "WordDecoder.DecodeHeader"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/79217"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/774481"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/tKs3rmcBcKw"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "p4p3r (https://hackerone.com/p4p3r_hak) "
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-5038"
+              }
+            },
+            {
+              "modified": "2026-07-31T10:44:48Z",
+              "published": "2026-06-02T21:39:47Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-5039",
+              "aliases": [
+                "BIT-golang-2026-42507",
+                "CVE-2026-42507"
+              ],
+              "related": [
+                "CGA-v7pm-5wx9-g4q8",
+                "RHSA-2026:23262",
+                "RHSA-2026:23264",
+                "RHSA-2026:29980",
+                "RHSA-2026:29981",
+                "RHSA-2026:38995"
+              ],
+              "summary": "Arbitrary inputs are included in errors without any escaping in net/textproto",
+              "details": "When returning errors, functions in the net/textproto package would include its input as part of the error. This might allow an attacker to inject misleading content to errors that are printed or logged.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.11"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.4"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-5039.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "net/textproto",
+                        "symbols": [
+                          "Error.Error",
+                          "Reader.ReadCodeLine",
+                          "Reader.ReadMIMEHeader",
+                          "Reader.ReadResponse",
+                          "parseCodeLine",
+                          "readMIMEHeader"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/79346"
+                },
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/777060"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/tKs3rmcBcKw"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-5039"
+              }
+            },
+            {
+              "modified": "2026-07-31T10:44:49Z",
+              "published": "2026-07-07T21:34:47Z",
+              "schema_version": "1.7.5",
+              "id": "GO-2026-5856",
+              "aliases": [
+                "BIT-golang-2026-42505",
+                "CVE-2026-42505"
+              ],
+              "related": [
+                "CGA-c2qp-qchh-369w",
+                "RHSA-2026:36477",
+                "RHSA-2026:36510",
+                "RHSA-2026:37435",
+                "RHSA-2026:37436",
+                "RHSA-2026:38995"
+              ],
+              "summary": "Invoking Encrypted Client Hello privacy leak in crypto/tls",
+              "details": "Handshakes which used Encrypted Client Hello could be de-anonymized by a passive network observer due to a disclosure of pre-shared key identities in the unencrypted client hello.",
+              "affected": [
+                {
+                  "package": {
+                    "ecosystem": "Go",
+                    "name": "stdlib",
+                    "purl": "pkg:golang/stdlib"
+                  },
+                  "ranges": [
+                    {
+                      "type": "SEMVER",
+                      "events": [
+                        {
+                          "introduced": "0"
+                        },
+                        {
+                          "fixed": "1.25.12"
+                        },
+                        {
+                          "introduced": "1.26.0-0"
+                        },
+                        {
+                          "fixed": "1.26.5"
+                        },
+                        {
+                          "introduced": "1.27.0-0"
+                        },
+                        {
+                          "fixed": "1.27.0-rc.2"
+                        }
+                      ]
+                    }
+                  ],
+                  "database_specific": {
+                    "source": "https://vuln.go.dev/ID/GO-2026-5856.json"
+                  },
+                  "ecosystem_specific": {
+                    "imports": [
+                      {
+                        "path": "crypto/tls",
+                        "symbols": [
+                          "Conn.Handshake",
+                          "Conn.HandshakeContext",
+                          "Conn.Read",
+                          "Conn.Write",
+                          "Dial",
+                          "DialWithDialer",
+                          "Dialer.Dial",
+                          "Dialer.DialContext",
+                          "QUICConn.HandleData",
+                          "QUICConn.SendSessionTicket",
+                          "QUICConn.Start",
+                          "clientHelloMsg.marshalMsg"
+                        ]
+                      }
+                    ]
+                  }
+                }
+              ],
+              "references": [
+                {
+                  "type": "FIX",
+                  "url": "https://go.dev/cl/775960"
+                },
+                {
+                  "type": "REPORT",
+                  "url": "https://go.dev/issue/79282"
+                },
+                {
+                  "type": "WEB",
+                  "url": "https://groups.google.com/g/golang-announce/c/OrmQE_Yp5Sc"
+                }
+              ],
+              "credits": [
+                {
+                  "name": "Coia Prant (github.com/rbqvq)"
+                }
+              ],
+              "database_specific": {
+                "review_status": "REVIEWED",
+                "url": "https://pkg.go.dev/vuln/GO-2026-5856"
+              }
+            }
+          ],
+          "groups": [
+            {
+              "ids": [
+                "GO-2026-4864"
+              ],
+              "aliases": [
+                "BIT-golang-2026-32282",
+                "CVE-2026-32282",
+                "GO-2026-4864"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4864": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4865"
+              ],
+              "aliases": [
+                "BIT-golang-2026-32289",
+                "CVE-2026-32289",
+                "GO-2026-4865"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4865": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4869"
+              ],
+              "aliases": [
+                "BIT-golang-2026-32288",
+                "CVE-2026-32288",
+                "GO-2026-4869"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4869": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4870"
+              ],
+              "aliases": [
+                "BIT-golang-2026-32283",
+                "CVE-2026-32283",
+                "GO-2026-4870"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4870": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4918"
+              ],
+              "aliases": [
+                "BIT-golang-2026-33814",
+                "CVE-2026-33814",
+                "GO-2026-4918"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4918": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4946"
+              ],
+              "aliases": [
+                "BIT-golang-2026-32281",
+                "CVE-2026-32281",
+                "GO-2026-4946"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4946": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4947"
+              ],
+              "aliases": [
+                "BIT-golang-2026-32280",
+                "CVE-2026-32280",
+                "GO-2026-4947"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4947": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4970"
+              ],
+              "aliases": [
+                "BIT-golang-2026-39822",
+                "CVE-2026-39822",
+                "GO-2026-4970"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4970": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4971"
+              ],
+              "aliases": [
+                "BIT-golang-2026-39836",
+                "CVE-2026-39836",
+                "GO-2026-4971"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4971": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4976"
+              ],
+              "aliases": [
+                "BIT-golang-2026-39825",
+                "CVE-2026-39825",
+                "GO-2026-4976"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4976": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4977"
+              ],
+              "aliases": [
+                "BIT-golang-2026-42499",
+                "CVE-2026-42499",
+                "GO-2026-4977"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4977": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4980"
+              ],
+              "aliases": [
+                "BIT-golang-2026-39826",
+                "CVE-2026-39826",
+                "GO-2026-4980"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4980": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4981"
+              ],
+              "aliases": [
+                "BIT-golang-2026-33811",
+                "CVE-2026-33811",
+                "GO-2026-4981"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4981": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4982"
+              ],
+              "aliases": [
+                "BIT-golang-2026-39823",
+                "CVE-2026-39823",
+                "GO-2026-4982"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4982": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-4986"
+              ],
+              "aliases": [
+                "BIT-golang-2026-39820",
+                "CVE-2026-39820",
+                "GO-2026-4986"
+              ],
+              "experimental_analysis": {
+                "GO-2026-4986": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-5037"
+              ],
+              "aliases": [
+                "BIT-golang-2026-27145",
+                "CVE-2026-27145",
+                "GO-2026-5037"
+              ],
+              "experimental_analysis": {
+                "GO-2026-5037": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-5038"
+              ],
+              "aliases": [
+                "BIT-golang-2026-42504",
+                "CVE-2026-42504",
+                "GO-2026-5038"
+              ],
+              "experimental_analysis": {
+                "GO-2026-5038": {
+                  "called": false,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-5039"
+              ],
+              "aliases": [
+                "BIT-golang-2026-42507",
+                "CVE-2026-42507",
+                "GO-2026-5039"
+              ],
+              "experimental_analysis": {
+                "GO-2026-5039": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            },
+            {
+              "ids": [
+                "GO-2026-5856"
+              ],
+              "aliases": [
+                "BIT-golang-2026-42505",
+                "CVE-2026-42505",
+                "GO-2026-5856"
+              ],
+              "experimental_analysis": {
+                "GO-2026-5856": {
+                  "called": true,
+                  "unimportant": false
+                }
+              },
+              "max_severity": ""
+            }
+          ],
+          "licenses": [
+            "UNKNOWN"
+          ]
+        }
+      ]
     }
   ],
   "experimental_config": {
@@ -7111,15 +10472,15 @@
   "license_summary": [
     {
       "name": "MIT",
-      "count": 164
+      "count": 178
     },
     {
       "name": "Apache-2.0",
-      "count": 133
+      "count": 177
     },
     {
       "name": "BSD-3-Clause",
-      "count": 71
+      "count": 109
     },
     {
       "name": "non-standard",
@@ -7127,11 +10488,11 @@
     },
     {
       "name": "ISC",
-      "count": 7
+      "count": 8
     },
     {
       "name": "UNKNOWN",
-      "count": 5
+      "count": 7
     },
     {
       "name": "BSD-2-Clause",

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/license/overrides.yaml
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/license/overrides.yaml
@@ -85,6 +85,7 @@ overrides:
   nemollm: NVIDIA Proprietary Software
   nvidia-cudnn-frontend: NVIDIA Proprietary Software
   nvidia-nvshmem-cu12: NVIDIA Proprietary Software
+  nvidia-nat-config-optimizer: Apache-2.0 # NVIDIA NeMo Agent Toolkit config optimizer
   triton: MIT
   # NeMo Fabric — Apache-2.0 per PyPI (`license_expression`) and deps.dev, but osv-scanner reports
   # UNKNOWN for the 0.1.x rc series, the same way it does for safetensors 0.8.0rc1 above. Revisit


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Normalize repository SPDX/copyright hygiene requested by OSRB and fix Helm template headers so license comments do not render into Kubernetes manifests. The copyright fixer now treats YAML files under real Helm chart `templates/` directories as Helm template source while keeping plain YAML values and fixtures on normal `#` comments.

## Related Issue
None.

## Changes
- Add the required NVIDIA copyright year range to the root `LICENSE`.
- Normalize Helm `.tpl`, `.gotmpl`, and chart `templates/*.yaml` SPDX headers to multi-line Helm template comments.
- Keep plain YAML files, including Helm values and CI fixture values, on normal YAML hash comments.
- Extend `script/copyright_fixer.py` and tests for OSRB-missed file types, explicit includes under `.copyrightignore`, proprietary license detection, and Helm template YAML style.
- Update Authentik static test helper to ignore both old inline and new multi-line Helm SPDX blocks.
- Add a stable Apache-2.0 override and generated inventory row for `nvidia-nat-config-optimizer`.
- Refresh third-party license artifacts and NOTICE coverage for vendored code.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [x] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: changes are repository license/header hygiene and validation behavior, not user-facing documentation semantics.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run ruff check script/copyright_fixer.py tests/test_copyright_fixer.py tests/auth_idp/static/test_authentik_kubernetes_demo.py` — passed.
- `uv run ruff format --check script/copyright_fixer.py tests/test_copyright_fixer.py tests/auth_idp/static/test_authentik_kubernetes_demo.py` — passed.
- `uv run --frozen pytest tests/test_copyright_fixer.py tests/auth_idp/static/test_authentik_kubernetes_demo.py::test_authentik_umbrella_values_define_one_shared_postgresql_instance -v` — passed.
- `make check-copyright-headers` — passed.
- `make check-licenses` — passed; local OSV scanner printed transient connection resets but generated matching license inventories with the reviewed override.
- `uv run --frozen pytest tools/nemo-platform-sdk-tools/tests/license/test_license_utils.py -v` — passed.
- `helm lint --strict k8s/helm` — passed.
- `helm template nemo-platform k8s/helm` plus scan for top-level rendered SPDX/comment joins — passed.
- `flox -q activate --dir . -- bash -lc 'for value_file in k8s/helm/ci/*.yaml; do helm template nemo-platform k8s/helm -f "$value_file" | kubeconform ...; done'` — passed for all chart CI values files.
- `uv run pre-commit run -a` — blocked before hooks ran because GitHub returned 503 fetching `https://github.com/norwoodj/helm-docs`.
- `helm dependency build contrib/auth/authentik/helm` — blocked locally because `https://charts.goauthentik.io/index.yaml` reset the connection; the focused Authentik source-text test above was run instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated copyright information to reflect NVIDIA CORPORATION & AFFILIATES and 2025–2026.
  * Standardized SPDX license notices across Helm and YAML resources for clearer, more consistent license metadata.

* **Chores**
  * Improved license-header handling for Helm templates and YAML files.
  * Added license coverage for the NVIDIA NAT configuration optimizer package.
  * Expanded validation coverage to help preserve deployment and configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
