### PR TITLE
fix: make helm readme generation idempotent

### DIFF
--- a/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
+++ b/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
@@ -1,7 +1,5 @@
-{{/*
-SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-SPDX-License-Identifier: Apache-2.0
-*/}}
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 
 # {{ template "chart.description" . }}
 

--- a/script/copyright_fixer.py
+++ b/script/copyright_fixer.py
@@ -468,6 +468,10 @@ def _has_frontmatter(content: str) -> bool:
     return content.startswith("---\n") or content.startswith("---\r\n")
 
 
+def _is_markdown_helm_template(path: Path) -> bool:
+    return path.suffix in {".gotmpl", ".tpl"} and Path(path.stem).suffix in {".md", ".mdx"}
+
+
 def _is_helm_template_yaml(path: Path) -> bool:
     """Return True for YAML files under a Helm chart templates directory."""
     if path.suffix not in {".yaml", ".yml"}:
@@ -518,6 +522,9 @@ def _get_header_for_file(filepath: str, content: str) -> str:
 
     if ext in {".md", ".mdx"} and _has_frontmatter(content):
         return _HASH_HEADER
+
+    if _is_markdown_helm_template(path):
+        return _HTML_HEADER + "\n"
 
     if _is_helm_template_yaml(path):
         return _HELM_TEMPLATE_HEADER + "\n"

--- a/tests/test_copyright_fixer.py
+++ b/tests/test_copyright_fixer.py
@@ -52,7 +52,8 @@ def test_add_header_uses_syntax_safe_styles_for_missing_osrb_file_types(tmp_path
 
     files = {
         "test_case.py": ('print("ok")\n', copyright_fixer._HASH_HEADER + "\n"),
-        "nemo-helm-readme.md.gotmpl": ("# title\n", copyright_fixer._HELM_TEMPLATE_HEADER + "\n"),
+        "nemo-helm-readme.md.gotmpl": ("# title\n", copyright_fixer._HTML_HEADER + "\n"),
+        "serviceaccount.gotmpl": ("{{ .Values.name }}\n", copyright_fixer._HELM_TEMPLATE_HEADER + "\n"),
         "values.yaml": ("apiVersion: v1\n", copyright_fixer._HASH_HEADER + "\n"),
         "chart/templates/serviceaccount.yaml": (
             "{{- if .Values.enabled -}}\napiVersion: v1\n{{- end }}\n",
@@ -91,6 +92,16 @@ def test_fix_style_converts_helm_template_yaml_to_non_rendering_comment(tmp_path
     assert chart_template.read_text(encoding="utf-8").startswith(copyright_fixer._HELM_TEMPLATE_HEADER + "\n")
 
 
+def test_fix_style_preserves_markdown_helm_template_html_header(tmp_path: Path) -> None:
+    readme_template = tmp_path / "nemo-helm-readme.md.gotmpl"
+    content = copyright_fixer._HTML_HEADER + '\n# {{ template "chart.description" . }}\n'
+    readme_template.write_text(content, encoding="utf-8")
+
+    assert not copyright_fixer._needs_style_fix(str(readme_template))
+    assert not copyright_fixer._fix_header_style(str(readme_template))
+    assert readme_template.read_text(encoding="utf-8") == content
+
+
 def test_plain_yaml_keeps_hash_comment_header(tmp_path: Path) -> None:
     values = tmp_path / "chart" / "values.yaml"
     values.parent.mkdir()
@@ -104,6 +115,22 @@ def test_plain_yaml_keeps_hash_comment_header(tmp_path: Path) -> None:
 def test_helm_template_header_keeps_spdx_identifier_on_own_line() -> None:
     assert "\nSPDX-License-Identifier: Apache-2.0\n*/}}\n" in copyright_fixer._HELM_TEMPLATE_HEADER
     assert "SPDX-License-Identifier: Apache-2.0 */}}" not in copyright_fixer._HELM_TEMPLATE_HEADER
+
+
+def test_helm_docs_readme_template_emits_markdown_spdx_header() -> None:
+    template = (
+        Path(__file__).resolve().parents[1] / "k8s" / "helm" / "helm-docs-template" / "nemo-helm-readme.md.gotmpl"
+    )
+    content = template.read_text(encoding="utf-8")
+
+    assert content.startswith(copyright_fixer._HTML_HEADER + '\n# {{ template "chart.description" . }}\n')
+
+
+def test_generated_helm_readme_has_single_blank_line_after_spdx_header() -> None:
+    readme = Path(__file__).resolve().parents[1] / "k8s" / "helm" / "README.md"
+    content = readme.read_text(encoding="utf-8")
+
+    assert content.startswith(copyright_fixer._HTML_HEADER + "\n# NeMo Platform Helm Chart\n")
 
 
 def test_inline_helm_template_header_is_not_accepted() -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
This makes Helm README generation idempotent by having the helm-docs template emit the same markdown HTML SPDX header that the copyright fixer expects. Before this change, `uv run pre-commit run -a` could regenerate the Helm README and then fail because follow-up hooks modified its header spacing; after this change, `Helm Docs` and `Fix copyright headers` pass without modifying files.

## Changes
- Render the SPDX header directly from `k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl` as markdown-safe HTML comments.
- Add regression coverage that checks the Helm docs template header and generated `k8s/helm/README.md` header spacing.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [x] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: No user-visible documentation content changed; this only makes generated Helm README header handling idempotent.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest tests/test_copyright_fixer.py::test_helm_docs_readme_template_emits_markdown_spdx_header tests/test_copyright_fixer.py::test_generated_helm_readme_has_single_blank_line_after_spdx_header -v` — 2 passed
- `uv run --frozen pytest tests/test_copyright_fixer.py -v` — 11 passed
- `uv run pre-commit run helm-docs -a` — Passed on two consecutive runs
- `uv run script/copyright_fixer.py k8s/helm/README.md k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl` — Processed 2 files, updated 0
- `uv run pre-commit run -a` — Passed
- DCO audit for `origin/main..HEAD` — `DCO OK 63d56112e5bac94b9709c0cac3e021e2d337d306`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SPDX copyright header formatting in Helm Markdown templates.
  * Preserved appropriate header styles for Markdown templates and generated YAML files.

* **Tests**
  * Added coverage to verify required SPDX formatting across Helm documentation templates and generated README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->