### PR TITLE
feat(evaluator): write both eval and publish durations to intake

### DIFF
--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py
@@ -19,7 +19,8 @@ is what Studio needs to get evaluation runs into Experiments.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+import time
+from datetime import UTC, datetime
 
 from nemo_evaluator.intake.publish import PublishError, PublishReport, publish_to_intake
 from nemo_evaluator.intake.row_adapter import RowIdentityError, row_result_to_agent_eval_result
@@ -33,10 +34,17 @@ from nemo_evaluator_sdk.values.multi_metric_results import BenchmarkEvaluationRe
 from nemo_evaluator_sdk.values.results import EvaluationResult
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform._exceptions import NeMoPlatformError, NotFoundError
+from nemo_platform.types.evaluations import EvaluationResponse
 from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
+
+#: Evaluation metadata keys carrying how long the run took and how long publishing it took, both as
+#: string-encoded seconds (the API takes ``dict[str, str]``). Two keys rather than one ``duration``
+#: because a reader cannot tell which of the two a single key means.
+EVAL_DURATION_KEY = "eval_duration_sec"
+PUBLISH_DURATION_KEY = "publish_duration_sec"
 
 
 class PublicationOutcome(BaseModel):
@@ -99,6 +107,39 @@ def _failed(evaluation_id: str, error: str, report: PublishReport | None) -> Pub
     )
 
 
+def _eval_duration_sec(result: AgentEvalResult) -> float | None:
+    """Wall-clock seconds the run itself took, or ``None`` when it cannot be known."""
+    if result.metadata.duration_sec is not None:
+        return result.metadata.duration_sec
+    if result.metadata.started_at is not None:
+        # A row-eval result carries only a start time (see ``intake.row_adapter``), so its length is
+        # measured here instead. That slightly overcounts: it also covers persisting the bundle
+        # between the run finishing and this publish.
+        return (datetime.now(UTC) - result.metadata.started_at).total_seconds()
+    return None
+
+
+async def _record_durations(
+    platform: AsyncNeMoPlatform,
+    *,
+    evaluation: EvaluationResponse,
+    spec: IntakePublicationSpec,
+    workspace: str,
+    eval_duration_sec: float | None,
+    publish_duration_sec: float,
+) -> None:
+    """Stamp the two durations onto the Evaluation's metadata.
+
+    PATCH replaces the metadata dict wholesale, so the merge with what is already there is
+    mandatory — a blind write would drop producer keys such as ``eval_config_fileset``.
+    """
+    metadata = dict(evaluation.metadata or {})
+    if eval_duration_sec is not None:
+        metadata[EVAL_DURATION_KEY] = f"{eval_duration_sec:.1f}"
+    metadata[PUBLISH_DURATION_KEY] = f"{publish_duration_sec:.1f}"
+    await platform.evaluations.patch(spec.evaluation_id, workspace=workspace, metadata=metadata)
+
+
 async def _publish(
     result: AgentEvalResult,
     *,
@@ -108,13 +149,14 @@ async def _publish(
     agent_name: str,
     model_name: str | None,
 ) -> PublishReport:
-    """Check the Evaluation exists, then publish under it."""
+    """Check the Evaluation exists, publish under it, then record how long both took."""
     # The Evaluation must pre-exist — ATIF ingest rejects an unknown one per trial, so without this
     # a typo would surface as N failed writes after a partial publish instead of one clear stop.
     # This reads the entity store, so it says nothing about whether Intake's span storage is up;
     # that surfaces on the first ingest below, and re-publish is idempotent, so it needs no probe.
-    await platform.evaluations.retrieve(spec.evaluation_id, workspace=workspace)
-    return await publish_to_intake(
+    evaluation = await platform.evaluations.retrieve(spec.evaluation_id, workspace=workspace)
+    publish_started = time.monotonic()
+    report = await publish_to_intake(
         result,
         platform=platform,
         experiment_id=spec.evaluation_id,
@@ -123,6 +165,26 @@ async def _publish(
         agent_version=spec.agent_version,
         model_name=model_name,
     )
+    publish_duration_sec = time.monotonic() - publish_started
+    try:
+        await _record_durations(
+            platform,
+            evaluation=evaluation,
+            spec=spec,
+            workspace=workspace,
+            eval_duration_sec=_eval_duration_sec(result),
+            publish_duration_sec=publish_duration_sec,
+        )
+    except Exception:
+        # The durations are informational, and the publish already succeeded. Every caller-side
+        # handler turns an exception here into a failed job (and a raise when `required`), so letting
+        # one escape would report a successful publish as a failure.
+        logger.warning(
+            "Published to Intake but could not record durations on evaluation %r",
+            spec.evaluation_id,
+            exc_info=True,
+        )
+    return report
 
 
 def publish_agent_eval_result(

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py
@@ -113,8 +113,9 @@ def _eval_duration_sec(result: AgentEvalResult) -> float | None:
         return result.metadata.duration_sec
     if result.metadata.started_at is not None:
         # A row-eval result carries only a start time (see ``intake.row_adapter``), so its length is
-        # measured here instead. That slightly overcounts: it also covers persisting the bundle
-        # between the run finishing and this publish.
+        # measured here instead. Call this before publishing, not after, or the run duration swallows
+        # the publish it is meant to be reported alongside. It still slightly overcounts: it covers
+        # persisting the bundle between the run finishing and this call.
         return (datetime.now(UTC) - result.metadata.started_at).total_seconds()
     return None
 
@@ -150,6 +151,9 @@ async def _publish(
     model_name: str | None,
 ) -> PublishReport:
     """Check the Evaluation exists, publish under it, then record how long both took."""
+    # Measured before the publish so the two durations stay disjoint — for a result that carries only
+    # a start time, reading this afterwards would fold the whole publish into the run's own length.
+    eval_duration_sec = _eval_duration_sec(result)
     # The Evaluation must pre-exist — ATIF ingest rejects an unknown one per trial, so without this
     # a typo would surface as N failed writes after a partial publish instead of one clear stop.
     # This reads the entity store, so it says nothing about whether Intake's span storage is up;
@@ -172,7 +176,7 @@ async def _publish(
             evaluation=evaluation,
             spec=spec,
             workspace=workspace,
-            eval_duration_sec=_eval_duration_sec(result),
+            eval_duration_sec=eval_duration_sec,
             publish_duration_sec=publish_duration_sec,
         )
     except Exception:

--- a/plugins/nemo-evaluator/tests/jobs/test_publication.py
+++ b/plugins/nemo-evaluator/tests/jobs/test_publication.py
@@ -32,7 +32,12 @@ from nemo_evaluator.jobs.agent_spec import (
     target_agent_identity,
 )
 from nemo_evaluator.jobs.evaluate import EvaluateInputSpec, EvaluateJob, EvaluateSpec
-from nemo_evaluator.jobs.publication import PublicationFailedError, publish_agent_eval_result
+from nemo_evaluator.jobs.publication import (
+    EVAL_DURATION_KEY,
+    PUBLISH_DURATION_KEY,
+    PublicationFailedError,
+    publish_agent_eval_result,
+)
 from nemo_evaluator.jobs.publication_spec import (
     IntakePublicationSpec,
     PublicationSpec,
@@ -96,10 +101,19 @@ class _FakeTraces:
 
 
 class _FakeEvaluations:
-    def __init__(self, *, missing: bool = False, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        missing: bool = False,
+        error: Exception | None = None,
+        patch_error: Exception | None = None,
+    ) -> None:
         self.missing = missing
         self.error = error
+        self.patch_error = patch_error
         self.retrieved: _SessionIds = []
+        self.patched: list[dict[str, Any]] = []
+        self.metadata: dict[str, str] = {"eval_config_fileset": "fs-1"}
 
     async def retrieve(self, name: str, *, workspace: str | None = None) -> object:
         self.retrieved.append(name)
@@ -107,6 +121,12 @@ class _FakeEvaluations:
             raise self.error
         if self.missing:
             raise NotFoundError("not found", response=_response(404), body=None)
+        return SimpleNamespace(name=name, metadata=dict(self.metadata))
+
+    async def patch(self, name: str, *, workspace: str | None = None, **kwargs: Any) -> object:
+        if self.patch_error is not None:
+            raise self.patch_error
+        self.patched.append({"name": name, **kwargs})
         return SimpleNamespace(name=name)
 
 
@@ -132,13 +152,14 @@ class _FakeClient:
         missing_evaluation: bool = False,
         ingest_error: Exception | None = None,
         preflight_error: Exception | None = None,
+        patch_error: Exception | None = None,
     ) -> None:
         self.workspace = "default"
         self.atif_calls: list[dict[str, Any]] = []
         self.eval_result_calls: list[dict[str, Any]] = []
         self.trace_calls: _SessionIds = []
         self.copy_calls = 0
-        self.evaluations = _FakeEvaluations(missing=missing_evaluation, error=preflight_error)
+        self.evaluations = _FakeEvaluations(missing=missing_evaluation, error=preflight_error, patch_error=patch_error)
         self.intake = SimpleNamespace(
             ingest=SimpleNamespace(atif=_FakeIngest(self.atif_calls, error=ingest_error)),
             evaluator_results=_FakeIngest(self.eval_result_calls),
@@ -315,6 +336,30 @@ def test_publishes_and_reports_what_landed() -> None:
     assert outcome.evaluator_result_count == 1
     assert outcome.error is None
     assert client.evaluations.retrieved == ["eval-1"]
+
+
+def test_durations_are_stamped_without_dropping_existing_metadata() -> None:
+    client = _FakeClient()
+    _publish(cast(AsyncNeMoPlatform, client))
+
+    (patched,) = client.evaluations.patched
+    metadata = patched["metadata"]
+    # PATCH replaces the metadata dict wholesale, so stamping the durations has to merge with what
+    # the producer already wrote. A blind write would silently drop `eval_config_fileset`.
+    assert metadata["eval_config_fileset"] == "fs-1"
+    assert float(metadata[EVAL_DURATION_KEY]) > 0
+    assert float(metadata[PUBLISH_DURATION_KEY]) >= 0
+
+
+def test_a_failed_duration_stamp_does_not_fail_the_publish() -> None:
+    client = _FakeClient(patch_error=APIConnectionError(request=httpx.Request("PATCH", "http://x")))
+    outcome = _publish(cast(AsyncNeMoPlatform, client), required=True)
+
+    # The durations are informational and the trials already landed, so losing them must not turn a
+    # successful publish into a failed job — which is what every caller-side handler would do.
+    assert outcome.status == PlatformJobStatus.COMPLETED
+    assert outcome.trial_count == 1
+    assert outcome.error is None
 
 
 def test_outcome_does_not_leak_experiment_id() -> None:

--- a/plugins/nemo-evaluator/tests/jobs/test_publication.py
+++ b/plugins/nemo-evaluator/tests/jobs/test_publication.py
@@ -131,13 +131,16 @@ class _FakeEvaluations:
 
 
 class _FakeIngest:
-    def __init__(self, calls: list[dict[str, Any]], *, error: Exception | None = None) -> None:
+    def __init__(self, calls: list[dict[str, Any]], *, error: Exception | None = None, delay_sec: float = 0.0) -> None:
         self._calls = calls
         self._error = error
+        self._delay_sec = delay_sec
         self.loop: asyncio.AbstractEventLoop | None = None
 
     async def create(self, **kwargs: Any) -> None:
         self.loop = asyncio.get_running_loop()
+        if self._delay_sec:
+            await asyncio.sleep(self._delay_sec)
         if self._error is not None:
             raise self._error
         self._calls.append(kwargs)
@@ -153,6 +156,7 @@ class _FakeClient:
         ingest_error: Exception | None = None,
         preflight_error: Exception | None = None,
         patch_error: Exception | None = None,
+        ingest_delay_sec: float = 0.0,
     ) -> None:
         self.workspace = "default"
         self.atif_calls: list[dict[str, Any]] = []
@@ -161,7 +165,7 @@ class _FakeClient:
         self.copy_calls = 0
         self.evaluations = _FakeEvaluations(missing=missing_evaluation, error=preflight_error, patch_error=patch_error)
         self.intake = SimpleNamespace(
-            ingest=SimpleNamespace(atif=_FakeIngest(self.atif_calls, error=ingest_error)),
+            ingest=SimpleNamespace(atif=_FakeIngest(self.atif_calls, error=ingest_error, delay_sec=ingest_delay_sec)),
             evaluator_results=_FakeIngest(self.eval_result_calls),
             traces=_FakeTraces(self.trace_calls),
         )
@@ -349,6 +353,28 @@ def test_durations_are_stamped_without_dropping_existing_metadata() -> None:
     assert metadata["eval_config_fileset"] == "fs-1"
     assert float(metadata[EVAL_DURATION_KEY]) > 0
     assert float(metadata[PUBLISH_DURATION_KEY]) >= 0
+
+
+def test_a_started_at_only_result_does_not_count_publish_time_as_run_time() -> None:
+    # A row-eval result carries no `duration_sec`, so the run's length is derived from `started_at`.
+    # Deriving it after the publish instead of before would fold the publish into the run.
+    publish_sec = 0.3
+    client = _FakeClient(ingest_delay_sec=publish_sec)
+    result = _result()
+    result.metadata.started_at = datetime.now(UTC)
+
+    publish_agent_eval_result(
+        result,
+        spec=IntakePublicationSpec(evaluation_id="eval-1", agent_name="a", required=True),
+        target=None,
+        workspace="default",
+        async_sdk=cast(AsyncNeMoPlatform, client),
+    )
+
+    (patched,) = client.evaluations.patched
+    metadata = patched["metadata"]
+    assert float(metadata[PUBLISH_DURATION_KEY]) >= publish_sec
+    assert float(metadata[EVAL_DURATION_KEY]) < publish_sec / 2
 
 
 def test_a_failed_duration_stamp_does_not_fail_the_publish() -> None:

--- a/web/packages/studio/src/api/evaluation/utils.ts
+++ b/web/packages/studio/src/api/evaluation/utils.ts
@@ -81,8 +81,11 @@ export const EVAL_DURATION_METADATA_KEY = 'eval_duration_sec';
  *  Metadata values are strings server-side, so a non-numeric one reads the same as an absent one. */
 export const evalDurationMs = (metadata?: Record<string, string> | null): number | undefined => {
   const raw = metadata?.[EVAL_DURATION_METADATA_KEY];
-  const seconds = raw == null ? NaN : Number(raw);
-  return Number.isFinite(seconds) ? seconds * 1000 : undefined;
+  // Metadata is free-form and hand-editable, so treat anything that is not a non-negative number as
+  // absent. `Number('')` is 0, which would otherwise render as a confident "0ms".
+  if (raw == null || raw.trim() === '') return undefined;
+  const seconds = Number(raw);
+  return Number.isFinite(seconds) && seconds >= 0 ? seconds * 1000 : undefined;
 };
 
 export const publishedEvaluationName = (job: PlatformJobResponse): string | null => {

--- a/web/packages/studio/src/api/evaluation/utils.ts
+++ b/web/packages/studio/src/api/evaluation/utils.ts
@@ -74,6 +74,17 @@ export const EVAL_JOB_KIND_LABEL: Record<EvalJobKind, string> = {
   dataset: 'Dataset-Driven',
 };
 
+/** Metadata key the evaluator stamps the run's wall-clock seconds under, at publish time. */
+export const EVAL_DURATION_METADATA_KEY = 'eval_duration_sec';
+
+/** How long the published run took, in milliseconds, or undefined when it was never recorded.
+ *  Metadata values are strings server-side, so a non-numeric one reads the same as an absent one. */
+export const evalDurationMs = (metadata?: Record<string, string> | null): number | undefined => {
+  const raw = metadata?.[EVAL_DURATION_METADATA_KEY];
+  const seconds = raw == null ? NaN : Number(raw);
+  return Number.isFinite(seconds) ? seconds * 1000 : undefined;
+};
+
 export const publishedEvaluationName = (job: PlatformJobResponse): string | null => {
   const intake = asRecord(asRecord(specOf(job).publication)?.intake);
   return asNonEmptyString(intake?.evaluation_id) ?? null;

--- a/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
@@ -21,6 +21,7 @@ import { formatDurationMs } from '@nemo/common/src/utils/date';
 import { formatEvaluatorScore, snakeCaseToTitleCase } from '@nemo/common/src/utils/formatters';
 import type { EvaluationFilter, ExperimentResponse } from '@nemo/sdk/generated/platform/schema';
 import { Button, Text, Tooltip } from '@nvidia/foundations-react-core';
+import { EVAL_DURATION_METADATA_KEY, evalDurationMs } from '@studio/api/evaluation/utils';
 import { ChangesetBadge } from '@studio/components/ChangesetBadge';
 import { ExperimentParetoChart } from '@studio/components/charts/ExperimentParetoChart';
 import { AddToGroupModal } from '@studio/components/dataViews/ExperimentDataView/AddToGroupModal';
@@ -230,13 +231,17 @@ export const ExperimentDataView: FC<ExperimentDataViewProps> = ({ group, paretoV
 
   // One column per metadata key: keys are lowercased so case variants (e.g. "status"
   // and "Status") collapse into one column rather than producing duplicate headers.
+  // The run duration is excluded because the Duration column below already renders it, formatted;
+  // publish duration is deliberately left in, which is what surfaces publish latency at all.
   const metadataKeys = useMemo(
     () =>
       [
         ...new Set(
           orderedData.flatMap((e) => Object.keys(e.metadata ?? {}).map((k) => k.toLowerCase()))
         ),
-      ].sort(),
+      ]
+        .filter((key) => key !== EVAL_DURATION_METADATA_KEY)
+        .sort(),
     [orderedData]
   );
 
@@ -480,6 +485,15 @@ export const ExperimentDataView: FC<ExperimentDataViewProps> = ({ group, paretoV
         header: 'Total test cases',
         enableSorting: true,
         cell: ({ row }) => <Text>{String(row.original.test_case_count ?? 0)}</Text>,
+      }),
+      // Written as metadata at publish time, so it is a string and only present for runs that
+      // published successfully. Not sortable: the API sorts metadata lexically, which would order
+      // "9" after "10", and the list pages at 100 so a client-side sort would lie across pages.
+      accessor((original) => evalDurationMs(original.metadata), {
+        id: 'eval_duration',
+        header: 'Duration',
+        enableSorting: false,
+        cell: ({ getValue }) => <Text>{formatDurationMs(getValue<number | undefined>())}</Text>,
       }),
       accessor('created_at', {
         header: 'Created',

--- a/web/packages/studio/src/components/evaluation/Jobs/DetailsPanel.tsx
+++ b/web/packages/studio/src/components/evaluation/Jobs/DetailsPanel.tsx
@@ -9,18 +9,16 @@ import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
 import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
 import { useLiveSeconds } from '@nemo/common/src/hooks/useLiveSeconds';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
-import {
-  formatTimeInSeconds,
-  getDifferenceInMilliseconds,
-  utcToLocalDate,
-} from '@nemo/common/src/utils/date';
+import { formatDurationMs, formatTimeInSeconds, utcToLocalDate } from '@nemo/common/src/utils/date';
 import { logger } from '@nemo/common/src/utils/logger';
 import {
   getEvaluatorGetEvaluateJobQueryKey,
   useEvaluatorCancelEvaluateJob,
 } from '@nemo/sdk/generated/evaluator/api';
 import type { EvaluateJob } from '@nemo/sdk/generated/evaluator/schema';
+import { useGetEvaluation } from '@nemo/sdk/generated/platform/api';
 import { Banner, Button, Flex, Modal, Panel, Stack, Text } from '@nvidia/foundations-react-core';
+import { evalDurationMs } from '@studio/api/evaluation/utils';
 import { ButtonLaunchEvaluation } from '@studio/components/evaluation/ButtonLaunchEvaluation';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { getFilesetRoute } from '@studio/routes/utils';
@@ -64,19 +62,20 @@ export const DetailsPanel = ({ evaluationJob, error }: DetailsPanelProps) => {
     }
   };
 
-  const differenceInMilliseconds = getDifferenceInMilliseconds(
-    evaluationJob?.created_at,
-    evaluationJob?.updated_at
-  );
-  const elapsedSeconds = differenceInMilliseconds
-    ? Math.floor(differenceInMilliseconds / 1000)
-    : undefined;
   const isTerminalStatus =
     evaluationJob?.status && PlatformJobTerminalStatuses.includes(evaluationJob.status);
   const canCancelJob = evaluationJob?.status && !isTerminalStatus;
   const liveSeconds = useLiveSeconds({
     startDate: !isTerminalStatus ? utcToLocalDate(evaluationJob?.created_at) : undefined,
   });
+
+  // A finished job has no end time of its own — `updated_at` is stamped at create and on rerun,
+  // never on a status change — so the run's length comes from the evaluation it published under.
+  const publishedEvaluation = evaluationJob?.spec.publication?.intake?.evaluation_id;
+  const { data: evaluation } = useGetEvaluation(workspace, publishedEvaluation ?? '', {
+    query: { enabled: !!workspace && !!publishedEvaluation && !!isTerminalStatus },
+  });
+  const durationMs = evalDurationMs(evaluation?.metadata);
 
   if (error || !evaluationJob) {
     return (
@@ -165,9 +164,9 @@ export const DetailsPanel = ({ evaluationJob, error }: DetailsPanelProps) => {
               status ? (
                 <Flex align="center" gap="2">
                   <StatusBadge status={status} />
-                  {formatTimeInSeconds(
-                    PlatformJobTerminalStatuses.includes(status) ? elapsedSeconds : liveSeconds
-                  )}
+                  {PlatformJobTerminalStatuses.includes(status)
+                    ? durationMs !== undefined && formatDurationMs(durationMs)
+                    : formatTimeInSeconds(liveSeconds)}
                 </Flex>
               ) : (
                 <Text kind="body/semibold/sm">Detail not available</Text>

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
@@ -5,11 +5,15 @@ import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataV
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
+import { PlatformJobTerminalStatuses } from '@nemo/common/src/constants/query';
+import { useLiveSeconds } from '@nemo/common/src/hooks/useLiveSeconds';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
+import { formatDurationMs, formatTimeInSeconds, utcToLocalDate } from '@nemo/common/src/utils/date';
 import { Text } from '@nvidia/foundations-react-core';
 import {
   EVAL_JOB_KIND_LABEL,
   type EvalJobRow,
+  evalDurationMs,
   evalJobDetailRoute,
 } from '@studio/api/evaluation/utils';
 import type { AgentEvaluationRow } from '@studio/routes/agents/AgentDetailRoute/useAgentDetails';
@@ -17,6 +21,20 @@ import { getEvaluationDetailRoute } from '@studio/routes/utils';
 import { ListChecks } from 'lucide-react';
 import { type ComponentProps, type FC, useCallback } from 'react';
 import { useNavigate } from 'react-router';
+
+/** Elapsed time for one job row: a live counter while it runs, the published run's recorded
+ *  duration once it finished, and an em dash for a job that ended without publishing.
+ *
+ *  A completed job's own `updated_at` is not an end time — the job row is written at create and on
+ *  rerun only, never on a status transition — so the duration has to come from the evaluation. */
+const DurationCell: FC<{ row: EvalJobRow; durationMs?: number }> = ({ row, durationMs }) => {
+  const isTerminal = PlatformJobTerminalStatuses.some((status) => status === row.status);
+  const liveSeconds = useLiveSeconds({
+    startDate: isTerminal ? undefined : utcToLocalDate(row.created_at),
+  });
+  if (!isTerminal) return <Text>{formatTimeInSeconds(liveSeconds)}</Text>;
+  return <Text>{formatDurationMs(durationMs)}</Text>;
+};
 
 interface JobsTableProps {
   workspace: string;
@@ -46,6 +64,16 @@ export const JobsTable: FC<JobsTableProps> = ({ workspace, jobs, evaluations }) 
     [workspace, evaluations]
   );
 
+  const durationMsFor = useCallback(
+    (row: EvalJobRow): number | undefined => {
+      const published = row.evaluationName
+        ? evaluations.find((evaluation) => evaluation.name === row.evaluationName)
+        : undefined;
+      return evalDurationMs(published?.metadata);
+    },
+    [evaluations]
+  );
+
   const makeColumns: ComponentProps<typeof StudioDataView<EvalJobRow>>['makeColumns'] = useCallback(
     ({ accessor }) => [
       accessor('name', {
@@ -73,8 +101,18 @@ export const JobsTable: FC<JobsTableProps> = ({ workspace, jobs, evaluations }) 
         cell: ({ row }) =>
           row.original.created_at ? <RelativeTime datetime={row.original.created_at} /> : '—',
       }),
+      // A just-finished run stays on '—' here for up to a minute: the evaluations it reads are
+      // filtered by `agent_name`, which Intake denormalizes on an interval after publish.
+      accessor(durationMsFor, {
+        id: 'duration',
+        header: 'Duration',
+        enableSorting: false,
+        cell: ({ row, getValue }) => (
+          <DurationCell row={row.original} durationMs={getValue<number | undefined>()} />
+        ),
+      }),
     ],
-    []
+    [durationMsFor]
   );
 
   return (

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
@@ -29,8 +29,12 @@ import { useNavigate } from 'react-router';
  *  rerun only, never on a status transition — so the duration has to come from the evaluation. */
 const DurationCell: FC<{ row: EvalJobRow; durationMs?: number }> = ({ row, durationMs }) => {
   const isTerminal = PlatformJobTerminalStatuses.some((status) => status === row.status);
+  // `enabled` is what actually stops the timer: the hook's interval effect keys off its *locked*
+  // start date, so clearing `startDate` alone leaves a row that finished mid-poll ticking (and
+  // re-rendering the table) once a second forever.
   const liveSeconds = useLiveSeconds({
     startDate: isTerminal ? undefined : utcToLocalDate(row.created_at),
+    enabled: !isTerminal,
   });
   if (!isTerminal) return <Text>{formatTimeInSeconds(liveSeconds)}</Text>;
   return <Text>{formatDurationMs(durationMs)}</Text>;

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationDetailRoute.tsx
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AgentEvaluationDetailRoute.tsx
@@ -9,8 +9,9 @@ import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
 import { useLiveSeconds } from '@nemo/common/src/hooks/useLiveSeconds';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
-import { formatTimeInSeconds, utcToLocalDate } from '@nemo/common/src/utils/date';
+import { formatDurationMs, formatTimeInSeconds, utcToLocalDate } from '@nemo/common/src/utils/date';
 import { evaluatorCancelAgentEvaluateJob } from '@nemo/sdk/generated/evaluator/api';
+import { useGetEvaluation } from '@nemo/sdk/generated/platform/api';
 import type { PlatformJobStatus } from '@nemo/sdk/generated/platform/schema';
 import {
   Block,
@@ -35,6 +36,7 @@ import {
   joinBundleByTask,
   parseBundleRef,
 } from '@studio/api/evaluation/agent-evaluations';
+import { evalDurationMs } from '@studio/api/evaluation/utils';
 import { AgentEvalTaskResultsPanel } from '@studio/components/evaluation/AgentEvalTaskResultsPanel';
 import { EvalAggregateScoresTable } from '@studio/components/evaluation/EvalAggregateScoresTable';
 import { StatusLogsContent } from '@studio/components/evaluation/Jobs/StatusLogsContent';
@@ -95,6 +97,15 @@ export const AgentEvaluationDetailRoute: FC = () => {
   const liveSeconds = useLiveSeconds({
     startDate: !isJobTerminal ? utcToLocalDate(job?.created_at) : undefined,
   });
+
+  // How long the run took, once it finished. The job row itself cannot answer this — it is written
+  // at create and on rerun, never on a status change — so the duration comes from the evaluation the
+  // run published under. Fetched by name, so it lands as soon as the publish does.
+  const publishedEvaluation = job?.spec.publication?.intake?.evaluation_id;
+  const { data: evaluation } = useGetEvaluation(workspace, publishedEvaluation ?? '', {
+    query: { enabled: !!workspace && !!publishedEvaluation && isJobTerminal },
+  });
+  const durationMs = evalDurationMs(evaluation?.metadata);
 
   const handleCancelJob = async () => {
     if (!jobName) return;
@@ -210,6 +221,9 @@ export const AgentEvaluationDetailRoute: FC = () => {
                     {!isJobTerminal && liveSeconds !== undefined && (
                       <Text kind="body/regular/sm">{formatTimeInSeconds(liveSeconds)}</Text>
                     )}
+                    {isJobTerminal && durationMs !== undefined && (
+                      <Text kind="body/regular/sm">{formatDurationMs(durationMs)}</Text>
+                    )}
                   </Flex>
                 }
                 loading={isLoadingJob}
@@ -236,11 +250,6 @@ export const AgentEvaluationDetailRoute: FC = () => {
               <KVPair
                 label="Created"
                 value={job.created_at ? <RelativeTime datetime={job.created_at} /> : ''}
-                loading={isLoadingJob}
-              />
-              <KVPair
-                label="Updated"
-                value={job.updated_at ? <RelativeTime datetime={job.updated_at} /> : ''}
                 loading={isLoadingJob}
               />
               {artifactsFileset && (


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Evaluation runs had no duration anywhere in Studio's Intake eval views — "how long did this eval take" could not be answered from any list. This records two wall-clock durations as Evaluation metadata at publish time (`eval_duration_sec`, `publish_duration_sec`) and surfaces them across the eval list, the agent jobs list, and both eval job detail panels. It also fixes a live display bug: the job detail panel derived elapsed time from `updated_at − created_at`, but a `PlatformJob` row is written only at create and on rerun — never on a status transition — so every completed job rendered ~0s.

## Changes

**Backend — `plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py`**

- `_publish` now keeps the Evaluation it already retrieves, times `publish_to_intake` with `time.monotonic()`, and PATCHes two string-encoded seconds keys onto the Evaluation's metadata.
- The stamp merges with existing metadata. PATCH replaces the metadata dict wholesale (`services/intake/.../experiments/endpoints.py:603`), so a blind write would drop producer keys such as `eval_config_fileset`.
- Read, merge, and PATCH sit inside one `try/except` that logs and continues. Every caller-side handler routes through `fail()`, which raises when `spec.required` (the default), so an escaping exception would report a fully successful publish as a failed job.
- The PATCH is outside the timed span, so `publish_duration_sec` does not measure our own write.
- `eval_duration_sec` comes from `result.metadata.duration_sec`, falling back to `now − started_at`. The fallback covers the dataset-driven path, whose adapted result carries only overcounts by including
seconds keys onto the Eva
- The stamp merges with eplaces the metadata dict
wholesale (`services/intats.py:603`), so a blind
write would drop producer_fileset`.
- Read, merge, and PATCH sit inside one `try/except` that logs and continues. Every caller-side handler routes through `fail()`, which raises when
`spec.required` (the defation would report a fullysuccessful publish as a failed job.
- The PATCH is outside the timed span, so `publish_duration_sec` does not measure our own write.
- `eval_duration_sec` comes from `result.metadata.duration_sec`, falling back to `now − started_at`. The fallback covers the dataset-driven path, whose adapted result carries only a start time; it slightly overcounts by including result-bundle persistence.

**Studio**

- `api/evaluation/utils.ts`: new `EVAL_DURATION_METADATA_KEY` and `evalDurationMs`, which guards with `Number.isFinite` since metadata values are strings server-side.
- `ExperimentDataView`: Duration column beside Created, `enableSorting: false` (metadata sorts lexically server-side, and the list pages at 100, so a client-side sort would lie across pages). `eval_duration_sec` is excluded from the dynamic metadata columns so it does not render twice; `publish_duration_sec` deliberately falls through to a dynamic column, which is what surfaces publish latency.
- `JobsTable`: Duration column — live counter while running, recorded duration
once published, em dash ft publishing.
- `AgentEvaluationDetailRoute` and `DetailsPanel`: duration beside the status
badge for terminal jobs, ` gated on the job havingpublished. Fetching by name skips the `agent_name` filter, so these surface the duration as soon as publish completes.
- `AgentEvaluationDetailRoute`: removed the "Updated" row. It rendered `job.updated_at` as a relative time, which reads as "last changed" but is really create time — the same bogus field behind the ~0s bug. Deleted rather
than corrected because thnal timestamp to put there.

No entity migration, no `refresh-openapi`, no `update-sdk` — Evaluation metadata is free-form and every type used is already generated.

## Type of Change

- [x] Code change (featur
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests covefication:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not a no user-facing docdescribes eval job timing; this surfaces a new value in existing views and adds no CLI flag, config key, or API field.

Two tests added to `plugins/nemo-evaluator/tests/jobs/test_publication.py`, both verified by mutation rather than by passing alone:

- `test_durations_are_stamped_without_dropping_existing_metadata` — replacing
the merge with a blank di: 'eval_config_fileset'`.
- `test_a_failed_duration_stamp_does_not_fail_the_publish` — removing the `try/except` fails it with `PublicationFailedError`.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit cked checks are identifiedbelow
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
| --- | --- |
| `uv run --frozen pytest plugins/nemo-evaluator/tests --ignore=plugins/nemo-evaluator/tests/integration -q` | 823 passed |
| `uv run ruff check plugchecks passed |
| `uv run ruff format --check` (both touched Python files) | 2 files already formatted |
| `uv run --frozen ty cheplugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py` | All checks passed |
| `pnpm --filter nemo-stu |
| `pnpm lint` (from `web/`) | passed, `--max-warnings 0` |
| `pnpm --filter nemo-studio-ui test <3 touched specs>` | 3 files, 13 tests passed |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added evaluation and publication duration tracking for completed evaluations.
  * Running jobs now show live elapsed time, while completed jobs display recorded duration.
  * Added Duration columns to experiment and job tables.
  * Added duration details to job and evaluation views.

* **Bug Fixes**
  * Duration-recording issues no longer cause successful publications to fail.
  * Existing evaluation metadata is preserved when duration information is added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->