### PR TITLE
fix(platform-runner): report controller thread failures as unhealthy

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/setup.py
@@ -506,10 +506,13 @@ def _check_controller_health(
 
     Returns ``(True, "")`` when controllers are populated and all healthy.
     Returns ``(True, detail)`` when ``/status`` is absent but ``/cluster-info`` confirms a hosted platform.
-    Returns ``(False, detail)`` when unhealthy, unreachable, or empty after retry.
+    Returns ``(False, detail)`` when unhealthy, unreachable, or still unhealthy after retry.
 
-    If ``controllers.status`` is empty on the first call (startup timing race),
-    waits ``_CONTROLLER_HEALTH_RETRY_DELAY`` seconds and retries once.
+    A controller shows up in ``controllers.status`` as soon as the runner starts
+    tracking it — before it has registered its control loop — so an in-progress
+    startup can legitimately report unhealthy on the first call, not just an
+    empty ``controllers.status``. Either case waits ``_CONTROLLER_HEALTH_RETRY_DELAY``
+    seconds and retries once before giving up.
     """
     tls_config = httpx_tls_config_from_env(certificate_authority)
     root = base_url.rstrip("/")
@@ -537,9 +540,12 @@ def _check_controller_health(
 
         if status_map:
             unhealthy = [name for name, ok in status_map.items() if not ok]
-            if unhealthy:
-                return False, f"Unhealthy controllers: {', '.join(unhealthy)}"
-            return True, ""
+            if not unhealthy:
+                return True, ""
+            if attempt == 0:
+                _pause(_CONTROLLER_HEALTH_RETRY_DELAY)
+                continue
+            return False, f"Unhealthy controllers: {', '.join(unhealthy)}"
 
         if attempt == 0:
             _pause(_CONTROLLER_HEALTH_RETRY_DELAY)

--- a/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_setup.py
@@ -4064,11 +4064,31 @@ class TestCheckControllerHealth:
         )
 
     def test_unhealthy_controller(self):
+        # A controller shows up as unhealthy immediately (before it has registered
+        # its control loop), so an in-progress startup can legitimately look
+        # unhealthy on the first call — this must retry once before giving up,
+        # same as the empty-status_map case below.
         resp = _status_response(healthy=False, controller_status={"models_controller": False})
-        with patch(f"{SETUP_MOD}.httpx.get", return_value=resp):
+        with (
+            patch(f"{SETUP_MOD}.httpx.get", return_value=resp),
+            patch(f"{SETUP_MOD}._pause") as mock_pause,
+        ):
             ok, msg = _check_controller_health("http://localhost:8080")
         assert ok is False
         assert "models_controller" in msg
+        mock_pause.assert_called_once_with(_CONTROLLER_HEALTH_RETRY_DELAY)
+
+    def test_unhealthy_controller_recovers_after_retry(self):
+        starting_resp = _status_response(healthy=False, controller_status={"models_controller": False})
+        healthy_resp = _status_response(healthy=True, controller_status={"models_controller": True})
+        with (
+            patch(f"{SETUP_MOD}.httpx.get", side_effect=[starting_resp, healthy_resp]),
+            patch(f"{SETUP_MOD}._pause") as mock_pause,
+        ):
+            ok, msg = _check_controller_health("http://localhost:8080")
+        assert ok is True
+        assert msg == ""
+        mock_pause.assert_called_once_with(_CONTROLLER_HEALTH_RETRY_DELAY)
 
     def test_empty_controllers_retries_then_succeeds(self):
         empty_resp = _status_response(healthy=True, controller_status={})

--- a/packages/nemo_platform_ext/tests/local/test_health_child.py
+++ b/packages/nemo_platform_ext/tests/local/test_health_child.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -23,6 +24,7 @@ import pytest
 from nemo_platform_ext.local import process
 from nemo_platform_ext.local.services import ServiceRunConfig
 from nemo_platform_ext.local.transport import probe_status, wait_for_status
+from nmp.common.controller import ControllerManager
 
 
 def _free_tcp_port() -> int:
@@ -70,17 +72,15 @@ def test_create_app_starts_and_joins_controller_threads() -> None:
 
 
 @pytest.mark.integration
-def test_create_app_controller_thread_join_timeout() -> None:
-    """A controller that ignores the stop signal should not hang shutdown —
-    ``thread.join(timeout=5)`` should return even if the controller is still running."""
+def test_create_app_controller_thread_join_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stuck controller must not hang shutdown."""
     started = threading.Event()
+    release = threading.Event()
 
-    def stubborn_controller(stop_signal: threading.Event) -> None:
+    def stubborn_controller(_stop_signal: threading.Event) -> None:
         started.set()
         # Ignore stop_signal — simulate a controller that hangs.
-        import time
-
-        time.sleep(300)
+        release.wait(timeout=300)
 
     with (
         patch("nmp.platform_runner.server.get_platform_config") as mock_pc,
@@ -93,17 +93,26 @@ def test_create_app_controller_thread_join_timeout() -> None:
 
         from nmp.platform_runner.server import create_app
 
+        monkeypatch.setattr(
+            "nmp.platform_runner.controller_threads.DEFAULT_RUNNER_JOIN_TIMEOUT_SECONDS",
+            0.05,
+        )
         app = create_app(services=[], controller_run_funcs={"stubborn": stubborn_controller})
 
         from fastapi.testclient import TestClient
 
-        # The TestClient __exit__ triggers lifespan exit, which calls thread.join(timeout=5).
-        # This should NOT hang forever — the 5s timeout should let shutdown proceed.
-        with TestClient(app):
-            assert started.wait(timeout=2.0), "controller thread did not start"
-
-        # If we got here, shutdown didn't hang. The stubborn thread is still running
-        # but as a daemon thread it will be cleaned up when the test process exits.
+        manager = ControllerManager.get_instance()
+        try:
+            started_at = time.monotonic()
+            with TestClient(app):
+                assert started.wait(timeout=2.0), "controller thread did not start"
+            assert time.monotonic() - started_at < 1.0
+        finally:
+            release.set()
+            for thread in app.state.controller_threads:
+                thread.join(timeout=2.0)
+            # Avoid leaking singleton state into later integration tests.
+            manager.clear()
 
 
 @pytest.mark.integration

--- a/packages/nmp_common/src/nmp/common/auth/workload_proxy/main.py
+++ b/packages/nmp_common/src/nmp/common/auth/workload_proxy/main.py
@@ -30,13 +30,15 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
+from ipaddress import ip_address
 
 import httpx
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
+from nmp.common.controller import Controller, ControllerManager, Loop, TimedLoopWaiter
 
 logger = logging.getLogger(__name__)
 
@@ -49,11 +51,14 @@ AUTH_PROXY_PRINCIPAL_ENVVAR = "NMP_AUTH_PROXY_PRINCIPAL"
 # creator). When set, the service principal acts on behalf of this identity so
 # the platform scopes access to what that principal can reach.
 AUTH_PROXY_ON_BEHALF_OF_ENVVAR = "NMP_AUTH_PROXY_ON_BEHALF_OF"
+AUTH_PROXY_ALLOW_NON_LOOPBACK_ENVVAR = "NMP_AUTH_PROXY_ALLOW_NON_LOOPBACK"
 DEFAULT_AUTH_PROXY_HOST = "127.0.0.1"
 DEFAULT_AUTH_PROXY_PORT = 8090
 
 _READ_TIMEOUT_ENVVAR = "NMP_AUTH_PROXY_READ_TIMEOUT"
 _PRINCIPAL_ID_HEADER = "x-nmp-principal-id"
+_PRINCIPAL_EMAIL_HEADER = "x-nmp-principal-email"
+_PRINCIPAL_GROUPS_HEADER = "x-nmp-principal-groups"
 _ON_BEHALF_OF_HEADER = "x-nmp-principal-on-behalf-of"
 # Companion metadata for the on-behalf-of principal. The platform derives the
 # delegated user's groups/email from these (Principal.from_headers -> effective_*),
@@ -64,29 +69,52 @@ _ON_BEHALF_OF_HEADER = "x-nmp-principal-on-behalf-of"
 _ON_BEHALF_OF_EMAIL_HEADER = "x-nmp-principal-on-behalf-of-email"
 _ON_BEHALF_OF_GROUPS_HEADER = "x-nmp-principal-on-behalf-of-groups"
 
-# Minimal request-header sanitization. We only drop what would be actively wrong:
+# Request-header sanitization drops identity, framing, and hop-by-hop metadata:
 # - the workload's own credential / principal / on-behalf-of headers (we set the
 #   identity), so they can't be spoofed or conflict with what we stamp;
 # - host and content-length, which httpx recomputes for the upstream request
 #   (a stale value corrupts routing / the body).
-_STRIP_REQUEST_HEADERS = frozenset(
+_HOP_BY_HOP_HEADERS = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+_STRIP_REQUEST_HEADERS = _HOP_BY_HOP_HEADERS | frozenset(
     {
         "host",
         "content-length",
         "authorization",
         _PRINCIPAL_ID_HEADER,
+        _PRINCIPAL_EMAIL_HEADER,
+        _PRINCIPAL_GROUPS_HEADER,
         _ON_BEHALF_OF_HEADER,
         _ON_BEHALF_OF_EMAIL_HEADER,
         _ON_BEHALF_OF_GROUPS_HEADER,
     }
 )
 # We stream the response, so the upstream's framing headers no longer apply.
-_STRIP_RESPONSE_HEADERS = frozenset(
-    {
-        "content-length",
-        "transfer-encoding",
+_STRIP_RESPONSE_HEADERS = _HOP_BY_HOP_HEADERS | frozenset({"content-length"})
+_MULTI_VALUE_RESPONSE_HEADERS = frozenset({"set-cookie"})
+
+
+def _sanitized_headers(headers: Mapping[str, str], *, strip: frozenset[str]) -> dict[str, str]:
+    """Remove fixed and Connection-nominated hop-by-hop headers."""
+    connection_tokens = {
+        token.strip().lower()
+        for key, value in headers.items()
+        if key.lower() == "connection"
+        for token in value.split(",")
+        if token.strip()
     }
-)
+    blocked = strip | connection_tokens
+    return {key: value for key, value in headers.items() if key.lower() not in blocked}
 
 
 def _upstream_base_url() -> str:
@@ -129,13 +157,14 @@ def build_app(*, base_url: str, principal: str, on_behalf_of: str | None = None)
         methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
     )
     async def forward(request: Request, path: str) -> StreamingResponse:
-        headers = {k: v for k, v in request.headers.items() if k.lower() not in _STRIP_REQUEST_HEADERS}
+        headers = _sanitized_headers(request.headers, strip=_STRIP_REQUEST_HEADERS)
         headers[_PRINCIPAL_ID_HEADER] = principal_id
         if on_behalf_of:
             headers[_ON_BEHALF_OF_HEADER] = on_behalf_of
         url = httpx.URL(path="/" + path, query=request.url.query.encode("utf-8"))
-        body = await request.body()
-        upstream = client.build_request(request.method, url, headers=headers, content=body)
+        # Stream request bodies to keep a co-located caller from forcing the
+        # privileged proxy to buffer an unbounded payload in memory.
+        upstream = client.build_request(request.method, url, headers=headers, content=request.stream())
         response = await client.send(upstream, stream=True)
 
         async def _body() -> AsyncIterator[bytes]:
@@ -148,51 +177,201 @@ def build_app(*, base_url: str, principal: str, on_behalf_of: str | None = None)
             finally:
                 await response.aclose()
 
-        resp_headers = {k: v for k, v in response.headers.items() if k.lower() not in _STRIP_RESPONSE_HEADERS}
-        return StreamingResponse(
+        resp_headers = _sanitized_headers(
+            response.headers,
+            strip=_STRIP_RESPONSE_HEADERS | _MULTI_VALUE_RESPONSE_HEADERS,
+        )
+        proxy_response = StreamingResponse(
             _body(),
             status_code=response.status_code,
             headers=resp_headers,
         )
+        for cookie in response.headers.get_list("set-cookie"):
+            proxy_response.headers.append("set-cookie", cookie)
+        return proxy_response
 
     return app
 
 
+_UVICORN_JOIN_TIMEOUT_SECONDS = 10.0
+
+
+def _join_uvicorn_thread(server: uvicorn.Server, thread: threading.Thread, *, context: str) -> bool:
+    """Signal the uvicorn server to stop and join its thread. Returns whether it's still alive."""
+    server.should_exit = True
+    thread.join(timeout=_UVICORN_JOIN_TIMEOUT_SECONDS)
+    still_alive = thread.is_alive()
+    if still_alive:
+        logger.warning("auth-proxy uvicorn thread did not finish %s", context)
+    return still_alive
+
+
+class _ServerThreadController(Controller):
+    """Reports unhealthy if the auth-proxy's uvicorn thread has died."""
+
+    def __init__(self, thread: threading.Thread) -> None:
+        self._thread = thread
+
+    def step(self) -> None:
+        pass
+
+    @property
+    def is_healthy(self) -> bool:
+        return self._thread.is_alive()
+
+    @property
+    def unhealthy_reason(self) -> str | None:
+        if self._thread.is_alive():
+            return None
+        return "auth-proxy uvicorn thread is not running"
+
+
+def _unregister_quietly(manager: ControllerManager, name: str, *, context: str) -> None:
+    """Best-effort unregister that never masks a caller's in-flight exception.
+
+    Called from inside ``except Exception:`` blocks below. A bare ``manager.unregister(...)``
+    there would let a second exception (e.g. a ``KeyError`` from racing with
+    ``ControllerManager.watch_delayed_exit``'s background cleanup thread over the same
+    loop name) replace the original failure on the bare ``raise`` that follows,
+    hiding the real cause from logs/health status.
+    """
+    try:
+        manager.unregister(name)
+    except Exception:
+        logger.exception("auth-proxy failed to unregister %r %s", name, context)
+
+
 def run(parent_stop_signal: threading.Event | None = None) -> None:
-    """Sidecar entrypoint. Serves the loopback auth-proxy until stopped."""
+    """Serve the auth proxy and report its lifecycle through ControllerManager."""
+    if parent_stop_signal is None:
+        _run_untracked()
+        return
+
+    manager = ControllerManager.get_instance()
+    generation = manager.await_controller_registration("auth-proxy")
+    with manager.controller_registration_context("auth-proxy", generation):
+        try:
+            base_url, principal, on_behalf_of, host, port, server = _build_server()
+        except Exception:
+            manager.mark_controller_failed("auth-proxy", generation, reason="auth-proxy server setup failed")
+            raise
+        _log_startup(host=host, port=port, base_url=base_url, principal=principal, on_behalf_of=on_behalf_of)
+
+        thread = threading.Thread(target=server.run, name="auth-proxy-uvicorn", daemon=True)
+
+        health_loop = Loop(
+            waiter=TimedLoopWaiter(sleep_secs=1.0, stop_signal=parent_stop_signal),
+            controller=_ServerThreadController(thread),
+            stop_signal=parent_stop_signal,
+        )
+        health_loop.name = "auth-proxy"
+        try:
+            # Register first so stale tracking blocks a second server bind.
+            manager.register(health_loop.name, health_loop)
+        except Exception:
+            manager.mark_controller_failed("auth-proxy", generation, reason="auth-proxy health registration failed")
+            raise
+
+        try:
+            thread.start()
+        except Exception:
+            _unregister_quietly(manager, health_loop.name, context="after Uvicorn thread failed to start")
+            manager.mark_controller_failed("auth-proxy", generation, reason="auth-proxy Uvicorn thread failed to start")
+            raise
+
+        try:
+            health_loop.start()
+        except Exception:
+            uvicorn_still_alive = _join_uvicorn_thread(server, thread, context="after startup failed")
+            manager.mark_controller_failed("auth-proxy", generation, reason="auth-proxy health loop failed to start")
+            if uvicorn_still_alive:
+                # Do not allow another generation to bind while the failed
+                # generation's Uvicorn thread still owns the listen socket.
+                manager.mark_controller_stopping("auth-proxy", generation)
+                manager.watch_delayed_exit(
+                    thread, "auth-proxy", generation, clear_state=False, thread_name="auth-proxy-uvicorn-cleanup"
+                )
+            else:
+                _unregister_quietly(manager, health_loop.name, context="after health loop failed to start")
+            raise
+
+        try:
+            while not parent_stop_signal.is_set():
+                parent_stop_signal.wait(timeout=1)
+        finally:
+            # The health loop may stop before Uvicorn, so check Uvicorn directly.
+            uvicorn_still_alive = _join_uvicorn_thread(server, thread, context="in time")
+            health_loop.join(timeout=5)
+            if uvicorn_still_alive:
+                logger.warning(
+                    "Leaving health tracking in place for %r; its uvicorn thread did not finish in time", "auth-proxy"
+                )
+                manager.mark_controller_stopping("auth-proxy", generation)
+                manager.watch_delayed_exit(
+                    thread, "auth-proxy", generation, clear_state=True, thread_name="auth-proxy-uvicorn-cleanup"
+                )
+            else:
+                manager.stop_tracking_controller("auth-proxy", generation)
+            logger.info("auth-proxy sidecar stopped")
+
+
+def _build_server() -> tuple[str, str, str | None, str, int, uvicorn.Server]:
     base_url = _upstream_base_url()
     principal = os.environ.get(AUTH_PROXY_PRINCIPAL_ENVVAR)
     if not principal:
         raise RuntimeError(f"{AUTH_PROXY_PRINCIPAL_ENVVAR} is required for the auth-proxy sidecar")
     on_behalf_of = os.environ.get(AUTH_PROXY_ON_BEHALF_OF_ENVVAR) or None
     host = os.environ.get(AUTH_PROXY_HOST_ENVVAR, DEFAULT_AUTH_PROXY_HOST)
+    if not _is_loopback_host(host) and os.environ.get(AUTH_PROXY_ALLOW_NON_LOOPBACK_ENVVAR, "").lower() not in {
+        "1",
+        "true",
+        "yes",
+    }:
+        raise RuntimeError(
+            f"{AUTH_PROXY_HOST_ENVVAR} must be a loopback address; set "
+            f"{AUTH_PROXY_ALLOW_NON_LOOPBACK_ENVVAR}=true only if external exposure is intentional"
+        )
     port = int(os.environ.get(AUTH_PROXY_PORT_ENVVAR, str(DEFAULT_AUTH_PROXY_PORT)))
     app = build_app(base_url=base_url, principal=principal, on_behalf_of=on_behalf_of)
-
     config = uvicorn.Config(app, host=host, port=port, log_level="info", access_log=False)
-    server = uvicorn.Server(config)
+    return base_url, principal, on_behalf_of, host, port, uvicorn.Server(config)
 
+
+def _is_loopback_host(host: str) -> bool:
+    """Return whether a bind host is explicitly loopback-only."""
+    normalized = host.strip().strip("[]")
+    if normalized.lower() == "localhost":
+        return True
+    try:
+        return ip_address(normalized).is_loopback
+    except ValueError:
+        return False
+
+
+def _log_startup(*, host: str, port: int, base_url: str, principal: str, on_behalf_of: str | None) -> None:
     logger.info(
         "Starting auth-proxy sidecar on %s:%s -> %s (principal=service:%s, delegated=%s)",
         host,
         port,
-        base_url,
+        _redact_url_credentials(base_url),
         principal,
         on_behalf_of is not None,
     )
-    if parent_stop_signal is None:
-        server.run()
-        return
 
-    thread = threading.Thread(target=server.run, name="auth-proxy-uvicorn", daemon=True)
-    thread.start()
+
+def _redact_url_credentials(url: str) -> str:
+    """Remove URL userinfo before writing an upstream address to logs."""
     try:
-        while not parent_stop_signal.is_set():
-            parent_stop_signal.wait(timeout=1)
-    finally:
-        server.should_exit = True
-        thread.join(timeout=10)
-        logger.info("auth-proxy sidecar stopped")
+        parsed = httpx.URL(url)
+        return str(parsed.copy_with(username=None, password=None))
+    except Exception:
+        return "<invalid upstream URL>"
+
+
+def _run_untracked() -> None:
+    base_url, principal, on_behalf_of, host, port, server = _build_server()
+    _log_startup(host=host, port=port, base_url=base_url, principal=principal, on_behalf_of=on_behalf_of)
+    server.run()
 
 
 if __name__ == "__main__":

--- a/packages/nmp_common/src/nmp/common/controller/controller_manager.py
+++ b/packages/nmp_common/src/nmp/common/controller/controller_manager.py
@@ -3,180 +3,436 @@
 
 """Controller manager for registering and managing control loops."""
 
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from enum import Enum
 from logging import getLogger
-from typing import Dict, Optional, Self
+from threading import RLock, local
+from typing import Self
 
 from .controller import Loop
 
 logger = getLogger(__name__)
 
+_MISSING = object()
+
+
+def _has_attr(obj: object, name: str) -> bool:
+    """Check attribute presence without risking a property's internal AttributeError being read as "missing"."""
+    if name in getattr(obj, "__dict__", {}):
+        return True
+    return getattr(type(obj), name, _MISSING) is not _MISSING
+
+
+class ControllerLifecycleState(str, Enum):
+    """Runner-visible lifecycle state for a controller or required sidecar."""
+
+    STARTING = "starting"
+    RUNNING = "running"
+    FAILED = "failed"
+    STOPPING = "stopping"
+
+
+@dataclass
+class _ControllerRecord:
+    generation: int
+    state: ControllerLifecycleState = ControllerLifecycleState.STARTING
+    loop_names: set[str] = field(default_factory=set)
+    ever_registered: bool = False
+    failure_reason: str | None = None
+
 
 class ControllerManager:
-    """Singleton manager for registering control loops and validating their health.
+    """Singleton manager for registering control loops and validating their health."""
 
-    Example usage:
-        manager = ControllerManager.get_instance()
-        manager.register("my_loop", my_loop_instance)
+    _instance: Self | None = None
+    _instance_lock = RLock()
 
-        # Check if all loops are healthy
-        all_healthy, status = manager.validate_all_healthy()
-        if not all_healthy:
-            logger.error(f"Unhealthy loops: {status}")
-    """
-
-    _instance: Optional[Self] = None
-
-    def __init__(self):
-        """Private constructor. Use get_instance() to get the singleton instance."""
+    def __init__(self) -> None:
+        """Private constructor. Use :meth:`get_instance` instead."""
         if ControllerManager._instance is not None:
             raise RuntimeError("Use ControllerManager.get_instance() to get the singleton instance")
-        self._loops: Dict[str, Loop] = {}
-        self._reported_health: Dict[str, bool] = {}
+        self._init_state()
+
+    def _init_state(self) -> None:
+        """Initialize mutable singleton state."""
+        self._loops: dict[str, Loop] = {}
+        self._reported_health: dict[str, bool] = {}
+        self._controllers: dict[str, _ControllerRecord] = {}
+        self._controller_generations: dict[str, int] = {}
+        self._loop_controllers: dict[str, tuple[str, int]] = {}
+        self._controller_context = local()
+        self._lock = RLock()
 
     @classmethod
     def get_instance(cls) -> "ControllerManager":
-        """Get the singleton instance of ControllerManager.
-
-        Returns:
-            The singleton ControllerManager instance.
-        """
-        if cls._instance is None:
-            cls._instance = cls.__new__(cls)
-            cls._instance._loops = {}
-            cls._instance._reported_health = {}
+        """Get the process-wide controller manager."""
+        with cls._instance_lock:
+            if cls._instance is None:
+                instance = cls.__new__(cls)
+                instance._init_state()
+                cls._instance = instance
         return cls._instance
 
-    def register(self, name: str, loop: Loop) -> None:
-        """Register a control loop with a unique name.
+    def await_controller_registration(self, name: str) -> int:
+        """Start a lifecycle generation that must register at least one loop.
 
-        The registration name is used as the loop's thread name for debugging
-        and observability context (traces/logs).
-
-        Args:
-            name: Unique identifier for the loop (also used as thread name).
-            loop: Loop instance to register.
-
-        Raises:
-            ValueError: If a loop with this name is already registered.
+        Calls made from the active registration context are idempotent. This is
+        useful for components that can run both through the platform runner and
+        directly in tests or standalone processes.
         """
-        if name in self._loops:
-            raise ValueError(f"Loop with name '{name}' is already registered")
-        loop.name = name
-        self._loops[name] = loop
-        logger.debug(f"Registered loop: {name}")
+        with self._lock:
+            context = getattr(self._controller_context, "value", None)
+            if context is not None and context[0] == name:
+                record = self._controllers.get(name)
+                if record is not None and record.generation == context[1]:
+                    return record.generation
+
+            existing = self._controllers.get(name)
+            if existing is not None and existing.state is ControllerLifecycleState.STOPPING:
+                raise RuntimeError(f"Controller '{name}' is still stopping")
+            if existing is not None:
+                if existing.state is not ControllerLifecycleState.FAILED:
+                    raise RuntimeError(f"Controller '{name}' is already {existing.state.value}")
+                live_loops = self._live_loop_names_locked(existing.loop_names)
+                if live_loops:
+                    raise RuntimeError(
+                        f"Controller '{name}' still has running loop(s): {', '.join(sorted(live_loops))}"
+                    )
+                self._remove_controller_loops_locked(name, existing)
+
+            generation = self._controller_generations.get(name, 0) + 1
+            self._controller_generations[name] = generation
+            self._controllers[name] = _ControllerRecord(generation=generation)
+            self._reported_health.pop(name, None)
+            return generation
+
+    def mark_controller_failed(
+        self,
+        name: str,
+        generation: int | None = None,
+        *,
+        reason: str | None = None,
+    ) -> bool:
+        """Mark the current lifecycle generation failed.
+
+        Returns ``False`` when a delayed callback refers to an older generation.
+
+        A no-op if the generation is already :attr:`ControllerLifecycleState.STOPPING`:
+        that state means a resource this generation still owns (e.g. a listening
+        socket) has not been released yet, and a *later*, more generic failure
+        report for the same generation (for example the runner's catch-all
+        "controller crashed" handler, invoked after the component's own code
+        already transitioned it to STOPPING and re-raised) must not downgrade it
+        back to FAILED — doing so would drop the "still stopping" guard in
+        :meth:`await_controller_registration` and let a new generation start
+        while the old one still holds the resource.
+        """
+        with self._lock:
+            record = self._record_for_update_locked(name, generation)
+            if record is None:
+                if generation is not None:
+                    return False
+                generation = self._controller_generations.get(name, 0) + 1
+                self._controller_generations[name] = generation
+                record = _ControllerRecord(generation=generation)
+                self._controllers[name] = record
+            if record.state is ControllerLifecycleState.STOPPING:
+                return True
+            record.state = ControllerLifecycleState.FAILED
+            record.failure_reason = reason
+            return True
+
+    def mark_controller_stopping(self, name: str, generation: int) -> bool:
+        """Transition an over-time generation to ``STOPPING``.
+
+        Returns ``True`` only for the caller that performs the transition. A
+        component that already entered ``STOPPING`` owns its delayed-resource
+        cleanup, so generic runner cleanup must not install a competing watcher.
+        """
+        with self._lock:
+            record = self._record_for_update_locked(name, generation)
+            if record is None:
+                return False
+            if record.state is ControllerLifecycleState.STOPPING:
+                return False
+            record.state = ControllerLifecycleState.STOPPING
+            if record.failure_reason is None:
+                record.failure_reason = "controller thread did not stop before the shutdown deadline"
+            return True
+
+    def stop_tracking_controller(
+        self,
+        name: str,
+        generation: int | None = None,
+        *,
+        clear_state: bool = True,
+        allow_stopping: bool = False,
+    ) -> bool:
+        """Remove stopped loops and optionally the lifecycle state.
+
+        Generation matching prevents delayed cleanup from erasing a newer run.
+        ``clear_state=False`` removes stale loop objects while preserving a
+        startup failure.
+        """
+        with self._lock:
+            record = self._record_for_update_locked(name, generation)
+            if record is None:
+                return False
+            if record.state is ControllerLifecycleState.STOPPING and not allow_stopping:
+                return False
+            still_running = self._live_loop_names_locked(record.loop_names)
+            if still_running:
+                logger.warning(
+                    "Leaving health tracking in place for %r; loop(s) %s still running",
+                    name,
+                    sorted(still_running),
+                )
+                return False
+
+            self._remove_controller_loops_locked(name, record)
+            if clear_state:
+                self._controllers.pop(name, None)
+                self._reported_health.pop(name, None)
+            else:
+                record.state = ControllerLifecycleState.FAILED
+            return True
+
+    def _record_for_update_locked(self, name: str, generation: int | None) -> _ControllerRecord | None:
+        record = self._controllers.get(name)
+        if record is None:
+            return None
+        if generation is not None and record.generation != generation:
+            return None
+        return record
+
+    def _remove_controller_loops_locked(self, name: str, record: _ControllerRecord) -> None:
+        for loop_name in set(record.loop_names):
+            owner = self._loop_controllers.get(loop_name)
+            if owner == (name, record.generation):
+                self._loop_controllers.pop(loop_name, None)
+                self._loops.pop(loop_name, None)
+                self._reported_health.pop(loop_name, None)
+        record.loop_names.clear()
+
+    def _live_loop_names_locked(self, loop_names: set[str]) -> set[str]:
+        """Return which of ``loop_names`` are registered threads that are still alive."""
+        return {
+            loop_name
+            for loop_name in loop_names
+            if isinstance((loop := self._loops.get(loop_name)), threading.Thread) and loop.is_alive()
+        }
+
+    def watch_delayed_exit(
+        self,
+        thread: threading.Thread,
+        name: str,
+        generation: int,
+        *,
+        clear_state: bool = True,
+        thread_name: str | None = None,
+    ) -> None:
+        """Untrack ``name``'s lifecycle generation, in the background, once ``thread`` exits.
+
+        Used after a shutdown deadline passes while ``thread`` is still alive: the
+        caller has already called :meth:`mark_controller_stopping` to keep the
+        generation reported unhealthy, and this spawns the watcher that clears it
+        once the thread actually finishes (or, with ``clear_state=False``, leaves
+        the failure recorded while dropping the now-dead loop object).
+        """
+
+        def _wait_and_untrack() -> None:
+            thread.join()
+            if self.stop_tracking_controller(name, generation, clear_state=clear_state, allow_stopping=True):
+                return
+            if self.watch_controller_loops_exit(name, generation, clear_state=clear_state):
+                return
+            # A loop may have exited between the failed untrack attempt and
+            # the watcher snapshot. Retry once with the same generation token.
+            self.stop_tracking_controller(name, generation, clear_state=clear_state, allow_stopping=True)
+
+        threading.Thread(
+            target=_wait_and_untrack,
+            name=thread_name or f"{thread.name}-cleanup",
+            daemon=True,
+        ).start()
+
+    def watch_controller_loops_exit(
+        self,
+        name: str,
+        generation: int,
+        *,
+        clear_state: bool = True,
+    ) -> bool:
+        """Untrack a generation after all of its currently live loops exit.
+
+        Returns ``False`` when the generation is stale or has no live loop
+        threads to watch. The generation check in the eventual cleanup keeps a
+        delayed watcher from erasing a later restart.
+        """
+        with self._lock:
+            record = self._record_for_update_locked(name, generation)
+            if record is None:
+                return False
+            live_loops = [
+                loop
+                for loop_name in record.loop_names
+                if isinstance((loop := self._loops.get(loop_name)), threading.Thread) and loop.is_alive()
+            ]
+        if not live_loops:
+            return False
+
+        def _wait_and_untrack() -> None:
+            for loop in live_loops:
+                loop.join()
+            self.stop_tracking_controller(name, generation, clear_state=clear_state, allow_stopping=True)
+
+        threading.Thread(
+            target=_wait_and_untrack,
+            name=f"controller-{name}-loops-cleanup",
+            daemon=True,
+        ).start()
+        return True
+
+    @contextmanager
+    def controller_registration_context(self, name: str, generation: int | None = None) -> Iterator[None]:
+        """Associate loop registrations in the current thread with a generation."""
+        previous = getattr(self._controller_context, "value", None)
+        if generation is None:
+            with self._lock:
+                record = self._controllers.get(name)
+                generation = record.generation if record is not None else self.await_controller_registration(name)
+        self._controller_context.value = (name, generation)
+        try:
+            yield
+        finally:
+            self._controller_context.value = previous
+
+    def register(self, name: str, loop: Loop) -> None:
+        """Register a control loop with a unique name."""
+        with self._lock:
+            if name in self._loops:
+                raise ValueError(f"Loop with name '{name}' is already registered")
+            context = getattr(self._controller_context, "value", None)
+            if context is not None:
+                controller_name, generation = context
+                record = self._controllers.get(controller_name)
+                if generation is None or record is None or record.generation != generation:
+                    raise RuntimeError(f"Controller '{controller_name}' registration belongs to a stale generation")
+
+            loop.name = name
+            self._loops[name] = loop
+            if context is not None:
+                record.loop_names.add(name)
+                record.ever_registered = True
+                record.state = ControllerLifecycleState.RUNNING
+                record.failure_reason = None
+                self._loop_controllers[name] = (controller_name, generation)
+        logger.debug("Registered loop: %s", name)
 
     def unregister(self, name: str) -> None:
-        """Unregister a loop by name.
-
-        Args:
-            name: Name of the loop to unregister.
-
-        Raises:
-            KeyError: If no loop with this name is registered.
-        """
-        if name not in self._loops:
-            raise KeyError(f"No loop with name '{name}' is registered")
-        del self._loops[name]
-        self._reported_health.pop(name, None)
-        logger.info(f"Unregistered loop: {name}")
+        """Unregister a loop by name."""
+        with self._lock:
+            if name not in self._loops:
+                raise KeyError(f"No loop with name '{name}' is registered")
+            del self._loops[name]
+            self._reported_health.pop(name, None)
+            owner = self._loop_controllers.pop(name, None)
+            if owner is not None:
+                controller_name, generation = owner
+                record = self._controllers.get(controller_name)
+                if record is not None and record.generation == generation:
+                    record.loop_names.discard(name)
+                    if not record.loop_names and record.state is ControllerLifecycleState.RUNNING:
+                        record.state = ControllerLifecycleState.FAILED
+                        record.failure_reason = "controller unregistered its last control loop"
+        logger.info("Unregistered loop: %s", name)
 
     def get_loop(self, name: str) -> Loop:
-        """Get a registered loop by name.
+        """Get a registered loop by name."""
+        with self._lock:
+            if name not in self._loops:
+                raise KeyError(f"No loop with name '{name}' is registered")
+            return self._loops[name]
 
-        Args:
-            name: Name of the loop to retrieve.
+    def get_all_loops(self) -> dict[str, Loop]:
+        """Get a snapshot of all registered loops."""
+        with self._lock:
+            return self._loops.copy()
 
-        Returns:
-            The registered Loop instance.
+    def validate_all_healthy(self, detailed: bool = True) -> tuple[bool, dict[str, bool]]:
+        """Validate runner lifecycle state and every registered loop."""
+        with self._lock:
+            loops = self._loops.copy()
+            unhealthy_controllers = {
+                name: (record.state, record.ever_registered, record.failure_reason)
+                for name, record in self._controllers.items()
+                if record.state is not ControllerLifecycleState.RUNNING
+            }
 
-        Raises:
-            KeyError: If no loop with this name is registered.
-        """
-        if name not in self._loops:
-            raise KeyError(f"No loop with name '{name}' is registered")
-        return self._loops[name]
-
-    def get_all_loops(self) -> Dict[str, Loop]:
-        """Get all registered loops.
-
-        Returns:
-            Dictionary mapping loop names to Loop instances.
-        """
-        return self._loops.copy()
-
-    def validate_all_healthy(self, detailed: bool = True) -> tuple[bool, Dict[str, bool]]:
-        """Validate that all registered loops are healthy.
-
-        Checks the is_healthy property on each loop. Loops without
-        an is_healthy property are considered healthy by default.
-
-        Args:
-            detailed: If True, returns detailed status for each loop.
-                     If False, only returns overall health status with empty dict.
-
-        Returns:
-            A tuple containing:
-            - bool: True if all loops are healthy, False otherwise.
-            - Dict[str, bool]: Mapping of loop names to their health status
-                              (only if detailed=True, otherwise empty dict).
-        """
-        if not self._loops:
+        if not loops and not unhealthy_controllers:
             logger.debug("No loops registered for health validation")
             return True, {}
 
-        health_status = {}
-        all_healthy = True
+        health_status = {name: False for name in sorted(unhealthy_controllers)} if detailed else {}
+        all_healthy = not unhealthy_controllers
 
-        for name, loop in self._loops.items():
-            # Check if loop has is_healthy property (duck typing)
-            if hasattr(loop, "is_healthy"):
-                try:
-                    is_healthy = loop.is_healthy  # type: ignore
-                    if detailed:
-                        health_status[name] = is_healthy
-                    if not is_healthy:
-                        all_healthy = False
-                        logger.debug(f"Loop '{name}' is unhealthy")
-                    self._log_health_transition(name, is_healthy, getattr(loop, "unhealthy_reason", None))
-                except Exception as e:
-                    if detailed:
-                        health_status[name] = False
-                    all_healthy = False
-                    logger.error(f"Error checking health of loop '{name}': {e}", exc_info=True)
-                    self._log_health_transition(name, False, f"health check raised: {e}")
-            else:
-                # No is_healthy property, assume healthy
+        for name, (state, ever_registered, failure_reason) in unhealthy_controllers.items():
+            reason = failure_reason
+            if reason is None:
+                if state is ControllerLifecycleState.STARTING:
+                    reason = "controller has not registered a control loop"
+                elif state is ControllerLifecycleState.STOPPING:
+                    reason = "controller is still stopping"
+                elif ever_registered:
+                    reason = "controller exited unexpectedly after registering a control loop"
+                else:
+                    reason = "controller failed before registering a control loop"
+            self._log_health_transition(name, False, reason)
+
+        for name, loop in loops.items():
+            if name in unhealthy_controllers:
+                continue
+            try:
+                is_healthy = loop.is_healthy if _has_attr(loop, "is_healthy") else True
                 if detailed:
-                    health_status[name] = True
-                logger.debug(f"Loop '{name}' does not implement is_healthy, assuming healthy")
+                    health_status[name] = is_healthy
+                if not is_healthy:
+                    all_healthy = False
+                    logger.debug("Loop '%s' is unhealthy", name)
+                unhealthy_reason = loop.unhealthy_reason if _has_attr(loop, "unhealthy_reason") else None
+                self._log_health_transition(name, is_healthy, unhealthy_reason)
+            except Exception as error:
+                if detailed:
+                    health_status[name] = False
+                all_healthy = False
+                logger.error("Error checking health of loop '%s': %s", name, error, exc_info=True)
+                self._log_health_transition(name, False, f"health check raised: {error}")
 
         return all_healthy, health_status if detailed else {}
 
     def _log_health_transition(self, name: str, is_healthy: bool, reason: str | None) -> None:
-        """Log only when a loop's health changes.
+        """Log only when a loop's health changes."""
+        with self._lock:
+            previous = self._reported_health.get(name)
+            if previous == is_healthy:
+                return
+            self._reported_health[name] = is_healthy
 
-        Health is evaluated on every readiness probe, so logging each unhealthy
-        evaluation would be far too noisy to be useful. Reporting the edges makes
-        the loop responsible for a degraded process identifiable from the logs
-        alone.
-        """
-        previous = self._reported_health.get(name)
-        if previous == is_healthy:
-            return
-
-        self._reported_health[name] = is_healthy
-        if is_healthy:
-            if previous is not None:
-                logger.info(f"Control loop '{name}' is healthy again")
-        else:
-            logger.warning(f"Control loop '{name}' is unhealthy: {reason or 'reason unavailable'}")
+            if is_healthy:
+                if previous is not None:
+                    logger.info("Control loop '%s' is healthy again", name)
+            else:
+                logger.warning("Control loop '%s' is unhealthy: %s", name, reason or "reason unavailable")
 
     def clear(self) -> None:
-        """Clear all registered loops.
-
-        This method is primarily useful for testing purposes.
-        """
-        count = len(self._loops)
-        self._loops.clear()
-        self._reported_health.clear()
-        logger.info(f"Cleared {count} registered loop(s)")
+        """Clear loops and lifecycle state without reusing generation tokens."""
+        with self._lock:
+            count = len(self._loops)
+            self._loops.clear()
+            self._reported_health.clear()
+            self._controllers.clear()
+            self._loop_controllers.clear()
+        logger.info("Cleared %d registered loop(s)", count)

--- a/packages/nmp_common/tests/auth/test_workload_proxy.py
+++ b/packages/nmp_common/tests/auth/test_workload_proxy.py
@@ -5,19 +5,30 @@
 
 from __future__ import annotations
 
+import logging
+import threading
+import time
+from collections.abc import Callable, Iterator
 from unittest.mock import patch
 
 import httpx
+import pytest
 import respx
 from fastapi.testclient import TestClient
+from nmp.common.auth.workload_proxy import main as workload_proxy_main
 from nmp.common.auth.workload_proxy.main import build_app
+from nmp.common.controller import ControllerManager, Loop
 
 
 @respx.mock
 def test_forward_stamps_service_principal_and_preserves_path() -> None:
     upstream = "http://nemo-platform-api:8080"
     route = respx.post(f"{upstream}/apis/inference-gateway/v2/workspaces/default/openai/-/v1/chat/completions").mock(
-        return_value=httpx.Response(200, json={"ok": True})
+        return_value=httpx.Response(
+            200,
+            json={"ok": True},
+            headers={"connection": "x-upstream-hop", "x-upstream-hop": "secret"},
+        )
     )
     app = build_app(base_url=upstream, principal="agents")
     client = TestClient(app)
@@ -25,7 +36,11 @@ def test_forward_stamps_service_principal_and_preserves_path() -> None:
     resp = client.post(
         "/apis/inference-gateway/v2/workspaces/default/openai/-/v1/chat/completions",
         json={"model": "m", "messages": []},
-        headers={"authorization": "Bearer not-used"},
+        headers={
+            "authorization": "Bearer not-used",
+            "connection": "x-client-hop",
+            "x-client-hop": "secret",
+        },
     )
 
     assert resp.status_code == 200
@@ -35,6 +50,10 @@ def test_forward_stamps_service_principal_and_preserves_path() -> None:
     # The proxy sets the service-principal identity and drops the placeholder auth.
     assert sent.headers["x-nmp-principal-id"] == "service:agents"
     assert "authorization" not in {k.lower() for k in sent.headers}
+    assert "x-client-hop" not in {k.lower() for k in sent.headers}
+    assert "connection" not in resp.headers
+    assert "x-upstream-hop" not in resp.headers
+    assert sent.content == b'{"model":"m","messages":[]}'
 
 
 @respx.mock
@@ -78,6 +97,8 @@ def test_forward_strips_inbound_on_behalf_of_to_prevent_spoofing() -> None:
         "/apis/entities/v2/workspaces",
         headers={
             "x-nmp-principal-id": "service:platform",
+            "x-nmp-principal-email": "attacker@evil.test",
+            "x-nmp-principal-groups": "platform-admins",
             "x-nmp-principal-on-behalf-of": "user:attacker",
             # Companion metadata must not be smuggled onto our stamped OBO id:
             # the platform derives effective groups/email from these and feeds
@@ -91,7 +112,9 @@ def test_forward_strips_inbound_on_behalf_of_to_prevent_spoofing() -> None:
     sent_keys = {k.lower() for k in sent.headers}
     assert sent.headers["x-nmp-principal-id"] == "service:agents"
     assert sent.headers["x-nmp-principal-on-behalf-of"] == "user:alice"
-    # The inbound companion headers are dropped (we stamp only the OBO id).
+    # Inbound companion metadata cannot be attached to either stamped identity.
+    assert "x-nmp-principal-email" not in sent_keys
+    assert "x-nmp-principal-groups" not in sent_keys
     assert "x-nmp-principal-on-behalf-of-email" not in sent_keys
     assert "x-nmp-principal-on-behalf-of-groups" not in sent_keys
 
@@ -141,6 +164,29 @@ def test_forward_passes_through_upstream_status() -> None:
     assert resp.status_code == 403
 
 
+@respx.mock
+def test_forward_preserves_separate_set_cookie_headers() -> None:
+    upstream = "http://nemo-platform-api:8080"
+    respx.get(f"{upstream}/session").mock(
+        return_value=httpx.Response(
+            200,
+            headers=[
+                ("set-cookie", "session=one; Path=/; HttpOnly"),
+                ("set-cookie", "csrf=two; Path=/"),
+            ],
+        )
+    )
+    app = build_app(base_url=upstream, principal="agents")
+
+    with TestClient(app) as client:
+        response = client.get("/session")
+
+    assert response.headers.get_list("set-cookie") == [
+        "session=one; Path=/; HttpOnly",
+        "csrf=two; Path=/",
+    ]
+
+
 def test_healthz_does_not_require_upstream() -> None:
     app = build_app(base_url="http://nemo-platform-api:8080", principal="agents")
     client = TestClient(app)
@@ -169,3 +215,290 @@ def test_lifespan_closes_upstream_client() -> None:
         assert test_client.get("/healthz").status_code == 200
         assert upstream_client.is_closed is False
     assert upstream_client.is_closed is True
+
+
+@pytest.fixture(autouse=True)
+def _reset_controller_manager() -> Iterator[None]:
+    ControllerManager._instance = None
+    yield
+    ControllerManager._instance = None
+
+
+def test_run_registers_and_unregisters_healthy_loop_for_health_reporting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Expose a running auth-proxy as healthy and remove it on shutdown."""
+    monkeypatch.setenv("NMP_AUTH_PROXY_PRINCIPAL", "agents")
+    monkeypatch.setenv("NEMO_BASE_URL", "http://nemo-platform-api:8080")
+
+    server_started = threading.Event()
+
+    class _FakeServer:
+        def __init__(self, config: object) -> None:
+            self.should_exit = False
+
+        def run(self) -> None:
+            server_started.set()
+            while not self.should_exit:
+                threading.Event().wait(timeout=0.05)
+
+    monkeypatch.setattr(workload_proxy_main.uvicorn, "Server", _FakeServer)
+
+    manager = ControllerManager.get_instance()
+    for _ in range(2):
+        server_started.clear()
+        stop_signal = threading.Event()
+        run_thread = threading.Thread(target=workload_proxy_main.run, args=(stop_signal,), daemon=True)
+        run_thread.start()
+        try:
+            assert server_started.wait(timeout=2)
+
+            def _registered() -> bool:
+                return "auth-proxy" in manager.get_all_loops()
+
+            assert _wait_until(_registered)
+            assert _wait_until(lambda: manager.validate_all_healthy() == (True, {"auth-proxy": True}))
+        finally:
+            stop_signal.set()
+            run_thread.join(timeout=5)
+        assert not run_thread.is_alive()
+        assert manager.validate_all_healthy() == (True, {})
+
+
+def test_run_leaves_controller_tracked_when_uvicorn_thread_outlives_shutdown(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Keep a hung Uvicorn server tracked until it exits."""
+    monkeypatch.setenv("NMP_AUTH_PROXY_PRINCIPAL", "agents")
+    monkeypatch.setenv("NEMO_BASE_URL", "http://nemo-platform-api:8080")
+    monkeypatch.setattr(workload_proxy_main, "_UVICORN_JOIN_TIMEOUT_SECONDS", 0.05)
+
+    server_started = threading.Event()
+    hang_forever = threading.Event()
+
+    class _HangingFakeServer:
+        def __init__(self, config: object) -> None:
+            self.should_exit = False
+
+        def run(self) -> None:
+            server_started.set()
+            hang_forever.wait(timeout=5)
+
+    monkeypatch.setattr(workload_proxy_main.uvicorn, "Server", _HangingFakeServer)
+
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+    run_thread = threading.Thread(target=workload_proxy_main.run, args=(stop_signal,), daemon=True)
+    run_thread.start()
+    try:
+        assert server_started.wait(timeout=2)
+        assert _wait_until(lambda: "auth-proxy" in manager.get_all_loops())
+
+        with caplog.at_level(logging.WARNING, logger="nmp.common.controller.controller_manager"):
+            stop_signal.set()
+            run_thread.join(timeout=5)
+        assert not run_thread.is_alive()
+
+        assert "auth-proxy" in manager.get_all_loops()
+        assert "Leaving health tracking in place for 'auth-proxy'" in caplog.text
+    finally:
+        hang_forever.set()
+
+    assert _wait_until(lambda: "auth-proxy" not in manager.get_all_loops())
+
+    restarted_server = threading.Event()
+
+    class _RestartedFakeServer:
+        def __init__(self, config: object) -> None:
+            self.should_exit = False
+
+        def run(self) -> None:
+            restarted_server.set()
+            while not self.should_exit:
+                threading.Event().wait(timeout=0.001)
+
+    monkeypatch.setattr(workload_proxy_main.uvicorn, "Server", _RestartedFakeServer)
+
+    second_stop_signal = threading.Event()
+    second_run_thread = threading.Thread(
+        target=workload_proxy_main.run,
+        args=(second_stop_signal,),
+        daemon=True,
+    )
+    second_run_thread.start()
+    try:
+        assert restarted_server.wait(timeout=2)
+        assert _wait_until(lambda: manager.validate_all_healthy() == (True, {"auth-proxy": True}))
+    finally:
+        second_stop_signal.set()
+        second_run_thread.join(timeout=5)
+
+    assert not second_run_thread.is_alive()
+    assert manager.validate_all_healthy() == (True, {})
+
+
+def test_run_setup_failure_before_server_start_is_visible_as_unhealthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Report auth-proxy setup failures through controller health."""
+    monkeypatch.delenv("NMP_AUTH_PROXY_PRINCIPAL", raising=False)
+
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+
+    with pytest.raises(RuntimeError, match="NMP_AUTH_PROXY_PRINCIPAL"):
+        workload_proxy_main.run(stop_signal)
+
+    all_healthy, status = manager.validate_all_healthy()
+    assert all_healthy is False
+    assert status.get("auth-proxy") is False
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "proxy.example.com"])
+def test_build_server_rejects_non_loopback_bind_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    host: str,
+) -> None:
+    monkeypatch.setenv("NMP_AUTH_PROXY_PRINCIPAL", "agents")
+    monkeypatch.setenv("NEMO_BASE_URL", "http://nemo-platform-api:8080")
+    monkeypatch.setenv("NMP_AUTH_PROXY_HOST", host)
+
+    with pytest.raises(RuntimeError, match="must be a loopback address"):
+        workload_proxy_main._build_server()
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "127.10.20.30", "::1", "[::1]", "localhost"])
+def test_loopback_host_validation_accepts_explicit_loopback(host: str) -> None:
+    assert workload_proxy_main._is_loopback_host(host)
+
+
+def test_startup_log_redacts_upstream_url_credentials(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger="nmp.common.auth.workload_proxy.main"):
+        workload_proxy_main._log_startup(
+            host="127.0.0.1",
+            port=8090,
+            base_url="https://sensitive-user:sensitive-password@platform.example.test:8443/base",  # trufflehog:ignore
+            principal="agents",
+            on_behalf_of=None,
+        )
+
+    assert "sensitive-user" not in caplog.text
+    assert "sensitive-password" not in caplog.text
+    assert "https://platform.example.test:8443/base" in caplog.text
+
+
+def test_build_server_allows_explicit_non_loopback_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NMP_AUTH_PROXY_PRINCIPAL", "agents")
+    monkeypatch.setenv("NEMO_BASE_URL", "http://nemo-platform-api:8080")
+    monkeypatch.setenv("NMP_AUTH_PROXY_HOST", "0.0.0.0")
+    monkeypatch.setenv("NMP_AUTH_PROXY_ALLOW_NON_LOOPBACK", "true")
+    monkeypatch.setattr(workload_proxy_main, "build_app", lambda **_kwargs: object())
+    sentinel_server = object()
+    monkeypatch.setattr(workload_proxy_main.uvicorn, "Server", lambda _config: sentinel_server)
+
+    _, _, _, host, _, server = workload_proxy_main._build_server()
+
+    assert host == "0.0.0.0"
+    assert server is sentinel_server
+
+
+def test_run_registration_failure_never_starts_server_and_remains_unhealthy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reject duplicate tracking before starting Uvicorn."""
+    monkeypatch.setenv("NMP_AUTH_PROXY_PRINCIPAL", "agents")
+    monkeypatch.setenv("NEMO_BASE_URL", "http://nemo-platform-api:8080")
+    server_started = threading.Event()
+
+    class _FakeServer:
+        def __init__(self, config: object) -> None:
+            self.should_exit = False
+
+        def run(self) -> None:
+            server_started.set()
+            while not self.should_exit:
+                threading.Event().wait(timeout=0.01)
+
+    monkeypatch.setattr(workload_proxy_main.uvicorn, "Server", _FakeServer)
+    manager = ControllerManager.get_instance()
+
+    def _fail_registration(_name: str, _loop: object) -> None:
+        raise ValueError("duplicate")
+
+    monkeypatch.setattr(manager, "register", _fail_registration)
+
+    with pytest.raises(ValueError, match="duplicate"):
+        workload_proxy_main.run(threading.Event())
+
+    assert not server_started.wait(timeout=0.5)
+    assert manager.validate_all_healthy() == (False, {"auth-proxy": False})
+
+
+def test_run_uvicorn_thread_start_failure_removes_registered_loop_and_remains_unhealthy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NMP_AUTH_PROXY_PRINCIPAL", "agents")
+    monkeypatch.setenv("NEMO_BASE_URL", "http://nemo-platform-api:8080")
+
+    real_start = threading.Thread.start
+
+    def _start(thread: threading.Thread) -> None:
+        if thread.name != "auth-proxy-uvicorn":
+            real_start(thread)
+        else:
+            raise RuntimeError("thread start failed")
+
+    monkeypatch.setattr(threading.Thread, "start", _start)
+    manager = ControllerManager.get_instance()
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        workload_proxy_main.run(threading.Event())
+
+    assert manager.get_all_loops() == {}
+    assert manager.validate_all_healthy() == (False, {"auth-proxy": False})
+
+
+def test_run_health_loop_start_failure_tracks_uvicorn_until_delayed_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("NMP_AUTH_PROXY_PRINCIPAL", "agents")
+    monkeypatch.setenv("NEMO_BASE_URL", "http://nemo-platform-api:8080")
+    monkeypatch.setattr(workload_proxy_main, "_UVICORN_JOIN_TIMEOUT_SECONDS", 0.05)
+
+    server_started = threading.Event()
+    release_server = threading.Event()
+
+    class _HangingFakeServer:
+        def __init__(self, config: object) -> None:
+            self.should_exit = False
+
+        def run(self) -> None:
+            server_started.set()
+            release_server.wait(timeout=5)
+
+    def _fail_health_loop_start(_loop: Loop) -> None:
+        raise RuntimeError("health loop start failed")
+
+    monkeypatch.setattr(workload_proxy_main.uvicorn, "Server", _HangingFakeServer)
+    monkeypatch.setattr(Loop, "start", _fail_health_loop_start)
+    manager = ControllerManager.get_instance()
+
+    try:
+        with pytest.raises(RuntimeError, match="health loop start failed"):
+            workload_proxy_main.run(threading.Event())
+
+        assert server_started.wait(timeout=2)
+        assert "auth-proxy" in manager.get_all_loops()
+        assert manager.validate_all_healthy() == (False, {"auth-proxy": False})
+        with pytest.raises(RuntimeError, match="still stopping"):
+            manager.await_controller_registration("auth-proxy")
+    finally:
+        release_server.set()
+
+    assert _wait_until(lambda: "auth-proxy" not in manager.get_all_loops())
+    assert manager.validate_all_healthy() == (False, {"auth-proxy": False})
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = 2.0, interval: float = 0.02) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()

--- a/packages/nmp_common/tests/controller/test_controller_manager.py
+++ b/packages/nmp_common/tests/controller/test_controller_manager.py
@@ -4,6 +4,9 @@
 """Tests for ControllerManager health checks and Loop shutdown behavior."""
 
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import cast
 
 import pytest
 from nmp.common.controller import Controller, Loop, TimedLoopWaiter, TrackLastExecutionTime
@@ -71,6 +74,21 @@ def clear_singleton():
     ControllerManager._instance = None
     yield
     ControllerManager._instance = None
+
+
+def test_singleton_initialization_is_thread_safe(monkeypatch: pytest.MonkeyPatch):
+    """Concurrent first access must return the same manager instance."""
+    original_new = ControllerManager.__new__
+
+    def slow_new(cls):
+        time.sleep(0.01)
+        return original_new(cls)
+
+    monkeypatch.setattr(ControllerManager, "__new__", slow_new)
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        managers = list(executor.map(lambda _: ControllerManager.get_instance(), range(16)))
+
+    assert all(manager is managers[0] for manager in managers)
 
 
 def test_all_healthy():
@@ -148,6 +166,17 @@ def test_no_health_property():
         loop_no_health.join(timeout=0.1)
 
 
+def test_registered_object_without_health_attribute_keeps_legacy_healthy_default():
+    manager = ControllerManager.get_instance()
+
+    class LoopWithoutHealth:
+        name = ""
+
+    manager.register("legacy", cast(Loop, LoopWithoutHealth()))
+
+    assert manager.validate_all_healthy() == (True, {"legacy": True})
+
+
 def test_detailed_false():
     """Test validation with detailed=False returns empty status dict."""
     manager = ControllerManager.get_instance()
@@ -167,6 +196,220 @@ def test_detailed_false():
         # Clean up thread
         unhealthy_loop.stop()
         unhealthy_loop.join(timeout=0.1)
+
+
+def test_awaited_controller_is_unhealthy_until_it_registers_a_loop():
+    manager = ControllerManager.get_instance()
+    manager.await_controller_registration("models")
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+
+    loop = _ToggleLoop(healthy=True)
+    with manager.controller_registration_context("models"):
+        manager.register("models_controller", loop)
+
+    assert manager.validate_all_healthy() == (True, {"models_controller": True})
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_message"),
+    [
+        ("starting", "already starting"),
+        ("running", "already running"),
+    ],
+)
+def test_duplicate_start_cannot_supersede_active_generation(state: str, expected_message: str):
+    manager = ControllerManager.get_instance()
+    generation = manager.await_controller_registration("models")
+    if state == "running":
+        with manager.controller_registration_context("models", generation):
+            manager.register("models_controller", _ToggleLoop(healthy=True))
+
+    with pytest.raises(RuntimeError, match=expected_message):
+        manager.await_controller_registration("models")
+
+    with manager.controller_registration_context("models", generation):
+        if state == "starting":
+            manager.register("models_controller", _ToggleLoop(healthy=True))
+
+    assert manager.validate_all_healthy() == (True, {"models_controller": True})
+
+
+def test_failed_controller_remains_unhealthy_after_registration():
+    manager = ControllerManager.get_instance()
+    manager.await_controller_registration("models")
+    with manager.controller_registration_context("models"):
+        manager.register("models_controller", _ToggleLoop(healthy=True))
+    manager.mark_controller_failed("models")
+
+    assert manager.validate_all_healthy() == (
+        False,
+        {"models": False, "models_controller": True},
+    )
+
+
+def test_failed_controller_status_takes_precedence_over_same_named_healthy_loop():
+    manager = ControllerManager.get_instance()
+    manager.await_controller_registration("models")
+    with manager.controller_registration_context("models"):
+        manager.register("models", _ToggleLoop(healthy=True))
+    manager.mark_controller_failed("models")
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+
+
+def test_awaiting_registration_for_restart_clears_previous_failure():
+    manager = ControllerManager.get_instance()
+    manager.mark_controller_failed("models")
+
+    manager.await_controller_registration("models")
+    with manager.controller_registration_context("models"):
+        manager.register("models_controller", _ToggleLoop(healthy=True))
+
+    assert manager.validate_all_healthy() == (True, {"models_controller": True})
+
+
+def test_stale_generation_cleanup_does_not_remove_restarted_controller():
+    manager = ControllerManager.get_instance()
+    old_generation = manager.await_controller_registration("models")
+    manager.mark_controller_failed("models", old_generation)
+
+    new_generation = manager.await_controller_registration("models")
+    with manager.controller_registration_context("models", new_generation):
+        manager.register("models_controller", _ToggleLoop(healthy=True))
+
+    assert manager.stop_tracking_controller("models", old_generation) is False
+    assert manager.validate_all_healthy() == (True, {"models_controller": True})
+
+
+def test_clear_does_not_reuse_generation_tokens():
+    manager = ControllerManager.get_instance()
+    old_generation = manager.await_controller_registration("models")
+    manager.clear()
+
+    new_generation = manager.await_controller_registration("models")
+
+    assert new_generation > old_generation
+    assert manager.stop_tracking_controller("models", old_generation) is False
+    assert manager.validate_all_healthy() == (False, {"models": False})
+
+
+def test_stale_generation_cannot_register_a_loop_into_a_restart():
+    manager = ControllerManager.get_instance()
+    old_generation = manager.await_controller_registration("models")
+    manager.mark_controller_failed("models", old_generation)
+    new_generation = manager.await_controller_registration("models")
+
+    with (
+        manager.controller_registration_context("models", old_generation),
+        pytest.raises(RuntimeError, match="stale generation"),
+    ):
+        manager.register("stale_loop", _ToggleLoop(healthy=True))
+
+    assert manager.get_all_loops() == {}
+    with manager.controller_registration_context("models", new_generation):
+        manager.register("models_controller", _ToggleLoop(healthy=True))
+    assert manager.validate_all_healthy() == (True, {"models_controller": True})
+
+
+def test_awaited_controller_is_unhealthy_after_its_last_loop_is_unregistered():
+    manager = ControllerManager.get_instance()
+    manager.await_controller_registration("models")
+    with manager.controller_registration_context("models"):
+        manager.register("models_controller", _ToggleLoop(healthy=True))
+
+    manager.unregister("models_controller")
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+
+
+def test_stopping_controller_tracking_removes_its_registered_loops():
+    manager = ControllerManager.get_instance()
+    manager.await_controller_registration("jobs")
+    with manager.controller_registration_context("jobs"):
+        manager.register("job_scheduler", _ToggleLoop(healthy=True))
+        manager.register("job_reconciler", _ToggleLoop(healthy=True))
+
+    manager.stop_tracking_controller("jobs")
+
+    assert manager.get_all_loops() == {}
+    assert manager.validate_all_healthy() == (True, {})
+
+
+def test_stopping_transition_preserves_the_original_failure_reason(caplog: pytest.LogCaptureFixture):
+    manager = ControllerManager.get_instance()
+    generation = manager.await_controller_registration("auth-proxy")
+    manager.mark_controller_failed("auth-proxy", generation, reason="health loop failed to start")
+    manager.mark_controller_stopping("auth-proxy", generation)
+
+    with caplog.at_level("WARNING"):
+        assert manager.validate_all_healthy() == (False, {"auth-proxy": False})
+
+    assert "health loop failed to start" in caplog.text
+    assert "did not stop before the shutdown deadline" not in caplog.text
+
+
+def test_stop_tracking_with_clear_state_false_does_not_downgrade_stopping():
+    """``clear_state=False`` must respect the same STOPPING guard as ``clear_state=True``;
+    otherwise a delayed cleanup call downgrades STOPPING back to FAILED and drops the
+    "still stopping" guard in :meth:`ControllerManager.await_controller_registration`,
+    letting a new generation start while the old one still owns a resource.
+    """
+    manager = ControllerManager.get_instance()
+    generation = manager.await_controller_registration("auth-proxy")
+    manager.mark_controller_stopping("auth-proxy", generation)
+
+    assert manager.stop_tracking_controller("auth-proxy", generation, clear_state=False) is False
+    assert manager.validate_all_healthy() == (False, {"auth-proxy": False})
+
+
+def test_stopping_controller_tracking_leaves_still_running_loop_tracked():
+    """A loop whose thread hasn't finished must stay tracked (and thus unhealthy),
+    so a controller that outlives its wrapper thread doesn't silently vanish from
+    health checks (regression test for the auth-proxy shutdown race).
+    """
+    manager = ControllerManager.get_instance()
+    release = threading.Event()
+
+    class BlockingController(Controller):
+        def step(self):
+            pass
+
+        @property
+        def is_healthy(self) -> bool:
+            return True
+
+    loop = Loop(
+        waiter=TimedLoopWaiter(sleep_secs=0.01, stop_signal=threading.Event()),
+        controller=BlockingController(),
+        stop_signal=threading.Event(),
+    )
+    loop.run = lambda: release.wait(timeout=5)
+
+    with manager.controller_registration_context("auth-proxy"):
+        manager.register("auth-proxy", loop)
+    loop.start()
+
+    try:
+        manager.stop_tracking_controller("auth-proxy")
+
+        assert manager.get_loop("auth-proxy") is loop
+        assert manager.validate_all_healthy() == (True, {"auth-proxy": True})
+    finally:
+        release.set()
+        loop.join(timeout=5)
+
+
+def test_registration_context_tracks_loop_ownership_without_requiring_registration():
+    manager = ControllerManager.get_instance()
+    with manager.controller_registration_context("adapters"):
+        manager.register("adapters_controller", _ToggleLoop(healthy=True))
+
+    assert manager.validate_all_healthy() == (True, {"adapters_controller": True})
+
+    manager.stop_tracking_controller("adapters")
+
+    assert manager.validate_all_healthy() == (True, {})
 
 
 # =============================================================================

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/controller_threads.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/controller_threads.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Thread lifecycle helpers for runner-owned controllers and sidecars."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable, Iterable, Mapping
+
+from nmp.common.controller import ControllerManager
+from nmp.platform_runner.loader import ControllerRunFunc
+
+logger = logging.getLogger(__name__)
+
+# Backward-compatible shared timeout and join override. New runner-owned
+# shutdown paths use the component-specific defaults below when no override is
+# supplied.
+RUNNER_JOIN_TIMEOUT_SECONDS = 16.0
+DEFAULT_RUNNER_JOIN_TIMEOUT_SECONDS = 10.0
+RUNNER_JOIN_TIMEOUT_SECONDS_BY_NAME: dict[str, float] = {
+    # Covers auth-proxy's nested Uvicorn and health-loop shutdown budgets.
+    "auth-proxy": RUNNER_JOIN_TIMEOUT_SECONDS,
+}
+
+
+class _RunnerThread(threading.Thread):
+    """Thread carrying the lifecycle generation it owns."""
+
+    def __init__(
+        self,
+        *,
+        target: Callable[[], None],
+        name: str,
+        component_name: str,
+        generation: int,
+    ) -> None:
+        super().__init__(target=target, name=name, daemon=True)
+        self.component_name = component_name
+        self.generation = generation
+
+
+def start_controller_threads(
+    controller_run_funcs: dict[str, ControllerRunFunc],
+    stop_signal: threading.Event,
+) -> list[threading.Thread]:
+    """Start controllers while making pre-registration failures observable."""
+    return _start_runner_threads(controller_run_funcs, stop_signal, kind="Controller", thread_prefix="controller")
+
+
+def start_sidecar_threads(
+    sidecar_run_funcs: dict[str, ControllerRunFunc],
+    stop_signal: threading.Event,
+) -> list[threading.Thread]:
+    """Start required sidecars with the same health contract as controllers."""
+    return _start_runner_threads(sidecar_run_funcs, stop_signal, kind="Sidecar", thread_prefix="sidecar")
+
+
+def _start_runner_threads(
+    run_funcs: dict[str, ControllerRunFunc],
+    stop_signal: threading.Event,
+    *,
+    kind: str,
+    thread_prefix: str,
+) -> list[threading.Thread]:
+    manager = ControllerManager.get_instance()
+    threads: list[threading.Thread] = []
+
+    for name, run_func in run_funcs.items():
+        try:
+            generation = manager.await_controller_registration(name)
+        except Exception as error:
+            logger.error("%s '%s' failed to register for startup: %s", kind, name, error)
+            _abort_runner_batch(manager, stop_signal, threads)
+            raise
+
+        def run_tracked(
+            run_func: ControllerRunFunc = run_func,
+            name: str = name,
+            generation: int = generation,
+        ) -> None:
+            with manager.controller_registration_context(name, generation):
+                try:
+                    run_func(stop_signal)
+                except BaseException as error:
+                    manager.mark_controller_failed(name, generation, reason=f"{kind.lower()} crashed: {error}")
+                    logger.exception("%s '%s' crashed", kind, name)
+                    return
+
+                if not stop_signal.is_set():
+                    manager.mark_controller_failed(name, generation, reason=f"{kind.lower()} exited unexpectedly")
+                    logger.error("%s '%s' exited unexpectedly", kind, name)
+
+        thread_name = name if name.startswith(f"{thread_prefix}-") else f"{thread_prefix}-{name}"
+        thread = _RunnerThread(
+            target=run_tracked,
+            name=thread_name,
+            component_name=name,
+            generation=generation,
+        )
+        try:
+            thread.start()
+        except Exception as error:
+            manager.mark_controller_failed(name, generation, reason=f"{kind.lower()} thread failed to start: {error}")
+            _abort_runner_batch(manager, stop_signal, threads)
+            raise
+        threads.append(thread)
+
+    return threads
+
+
+def _abort_runner_batch(
+    manager: ControllerManager,
+    stop_signal: threading.Event,
+    threads: list[threading.Thread],
+) -> None:
+    """Tear down already-started threads in this batch after a startup failure."""
+    stop_signal.set()
+    started_by_name = {started.component_name: started for started in threads if isinstance(started, _RunnerThread)}
+    join_and_untrack_runner_threads(threads, started_by_name, started_by_name)
+
+
+def join_and_untrack_runner_threads(
+    threads: list[threading.Thread],
+    thread_by_name: Mapping[str, threading.Thread],
+    names: Iterable[str],
+    *,
+    join_timeout: float | None = None,
+) -> None:
+    """Join runner threads using component-specific deadlines.
+
+    A delayed cleanup watcher owns the same generation as its thread, so it
+    cannot erase health state belonging to a later restart.
+
+    ``join_timeout`` preserves the previous API as an explicit shared timeout;
+    when omitted, each component uses its configured shutdown budget.
+    """
+    started_waiting = time.monotonic()
+    pending = list(threads)
+    while pending:
+        now = time.monotonic()
+        still_pending = []
+        for thread in pending:
+            # RUNNER_JOIN_TIMEOUT_SECONDS_BY_NAME is keyed by component name
+            # (e.g. "auth-proxy"), not by thread name (e.g. "sidecar-auth-proxy") —
+            # fall back to the thread name only when no component name is known,
+            # so a future non-_RunnerThread caller doesn't silently lose a
+            # component's configured shutdown budget.
+            component_name = getattr(thread, "component_name", thread.name)
+            timeout = (
+                join_timeout
+                if join_timeout is not None
+                else RUNNER_JOIN_TIMEOUT_SECONDS_BY_NAME.get(
+                    component_name,
+                    DEFAULT_RUNNER_JOIN_TIMEOUT_SECONDS,
+                )
+            )
+            if thread.is_alive() and now - started_waiting < timeout:
+                still_pending.append(thread)
+        pending = still_pending
+        if pending:
+            time.sleep(0.05)
+
+    manager = ControllerManager.get_instance()
+    for name in names:
+        thread = thread_by_name.get(name)
+        if thread is None:
+            continue
+        generation = thread.generation if isinstance(thread, _RunnerThread) else None
+        if thread.is_alive():
+            logger.warning("Runner thread %s did not finish in time", thread.name)
+            if generation is not None and manager.mark_controller_stopping(name, generation):
+                manager.watch_delayed_exit(thread, name, generation)
+            continue
+        if manager.stop_tracking_controller(name, generation):
+            continue
+        if generation is not None and manager.mark_controller_stopping(name, generation):
+            if not manager.watch_controller_loops_exit(name, generation):
+                # The last loop can exit after stop_tracking_controller saw it
+                # alive but before the delayed-loop watcher snapshots it.
+                manager.stop_tracking_controller(name, generation, allow_stopping=True)

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/health.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/health.py
@@ -105,6 +105,11 @@ def create_platform_health_router(
 
         manager = ControllerManager.get_instance()
         all_healthy, controllers = manager.validate_all_healthy(detailed=True)
+        if not all_healthy:
+            # Keep the aggregate signal consistent with /health/ready. A caller
+            # looking only at the top-level field must not miss a controller or
+            # required-sidecar failure.
+            status_value = "unhealthy"
 
         return PlatformStatusResponse(
             status=status_value,

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/plugin_adapter.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/plugin_adapter.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI
 from nemo_platform_plugin.controller import NemoController
 from nemo_platform_plugin.service import NemoService
 from nmp.common.config import get_platform_config
-from nmp.common.controller import Controller, Loop, TimedLoopWaiter, TrackLastExecutionTime
+from nmp.common.controller import Controller, ControllerManager, Loop, TimedLoopWaiter, TrackLastExecutionTime
 from nmp.common.service import RouterConfig, Service
 from nmp.common.service.api.health import wait_for_service_ready
 
@@ -201,8 +201,8 @@ def make_controller_run_func(controller_cls: type[NemoController]) -> Callable[[
                 "Plugin controller %r on_startup() failed — controller will not run.",
                 controller.name,
             )
-            adapter._loop.close()
-            return
+            adapter.shutdown()
+            raise
 
         monitored = TrackLastExecutionTime(adapter)
         waiter = TimedLoopWaiter(
@@ -216,7 +216,38 @@ def make_controller_run_func(controller_cls: type[NemoController]) -> Callable[[
             stop_signal=stop_signal,
         )
         loop.name = f"controller-plugin-{controller.name}"
-        loop.start()
+        try:
+            ControllerManager.get_instance().register(loop.name, loop)
+        except Exception:
+            logger.exception(
+                "Plugin controller %r failed to register its control loop — controller will not run.",
+                controller.name,
+            )
+            adapter.shutdown()
+            raise
+        try:
+            loop.start()
+        except Exception:
+            _unregister_quietly(loop.name, controller.name)
+            adapter.shutdown()
+            raise
         loop.join()
 
     return run
+
+
+def _unregister_quietly(loop_name: str, controller_name: str) -> None:
+    """Best-effort unregister that never masks the caller's in-flight exception.
+
+    Called from an ``except Exception:`` block after ``loop.start()`` fails. A
+    bare ``ControllerManager.unregister(...)`` there would let a second
+    exception replace the original failure on the ``raise`` that follows,
+    hiding the real cause from logs/health status.
+    """
+    try:
+        ControllerManager.get_instance().unregister(loop_name)
+    except Exception:
+        logger.exception(
+            "Plugin controller %r failed to unregister its control loop after loop.start() failed",
+            controller_name,
+        )

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/registry.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/registry.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from functools import cache
 
 from nemo_platform_plugin.discovery import discover_controllers, discover_services
@@ -39,6 +40,14 @@ AVAILABLE_SIDECARS: dict[str, str] = {
     "adapters": "nmp.core.models.sidecars.adapters.main:run",
     "auth-proxy": "nmp.common.auth.workload_proxy.main:run",
 }
+
+
+def check_no_controller_sidecar_collision(controller_names: Iterable[str], sidecar_names: Iterable[str]) -> None:
+    """Reject names that make controller and sidecar health indistinguishable."""
+    collisions = set(controller_names) & set(sidecar_names)
+    if collisions:
+        raise ValueError(f"Controller/sidecar name collision: {', '.join(sorted(collisions))}")
+
 
 CORE_SERVICES = [
     "auth",

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/run.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/run.py
@@ -22,6 +22,11 @@ from nmp.platform_runner.config import (
     apply_run_environment,
     resolve_run_configuration,
 )
+from nmp.platform_runner.controller_threads import (
+    join_and_untrack_runner_threads,
+    start_controller_threads,
+    start_sidecar_threads,
+)
 from nmp.platform_runner.health import get_platform_resource_attributes
 from nmp.platform_runner.loader import (
     ControllerRunFunc,
@@ -29,7 +34,10 @@ from nmp.platform_runner.loader import (
     load_service,
     order_services_by_dependencies,
 )
-from nmp.platform_runner.registry import AVAILABLE_SIDECARS
+from nmp.platform_runner.registry import (
+    AVAILABLE_SIDECARS,
+    check_no_controller_sidecar_collision,
+)
 from nmp.platform_runner.server import run_server, run_server_with_reload
 from nmp.platform_runner.version import get_platform_version
 from rich.console import Console
@@ -67,12 +75,15 @@ def run_controllers_in_threads(
     stop_signal: threading.Event,
 ) -> list[threading.Thread]:
     """Start controller run functions in daemon threads."""
-    threads = []
-    for name, run_func in controller_run_funcs.items():
-        thread = threading.Thread(target=run_func, args=(stop_signal,), name=f"controller-{name}", daemon=True)
-        thread.start()
-        threads.append(thread)
-    return threads
+    return start_controller_threads(controller_run_funcs, stop_signal)
+
+
+def run_sidecars_in_threads(
+    sidecar_run_funcs: dict[str, ControllerRunFunc],
+    stop_signal: threading.Event,
+) -> list[threading.Thread]:
+    """Start sidecar run functions in daemon threads."""
+    return start_sidecar_threads(sidecar_run_funcs, stop_signal)
 
 
 def run_platform(
@@ -100,9 +111,7 @@ def run_platform(
     setup_global_instrumentations()
     _startup_phase("observability_init", t0)
 
-    collisions = resolved.controllers & resolved.sidecars
-    if collisions:
-        raise ValueError(f"Controller/sidecar name collision: {', '.join(sorted(collisions))}")
+    check_no_controller_sidecar_collision(resolved.controllers, resolved.sidecars)
 
     service_instances = _load_service_instances(sorted(resolved.services), resolved.available_services)
     get_platform_config().services = ",".join(sorted(service.name for service in service_instances))
@@ -138,6 +147,7 @@ def run_platform(
     )
 
     controller_threads: list[threading.Thread] = []
+    thread_by_name: dict[str, threading.Thread] = {}
     try:
         reload_enabled = os.environ.get("UVICORN_RELOAD", "").lower() in {"true", "1", "yes"}
         if reload_enabled:
@@ -149,9 +159,13 @@ def run_platform(
             )
         else:
             if controller_run_funcs:
-                controller_threads.extend(run_controllers_in_threads(controller_run_funcs, controller_stop_signal))
+                started = run_controllers_in_threads(controller_run_funcs, controller_stop_signal)
+                thread_by_name.update(zip(controller_run_funcs, started))
+                controller_threads.extend(started)
             if sidecar_run_funcs:
-                controller_threads.extend(run_controllers_in_threads(sidecar_run_funcs, controller_stop_signal))
+                started = run_sidecars_in_threads(sidecar_run_funcs, controller_stop_signal)
+                thread_by_name.update(zip(sidecar_run_funcs, started))
+                controller_threads.extend(started)
             run_server(
                 service_instances,
                 host=resolved.host,
@@ -174,10 +188,11 @@ def run_platform(
                 on_shutdown()
             except Exception:
                 logger.debug("on_shutdown callback failed", exc_info=True)
-        for thread in controller_threads:
-            thread.join(timeout=10)
-            if thread.is_alive():
-                logger.warning("Controller thread %s did not finish in time", thread.name)
+        join_and_untrack_runner_threads(
+            controller_threads,
+            thread_by_name,
+            controller_run_funcs.keys() | sidecar_run_funcs.keys(),
+        )
 
 
 def _load_service_instances(

--- a/packages/nmp_platform_runner/src/nmp/platform_runner/server.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/server.py
@@ -28,6 +28,11 @@ from nmp.common.observability.context import create_app_context_dependency
 from nmp.common.pyleak import detect_blocking
 from nmp.common.service import Service
 from nmp.platform_runner.config import DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_SECONDS, PlatformAppConfig
+from nmp.platform_runner.controller_threads import (
+    join_and_untrack_runner_threads,
+    start_controller_threads,
+    start_sidecar_threads,
+)
 from nmp.platform_runner.health import ReadinessCheck, create_platform_health_router, get_platform_resource_attributes
 from nmp.platform_runner.loader import (
     ControllerRunFunc,
@@ -37,6 +42,7 @@ from nmp.platform_runner.loader import (
 )
 from nmp.platform_runner.registry import (
     AVAILABLE_SIDECARS,
+    check_no_controller_sidecar_collision,
     get_available_controllers,
     get_available_services,
     get_openapi_service_names,
@@ -141,10 +147,13 @@ def create_app(
     controller_run_funcs: dict[str, ControllerRunFunc] | None = None,
     http_client: httpx.AsyncClient | None = None,
     access_key_lifecycle_http_client: httpx.AsyncClient | None = None,
+    sidecar_run_funcs: dict[str, ControllerRunFunc] | None = None,
 ) -> FastAPI:
     """Create the FastAPI app from service instances."""
     services = services or []
     controller_run_funcs = controller_run_funcs or {}
+    sidecar_run_funcs = sidecar_run_funcs or {}
+    check_no_controller_sidecar_collision(controller_run_funcs.keys(), sidecar_run_funcs.keys())
     controller_stop_signal = threading.Event()
     platform_config = get_platform_config()
     platform_config.services = ",".join(sorted(service.name for service in services))
@@ -164,18 +173,37 @@ def create_app(
     async def lifespan(app: FastAPI):
         logger.info("Starting Nemo Platform server")
         controller_threads = []
+        thread_by_name: dict[str, threading.Thread] = {}
         platform_seed_task: asyncio.Task[None] | None = None
-        if controller_run_funcs:
-            logger.info("Starting controllers in lifespan: %s", list(controller_run_funcs))
-            for name, run_func in controller_run_funcs.items():
-                thread = threading.Thread(
-                    target=run_func,
-                    args=(controller_stop_signal,),
-                    name=f"controller-{name}",
-                    daemon=True,
+        try:
+            # start_*_threads can block synchronously: on a mid-batch failure
+            # (e.g. thread.start() raising under thread exhaustion) it rolls
+            # back already-started components by joining them, which — like
+            # the shutdown join below — can take up to each component's
+            # configured timeout. Run it off the event loop so a failure here
+            # doesn't stall every other in-flight request during startup.
+            if controller_run_funcs:
+                logger.info("Starting controllers in lifespan: %s", list(controller_run_funcs))
+                started = await asyncio.to_thread(
+                    start_controller_threads, controller_run_funcs, controller_stop_signal
                 )
-                thread.start()
-                controller_threads.append(thread)
+                thread_by_name.update(zip(controller_run_funcs, started))
+                controller_threads.extend(started)
+            if sidecar_run_funcs:
+                logger.info("Starting sidecars in lifespan: %s", list(sidecar_run_funcs))
+                started = await asyncio.to_thread(start_sidecar_threads, sidecar_run_funcs, controller_stop_signal)
+                thread_by_name.update(zip(sidecar_run_funcs, started))
+                controller_threads.extend(started)
+        except Exception:
+            controller_stop_signal.set()
+            await asyncio.to_thread(
+                join_and_untrack_runner_threads,
+                controller_threads,
+                thread_by_name,
+                controller_run_funcs.keys() | sidecar_run_funcs.keys(),
+            )
+            await close_shared_http_clients()
+            raise
 
         if platform_seed_state is not None:
             try:
@@ -214,8 +242,16 @@ def create_app(
                 pass
 
         controller_stop_signal.set()
-        for thread in controller_threads:
-            thread.join(timeout=5)
+        # join_and_untrack_runner_threads blocks synchronously (it polls with
+        # time.sleep) for up to each component's shutdown timeout — offload it
+        # so a slow-to-stop controller/sidecar (e.g. auth-proxy's 16s budget)
+        # doesn't stall the event loop and every other in-flight request.
+        await asyncio.to_thread(
+            join_and_untrack_runner_threads,
+            controller_threads,
+            thread_by_name,
+            controller_run_funcs.keys() | sidecar_run_funcs.keys(),
+        )
 
         await close_shared_http_clients()
         logger.info("Shutting down Nemo Platform API server")
@@ -331,17 +367,15 @@ def build_platform_app(
         )
     service_instances = order_services_by_dependencies(service_instances)
 
-    collisions = resolved.controllers & resolved.sidecars
-    if collisions:
-        raise ValueError(f"Controller/sidecar name collision: {', '.join(sorted(collisions))}")
-
+    # Fail before loading colliding functions; create_app() checks direct callers.
+    check_no_controller_sidecar_collision(resolved.controllers, resolved.sidecars)
     controller_run_funcs = _load_run_functions(sorted(resolved.controllers), resolved.available_controllers)
     sidecar_run_funcs = _load_run_functions(sorted(resolved.sidecars), AVAILABLE_SIDECARS)
-    controller_run_funcs.update(sidecar_run_funcs)
 
     return create_app(
         service_instances,
         controller_run_funcs=controller_run_funcs,
+        sidecar_run_funcs=sidecar_run_funcs,
         http_client=http_client,
         access_key_lifecycle_http_client=access_key_lifecycle_http_client,
     )

--- a/packages/nmp_platform_runner/tests/test_controller_threads.py
+++ b/packages/nmp_platform_runner/tests/test_controller_threads.py
@@ -1,0 +1,384 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for runner-owned controller thread health tracking."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Iterator
+from typing import cast
+
+import pytest
+from nmp.common.controller import ControllerManager, Loop
+from nmp.platform_runner import controller_threads
+from nmp.platform_runner.controller_threads import (
+    join_and_untrack_runner_threads,
+    start_controller_threads,
+    start_sidecar_threads,
+)
+
+
+class _HealthyLoop:
+    name = ""
+    is_healthy = True
+    unhealthy_reason = None
+
+
+@pytest.fixture(autouse=True)
+def reset_controller_manager() -> Iterator[None]:
+    ControllerManager._instance = None
+    yield
+    ControllerManager._instance = None
+
+
+def test_controller_is_pending_until_run_func_registers_loop() -> None:
+    manager = ControllerManager.get_instance()
+    allow_registration = threading.Event()
+    registered = threading.Event()
+    stop_signal = threading.Event()
+
+    def run(stop_signal: threading.Event) -> None:
+        allow_registration.wait(timeout=2)
+        manager.register("models_controller", cast(Loop, _HealthyLoop()))
+        registered.set()
+        stop_signal.wait(timeout=2)
+
+    threads = start_controller_threads({"models": run}, stop_signal)
+    try:
+        assert manager.validate_all_healthy() == (False, {"models": False})
+
+        allow_registration.set()
+        assert registered.wait(timeout=2)
+        assert manager.validate_all_healthy() == (True, {"models_controller": True})
+    finally:
+        stop_signal.set()
+        for thread in threads:
+            thread.join(timeout=2)
+
+
+def test_controller_that_exits_without_shutdown_is_unhealthy(caplog: pytest.LogCaptureFixture) -> None:
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+
+    with caplog.at_level(logging.ERROR, logger="nmp.platform_runner.controller_threads"):
+        threads = start_controller_threads({"models": lambda _stop_signal: None}, stop_signal)
+        for thread in threads:
+            thread.join(timeout=2)
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+    assert "Controller 'models' exited unexpectedly" in caplog.text
+
+
+def test_controller_system_exit_is_recorded_as_a_crash(caplog: pytest.LogCaptureFixture) -> None:
+    manager = ControllerManager.get_instance()
+
+    def exit_controller(_stop_signal: threading.Event) -> None:
+        raise SystemExit(7)
+
+    with caplog.at_level(logging.ERROR, logger="nmp.platform_runner.controller_threads"):
+        threads = start_controller_threads({"models": exit_controller}, threading.Event())
+        threads[0].join(timeout=2)
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+    assert "Controller 'models' crashed" in caplog.text
+
+
+def test_controller_thread_name_does_not_duplicate_prefix() -> None:
+    stop_signal = threading.Event()
+
+    threads = start_controller_threads({"controller-models": lambda _stop_signal: None}, stop_signal)
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert threads[0].name == "controller-models"
+
+
+def test_required_sidecar_failure_is_unhealthy(caplog: pytest.LogCaptureFixture) -> None:
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+
+    def crash(_stop_signal: threading.Event) -> None:
+        raise ValueError("optional configuration is missing")
+
+    with caplog.at_level(logging.ERROR, logger="nmp.platform_runner.controller_threads"):
+        threads = start_sidecar_threads({"adapters": crash}, stop_signal)
+        for thread in threads:
+            thread.join(timeout=2)
+
+    assert manager.validate_all_healthy() == (False, {"adapters": False})
+    assert "Sidecar 'adapters' crashed" in caplog.text
+    assert threads[0].name == "sidecar-adapters"
+
+
+def test_self_tracking_sidecar_is_pending_before_its_thread_runs_any_code() -> None:
+    """Expose a self-tracking sidecar before its thread is scheduled."""
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+    thread_may_proceed = threading.Event()
+
+    def run(stop_signal: threading.Event) -> None:
+        # Hold the thread before its own registration call.
+        thread_may_proceed.wait(timeout=2)
+        stop_signal.wait(timeout=2)
+
+    threads = start_sidecar_threads({"auth-proxy": run}, stop_signal)
+    try:
+        all_healthy, status = manager.validate_all_healthy()
+        assert all_healthy is False
+        assert status.get("auth-proxy") is False
+    finally:
+        thread_may_proceed.set()
+        stop_signal.set()
+        for thread in threads:
+            thread.join(timeout=2)
+        manager.stop_tracking_controller("auth-proxy")
+
+
+def test_delayed_runner_exit_is_untracked_after_its_generation_stops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(controller_threads, "DEFAULT_RUNNER_JOIN_TIMEOUT_SECONDS", 0.05)
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+    release = threading.Event()
+
+    def run(_stop_signal: threading.Event) -> None:
+        release.wait(timeout=2)
+
+    threads = start_controller_threads({"models": run}, stop_signal)
+    stop_signal.set()
+    join_and_untrack_runner_threads(threads, {"models": threads[0]}, {"models"})
+
+    assert manager.validate_all_healthy() == (False, {"models": False})
+    with pytest.raises(RuntimeError, match="still stopping"):
+        manager.await_controller_registration("models")
+
+    release.set()
+    deadline = time.monotonic() + 2
+    while manager.validate_all_healthy() != (True, {}) and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert manager.validate_all_healthy() == (True, {})
+
+
+def test_join_timeout_override_remains_supported() -> None:
+    manager = ControllerManager.get_instance()
+    release = threading.Event()
+    threads = start_controller_threads({"models": lambda _stop_signal: release.wait(timeout=2)}, threading.Event())
+
+    started_at = time.monotonic()
+    join_and_untrack_runner_threads(
+        threads,
+        {"models": threads[0]},
+        {"models"},
+        join_timeout=0.01,
+    )
+
+    assert time.monotonic() - started_at < 1
+    assert manager.validate_all_healthy() == (False, {"models": False})
+    release.set()
+    threads[0].join(timeout=2)
+    deadline = time.monotonic() + 2
+    while manager.validate_all_healthy() != (True, {}) and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert manager.validate_all_healthy() == (True, {})
+
+
+def test_delayed_runner_hands_cleanup_to_delayed_control_loop() -> None:
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+    wrapper_started = threading.Event()
+    loop_started = threading.Event()
+    release_wrapper = threading.Event()
+    release_loop = threading.Event()
+
+    class _BlockingLoop(threading.Thread):
+        name = ""
+        is_healthy = True
+        unhealthy_reason = None
+
+        def run(self) -> None:
+            loop_started.set()
+            release_loop.wait(timeout=2)
+
+    def run(_stop_signal: threading.Event) -> None:
+        loop = cast(Loop, _BlockingLoop(daemon=True))
+        manager.register("models_controller", loop)
+        loop.start()
+        wrapper_started.set()
+        release_wrapper.wait(timeout=2)
+
+    threads = start_controller_threads({"models": run}, stop_signal)
+    assert wrapper_started.wait(timeout=2)
+    assert loop_started.wait(timeout=2)
+
+    join_and_untrack_runner_threads(
+        threads,
+        {"models": threads[0]},
+        {"models"},
+        join_timeout=0,
+    )
+    assert manager.validate_all_healthy() == (False, {"models": False, "models_controller": True})
+
+    release_wrapper.set()
+    threads[0].join(timeout=2)
+    assert manager.validate_all_healthy() == (False, {"models": False, "models_controller": True})
+
+    release_loop.set()
+    deadline = time.monotonic() + 2
+    while manager.validate_all_healthy() != (True, {}) and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert manager.validate_all_healthy() == (True, {})
+
+
+def test_dead_runner_with_live_control_loop_is_untracked_after_loop_exits() -> None:
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+    loop_started = threading.Event()
+    release_loop = threading.Event()
+
+    class _BlockingLoop(threading.Thread):
+        name = ""
+        is_healthy = True
+        unhealthy_reason = None
+
+        def run(self) -> None:
+            loop_started.set()
+            release_loop.wait(timeout=2)
+
+    def run(stop_signal: threading.Event) -> None:
+        loop = cast(Loop, _BlockingLoop(daemon=True))
+        manager.register("models_controller", loop)
+        loop.start()
+        stop_signal.wait(timeout=2)
+        # Simulate a controller wrapper whose own shutdown deadline expires
+        # before its owned control-loop thread has stopped.
+
+    threads = start_controller_threads({"models": run}, stop_signal)
+    assert loop_started.wait(timeout=2)
+    stop_signal.set()
+    threads[0].join(timeout=2)
+
+    join_and_untrack_runner_threads(threads, {"models": threads[0]}, {"models"})
+
+    assert manager.validate_all_healthy() == (False, {"models": False, "models_controller": True})
+    with pytest.raises(RuntimeError, match="still stopping"):
+        manager.await_controller_registration("models")
+
+    release_loop.set()
+    deadline = time.monotonic() + 2
+    while manager.validate_all_healthy() != (True, {}) and time.monotonic() < deadline:
+        time.sleep(0.01)
+
+    assert manager.validate_all_healthy() == (True, {})
+    assert manager.await_controller_registration("models") > 1
+
+
+def test_loop_exit_between_cleanup_and_watcher_does_not_leave_stopping_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+    loop_started = threading.Event()
+    release_loop = threading.Event()
+    owned_loop: threading.Thread | None = None
+
+    class _BlockingLoop(threading.Thread):
+        name = ""
+        is_healthy = True
+        unhealthy_reason = None
+
+        def run(self) -> None:
+            loop_started.set()
+            release_loop.wait(timeout=2)
+
+    def run(stop_signal: threading.Event) -> None:
+        nonlocal owned_loop
+        owned_loop = _BlockingLoop(daemon=True)
+        manager.register("models_controller", cast(Loop, owned_loop))
+        owned_loop.start()
+        stop_signal.wait(timeout=2)
+
+    threads = start_controller_threads({"models": run}, stop_signal)
+    assert loop_started.wait(timeout=2)
+    stop_signal.set()
+    threads[0].join(timeout=2)
+
+    def exit_before_snapshot(*_args: object, **_kwargs: object) -> bool:
+        release_loop.set()
+        assert owned_loop is not None
+        owned_loop.join(timeout=2)
+        return False
+
+    monkeypatch.setattr(manager, "watch_controller_loops_exit", exit_before_snapshot)
+
+    join_and_untrack_runner_threads(threads, {"models": threads[0]}, {"models"})
+
+    assert manager.validate_all_healthy() == (True, {})
+
+
+def test_existing_stopping_owner_keeps_control_of_delayed_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = ControllerManager.get_instance()
+    release = threading.Event()
+    threads = start_sidecar_threads({"auth-proxy": lambda _stop: release.wait(timeout=2)}, threading.Event())
+    thread = threads[0]
+    assert isinstance(thread, controller_threads._RunnerThread)
+    manager.mark_controller_stopping("auth-proxy", thread.generation)
+    watcher_called = False
+
+    def record_watcher(*_args: object, **_kwargs: object) -> None:
+        nonlocal watcher_called
+        watcher_called = True
+
+    monkeypatch.setattr(manager, "watch_delayed_exit", record_watcher)
+
+    join_and_untrack_runner_threads(
+        threads,
+        {"auth-proxy": thread},
+        {"auth-proxy"},
+        join_timeout=0,
+    )
+
+    assert watcher_called is False
+    assert manager.validate_all_healthy() == (False, {"auth-proxy": False})
+    release.set()
+    thread.join(timeout=2)
+
+
+def test_thread_start_failure_rolls_back_already_started_components(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = ControllerManager.get_instance()
+    stop_signal = threading.Event()
+    first_stopped = threading.Event()
+
+    def first_run(stop_signal: threading.Event) -> None:
+        manager.register("first_loop", cast(Loop, _HealthyLoop()))
+        stop_signal.wait(timeout=2)
+        first_stopped.set()
+
+    original_start = controller_threads._RunnerThread.start
+
+    def fail_second_start(thread: controller_threads._RunnerThread) -> None:
+        if thread.component_name == "second":
+            raise RuntimeError("thread start failed")
+        original_start(thread)
+
+    monkeypatch.setattr(controller_threads._RunnerThread, "start", fail_second_start)
+
+    with pytest.raises(RuntimeError, match="thread start failed"):
+        start_controller_threads(
+            {
+                "first": first_run,
+                "second": lambda _stop_signal: None,
+            },
+            stop_signal,
+        )
+
+    assert first_stopped.wait(timeout=2)
+    assert manager.get_all_loops() == {}
+    assert manager.validate_all_healthy() == (False, {"second": False})

--- a/packages/nmp_platform_runner/tests/test_health.py
+++ b/packages/nmp_platform_runner/tests/test_health.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Iterator
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -22,7 +24,7 @@ class ProbeService(Service):
 
 
 @pytest.fixture(autouse=True)
-def reset_controller_manager() -> None:
+def reset_controller_manager() -> Iterator[None]:
     ControllerManager._instance = None
     yield
     ControllerManager._instance = None
@@ -101,3 +103,19 @@ def test_registered_not_ready_service_degrades_status_and_blocks_readiness() -> 
     }
     assert ready_response.status_code == 503
     assert ready_response.json() == {"detail": {"status": "not_ready"}}
+
+
+def test_failed_controller_makes_top_level_status_unhealthy() -> None:
+    manager = ControllerManager.get_instance()
+    manager.mark_controller_failed("models", reason="startup failed")
+    client = _client_for([ProbeService("entities", ready=True)])
+
+    status_response = client.get("/status")
+
+    assert status_response.status_code == 200
+    assert status_response.json()["status"] == "unhealthy"
+    assert status_response.json()["controllers"] == {
+        "healthy": False,
+        "status": {"models": False},
+    }
+    assert client.get("/health/ready").status_code == 503

--- a/packages/nmp_platform_runner/tests/test_plugin_adapter.py
+++ b/packages/nmp_platform_runner/tests/test_plugin_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import threading
 import time
+from collections.abc import Iterator
 from typing import ClassVar
 from unittest.mock import MagicMock
 
@@ -12,6 +13,7 @@ import pytest
 from fastapi import APIRouter, Request
 from nemo_platform_plugin.controller import NemoController
 from nemo_platform_plugin.service import NemoService, RouterSpec
+from nmp.common.controller import ControllerManager, Loop
 from nmp.platform_runner.plugin_adapter import NemoServiceAdapter, make_controller_run_func
 from starlette.responses import JSONResponse
 
@@ -72,9 +74,12 @@ class _StubControllerWithDeps(_StubController):
 
 
 @pytest.fixture(autouse=True)
-def _clear_stub_controller_call_history() -> None:
+def _clear_stub_controller_call_history() -> Iterator[None]:
     _list_objects_calls.clear()
     _on_startup_calls.clear()
+    ControllerManager._instance = None
+    yield
+    ControllerManager._instance = None
 
 
 @pytest.fixture
@@ -212,3 +217,90 @@ def test_controller_skips_wait_when_no_dependencies(monkeypatch: pytest.MonkeyPa
 
     mock_wait.assert_not_called()
     assert _list_objects_calls
+
+
+def test_registration_name_collision_still_runs_shutdown_and_reports_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Close the adapter event loop when loop registration collides.
+
+    Registration failures must propagate (like ``loop.start()`` failures do,
+    see ``test_loop_start_failure_unregisters_loop_and_runs_shutdown``) so the
+    controller_threads.py wrapper unconditionally records the failure instead
+    of relying on ``stop_signal`` happening to still be unset.
+    """
+    manager = ControllerManager.get_instance()
+    manager.register("controller-plugin-test-controller", MagicMock(is_healthy=True, unhealthy_reason=None))
+
+    shutdown_calls: list[float] = []
+
+    class _CollidingController(_StubController):
+        async def on_shutdown(self) -> None:
+            shutdown_calls.append(time.monotonic())
+
+    run_func = make_controller_run_func(_CollidingController)
+    with caplog.at_level("ERROR"), pytest.raises(ValueError, match="already registered"):
+        run_func(threading.Event())
+
+    assert shutdown_calls
+    assert "failed to register its control loop" in caplog.text
+
+
+def test_plugin_controller_registers_loop_for_health_reporting() -> None:
+    stop_signal = threading.Event()
+    thread = _run_controller_until_list_objects(_StubController, stop_signal)
+
+    try:
+        loops = ControllerManager.get_instance().get_all_loops()
+        assert list(loops) == ["controller-plugin-test-controller"]
+        assert loops["controller-plugin-test-controller"].is_alive()
+    finally:
+        stop_signal.set()
+        thread.join(timeout=_WAIT_DEADLINE_SECONDS)
+
+
+def test_loop_start_failure_unregisters_loop_and_runs_shutdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    shutdown_calls: list[float] = []
+
+    class _StartFailingController(_StubController):
+        async def on_shutdown(self) -> None:
+            shutdown_calls.append(time.monotonic())
+
+    def _fail_start(_loop: Loop) -> None:
+        raise RuntimeError("loop thread start failed")
+
+    monkeypatch.setattr(Loop, "start", _fail_start)
+    run_func = make_controller_run_func(_StartFailingController)
+
+    with pytest.raises(RuntimeError, match="loop thread start failed"):
+        run_func(threading.Event())
+
+    assert ControllerManager.get_instance().get_all_loops() == {}
+    assert shutdown_calls
+
+
+def test_on_startup_failure_raises_and_runs_shutdown_hook(caplog: pytest.LogCaptureFixture) -> None:
+    """A failing on_startup() must propagate and still run the plugin's on_shutdown().
+
+    Matches the register()/loop.start() failure paths above: the caller
+    (controller_threads.py's wrapper) relies on the exception to unconditionally
+    record the failure, and any resources on_startup() partially acquired
+    should still be released via on_shutdown().
+    """
+    shutdown_calls: list[float] = []
+
+    class _StartupFailingController(_StubController):
+        async def on_startup(self) -> None:
+            await super().on_startup()
+            raise RuntimeError("on_startup failed")
+
+        async def on_shutdown(self) -> None:
+            shutdown_calls.append(time.monotonic())
+
+    run_func = make_controller_run_func(_StartupFailingController)
+    with caplog.at_level("ERROR"), pytest.raises(RuntimeError, match="on_startup failed"):
+        run_func(threading.Event())
+
+    assert shutdown_calls
+    assert "on_startup() failed" in caplog.text
+    assert ControllerManager.get_instance().get_all_loops() == {}

--- a/packages/nmp_platform_runner/tests/test_server.py
+++ b/packages/nmp_platform_runner/tests/test_server.py
@@ -4,6 +4,7 @@
 import asyncio
 import builtins
 import inspect
+import logging
 import os
 import sys
 import threading
@@ -17,6 +18,7 @@ from fastapi.testclient import TestClient
 from nemo_platform_plugin.jobs.openapi_utils import clear_query_param_schemas, generate_openapi_extra_params
 from nmp.common.config import AuthConfig, Configuration
 from nmp.common.config.base import OIDCConfig
+from nmp.common.controller import ControllerManager
 from nmp.common.service import RouterConfig, Service
 from nmp.platform_runner import config as runner_config
 from nmp.platform_runner import server
@@ -285,9 +287,11 @@ def test_build_platform_app_returns_app_without_running_uvicorn(monkeypatch):
         controller_run_funcs=None,
         http_client=None,
         access_key_lifecycle_http_client=None,
+        sidecar_run_funcs=None,
     ):
         captured["services"] = services
         captured["controller_run_funcs"] = controller_run_funcs
+        captured["sidecar_run_funcs"] = sidecar_run_funcs
         captured["http_client"] = http_client
         captured["access_key_lifecycle_http_client"] = access_key_lifecycle_http_client
         return FastAPI()
@@ -304,6 +308,7 @@ def test_build_platform_app_returns_app_without_running_uvicorn(monkeypatch):
     assert isinstance(app, FastAPI)
     assert captured["services"] == [plugin_service]
     assert captured["controller_run_funcs"] == {}
+    assert captured["sidecar_run_funcs"] == {}
     assert captured["http_client"] is None
     assert captured["access_key_lifecycle_http_client"] is lifecycle_http_client
 
@@ -322,9 +327,11 @@ def test_build_platform_app_accepts_platform_app_config(monkeypatch):
         controller_run_funcs=None,
         http_client=None,
         access_key_lifecycle_http_client=None,
+        sidecar_run_funcs=None,
     ):
         captured["services"] = services
         captured["controller_run_funcs"] = controller_run_funcs
+        captured["sidecar_run_funcs"] = sidecar_run_funcs
         captured["http_client"] = http_client
         captured["access_key_lifecycle_http_client"] = access_key_lifecycle_http_client
         return FastAPI()
@@ -339,6 +346,7 @@ def test_build_platform_app_accepts_platform_app_config(monkeypatch):
     assert isinstance(app, FastAPI)
     assert captured["services"] == [plugin_service]
     assert captured["controller_run_funcs"] == {}
+    assert captured["sidecar_run_funcs"] == {}
     assert captured["http_client"] is None
     assert captured["access_key_lifecycle_http_client"] is None
 
@@ -526,6 +534,46 @@ def test_create_app_without_seed_on_startup_keeps_health_ready_unchanged(monkeyp
     assert response.status_code == 200
     assert "platform-seed" not in status["services"]["ready"]
     assert all(item["name"] != "platform-seed" for item in status["services"]["not_ready"])
+
+
+def test_create_app_rejects_controller_sidecar_name_collision(monkeypatch):
+    _patch_platform_app_config(monkeypatch, seed_on_startup=False)
+
+    with pytest.raises(ValueError, match="Controller/sidecar name collision: shared"):
+        server.create_app(
+            services=[],
+            controller_run_funcs={"shared": lambda _stop_signal: None},
+            sidecar_run_funcs={"shared": lambda _stop_signal: None},
+        )
+
+
+def test_create_app_reports_controller_that_crashes_before_registration(monkeypatch, caplog):
+    _patch_platform_app_config(monkeypatch, seed_on_startup=False)
+    crashed = threading.Event()
+
+    def crashing_controller(_stop_signal: threading.Event) -> None:
+        try:
+            raise RuntimeError("startup failed")
+        finally:
+            crashed.set()
+
+    manager = ControllerManager.get_instance()
+    manager.clear()
+    try:
+        with caplog.at_level(logging.ERROR, logger="nmp.platform_runner.controller_threads"):
+            with TestClient(
+                server.create_app(services=[], controller_run_funcs={"models": crashing_controller})
+            ) as client:
+                assert crashed.wait(timeout=2)
+                # The wrapper records failure after crashed is set.
+                response = _wait_for_response(client, "/health/ready", 503)
+                status = client.get("/status").json()
+
+        assert response.status_code == 503
+        assert status["controllers"] == {"healthy": False, "status": {"models": False}}
+        assert "Controller 'models' crashed" in caplog.text
+    finally:
+        manager.clear()
 
 
 def test_create_app_with_seed_on_startup_blocks_readiness_until_seed_completes(monkeypatch):

--- a/packages/nmp_platform_runner/tests/test_sidecars.py
+++ b/packages/nmp_platform_runner/tests/test_sidecars.py
@@ -11,9 +11,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from nmp.common.config import AuthConfig
 from nmp.common.config.base import OIDCConfig
+from nmp.common.controller import Controller, ControllerManager, Loop, TimedLoopWaiter
 from nmp.common.service import Service
 from nmp.platform_runner import config as runner_config
-from nmp.platform_runner import server
+from nmp.platform_runner import controller_threads, server
 
 
 class DummyService(Service):
@@ -110,7 +111,7 @@ def test_create_app_starts_and_stops_dummy_sidecar_with_lifespan() -> None:
         platform_config.return_value.redirect_root_to_studio = False
         app = server.create_app(
             services=[],
-            controller_run_funcs={"adapters": _sidecar_with_events(started, stopped)},
+            sidecar_run_funcs={"adapters": _sidecar_with_events(started, stopped)},
         )
         from fastapi.testclient import TestClient
 
@@ -119,6 +120,139 @@ def test_create_app_starts_and_stops_dummy_sidecar_with_lifespan() -> None:
             assert client.get("/").status_code == 200
 
     assert stopped.wait(timeout=1.0)
+
+
+def test_registered_sidecar_loop_is_removed_after_each_lifespan() -> None:
+    manager = ControllerManager.get_instance()
+    manager.clear()
+    registered = threading.Event()
+
+    def run(stop_signal: threading.Event) -> None:
+        loop = MagicMock(is_healthy=True, unhealthy_reason=None)
+        manager.register("adapters_controller", loop)
+        registered.set()
+        stop_signal.wait(timeout=5.0)
+
+    try:
+        with (
+            patch("nmp.platform_runner.server.get_platform_config") as platform_config,
+            patch("nmp.platform_runner.server.get_auth_config", return_value=_auth_config(False)),
+            patch("nmp.common.auth.middleware.get_auth_config", return_value=_auth_config(False)),
+        ):
+            platform_config.return_value.seed_on_startup = False
+            platform_config.return_value.redirect_root_to_studio = False
+
+            for _ in range(2):
+                registered.clear()
+                app = server.create_app(services=[], sidecar_run_funcs={"adapters": run})
+
+                from fastapi.testclient import TestClient
+
+                with TestClient(app) as client:
+                    assert registered.wait(timeout=1.0)
+                    assert client.get("/health/ready").status_code == 200
+
+                assert manager.validate_all_healthy() == (True, {})
+    finally:
+        manager.clear()
+
+
+def test_self_tracking_sidecar_survives_generic_shutdown_untracking() -> None:
+    """Leave tracking to a sidecar whose resource outlives its wrapper."""
+    manager = ControllerManager.get_instance()
+    manager.clear()
+    registered = threading.Event()
+    # Model a resource that outlives its sidecar wrapper.
+    hang_forever = threading.Event()
+    resource_thread = threading.Thread(target=lambda: hang_forever.wait(timeout=5), daemon=True)
+
+    class _ResourceController(Controller):
+        def step(self) -> None:
+            pass
+
+        @property
+        def is_healthy(self) -> bool:
+            return resource_thread.is_alive()
+
+    def run(stop_signal: threading.Event) -> None:
+        generation = manager.await_controller_registration("auth-proxy")
+        resource_thread.start()
+        # The health loop stops independently of the resource thread.
+        health_loop = Loop(
+            waiter=TimedLoopWaiter(sleep_secs=0.01, stop_signal=stop_signal),
+            controller=_ResourceController(),
+            stop_signal=stop_signal,
+        )
+        health_loop.name = "auth-proxy"
+        manager.register(health_loop.name, health_loop)
+        health_loop.start()
+        registered.set()
+        stop_signal.wait(timeout=5.0)
+        health_loop.join(timeout=2.0)
+        # The sidecar intentionally leaves the live resource tracked.
+        manager.mark_controller_stopping("auth-proxy", generation)
+
+        def cleanup_after_resource_exit() -> None:
+            resource_thread.join()
+            manager.stop_tracking_controller(
+                "auth-proxy",
+                generation,
+                allow_stopping=True,
+            )
+
+        threading.Thread(target=cleanup_after_resource_exit, daemon=True).start()
+
+    try:
+        with (
+            patch("nmp.platform_runner.server.get_platform_config") as platform_config,
+            patch("nmp.platform_runner.server.get_auth_config", return_value=_auth_config(False)),
+            patch("nmp.common.auth.middleware.get_auth_config", return_value=_auth_config(False)),
+        ):
+            platform_config.return_value.seed_on_startup = False
+            platform_config.return_value.redirect_root_to_studio = False
+            app = server.create_app(services=[], sidecar_run_funcs={"auth-proxy": run})
+
+            from fastapi.testclient import TestClient
+
+            with TestClient(app) as client:
+                assert registered.wait(timeout=1.0)
+                assert client.get("/health/ready").status_code == 200
+
+            assert "auth-proxy" in manager.get_all_loops()
+    finally:
+        hang_forever.set()
+        manager.clear()
+
+
+def test_crashed_required_sidecar_blocks_readiness() -> None:
+    crashed = threading.Event()
+
+    def crash(_stop_signal: threading.Event) -> None:
+        crashed.set()
+        raise ValueError("optional configuration is missing")
+
+    manager = ControllerManager.get_instance()
+    manager.clear()
+    try:
+        with (
+            patch("nmp.platform_runner.server.get_platform_config") as platform_config,
+            patch("nmp.platform_runner.server.get_auth_config", return_value=_auth_config(False)),
+            patch("nmp.common.auth.middleware.get_auth_config", return_value=_auth_config(False)),
+        ):
+            platform_config.return_value.seed_on_startup = False
+            platform_config.return_value.redirect_root_to_studio = False
+            app = server.create_app(services=[], sidecar_run_funcs={"adapters": crash})
+
+            from fastapi.testclient import TestClient
+
+            with TestClient(app) as client:
+                assert crashed.wait(timeout=1.0)
+                assert client.get("/health/ready").status_code == 503
+                status = client.get("/status").json()
+                assert status["status"] == "unhealthy"
+                assert status["controllers"] == {"healthy": False, "status": {"adapters": False}}
+    finally:
+        manager.clear()
 
 
 def test_build_platform_app_loads_explicit_sidecar_into_lifespan(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -144,6 +278,51 @@ def test_build_platform_app_loads_explicit_sidecar_into_lifespan(monkeypatch: py
             assert client.get("/").status_code == 200
 
     assert stopped.wait(timeout=1.0)
+
+
+def test_sidecar_thread_start_failure_rolls_back_started_controllers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller_stopped = threading.Event()
+    manager = ControllerManager.get_instance()
+    manager.clear()
+
+    def controller_run(stop_signal: threading.Event) -> None:
+        manager.register("models_controller", MagicMock(is_healthy=True, unhealthy_reason=None))
+        stop_signal.wait(timeout=2)
+        controller_stopped.set()
+
+    original_start = controller_threads._RunnerThread.start
+
+    def fail_sidecar_start(thread: controller_threads._RunnerThread) -> None:
+        if thread.component_name == "adapters":
+            raise RuntimeError("sidecar thread start failed")
+        original_start(thread)
+
+    monkeypatch.setattr(controller_threads._RunnerThread, "start", fail_sidecar_start)
+
+    with (
+        patch("nmp.platform_runner.server.get_platform_config") as platform_config,
+        patch("nmp.platform_runner.server.get_auth_config", return_value=_auth_config(False)),
+        patch("nmp.common.auth.middleware.get_auth_config", return_value=_auth_config(False)),
+    ):
+        platform_config.return_value.seed_on_startup = False
+        platform_config.return_value.redirect_root_to_studio = False
+        app = server.create_app(
+            services=[],
+            controller_run_funcs={"models": controller_run},
+            sidecar_run_funcs={"adapters": _dummy_sidecar},
+        )
+
+        from fastapi.testclient import TestClient
+
+        with pytest.raises(RuntimeError, match="sidecar thread start failed"), TestClient(app):
+            pass
+
+    assert controller_stopped.wait(timeout=2)
+    assert manager.get_all_loops() == {}
+    assert manager.validate_all_healthy() == (False, {"adapters": False})
+    manager.clear()
 
 
 def test_build_platform_app_rejects_controller_sidecar_name_collision(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Tracks runner-owned controllers from startup so controllers that crash before registering a control loop are reported as unhealthy. `/health/ready` now returns `503`, `/status` identifies the failed controller, and startup failures produce error-level logs.

## Related Issue

Resolves [NAP-19](https://linear.app/nvidia/issue/NAP-19/controller-that-crashes-before-registration-is-invisible-to).

## Changes

- Track controllers awaiting registration, registered controllers, and failed controllers in `ControllerManager`.
- Synchronize singleton initialization and controller health state.
- Start controllers and sidecars through a shared lifecycle wrapper that records startup crashes and unexpected exits.
- Register plugin controller loops with the health manager.
- Add an auth-proxy health loop that detects a terminated Uvicorn thread and unregisters cleanly on shutdown.
- Track loop ownership and remove stale controller loops during unregister and shutdown.
- Avoid duplicate `controller-` prefixes and improve controller log formatting.
- Add regression coverage for readiness, status reporting, error logging, registration, restart cleanup, singleton construction, and thread naming.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Restores the documented readiness behavior without changing configuration or API schemas.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/nmp_common/tests/auth/test_workload_proxy.py packages/nmp_common/tests/controller/test_controller_manager.py packages/nmp_platform_runner/tests/test_server.py -q`
  - Passed: 68 tests.
- Focused `uv run --frozen ruff check` and `ruff format --check` on changed Python files.
  - Passed.
- Focused `uv run --frozen ty check` on changed source files.
  - Passed.
- DCO audit of all three commits.
  - Passed.
- Pre-push hooks with repository-pinned uv 0.9.14.
  - Passed.
- `git diff --check`.
  - Passed.
- `uv run pre-commit run -a`
  - Code-related hooks passed; blocked only because `helm-docs` is not installed and the host uv 0.9.18 does not match the hook-pinned uv 0.9.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health monitoring for authentication proxy, controller, and sidecar processes.
  * Readiness now reflects missing, crashed, or unexpectedly stopped controllers.
  * Standardized controller and sidecar startup, shutdown, and timeout handling.
  * Added validation to prevent controller and sidecar name collisions.

* **Bug Fixes**
  * Improved health-status cleanup during shutdown and restarts.
  * Improved handling of authentication proxy startup and shutdown failures.
  * Prevented failed controllers from appearing healthy when names overlap.

* **Tests**
  * Added coverage for registration, crash detection, readiness failures, health transitions, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
