### PR TITLE
fix(cli): don't print unqualified Setup complete when no default model was set

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -2356,10 +2356,14 @@ def _run_auto_mode(
         headers=_platform_request_headers(cli_context),
     )
 
-    if _verify_platform_health(base_url):
+    if not _verify_platform_health(base_url):
+        raise typer.Exit(1)
+
+    if default_model:
         console.print(f"\n{CHECK} [green]Setup complete![/green]")
     else:
-        raise typer.Exit(1)
+        console.print(f"\n{WARN} [yellow]Setup complete with warnings.[/yellow]")
+        console.print("  No default model was set; review the warnings above before using the platform.")
 
 
 def _run_interactive_mode(

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -2279,6 +2279,34 @@ class TestAutoModelPairSelection:
 
         save_pair.assert_not_called()
         assert any("NEMO_FAST_MODEL is ignored" in call.args[0] for call in print_message.call_args_list)
+        printed = " ".join(str(c) for c in print_message.call_args_list)
+        assert "Setup complete with warnings" in printed
+        assert "[green]Setup complete![/green]" not in printed
+
+    def test_setup_complete_is_unqualified_when_default_model_is_set(self):
+        cli_context = MagicMock()
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(f"{SETUP_MOD}._auto_setup", return_value="openai"),
+            patch(f"{SETUP_MOD}._get_all_model_entity_ids", return_value=["default/a-model"]),
+            patch(f"{SETUP_MOD}._save_model_pair"),
+            patch(f"{SETUP_MOD}._maybe_install_skills"),
+            patch(f"{SETUP_MOD}._maybe_deploy_agent"),
+            patch(f"{SETUP_MOD}._verify_platform_health", return_value=True),
+            patch(f"{SETUP_MOD}.console.print") as print_message,
+        ):
+            _run_auto_mode(
+                cli_context,
+                MagicMock(),
+                "default",
+                "http://localhost:8080",
+                install_skills=False,
+                deploy_agent=False,
+            )
+
+        printed = " ".join(str(c) for c in print_message.call_args_list)
+        assert "[green]Setup complete![/green]" in printed
+        assert "Setup complete with warnings" not in printed
 
 
 # ---------------------------------------------------------------------------

--- a/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py
@@ -2356,10 +2356,14 @@ def _run_auto_mode(
         headers=_platform_request_headers(cli_context),
     )
 
-    if _verify_platform_health(base_url):
+    if not _verify_platform_health(base_url):
+        raise typer.Exit(1)
+
+    if default_model:
         console.print(f"\n{CHECK} [green]Setup complete![/green]")
     else:
-        raise typer.Exit(1)
+        console.print(f"\n{WARN} [yellow]Setup complete with warnings.[/yellow]")
+        console.print("  No default model was set; review the warnings above before using the platform.")
 
 
 def _run_interactive_mode(

--- a/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
+++ b/sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py
@@ -2279,6 +2279,34 @@ class TestAutoModelPairSelection:
 
         save_pair.assert_not_called()
         assert any("NEMO_FAST_MODEL is ignored" in call.args[0] for call in print_message.call_args_list)
+        printed = " ".join(str(c) for c in print_message.call_args_list)
+        assert "Setup complete with warnings" in printed
+        assert "[green]Setup complete![/green]" not in printed
+
+    def test_setup_complete_is_unqualified_when_default_model_is_set(self):
+        cli_context = MagicMock()
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(f"{SETUP_MOD}._auto_setup", return_value="openai"),
+            patch(f"{SETUP_MOD}._get_all_model_entity_ids", return_value=["default/a-model"]),
+            patch(f"{SETUP_MOD}._save_model_pair"),
+            patch(f"{SETUP_MOD}._maybe_install_skills"),
+            patch(f"{SETUP_MOD}._maybe_deploy_agent"),
+            patch(f"{SETUP_MOD}._verify_platform_health", return_value=True),
+            patch(f"{SETUP_MOD}.console.print") as print_message,
+        ):
+            _run_auto_mode(
+                cli_context,
+                MagicMock(),
+                "default",
+                "http://localhost:8080",
+                install_skills=False,
+                deploy_agent=False,
+            )
+
+        printed = " ".join(str(c) for c in print_message.call_args_list)
+        assert "[green]Setup complete![/green]" in printed
+        assert "Setup complete with warnings" not in printed
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`nemo setup --auto` already detects when model discovery finds nothing and prints a warning (No default model set), but the function still fell through to an unconditional green "Setup complete!" banner if the platform health check passed. A user running setup against a working API key but the wrong inference endpoint (or any other path that leaves the model registry empty) saw a clean success message despite the platform being non-functional for inference. This gates the final banner on whether a default model was actually set.

## Related Issue

Linear: [NMP-14](https://linear.app/nvidia/issue/NMP-14/nemo-setup-auto-silently-continues-after-api-key-validation-failure)

## Changes

- `_run_auto_mode` now shows the existing green "Setup complete!" message only when a default model was set, otherwise it shows "Setup complete with warnings" and points back at the warnings already printed above (`sdk/python/nemo-platform/src/nemo_platform/cli/commands/setup.py`, `packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py`; these are two separately-maintained copies of the same function, both fixed identically)
- Added a test confirming the clean success message still shows when a default model is set
- Extended the existing "no default model" test to assert the warning banner shows and the plain success message does not

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: CLI output message change only, no documented behavior contract to update

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` — ran pre-commit scoped to the 4 changed files instead of the full repo; ruff, ty, copyright header, and merge-conflict checks all passed
- [x] Targeted tests pass
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pytest sdk/python/nemo-platform/tests/vendored/nemo_platform_ext/cli/commands/test_setup.py -q` → 233 passed, 3 failed (pre-existing on `main`, unrelated `TestMaybeStartServices` tests, confirmed by running the same command against a clean checkout of `main`)
- `uv run pytest packages/nemo_platform_ext/tests/cli/commands/test_setup.py -q` → same result, same 3 pre-existing failures
- Manually exercised `_run_auto_mode` with no models discovered against the real (non-mocked) console output: confirmed it now prints "Setup complete with warnings" instead of the plain green success message
- I intentionally left `_validate_api_key`'s fail-open behavior on ambiguous status codes untouched; its docstring documents that as a deliberate design choice (avoid blocking setup when a provider is unreachable), and this PR only fixes the final banner not reflecting a degraded state the function already knew about

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto setup now verifies platform health before reporting completion.
  * Failed health checks stop setup and prevent a misleading success message.
  * Setup reports warnings when no default model is configured, and confirms success when one is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->