### PR TITLE
fix(packaging): bundle deployments plugin in nemo-platform all extra

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -229,6 +229,7 @@ nemo-agents-example-calculator = [
 # Generated from [tool.bundle-package]; do not edit by hand.
 nemo-agents-plugin = [
   "nemo-platform-plugin",
+  "nemo-deployments-plugin",
   "nemo-optimization-plugin",
   "nemo-agents-example-calculator",
   "nvidia-nat-core>=1.9.0a20260811,<1.10",
@@ -278,6 +279,16 @@ nemo-data-designer-plugin = [
   "httpx>=0.27",
   "fastapi",
   "pandas",
+]
+
+# Generated from [tool.bundle-package]; do not edit by hand.
+nemo-deployments-plugin = [
+  "fastapi>=0.115",
+  "httpx>=0.27",
+  "nemo-platform-sdk",
+  "nemo-platform-plugin",
+  "pydantic>=2.10.6",
+  "pyyaml>=6.0",
 ]
 
 # Generated from [tool.bundle-package]; do not edit by hand.
@@ -479,6 +490,7 @@ plugins = [
     "nemo-platform[nemo-anonymizer-plugin]",
     "nemo-platform[nemo-auditor-plugin]",
     "nemo-platform[nemo-data-designer-plugin]",
+    "nemo-platform[nemo-deployments-plugin]",
     "nemo-platform[nemo-eval-author-plugin]",
     "nemo-platform[nemo-evaluator-plugin]",
     "nemo-platform[nemo-experimentalist-plugin]",
@@ -572,6 +584,7 @@ platform = "nmp.common.client_factory:PlatformNemoClientProvider"
 [project.entry-points."nemo.controllers"]
 agents-deployment = "nemo_agents_plugin.runner.controller:AgentDeploymentController"
 insights-analysis = "nemo_insights_plugin.controller:InsightsAnalysisController"
+deployments = "nemo_deployments_plugin.controller:DeploymentsController"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nemo.docs"]
@@ -620,6 +633,10 @@ optuna = "nemo_optimization.backends.optuna.backend:OptunaBackend"
 ga = "nemo_optimization.backends.ga.backend:GaBackend"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
+[project.entry-points."nemo.sandbox_profiles"]
+openshell = "nemo_deployments_plugin.backends.openshell.sandbox_profile:PROFILE"
+
+# Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nemo.sdk"]
 agents = "nemo_agents_plugin.sdk:agents_sdk_resources"
 anonymizer = "nemo_anonymizer_plugin.sdk.resources:anonymizer_sdk_resources"
@@ -646,6 +663,7 @@ auditor = "nemo_auditor.service:AuditorPluginService"
 data-designer = "nemo_data_designer_plugin.service:DataDesignerService"
 evaluator = "nemo_evaluator.service:EvaluatorPluginService"
 insights = "nemo_insights_plugin.service:InsightsService"
+deployments = "nemo_deployments_plugin.service:DeploymentsService"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nemo.skills"]
@@ -659,6 +677,7 @@ platform = "nemo_platform.skills:skills_dir"
 safe-synthesizer = "nemo_safe_synthesizer_plugin.skills:get_skills_path"
 experimentalist = "nemo_experimentalist_plugin.skills:skills_dir"
 insights = "nemo_insights_plugin.skills:skills_dir"
+deployments = "nemo_deployments_plugin.skills:skills_dir"
 [tool.uv.sources]
 nemo-platform-sdk = { workspace = true }
 nemo-platform-ext = { workspace = true }
@@ -710,6 +729,7 @@ nemo-agents-plugin = { source = "../../plugins/nemo-agents/src/nemo_agents_plugi
 nemo-anonymizer-plugin = { source = "../../plugins/nemo-anonymizer/src/nemo_anonymizer_plugin", module = "nemo_anonymizer_plugin", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-auditor-plugin = { source = "../../plugins/nemo-auditor/src/nemo_auditor", module = "nemo_auditor", inherit = { "entry-points" = ["nemo.*"] } }
 nemo-data-designer-plugin = { source = "../../plugins/nemo-data-designer/src/nemo_data_designer_plugin", module = "nemo_data_designer_plugin", inherit = { "entry-points" = ["nemo.*"] } }
+nemo-deployments-plugin = { source = "../../plugins/nemo-deployments/src/nemo_deployments_plugin", module = "nemo_deployments_plugin", inherit = { "entry-points" = ["nemo.*"] } }
 # Eval Author, Experimentalist, and Insights ship together: Experimentalist imports
 # EvalAuthor and EvalAuthorConfig at module scope, Eval Author still borrows
 # Experimentalist helpers, and both read the Insights profile contract. Bundling all

--- a/services/core/models/src/nmp/core/models/controllers/backends/registry.py
+++ b/services/core/models/src/nmp/core/models/controllers/backends/registry.py
@@ -31,8 +31,8 @@ _LAZY_BACKEND_NAMES = frozenset({"deployments_plugin"})
 
 _DEPLOYMENTS_PLUGIN_IMPORT_ERROR = (
     "The deployments_plugin models backend requires the nemo-deployments-plugin "
-    "package. Install it (or include the deployments plugin in your platform "
-    "profile) before setting models.controller.backends.deployments_plugin.enabled."
+    'package. Install the complete platform distribution with `pip install "nemo-platform[all]"` '
+    "before setting models.controller.backends.deployments_plugin.enabled."
 )
 
 

--- a/services/core/models/tests/unit/controllers/test_backend_registry.py
+++ b/services/core/models/tests/unit/controllers/test_backend_registry.py
@@ -182,13 +182,13 @@ def test_deployments_plugin_missing_package_raises_guidance(mock_nmp_sdk):
 
     with (
         patch("builtins.__import__", side_effect=mock_import),
-        pytest.raises(ImportError, match="nemo-deployments-plugin"),
+        pytest.raises(ImportError, match=r'pip install "nemo-platform\[all\]"'),
     ):
         _resolve_backend_class("deployments_plugin", backend_classes)
 
     with (
         patch("builtins.__import__", side_effect=mock_import),
-        pytest.raises(ImportError, match="nemo-deployments-plugin"),
+        pytest.raises(ImportError, match=r'pip install "nemo-platform\[all\]"'),
     ):
         BackendRegistry.from_config(
             nmp_sdk=mock_nmp_sdk,

--- a/tests/unit/test_wrapper_distribution.py
+++ b/tests/unit/test_wrapper_distribution.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the published ``nemo-platform`` wrapper distribution."""
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent.parent
+
+
+def test_all_extra_bundles_default_deployments_backend() -> None:
+    """The backend enabled by the packaged config must ship in ``nemo-platform[all]``."""
+    pyproject_path = ROOT / "packages/nemo_platform/pyproject.toml"
+    with open(pyproject_path, "rb") as pyproject:
+        wrapper = tomllib.load(pyproject)
+
+    project = wrapper["project"]
+    bundle = wrapper["tool"]["bundle-package"]["nemo-deployments-plugin"]
+
+    assert bundle["inherit"]["entry-points"] == ["nemo.*"]
+    assert bundle["module"] == "nemo_deployments_plugin"
+    assert (pyproject_path.parent / bundle["source"]).resolve().is_dir()
+    assert "nemo-platform[services]" in project["optional-dependencies"]["all"]
+    assert "nemo-platform[plugins]" in project["optional-dependencies"]["services"]
+    assert "nemo-platform[nemo-deployments-plugin]" in project["optional-dependencies"]["plugins"]
+    assert "nemo-deployments-plugin" in project["optional-dependencies"]
+    assert project["entry-points"]["nemo.services"]["deployments"].startswith("nemo_deployments_plugin.")
+    assert project["entry-points"]["nemo.controllers"]["deployments"].startswith("nemo_deployments_plugin.")
+    assert project["entry-points"]["nemo.sandbox_profiles"]["openshell"].startswith("nemo_deployments_plugin.")
+    assert project["entry-points"]["nemo.skills"]["deployments"].startswith("nemo_deployments_plugin.")

--- a/uv.lock
+++ b/uv.lock
@@ -4852,6 +4852,7 @@ all = [
     { name = "nemo-agents-example-calculator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-anonymizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-auditor-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-deployments-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-eval-author-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-evaluator-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-experimentalist-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5088,6 +5089,7 @@ nemo-agents-plugin = [
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "langchain-aws", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-agents-example-calculator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-deployments-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-fabric", extra = ["claude", "codex", "deepagents", "relay"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-fabric-adapters-hermes", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-optimization-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5126,6 +5128,14 @@ nemo-data-designer-plugin = [
     { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "pandas", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+nemo-deployments-plugin = [
+    { name = "fastapi", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httpx", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-platform-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-platform-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pydantic", extra = ["email"], marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nemo-eval-author-plugin = [
     { name = "harbor", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5315,6 +5325,7 @@ plugins = [
     { name = "matplotlib", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-agents-example-calculator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-anonymizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-deployments-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-eval-author-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-evaluator-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-experimentalist-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5396,6 +5407,7 @@ services = [
     { name = "nemo-agents-example-calculator", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-anonymizer", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-auditor-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nemo-deployments-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-eval-author-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-evaluator-sdk", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "nemo-experimentalist-plugin", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -5580,6 +5592,7 @@ requires-dist = [
     { name = "fastapi", marker = "extra == 'models-service'", specifier = ">=0.115.8" },
     { name = "fastapi", marker = "extra == 'nemo-anonymizer-plugin'" },
     { name = "fastapi", marker = "extra == 'nemo-data-designer-plugin'" },
+    { name = "fastapi", marker = "extra == 'nemo-deployments-plugin'", specifier = ">=0.115" },
     { name = "fastapi", marker = "extra == 'nemo-insights-plugin'", specifier = ">=0.115" },
     { name = "fastapi", marker = "extra == 'nemo-platform-plugin'", specifier = ">=0.115.4" },
     { name = "fastapi", marker = "extra == 'nemo-safe-synthesizer-plugin'", specifier = ">=0.115.8" },
@@ -5642,6 +5655,7 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'nemo-anonymizer-plugin'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'nemo-auditor-plugin'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'nemo-data-designer-plugin'", specifier = ">=0.27" },
+    { name = "httpx", marker = "extra == 'nemo-deployments-plugin'", specifier = ">=0.27" },
     { name = "httpx", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=0.27.0,<1" },
     { name = "httpx", marker = "extra == 'nemo-experimentalist-plugin'" },
     { name = "httpx", marker = "extra == 'nemo-insights-plugin'" },
@@ -5719,6 +5733,10 @@ requires-dist = [
     { name = "nemo-auditor-plugin", marker = "extra == 'all'", editable = "plugins/nemo-auditor" },
     { name = "nemo-auditor-plugin", marker = "extra == 'platform-seed-service'", editable = "plugins/nemo-auditor" },
     { name = "nemo-auditor-plugin", marker = "extra == 'services'", editable = "plugins/nemo-auditor" },
+    { name = "nemo-deployments-plugin", marker = "extra == 'all'", editable = "plugins/nemo-deployments" },
+    { name = "nemo-deployments-plugin", marker = "extra == 'nemo-agents-plugin'", editable = "plugins/nemo-deployments" },
+    { name = "nemo-deployments-plugin", marker = "extra == 'plugins'", editable = "plugins/nemo-deployments" },
+    { name = "nemo-deployments-plugin", marker = "extra == 'services'", editable = "plugins/nemo-deployments" },
     { name = "nemo-eval-author-plugin", marker = "extra == 'all'", editable = "plugins/nemo-eval-author" },
     { name = "nemo-eval-author-plugin", marker = "extra == 'nemo-experimentalist-plugin'", editable = "plugins/nemo-eval-author" },
     { name = "nemo-eval-author-plugin", marker = "extra == 'plugins'", editable = "plugins/nemo-eval-author" },
@@ -5761,6 +5779,7 @@ requires-dist = [
     { name = "nemo-platform-plugin", marker = "extra == 'nemo-anonymizer-plugin'", editable = "packages/nemo_platform_plugin" },
     { name = "nemo-platform-plugin", marker = "extra == 'nemo-auditor-plugin'", editable = "packages/nemo_platform_plugin" },
     { name = "nemo-platform-plugin", marker = "extra == 'nemo-data-designer-plugin'", editable = "packages/nemo_platform_plugin" },
+    { name = "nemo-platform-plugin", marker = "extra == 'nemo-deployments-plugin'", editable = "packages/nemo_platform_plugin" },
     { name = "nemo-platform-plugin", marker = "extra == 'nemo-eval-author-plugin'", editable = "packages/nemo_platform_plugin" },
     { name = "nemo-platform-plugin", marker = "extra == 'nemo-evaluator-plugin'", editable = "packages/nemo_platform_plugin" },
     { name = "nemo-platform-plugin", marker = "extra == 'nemo-experimentalist-plugin'", editable = "packages/nemo_platform_plugin" },
@@ -5777,6 +5796,7 @@ requires-dist = [
     { name = "nemo-platform-sdk", marker = "extra == 'all'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'core-service'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'entities-service'", editable = "sdk/python/nemo-platform" },
+    { name = "nemo-platform-sdk", marker = "extra == 'nemo-deployments-plugin'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nemo-evaluator-plugin'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nemo-platform-plugin'", editable = "sdk/python/nemo-platform" },
     { name = "nemo-platform-sdk", marker = "extra == 'nmp-common'", editable = "sdk/python/nemo-platform" },
@@ -5955,6 +5975,7 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'jobs-service'", specifier = ">=2.10.6" },
     { name = "pydantic", marker = "extra == 'models-service'", specifier = ">=2.10.6" },
     { name = "pydantic", marker = "extra == 'nemo-auditor-plugin'", specifier = ">=2.10.6" },
+    { name = "pydantic", marker = "extra == 'nemo-deployments-plugin'", specifier = ">=2.10.6" },
     { name = "pydantic", marker = "extra == 'nemo-eval-author-plugin'", specifier = ">=2" },
     { name = "pydantic", marker = "extra == 'nemo-evaluator-plugin'", specifier = ">=2.12.0" },
     { name = "pydantic", marker = "extra == 'nemo-evaluator-sdk'", specifier = ">=2.10.6" },
@@ -6026,6 +6047,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'nemo-agents-plugin'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'nemo-anonymizer-plugin'", specifier = ">=6.0.2" },
     { name = "pyyaml", marker = "extra == 'nemo-auditor-plugin'", specifier = ">=6.0.2" },
+    { name = "pyyaml", marker = "extra == 'nemo-deployments-plugin'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'nemo-eval-author-plugin'", specifier = ">=6.0.3" },
     { name = "pyyaml", marker = "extra == 'nemo-experimentalist-plugin'", specifier = ">=6.0.3" },
     { name = "pyyaml", marker = "extra == 'nemo-insights-plugin'", specifier = ">=6.0.3" },
@@ -6149,7 +6171,7 @@ requires-dist = [
     { name = "yara-python", marker = "extra == 'guardrails-service'", specifier = "==4.5.1" },
     { name = "yara-python", marker = "extra == 'services'", specifier = "==4.5.1" },
 ]
-provides-extras = ["aiohttp", "all", "auditor-service", "auth-service", "core-service", "data-designer-nemo", "entities-service", "files-service", "guardrails-service", "hello-world-service", "inference-gateway-service", "intake-service", "jobs-service", "models-service", "nemo-agents-example-calculator", "nemo-agents-plugin", "nemo-anonymizer-plugin", "nemo-auditor-plugin", "nemo-data-designer-plugin", "nemo-eval-author-plugin", "nemo-evaluator-plugin", "nemo-evaluator-sdk", "nemo-experimentalist-plugin", "nemo-guardrails-plugin", "nemo-insights-plugin", "nemo-optimization-plugin", "nemo-platform-plugin", "nemo-platform-sdk", "nemo-safe-synthesizer-plugin", "nemo-switchyard", "nmp-common", "platform-seed-service", "plugins", "secrets-service", "services", "studio-service", "switchyard-vendored"]
+provides-extras = ["aiohttp", "all", "auditor-service", "auth-service", "core-service", "data-designer-nemo", "entities-service", "files-service", "guardrails-service", "hello-world-service", "inference-gateway-service", "intake-service", "jobs-service", "models-service", "nemo-agents-example-calculator", "nemo-agents-plugin", "nemo-anonymizer-plugin", "nemo-auditor-plugin", "nemo-data-designer-plugin", "nemo-deployments-plugin", "nemo-eval-author-plugin", "nemo-evaluator-plugin", "nemo-evaluator-sdk", "nemo-experimentalist-plugin", "nemo-guardrails-plugin", "nemo-insights-plugin", "nemo-optimization-plugin", "nemo-platform-plugin", "nemo-platform-sdk", "nemo-safe-synthesizer-plugin", "nemo-switchyard", "nmp-common", "platform-seed-service", "plugins", "secrets-service", "services", "studio-service", "switchyard-vendored"]
 
 [[package]]
 name = "nemo-platform-ext"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Bundle the default-enabled deployments backend in `nemo-platform[all]`, allowing the models controller to start after the documented installation. The missing-package error now recommends an installation command that provides the backend.

## Related Issue

Fixes [NAP-20](https://linear.app/nvidia/issue/NAP-20/nemo-platformall-cannot-install-the-only-models-backend-it-enables-by)

## Changes

- Bundle `nemo-deployments-plugin` in the `nemo-platform` wrapper wheel.
- Include the plugin through the `plugins`, `services`, and `all` extras.
- Inherit the deployments service, controller, sandbox-profile, and skill entry points.
- Update the models backend import error to recommend `pip install "nemo-platform[all]"`.
- Add regression coverage for the complete `[all] → [services] → [plugins] → [nemo-deployments-plugin]` dependency chain.
- Regenerate `uv.lock`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: The documented `nemo-platform[all]` installation command remains unchanged; this PR makes the package conform to that existing documentation.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest tests/unit/test_wrapper_distribution.py services/core/models/tests/unit/controllers/test_backend_registry.py packages/nmp_build_tools/tests/test_hatch.py -q` — 21 passed.
- `uv run --frozen pytest services/core/models/tests/unit/test_config.py services/core/models/tests/unit/controllers/test_backend_registry.py services/core/models/tests/unit/controllers/backends/deployments_plugin/test_executor.py tests/unit/test_wrapper_distribution.py tests/unit/test_docker_workspace_slices.py packages/nmp_platform_runner/tests/test_registry.py -q` — 56 passed.
- `uv run --frozen ruff check tests/unit/test_wrapper_distribution.py services/core/models/src/nmp/core/models/controllers/backends/registry.py services/core/models/tests/unit/controllers/test_backend_registry.py` — passed.
- `uv run --frozen ruff format --check tests/unit/test_wrapper_distribution.py services/core/models/src/nmp/core/models/controllers/backends/registry.py services/core/models/tests/unit/controllers/test_backend_registry.py` — passed.
- `uv lock --check` — passed.
- `uv build --package nemo-platform --wheel --out-dir /private/tmp/nap20-wheel` — passed; verified the wheel contains `nemo_deployments_plugin`, its inherited entry points, and the deployments extra in `[all]` metadata.
- `unzip -t /private/tmp/nap20-wheel/nemo_platform-*.whl` — passed.
- `uv run --frozen ty check services/core/models/src/nmp/core/models/controllers/backends/registry.py` — reports a pre-existing constructor typing mismatch on an unchanged line; no new diagnostics were introduced.
- Full pre-commit was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bundled support for Nemo Deployments, Eval Author, Experimentalist, and Insights plugins.
  * Expanded the complete platform installation with related commands, services, controllers, jobs, skills, SDK resources, and sandbox support.
  * Deployment functionality is now available through the platform’s bundled installation.
* **Bug Fixes**
  * Improved setup guidance when deployment functionality is unavailable.
* **Tests**
  * Added coverage verifying plugin packaging, dependency configuration, discovery, and deployment components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->