### PR TITLE
fix(intake): repair local ClickHouse permissions

### DIFF
--- a/services/intake/src/nmp/intake/local_clickhouse.py
+++ b/services/intake/src/nmp/intake/local_clickhouse.py
@@ -542,8 +542,14 @@ def _ensure_data_directory_identity(data_dir: Path, *, manage_permissions: bool)
     tmp_dir = data_dir / "tmp"
     tmp_dir.mkdir(exist_ok=True)
     if manage_permissions:
-        data_dir.chmod(0o755)
-        tmp_dir.chmod(0o755)
+        for path in (data_dir, tmp_dir):
+            try:
+                path.chmod(0o755)
+            except PermissionError:
+                # A rootless Docker bind mount can leave this path owned by a
+                # container-mapped UID after a previous run. The container-side
+                # reconciliation repairs that ownership before ClickHouse starts.
+                logger.debug("Could not update permissions for existing ClickHouse data path %s", path)
 
     # Keep the identity inside the bind mount intentionally: it belongs to this
     # data incarnation and must disappear with the ClickHouse data during a wipe.
@@ -583,23 +589,38 @@ def _ensure_data_directory_identity(data_dir: Path, *, manage_permissions: bool)
     )
 
 
-def _ensure_clickhouse_tmp_dir(container: Container) -> None:
+def _ensure_clickhouse_data_directory_access(container: Container) -> None:
     result = container.exec_run(
         [
             "sh",
             "-c",
-            "mkdir -p /var/lib/clickhouse/tmp && chown clickhouse:clickhouse /var/lib/clickhouse/tmp",
-        ]
+            "mkdir -p /var/lib/clickhouse/tmp && chown -R clickhouse:clickhouse /var/lib/clickhouse",
+        ],
+        user="root",
     )
     if result.exit_code != 0:
         output = result.output.decode(errors="replace") if isinstance(result.output, bytes) else str(result.output)
         raise LocalClickHouseProvisioningError(
-            f"Could not prepare ClickHouse temporary storage in {container.name}: {output.strip()}"
+            f"Could not prepare ClickHouse data storage in {container.name}: {output.strip()}"
+        )
+
+    result = container.exec_run(
+        [
+            "sh",
+            "-c",
+            'probe=$(mktemp /var/lib/clickhouse/tmp/.nmp-write-probe.XXXXXX) && rm -f "$probe"',
+        ],
+        user="clickhouse",
+    )
+    if result.exit_code != 0:
+        output = result.output.decode(errors="replace") if isinstance(result.output, bytes) else str(result.output)
+        raise LocalClickHouseProvisioningError(
+            f"ClickHouse data storage in {container.name} is not writable by the clickhouse user: {output.strip()}"
         )
 
 
 def _prepare_and_wait_until_ready(container: Container, settings: ClickHouseSettings) -> str:
-    _ensure_clickhouse_tmp_dir(container)
+    _ensure_clickhouse_data_directory_access(container)
     url = _container_http_url(container)
     _wait_until_ready(replace(settings, url=url))
     logger.info("Local ClickHouse is ready at %s", url, extra={"container": container.name})

--- a/services/intake/tests/test_local_clickhouse.py
+++ b/services/intake/tests/test_local_clickhouse.py
@@ -26,6 +26,7 @@ from nmp.intake.local_clickhouse import (
     DockerUnavailableError,
     LocalClickHouseProvisioningError,
     ProvisioningMode,
+    _ensure_clickhouse_data_directory_access,
     _ensure_data_directory_identity,
     _expected_labels,
     _managed_container_name,
@@ -56,6 +57,7 @@ class FakeContainer:
         host_port: int = 55123,
         user: str = "default",
         password: str = "",
+        exec_results: list[FakeExecResult] | None = None,
     ) -> None:
         self.name = name
         self.status = status
@@ -75,6 +77,7 @@ class FakeContainer:
         self.removed = False
         self.restart_policy_updates: list[dict[str, str]] = []
         self.exec_calls: list[tuple[list[str], str | None]] = []
+        self.exec_results = list(exec_results or [])
 
     def reload(self) -> None:
         return None
@@ -93,7 +96,7 @@ class FakeContainer:
 
     def exec_run(self, command: list[str], *, user: str | None = None) -> FakeExecResult:
         self.exec_calls.append((command, user))
-        return FakeExecResult()
+        return self.exec_results.pop(0) if self.exec_results else FakeExecResult()
 
     def remove(self) -> None:
         self.removed = True
@@ -175,6 +178,44 @@ def test_default_unconfigured_url_is_locally_managed(monkeypatch: pytest.MonkeyP
     monkeypatch.delenv("NMP_INTAKE_CLICKHOUSE_URL", raising=False)
 
     assert should_provision_local_clickhouse(ClickHouseConfig()) is True
+
+
+def test_clickhouse_data_directory_is_repaired_as_root_and_verified_as_clickhouse() -> None:
+    container = FakeContainer(name="clickhouse", image="clickhouse/clickhouse-server")
+
+    _ensure_clickhouse_data_directory_access(container)
+
+    assert container.exec_calls == [
+        (
+            [
+                "sh",
+                "-c",
+                "mkdir -p /var/lib/clickhouse/tmp && chown -R clickhouse:clickhouse /var/lib/clickhouse",
+            ],
+            "root",
+        ),
+        (
+            [
+                "sh",
+                "-c",
+                'probe=$(mktemp /var/lib/clickhouse/tmp/.nmp-write-probe.XXXXXX) && rm -f "$probe"',
+            ],
+            "clickhouse",
+        ),
+    ]
+
+
+def test_clickhouse_data_directory_reports_nonwritable_directory() -> None:
+    container = FakeContainer(
+        name="clickhouse",
+        image="clickhouse/clickhouse-server",
+        exec_results=[FakeExecResult(), FakeExecResult(exit_code=1, output=b"Permission denied")],
+    )
+
+    with pytest.raises(
+        LocalClickHouseProvisioningError, match="not writable by the clickhouse user: Permission denied"
+    ):
+        _ensure_clickhouse_data_directory_access(container)
 
 
 def test_explicit_default_url_is_externally_managed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -425,6 +466,23 @@ def test_ensure_data_directory_identity_reuses_unreadable_marker(tmp_path: Path)
     data_instance_id = _ensure_data_directory_identity(data_dir, manage_permissions=True)
     identity_path = data_dir / ".nmp-clickhouse-identity"
     identity_path.chmod(0)
+
+    assert _ensure_data_directory_identity(data_dir, manage_permissions=True) == data_instance_id
+
+
+def test_ensure_data_directory_identity_tolerates_rootless_bind_mount_permissions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = tmp_path / "intake-clickhouse"
+    data_instance_id = _ensure_data_directory_identity(data_dir, manage_permissions=True)
+    original_chmod = Path.chmod
+
+    def reject_container_owned_paths(path: Path, mode: int, *, follow_symlinks: bool = True) -> None:
+        if path in {data_dir, data_dir / "tmp"}:
+            raise PermissionError("Operation not permitted")
+        original_chmod(path, mode, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(Path, "chmod", reject_container_owned_paths)
 
     assert _ensure_data_directory_identity(data_dir, manage_permissions=True) == data_instance_id
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Repairs local, rootless-Docker ClickHouse bootstrap so Intake can access existing trace data. Before this change, container-mapped ownership could cause Observed Sessions to fail with a ClickHouse permission error; startup now repairs the local data directory and verifies temporary-storage access as the ClickHouse user.

## Related Issue

None.

## Changes

- Reconcile ownership for the locally managed ClickHouse data directory as root before ClickHouse starts.
- Tolerate rootless bind-mount permission errors during host-side directory preparation.
- Verify ClickHouse can create and remove a temporary probe file as its service user.
- Add regression coverage for ownership repair, non-writable storage, and rootless bind-mount permissions.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: this repairs local bootstrap behavior without changing user configuration or documented workflows.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox -q activate -- uv run pytest services/intake/tests/test_local_clickhouse.py` — 35 passed.
- `flox -q activate -- uv run ruff check services/intake/src/nmp/intake/local_clickhouse.py services/intake/tests/test_local_clickhouse.py` — passed.
- Restarted local platform from this branch; Intake logged `Local ClickHouse is ready`. The Insight Observed Sessions trace-list API returned HTTP 200 with one matching trace.
- `flox -q activate -- uv run pre-commit run -a` — all code, type, lock, version, UI, plugin, conflict, and Flox checks passed. The Helm Docs/copyright hooks modify `k8s/helm/README.md`, which is covered by a separate pending PR and is intentionally excluded from this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ClickHouse startup preparation for mounted data directories.
  - Corrected ownership and write-permission handling to support reliable container readiness.
  - Permission failures are now reported with clearer, storage-specific error messages.
  - Improved compatibility with rootless bind mounts by allowing non-critical permission setup failures to continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->