### PR TITLE
chore: bump wheels-tag

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -123,7 +123,7 @@ variable "RL_BASE_CONTEXT" {
 
 # The tag for base images if needed
 variable "WHEELS_TAG" {
-  default = "54ae40bf653127f1300399912e6c1083f0b96771"
+  default = "fae90faed83f5c6b0c097c79bde6f980a2269825"
 }
 
 variable "BAKE_CACHE_SOURCE_BRANCH" {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Bumps the `WHEELS_TAG` default in `docker-bake.hcl` from `54ae40bf653127f1300399912e6c1083f0b96771` to `fae90faed83f5c6b0c097c79bde6f980a2269825`, updating the base image wheels commit used for builds.

## Related Issue

## Changes

- Updated `WHEELS_TAG` default in `docker-bake.hcl`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: single default-value bump for a build variable, no code behavior changes.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal build tag bump, no user-visible behavior change.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default build artifact version to an immutable identifier.
  * Builds now consistently use the updated artifact by default, improving reproducibility and ensuring the intended version is selected automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->