### PR TITLE
feat(evaluator): submit a live Gym runner as an agent-evaluation job

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/gym/runtime.py
@@ -67,6 +67,20 @@ class GymAgentTaskRunner:
         self._config = config
         self._run_aggregations: dict[str, Any] | None = None
 
+    @property
+    def config(self) -> GymRuntimeConfig:
+        """The settings this runner was constructed with.
+
+        Read-only, and the whole config rather than a property per field: unlike the Codex and
+        Fabric runtimes, everything shaping a Gym run already lives in one validated object.
+
+        Exposed so a live runner can be described as the job-spec target that reproduces it, without
+        reaching into a private attribute from another package. ``runner_info()`` cannot serve that
+        purpose — it redacts credential-shaped values, so what it returns is provenance to read, not
+        configuration to rebuild from.
+        """
+        return self._config
+
     def run_aggregate_scores(self) -> Sequence[AggregateScore]:
         """Gym's ``agent_metrics`` mapped onto typed aggregate scores, namespaced ``runner.gym.<metric>``.
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/runner_targets.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/runner_targets.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Describe a live agent runner as the target spec that reproduces it job-side.
+
+The SDK's runners are Python objects built for the process they run in; the plugin's targets are
+wire DTOs built to survive being sent somewhere else. This module is the one-way bridge: take a
+runner someone got working locally with ``AgentEvaluator().run()``, and produce the spec that runs
+the same evaluation as a governed job — without asking them to retype its configuration and get it
+subtly wrong.
+
+**One-way on purpose.** The reverse direction (spec to runner) already exists in
+:mod:`nemo_evaluator.jobs.agent_evaluate`, where the job resolves its own target and can inject the
+runtime-only values a spec has no business carrying — the way Harbor's ``jobs_dir`` comes from the
+job's storage. Keeping construction there and description here means neither side has to know the
+other's local details.
+
+**Refuses rather than quietly drops.** A runner can hold state with no wire form: a callable, a
+handle to something in this process, a path that means nothing on another machine. Silently
+dropping it would submit a job that runs something *different* from what was tested locally, which
+is worse than not submitting at all. Those cases raise :class:`UnsubmittableRunnerError` naming what
+could not travel.
+
+Only :class:`GymAgentTaskRunner` is supported today. The other shipped runners each need their own
+decisions about what survives translation, and are deliberately not guessed at here.
+"""
+
+from __future__ import annotations
+
+from nemo_evaluator.jobs.agent_spec import AgentRunnerTarget, GymRunnerTarget
+from nemo_evaluator_sdk.agent_eval.runtimes.gym import GymAgentTaskRunner
+from nemo_evaluator_sdk.agent_eval.trials import AgentTaskRunner
+
+
+class UnsubmittableRunnerError(TypeError):
+    """A live runner cannot be described as a submittable target spec.
+
+    Raised both for runner types with no wire form at all and for a supported runner configured with
+    state the wire cannot carry.
+    """
+
+
+def runner_to_target(runner: AgentTaskRunner) -> AgentRunnerTarget:
+    """The target spec that reproduces ``runner`` as a job.
+
+    Raises:
+        UnsubmittableRunnerError: If the runner has no wire form, or carries state that would be
+            lost in translation.
+    """
+    if isinstance(runner, GymAgentTaskRunner):
+        return _gym_target(runner)
+    raise UnsubmittableRunnerError(
+        f"{type(runner).__name__} has no target spec, so it cannot be submitted as a job. Run it "
+        "in-process with AgentEvaluator(), or pass a runner target spec directly."
+    )
+
+
+def _gym_target(runner: GymAgentTaskRunner) -> GymRunnerTarget:
+    """``GymAgentTaskRunner`` -> ``GymRunnerTarget``.
+
+    Every field carries, and nothing is rejected — unusual among the runners, and worth saying
+    plainly rather than inventing rejections to look careful. Gym's settings are all *behaviour*
+    (which environment, which agent, how many attempts, how long to wait) rather than *location*:
+    there is no work root, no local base directory, and no injected callable to lose. The one thing
+    that reads like a local path, ``agent_config``, is resolved relative to the Gym installation
+    rather than the caller's filesystem, and the job container is required to have Gym installed
+    regardless.
+
+    ``env_vars`` carries verbatim, including absolute paths. A value like a model-cache root may
+    well be wrong job-side — but a container path is absolute too, so nothing here can tell a local
+    path from one that is correct in the job's image, and guessing would break the legitimate case
+    to protect against a mistake the submitter is better placed to catch.
+    """
+    return GymRunnerTarget(**runner.config.model_dump())

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/runner_targets.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/runner_targets.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 from nemo_evaluator.jobs.agent_spec import AgentRunnerTarget, GymRunnerTarget
 from nemo_evaluator_sdk.agent_eval.runtimes.gym import GymAgentTaskRunner
 from nemo_evaluator_sdk.agent_eval.trials import AgentTaskRunner
+from pydantic_core import PydanticSerializationError
 
 
 class UnsubmittableRunnerError(TypeError):
@@ -70,5 +71,21 @@ def _gym_target(runner: GymAgentTaskRunner) -> GymRunnerTarget:
     well be wrong job-side — but a container path is absolute too, so nothing here can tell a local
     path from one that is correct in the job's image, and guessing would break the legitimate case
     to protect against a mistake the submitter is better placed to catch.
+
+    The one rejection is a value with no JSON form. ``hydra_params`` and ``env_vars`` are typed
+    loosely enough to hold a callable or an arbitrary object, which survives construction here and
+    then fails inside ``model_dump(mode="json")`` at submit time — a ``PydanticSerializationError``
+    raised from the transport, naming neither the runner nor the field. Checking here turns that
+    into the refusal this module promises.
     """
-    return GymRunnerTarget(**runner.config.model_dump())
+    target = GymRunnerTarget(**runner.config.model_dump())
+    try:
+        target.model_dump(mode="json")
+    except PydanticSerializationError as error:
+        raise UnsubmittableRunnerError(
+            "this GymAgentTaskRunner holds configuration with no JSON form, so it cannot be sent to "
+            f"the service: {error}. `hydra_params` and `env_vars` are free-form, but their values "
+            "must be JSON-compatible — Gym receives them as Hydra overrides and environment "
+            "variables, so a callable or a live object could not have travelled anyway."
+        ) from error
+    return target

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/_executor.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/_executor.py
@@ -9,12 +9,16 @@ from collections.abc import Sequence
 from typing import Any
 
 import httpx
-from nemo_evaluator.api.schemas import MetricInline
+from nemo_evaluator.api.schemas import MetricInline, TasksetRef
 from nemo_evaluator.filesets import FilesetRef
+from nemo_evaluator.jobs.agent_spec import AgentEvalInputSpec
 from nemo_evaluator.jobs.evaluate import EvaluateInputSpec, TargetSpec
+from nemo_evaluator.jobs.runner_targets import runner_to_target
 from nemo_evaluator.resolvers import PlatformModelResolver
 from nemo_evaluator.sdk import http_utils
 from nemo_evaluator.sdk.job_resources import (
+    AgentEvaluatorJob,
+    AgentEvaluatorJobResource,
     AsyncEvaluatorJobResource,
     EvaluatorJob,
     EvaluatorJobResource,
@@ -26,6 +30,7 @@ from nemo_evaluator.shared.metric_bundles.bundles import (
     MetricBundlePackagerPolicyError,
     bundle_metric,
 )
+from nemo_evaluator_sdk.agent_eval.trials import AgentTaskRunner
 from nemo_evaluator_sdk.datasets.loader import prepare_dataset_rows
 from nemo_evaluator_sdk.execution.config import resolve_params
 from nemo_evaluator_sdk.execution.metric_execution import run_sync
@@ -194,6 +199,66 @@ class _SyncEvaluatorPluginExecutor:
                 pending_timeout_seconds=self._pending_timeout_seconds,
             )
         return job_resource
+
+    def create_agent_eval(
+        self,
+        *,
+        spec: AgentEvalInputSpec,
+        workspace: str | None = None,
+        wait_until_done: bool = False,
+    ) -> AgentEvaluatorJobResource:
+        """Create an agent-evaluation job with a sync platform client.
+
+        The twin of :meth:`create`, against the ``agent-evaluate`` collection rather than
+        ``evaluate``. The two job kinds share a resource type because a submitted job is a submitted
+        job — polling, status, and artifacts do not differ by what produced the trials.
+        """
+        resolved_workspace = http_utils.resolve_workspace(self._platform, workspace)
+        response = self._http_client.post(
+            http_utils.url(self._platform, "/v2/workspaces/{workspace}/agent-evaluate/jobs", resolved_workspace),
+            json={"spec": spec.model_dump(mode="json")},
+            headers=http_utils.platform_default_headers(self._platform),
+            timeout=self._platform.timeout,
+        )
+
+        response.raise_for_status()
+
+        job_resource = AgentEvaluatorJobResource(
+            job=AgentEvaluatorJob.model_validate(response.json()),
+            http_client=self._http_client,
+            base_url=http_utils.base_url(str(self._platform.base_url)),
+            workspace=resolved_workspace,
+            headers=http_utils.platform_default_headers(self._platform),
+        )
+
+        if wait_until_done:
+            job_resource.wait_until_done(
+                poll_interval_seconds=self._poll_interval_seconds,
+                job_timeout_seconds=self._job_timeout_seconds,
+                pending_timeout_seconds=self._pending_timeout_seconds,
+            )
+        return job_resource
+
+    def submit_agent_eval(
+        self,
+        *,
+        tasks: TasksetRef,
+        target: AgentTaskRunner,
+        wait_until_done: bool = False,
+    ) -> AgentEvaluatorJobResource:
+        """Submit an agent evaluation over a stored taskset, run by ``target``.
+
+        ``target`` is a *live* runner — the object someone already ran locally with
+        ``AgentEvaluator()``. :func:`runner_to_target` describes it as the spec that reproduces it
+        job-side, and refuses runners carrying state the wire cannot express, so a submitted job
+        cannot silently run something other than what was tested.
+        """
+        spec = AgentEvalInputSpec(tasks=tasks, target=runner_to_target(target))
+        return self.create_agent_eval(
+            spec=spec,
+            workspace=http_utils.resolve_workspace(self._platform, self._workspace, strict=True),
+            wait_until_done=wait_until_done,
+        )
 
     def submit(
         self,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/job_resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/job_resources.py
@@ -17,6 +17,7 @@ from time import monotonic
 from typing import TypeAlias, cast
 
 import httpx
+from nemo_evaluator.jobs.agent_spec import AgentEvalSpec
 from nemo_evaluator.jobs.evaluate import EvaluateSpec
 from nemo_evaluator.sdk import http_utils
 from nemo_evaluator.sdk.utils import filter_aggregate_scores
@@ -28,6 +29,10 @@ from nemo_platform_plugin.jobs.schemas import PlatformJobStatusResponse
 from pydantic import BaseModel
 
 EvaluatorJob: TypeAlias = BaseJob[EvaluateSpec]
+#: The agent counterpart. Separate because the two jobs' specs genuinely differ — an agent job
+#: carries tasks and a runner target where a row job carries metrics and a dataset — so reusing
+#: `EvaluatorJob` here would fail validation on every field of the spec that came back.
+AgentEvaluatorJob: TypeAlias = BaseJob[AgentEvalSpec]
 
 _TERMINAL_FAILURE_STATUSES = frozenset({"error", "cancelled", "failed"})
 _TERMINAL_SUCCESS_STATUS = "completed"
@@ -204,6 +209,107 @@ def _poll_until_terminal(
             pending_elapsed += sleep_duration
         else:
             elapsed += sleep_duration
+
+
+class AgentEvaluatorJobResource:
+    """High-level SDK handle for a submitted agent-evaluation job.
+
+    Deliberately *not* a subclass of, or base for, :class:`EvaluatorJobResource`. The polling half
+    of the two is identical today, but the result half is not: a row evaluation publishes
+    ``aggregate-scores`` and ``row-scores`` artifacts, while an agent evaluation publishes
+    ``agent-eval-results`` and ``summary`` and produces trials rather than rows. Sharing a base to
+    save the polling duplication would put :meth:`EvaluatorJobResource.get_result` on this class,
+    where it would fetch row-score routes an agent job never writes — a method whose type says
+    "results" and whose behaviour is a 404. The duplication is the cheaper mistake while the two
+    shapes are still settling.
+
+    **No ``get_result`` yet.** Reading the trial bundle back means downloading and parsing this
+    job's artifacts, which nothing does today, and the name ``AgentEvalResult`` is already taken by
+    two different types — the persisted API record and the SDK's trials-and-scores bundle. That
+    distinction deserves its own change rather than being settled as a side effect of submission.
+    Until then, the persisted record is queryable::
+
+        evaluator.agent_eval_results.list(job_id=job.name)
+
+    **No ``download_artifacts`` either**, for the same reason: the row job publishes an ``artifacts``
+    result and this one does not — it saves ``agent-eval-results`` and ``summary``. Offering the
+    row job's downloader here would 404. What remains is status and polling, which the platform
+    serves per job regardless of what produced it.
+    """
+
+    def __init__(
+        self,
+        *,
+        job: AgentEvaluatorJob,
+        http_client: httpx.Client,
+        base_url: str,
+        workspace: str,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        """Store the job identity and HTTP client used for status calls."""
+        self._job = job
+        self._http_client = http_client
+        self._base_url = http_utils.base_url(base_url)
+        self._workspace = workspace
+        self._headers = dict(headers or {})
+        self._job_base_url = http_utils.job_route_base_url(
+            raw_base_url=self._base_url,
+            workspace=self._workspace,
+            job_name=self.name,
+        )
+
+    @property
+    def name(self) -> str:
+        """Return the agent-evaluation job name."""
+        return self._job.name
+
+    @property
+    def job(self) -> AgentEvaluatorJob:
+        """Return the raw job payload captured at resource creation."""
+        return self._job
+
+    def get_job_status(self) -> PlatformJobStatusResponse:
+        """Fetch the current job status from the evaluator plugin API."""
+        response = self._http_client.get(
+            http_utils.job_route_resource_url(job_base_url=self._job_base_url, resource_path=_RES_STATUS),
+            headers=self._headers,
+        )
+        response.raise_for_status()
+        return PlatformJobStatusResponse.model_validate(response.json())
+
+    def check_if_complete(self, *, raise_if_not_complete: bool = False) -> bool:
+        """Return whether the job has completed.
+
+        Args:
+            raise_if_not_complete: When true, raise ``RuntimeError`` for any status other than
+                ``completed``.
+
+        Returns:
+            ``True`` only when the current status is ``completed``.
+        """
+        return _status_is_complete(self.get_job_status(), raise_if_not_complete)
+
+    def wait_until_done(
+        self,
+        *,
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+        job_timeout_seconds: float = _DEFAULT_JOB_TIMEOUT_SECONDS,
+        pending_timeout_seconds: float = _DEFAULT_PENDING_TIMEOUT_SECONDS,
+    ) -> None:
+        """Block until the job reaches a terminal platform status.
+
+        Raises:
+            RuntimeError: If the job reaches a terminal failure status.
+            TimeoutError: If polling exceeds configured timeouts.
+        """
+        status = _poll_until_terminal(
+            self.get_job_status,
+            job_name=self.name,
+            timeout=job_timeout_seconds,
+            pending_timeout=pending_timeout_seconds,
+            poll_interval=poll_interval_seconds,
+        )
+        _raise_for_terminal_status(status)
 
 
 class EvaluatorJobResource:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import Any, overload
 from urllib.parse import quote
 
+from nemo_evaluator.api.schemas import TasksetRef
 from nemo_evaluator.sdk import http_utils
 from nemo_evaluator.sdk._executor import (
     SubmitTargetSpec,
@@ -15,6 +16,7 @@ from nemo_evaluator.sdk._executor import (
     _SyncEvaluatorPluginExecutor,
 )
 from nemo_evaluator.sdk.job_resources import (
+    AgentEvaluatorJobResource,
     AsyncEvaluatorJobResource,
     EvaluatorJob,
     EvaluatorJobResource,
@@ -45,6 +47,7 @@ from nemo_evaluator.sdk.types import (
 )
 from nemo_evaluator.shared.metric_bundles.bundles import MetricBundlePackager
 from nemo_evaluator.shared.metric_bundles.defaults import resolve_default_metric_bundle_packager
+from nemo_evaluator_sdk.agent_eval.trials import AgentTaskRunner
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.values import (
     Agent,
@@ -140,18 +143,61 @@ class Evaluator:
         metric_bundle_packager: MetricBundlePackager | None = None,
     ) -> EvaluatorJobResource: ...
 
+    @overload
     def submit(
         self,
         *,
-        metric: Metric,
-        dataset: PluginDatasetInput,
+        tasks: TasksetRef,
+        target: AgentTaskRunner,
+        metric: None = None,
+        dataset: None = None,
+    ) -> AgentEvaluatorJobResource: ...
+
+    def submit(
+        self,
+        *,
+        metric: Metric | None = None,
+        dataset: PluginDatasetInput | None = None,
+        tasks: TasksetRef | None = None,
         config: RunConfig | RunConfigOnline | RunConfigOnlineModel | None = None,
-        target: SubmitTargetSpec | None = None,
+        target: SubmitTargetSpec | AgentTaskRunner | None = None,
         field_mapping: FieldMapping | None = None,
         prompt_template: str | dict[str, Any] | None = None,
         metric_bundle_packager: MetricBundlePackager | None = None,
-    ) -> EvaluatorJobResource:
-        """Submit a metric job through the evaluator plugin executor."""
+    ) -> EvaluatorJobResource | AgentEvaluatorJobResource:
+        """Submit an evaluation job through the evaluator plugin executor.
+
+        Two shapes, discriminated by what you supply: ``metric`` + ``dataset`` evaluates rows, and
+        ``tasks`` + ``target`` evaluates a stored taskset with a live agent runner. They are one
+        method because they are one concept — the split is a property of how the work is described
+        today, not of what the caller is asking for.
+        """
+        if tasks is not None:
+            if metric is not None or dataset is not None:
+                raise TypeError(
+                    "submit() takes either `tasks` (a taskset evaluation) or `metric` + `dataset` "
+                    "(a row evaluation), not both. Drop whichever does not describe this run."
+                )
+            if not isinstance(target, AgentTaskRunner):
+                raise TypeError(
+                    "submit(tasks=...) evaluates a taskset with an agent runner, so `target` must be "
+                    f"an AgentTaskRunner; got {type(target).__name__}. Pass a runner such as "
+                    "GymAgentTaskRunner(config=...)."
+                )
+            return self._executor.submit_agent_eval(tasks=tasks, target=target)
+        if metric is None or dataset is None:
+            raise TypeError(
+                "submit() needs either `tasks` + `target` for a taskset evaluation, or `metric` + "
+                "`dataset` for a row evaluation; neither was supplied."
+            )
+        if isinstance(target, AgentTaskRunner):
+            # The mirror of the check above: a runner is only meaningful for a taskset evaluation,
+            # so this is a caller who meant to pass `tasks` and passed a dataset instead. Reaching
+            # the row path with it would fail much deeper, describing the runner as a model endpoint.
+            raise TypeError(
+                f"{type(target).__name__} is an agent runner, which runs a taskset rather than "
+                "rows. Pass `tasks=TasksetRef(...)` instead of `metric` + `dataset`."
+            )
         return self._executor.submit(
             metric=metric,
             dataset=dataset,

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
@@ -149,8 +149,6 @@ class Evaluator:
         *,
         tasks: TasksetRef,
         target: AgentTaskRunner,
-        metric: None = None,
-        dataset: None = None,
     ) -> AgentEvaluatorJobResource: ...
 
     def submit(

--- a/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/sdk/resources.py
@@ -184,6 +184,21 @@ class Evaluator:
                     f"an AgentTaskRunner; got {type(target).__name__}. Pass a runner such as "
                     "GymAgentTaskRunner(config=...)."
                 )
+            # Everything below configures a *row* evaluation. The taskset path cannot honour any of
+            # it, so accepting it silently would run a job that ignores what the caller asked for.
+            row_only = {
+                "config": config,
+                "field_mapping": field_mapping,
+                "prompt_template": prompt_template,
+                "metric_bundle_packager": metric_bundle_packager,
+            }
+            supplied = sorted(name for name, value in row_only.items() if value is not None)
+            if supplied:
+                raise TypeError(
+                    f"submit(tasks=...) does not use {', '.join(supplied)} — those configure a row "
+                    "evaluation. A taskset evaluation is configured by the runner passed as "
+                    "`target`, so supplying them here would have no effect."
+                )
             return self._executor.submit_agent_eval(tasks=tasks, target=target)
         if metric is None or dataset is None:
             raise TypeError(

--- a/plugins/nemo-evaluator/tests/integration/conftest.py
+++ b/plugins/nemo-evaluator/tests/integration/conftest.py
@@ -31,7 +31,7 @@ REPO_ROOT = Path(__file__).resolve().parents[4]
 #: IGW mock-provider prefix, and the env var the in-process IGW config reads it from. Applied to
 #: *this* (test) process via the ``_igw_mock_prefix`` fixture (not at import) so it never leaks into
 #: unrelated unit suites that merely collect this conftest; passed to the platform subprocess via
-#: each fixture's ``hydra_params``.
+#: each fixture's ``env_vars``.
 MOCK_PROVIDER_PREFIX = "igw-mock-"
 MOCK_PROVIDER_PREFIX_ENVVAR = "NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX"
 CLICKHOUSE_XDIST_GROUP = "nmp_intake_clickhouse"
@@ -94,7 +94,7 @@ def running_platform(
     *,
     run_args: list[str],
     base_url: str,
-    hydra_params: dict[str, str] | None = None,
+    env_vars: dict[str, str] | None = None,
     ready_timeout: float = 180.0,
 ) -> Iterator[str]:
     """Run ``nemo services run`` bound to ``base_url``'s port, yield the URL, then tear it down.
@@ -112,7 +112,7 @@ def running_platform(
     process = subprocess.Popen(
         ["uv", "run", "nemo", "services", "run", *run_args, "--port", str(port)],
         cwd=REPO_ROOT,
-        env={**os.environ, "NMP_BASE_URL": base_url, **(hydra_params or {})},
+        env={**os.environ, "NMP_BASE_URL": base_url, **(env_vars or {})},
     )
     try:
         _wait_for_ready(base_url, timeout=ready_timeout, process=process)
@@ -138,7 +138,7 @@ def _igw_mock_prefix() -> Iterator[None]:
     var: the override is honored ahead of the cached/env config, so it works regardless of when the
     IGW config was first read, whereas a whole-repo run can read and cache that config before any
     plugin-local hook fires. The platform *subprocess* gets the same prefix via each fixture's
-    ``hydra_params``.
+    ``env_vars``.
     """
     with igw_mock_provider_mode(MOCK_PROVIDER_PREFIX):
         yield
@@ -186,6 +186,16 @@ def _materialize_subprocess_config(work_root: Path, *, base_url: str, auth_enabl
     return config_path
 
 
+#: The platform's entity store defaults to the *developer's* data directory
+#: (``~/.local/share/nemo/nmp-platform.db``). These fixtures already point file storage at a
+#: per-run temp dir, so leaving the database shared both writes test entities into a real local
+#: platform and breaks reruns: metric bundles are content-addressed, so the second run finds last
+#: run's bundle entity, skips the upload as a duplicate, and then fails to download a blob that
+#: went away with the previous run's temp dir. Pointing NMP_DATA_DIR at the same work root keeps
+#: entities and blobs with the same lifetime.
+DATA_DIR_ENVVAR = "NMP_DATA_DIR"
+
+
 @pytest.fixture(scope="session")
 def subprocess_platform(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     """Session-scoped platform with the subprocess jobs backend + IGW mock-provider mode.
@@ -196,12 +206,14 @@ def subprocess_platform(tmp_path_factory: pytest.TempPathFactory) -> Iterator[st
     or key. Codex-dependent tests gate themselves with ``@requires_codex``; this fixture does not, so
     Model/Agent tests (which need only the running IGW) can use it without codex installed.
     """
-    config_path = _materialize_subprocess_config(tmp_path_factory.mktemp("platform"), base_url=AGENT_PLATFORM_BASE_URL)
+    work_root = tmp_path_factory.mktemp("platform")
+    config_path = _materialize_subprocess_config(work_root, base_url=AGENT_PLATFORM_BASE_URL)
     with running_platform(
         run_args=["--service-group", "all", "--controller-group", "all"],
         base_url=AGENT_PLATFORM_BASE_URL,
-        hydra_params={
+        env_vars={
             "NMP_CONFIG_FILE_PATH": str(config_path),
+            DATA_DIR_ENVVAR: str(work_root / "data"),
             MOCK_PROVIDER_PREFIX_ENVVAR: MOCK_PROVIDER_PREFIX,
         },
     ) as base_url:
@@ -216,14 +228,14 @@ def auth_subprocess_platform(tmp_path_factory: pytest.TempPathFactory) -> Iterat
     authenticates its online IGW inference under auth (no bearer). Test-side calls authenticate as an
     internal service principal (which the default PDP policy grants full permissions).
     """
-    config_path = _materialize_subprocess_config(
-        tmp_path_factory.mktemp("auth-platform"), base_url=AGENT_AUTH_PLATFORM_BASE_URL, auth_enabled=True
-    )
+    work_root = tmp_path_factory.mktemp("auth-platform")
+    config_path = _materialize_subprocess_config(work_root, base_url=AGENT_AUTH_PLATFORM_BASE_URL, auth_enabled=True)
     with running_platform(
         run_args=["--service-group", "all", "--controller-group", "all"],
         base_url=AGENT_AUTH_PLATFORM_BASE_URL,
-        hydra_params={
+        env_vars={
             "NMP_CONFIG_FILE_PATH": str(config_path),
+            DATA_DIR_ENVVAR: str(work_root / "data"),
             MOCK_PROVIDER_PREFIX_ENVVAR: MOCK_PROVIDER_PREFIX,
         },
     ) as base_url:
@@ -283,12 +295,11 @@ def docker_platform(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     """
     if not _docker_available():
         pytest.skip("docker daemon not available")
-    config_path = _materialize_docker_config(
-        tmp_path_factory.mktemp("docker-platform"), base_url=AGENT_DOCKER_PLATFORM_BASE_URL
-    )
+    work_root = tmp_path_factory.mktemp("docker-platform")
+    config_path = _materialize_docker_config(work_root, base_url=AGENT_DOCKER_PLATFORM_BASE_URL)
     with running_platform(
         run_args=["--service-group", "all", "--controller-group", "all"],
         base_url=AGENT_DOCKER_PLATFORM_BASE_URL,
-        hydra_params={"NMP_CONFIG_FILE_PATH": str(config_path)},
+        env_vars={"NMP_CONFIG_FILE_PATH": str(config_path), DATA_DIR_ENVVAR: str(work_root / "data")},
     ) as base_url:
         yield base_url

--- a/plugins/nemo-evaluator/tests/integration/test_submit_gym_agent_eval.py
+++ b/plugins/nemo-evaluator/tests/integration/test_submit_gym_agent_eval.py
@@ -135,6 +135,14 @@ def test_a_live_gym_runner_submits_and_round_trips_through_the_service(subproces
     )
     assert job.name, "the service returned no job name"
 
+    # The resource's own status route resolves for an agent job. Worth asserting rather than
+    # assuming: `job_route_base_url` builds the status path from `/evaluate/jobs` while agent jobs
+    # live under `/agent-evaluate/jobs`, and a review round questioned whether that 404s. It does
+    # not — the status lookup ignores the collection prefix — but nothing else covers it, since the
+    # execution path polls through `nmp.testing` rather than this resource.
+    status = job.get_job_status()
+    assert status.status, f"the agent job's status route returned no status: {status!r}"
+
     # Read back over the wire rather than trusting the submit response, so what is asserted is what
     # the service *stored*. Fetched with a plain GET because ``evaluator.get_job_resource`` is the
     # row-evaluation reader — it validates the job's spec as an ``EvaluateSpec``, which an agent

--- a/plugins/nemo-evaluator/tests/integration/test_submit_gym_agent_eval.py
+++ b/plugins/nemo-evaluator/tests/integration/test_submit_gym_agent_eval.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Submitting a Gym runner as an agent-evaluation job, against a live platform.
+
+Covers the seam the unit tests deliberately stub: that a live ``GymAgentTaskRunner`` survives
+description as a target spec, transport to the service, and persistence — so what comes back out is
+the evaluation that was configured going in.
+
+**Scope is submission, not execution.** Running a Gym eval additionally needs the ``gym`` CLI on the
+job's PATH and tasks carrying ``gym_dataset_path`` metadata from ``discover_gym_tasks``; neither is
+a property of the submit path, and asserting on them here would make this test fail for reasons that
+have nothing to do with what it covers. The job is therefore submitted and its stored spec inspected,
+not run to completion.
+
+Run directly::
+
+    RUN_AGENT_EVAL_INTEGRATION=1 uv run pytest \\
+        plugins/nemo-evaluator/tests/integration/test_submit_gym_agent_eval.py -v
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+
+import cloudpickle
+import httpx
+import pytest
+from nemo_evaluator.api.schemas import (
+    EvaluatorTaskDefinition,
+    MetricInline,
+    TaskInput,
+    TaskInputs,
+    TaskRef,
+    TasksetInput,
+    TasksetRef,
+)
+from nemo_evaluator.sdk.job_resources import AgentEvaluatorJobResource
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.agent_eval.runtimes.gym import GymAgentTaskRunner, GymRuntimeConfig
+from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
+from nemo_platform import NeMoPlatform
+
+WORKSPACE = "default"
+
+#: Opt-in: shares the evaluator-plugin integration opt-in (spins a real ``nemo services`` platform).
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.environ.get("RUN_AGENT_EVAL_INTEGRATION"),
+        reason="opt-in; set RUN_AGENT_EVAL_INTEGRATION=1 to run (spins real nemo services platforms)",
+    ),
+]
+
+
+# Pickle metrics defined in this module BY VALUE, so the bundle embeds the class itself: the service
+# resolves the taskset in its own process, which cannot import this test module.
+cloudpickle.register_pickle_by_value(sys.modules[__name__])
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+class _AlwaysOneMetric:
+    """A trivial metric so the stored task is valid. Never scored — this test never runs the job."""
+
+    @property
+    def type(self) -> str:
+        return "always-one"
+
+    def output_spec(self) -> list[MetricOutputSpec]:
+        return [MetricOutputSpec.continuous_score("score")]
+
+    async def compute_scores(self, input: MetricInput) -> MetricResult:  # pragma: no cover - never run
+        return MetricResult(outputs=[MetricOutput(name="score", value=1.0)])
+
+
+def _inline_metric() -> MetricInline:
+    """Bundle the metric into the inline wire form a stored task requires."""
+    bundle = bundle_metric(_AlwaysOneMetric(), CloudpickleMetricBundlePackager())
+    return MetricInline.model_validate(bundle.model_dump(mode="json"))
+
+
+def _stored_taskset(client: NeMoPlatform) -> str:
+    """A one-task taskset to reference. Its content is irrelevant — only the reference travels."""
+    task_name = _unique("gym-submit-task")
+    client.evaluator.tasks.create(
+        task_name,
+        task=TaskInput(
+            spec=EvaluatorTaskDefinition(
+                kind="evaluator",
+                intent="Placeholder task; this test asserts on submission, not execution.",
+                inputs=TaskInputs(instruction="unused"),
+                metrics=[_inline_metric()],
+            )
+        ),
+    )
+    taskset_name = _unique("gym-submit-suite")
+    client.evaluator.tasksets.create(
+        taskset_name,
+        taskset=TasksetInput(tasks=[TaskRef(f"{WORKSPACE}/{task_name}")]),
+    )
+    return taskset_name
+
+
+def test_a_live_gym_runner_submits_and_round_trips_through_the_service(subprocess_platform: str) -> None:
+    client = NeMoPlatform(base_url=subprocess_platform, workspace=WORKSPACE, max_retries=2)
+    taskset_name = _stored_taskset(client)
+
+    # Non-default values throughout: a field dropped anywhere along runner -> target -> wire ->
+    # storage would come back as its default, which is exactly the silent divergence this path
+    # exists to prevent.
+    runner = GymAgentTaskRunner(
+        config=GymRuntimeConfig(
+            agent="simple_agent",
+            agent_config="responses_api_agents/simple_agent/configs/simple_agent.yaml",
+            resources_server="mcqa",
+            bind_resources_server=False,
+            num_repeats=3,
+            concurrency=7,
+            hydra_params={"simple_agent": {"responses_api_agents": {"x": 1}}},
+            env_vars={"WMT_TRANSLATION_COMET_PY_CACHE": "/shared/cache"},
+            reward_key="score",
+        )
+    )
+
+    job = client.evaluator.submit(tasks=TasksetRef(f"{WORKSPACE}/{taskset_name}"), target=runner)
+
+    assert isinstance(job, AgentEvaluatorJobResource), (
+        "a taskset submission must return the agent job resource, not the row-evaluation one"
+    )
+    assert job.name, "the service returned no job name"
+
+    # Read back over the wire rather than trusting the submit response, so what is asserted is what
+    # the service *stored*. Fetched with a plain GET because ``evaluator.get_job_resource`` is the
+    # row-evaluation reader — it validates the job's spec as an ``EvaluateSpec``, which an agent
+    # job's spec is not. An agent-job reader is worth having; it is not part of submission.
+    fetched = httpx.get(
+        f"{subprocess_platform}/apis/evaluator/v2/workspaces/{WORKSPACE}/agent-evaluate/jobs/{job.name}",
+        timeout=30,
+    )
+    assert fetched.status_code == 200, fetched.text
+    target = fetched.json()["spec"]["target"]
+
+    # The target survived as a Gym target carrying the runner's own settings, rather than defaults
+    # or a different kind.
+    assert target["kind"] == "gym"
+    assert target["resources_server"] == "mcqa"
+    assert target["num_repeats"] == 3
+    assert target["concurrency"] == 7
+    assert target["reward_key"] == "score"
+    assert target["bind_resources_server"] is False
+    assert target["hydra_params"] == {"simple_agent": {"responses_api_agents": {"x": 1}}}
+    assert target["env_vars"] == {"WMT_TRANSLATION_COMET_PY_CACHE": "/shared/cache"}

--- a/plugins/nemo-evaluator/tests/test_runner_targets.py
+++ b/plugins/nemo-evaluator/tests/test_runner_targets.py
@@ -82,6 +82,31 @@ def test_the_config_read_back_is_the_one_the_runner_holds() -> None:
     assert target.env_vars["OPENAI_API_KEY"] == "sk-real-value"
 
 
+def test_configuration_with_no_json_form_is_refused_rather_than_failing_at_submit() -> None:
+    """`hydra_params` and `env_vars` are typed loosely enough to hold anything.
+
+    A callable survives `GymRuntimeConfig` construction and only fails inside
+    `model_dump(mode="json")` when the spec is posted — a `PydanticSerializationError` raised from
+    the transport, naming neither the runner nor the field. This module promises to refuse what
+    cannot travel, so the refusal has to happen here.
+    """
+    runner = GymAgentTaskRunner(
+        config=GymRuntimeConfig(
+            agent="a",
+            agent_config="c",
+            resources_server="r",
+            hydra_params={"callback": lambda value: value},
+        )
+    )
+
+    with pytest.raises(UnsubmittableRunnerError) as excinfo:
+        runner_to_target(runner)
+
+    message = str(excinfo.value)
+    assert "JSON" in message, "the message should say what is wrong with the value"
+    assert "hydra_params" in message, "and name the fields that are free-form"
+
+
 def test_an_unsupported_runner_is_refused_by_name() -> None:
     # Only Gym has a target today. A runner with no wire form must say so rather than produce a
     # spec that silently runs something else.

--- a/plugins/nemo-evaluator/tests/test_runner_targets.py
+++ b/plugins/nemo-evaluator/tests/test_runner_targets.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Describing a live runner as the target spec that reproduces it as a job."""
+
+from __future__ import annotations
+
+import pytest
+from nemo_evaluator.jobs.agent_spec import GymRunnerTarget
+from nemo_evaluator.jobs.runner_targets import UnsubmittableRunnerError, runner_to_target
+from nemo_evaluator_sdk.agent_eval.runtimes.gym import GymAgentTaskRunner, GymRuntimeConfig
+
+
+def _configured() -> GymRuntimeConfig:
+    """A config with every field set away from its default.
+
+    Defaults would let a dropped field pass by coincidence — the target would carry the same value
+    the runner had, for the wrong reason.
+    """
+    return GymRuntimeConfig(
+        agent="simple_agent",
+        agent_config="responses_api_agents/simple_agent/configs/simple_agent.yaml",
+        resources_server="gdpval",
+        model_type="openai_model",
+        bind_resources_server=False,
+        hydra_params={"simple_agent": {"responses_api_agents": {"x": 1}}},
+        env_vars={"WMT_TRANSLATION_COMET_PY_CACHE": "/shared/cache"},
+        num_repeats=3,
+        concurrency=7,
+        startup_timeout_s=1800.0,
+        collection_timeout_s=3600.0,
+        shutdown_grace_s=45.0,
+        reward_key="score",
+    )
+
+
+def test_a_gym_runner_describes_itself_as_a_submittable_target() -> None:
+    # The point of the conversion: an evaluation someone got working locally becomes a job spec
+    # without retyping its configuration — which is where the subtle divergences come from.
+    config = _configured()
+
+    target = runner_to_target(GymAgentTaskRunner(config=config))
+
+    assert isinstance(target, GymRunnerTarget)
+    assert target.kind == "gym"
+    # Every field arrives, unchanged. `kind` is the only addition — it discriminates the union and
+    # has no runtime counterpart.
+    assert target.model_dump(exclude={"kind"}) == config.model_dump()
+
+
+def test_every_field_actually_travels_rather_than_defaulting() -> None:
+    # Guards the failure this conversion exists to prevent: a field silently dropped, so the
+    # submitted job runs something different from what was tested. Asserting values differ from
+    # their defaults is what makes the round-trip above meaningful.
+    config = _configured()
+    defaults = {
+        name: field.get_default(call_default_factory=True) for name, field in GymRuntimeConfig.model_fields.items()
+    }
+    carried = runner_to_target(GymAgentTaskRunner(config=config)).model_dump(exclude={"kind"})
+
+    indistinguishable = [name for name, value in carried.items() if value == defaults.get(name)]
+    assert not indistinguishable, (
+        f"these fields match their defaults, so carrying them is untested: {indistinguishable}"
+    )
+
+
+def test_the_config_read_back_is_the_one_the_runner_holds() -> None:
+    # The conversion reads `runner.config`, not `runner_info()`, because the latter redacts
+    # credential-shaped values — rebuilding from it would submit `<redacted>` as a real setting.
+    config = GymRuntimeConfig(
+        agent="a",
+        agent_config="c",
+        resources_server="r",
+        env_vars={"OPENAI_API_KEY": "sk-real-value", "HTTPS_PROXY": "http://proxy:8080"},
+    )
+    runner = GymAgentTaskRunner(config=config)
+
+    target = runner_to_target(runner)
+
+    assert runner.runner_info().config["env_vars"]["OPENAI_API_KEY"] == "<redacted>"
+    assert isinstance(target, GymRunnerTarget)
+    assert target.env_vars["OPENAI_API_KEY"] == "sk-real-value"
+
+
+def test_an_unsupported_runner_is_refused_by_name() -> None:
+    # Only Gym has a target today. A runner with no wire form must say so rather than produce a
+    # spec that silently runs something else.
+    class _Unsupported:
+        def runner_info(self):  # pragma: no cover - never reached
+            raise NotImplementedError
+
+        async def run_tasks(self, tasks, config=None):  # pragma: no cover - never reached
+            return []
+
+    with pytest.raises(UnsubmittableRunnerError) as excinfo:
+        runner_to_target(_Unsupported())
+
+    message = str(excinfo.value)
+    assert "_Unsupported" in message, "the message must name the runner that could not be converted"
+    # Points at the alternative rather than dead-ending.
+    assert "AgentEvaluator()" in message

--- a/plugins/nemo-evaluator/tests/test_submit_agent_eval.py
+++ b/plugins/nemo-evaluator/tests/test_submit_agent_eval.py
@@ -97,7 +97,8 @@ def test_supplying_both_shapes_is_refused_rather_than_silently_preferring_one() 
     evaluator, _ = _evaluator()
 
     with pytest.raises(TypeError) as excinfo:
-        evaluator.submit(tasks=TasksetRef("ts"), metric=MagicMock(), dataset=MagicMock(), target=_runner())
+        # Rejected statically too; the runtime guard is for callers without a type checker.
+        evaluator.submit(tasks=TasksetRef("ts"), metric=MagicMock(), dataset=MagicMock(), target=_runner())  # ty: ignore[no-matching-overload]
 
     assert "not both" in str(excinfo.value)
 

--- a/plugins/nemo-evaluator/tests/test_submit_agent_eval.py
+++ b/plugins/nemo-evaluator/tests/test_submit_agent_eval.py
@@ -71,6 +71,27 @@ def test_a_runner_passed_to_the_row_path_is_refused_rather_than_sent_as_an_endpo
     executor.submit.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "option",
+    ["config", "field_mapping", "prompt_template", "metric_bundle_packager"],
+)
+def test_row_only_options_are_refused_rather_than_silently_dropped(option: str) -> None:
+    """A taskset evaluation is configured by its runner, so these four have nowhere to go.
+
+    Accepting them silently would submit a job that ignores what the caller supplied — the failure
+    mode is a run that looks fine and used none of the requested configuration.
+    """
+    evaluator, executor = _evaluator()
+
+    with pytest.raises(TypeError) as excinfo:
+        evaluator.submit(tasks=TasksetRef("ts"), target=_runner(), **{option: MagicMock()})
+
+    message = str(excinfo.value)
+    assert option in message, "the message should name the option that cannot be honoured"
+    assert "target" in message, "and point at what does configure a taskset run"
+    executor.submit_agent_eval.assert_not_called()
+
+
 def test_supplying_both_shapes_is_refused_rather_than_silently_preferring_one() -> None:
     # Picking one for the caller would run an evaluation they did not ask for. Better to stop.
     evaluator, _ = _evaluator()

--- a/plugins/nemo-evaluator/tests/test_submit_agent_eval.py
+++ b/plugins/nemo-evaluator/tests/test_submit_agent_eval.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Submitting a taskset evaluation with a live agent runner, through ``Evaluator.submit``."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from nemo_evaluator.api.fields import TasksetRef
+from nemo_evaluator.sdk.resources import Evaluator
+from nemo_evaluator_sdk.agent_eval.runtimes.gym import GymAgentTaskRunner, GymRuntimeConfig
+
+
+def _evaluator() -> tuple[Evaluator, MagicMock]:
+    """An Evaluator with its executor stubbed — these tests are about dispatch, not transport."""
+    evaluator = Evaluator.__new__(Evaluator)
+    executor = MagicMock()
+    evaluator._executor = executor
+    return evaluator, executor
+
+
+def _runner() -> GymAgentTaskRunner:
+    return GymAgentTaskRunner(
+        config=GymRuntimeConfig(agent="simple_agent", agent_config="c.yaml", resources_server="mcqa", num_repeats=3)
+    )
+
+
+def test_a_taskset_and_a_live_runner_route_to_the_agent_eval_path() -> None:
+    # The shape this change exists for: what you ran locally with AgentEvaluator() becomes a job,
+    # with the runner carried through rather than described again by hand.
+    evaluator, executor = _evaluator()
+    runner = _runner()
+
+    evaluator.submit(tasks=TasksetRef("my-taskset"), target=runner)
+
+    kwargs = executor.submit_agent_eval.call_args.kwargs
+    assert kwargs["target"] is runner, "the live runner must reach the executor, not a copy of it"
+    assert kwargs["tasks"].root == "my-taskset"
+    # ...and the row path is not also taken.
+    executor.submit.assert_not_called()
+
+
+def test_the_row_path_is_untouched_by_the_new_overload() -> None:
+    # The overload adds a shape; it must not change the existing one. A regression here would break
+    # every caller that predates taskset evaluation.
+    evaluator, executor = _evaluator()
+
+    # An explicit packager: a MagicMock metric is not a built-in, and the real resolver refuses to
+    # guess a bundling policy for one. That rejection is the row path working, not a test problem.
+    evaluator.submit(metric=MagicMock(), dataset=MagicMock(), metric_bundle_packager=MagicMock())
+
+    executor.submit.assert_called_once()
+    executor.submit_agent_eval.assert_not_called()
+
+
+def test_a_runner_passed_to_the_row_path_is_refused_rather_than_sent_as_an_endpoint() -> None:
+    # The likely mistake once both shapes exist: reaching for a runner while still describing the
+    # work as rows. Without this, the runner would travel the row path and be described as a model
+    # endpoint, failing somewhere far from the call that got it wrong.
+    evaluator, executor = _evaluator()
+
+    with pytest.raises(TypeError) as excinfo:
+        # Rejected statically too — the runtime guard is for callers without a type checker.
+        evaluator.submit(metric=MagicMock(), dataset=MagicMock(), target=_runner())  # ty: ignore[invalid-argument-type]
+
+    message = str(excinfo.value)
+    assert "GymAgentTaskRunner" in message
+    assert "tasks=" in message, "the message should name the shape that does accept a runner"
+    executor.submit.assert_not_called()
+
+
+def test_supplying_both_shapes_is_refused_rather_than_silently_preferring_one() -> None:
+    # Picking one for the caller would run an evaluation they did not ask for. Better to stop.
+    evaluator, _ = _evaluator()
+
+    with pytest.raises(TypeError) as excinfo:
+        evaluator.submit(tasks=TasksetRef("ts"), metric=MagicMock(), dataset=MagicMock(), target=_runner())
+
+    assert "not both" in str(excinfo.value)
+
+
+def test_supplying_neither_shape_says_what_was_expected() -> None:
+    # The failure mode of an overloaded entry point is a confusing error deep inside spec
+    # construction. This one names both shapes at the boundary.
+    evaluator, _ = _evaluator()
+
+    with pytest.raises(TypeError) as excinfo:
+        evaluator.submit()  # ty: ignore[no-matching-overload]
+
+    message = str(excinfo.value)
+    assert "tasks" in message and "metric" in message
+
+
+def test_a_taskset_submitted_with_a_non_runner_target_is_refused_by_type() -> None:
+    # `target` is overloaded across the two shapes: a Model/Agent for rows, a runner for tasksets.
+    # Passing the wrong one is easy, so the error names the type given and what to pass instead.
+    evaluator, _ = _evaluator()
+
+    with pytest.raises(TypeError) as excinfo:
+        evaluator.submit(tasks=TasksetRef("ts"), target="gpt-5")  # ty: ignore[invalid-argument-type]
+
+    message = str(excinfo.value)
+    assert "AgentTaskRunner" in message
+    assert "str" in message, "the message should name the type actually supplied"
+    assert "GymAgentTaskRunner" in message, "and point at a concrete runner to use"
+
+
+def test_the_agent_job_resource_does_not_offer_row_evaluation_readers() -> None:
+    """The reason this resource is separate rather than shared.
+
+    A row evaluation publishes ``aggregate-scores``, ``row-scores`` and ``artifacts`` results; an
+    agent evaluation publishes ``agent-eval-results`` and ``summary``. Inheriting the row job's
+    readers would put methods here whose type says "results" and whose behaviour is a 404 against
+    routes this job never writes. Status and polling are shared because the platform serves those
+    per job, regardless of what produced it.
+    """
+    from nemo_evaluator.sdk.job_resources import AgentEvaluatorJobResource, EvaluatorJobResource
+
+    agent_surface = {name for name in vars(AgentEvaluatorJobResource) if not name.startswith("_")}
+
+    assert {"get_job_status", "check_if_complete", "wait_until_done", "name", "job"} <= agent_surface
+    # Absent on purpose — see the class docstring. If either is added, it must target this job's own
+    # artifacts rather than the row job's.
+    assert "get_result" not in agent_surface
+    assert "download_artifacts" not in agent_surface
+    # And it is not related to the row resource by inheritance in either direction.
+    assert not issubclass(AgentEvaluatorJobResource, EvaluatorJobResource)
+    assert not issubclass(EvaluatorJobResource, AgentEvaluatorJobResource)

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/gym/runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/gym/runtime.py
@@ -67,6 +67,20 @@ class GymAgentTaskRunner:
         self._config = config
         self._run_aggregations: dict[str, Any] | None = None
 
+    @property
+    def config(self) -> GymRuntimeConfig:
+        """The settings this runner was constructed with.
+
+        Read-only, and the whole config rather than a property per field: unlike the Codex and
+        Fabric runtimes, everything shaping a Gym run already lives in one validated object.
+
+        Exposed so a live runner can be described as the job-spec target that reproduces it, without
+        reaching into a private attribute from another package. ``runner_info()`` cannot serve that
+        purpose — it redacts credential-shaped values, so what it returns is provenance to read, not
+        configuration to rebuild from.
+        """
+        return self._config
+
     def run_aggregate_scores(self) -> Sequence[AggregateScore]:
         """Gym's ``agent_metrics`` mapped onto typed aggregate scores, namespaced ``runner.gym.<metric>``.
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

An evaluation someone got working locally with `AgentEvaluator()` can now be submitted as a governed job, without retyping its configuration into a target spec and getting it subtly wrong. Before, a live `GymAgentTaskRunner` could only run in-process; there was no supported way to hand one to the platform. After, `evaluator.submit(tasks=TasksetRef("default/my-suite"), target=runner)` derives the target spec from the runner and the job runs the same evaluation.

## Related Issue

Tracked by AALGO-485 (no GitHub issue).

## Changes

- **`runner_to_target`** (`jobs/runner_targets.py`): describes a live `GymAgentTaskRunner` as the `GymRunnerTarget` that reproduces it job-side. Raises `UnsubmittableRunnerError` for runners with no wire form rather than silently submitting something other than what was tested. Gym only; the other runners each need their own decisions about what survives translation and are deliberately not guessed at.
- **`Evaluator.submit()` overload**: a fourth shape discriminated by `tasks`. Supplying both shapes, neither, or a non-runner `target` each raise a distinct `TypeError` at the boundary. A runner passed to the row path is also refused, rather than travelling on to be described as a model endpoint.
- **`AgentEvaluatorJobResource` / `AgentEvaluatorJob`**: agent jobs get their own resource and job model. Deliberately unrelated to `EvaluatorJobResource` by inheritance in either direction — a row evaluation publishes `aggregate-scores`/`row-scores`, an agent evaluation publishes `agent-eval-results`/`summary`, so a shared base would put readers here whose type says "results" and whose behaviour is a 404. `AgentEvaluatorJob` is `BaseJob[AgentEvalSpec]`; validating an agent job's response as `EvaluateSpec` failed on every field of the spec.
- **Integration fixtures isolate their entity store** (`NMP_DATA_DIR`) alongside their file storage. They already pointed file storage at a per-run temp dir but left the database on the developer's real platform (`~/.local/share/nemo/nmp-platform.db`), which both wrote test entities into a live local install and broke reruns: metric bundles are content-addressed, so a second run found the first run's bundle entity, skipped the upload as a duplicate, then failed to download a blob that went away with the old temp dir.

## Relationship to #1315 / #1366

Scoped to avoid overlap with @JashG's Gym work:

- **Task-schema widening is not here.** #1315 widens `TaskInputs` so `gym_row` can move from `metadata` into `inputs`. An earlier revision of this PR carried its own version of that change; it has been dropped so the widening lands once, in #1315.
- **Gym *execution* coverage is not here.** #1315 runs a real `mcqa` evaluation to completion in CI on Kind with a dedicated task image (#1366). An earlier revision of this PR carried a local-only execution test that skipped unless the `gym` CLI was on `PATH`; #1315's CI job supersedes it, so it was removed.
- **What remains is the submit path**, which neither of those PRs touches: #1315 posts inline task dicts with a hand-constructed `GymRunnerTarget`, whereas this PR derives the target from a live runner and resolves a stored taskset reference.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the new surface is documented in module and class docstrings; no user-facing docs page covers taskset submission yet.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
| --- | --- |
| `uv run --frozen pytest plugins/nemo-evaluator/tests --ignore=.../integration` | 848 passed |
| `uv run --frozen pytest packages/nemo_evaluator_sdk/tests` | 1592 passed, 10 skipped |
| `RUN_AGENT_EVAL_INTEGRATION=1 pytest .../integration/{test_evaluate_job,test_metric_filtering,test_docs_manage_tasks_tasksets,test_task_revisions,test_submit_gym_agent_eval}.py` | 17 passed (live platform) |
| `uv run ruff check plugins/nemo-evaluator packages/nemo_evaluator_sdk` | passed |
| `uv run ruff format --check plugins/nemo-evaluator` | passed |
| `uv run --frozen ty check plugins/nemo-evaluator` | no diagnostics on changed files |

**`uv run pre-commit run -a` is not fully green, and neither failure is caused by this branch:**

1. `Run UI lint-staged` fails with `mise ERROR No version is set for shim: pnpm` — Studio tooling is not bootstrapped in this worktree.
2. The license-header hook rewrites **42 files this branch does not touch** (e2e configs, `skills/**`, other plugins' `openapi.yaml`, both `pnpm-lock.yaml`). `main` is missing those headers too, so this is pre-existing repo-wide drift that `-a` surfaces and a normal staged commit does not. Those edits were reverted rather than swept into this PR.

**No SDK regeneration is needed.** `make update-sdk` was run against Stainless and produced no model changes — this PR's surface is not part of the generated SDK. Its only effect was stripping SPDX headers from 33 vendored files (the post-generation license step covers Python files only), so that was reverted. The one vendored change kept is the `GymRuntimeConfig` accessor this PR adds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for submitting taskset-based agent evaluations through the synchronous evaluator SDK.
  - Added job resources for tracking agent-evaluation status, completion, and terminal outcomes.
  - Preserved Gym agent runner settings when creating evaluation jobs.

- **Bug Fixes**
  - Prevented invalid mixing of row-evaluation and agent-evaluation inputs.
  - Added clear validation for unsupported runners and non-serializable configuration values.

- **Tests**
  - Added coverage for submission workflows, configuration preservation, status tracking, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->