### PR TITLE
fix(studio): remove stroke-width override on .lucide icons

### DIFF
--- a/web/packages/studio/src/index.css
+++ b/web/packages/studio/src/index.css
@@ -50,7 +50,6 @@ body {
   .lucide {
     width: 16px;
     height: 16px;
-    stroke-width: 1;
   }
 
   .lucide * {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Removes the `stroke-width: 1` override on `.lucide` icons in `web/packages/studio/src/index.css`. Icons now fall back to lucide-react's native default stroke width of 2. 

|Before|After|
|---|---|
|<img width="444" height="339" alt="icons_before" src="https://github.com/user-attachments/assets/31991fed-df8c-4280-a241-3129b3153f31" />|<img width="444" height="339" alt="icons_after" src="https://github.com/user-attachments/assets/82a2623b-d4f5-4e66-abab-460523f1c651" />|



## Changes
- `web/packages/studio/src/index.css`: removed `stroke-width: 1;` from the `.lucide` base rule.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: pure CSS default-value removal (falls back to library default), no existing automated coverage of icon stroke width; verified visually.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs reference icon stroke width.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a`: ran repo-wide; it also rewrote ~44 unrelated files across the tree (license-header/EOF fixers touching files this PR doesn't otherwise change), which is pre-existing repo drift unrelated to this change. Those unrelated rewrites were reverted to keep this PR scoped to the single intended file; the relevant hooks (merge-conflict check, Flox lock check, plugin-import check) passed against the actual diff.
- No test suite exists for `.lucide` CSS stroke width; change verified by inspection of the resulting CSS (icons inherit lucide-react's native `stroke-width: 2` default).
