### PR TITLE
fix(platform-runner): report controller thread failures as unhealthy

### DIFF
--- a/packages/nmp_common/src/nmp/common/auth/workload_proxy/main.py
+++ b/packages/nmp_common/src/nmp/common/auth/workload_proxy/main.py
@@ -37,6 +37,7 @@ import httpx
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
+from nmp.common.controller import Controller, ControllerManager, Loop, TimedLoopWaiter
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +159,20 @@ def build_app(*, base_url: str, principal: str, on_behalf_of: str | None = None)
     return app
 
 
+class _ServerThreadController(Controller):
+    """Reports unhealthy if the auth-proxy's uvicorn thread has died."""
+
+    def __init__(self, thread: threading.Thread) -> None:
+        self._thread = thread
+
+    def step(self) -> None:
+        pass
+
+    @property
+    def is_healthy(self) -> bool:
+        return self._thread.is_alive()
+
+
 def run(parent_stop_signal: threading.Event | None = None) -> None:
     """Sidecar entrypoint. Serves the loopback auth-proxy until stopped."""
     base_url = _upstream_base_url()
@@ -186,12 +201,23 @@ def run(parent_stop_signal: threading.Event | None = None) -> None:
 
     thread = threading.Thread(target=server.run, name="auth-proxy-uvicorn", daemon=True)
     thread.start()
+
+    health_loop = Loop(
+        waiter=TimedLoopWaiter(sleep_secs=1.0, stop_signal=parent_stop_signal),
+        controller=_ServerThreadController(thread),
+        stop_signal=parent_stop_signal,
+    )
+    health_loop.name = "auth-proxy"
+    health_loop.start()
+    ControllerManager.get_instance().register(health_loop.name, health_loop)
+
     try:
         while not parent_stop_signal.is_set():
             parent_stop_signal.wait(timeout=1)
     finally:
         server.should_exit = True
         thread.join(timeout=10)
+        health_loop.join(timeout=5)
         logger.info("auth-proxy sidecar stopped")
 
 

--- a/packages/nmp_common/src/nmp/common/controller/controller_manager.py
+++ b/packages/nmp_common/src/nmp/common/controller/controller_manager.py
@@ -3,7 +3,10 @@
 
 """Controller manager for registering and managing control loops."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from logging import getLogger
+from threading import RLock, local
 from typing import Dict, Optional, Self
 
 from .controller import Loop
@@ -32,6 +35,13 @@ class ControllerManager:
             raise RuntimeError("Use ControllerManager.get_instance() to get the singleton instance")
         self._loops: Dict[str, Loop] = {}
         self._reported_health: Dict[str, bool] = {}
+        self._expected_controllers: set[str] = set()
+        self._registered_controllers: set[str] = set()
+        self._failed_controllers: set[str] = set()
+        self._controller_loops: Dict[str, set[str]] = {}
+        self._loop_controllers: Dict[str, str] = {}
+        self._controller_context = local()
+        self._lock = RLock()
 
     @classmethod
     def get_instance(cls) -> "ControllerManager":
@@ -44,7 +54,50 @@ class ControllerManager:
             cls._instance = cls.__new__(cls)
             cls._instance._loops = {}
             cls._instance._reported_health = {}
+            cls._instance._expected_controllers = set()
+            cls._instance._registered_controllers = set()
+            cls._instance._failed_controllers = set()
+            cls._instance._controller_loops = {}
+            cls._instance._loop_controllers = {}
+            cls._instance._controller_context = local()
+            cls._instance._lock = RLock()
         return cls._instance
+
+    def expect_controller(self, name: str) -> None:
+        """Declare a runner-owned controller that must register at least one loop."""
+        with self._lock:
+            self._expected_controllers.add(name)
+            self._registered_controllers.discard(name)
+            self._failed_controllers.discard(name)
+
+    def mark_controller_failed(self, name: str) -> None:
+        """Record that a runner-owned controller exited unexpectedly."""
+        with self._lock:
+            self._expected_controllers.add(name)
+            self._registered_controllers.discard(name)
+            self._failed_controllers.add(name)
+
+    def stop_expecting_controller(self, name: str) -> None:
+        """Remove runner-owned controller state during platform shutdown."""
+        with self._lock:
+            self._expected_controllers.discard(name)
+            self._registered_controllers.discard(name)
+            self._failed_controllers.discard(name)
+            self._reported_health.pop(name, None)
+            for loop_name in self._controller_loops.pop(name, set()):
+                self._loop_controllers.pop(loop_name, None)
+                self._loops.pop(loop_name, None)
+                self._reported_health.pop(loop_name, None)
+
+    @contextmanager
+    def controller_registration_context(self, name: str) -> Iterator[None]:
+        """Associate loop registrations in the current thread with a controller."""
+        previous = getattr(self._controller_context, "name", None)
+        self._controller_context.name = name
+        try:
+            yield
+        finally:
+            self._controller_context.name = previous
 
     def register(self, name: str, loop: Loop) -> None:
         """Register a control loop with a unique name.
@@ -59,10 +112,16 @@ class ControllerManager:
         Raises:
             ValueError: If a loop with this name is already registered.
         """
-        if name in self._loops:
-            raise ValueError(f"Loop with name '{name}' is already registered")
-        loop.name = name
-        self._loops[name] = loop
+        with self._lock:
+            if name in self._loops:
+                raise ValueError(f"Loop with name '{name}' is already registered")
+            loop.name = name
+            self._loops[name] = loop
+            controller_name = getattr(self._controller_context, "name", None)
+            if controller_name in self._expected_controllers:
+                self._registered_controllers.add(controller_name)
+                self._controller_loops.setdefault(controller_name, set()).add(name)
+                self._loop_controllers[name] = controller_name
         logger.debug(f"Registered loop: {name}")
 
     def unregister(self, name: str) -> None:
@@ -74,10 +133,18 @@ class ControllerManager:
         Raises:
             KeyError: If no loop with this name is registered.
         """
-        if name not in self._loops:
-            raise KeyError(f"No loop with name '{name}' is registered")
-        del self._loops[name]
-        self._reported_health.pop(name, None)
+        with self._lock:
+            if name not in self._loops:
+                raise KeyError(f"No loop with name '{name}' is registered")
+            del self._loops[name]
+            self._reported_health.pop(name, None)
+            controller_name = self._loop_controllers.pop(name, None)
+            if controller_name is not None:
+                controller_loops = self._controller_loops[controller_name]
+                controller_loops.discard(name)
+                if not controller_loops:
+                    del self._controller_loops[controller_name]
+                    self._registered_controllers.discard(controller_name)
         logger.info(f"Unregistered loop: {name}")
 
     def get_loop(self, name: str) -> Loop:
@@ -92,9 +159,10 @@ class ControllerManager:
         Raises:
             KeyError: If no loop with this name is registered.
         """
-        if name not in self._loops:
-            raise KeyError(f"No loop with name '{name}' is registered")
-        return self._loops[name]
+        with self._lock:
+            if name not in self._loops:
+                raise KeyError(f"No loop with name '{name}' is registered")
+            return self._loops[name]
 
     def get_all_loops(self) -> Dict[str, Loop]:
         """Get all registered loops.
@@ -102,7 +170,8 @@ class ControllerManager:
         Returns:
             Dictionary mapping loop names to Loop instances.
         """
-        return self._loops.copy()
+        with self._lock:
+            return self._loops.copy()
 
     def validate_all_healthy(self, detailed: bool = True) -> tuple[bool, Dict[str, bool]]:
         """Validate that all registered loops are healthy.
@@ -120,18 +189,30 @@ class ControllerManager:
             - Dict[str, bool]: Mapping of loop names to their health status
                               (only if detailed=True, otherwise empty dict).
         """
-        if not self._loops:
+        with self._lock:
+            loops = self._loops.copy()
+            missing_controllers = self._expected_controllers - self._registered_controllers
+            missing_controllers.update(self._failed_controllers)
+
+        if not loops and not missing_controllers:
             logger.debug("No loops registered for health validation")
             return True, {}
 
-        health_status = {}
-        all_healthy = True
+        health_status = {name: False for name in sorted(missing_controllers)} if detailed else {}
+        all_healthy = not missing_controllers
 
-        for name, loop in self._loops.items():
+        for name in missing_controllers:
+            self._log_health_transition(name, False, "controller has not registered a control loop")
+
+        for name, loop in loops.items():
+            # Runner-level startup/exit failure takes precedence when a
+            # controller and its registered loop use the same name.
+            if name in missing_controllers:
+                continue
             # Check if loop has is_healthy property (duck typing)
             if hasattr(loop, "is_healthy"):
                 try:
-                    is_healthy = loop.is_healthy  # type: ignore
+                    is_healthy = loop.is_healthy
                     if detailed:
                         health_status[name] = is_healthy
                     if not is_healthy:
@@ -160,11 +241,12 @@ class ControllerManager:
         the loop responsible for a degraded process identifiable from the logs
         alone.
         """
-        previous = self._reported_health.get(name)
-        if previous == is_healthy:
-            return
+        with self._lock:
+            previous = self._reported_health.get(name)
+            if previous == is_healthy:
+                return
+            self._reported_health[name] = is_healthy
 
-        self._reported_health[name] = is_healthy
         if is_healthy:
             if previous is not None:
                 logger.info(f"Control loop '{name}' is healthy again")
@@ -176,7 +258,13 @@ class ControllerManager:
 
         This method is primarily useful for testing purposes.
         """
-        count = len(self._loops)
-        self._loops.clear()
-        self._reported_health.clear()
+        with self._lock:
+            count = len(self._loops)
+            self._loops.clear()
+            self._reported_health.clear()
+            self._expected_controllers.clear()
+            self._registered_controllers.clear()
+            self._failed_controllers.clear()
+            self._controller_loops.clear()
+            self._loop_controllers.clear()
         logger.info(f"Cleared {count} registered loop(s)")

--- a/packages/nmp_common/tests/auth/test_workload_proxy.py
+++ b/packages/nmp_common/tests/auth/test_workload_proxy.py
@@ -5,12 +5,17 @@
 
 from __future__ import annotations
 
+import threading
+from collections.abc import Iterator
 from unittest.mock import patch
 
 import httpx
+import pytest
 import respx
 from fastapi.testclient import TestClient
+from nmp.common.auth.workload_proxy import main as workload_proxy_main
 from nmp.common.auth.workload_proxy.main import build_app
+from nmp.common.controller import ControllerManager
 
 
 @respx.mock
@@ -169,3 +174,61 @@ def test_lifespan_closes_upstream_client() -> None:
         assert test_client.get("/healthz").status_code == 200
         assert upstream_client.is_closed is False
     assert upstream_client.is_closed is True
+
+
+@pytest.fixture(autouse=True)
+def _reset_controller_manager() -> Iterator[None]:
+    ControllerManager._instance = None
+    yield
+    ControllerManager._instance = None
+
+
+def test_run_registers_healthy_loop_for_health_reporting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A running auth-proxy must be visible to ControllerManager, not merely absent.
+
+    Regression test for the sidecar being silently exempt from the crash-before-
+    registration health tracking added for controller run_funcs.
+    """
+    monkeypatch.setenv("NMP_AUTH_PROXY_PRINCIPAL", "agents")
+    monkeypatch.setenv("NEMO_BASE_URL", "http://nemo-platform-api:8080")
+
+    server_started = threading.Event()
+
+    class _FakeServer:
+        def __init__(self, config: object) -> None:
+            self.should_exit = False
+
+        def run(self) -> None:
+            server_started.set()
+            while not self.should_exit:
+                threading.Event().wait(timeout=0.05)
+
+    monkeypatch.setattr(workload_proxy_main.uvicorn, "Server", _FakeServer)
+
+    stop_signal = threading.Event()
+    run_thread = threading.Thread(target=workload_proxy_main.run, args=(stop_signal,), daemon=True)
+    run_thread.start()
+
+    try:
+        assert server_started.wait(timeout=2)
+        manager = ControllerManager.get_instance()
+
+        def _registered() -> bool:
+            return "auth-proxy" in manager.get_all_loops()
+
+        assert _wait_until(_registered)
+        assert manager.validate_all_healthy() == (True, {"auth-proxy": True})
+    finally:
+        stop_signal.set()
+        run_thread.join(timeout=5)
+
+
+def _wait_until(predicate, timeout: float = 2.0, interval: float = 0.02) -> bool:
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()

--- a/packages/nmp_common/tests/controller/test_controller_manager.py
+++ b/packages/nmp_common/tests/controller/test_controller_manager.py
@@ -169,6 +169,66 @@ def test_detailed_false():
         unhealthy_loop.join(timeout=0.1)
 
 
+def test_expected_controller_is_unhealthy_until_it_registers_a_loop():
+    manager = ControllerManager.get_instance()
+    manager.expect_controller("models")
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+
+    loop = _ToggleLoop(healthy=True)
+    with manager.controller_registration_context("models"):
+        manager.register("models_controller", loop)
+
+    assert manager.validate_all_healthy() == (True, {"models_controller": True})
+
+
+def test_failed_controller_remains_unhealthy_after_registration():
+    manager = ControllerManager.get_instance()
+    manager.expect_controller("models")
+    with manager.controller_registration_context("models"):
+        manager.register("models_controller", _ToggleLoop(healthy=True))
+    manager.mark_controller_failed("models")
+
+    assert manager.validate_all_healthy() == (
+        False,
+        {"models": False, "models_controller": True},
+    )
+
+
+def test_failed_controller_status_takes_precedence_over_same_named_healthy_loop():
+    manager = ControllerManager.get_instance()
+    manager.expect_controller("models")
+    with manager.controller_registration_context("models"):
+        manager.register("models", _ToggleLoop(healthy=True))
+    manager.mark_controller_failed("models")
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+
+
+def test_expected_controller_is_unhealthy_after_its_last_loop_is_unregistered():
+    manager = ControllerManager.get_instance()
+    manager.expect_controller("models")
+    with manager.controller_registration_context("models"):
+        manager.register("models_controller", _ToggleLoop(healthy=True))
+
+    manager.unregister("models_controller")
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+
+
+def test_stopping_controller_expectation_removes_its_registered_loops():
+    manager = ControllerManager.get_instance()
+    manager.expect_controller("jobs")
+    with manager.controller_registration_context("jobs"):
+        manager.register("job_scheduler", _ToggleLoop(healthy=True))
+        manager.register("job_reconciler", _ToggleLoop(healthy=True))
+
+    manager.stop_expecting_controller("jobs")
+
+    assert manager.get_all_loops() == {}
+    assert manager.validate_all_healthy() == (True, {})
+
+
 # =============================================================================
 # Loop shutdown_func Tests
 # =============================================================================

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/controller_threads.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/controller_threads.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Thread lifecycle helpers for runner-owned controllers and sidecars."""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+from nmp.common.controller import ControllerManager
+from nmp.platform_runner.loader import ControllerRunFunc
+
+logger = logging.getLogger(__name__)
+
+
+def start_controller_threads(
+    controller_run_funcs: dict[str, ControllerRunFunc],
+    stop_signal: threading.Event,
+) -> list[threading.Thread]:
+    """Start controllers while making pre-registration failures observable."""
+    manager = ControllerManager.get_instance()
+    threads = []
+
+    for name, run_func in controller_run_funcs.items():
+        manager.expect_controller(name)
+
+        def run_tracked_controller(
+            run_func: ControllerRunFunc = run_func,
+            name: str = name,
+        ) -> None:
+            with manager.controller_registration_context(name):
+                try:
+                    run_func(stop_signal)
+                except Exception:
+                    manager.mark_controller_failed(name)
+                    logger.exception("Controller %s crashed", name)
+                    return
+
+                if not stop_signal.is_set():
+                    manager.mark_controller_failed(name)
+                    logger.error("Controller %s exited unexpectedly", name)
+
+        thread = threading.Thread(target=run_tracked_controller, name=f"controller-{name}", daemon=True)
+        thread.start()
+        threads.append(thread)
+
+    return threads

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/plugin_adapter.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/plugin_adapter.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI
 from nemo_platform_plugin.controller import NemoController
 from nemo_platform_plugin.service import NemoService
 from nmp.common.config import get_platform_config
-from nmp.common.controller import Controller, Loop, TimedLoopWaiter, TrackLastExecutionTime
+from nmp.common.controller import Controller, ControllerManager, Loop, TimedLoopWaiter, TrackLastExecutionTime
 from nmp.common.service import RouterConfig, Service
 from nmp.common.service.api.health import wait_for_service_ready
 
@@ -216,6 +216,7 @@ def make_controller_run_func(controller_cls: type[NemoController]) -> Callable[[
             stop_signal=stop_signal,
         )
         loop.name = f"controller-plugin-{controller.name}"
+        ControllerManager.get_instance().register(loop.name, loop)
         loop.start()
         loop.join()
 

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/run.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/run.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Mapping
 from typing import cast
 
 from nmp.common.config import get_auth_config, get_common_service_config, get_platform_config, get_service_config
+from nmp.common.controller import ControllerManager
 from nmp.common.observability import initialize_obs, setup_global_instrumentations
 from nmp.common.observability.otel import settings as otel_settings
 from nmp.common.service import CircularDependencyError, Service
@@ -22,6 +23,7 @@ from nmp.platform_runner.config import (
     apply_run_environment,
     resolve_run_configuration,
 )
+from nmp.platform_runner.controller_threads import start_controller_threads
 from nmp.platform_runner.health import get_platform_resource_attributes
 from nmp.platform_runner.loader import (
     ControllerRunFunc,
@@ -67,12 +69,7 @@ def run_controllers_in_threads(
     stop_signal: threading.Event,
 ) -> list[threading.Thread]:
     """Start controller run functions in daemon threads."""
-    threads = []
-    for name, run_func in controller_run_funcs.items():
-        thread = threading.Thread(target=run_func, args=(stop_signal,), name=f"controller-{name}", daemon=True)
-        thread.start()
-        threads.append(thread)
-    return threads
+    return start_controller_threads(controller_run_funcs, stop_signal)
 
 
 def run_platform(
@@ -178,6 +175,9 @@ def run_platform(
             thread.join(timeout=10)
             if thread.is_alive():
                 logger.warning("Controller thread %s did not finish in time", thread.name)
+        manager = ControllerManager.get_instance()
+        for name in controller_run_funcs | sidecar_run_funcs:
+            manager.stop_expecting_controller(name)
 
 
 def _load_service_instances(

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/server.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/server.py
@@ -22,12 +22,14 @@ from fastapi.responses import JSONResponse
 from nmp.common.api.utils import install_query_param_schema_openapi_hook
 from nmp.common.auth import AuthorizationMiddleware
 from nmp.common.config import get_auth_config, get_platform_config
+from nmp.common.controller import ControllerManager
 from nmp.common.http_clients import close_shared_http_clients
 from nmp.common.observability import initialize_obs, setup_fastapi_instrumentations, setup_global_instrumentations
 from nmp.common.observability.context import create_app_context_dependency
 from nmp.common.pyleak import detect_blocking
 from nmp.common.service import Service
 from nmp.platform_runner.config import DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_SECONDS, PlatformAppConfig
+from nmp.platform_runner.controller_threads import start_controller_threads
 from nmp.platform_runner.health import ReadinessCheck, create_platform_health_router, get_platform_resource_attributes
 from nmp.platform_runner.loader import (
     ControllerRunFunc,
@@ -167,15 +169,7 @@ def create_app(
         platform_seed_task: asyncio.Task[None] | None = None
         if controller_run_funcs:
             logger.info("Starting controllers in lifespan: %s", list(controller_run_funcs))
-            for name, run_func in controller_run_funcs.items():
-                thread = threading.Thread(
-                    target=run_func,
-                    args=(controller_stop_signal,),
-                    name=f"controller-{name}",
-                    daemon=True,
-                )
-                thread.start()
-                controller_threads.append(thread)
+            controller_threads.extend(start_controller_threads(controller_run_funcs, controller_stop_signal))
 
         if platform_seed_state is not None:
             try:
@@ -216,6 +210,9 @@ def create_app(
         controller_stop_signal.set()
         for thread in controller_threads:
             thread.join(timeout=5)
+        manager = ControllerManager.get_instance()
+        for name in controller_run_funcs:
+            manager.stop_expecting_controller(name)
 
         await close_shared_http_clients()
         logger.info("Shutting down Nemo Platform API server")

--- a/packages/nmp_platform_runner/tests/test_controller_threads.py
+++ b/packages/nmp_platform_runner/tests/test_controller_threads.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for runner-owned controller thread health tracking."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Iterator
+from typing import cast
+
+import pytest
+from nmp.common.controller import ControllerManager, Loop
+from nmp.platform_runner.controller_threads import start_controller_threads
+
+
+class _HealthyLoop:
+    name = ""
+    is_healthy = True
+    unhealthy_reason = None
+
+
+@pytest.fixture(autouse=True)
+def reset_controller_manager() -> Iterator[None]:
+    ControllerManager._instance = None
+    yield
+    ControllerManager._instance = None
+
+
+def test_controller_is_pending_until_run_func_registers_loop() -> None:
+    manager = ControllerManager.get_instance()
+    allow_registration = threading.Event()
+    registered = threading.Event()
+    stop_signal = threading.Event()
+
+    def run(stop_signal: threading.Event) -> None:
+        allow_registration.wait(timeout=2)
+        manager.register("models_controller", cast(Loop, _HealthyLoop()))
+        registered.set()
+        stop_signal.wait(timeout=2)
+
+    threads = start_controller_threads({"models": run}, stop_signal)
+    try:
+        assert manager.validate_all_healthy() == (False, {"models": False})
+
+        allow_registration.set()
+        assert registered.wait(timeout=2)
+        assert manager.validate_all_healthy() == (True, {"models_controller": True})
+    finally:
+        stop_signal.set()
+        for thread in threads:
+            thread.join(timeout=2)
+
+
+def test_controller_that_exits_without_shutdown_is_unhealthy(caplog: pytest.LogCaptureFixture) -> None:
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+
+    with caplog.at_level(logging.ERROR, logger="nmp.platform_runner.controller_threads"):
+        threads = start_controller_threads({"models": lambda _stop_signal: None}, stop_signal)
+        for thread in threads:
+            thread.join(timeout=2)
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+    assert "Controller models exited unexpectedly" in caplog.text

--- a/packages/nmp_platform_runner/tests/test_plugin_adapter.py
+++ b/packages/nmp_platform_runner/tests/test_plugin_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Iterator
 from typing import ClassVar
 from unittest.mock import MagicMock
 
@@ -12,6 +13,7 @@ import pytest
 from fastapi import APIRouter, Request
 from nemo_platform_plugin.controller import NemoController
 from nemo_platform_plugin.service import NemoService, RouterSpec
+from nmp.common.controller import ControllerManager
 from nmp.platform_runner.plugin_adapter import NemoServiceAdapter, make_controller_run_func
 from starlette.responses import JSONResponse
 
@@ -72,9 +74,12 @@ class _StubControllerWithDeps(_StubController):
 
 
 @pytest.fixture(autouse=True)
-def _clear_stub_controller_call_history() -> None:
+def _clear_stub_controller_call_history() -> Iterator[None]:
     _list_objects_calls.clear()
     _on_startup_calls.clear()
+    ControllerManager._instance = None
+    yield
+    ControllerManager._instance = None
 
 
 @pytest.fixture
@@ -212,3 +217,16 @@ def test_controller_skips_wait_when_no_dependencies(monkeypatch: pytest.MonkeyPa
 
     mock_wait.assert_not_called()
     assert _list_objects_calls
+
+
+def test_plugin_controller_registers_loop_for_health_reporting() -> None:
+    stop_signal = threading.Event()
+    thread = _run_controller_until_list_objects(_StubController, stop_signal)
+
+    try:
+        loops = ControllerManager.get_instance().get_all_loops()
+        assert list(loops) == ["controller-plugin-test-controller"]
+        assert loops["controller-plugin-test-controller"].is_alive()
+    finally:
+        stop_signal.set()
+        thread.join(timeout=_WAIT_DEADLINE_SECONDS)

--- a/packages/nmp_platform_runner/tests/test_server.py
+++ b/packages/nmp_platform_runner/tests/test_server.py
@@ -4,6 +4,7 @@
 import asyncio
 import builtins
 import inspect
+import logging
 import os
 import sys
 import threading
@@ -17,6 +18,7 @@ from fastapi.testclient import TestClient
 from nemo_platform_plugin.jobs.openapi_utils import clear_query_param_schemas, generate_openapi_extra_params
 from nmp.common.config import AuthConfig, Configuration
 from nmp.common.config.base import OIDCConfig
+from nmp.common.controller import ControllerManager
 from nmp.common.service import RouterConfig, Service
 from nmp.platform_runner import config as runner_config
 from nmp.platform_runner import server
@@ -526,6 +528,30 @@ def test_create_app_without_seed_on_startup_keeps_health_ready_unchanged(monkeyp
     assert response.status_code == 200
     assert "platform-seed" not in status["services"]["ready"]
     assert all(item["name"] != "platform-seed" for item in status["services"]["not_ready"])
+
+
+def test_create_app_reports_controller_that_crashes_before_registration(monkeypatch, caplog):
+    _patch_platform_app_config(monkeypatch, seed_on_startup=False)
+    crashed = threading.Event()
+
+    def crashing_controller(_stop_signal: threading.Event) -> None:
+        try:
+            raise RuntimeError("startup failed")
+        finally:
+            crashed.set()
+
+    manager = ControllerManager.get_instance()
+    manager.clear()
+    with caplog.at_level(logging.ERROR, logger="nmp.platform_runner.controller_threads"):
+        with TestClient(server.create_app(services=[], controller_run_funcs={"models": crashing_controller})) as client:
+            assert crashed.wait(timeout=2)
+            response = client.get("/health/ready")
+            status = client.get("/status").json()
+
+    assert response.status_code == 503
+    assert status["controllers"] == {"healthy": False, "status": {"models": False}}
+    assert "Controller models crashed" in caplog.text
+    manager.clear()
 
 
 def test_create_app_with_seed_on_startup_blocks_readiness_until_seed_completes(monkeypatch):


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Tracks runner-owned controllers from startup so controllers that crash before registering a control loop are reported as unhealthy. `/health/ready` now returns `503`, `/status` identifies the failed controller, and startup failures produce error-level logs.

## Related Issue

Resolves [NAP-19](https://linear.app/nvidia/issue/NAP-19/controller-that-crashes-before-registration-is-invisible-to).

## Changes

- Track expected, registered, and failed controllers in `ControllerManager`.
- Start controllers and sidecars through a shared lifecycle wrapper that records startup crashes and unexpected exits.
- Make controller registration and health tracking thread-safe.
- Register plugin controller loops with the health manager.
- Add an auth-proxy health loop that detects a terminated Uvicorn thread.
- Track loop ownership and remove stale controller loops during unregister and shutdown.
- Add regression coverage for readiness, status reporting, error logging, registration, and cleanup.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Restores the documented readiness behavior without changing configuration or API schemas.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/nmp_common/tests/controller/test_controller_manager.py packages/nmp_common/tests/auth/test_workload_proxy.py packages/nmp_platform_runner/tests -q`
  - Passed: 153 tests.
- Focused `uv run --frozen ruff check` on changed Python files.
  - Passed.
- Focused `uv run --frozen ty check` on changed source files.
  - Passed.
- `git diff --cached --check`
  - Passed.
- `uv run pre-commit run -a`
  - Not run; targeted tests, lint, type checking, and diff validation were run instead.
- DCO verification is pending creation of the signed commit.