### PR TITLE
fix(switchyard): key VM config bookkeeping by workspace/name, not the unmapped entity id

### DIFF
--- a/plugins/nemo-switchyard/src/nemo_switchyard/_state.py
+++ b/plugins/nemo-switchyard/src/nemo_switchyard/_state.py
@@ -32,8 +32,10 @@ Phase = Literal["request", "response"]
 # config_hash -> factory_name. Multiple VMs with identical configs share one factory.
 FACTORIES_BY_CONFIG_HASH: dict[str, str] = {}
 
-# vm_id -> [config_hash, ...]. A VM may have multiple nemo-switchyard middlewares
-# (e.g., random_routing + translate); we track all so destroy can clean them all up.
+# vm_key ("workspace/name") -> [config_hash, ...]. A VM may have multiple
+# nemo-switchyard middlewares (e.g., random_routing + translate); we track all so
+# destroy can clean them all up. Keyed by vm_key because the IGW lifecycle hooks
+# do not carry the entity id (see NVBug 6563245).
 VM_CONFIG_MAPPING: dict[str, list[str]] = {}
 
 # (vm_key, config_type, phase) -> config_hash. Phase is "request" or "response".

--- a/plugins/nemo-switchyard/src/nemo_switchyard/middleware.py
+++ b/plugins/nemo-switchyard/src/nemo_switchyard/middleware.py
@@ -322,7 +322,15 @@ class SwitchyardMiddleware(NemoInferenceMiddleware):
                 )
             )
 
-        _state.VM_CONFIG_MAPPING[virtual_model.id] = registered_hashes
+        # Key by vm_key (workspace/name), NOT virtual_model.id: the IGW lifecycle
+        # dispatcher builds plugin VMs without mapping the entity id, so .id is the
+        # same empty string for every VM. Keying on it collapsed all VMs into one
+        # VM_CONFIG_MAPPING slot — each upsert overwrote the previous VM's entry and
+        # destroying ANY VM popped the shared slot and unregistered factories that
+        # live VMs still referenced ("Factory not found for config hash ..." 500s
+        # on catalog-visible VMs; NVBug 6563245). vm_key is the identity that both
+        # hooks reliably carry.
+        _state.VM_CONFIG_MAPPING[vm_key] = registered_hashes
 
     def _register_entry(
         self,
@@ -393,10 +401,9 @@ class SwitchyardMiddleware(NemoInferenceMiddleware):
 
     async def on_virtual_model_destroyed(self, virtual_model: VirtualModel) -> None:
         """Unregister this VM's middlewares; factories shared with other VMs stay."""
-        vm_id = virtual_model.id
         vm_key = f"{virtual_model.workspace}/{virtual_model.name}"
 
-        config_hashes = _state.VM_CONFIG_MAPPING.pop(vm_id, None)
+        config_hashes = _state.VM_CONFIG_MAPPING.pop(vm_key, None)
         if not config_hashes:
             logger.debug("SwitchyardMiddleware: VirtualModel %s has no registered configs", vm_key)
             return

--- a/plugins/nemo-switchyard/tests/test_integration.py
+++ b/plugins/nemo-switchyard/tests/test_integration.py
@@ -155,7 +155,7 @@ class TestSwitchyardRandomRoutingIntegration:
 
         # VM should be unregistered from all mappings
         assert (vm_key, "random_routing", "request") not in middleware_state.VM_NAME_TO_CONFIG_HASH
-        assert virtual_model.id not in middleware_state.VM_CONFIG_MAPPING
+        assert vm_key not in middleware_state.VM_CONFIG_MAPPING
         # And since no other VM uses this config, the factory should be unregistered
         assert config_hash not in middleware_state.FACTORIES_BY_CONFIG_HASH
 

--- a/plugins/nemo-switchyard/tests/test_lifecycle_identity.py
+++ b/plugins/nemo-switchyard/tests/test_lifecycle_identity.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lifecycle identity regressions for SwitchyardMiddleware (NVBug 6563245).
+
+The IGW lifecycle dispatcher (middleware_registry._sdk_vm_to_plugin_vm) builds
+plugin VirtualModels WITHOUT mapping the entity id, so every hook receives
+``id == ""``. The per-VM config bookkeeping therefore must key on the
+workspace/name identity, never on ``.id``. These tests replicate the production
+shape (no id) and the exact create/destroy interleaving from the QA skill-eval
+suite that produced "Factory not found for config hash ..." 500s on
+catalog-visible VMs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from nemo_platform_plugin.inference_middleware import (
+    BackendFormat,
+    InferenceMiddlewareContext,
+    InferenceRequest,
+    MiddlewareCall,
+    VirtualModel,
+    VirtualModelInferenceConfig,
+)
+from nemo_switchyard import _state
+from nemo_switchyard.middleware import SwitchyardMiddleware
+
+
+@pytest.fixture
+async def middleware() -> SwitchyardMiddleware:
+    mw = SwitchyardMiddleware()
+    await mw.on_startup()
+    yield mw
+    await mw.on_shutdown()
+
+
+def _vm_without_id(name: str, *, strong_probability: float = 1.0) -> VirtualModel:
+    """A VM exactly as the IGW dispatcher delivers it: entity id NOT mapped."""
+    return VirtualModel(
+        workspace="ws",
+        name=name,
+        models=[
+            VirtualModelInferenceConfig(model="ws/strong", backend_format=BackendFormat.OPENAI_CHAT),
+            VirtualModelInferenceConfig(model="ws/weak", backend_format=BackendFormat.OPENAI_CHAT),
+        ],
+        request_middleware=[
+            MiddlewareCall(
+                name="nemo-switchyard",
+                config_type="random_routing",
+                config={
+                    "strong": {"model": "ws/strong"},
+                    "weak": {"model": "ws/weak"},
+                    "strong_probability": strong_probability,
+                    "rng_seed": 1,
+                    "enable_stats": False,
+                },
+            )
+        ],
+        response_middleware=[],
+        post_response_middleware=[],
+    )
+
+
+def _request_ctx(vm_name: str, request: InferenceRequest) -> InferenceMiddlewareContext:
+    return InferenceMiddlewareContext(
+        request_id="test-req",
+        workspace="ws",
+        virtual_model_name=vm_name,
+        original_request=InferenceRequest(
+            body=dict(request.body),
+            headers=dict(request.headers),
+            path=request.path,
+        ),
+    )
+
+
+def _openai_request() -> InferenceRequest:
+    body: dict[str, Any] = {
+        "model": "ws/vm",
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    return InferenceRequest(body=body, headers={}, path="v1/chat/completions", typed_body=body)
+
+
+class TestLifecycleIdentityWithoutEntityId:
+    """Reproduces NVBug 6563245 with the production (id-less) VM shape."""
+
+    async def test_destroying_one_vm_keeps_other_vms_factory(self, middleware: SwitchyardMiddleware) -> None:
+        """skill-eval pattern: old VM destroyed right after a new VM registers.
+
+        With id-keyed bookkeeping both VMs collapsed into one mapping slot, so
+        destroy(vm_old) unregistered the factory vm_new still referenced and its
+        next request failed with "Factory not found for config hash" (500).
+        """
+        vm_old = _vm_without_id("skill-eval-old", strong_probability=1.0)
+        vm_new = _vm_without_id("skill-eval-new", strong_probability=0.25)
+
+        await middleware.on_virtual_model_upserted(vm_old)
+        await middleware.on_virtual_model_upserted(vm_new)
+        await middleware.on_virtual_model_destroyed(vm_old)
+
+        # vm_new must still be fully wired: mapping present, factory resolvable,
+        # and a live request must route instead of raising.
+        assert ("ws/skill-eval-new", "random_routing", "request") in _state.VM_NAME_TO_CONFIG_HASH
+        cfg_hash = _state.VM_NAME_TO_CONFIG_HASH[("ws/skill-eval-new", "random_routing", "request")]
+        assert cfg_hash in _state.FACTORIES_BY_CONFIG_HASH, (
+            "destroying vm_old unregistered vm_new's factory (NVBug 6563245 regression)"
+        )
+        request = _openai_request()
+        result = await middleware.process_request(
+            _request_ctx("skill-eval-new", request),
+            request,
+            {"config_type": "random_routing"},
+        )
+        assert result is not None
+
+    async def test_identical_config_vms_share_factory_until_last_destroy(
+        self, middleware: SwitchyardMiddleware
+    ) -> None:
+        """Two id-less VMs with IDENTICAL configs share one factory; the factory
+        must survive until the LAST referencing VM is destroyed."""
+        vm_a = _vm_without_id("twin-a", strong_probability=1.0)
+        vm_b = _vm_without_id("twin-b", strong_probability=1.0)
+
+        await middleware.on_virtual_model_upserted(vm_a)
+        await middleware.on_virtual_model_upserted(vm_b)
+        cfg_hash = _state.VM_NAME_TO_CONFIG_HASH[("ws/twin-a", "random_routing", "request")]
+        assert cfg_hash == _state.VM_NAME_TO_CONFIG_HASH[("ws/twin-b", "random_routing", "request")]
+
+        await middleware.on_virtual_model_destroyed(vm_a)
+        assert cfg_hash in _state.FACTORIES_BY_CONFIG_HASH, "twin-b still references the shared factory"
+
+        await middleware.on_virtual_model_destroyed(vm_b)
+        assert cfg_hash not in _state.FACTORIES_BY_CONFIG_HASH, "last destroy must release the factory"
+
+    async def test_reupsert_same_vm_keeps_single_mapping_entry(self, middleware: SwitchyardMiddleware) -> None:
+        """Upserting the same VM twice (config change) must not leak mapping entries
+        or leave the VM pointing at an unregistered factory."""
+        await middleware.on_virtual_model_upserted(_vm_without_id("solo", strong_probability=1.0))
+        await middleware.on_virtual_model_upserted(_vm_without_id("solo", strong_probability=0.5))
+
+        assert list(_state.VM_CONFIG_MAPPING) == ["ws/solo"]
+        cfg_hash = _state.VM_NAME_TO_CONFIG_HASH[("ws/solo", "random_routing", "request")]
+        assert cfg_hash in _state.FACTORIES_BY_CONFIG_HASH
+
+        await middleware.on_virtual_model_destroyed(_vm_without_id("solo", strong_probability=0.5))
+        assert "ws/solo" not in _state.VM_CONFIG_MAPPING


### PR DESCRIPTION
## Problem

Deleting ANY Switchyard VirtualModel breaks inference for other still-live Switchyard VMs: they stay catalog-visible but answer `500 "Factory not found for config hash ..."`.

Fixes #1341 · NVBug 6563245 (hit daily by the QA skill-eval suite, which creates/destroys VMs per test).

## Root cause

The IGW lifecycle dispatcher (`middleware_registry._sdk_vm_to_plugin_vm`) does not map the entity id, so every lifecycle hook receives `id == ""`. `nemo_switchyard` keyed `VM_CONFIG_MAPPING` on that id:

- every upsert wrote to the same `""` slot, overwriting the previous VM's entry;
- any destroy popped the shared slot and unregistered factories that surviving VMs still referenced (`remaining_hashes` no longer saw them).

1-ms collision from the production log (rev 5d4aa2540): `07:48:33.483 Registered factory ...0c264eb2` → `07:48:33.484 Unregistered factory ...0c264eb2` (destroy of the *previous* VM) → surviving VM's next request 500s.

## Fix

Key the bookkeeping by `vm_key` (`workspace/name`) — the identity both hooks reliably carry — in `on_virtual_model_upserted` / `on_virtual_model_destroyed` (2 lines), align the one `test_integration` assertion that checked the never-present id key, and add `tests/test_lifecycle_identity.py` reproducing the production (id-less) shape:

- destroy(vm_old) immediately after upsert(vm_new) keeps vm_new's factory (the QA interleaving);
- identical-config VMs share one factory until the LAST referencing VM is destroyed;
- re-upsert keeps a single mapping entry.

## Verification

- **Plugin suite**: 77 passed (74 stock + 3 new), zero regressions.
- **Mutation check**: with the fix reverted the new tests fail 3/3 ("destroying vm_old unregistered vm_new's factory"); with the fix they pass.
- **Live A/B on revision 5d4aa2540**: source deployment with this fix (:8090): `create race-a` → `create race-b` (identical config) → `delete race-a` → `invoke race-b` ⇒ **200**, correctly routed. Identical sequence on the unfixed deployment (:8080): ⇒ **500 "Factory not found for config hash 6e24859f4d219a91"**.
- Live rerun of the QA skill-eval suite against the fixed build: **zero `Factory not found` errors** (remaining failures are unrelated: fresh-env Data Designer preconditions, and the separate SSE double-encoding defect NVBug 6563029).

## Out of scope

- `/v1/responses` SSE double-encoding for Switchyard VMs (NVBug 6563029) — separate defect, still reproducible after this fix.
- Pre-existing (and unchanged) behavior: re-upserting a VM with a NEW config leaves the old config's factory registered until shutdown; present on unfixed code too, harmless (stale factory is unreachable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed virtual machine lifecycle handling to prevent factory registration conflicts between similarly configured VMs.
  - Ensured destroying one VM does not remove another VM’s factory.
  - Improved cleanup when VM entity IDs are unavailable.
  - Preserved shared factories until the final associated VM is removed.

- **Tests**
  - Added regression coverage for VM registration, replacement, sharing, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->