### PR TITLE
feat(agents): Call Fabric from the job

### DIFF
--- a/e2e/agents_deploy_helpers.py
+++ b/e2e/agents_deploy_helpers.py
@@ -74,7 +74,7 @@ def _mock_backed_nat_agent_config(model_name: str) -> dict[str, Any]:
     }
 
 
-def _mock_backed_fabric_agent_config(agent_name: str, model_name: str) -> dict[str, Any]:
+def mock_backed_fabric_agent_config(agent_name: str, model_name: str) -> dict[str, Any]:
     """A deterministic DeepAgents-backed Fabric agent pointed at the mock model."""
     return {
         "config_format": NEMO_AGENTS_SPEC_CONFIG_FORMAT,
@@ -103,7 +103,7 @@ def _mock_backed_agent_config(config_format: str, *, agent_name: str, model_name
     if config_format == NAT_WORKFLOW_CONFIG_FORMAT:
         return _mock_backed_nat_agent_config(model_name)
     if config_format == NEMO_AGENTS_SPEC_CONFIG_FORMAT:
-        return _mock_backed_fabric_agent_config(agent_name, model_name)
+        return mock_backed_fabric_agent_config(agent_name, model_name)
     raise ValueError(f"Unsupported agent config format: {config_format!r}")
 
 

--- a/e2e/test_nemo_agents_invoke_job.py
+++ b/e2e/test_nemo_agents_invoke_job.py
@@ -1,0 +1,369 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for Fabric-backed agent invocation jobs."""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from typing import Any
+
+import pytest
+from nemo_agents_plugin.entities import NEMO_AGENTS_SPEC_CONFIG_FORMAT
+from nemo_platform import NeMoPlatform
+from nmp.testing import MockProviderResponse, add_mock_provider
+from nmp.testing.e2e import wait_for_platform_job
+
+from e2e.agents_deploy_helpers import (
+    TEST_AGENT_RESPONSE,
+    _mock_backed_fabric_agent_config,
+    delete_agent_if_exists,
+    unique_name,
+)
+
+pytestmark = [
+    pytest.mark.subprocess_only,
+    pytest.mark.e2e_config(
+        "e2e/configs/local-subprocess.yaml",
+        harness={"backend": "subprocess"},
+    ),
+    pytest.mark.timeout(600),
+]
+
+
+def _agents_url(sdk: NeMoPlatform, workspace: str, path: str) -> str:
+    return f"{str(sdk.base_url).rstrip('/')}/apis/agents/v2/workspaces/{workspace}/{path.lstrip('/')}"
+
+
+def _job_diagnostic_message(sdk: NeMoPlatform, job: Any, workspace: str, prefix: str) -> str:
+    parts = [prefix]
+    if job.status_details:
+        parts.append(f"Status details: {job.status_details}")
+    if job.error_details:
+        parts.append(f"Error details: {job.error_details}")
+    try:
+        logs = sdk.jobs.get_logs(workspace=workspace, name=job.name)
+        if logs.data:
+            parts.append(f"Job logs ({len(logs.data)} entries):")
+            for entry in logs.data:
+                parts.append(f"  - {entry.message}")
+    except Exception as error:
+        parts.append(f"Could not fetch job logs: {error}")
+    return "\n".join(parts)
+
+
+def _list_invoke_job_results(sdk: NeMoPlatform, workspace: str, job_name: str) -> dict[str, Any]:
+    response = sdk._client.get(_agents_url(sdk, workspace, f"jobs/invoke/{job_name}/results"))
+    assert response.status_code == 200, f"Failed to list invoke job results for {job_name}: {response.text}"
+    return response.json()
+
+
+def _download_invoke_job_result(sdk: NeMoPlatform, workspace: str, job_name: str, result_name: str) -> bytes:
+    response = sdk._client.get(_agents_url(sdk, workspace, f"jobs/invoke/{job_name}/results/{result_name}/download"))
+    assert response.status_code == 200, f"Failed to download result {result_name!r} for {job_name}: {response.text}"
+    return response.content
+
+
+def _result_names(results: dict[str, Any]) -> set[str]:
+    return {str(result["name"]) for result in results.get("data", [])}
+
+
+def _tar_member_names(content: bytes) -> set[str]:
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as tar:
+        return {member.name for member in tar.getmembers()}
+
+
+def _tar_text_by_suffix(content: bytes, suffix: str) -> str:
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as tar:
+        for member in tar.getmembers():
+            if not member.name.endswith(suffix) or not member.isfile():
+                continue
+            extracted = tar.extractfile(member)
+            assert extracted is not None
+            return extracted.read().decode("utf-8")
+    raise AssertionError(f"{suffix!r} not found in tarball")
+
+
+def _tar_contains(member_names: set[str], suffix: str) -> bool:
+    return any(name.endswith(suffix) for name in member_names)
+
+
+def _write_file_tool_call_response(*, model: str, file_path: str, content: str) -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-agents-invoke-e2e-tool",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_write_report",
+                            "type": "function",
+                            "function": {
+                                "name": "write_file",
+                                "arguments": json.dumps({"file_path": file_path, "content": content}),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _final_chat_completion_response(content: str, model: str) -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-agents-invoke-e2e-final",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _chat_completion_error(message: str) -> dict[str, Any]:
+    return {
+        "error": {
+            "message": message,
+            "type": "intentional_e2e_error",
+        }
+    }
+
+
+def _mock_backed_workspace_agent_config(agent_name: str, model_name: str) -> dict[str, Any]:
+    config = _mock_backed_fabric_agent_config(agent_name, model_name)
+    config["instructions"] = {
+        "system": {
+            "content": (
+                "Use the write_file tool when asked to create files. "
+                "Write paths exactly as requested and then summarize what changed."
+            )
+        },
+    }
+    return config
+
+
+def test_fabric_agent_invocation_job_runs_and_saves_results(sdk: NeMoPlatform, workspace: str) -> None:
+    agent_name = unique_name("invoke-agent")
+    job_name = unique_name("invoke-job")
+    model_name = unique_name("invoke-model")
+    fileset_name = unique_name("invoke-inputs")
+    generated_report = "Fabric wrote this deterministic e2e report.\n"
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("invoke-provider"),
+        mock_response_body_by_model={
+            f"{workspace}/{model_name}": [
+                MockProviderResponse(
+                    response_body=_write_file_tool_call_response(
+                        model=model_name,
+                        file_path="/generated-report.md",
+                        content=generated_report,
+                    )
+                ),
+                MockProviderResponse(response_body=_final_chat_completion_response(TEST_AGENT_RESPONSE, model_name)),
+            ],
+        },
+        served_models={model_name: model_name},
+    )
+
+    sdk.files.upload_content(
+        fileset=fileset_name,
+        workspace=workspace,
+        remote_path="project/context.txt",
+        content="This file proves the input workdir was staged.\n",
+        fileset_auto_create=True,
+    )
+
+    sdk.agents.create(
+        workspace=workspace,
+        name=agent_name,
+        config=_mock_backed_workspace_agent_config(agent_name, f"{workspace}/{model_name}"),
+        config_format=NEMO_AGENTS_SPEC_CONFIG_FORMAT,
+    )
+
+    try:
+        response = sdk._client.post(
+            _agents_url(sdk, workspace, "jobs/invoke"),
+            json={
+                "name": job_name,
+                "spec": {
+                    "agent": agent_name,
+                    "input": "Answer with the deterministic mock provider response.",
+                    "workdir": {"base_workdir": f"{fileset_name}#project/"},
+                },
+            },
+        )
+        assert response.status_code == 201, response.text
+
+        completed_job = wait_for_platform_job(sdk, job_name, workspace, timeout=300)
+        assert completed_job.status == "completed", _job_diagnostic_message(
+            sdk,
+            completed_job,
+            workspace,
+            f"Invoke job failed with status: {completed_job.status}",
+        )
+
+        results = _list_invoke_job_results(sdk, workspace, job_name)
+        assert {
+            "input_workdir",
+            "output_workdir",
+            "output_artifacts",
+            "fabric_run_result",
+        }.issubset(_result_names(results))
+
+        # The input snapshot contains the original file, but not the agent-generated one
+        input_workdir = _download_invoke_job_result(sdk, workspace, job_name, "input_workdir")
+        input_members = _tar_member_names(input_workdir)
+        assert _tar_contains(input_members, "context.txt")
+        assert not _tar_contains(input_members, "generated-report.md")
+
+        # The output snapshot contains the original file AND the agent-generated one
+        output_workdir = _download_invoke_job_result(sdk, workspace, job_name, "output_workdir")
+        output_members = _tar_member_names(output_workdir)
+        assert _tar_contains(output_members, "context.txt")
+        assert _tar_contains(output_members, "generated-report.md")
+        assert _tar_text_by_suffix(output_workdir, "generated-report.md") == generated_report
+
+        # The output artifacts contains Fabric-produced files
+        artifacts = _download_invoke_job_result(sdk, workspace, job_name, "output_artifacts")
+        artifacts_members = _tar_member_names(artifacts)
+        assert _tar_contains(artifacts_members, "adapter-invocation.json")
+        assert _tar_contains(artifacts_members, "stdout.txt")
+        assert _tar_contains(artifacts_members, "stderr.txt")
+
+        # The run result captures platform-normalized Fabric RunResult details
+        run_result = json.loads(_download_invoke_job_result(sdk, workspace, job_name, "fabric_run_result"))
+        assert run_result["status"] == "succeeded"
+        assert run_result["runtime_id"].startswith("runtime-")
+        assert run_result["invocation_id"]
+        assert run_result["request_id"] == job_name
+        assert run_result["response"] == TEST_AGENT_RESPONSE
+        assert run_result["output"]["event_count"] > 0
+        assert run_result["output"]["message_count"] >= 4
+        run_result_json = json.dumps(run_result)
+        assert "write_file" in run_result_json
+        assert "generated-report.md" in run_result_json
+        assert TEST_AGENT_RESPONSE in run_result_json
+    finally:
+        delete_agent_if_exists(sdk, workspace=workspace, name=agent_name)
+
+
+def test_fabric_agent_invocation_job_saves_failed_run_result_and_partial_outputs(
+    sdk: NeMoPlatform,
+    workspace: str,
+) -> None:
+    agent_name = unique_name("invoke-agent")
+    job_name = unique_name("invoke-job")
+    model_name = unique_name("invoke-model")
+    fileset_name = unique_name("invoke-inputs")
+    partial_report = "Fabric wrote this file before the model failed.\n"
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("invoke-provider"),
+        mock_response_body_by_model={
+            f"{workspace}/{model_name}": [
+                MockProviderResponse(
+                    response_body=_write_file_tool_call_response(
+                        model=model_name,
+                        file_path="/partial-before-error.txt",
+                        content=partial_report,
+                    )
+                ),
+                # Force Fabric to fail
+                MockProviderResponse(
+                    response_code=500,
+                    response_body=_chat_completion_error("intentional e2e model failure"),
+                ),
+            ],
+        },
+        served_models={model_name: model_name},
+    )
+
+    sdk.files.upload_content(
+        fileset=fileset_name,
+        workspace=workspace,
+        remote_path="project/context.txt",
+        content="This file proves the failed invocation still saves the input snapshot.\n",
+        fileset_auto_create=True,
+    )
+
+    sdk.agents.create(
+        workspace=workspace,
+        name=agent_name,
+        config=_mock_backed_workspace_agent_config(agent_name, f"{workspace}/{model_name}"),
+        config_format=NEMO_AGENTS_SPEC_CONFIG_FORMAT,
+    )
+
+    try:
+        response = sdk._client.post(
+            _agents_url(sdk, workspace, "jobs/invoke"),
+            json={
+                "name": job_name,
+                "spec": {
+                    "agent": agent_name,
+                    "input": "Write the partial file, then continue.",
+                    "workdir": {"base_workdir": f"{fileset_name}#project/"},
+                },
+            },
+        )
+        assert response.status_code == 201, response.text
+
+        completed_job = wait_for_platform_job(sdk, job_name, workspace, timeout=300)
+        assert completed_job.status == "error", _job_diagnostic_message(
+            sdk,
+            completed_job,
+            workspace,
+            f"Invoke job unexpectedly finished with status: {completed_job.status}",
+        )
+
+        results = _list_invoke_job_results(sdk, workspace, job_name)
+        assert {
+            "input_workdir",
+            "output_workdir",
+            "output_artifacts",
+            "fabric_run_result",
+        }.issubset(_result_names(results))
+        assert "fabric_error" not in _result_names(results)
+
+        # The input snapshot is as expected
+        input_workdir = _download_invoke_job_result(sdk, workspace, job_name, "input_workdir")
+        assert _tar_contains(_tar_member_names(input_workdir), "context.txt")
+        assert not _tar_contains(_tar_member_names(input_workdir), "partial-before-error.txt")
+
+        # We do still get an output snapshot even when Fabric fails, and it does contain
+        # the file that Fabric created before failing
+        output_workdir = _download_invoke_job_result(sdk, workspace, job_name, "output_workdir")
+        output_members = _tar_member_names(output_workdir)
+        assert _tar_contains(output_members, "context.txt")
+        assert _tar_contains(output_members, "partial-before-error.txt")
+        assert _tar_text_by_suffix(output_workdir, "partial-before-error.txt") == partial_report
+
+        # The run result includes status=failed and error details
+        run_result = json.loads(_download_invoke_job_result(sdk, workspace, job_name, "fabric_run_result"))
+        assert run_result["status"] == "failed"
+        assert run_result["request_id"] == job_name
+        assert run_result["runtime_id"].startswith("runtime-")
+        assert run_result["invocation_id"]
+        assert run_result["error"]["code"] == "adapter_reported_failure"
+        assert run_result["error"]["message"] == "adapter reported an invocation failure"
+    finally:
+        delete_agent_if_exists(sdk, workspace=workspace, name=agent_name)

--- a/e2e/test_nemo_agents_invoke_job.py
+++ b/e2e/test_nemo_agents_invoke_job.py
@@ -18,8 +18,8 @@ from nmp.testing.e2e import wait_for_platform_job
 
 from e2e.agents_deploy_helpers import (
     TEST_AGENT_RESPONSE,
-    _mock_backed_fabric_agent_config,
     delete_agent_if_exists,
+    mock_backed_fabric_agent_config,
     unique_name,
 )
 
@@ -145,7 +145,7 @@ def _chat_completion_error(message: str) -> dict[str, Any]:
 
 
 def _mock_backed_workspace_agent_config(agent_name: str, model_name: str) -> dict[str, Any]:
-    config = _mock_backed_fabric_agent_config(agent_name, model_name)
+    config = mock_backed_fabric_agent_config(agent_name, model_name)
     config["instructions"] = {
         "system": {
             "content": (

--- a/e2e/test_nemo_agents_invoke_job.py
+++ b/e2e/test_nemo_agents_invoke_job.py
@@ -23,14 +23,7 @@ from e2e.agents_deploy_helpers import (
     unique_name,
 )
 
-pytestmark = [
-    pytest.mark.subprocess_only,
-    pytest.mark.e2e_config(
-        "e2e/configs/local-subprocess.yaml",
-        harness={"backend": "subprocess"},
-    ),
-    pytest.mark.timeout(600),
-]
+pytestmark = [pytest.mark.timeout(600)]
 
 
 def _agents_url(sdk: NeMoPlatform, workspace: str, path: str) -> str:

--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -613,6 +613,7 @@ nemo-switchyard = "nemo_switchyard.middleware:SwitchyardMiddleware"
 "evaluator.evaluate" = "nemo_evaluator.jobs.evaluate:EvaluateJob"
 "evaluator.agent-evaluate" = "nemo_evaluator.jobs.agent_evaluate:AgentEvalJob"
 "insights.analyze-job" = "nemo_insights_plugin.jobs.analyze:AnalyzeJob"
+"agents.invoke" = "nemo_agents_plugin.jobs.invoke:AgentInvocationJob"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nemo.optimization.backends"]

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -1505,6 +1505,380 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/invoke:
+    post:
+      tags:
+      - Agents
+      summary: Create Job
+      operationId: create_job_apis_agents_v2_workspaces__workspace__jobs_invoke_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InvokeJobRequest'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvokeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Agents
+      summary: List Jobs
+      operationId: list_jobs_apis_agents_v2_workspaces__workspace__jobs_invoke_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page number.
+          default: 1
+          title: Page
+        description: Page number.
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          exclusiveMinimum: 0
+          description: Page size.
+          default: 10
+          title: Page Size
+        description: Page size.
+      - name: sort
+        in: query
+        required: false
+        schema:
+          allOf:
+          - $ref: '#/components/schemas/InvokeJobsSortField'
+          description: The field to sort by. To sort in decreasing order, use `-`
+            in front of the field name.
+          default: -created_at
+        description: The field to sort by. To sort in decreasing order, use `-` in
+          front of the field name.
+      - in: query
+        name: filter
+        style: deepObject
+        required: false
+        explode: true
+        schema:
+          $ref: '#/components/schemas/InvokeJobsListFilter'
+        description: Filter jobs on various criteria.
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvokeJobsPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/invoke/{job}/results/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Result
+      operationId: get_job_result_apis_agents_v2_workspaces__workspace__jobs_invoke__job__results__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/invoke/{job}/results/{name}/download:
+    get:
+      tags:
+      - Agents
+      summary: Download Job Result
+      operationId: download_job_result_apis_agents_v2_workspaces__workspace__jobs_invoke__job__results__name__download_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: job
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Job
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: Not Found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/invoke/{name}:
+    get:
+      tags:
+      - Agents
+      summary: Get Job
+      operationId: get_job_apis_agents_v2_workspaces__workspace__jobs_invoke__name__get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvokeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Agents
+      summary: Delete Job
+      operationId: delete_job_apis_agents_v2_workspaces__workspace__jobs_invoke__name__delete
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/invoke/{name}/cancel:
+    post:
+      tags:
+      - Agents
+      summary: Cancel Job
+      operationId: cancel_job_apis_agents_v2_workspaces__workspace__jobs_invoke__name__cancel_post
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InvokeJob'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/invoke/{name}/logs:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Logs
+      operationId: get_job_logs_apis_agents_v2_workspaces__workspace__jobs_invoke__name__logs_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      - name: limit
+        in: query
+        required: false
+        schema:
+          title: Limit
+          type: integer
+      - name: page_cursor
+        in: query
+        required: false
+        schema:
+          title: Page Cursor
+          type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobLogPage'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/invoke/{name}/results:
+    get:
+      tags:
+      - Agents
+      summary: List Job Results
+      operationId: list_job_results_apis_agents_v2_workspaces__workspace__jobs_invoke__name__results_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobListResultResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /apis/agents/v2/workspaces/{workspace}/jobs/invoke/{name}/status:
+    get:
+      tags:
+      - Agents
+      summary: Get Job Status
+      operationId: get_job_status_apis_agents_v2_workspaces__workspace__jobs_invoke__name__status_get
+      parameters:
+      - name: workspace
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace
+      - name: name
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlatformJobStatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/agents/v2/workspaces/{workspace}/jobs/optimize:
     post:
       tags:
@@ -2487,6 +2861,66 @@ components:
         \ ``agent_deployment``\nLifecycle: pending \u2192 starting \u2192 running\
         \ | failed.\nThe :class:`~nemo_agents_plugin.runner.controller.AgentDeploymentController`\n\
         drives state transitions by reconciling this entity against the\n:class:`~nemo_agents_plugin.runner.backend.RunnerBackend`."
+    AgentInvocationJobConfig:
+      properties:
+        agent:
+          type: string
+          pattern: ^[\w\-.]+(/[\w\-.]+)?$
+          title: Agent
+          description: Agent entity name or workspace/name ref.
+        input:
+          type: string
+          title: Input
+          description: Prompt to pass to the agent.
+        workdir:
+          allOf:
+          - $ref: '#/components/schemas/AgentWorkdir'
+          description: Optional working directory configuration for the invocation.
+      type: object
+      required:
+      - agent
+      - input
+      title: AgentInvocationJobConfig
+    AgentInvocationStepConfig:
+      properties:
+        request:
+          $ref: '#/components/schemas/AgentInvocationJobConfig'
+        agent:
+          $ref: '#/components/schemas/ResolvedAgentConfig'
+        workdir:
+          $ref: '#/components/schemas/AgentWorkdir'
+      type: object
+      required:
+      - request
+      - agent
+      title: AgentInvocationStepConfig
+    AgentWorkdir:
+      properties:
+        base_workdir:
+          title: Base Workdir
+          description: Optional Files reference for the initial working directory.
+          type: string
+        artifact_mounts:
+          items:
+            $ref: '#/components/schemas/AgentWorkdirArtifactMount'
+          type: array
+          title: Artifact Mounts
+          description: Optional fileset artifacts to layer into the working directory.
+      type: object
+      title: AgentWorkdir
+    AgentWorkdirArtifactMount:
+      properties:
+        ref:
+          type: string
+          title: Ref
+        mount_path:
+          type: string
+          title: Mount Path
+      type: object
+      required:
+      - ref
+      - mount_path
+      title: AgentWorkdirArtifactMount
     AnalyzeBatchConfig:
       properties:
         batch:
@@ -3311,6 +3745,147 @@ components:
           title: Detail
       type: object
       title: HTTPValidationError
+    InvokeJob:
+      properties:
+        id:
+          title: Id
+          type: string
+        name:
+          type: string
+          title: Name
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        workspace:
+          title: Workspace
+          type: string
+        created_at:
+          title: Created At
+          type: string
+          format: date-time
+        updated_at:
+          title: Updated At
+          type: string
+          format: date-time
+        spec:
+          $ref: '#/components/schemas/AgentInvocationStepConfig'
+        status:
+          $ref: '#/components/schemas/PlatformJobStatus'
+        status_details:
+          title: Status Details
+          additionalProperties: true
+          type: object
+        error_details:
+          title: Error Details
+          additionalProperties: true
+          type: object
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - name
+      - spec
+      title: InvokeJob
+    InvokeJobRequest:
+      properties:
+        name:
+          title: Name
+          type: string
+        description:
+          title: Description
+          type: string
+        project:
+          title: Project
+          type: string
+        spec:
+          $ref: '#/components/schemas/AgentInvocationJobConfig'
+        ownership:
+          title: Ownership
+          additionalProperties: true
+          type: object
+        custom_fields:
+          title: Custom Fields
+          additionalProperties: true
+          type: object
+        output_location:
+          title: Output Location
+          type: string
+      type: object
+      required:
+      - spec
+      title: InvokeJobRequest
+    InvokeJobsListFilter:
+      additionalProperties: false
+      properties:
+        created_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs created at 'gte' datetime or 'lte' datetime.
+        name:
+          anyOf:
+          - $ref: '#/components/schemas/StringFilter'
+          - type: string
+          description: Name of the job.
+          title: Name
+        workspace:
+          description: Workspace of the job.
+          title: Workspace
+          type: string
+        project:
+          description: Project containing the job.
+          title: Project
+          type: string
+        status:
+          allOf:
+          - $ref: '#/components/schemas/PlatformJobStatus'
+          description: The current status.
+        updated_at:
+          allOf:
+          - $ref: '#/components/schemas/DatetimeFilter'
+          description: Jobs updated at 'gte' datetime or 'lte' datetime.
+      title: InvokeJobsListFilter
+      type: object
+    InvokeJobsPage:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/InvokeJob'
+          type: array
+          title: Data
+        pagination:
+          allOf:
+          - $ref: '#/components/schemas/PaginationData'
+          description: Pagination information.
+        sort:
+          title: Sort
+          description: The field on which the results are sorted.
+          type: string
+        filter:
+          title: Filter
+          description: Filtering information.
+          additionalProperties: true
+          type: object
+      type: object
+      required:
+      - data
+      title: InvokeJobsPage
+    InvokeJobsSortField:
+      type: string
+      enum:
+      - created_at
+      - -created_at
+      - updated_at
+      - -updated_at
+      title: InvokeJobsSortField
     LogLine:
       properties:
         timestamp:
@@ -4043,6 +4618,28 @@ components:
       - created_at
       - updated_at
       title: PlatformJobTaskStatusResponse
+    ResolvedAgentConfig:
+      properties:
+        name:
+          type: string
+          title: Name
+        workspace:
+          type: string
+          title: Workspace
+        config:
+          additionalProperties: true
+          type: object
+          title: Config
+        config_format:
+          type: string
+          title: Config Format
+      type: object
+      required:
+      - name
+      - workspace
+      - config
+      - config_format
+      title: ResolvedAgentConfig
     StringFilter:
       additionalProperties: false
       properties:

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -2876,6 +2876,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/AgentWorkdir'
           description: Optional working directory configuration for the invocation.
+        timeout_seconds:
+          type: number
+          exclusiveMinimum: 0.0
+          title: Timeout Seconds
+          description: Maximum time to wait for Fabric to return an invocation result.
+          default: 3600
       type: object
       required:
       - agent

--- a/plugins/nemo-agents/pyproject.toml
+++ b/plugins/nemo-agents/pyproject.toml
@@ -59,6 +59,7 @@ agents = "nemo_agents_plugin.skills:skills_dir"
 
 [project.entry-points."nemo.jobs"]
 "agents.evaluate" = "nemo_agents_plugin.jobs.evaluate_agent:EvaluateAgentJob"
+"agents.invoke" = "nemo_agents_plugin.jobs.invoke:AgentInvocationJob"
 # POC: agent-improvement workflow
 "agents.evaluate-suite" = "nemo_agents_plugin.jobs.evaluate_suite:EvaluateSuiteJob"
 "agents.analyze" = "nemo_agents_plugin.jobs.analyze_batch:AnalyzeBatchJob"
@@ -119,6 +120,9 @@ nemo-agent-config-example-calculator = {workspace = true}
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "integration: service integration tests",
+]
 # "src" puts nemo_agents_plugin on sys.path.  nemo-platform is resolved
 # from the workspace — run `uv sync` at the repo root before running these tests.
 pythonpath = ["src"]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/invocation.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/invocation.py
@@ -6,14 +6,102 @@
 from __future__ import annotations
 
 import asyncio
+import shutil
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Self
 
 from nemo_agents_plugin.agent_config import AgentConfig
 from nemo_agents_plugin.fabric.environment import ensure_local_workspace_dir
 from nemo_agents_plugin.fabric.runtime import FabricOneShotRequest, FabricRuntimeResult, run_fabric_agent_once
 from nemo_agents_plugin.fabric.translator import translate_agent_config
+
+FABRIC_BASE_DIR_NAME = "fabric"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentConfigInvocationRequest:
+    """Platform-owned request for one Fabric invocation from an agent config."""
+
+    agent_config: AgentConfig
+    input: Any
+    base_dir: Path
+    request_id: str | None = None
+    caller_context: dict[str, Any] = field(default_factory=dict)
+    timeout_seconds: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FabricDirectories:
+    base: Path
+    workspace: Path
+    artifacts: Path
+
+    @classmethod
+    def create(cls, agent_config: AgentConfig, root: Path) -> Self:
+        base = root / FABRIC_BASE_DIR_NAME
+        workspace = _local_environment_path(
+            base,
+            agent_config.environment.workspace,
+            field="workspace",
+        )
+        artifacts = _local_environment_path(
+            base,
+            agent_config.environment.artifacts,
+            field="artifacts",
+        )
+
+        _reset_directory(workspace)
+        _reset_directory(artifacts)
+
+        return cls(base=base, workspace=workspace, artifacts=artifacts)
+
+
+def _reset_directory(path: Path) -> None:
+    if path.exists() or path.is_symlink():
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path)
+        else:
+            path.unlink()
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _local_environment_path(base_dir: Path, configured_path: str, *, field: str) -> Path:
+    """Resolve a Fabric local environment path beneath ``base_dir``."""
+    path = Path(configured_path)
+    if path.is_absolute():
+        raise ValueError(f"Local {field} path must be relative to the agent base directory.")
+
+    resolved_base_dir = base_dir.resolve()
+    resolved = (resolved_base_dir / path).resolve()
+    if not resolved.is_relative_to(resolved_base_dir):
+        raise ValueError(f"Local {field} path must remain within the agent base directory.")
+    return resolved
+
+
+async def invoke_agent_config_request_once(request: AgentConfigInvocationRequest) -> FabricRuntimeResult:
+    """Translate a Platform agent config and run one input through Fabric once."""
+    fabric_config = translate_agent_config(request.agent_config)
+    await asyncio.to_thread(ensure_local_workspace_dir, request.agent_config, request.base_dir)
+    if request.agent_config.environment.provider == "local":
+        artifacts_dir = _local_environment_path(
+            request.base_dir,
+            request.agent_config.environment.artifacts,
+            field="artifacts",
+        )
+        await asyncio.to_thread(artifacts_dir.mkdir, parents=True, exist_ok=True)
+
+    return await run_fabric_agent_once(
+        FabricOneShotRequest(
+            fabric_config=fabric_config,
+            base_dir=request.base_dir,
+            input=request.input,
+            request_id=request.request_id,
+            caller_context=request.caller_context,
+            timeout_seconds=request.timeout_seconds,
+        )
+    )
 
 
 async def invoke_agent_config_once(
@@ -23,17 +111,14 @@ async def invoke_agent_config_once(
     base_dir: Path,
 ) -> list[FabricRuntimeResult]:
     """Translate a Platform agent config and run each input through Fabric once."""
-    fabric_config = translate_agent_config(agent_config)
-    await asyncio.to_thread(ensure_local_workspace_dir, agent_config, base_dir)
-
     results: list[FabricRuntimeResult] = []
     for item in inputs:
         results.append(
-            await run_fabric_agent_once(
-                FabricOneShotRequest(
-                    fabric_config=fabric_config,
-                    base_dir=base_dir,
+            await invoke_agent_config_request_once(
+                AgentConfigInvocationRequest(
+                    agent_config=agent_config,
                     input=item,
+                    base_dir=base_dir,
                 )
             )
         )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/invoke.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/invoke.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar, cast
 
 from nemo_agents_plugin.agent_config import AgentConfig
 from nemo_agents_plugin.agent_config_formats import resolve_agent_config_for_deployment
+from nemo_agents_plugin.config import AgentsConfig
 from nemo_agents_plugin.entities import NEMO_AGENTS_SPEC_CONFIG_FORMAT, Agent
 from nemo_agents_plugin.fabric.invocation import (
     AgentConfigInvocationRequest,
@@ -54,6 +55,7 @@ FABRIC_RUN_RESULT_FILENAME = "fabric_run_result.json"
 FABRIC_ERROR_FILENAME = "fabric_error.json"
 SUCCESSFUL_FABRIC_STATUSES = {"succeeded"}
 DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS = 60 * 60
+DEFAULT_AGENT_INVOCATION_IMAGE_NAME = "nmp-api"
 
 
 class AgentInvocationJobConfig(BaseModel):
@@ -91,6 +93,10 @@ class AgentInvocationJob(NemoJob):
     container: ClassVar[str] = "cpu-tasks"
     input_spec_schema: ClassVar[type[BaseModel]] = AgentInvocationJobConfig
     spec_schema: ClassVar[type[BaseModel]] = AgentInvocationStepConfig
+
+    @staticmethod
+    def _invocation_image() -> str:
+        return AgentsConfig.get().deployments.default_image or get_qualified_image(DEFAULT_AGENT_INVOCATION_IMAGE_NAME)
 
     @classmethod
     async def to_spec(  # type: ignore[override]
@@ -167,7 +173,7 @@ class AgentInvocationJob(NemoJob):
                         profile=profile or "default",
                         provider="cpu",
                         container=ContainerSpec(
-                            image=get_qualified_image("nmp-cpu-tasks"),
+                            image=cls._invocation_image(),
                             entrypoint=["python", "-m"],
                             command=["nemo_agents_plugin.tasks.invoke"],
                         ),

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/invoke.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/invoke.py
@@ -53,6 +53,7 @@ FABRIC_ERROR_RESULT_NAME = "fabric_error"
 FABRIC_RUN_RESULT_FILENAME = "fabric_run_result.json"
 FABRIC_ERROR_FILENAME = "fabric_error.json"
 SUCCESSFUL_FABRIC_STATUSES = {"succeeded"}
+DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS = 60 * 60
 
 
 class AgentInvocationJobConfig(BaseModel):
@@ -63,6 +64,11 @@ class AgentInvocationJobConfig(BaseModel):
     workdir: AgentWorkdir | None = Field(
         default=None,
         description="Optional working directory configuration for the invocation.",
+    )
+    timeout_seconds: float = Field(
+        default=DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS,
+        gt=0,
+        description="Maximum time to wait for Fabric to return an invocation result.",
     )
 
 
@@ -199,6 +205,7 @@ class AgentInvocationJob(NemoJob):
                             "job_workspace": ctx.workspace,
                             "agent": f"{step_config.agent.workspace}/{step_config.agent.name}",
                         },
+                        timeout_seconds=step_config.request.timeout_seconds,
                     )
                 )
             )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/invoke.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/invoke.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agent invocation job skeleton."""
+
+from __future__ import annotations
+
+import shutil
+from typing import Any, ClassVar, cast
+
+from nemo_agents_plugin.entities import Agent
+from nemo_agents_plugin.tasks.invoke.workdir import (
+    AgentWorkdir,
+    materialize_agent_workdir,
+    validate_agent_workdir,
+)
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.jobs.api_factory import (
+    ContainerSpec,
+    CPUExecutionProviderSpec,
+    PlatformJobSpec,
+    PlatformJobStep,
+)
+from nemo_platform_plugin.jobs.image import get_qualified_image
+from nemo_platform_plugin.refs import ENTITY_REF_PATTERN, parse_entity_ref
+from pydantic import BaseModel, Field
+
+INPUT_WORKDIR_RESULT_NAME = "input_workdir"
+
+
+class AgentInvocationJobConfig(BaseModel):
+    model_config = {"json_schema_mode_override": "validation"}
+
+    agent: str = Field(pattern=ENTITY_REF_PATTERN, description="Agent entity name or workspace/name ref.")
+    input: str = Field(description="Prompt to pass to the agent.")
+    workdir: AgentWorkdir | None = Field(
+        default=None,
+        description="Optional working directory configuration for the invocation.",
+    )
+
+
+class ResolvedAgentConfig(BaseModel):
+    name: str
+    workspace: str
+    config: dict[str, Any]
+    config_format: str
+
+
+class AgentInvocationStepConfig(BaseModel):
+    request: AgentInvocationJobConfig
+    agent: ResolvedAgentConfig
+    workdir: AgentWorkdir | None = None
+
+
+class AgentInvocationJob(NemoJob):
+    name: ClassVar[str] = "invoke"
+    description: ClassVar[str] = "Invoke an agent as a scheduled platform job."
+    container: ClassVar[str] = "cpu-tasks"
+    input_spec_schema: ClassVar[type[BaseModel]] = AgentInvocationJobConfig
+    spec_schema: ClassVar[type[BaseModel]] = AgentInvocationStepConfig
+
+    @classmethod
+    async def to_spec(  # type: ignore[override]
+        cls,
+        input_spec: BaseModel,
+        *,
+        workspace: str,
+        entity_client: object,
+        async_sdk: object,
+        is_local: bool,
+    ) -> BaseModel:
+        """Validates an ``AgentInvocationJobConfig`` (external-facing) and resolves
+        it to an ``AgentInvocationStepConfig`` (internal). Validating entity references
+        in this step ensures errors surface to the user on their create request; storing
+        resolved values on the step config obviates the need for a second fetch from the Job,
+        and ensures we have an immutable snapshot of referenced entities as they existed
+        at job creation time (stored on the Job record). The exceptions are File references
+        in the AgentWorkdir, which are validated here, but not materialized; the Job snapshots
+        them as a named result before doing any work.
+        """
+        del is_local
+        request = cast(AgentInvocationJobConfig, input_spec)
+        agent_ref = parse_entity_ref(request.agent, default_workspace=workspace)
+        typed_entity_client = cast(Any, entity_client)
+        try:
+            agent = await typed_entity_client.get(Agent, name=agent_ref.name, workspace=agent_ref.workspace)
+        except NemoEntityNotFoundError as exc:
+            raise ValueError(f"Agent '{request.agent}' not found.") from exc
+
+        workdir = None
+        if request.workdir is not None:
+            sdk = cast(AsyncNeMoPlatform, async_sdk)
+            workdir = await validate_agent_workdir(request.workdir, sdk.files, default_workspace=workspace)
+
+        return AgentInvocationStepConfig(
+            request=request,
+            agent=ResolvedAgentConfig(
+                name=agent.name,
+                workspace=agent.workspace,
+                config=agent.config,
+                config_format=agent.config_format,
+            ),
+            workdir=workdir,
+        )
+
+    @classmethod
+    async def compile(  # type: ignore[override]
+        cls,
+        *,
+        workspace: str,
+        spec: BaseModel,
+        entity_client: object,
+        job_name: str | None,
+        async_sdk: object,
+        profile: str | None = None,
+        options: dict | None = None,
+    ) -> PlatformJobSpec:
+        del workspace, entity_client, job_name, async_sdk, options
+        step_config = AgentInvocationStepConfig.model_validate(spec)
+        return PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="invoke-agent",
+                    executor=CPUExecutionProviderSpec(
+                        profile=profile or "default",
+                        provider="cpu",
+                        container=ContainerSpec(
+                            image=get_qualified_image("nmp-cpu-tasks"),
+                            entrypoint=["python", "-m"],
+                            command=["nemo_agents_plugin.tasks.invoke"],
+                        ),
+                    ),
+                    config=step_config.model_dump(mode="json"),
+                    environment=[],
+                )
+            ],
+        )
+
+    def run(self, config: dict, *, ctx: JobContext, sdk: NeMoPlatform | None = None) -> dict:
+        step_config = AgentInvocationStepConfig.model_validate(config)
+        result_ref = None
+        if step_config.workdir is not None and (
+            step_config.workdir.base_workdir is not None or step_config.workdir.artifact_mounts
+        ):
+            if sdk is None:
+                raise RuntimeError("sdk is required to stage workdir inputs.")
+            local_workdir = ctx.storage.ephemeral / INPUT_WORKDIR_RESULT_NAME
+            if local_workdir.exists() or local_workdir.is_symlink():
+                if local_workdir.is_dir() and not local_workdir.is_symlink():
+                    shutil.rmtree(local_workdir)
+                else:
+                    local_workdir.unlink()
+            materialize_agent_workdir(step_config.workdir, sdk.files, local_workdir)
+            result_ref = ctx.results.save(INPUT_WORKDIR_RESULT_NAME, local_workdir)
+
+        return {
+            "status": "completed",
+            "agent": f"{step_config.agent.workspace}/{step_config.agent.name}",
+            "input_workdir": result_ref.model_dump() if result_ref else None,
+        }

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/invoke.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/invoke.py
@@ -5,10 +5,22 @@
 
 from __future__ import annotations
 
-import shutil
+import asyncio
+import json
+import logging
+from dataclasses import asdict
+from pathlib import Path
 from typing import Any, ClassVar, cast
 
-from nemo_agents_plugin.entities import Agent
+from nemo_agents_plugin.agent_config import AgentConfig
+from nemo_agents_plugin.agent_config_formats import resolve_agent_config_for_deployment
+from nemo_agents_plugin.entities import NEMO_AGENTS_SPEC_CONFIG_FORMAT, Agent
+from nemo_agents_plugin.fabric.invocation import (
+    AgentConfigInvocationRequest,
+    FabricDirectories,
+    invoke_agent_config_request_once,
+)
+from nemo_agents_plugin.fabric.runtime import FabricRuntimeTimeoutError
 from nemo_agents_plugin.tasks.invoke.workdir import (
     AgentWorkdir,
     materialize_agent_workdir,
@@ -18,6 +30,7 @@ from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.job_results import ResultRef
 from nemo_platform_plugin.jobs.api_factory import (
     ContainerSpec,
     CPUExecutionProviderSpec,
@@ -28,7 +41,18 @@ from nemo_platform_plugin.jobs.image import get_qualified_image
 from nemo_platform_plugin.refs import ENTITY_REF_PATTERN, parse_entity_ref
 from pydantic import BaseModel, Field
 
+logger = logging.getLogger(__name__)
+
+FABRIC_AGENT_CONFIG_FORMAT = NEMO_AGENTS_SPEC_CONFIG_FORMAT
+FABRIC_BASE_DIR_NAME = "fabric"
 INPUT_WORKDIR_RESULT_NAME = "input_workdir"
+OUTPUT_WORKDIR_RESULT_NAME = "output_workdir"
+OUTPUT_ARTIFACTS_RESULT_NAME = "output_artifacts"
+FABRIC_RUN_RESULT_NAME = "fabric_run_result"
+FABRIC_ERROR_RESULT_NAME = "fabric_error"
+FABRIC_RUN_RESULT_FILENAME = "fabric_run_result.json"
+FABRIC_ERROR_FILENAME = "fabric_error.json"
+SUCCESSFUL_FABRIC_STATUSES = {"succeeded"}
 
 
 class AgentInvocationJobConfig(BaseModel):
@@ -90,6 +114,15 @@ class AgentInvocationJob(NemoJob):
         except NemoEntityNotFoundError as exc:
             raise ValueError(f"Agent '{request.agent}' not found.") from exc
 
+        _validate_agent_config_format(agent.config_format)
+        resolved_agent_config = resolve_agent_config_for_deployment(
+            agent.config_format,
+            agent.config,
+            workspace=agent.workspace,
+            agent_name=agent.name,
+        )
+        _validate_agent_config(resolved_agent_config)
+
         workdir = None
         if request.workdir is not None:
             sdk = cast(AsyncNeMoPlatform, async_sdk)
@@ -100,7 +133,7 @@ class AgentInvocationJob(NemoJob):
             agent=ResolvedAgentConfig(
                 name=agent.name,
                 workspace=agent.workspace,
-                config=agent.config,
+                config=resolved_agent_config,
                 config_format=agent.config_format,
             ),
             workdir=workdir,
@@ -141,23 +174,115 @@ class AgentInvocationJob(NemoJob):
 
     def run(self, config: dict, *, ctx: JobContext, sdk: NeMoPlatform | None = None) -> dict:
         step_config = AgentInvocationStepConfig.model_validate(config)
-        result_ref = None
-        if step_config.workdir is not None and (
-            step_config.workdir.base_workdir is not None or step_config.workdir.artifact_mounts
-        ):
+        _validate_agent_config_format(step_config.agent.config_format)
+        agent_config = _validate_agent_config(step_config.agent.config)
+
+        fabric_dirs = FabricDirectories.create(agent_config, ctx.storage.ephemeral)
+
+        if step_config.workdir is not None and _has_workdir_inputs(step_config.workdir):
             if sdk is None:
                 raise RuntimeError("sdk is required to stage workdir inputs.")
-            local_workdir = ctx.storage.ephemeral / INPUT_WORKDIR_RESULT_NAME
-            if local_workdir.exists() or local_workdir.is_symlink():
-                if local_workdir.is_dir() and not local_workdir.is_symlink():
-                    shutil.rmtree(local_workdir)
-                else:
-                    local_workdir.unlink()
-            materialize_agent_workdir(step_config.workdir, sdk.files, local_workdir)
-            result_ref = ctx.results.save(INPUT_WORKDIR_RESULT_NAME, local_workdir)
+            materialize_agent_workdir(step_config.workdir, sdk.files, fabric_dirs.workspace)
+
+        input_workdir_ref = ctx.results.save(INPUT_WORKDIR_RESULT_NAME, fabric_dirs.workspace)
+
+        try:
+            result = asyncio.run(
+                invoke_agent_config_request_once(
+                    AgentConfigInvocationRequest(
+                        agent_config=agent_config,
+                        input=step_config.request.input,
+                        base_dir=fabric_dirs.base,
+                        request_id=ctx.job_id,
+                        caller_context={
+                            "job_id": ctx.job_id,
+                            "job_workspace": ctx.workspace,
+                            "agent": f"{step_config.agent.workspace}/{step_config.agent.name}",
+                        },
+                    )
+                )
+            )
+        except Exception as error:
+            self._save_fabric_error_results(
+                ctx, workspace_dir=fabric_dirs.workspace, artifacts_dir=fabric_dirs.artifacts, error=error
+            )
+            raise
+
+        fabric_run_result_ref = _save_json_result(
+            ctx,
+            FABRIC_RUN_RESULT_NAME,
+            ctx.storage.ephemeral / FABRIC_RUN_RESULT_FILENAME,
+            asdict(result),
+        )
+        output_workdir_ref = ctx.results.save(OUTPUT_WORKDIR_RESULT_NAME, fabric_dirs.workspace)
+        output_artifacts_ref = ctx.results.save(OUTPUT_ARTIFACTS_RESULT_NAME, fabric_dirs.artifacts)
+        status = "completed" if result.status in SUCCESSFUL_FABRIC_STATUSES else "failed"
 
         return {
-            "status": "completed",
+            "status": status,
             "agent": f"{step_config.agent.workspace}/{step_config.agent.name}",
-            "input_workdir": result_ref.model_dump() if result_ref else None,
+            "fabric_status": result.status,
+            "runtime_id": result.runtime_id,
+            "invocation_id": result.invocation_id,
+            "request_id": result.request_id,
+            "input_workdir": input_workdir_ref.model_dump(),
+            "output_workdir": output_workdir_ref.model_dump(),
+            "output_artifacts": output_artifacts_ref.model_dump(),
+            "fabric_run_result": fabric_run_result_ref.model_dump(),
         }
+
+    def _save_fabric_error_results(
+        self,
+        ctx: JobContext,
+        *,
+        workspace_dir: Path,
+        artifacts_dir: Path,
+        error: Exception,
+    ) -> None:
+        cause = error.__cause__
+        payload = {
+            "type": type(error).__name__,
+            "message": str(error),
+            "fabric_status": "timeout" if isinstance(error, (TimeoutError, FabricRuntimeTimeoutError)) else "error",
+            "cause_type": type(cause).__name__ if cause is not None else None,
+            "cause_message": str(cause) if cause is not None else None,
+        }
+        for name, path in (
+            (OUTPUT_WORKDIR_RESULT_NAME, workspace_dir),
+            (OUTPUT_ARTIFACTS_RESULT_NAME, artifacts_dir),
+        ):
+            try:
+                if path.exists():
+                    ctx.results.save(name, path)
+            except Exception:
+                logger.warning("Failed to save %s after Fabric invocation error.", name, exc_info=True)
+        try:
+            _save_json_result(ctx, FABRIC_ERROR_RESULT_NAME, ctx.storage.ephemeral / FABRIC_ERROR_FILENAME, payload)
+        except Exception:
+            logger.warning("Failed to save Fabric error result.", exc_info=True)
+
+
+def _has_workdir_inputs(workdir: AgentWorkdir) -> bool:
+    return workdir.base_workdir is not None or bool(workdir.artifact_mounts)
+
+
+def _save_json_result(ctx: JobContext, name: str, path: Path, payload: dict[str, Any]) -> ResultRef:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return ctx.results.save(name, path)
+
+
+def _validate_agent_config_format(config_format: str) -> None:
+    if config_format != FABRIC_AGENT_CONFIG_FORMAT:
+        raise ValueError(
+            f"Config format {config_format!r} is not supported; "
+            f"agents.invoke jobs only support {FABRIC_AGENT_CONFIG_FORMAT!r}."
+        )
+
+
+def _validate_agent_config(config: dict) -> AgentConfig:
+    agent_config = AgentConfig.model_validate(config)
+    if agent_config.environment.provider != "local":
+        raise ValueError("agents.invoke jobs only support local Fabric environments.")
+
+    return agent_config

--- a/plugins/nemo-agents/src/nemo_agents_plugin/service.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/service.py
@@ -34,6 +34,7 @@ class _JobCollection(NamedTuple):
 #   OptimizeJob        /jobs/optimize        -> agents.optimize
 #   OptimizeSkillsJob  /jobs/optimize-skills -> agents.optimize-skills
 #   AnalyzeBatchJob    /jobs/analyze         -> agents.analyze
+#   AgentInvocationJob /jobs/invoke          -> agents.invoke
 # Distinct service_name per job type so each list endpoint filters to rows of its own type only
 # (add_job_routes filters source=service_name); sharing the default would let /jobs/<x> pull in
 # sibling-type rows and 500 on the wrong schema.
@@ -41,11 +42,18 @@ def _job_collections() -> list[_JobCollection]:
     from nemo_agents_plugin.jobs.analyze_batch import AnalyzeBatchJob
     from nemo_agents_plugin.jobs.evaluate_agent import EvaluateAgentJob
     from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteJob
+    from nemo_agents_plugin.jobs.invoke import AgentInvocationJob
     from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsJob
     from nemo_optimization.jobs.optimize import OptimizeJob
 
     return [
         _JobCollection(EvaluateAgentJob, "evaluate", None, "Submit and track agent evaluation jobs"),
+        _JobCollection(
+            AgentInvocationJob,
+            "invoke",
+            "nemo-agents-plugin-invoke",
+            "Submit and track agent invocation jobs.",
+        ),
         _JobCollection(
             EvaluateSuiteJob,
             "suite",

--- a/plugins/nemo-agents/src/nemo_agents_plugin/tasks/invoke/__main__.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/tasks/invoke/__main__.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task entrypoint for ``agents.invoke``."""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+from types import FrameType
+
+from nemo_agents_plugin.jobs.invoke import AgentInvocationJob
+from nemo_platform_plugin.sdk_provider import get_task_sdk
+from nemo_platform_plugin.tasks.dispatcher import run_task
+
+logger = logging.getLogger(__name__)
+
+
+def _shutdown_handler(signum: int, frame: FrameType | None) -> None:
+    del frame
+    logger.warning("Received shutdown signal (%d). Exiting.", signum)
+    raise SystemExit(128 + signum)
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _shutdown_handler)
+    try:
+        sdk = get_task_sdk("agents")
+    except Exception:
+        logger.exception("Failed to build task SDK for agents")
+        return 2
+    return run_task(AgentInvocationJob, sdk=sdk)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/nemo-agents/src/nemo_agents_plugin/tasks/invoke/workdir.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/tasks/invoke/workdir.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Working directory config validation and materialization for agent invocation tasks."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+
+from nemo_platform.filesets import FilesetPathError, build_fileset_ref, parse_fileset_ref
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class AsyncFilesClient(Protocol):
+    async def list(self, *, remote_path: str) -> Any: ...
+
+
+class FilesClient(Protocol):
+    def download(self, *, remote_path: str, local_path: str) -> Any: ...
+
+
+class AgentWorkdirArtifactMount(BaseModel):
+    ref: str
+    mount_path: str
+
+    @field_validator("mount_path")
+    @classmethod
+    def validate_mount_path(cls, value: str) -> str:
+        return _normalize_relative_path(value, field="mount_path")
+
+
+class AgentWorkdir(BaseModel):
+    base_workdir: str | None = Field(
+        default=None,
+        description="Optional Files reference for the initial working directory.",
+    )
+    artifact_mounts: list[AgentWorkdirArtifactMount] = Field(
+        default_factory=list,
+        description="Optional fileset artifacts to layer into the working directory.",
+    )
+
+    @model_validator(mode="after")
+    def validate_non_overlapping_mounts(self) -> "AgentWorkdir":
+        mount_parts = [(mount.mount_path, PurePosixPath(mount.mount_path).parts) for mount in self.artifact_mounts]
+        for index, (left_path, left_parts) in enumerate(mount_parts):
+            for right_path, right_parts in mount_parts[index + 1 :]:
+                if _paths_overlap(left_parts, right_parts):
+                    raise ValueError(
+                        f"artifact_mounts contain overlapping mount paths: {left_path!r} and {right_path!r}"
+                    )
+        return self
+
+
+async def validate_agent_workdir(
+    workdir: AgentWorkdir,
+    files_client: AsyncFilesClient,
+    *,
+    default_workspace: str,
+) -> AgentWorkdir | None:
+    base_workdir = None
+    if workdir.base_workdir is not None:
+        base_workdir = await _validate_ref(
+            workdir.base_workdir,
+            files_client,
+            default_workspace=default_workspace,
+            field="workdir.base_workdir",
+            directory_like=True,
+        )
+
+    artifact_mounts = []
+    for mount in workdir.artifact_mounts:
+        ref = await _validate_ref(
+            mount.ref,
+            files_client,
+            default_workspace=default_workspace,
+            field="workdir.artifact_mounts.ref",
+            directory_like=False,
+        )
+        artifact_mounts.append(AgentWorkdirArtifactMount(ref=ref, mount_path=mount.mount_path))
+
+    if not base_workdir and not artifact_mounts:
+        return None
+
+    return AgentWorkdir(base_workdir=base_workdir, artifact_mounts=artifact_mounts)
+
+
+def materialize_agent_workdir(spec: AgentWorkdir, files_client: FilesClient, target_dir: Path) -> None:
+    target_dir.mkdir(parents=True, exist_ok=True)
+    if spec.base_workdir is not None:
+        files_client.download(remote_path=spec.base_workdir, local_path=str(target_dir))
+
+    for mount in spec.artifact_mounts:
+        mount_local_path = target_dir / mount.mount_path
+        mount_local_path.parent.mkdir(parents=True, exist_ok=True)
+        if mount_local_path.is_dir() and not mount_local_path.is_symlink():
+            shutil.rmtree(mount_local_path)
+        files_client.download(remote_path=mount.ref, local_path=str(mount_local_path))
+
+
+async def _validate_ref(
+    ref: str,
+    files_client: AsyncFilesClient,
+    *,
+    default_workspace: str,
+    field: str,
+    directory_like: bool,
+) -> str:
+    canonical_ref = _canonical_files_ref(
+        ref,
+        default_workspace=default_workspace,
+        field=field,
+        directory_like=directory_like,
+    )
+    response = await files_client.list(remote_path=canonical_ref)
+    if not response.data:
+        if directory_like:
+            raise ValueError(f"{field} must point to a non-empty directory or fileset root.")
+        raise ValueError(f"{field} must point to an existing fileset artifact.")
+    return canonical_ref
+
+
+def _canonical_files_ref(ref: str, *, default_workspace: str, field: str, directory_like: bool) -> str:
+    raw = ref.strip()
+    if not raw:
+        raise ValueError(f"{field} must not be empty.")
+    if raw.startswith("fileset://"):
+        raise ValueError(f"{field} must use 'workspace/fileset#path' or 'fileset#path' syntax.")
+    if raw.count("#") > 1:
+        raise ValueError(f"{field} contains more than one '#'.")
+    if "#" not in raw and len(raw.split("/")) > 2:
+        raise ValueError(f"{field} must use '#' before fileset paths.")
+
+    path_supplied = "#" in raw
+    fragment = raw.split("#", 1)[1] if path_supplied else ""
+    if fragment.startswith("/"):
+        raise ValueError(f"{field} fragment must be relative.")
+    _validate_fragment(fragment, field=field)
+
+    try:
+        workspace, fileset, path = parse_fileset_ref(raw, workspace_fallback=default_workspace)
+    except FilesetPathError as exc:
+        raise ValueError(str(exc)) from exc
+
+    if not fileset:
+        raise ValueError(f"{field} must include a fileset name.")
+    if directory_like and path_supplied and path:
+        path = f"{path.rstrip('/')}/"
+    if not path:
+        return f"{workspace}/{fileset}#"
+    return build_fileset_ref(path, workspace=workspace, fileset=fileset)
+
+
+def _validate_fragment(fragment: str, *, field: str) -> None:
+    if not fragment:
+        return
+    if "\\" in fragment:
+        raise ValueError(f"{field} fragment must use '/' separators.")
+    path = PurePosixPath(fragment)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{field} fragment must not contain path escapes.")
+
+
+def _normalize_relative_path(value: str, *, field: str) -> str:
+    raw = value.strip()
+    if raw.startswith("/"):
+        raise ValueError(f"{field} must be a relative path and must not contain path escapes.")
+    normalized = raw.rstrip("/")
+    if not normalized or normalized == ".":
+        raise ValueError(f"{field} must be a non-empty relative path.")
+    if "\\" in normalized:
+        raise ValueError(f"{field} must use '/' separators.")
+    path = PurePosixPath(normalized)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{field} must be a relative path and must not contain path escapes.")
+    return path.as_posix()
+
+
+def _paths_overlap(left: tuple[str, ...], right: tuple[str, ...]) -> bool:
+    shortest = min(len(left), len(right))
+    return left[:shortest] == right[:shortest]

--- a/plugins/nemo-agents/tests/integration/test_invoke_job_integration.py
+++ b/plugins/nemo-agents/tests/integration/test_invoke_job_integration.py
@@ -4,10 +4,14 @@
 from __future__ import annotations
 
 import io
+import json
 import tarfile
 from pathlib import Path
+from typing import Any
+from unittest.mock import patch
 
 import pytest
+from nemo_agents_plugin.fabric.runtime import FabricRuntimeResult
 from nemo_agents_plugin.jobs.invoke import AgentInvocationJob
 from nemo_agents_plugin.service import AgentsService
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
@@ -49,7 +53,17 @@ def test_invoke_job_materializes_layered_input_workspace(tmp_path: Path) -> None
         # resolution path sees the same entity shape as a real caller.
         agent_response = ctx.test_client.post(
             "/apis/agents/v2/workspaces/default/agents",
-            json={"name": "calc", "config": {}},
+            json={
+                "name": "calc",
+                "config_format": "nemo-agents-spec-v1",
+                "config": {
+                    "config_format": "nemo-agents-spec-v1",
+                    "name": "calc",
+                    "default_harness": "hermes",
+                    "harnesses": {"hermes": {"kind": "hermes"}},
+                    "models": {"default": {"provider": "openai", "model": "openai/gpt-5.4"}},
+                },
+            },
         )
         assert agent_response.status_code == 201, agent_response.text
 
@@ -120,13 +134,26 @@ def test_invoke_job_materializes_layered_input_workspace(tmp_path: Path) -> None
             job_id=job["id"],
         )
 
-        result = AgentInvocationJob().run(job["spec"], ctx=job_ctx, sdk=ctx.sdk)
+        async def _invoke(request: Any) -> FabricRuntimeResult:
+            (request.base_dir / "workspace" / "agent-output.txt").write_text("agent output\n")
+            (request.base_dir / "artifacts" / "trace.json").write_text("{}\n")
+            return FabricRuntimeResult(status="succeeded", response="done")
+
+        with patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke):
+            result = AgentInvocationJob().run(job["spec"], ctx=job_ctx, sdk=ctx.sdk)
         assert result["status"] == "completed"
         assert result["input_workdir"]["name"] == "input_workdir"
 
         results_response = ctx.test_client.get(f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results")
         assert results_response.status_code == 200, results_response.text
-        assert [item["name"] for item in results_response.json()["data"]] == ["input_workdir"]
+        assert sorted(item["name"] for item in results_response.json()["data"]) == sorted(
+            [
+                "input_workdir",
+                "fabric_run_result",
+                "output_workdir",
+                "output_artifacts",
+            ]
+        )
 
         result_response = ctx.test_client.get(
             f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results/input_workdir"
@@ -146,3 +173,123 @@ def test_invoke_job_materializes_layered_input_workspace(tmp_path: Path) -> None
         )
         assert any(path.endswith("notes/notes.txt") and content == "mounted notes\n" for path, content in files.items())
         assert "source: base\n" not in files.values()
+
+        output_download_response = ctx.test_client.get(
+            f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results/output_workdir/download"
+        )
+        assert output_download_response.status_code == 200, output_download_response.text
+        output_files = _extract_tar_members(output_download_response.content, tmp_path / "downloaded-output-workdir")
+        assert any(
+            path.endswith("agent-output.txt") and content == "agent output\n" for path, content in output_files.items()
+        )
+
+
+def test_invoke_job_saves_error_results_when_fabric_raises(tmp_path: Path) -> None:
+    with create_test_client(
+        _TestAgentsService,
+        FilesService,
+        JobsService,
+        client_type=ClientContext,
+        workspace="default",
+    ) as ctx:
+        agent_response = ctx.test_client.post(
+            "/apis/agents/v2/workspaces/default/agents",
+            json={
+                "name": "calc",
+                "config_format": "nemo-agents-spec-v1",
+                "config": {
+                    "config_format": "nemo-agents-spec-v1",
+                    "name": "calc",
+                    "default_harness": "hermes",
+                    "harnesses": {"hermes": {"kind": "hermes"}},
+                    "models": {"default": {"provider": "openai", "model": "openai/gpt-5.4"}},
+                },
+            },
+        )
+        assert agent_response.status_code == 201, agent_response.text
+
+        ctx.sdk.files.upload_content(
+            workspace="default",
+            fileset="base-workdir",
+            remote_path="README.md",
+            content="base readme\n",
+            fileset_auto_create=True,
+        )
+
+        job_name = "invoke-fabric-raises"
+        create_response = ctx.test_client.post(
+            "/apis/agents/v2/workspaces/default/jobs/invoke",
+            json={
+                "name": job_name,
+                "spec": {
+                    "agent": "calc",
+                    "input": "hello",
+                    "workdir": {"base_workdir": "base-workdir"},
+                },
+            },
+        )
+        assert create_response.status_code == 201, create_response.text
+        job = create_response.json()
+
+        storage_root = tmp_path / "job-storage"
+        ephemeral = storage_root / "ephemeral"
+        persistent = storage_root / "persistent"
+        ephemeral.mkdir(parents=True)
+        persistent.mkdir(parents=True)
+        job_ctx = JobContext(
+            workspace="default",
+            storage=StoragePaths(ephemeral=ephemeral, persistent=persistent),
+            results=PlatformJobResults(job_name=job_name, workspace="default", sdk=ctx.sdk),
+            job_id=job["id"],
+        )
+
+        async def _invoke(request: Any) -> FabricRuntimeResult:
+            (request.base_dir / "workspace" / "partial.txt").write_text("partial workspace\n")
+            (request.base_dir / "artifacts" / "partial.log").write_text("partial artifacts\n")
+            raise RuntimeError("fabric exploded")
+
+        with (
+            patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke),
+            pytest.raises(RuntimeError, match="fabric exploded"),
+        ):
+            AgentInvocationJob().run(job["spec"], ctx=job_ctx, sdk=ctx.sdk)
+
+        results_response = ctx.test_client.get(f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results")
+        assert results_response.status_code == 200, results_response.text
+        assert sorted(item["name"] for item in results_response.json()["data"]) == sorted(
+            [
+                "input_workdir",
+                "output_workdir",
+                "output_artifacts",
+                "fabric_error",
+            ]
+        )
+
+        output_workdir_response = ctx.test_client.get(
+            f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results/output_workdir/download"
+        )
+        assert output_workdir_response.status_code == 200, output_workdir_response.text
+        output_files = _extract_tar_members(output_workdir_response.content, tmp_path / "downloaded-output-workdir")
+        assert any(path.endswith("README.md") and content == "base readme\n" for path, content in output_files.items())
+        assert any(
+            path.endswith("partial.txt") and content == "partial workspace\n" for path, content in output_files.items()
+        )
+
+        artifacts_response = ctx.test_client.get(
+            f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results/output_artifacts/download"
+        )
+        assert artifacts_response.status_code == 200, artifacts_response.text
+        artifact_files = _extract_tar_members(artifacts_response.content, tmp_path / "downloaded-output-artifacts")
+        assert any(
+            path.endswith("partial.log") and content == "partial artifacts\n"
+            for path, content in artifact_files.items()
+        )
+
+        error_response = ctx.test_client.get(
+            f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results/fabric_error/download"
+        )
+        assert error_response.status_code == 200, error_response.text
+        error_payload = json.loads(error_response.content)
+        assert error_payload["fabric_status"] == "error"
+        assert error_payload["type"] == "RuntimeError"
+        assert error_payload["message"] == "fabric exploded"

--- a/plugins/nemo-agents/tests/integration/test_invoke_job_integration.py
+++ b/plugins/nemo-agents/tests/integration/test_invoke_job_integration.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+from nemo_agents_plugin.jobs.invoke import AgentInvocationJob
+from nemo_agents_plugin.service import AgentsService
+from nemo_platform_plugin.job_context import JobContext, StoragePaths
+from nemo_platform_plugin.job_results import PlatformJobResults
+from nmp.core.files.service import FilesService
+from nmp.core.jobs.service import JobsService
+from nmp.platform_runner.plugin_adapter import NemoServiceAdapter
+from nmp.testing import ClientContext, create_test_client
+
+pytestmark = pytest.mark.integration
+
+
+class _TestAgentsService(NemoServiceAdapter):
+    def __init__(self) -> None:
+        super().__init__(AgentsService())
+
+
+def _extract_tar_members(content: bytes, target_dir: Path) -> dict[str, str]:
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as tar:
+        tar.extractall(target_dir, filter="data")
+
+    files: dict[str, str] = {}
+    for path in target_dir.rglob("*"):
+        if path.is_file():
+            relative = path.relative_to(target_dir)
+            files[relative.as_posix()] = path.read_text()
+    return files
+
+
+def test_invoke_job_materializes_layered_input_workspace(tmp_path: Path) -> None:
+    with create_test_client(
+        _TestAgentsService,
+        FilesService,
+        JobsService,
+        client_type=ClientContext,
+        workspace="default",
+    ) as ctx:
+        # Create an Agent through the public Agents API so the job's to_spec
+        # resolution path sees the same entity shape as a real caller.
+        agent_response = ctx.test_client.post(
+            "/apis/agents/v2/workspaces/default/agents",
+            json={"name": "calc", "config": {}},
+        )
+        assert agent_response.status_code == 201, agent_response.text
+
+        ctx.sdk.files.upload_content(
+            workspace="default",
+            fileset="base-workdir",
+            remote_path="README.md",
+            content="base readme\n",
+            fileset_auto_create=True,
+        )
+        ctx.sdk.files.upload_content(
+            workspace="default",
+            fileset="base-workdir",
+            remote_path="app/config.yaml",
+            content="source: base\n",
+        )
+        ctx.sdk.files.upload_content(
+            workspace="default",
+            fileset="config-artifact",
+            remote_path="config.yaml",
+            content="source: artifact\n",
+            fileset_auto_create=True,
+        )
+        ctx.sdk.files.upload_content(
+            workspace="default",
+            fileset="notes-artifact",
+            remote_path="notes.txt",
+            content="mounted notes\n",
+            fileset_auto_create=True,
+        )
+
+        job_name = "invoke-layered-workdir"
+        create_response = ctx.test_client.post(
+            "/apis/agents/v2/workspaces/default/jobs/invoke",
+            json={
+                "name": job_name,
+                "spec": {
+                    "agent": "calc",
+                    "input": "hello",
+                    "workdir": {
+                        "base_workdir": "base-workdir",
+                        "artifact_mounts": [
+                            {"ref": "config-artifact#config.yaml", "mount_path": "app/config.yaml"},
+                            {"ref": "notes-artifact#notes.txt", "mount_path": "notes/notes.txt"},
+                        ],
+                    },
+                },
+            },
+        )
+        assert create_response.status_code == 201, create_response.text
+        job = create_response.json()
+        assert job["name"] == job_name
+        assert job["spec"]["workdir"]["base_workdir"] == "default/base-workdir#"
+        assert job["spec"]["workdir"]["artifact_mounts"] == [
+            {"ref": "default/config-artifact#config.yaml", "mount_path": "app/config.yaml"},
+            {"ref": "default/notes-artifact#notes.txt", "mount_path": "notes/notes.txt"},
+        ]
+
+        storage_root = tmp_path / "job-storage"
+        ephemeral = storage_root / "ephemeral"
+        persistent = storage_root / "persistent"
+        ephemeral.mkdir(parents=True)
+        persistent.mkdir(parents=True)
+        job_ctx = JobContext(
+            workspace="default",
+            storage=StoragePaths(ephemeral=ephemeral, persistent=persistent),
+            results=PlatformJobResults(job_name=job_name, workspace="default", sdk=ctx.sdk),
+            job_id=job["id"],
+        )
+
+        result = AgentInvocationJob().run(job["spec"], ctx=job_ctx, sdk=ctx.sdk)
+        assert result["status"] == "completed"
+        assert result["input_workdir"]["name"] == "input_workdir"
+
+        results_response = ctx.test_client.get(f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results")
+        assert results_response.status_code == 200, results_response.text
+        assert [item["name"] for item in results_response.json()["data"]] == ["input_workdir"]
+
+        result_response = ctx.test_client.get(
+            f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results/input_workdir"
+        )
+        assert result_response.status_code == 200, result_response.text
+        assert result_response.json()["name"] == "input_workdir"
+
+        download_response = ctx.test_client.get(
+            f"/apis/agents/v2/workspaces/default/jobs/invoke/{job_name}/results/input_workdir/download"
+        )
+        assert download_response.status_code == 200, download_response.text
+        files = _extract_tar_members(download_response.content, tmp_path / "downloaded-input-workdir")
+
+        assert any(path.endswith("README.md") and content == "base readme\n" for path, content in files.items())
+        assert any(
+            path.endswith("app/config.yaml") and content == "source: artifact\n" for path, content in files.items()
+        )
+        assert any(path.endswith("notes/notes.txt") and content == "mounted notes\n" for path, content in files.items())
+        assert "source: base\n" not in files.values()

--- a/plugins/nemo-agents/tests/unit/test_cli_list_output.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_list_output.py
@@ -51,7 +51,7 @@ def _deployments_response() -> dict[str, Any]:
                 "endpoint": "http://localhost:8001",
                 "config": {"workflow": {"_type": "react_agent"}},
                 "port": 8001,
-                "pid": 12345,
+                "pid": 67890,
                 "created_at": "2026-05-12T20:01:00.123456",
             }
         ],
@@ -95,7 +95,7 @@ class TestDeploymentsListOutput:
         assert "http://loc" in result.output
         assert '"data"' not in result.output
         assert "react_agent" not in result.output
-        assert "12345" not in result.output
+        assert "67890" not in result.output
 
     @pytest.mark.parametrize("flag", ["--format", "-o", "--output-format", "-f"])
     def test_deployments_list_supports_json_output(self, app, flag: str) -> None:

--- a/plugins/nemo-agents/tests/unit/test_fabric_invocation.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_invocation.py
@@ -11,7 +11,12 @@ from unittest.mock import patch
 
 import pytest
 from nemo_agents_plugin.agent_config import AgentConfig
-from nemo_agents_plugin.fabric.invocation import invoke_agent_config_once
+from nemo_agents_plugin.fabric.invocation import (
+    AgentConfigInvocationRequest,
+    FabricDirectories,
+    invoke_agent_config_once,
+    invoke_agent_config_request_once,
+)
 from nemo_agents_plugin.fabric.runtime import FabricRuntimeResult
 
 
@@ -32,6 +37,37 @@ def _agent_config() -> dict[str, Any]:
             },
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_config_request_once_translates_and_runs_one_input(tmp_path: Path) -> None:
+    captured: list[Any] = []
+
+    async def _run_fabric_agent_once(request: Any) -> FabricRuntimeResult:
+        captured.append(request)
+        return FabricRuntimeResult(status="succeeded", response=f"response:{request.input}")
+
+    agent_config = AgentConfig.model_validate(_agent_config())
+    with patch("nemo_agents_plugin.fabric.invocation.run_fabric_agent_once", _run_fabric_agent_once):
+        result = await invoke_agent_config_request_once(
+            AgentConfigInvocationRequest(
+                agent_config=agent_config,
+                input="one",
+                base_dir=tmp_path,
+                request_id="job-1",
+                caller_context={"source": "job"},
+                timeout_seconds=12,
+            )
+        )
+
+    assert result.response == "response:one"
+    request = captured[0]
+    assert request.input == "one"
+    assert request.base_dir == tmp_path
+    assert request.request_id == "job-1"
+    assert request.caller_context == {"source": "job"}
+    assert request.timeout_seconds == 12
+    assert request.fabric_config.metadata.name == "fabric-agent"
 
 
 @pytest.mark.asyncio
@@ -67,12 +103,34 @@ async def test_invoke_agent_config_once_creates_local_workspace_dir(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_invoke_agent_config_request_once_creates_local_artifacts_dir(tmp_path: Path) -> None:
+    config = _agent_config()
+    config["environment"] = {"workspace": "./workspace", "artifacts": "./artifacts"}
+
+    async def _run_fabric_agent_once(request: Any) -> FabricRuntimeResult:
+        assert (tmp_path / "workspace").is_dir()
+        assert (tmp_path / "artifacts").is_dir()
+        return FabricRuntimeResult(status="succeeded")
+
+    agent_config = AgentConfig.model_validate(config)
+    with patch("nemo_agents_plugin.fabric.invocation.run_fabric_agent_once", _run_fabric_agent_once):
+        await invoke_agent_config_request_once(
+            AgentConfigInvocationRequest(agent_config=agent_config, input="one", base_dir=tmp_path)
+        )
+
+
+@pytest.mark.asyncio
 async def test_invoke_agent_config_once_rejects_absolute_local_workspace(tmp_path: Path) -> None:
     config = _agent_config()
     config["environment"] = {"workspace": str(tmp_path.parent / "outside")}
     agent_config = AgentConfig.model_validate(config)
 
-    with pytest.raises(ValueError, match="Local workspace path must be relative"):
+    expected_msg = "Local workspace path must be relative"
+
+    with pytest.raises(ValueError, match=expected_msg):
+        FabricDirectories.create(agent_config, tmp_path)
+
+    with pytest.raises(ValueError, match=expected_msg):
         await invoke_agent_config_once(agent_config, ["one"], base_dir=tmp_path)
 
 
@@ -82,5 +140,10 @@ async def test_invoke_agent_config_once_rejects_workspace_traversal(tmp_path: Pa
     config["environment"] = {"workspace": "../../outside"}
     agent_config = AgentConfig.model_validate(config)
 
-    with pytest.raises(ValueError, match="Local workspace path must remain within"):
+    expected_msg = "Local workspace path must remain within"
+
+    with pytest.raises(ValueError, match=expected_msg):
+        FabricDirectories.create(agent_config, tmp_path)
+
+    with pytest.raises(ValueError, match=expected_msg):
         await invoke_agent_config_once(agent_config, ["one"], base_dir=tmp_path)

--- a/plugins/nemo-agents/tests/unit/test_invoke_job.py
+++ b/plugins/nemo-agents/tests/unit/test_invoke_job.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 from nemo_agents_plugin.entities import Agent
 from nemo_agents_plugin.fabric.runtime import FabricRuntimeResult
 from nemo_agents_plugin.jobs.invoke import (
+    DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS,
     FABRIC_ERROR_RESULT_NAME,
     FABRIC_RUN_RESULT_NAME,
     INPUT_WORKDIR_RESULT_NAME,
@@ -71,6 +72,17 @@ def _resolved_agent(name: str = "calc", workspace: str = "default") -> ResolvedA
     )
 
 
+def test_job_config_defaults_to_bounded_fabric_timeout() -> None:
+    config = AgentInvocationJobConfig(agent="calc", input="hello")
+
+    assert config.timeout_seconds == DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS
+
+
+def test_job_config_rejects_non_positive_fabric_timeout() -> None:
+    with pytest.raises(ValueError, match="greater than 0"):
+        AgentInvocationJobConfig(agent="calc", input="hello", timeout_seconds=0)
+
+
 @pytest.mark.asyncio
 async def test_to_spec_resolves_bare_agent_against_route_workspace() -> None:
     entity_client = AsyncMock()
@@ -88,6 +100,7 @@ async def test_to_spec_resolves_bare_agent_against_route_workspace() -> None:
     assert step_config.agent.name == "calc"
     assert step_config.agent.workspace == "default"
     assert step_config.request.input == "hello"
+    assert step_config.request.timeout_seconds == DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS
     assert step_config.workdir is None
     assert (
         step_config.agent.config["models"]["default"]["base_url"]
@@ -418,6 +431,7 @@ def test_run_without_input_workdir_saves_empty_input_snapshot(ctx: JobContext) -
     async def _invoke(request: Any) -> FabricRuntimeResult:
         assert request.input == "hello"
         assert request.base_dir == ctx.storage.ephemeral / "fabric"
+        assert request.timeout_seconds == DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS
         (request.base_dir / "workspace" / "answer.txt").write_text("done\n")
         (request.base_dir / "artifacts" / "trace.json").write_text("{}\n")
         return FabricRuntimeResult(
@@ -444,6 +458,22 @@ def test_run_without_input_workdir_saves_empty_input_snapshot(ctx: JobContext) -
     payload = json.loads((ctx.storage.persistent / "results" / FABRIC_RUN_RESULT_NAME).read_text())
     assert payload["metadata"] == {"adapter_runner": "python"}
     assert payload["runtime_id"] == "runtime-1"
+
+
+def test_run_threads_custom_timeout_to_fabric(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello", timeout_seconds=12.5),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        assert request.timeout_seconds == 12.5
+        return FabricRuntimeResult(status="succeeded")
+
+    with patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke):
+        result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert result["status"] == "completed"
 
 
 def test_run_rejects_non_fabric_step_config(ctx: JobContext) -> None:
@@ -728,6 +758,7 @@ def test_invoke_job_create_route_stores_canonical_step_config() -> None:
         "agent": "calc",
         "input": "hello",
         "workdir": {"base_workdir": "source#project", "artifact_mounts": []},
+        "timeout_seconds": DEFAULT_AGENT_INVOCATION_TIMEOUT_SECONDS,
     }
     assert body.spec["workdir"] == {"base_workdir": "default/source#project/", "artifact_mounts": []}
     assert body.platform_spec.steps[0].name == "invoke-agent"

--- a/plugins/nemo-agents/tests/unit/test_invoke_job.py
+++ b/plugins/nemo-agents/tests/unit/test_invoke_job.py
@@ -402,24 +402,54 @@ async def test_compile_produces_single_cpu_step_with_canonical_config() -> None:
         workdir=AgentWorkdir(base_workdir="default/source#project/"),
     )
 
-    platform_spec = await AgentInvocationJob.compile(
-        workspace="default",
-        spec=spec,
-        entity_client=MagicMock(),
-        job_name=None,
-        async_sdk=MagicMock(),
-    )
+    with patch("nemo_agents_plugin.jobs.invoke.AgentsConfig.get") as get_config:
+        get_config.return_value.deployments.default_image = "registry.example/nmp-api:test"
+        platform_spec = await AgentInvocationJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
 
     steps = list(platform_spec["steps"])
     assert len(steps) == 1
     step = steps[0]
     assert step["name"] == "invoke-agent"
     assert step["executor"]["provider"] == "cpu"
+    assert step["executor"]["container"]["image"] == "registry.example/nmp-api:test"
     assert step["executor"]["container"]["command"] == ["nemo_agents_plugin.tasks.invoke"]
     assert step["config"] == spec.model_dump(mode="json")
     step_config = cast(dict[str, Any], step["config"])
     assert cast(dict[str, Any], step_config["request"])["input"] == "hello"
     assert step["environment"] == []
+
+
+@pytest.mark.asyncio
+async def test_compile_falls_back_to_qualified_api_image() -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    with (
+        patch("nemo_agents_plugin.jobs.invoke.AgentsConfig.get") as get_config,
+        patch("nemo_agents_plugin.jobs.invoke.get_qualified_image", return_value="qualified/nmp-api:dev"),
+    ):
+        get_config.return_value.deployments.default_image = ""
+        platform_spec = await AgentInvocationJob.compile(
+            workspace="default",
+            spec=spec,
+            entity_client=MagicMock(),
+            job_name=None,
+            async_sdk=MagicMock(),
+        )
+
+    steps = list(platform_spec["steps"])
+    assert len(steps) == 1
+    step = steps[0]
+    assert step["executor"]["provider"] == "cpu"
+    assert step["executor"]["container"]["image"] == "qualified/nmp-api:dev"
 
 
 def test_run_without_input_workdir_saves_empty_input_snapshot(ctx: JobContext) -> None:

--- a/plugins/nemo-agents/tests/unit/test_invoke_job.py
+++ b/plugins/nemo-agents/tests/unit/test_invoke_job.py
@@ -1,0 +1,490 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from nemo_agents_plugin.entities import Agent
+from nemo_agents_plugin.jobs.invoke import (
+    AgentInvocationJob,
+    AgentInvocationJobConfig,
+    AgentInvocationStepConfig,
+    ResolvedAgentConfig,
+)
+from nemo_agents_plugin.tasks.invoke.workdir import (
+    AgentWorkdir,
+    AgentWorkdirArtifactMount,
+    _canonical_files_ref,
+    materialize_agent_workdir,
+    validate_agent_workdir,
+)
+from nemo_platform_plugin.dependencies import get_entity_client, get_sdk_client
+from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+from nemo_platform_plugin.job_context import JobContext
+from nemo_platform_plugin.jobs.routes import add_job_routes
+
+
+def _agent(name: str = "calc", workspace: str = "default") -> Agent:
+    return Agent(name=name, workspace=workspace, config={"workflow": {}}, config_format="nat-workflow-v1")
+
+
+def _sdk_with_files(data: list[object] | None = None) -> MagicMock:
+    sdk = MagicMock()
+    sdk.files.list = AsyncMock(return_value=SimpleNamespace(data=data if data is not None else [object()]))
+    return sdk
+
+
+def _resolved_agent(name: str = "calc", workspace: str = "default") -> ResolvedAgentConfig:
+    return ResolvedAgentConfig(name=name, workspace=workspace, config={}, config_format="nat-workflow-v1")
+
+
+@pytest.mark.asyncio
+async def test_to_spec_resolves_bare_agent_against_route_workspace() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _agent()
+
+    spec = await AgentInvocationJob.to_spec(
+        AgentInvocationJobConfig(agent="calc", input="hello"),
+        workspace="default",
+        entity_client=entity_client,
+        async_sdk=_sdk_with_files(),
+        is_local=False,
+    )
+
+    step_config = AgentInvocationStepConfig.model_validate(spec)
+    assert step_config.agent.name == "calc"
+    assert step_config.agent.workspace == "default"
+    assert step_config.request.input == "hello"
+    assert step_config.workdir is None
+    entity_client.get.assert_awaited_once_with(Agent, name="calc", workspace="default")
+
+
+@pytest.mark.asyncio
+async def test_to_spec_preserves_explicit_agent_workspace() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _agent(workspace="research")
+
+    await AgentInvocationJob.to_spec(
+        AgentInvocationJobConfig(agent="research/calc", input="hello"),
+        workspace="default",
+        entity_client=entity_client,
+        async_sdk=_sdk_with_files(),
+        is_local=False,
+    )
+
+    entity_client.get.assert_awaited_once_with(Agent, name="calc", workspace="research")
+
+
+@pytest.mark.asyncio
+async def test_to_spec_rejects_missing_agent() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = NemoEntityNotFoundError("missing")
+
+    with pytest.raises(ValueError, match="Agent 'missing' not found"):
+        await AgentInvocationJob.to_spec(
+            AgentInvocationJobConfig(agent="missing", input="hello"),
+            workspace="default",
+            entity_client=entity_client,
+            async_sdk=_sdk_with_files(),
+            is_local=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_to_spec_validates_and_canonicalizes_base_workdir() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _agent()
+    sdk = _sdk_with_files()
+
+    spec = await AgentInvocationJob.to_spec(
+        AgentInvocationJobConfig(agent="calc", input="hello", workdir=AgentWorkdir(base_workdir="source#project")),
+        workspace="default",
+        entity_client=entity_client,
+        async_sdk=sdk,
+        is_local=False,
+    )
+
+    step_config = AgentInvocationStepConfig.model_validate(spec)
+    assert step_config.workdir is not None
+    assert step_config.workdir.base_workdir == "default/source#project/"
+    sdk.files.list.assert_awaited_once_with(remote_path="default/source#project/")
+
+
+@pytest.mark.asyncio
+async def test_to_spec_rejects_single_file_base_workdir() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _agent()
+
+    with pytest.raises(ValueError, match="non-empty directory"):
+        await AgentInvocationJob.to_spec(
+            AgentInvocationJobConfig(
+                agent="calc", input="hello", workdir=AgentWorkdir(base_workdir="source#README.md")
+            ),
+            workspace="default",
+            entity_client=entity_client,
+            async_sdk=_sdk_with_files(data=[]),
+            is_local=False,
+        )
+
+
+def test_canonical_base_workdir_ref_rejects_path_escape() -> None:
+    with pytest.raises(ValueError, match="path escapes"):
+        _canonical_files_ref(
+            "source#../secret",
+            default_workspace="default",
+            field="workdir.base_workdir",
+            directory_like=True,
+        )
+
+
+def test_canonical_base_workdir_ref_rejects_legacy_path_shape() -> None:
+    with pytest.raises(ValueError, match="before fileset paths"):
+        _canonical_files_ref(
+            "default/source/project",
+            default_workspace="default",
+            field="workdir.base_workdir",
+            directory_like=True,
+        )
+
+
+def test_canonical_base_workdir_root_ref_keeps_fileset_delimiter() -> None:
+    assert (
+        _canonical_files_ref(
+            "source",
+            default_workspace="default",
+            field="workdir.base_workdir",
+            directory_like=True,
+        )
+        == "default/source#"
+    )
+
+
+@pytest.mark.parametrize("mount_path", ["../secret", "data/../../secret", "/abs/path", "", ".", "data\\file"])
+def test_workdir_artifact_mount_rejects_escaping_mount_paths(mount_path: str) -> None:
+    with pytest.raises(ValueError):
+        AgentWorkdirArtifactMount(ref="source#artifact", mount_path=mount_path)
+
+
+def test_workdir_artifact_mount_normalizes_relative_mount_path() -> None:
+    mount = AgentWorkdirArtifactMount(ref="source#artifact", mount_path="data/output/")
+    assert mount.mount_path == "data/output"
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [("data", "data"), ("data", "data/file.txt"), ("data/project", "data/project/subdir")],
+)
+def test_workdir_spec_rejects_overlapping_mount_paths(left: str, right: str) -> None:
+    with pytest.raises(ValueError, match="overlapping mount paths"):
+        AgentWorkdir(
+            artifact_mounts=[
+                AgentWorkdirArtifactMount(ref="source#a", mount_path=left),
+                AgentWorkdirArtifactMount(ref="source#b", mount_path=right),
+            ]
+        )
+
+
+def test_workdir_spec_allows_sibling_mount_paths() -> None:
+    spec = AgentWorkdir(
+        artifact_mounts=[
+            AgentWorkdirArtifactMount(ref="source#a", mount_path="data/a"),
+            AgentWorkdirArtifactMount(ref="source#b", mount_path="data/b"),
+        ]
+    )
+    assert [mount.mount_path for mount in spec.artifact_mounts] == ["data/a", "data/b"]
+
+
+@pytest.mark.asyncio
+async def test_validate_agent_workdir_canonicalizes_refs() -> None:
+    files_client = MagicMock()
+    files_client.list = AsyncMock(return_value=SimpleNamespace(data=[object()]))
+
+    spec = await validate_agent_workdir(
+        AgentWorkdir(
+            base_workdir="source#project",
+            artifact_mounts=[AgentWorkdirArtifactMount(ref="artifacts#notes.txt", mount_path="notes.txt")],
+        ),
+        files_client,
+        default_workspace="default",
+    )
+
+    assert spec is not None
+    assert spec.base_workdir == "default/source#project/"
+    assert spec.artifact_mounts == [
+        AgentWorkdirArtifactMount(ref="default/artifacts#notes.txt", mount_path="notes.txt")
+    ]
+    files_client.list.assert_has_awaits(
+        [call(remote_path="default/source#project/"), call(remote_path="default/artifacts#notes.txt")]
+    )
+
+
+def test_materialize_agent_workdir_downloads_base_and_mounts(tmp_path: Path) -> None:
+    files_client = MagicMock()
+    calls: list[tuple[str, str]] = []
+
+    def _download(*, remote_path: str, local_path: str) -> None:
+        calls.append((remote_path, local_path))
+        local = Path(local_path)
+        local.parent.mkdir(parents=True, exist_ok=True)
+        if remote_path == "default/source#project/":
+            local.mkdir(parents=True, exist_ok=True)
+            (local / "config.yaml").write_text("name: calc\n")
+        else:
+            local.write_text("mounted artifact\n")
+
+    files_client.download.side_effect = _download
+    target = tmp_path / "workdir"
+
+    materialize_agent_workdir(
+        AgentWorkdir(
+            base_workdir="default/source#project/",
+            artifact_mounts=[AgentWorkdirArtifactMount(ref="default/artifacts#notes.txt", mount_path="notes.txt")],
+        ),
+        files_client,
+        target,
+    )
+
+    assert calls == [
+        ("default/source#project/", str(target)),
+        ("default/artifacts#notes.txt", str(target / "notes.txt")),
+    ]
+    assert (target / "config.yaml").read_text() == "name: calc\n"
+    assert (target / "notes.txt").read_text() == "mounted artifact\n"
+
+
+def test_materialize_agent_workdir_replaces_base_directory_for_directory_mount(tmp_path: Path) -> None:
+    files_client = MagicMock()
+    calls: list[tuple[str, str]] = []
+
+    def _download(*, remote_path: str, local_path: str) -> None:
+        calls.append((remote_path, local_path))
+        local = Path(local_path)
+        local.parent.mkdir(parents=True, exist_ok=True)
+        if remote_path == "default/source#project/":
+            (local / "data").mkdir(parents=True)
+            (local / "data" / "stale.txt").write_text("stale\n")
+        else:
+            if local.is_dir():
+                raise IsADirectoryError(local)
+            local.mkdir(parents=True)
+            (local / "mounted.txt").write_text("mounted artifact\n")
+
+    files_client.download.side_effect = _download
+    target = tmp_path / "workdir"
+
+    materialize_agent_workdir(
+        AgentWorkdir(
+            base_workdir="default/source#project/",
+            artifact_mounts=[AgentWorkdirArtifactMount(ref="default/artifacts#data/", mount_path="data")],
+        ),
+        files_client,
+        target,
+    )
+
+    assert calls == [
+        ("default/source#project/", str(target)),
+        ("default/artifacts#data/", str(target / "data")),
+    ]
+    assert not (target / "data" / "stale.txt").exists()
+    assert (target / "data" / "mounted.txt").read_text() == "mounted artifact\n"
+
+
+@pytest.mark.asyncio
+async def test_compile_produces_single_cpu_step_with_canonical_config() -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+        workdir=AgentWorkdir(base_workdir="default/source#project/"),
+    )
+
+    platform_spec = await AgentInvocationJob.compile(
+        workspace="default",
+        spec=spec,
+        entity_client=MagicMock(),
+        job_name=None,
+        async_sdk=MagicMock(),
+    )
+
+    steps = list(platform_spec["steps"])
+    assert len(steps) == 1
+    step = steps[0]
+    assert step["name"] == "invoke-agent"
+    assert step["executor"]["provider"] == "cpu"
+    assert step["executor"]["container"]["command"] == ["nemo_agents_plugin.tasks.invoke"]
+    assert step["config"] == spec.model_dump(mode="json")
+    step_config = cast(dict[str, Any], step["config"])
+    assert cast(dict[str, Any], step_config["request"])["input"] == "hello"
+    assert step["environment"] == []
+
+
+def test_run_without_input_workdir_completes_without_result(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert result == {"status": "completed", "agent": "default/calc", "input_workdir": None}
+    assert not (ctx.storage.persistent / "results" / "input_workdir").exists()
+
+
+def test_run_downloads_and_registers_input_workdir(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(
+            agent="calc",
+            input="hello",
+            workdir=AgentWorkdir(base_workdir="source#project/"),
+        ),
+        agent=_resolved_agent(),
+        workdir=AgentWorkdir(
+            base_workdir="default/source#project/",
+            artifact_mounts=[AgentWorkdirArtifactMount(ref="default/artifacts#notes.txt", mount_path="notes.txt")],
+        ),
+    )
+    sdk = MagicMock()
+    download_calls: list[tuple[str, str]] = []
+
+    def _download(*, remote_path: str, local_path: str) -> None:
+        download_calls.append((remote_path, local_path))
+        local = Path(local_path)
+        local.parent.mkdir(parents=True, exist_ok=True)
+        if remote_path == "default/source#project/":
+            local.mkdir(parents=True, exist_ok=True)
+            Path(local_path, "config.yaml").write_text("name: calc\n")
+        else:
+            local.write_text("mounted artifact\n")
+
+    sdk.files.download.side_effect = _download
+
+    result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
+
+    assert result["status"] == "completed"
+    assert result["input_workdir"]["name"] == "input_workdir"
+    assert [remote_path for remote_path, _ in download_calls] == [
+        "default/source#project/",
+        "default/artifacts#notes.txt",
+    ]
+    assert (ctx.storage.persistent / "results" / "input_workdir" / "config.yaml").read_text() == "name: calc\n"
+    assert (ctx.storage.persistent / "results" / "input_workdir" / "notes.txt").read_text() == "mounted artifact\n"
+
+
+def test_run_clears_stale_input_workdir_before_materializing(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(
+            agent="calc",
+            input="hello",
+            workdir=AgentWorkdir(base_workdir="source#project/"),
+        ),
+        agent=_resolved_agent(),
+        workdir=AgentWorkdir(base_workdir="default/source#project/"),
+    )
+    stale_workdir = ctx.storage.ephemeral / "input_workdir"
+    stale_workdir.mkdir()
+    (stale_workdir / "stale.txt").write_text("stale\n")
+    sdk = MagicMock()
+
+    def _download(*, remote_path: str, local_path: str) -> None:
+        assert remote_path == "default/source#project/"
+        local = Path(local_path)
+        assert not (local / "stale.txt").exists()
+        local.mkdir(parents=True, exist_ok=True)
+        (local / "config.yaml").write_text("name: calc\n")
+
+    sdk.files.download.side_effect = _download
+
+    result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
+
+    assert result["status"] == "completed"
+    assert result["input_workdir"]["name"] == "input_workdir"
+    saved_workdir = ctx.storage.persistent / "results" / "input_workdir"
+    assert not (saved_workdir / "stale.txt").exists()
+    assert (saved_workdir / "config.yaml").read_text() == "name: calc\n"
+
+
+def test_run_failed_download_does_not_register_partial_result(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(
+            agent="calc",
+            input="hello",
+            workdir=AgentWorkdir(base_workdir="source#project/"),
+        ),
+        agent=_resolved_agent(),
+        workdir=AgentWorkdir(base_workdir="default/source#project/"),
+    )
+    sdk = MagicMock()
+    sdk.files.download.side_effect = RuntimeError("download failed")
+
+    with pytest.raises(RuntimeError, match="download failed"):
+        AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
+
+    assert not (ctx.storage.persistent / "results" / "input_workdir").exists()
+
+
+def test_invoke_job_create_route_stores_canonical_step_config() -> None:
+    app = FastAPI()
+    app.include_router(add_job_routes(AgentInvocationJob), prefix="/apis/agents/v2/workspaces/{workspace}")
+
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _agent()
+    sdk = _sdk_with_files()
+    app.dependency_overrides[get_entity_client] = lambda: entity_client
+    app.dependency_overrides[get_sdk_client] = lambda: sdk
+
+    captured_body: dict[str, Any] = {}
+
+    async def _create_job(*, workspace: str, body: object) -> MagicMock:
+        del workspace
+        typed_body = cast(Any, body)
+        captured_body["body"] = body
+        response = MagicMock()
+        response.data.return_value = SimpleNamespace(
+            id="job-1",
+            name="invoke-1",
+            description=None,
+            workspace="default",
+            created_at=None,
+            updated_at=None,
+            spec=typed_body.spec,
+            status="created",
+            status_details=None,
+            error_details=None,
+            ownership=None,
+            custom_fields=None,
+        )
+        return response
+
+    fake_jobs = SimpleNamespace(create_job=_create_job)
+    with patch("nemo_platform_plugin.jobs.api_factory.client_from_platform", return_value=fake_jobs):
+        response = TestClient(app).post(
+            "/apis/agents/v2/workspaces/default/jobs/invoke",
+            json={
+                "name": "invoke-1",
+                "spec": {"agent": "calc", "input": "hello", "workdir": {"base_workdir": "source#project"}},
+            },
+        )
+
+    assert response.status_code == 201, response.text
+    body = captured_body["body"]
+    assert body.source == "nemo-agents-plugin"
+    assert body.spec["agent"] == {
+        "name": "calc",
+        "workspace": "default",
+        "config": {"workflow": {}},
+        "config_format": "nat-workflow-v1",
+    }
+    assert body.spec["request"] == {
+        "agent": "calc",
+        "input": "hello",
+        "workdir": {"base_workdir": "source#project", "artifact_mounts": []},
+    }
+    assert body.spec["workdir"] == {"base_workdir": "default/source#project/", "artifact_mounts": []}
+    assert body.platform_spec.steps[0].name == "invoke-agent"
+    assert response.json()["spec"]["workdir"]["base_workdir"] == "default/source#project/"

--- a/plugins/nemo-agents/tests/unit/test_invoke_job.py
+++ b/plugins/nemo-agents/tests/unit/test_invoke_job.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -12,7 +13,13 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_agents_plugin.entities import Agent
+from nemo_agents_plugin.fabric.runtime import FabricRuntimeResult
 from nemo_agents_plugin.jobs.invoke import (
+    FABRIC_ERROR_RESULT_NAME,
+    FABRIC_RUN_RESULT_NAME,
+    INPUT_WORKDIR_RESULT_NAME,
+    OUTPUT_ARTIFACTS_RESULT_NAME,
+    OUTPUT_WORKDIR_RESULT_NAME,
     AgentInvocationJob,
     AgentInvocationJobConfig,
     AgentInvocationStepConfig,
@@ -31,8 +38,22 @@ from nemo_platform_plugin.job_context import JobContext
 from nemo_platform_plugin.jobs.routes import add_job_routes
 
 
-def _agent(name: str = "calc", workspace: str = "default") -> Agent:
-    return Agent(name=name, workspace=workspace, config={"workflow": {}}, config_format="nat-workflow-v1")
+def _agent_config(**environment: str) -> dict[str, Any]:
+    config = {
+        "config_format": "nemo-agents-spec-v1",
+        "name": "calc",
+        "default_harness": "hermes",
+        "harnesses": {"hermes": {"kind": "hermes"}},
+        "models": {"default": {"provider": "openai", "model": "openai/gpt-5.4"}},
+    }
+    if environment:
+        config["environment"] = environment
+    return config
+
+
+def _agent(name: str = "calc", workspace: str = "default", config_format: str = "nemo-agents-spec-v1") -> Agent:
+    config = _agent_config() if config_format == "nemo-agents-spec-v1" else {"workflow": {}}
+    return Agent(name=name, workspace=workspace, config=config, config_format=config_format)
 
 
 def _sdk_with_files(data: list[object] | None = None) -> MagicMock:
@@ -42,7 +63,12 @@ def _sdk_with_files(data: list[object] | None = None) -> MagicMock:
 
 
 def _resolved_agent(name: str = "calc", workspace: str = "default") -> ResolvedAgentConfig:
-    return ResolvedAgentConfig(name=name, workspace=workspace, config={}, config_format="nat-workflow-v1")
+    return ResolvedAgentConfig(
+        name=name,
+        workspace=workspace,
+        config=_agent_config(),
+        config_format="nemo-agents-spec-v1",
+    )
 
 
 @pytest.mark.asyncio
@@ -63,6 +89,10 @@ async def test_to_spec_resolves_bare_agent_against_route_workspace() -> None:
     assert step_config.agent.workspace == "default"
     assert step_config.request.input == "hello"
     assert step_config.workdir is None
+    assert (
+        step_config.agent.config["models"]["default"]["base_url"]
+        == "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1"
+    )
     entity_client.get.assert_awaited_once_with(Agent, name="calc", workspace="default")
 
 
@@ -90,6 +120,61 @@ async def test_to_spec_rejects_missing_agent() -> None:
     with pytest.raises(ValueError, match="Agent 'missing' not found"):
         await AgentInvocationJob.to_spec(
             AgentInvocationJobConfig(agent="missing", input="hello"),
+            workspace="default",
+            entity_client=entity_client,
+            async_sdk=_sdk_with_files(),
+            is_local=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_to_spec_rejects_non_fabric_agent() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _agent(config_format="nat-workflow-v1")
+
+    with pytest.raises(ValueError, match="only support 'nemo-agents-spec-v1'"):
+        await AgentInvocationJob.to_spec(
+            AgentInvocationJobConfig(agent="calc", input="hello"),
+            workspace="default",
+            entity_client=entity_client,
+            async_sdk=_sdk_with_files(),
+            is_local=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_to_spec_rejects_malformed_fabric_agent_config() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = Agent(
+        name="calc",
+        workspace="default",
+        config={"config_format": "nemo-agents-spec-v1", "name": "calc"},
+        config_format="nemo-agents-spec-v1",
+    )
+
+    with pytest.raises(ValueError, match="default_harness"):
+        await AgentInvocationJob.to_spec(
+            AgentInvocationJobConfig(agent="calc", input="hello"),
+            workspace="default",
+            entity_client=entity_client,
+            async_sdk=_sdk_with_files(),
+            is_local=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_to_spec_rejects_non_local_fabric_environment() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = Agent(
+        name="calc",
+        workspace="default",
+        config=_agent_config(provider="docker"),
+        config_format="nemo-agents-spec-v1",
+    )
+
+    with pytest.raises(ValueError, match="only support local Fabric environments"):
+        await AgentInvocationJob.to_spec(
+            AgentInvocationJobConfig(agent="calc", input="hello"),
             workspace="default",
             entity_client=entity_client,
             async_sdk=_sdk_with_files(),
@@ -324,16 +409,56 @@ async def test_compile_produces_single_cpu_step_with_canonical_config() -> None:
     assert step["environment"] == []
 
 
-def test_run_without_input_workdir_completes_without_result(ctx: JobContext) -> None:
+def test_run_without_input_workdir_saves_empty_input_snapshot(ctx: JobContext) -> None:
     spec = AgentInvocationStepConfig(
         request=AgentInvocationJobConfig(agent="calc", input="hello"),
         agent=_resolved_agent(),
     )
 
-    result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        assert request.input == "hello"
+        assert request.base_dir == ctx.storage.ephemeral / "fabric"
+        (request.base_dir / "workspace" / "answer.txt").write_text("done\n")
+        (request.base_dir / "artifacts" / "trace.json").write_text("{}\n")
+        return FabricRuntimeResult(
+            status="succeeded",
+            response="done",
+            metadata={"adapter_runner": "python"},
+            runtime_id="runtime-1",
+            invocation_id="invocation-1",
+            request_id="request-1",
+        )
 
-    assert result == {"status": "completed", "agent": "default/calc", "input_workdir": None}
-    assert not (ctx.storage.persistent / "results" / "input_workdir").exists()
+    with patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke):
+        result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert result["status"] == "completed"
+    assert result["fabric_status"] == "succeeded"
+    assert result["input_workdir"]["name"] == INPUT_WORKDIR_RESULT_NAME
+    assert result["output_workdir"]["name"] == OUTPUT_WORKDIR_RESULT_NAME
+    assert result["output_artifacts"]["name"] == OUTPUT_ARTIFACTS_RESULT_NAME
+    assert result["fabric_run_result"]["name"] == FABRIC_RUN_RESULT_NAME
+    assert list((ctx.storage.persistent / "results" / INPUT_WORKDIR_RESULT_NAME).iterdir()) == []
+    assert (ctx.storage.persistent / "results" / OUTPUT_WORKDIR_RESULT_NAME / "answer.txt").read_text() == "done\n"
+    assert (ctx.storage.persistent / "results" / OUTPUT_ARTIFACTS_RESULT_NAME / "trace.json").read_text() == "{}\n"
+    payload = json.loads((ctx.storage.persistent / "results" / FABRIC_RUN_RESULT_NAME).read_text())
+    assert payload["metadata"] == {"adapter_runner": "python"}
+    assert payload["runtime_id"] == "runtime-1"
+
+
+def test_run_rejects_non_fabric_step_config(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello"),
+        agent=ResolvedAgentConfig(
+            name="calc",
+            workspace="default",
+            config={"workflow": {}},
+            config_format="nat-workflow-v1",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="only support 'nemo-agents-spec-v1'"):
+        AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
 
 
 def test_run_downloads_and_registers_input_workdir(ctx: JobContext) -> None:
@@ -364,7 +489,13 @@ def test_run_downloads_and_registers_input_workdir(ctx: JobContext) -> None:
 
     sdk.files.download.side_effect = _download
 
-    result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        (request.base_dir / "workspace" / "answer.txt").write_text("done\n")
+        (request.base_dir / "artifacts" / "artifact.txt").write_text("artifact\n")
+        return FabricRuntimeResult(status="succeeded", response="done")
+
+    with patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke):
+        result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
 
     assert result["status"] == "completed"
     assert result["input_workdir"]["name"] == "input_workdir"
@@ -374,6 +505,8 @@ def test_run_downloads_and_registers_input_workdir(ctx: JobContext) -> None:
     ]
     assert (ctx.storage.persistent / "results" / "input_workdir" / "config.yaml").read_text() == "name: calc\n"
     assert (ctx.storage.persistent / "results" / "input_workdir" / "notes.txt").read_text() == "mounted artifact\n"
+    assert (ctx.storage.persistent / "results" / "output_workdir" / "answer.txt").read_text() == "done\n"
+    assert (ctx.storage.persistent / "results" / "output_artifacts" / "artifact.txt").read_text() == "artifact\n"
 
 
 def test_run_clears_stale_input_workdir_before_materializing(ctx: JobContext) -> None:
@@ -386,8 +519,8 @@ def test_run_clears_stale_input_workdir_before_materializing(ctx: JobContext) ->
         agent=_resolved_agent(),
         workdir=AgentWorkdir(base_workdir="default/source#project/"),
     )
-    stale_workdir = ctx.storage.ephemeral / "input_workdir"
-    stale_workdir.mkdir()
+    stale_workdir = ctx.storage.ephemeral / "fabric" / "workspace"
+    stale_workdir.mkdir(parents=True)
     (stale_workdir / "stale.txt").write_text("stale\n")
     sdk = MagicMock()
 
@@ -400,13 +533,40 @@ def test_run_clears_stale_input_workdir_before_materializing(ctx: JobContext) ->
 
     sdk.files.download.side_effect = _download
 
-    result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        return FabricRuntimeResult(status="succeeded")
+
+    with patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke):
+        result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
 
     assert result["status"] == "completed"
     assert result["input_workdir"]["name"] == "input_workdir"
     saved_workdir = ctx.storage.persistent / "results" / "input_workdir"
     assert not (saved_workdir / "stale.txt").exists()
     assert (saved_workdir / "config.yaml").read_text() == "name: calc\n"
+
+
+def test_run_clears_stale_artifacts_dir_before_invoking(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+    stale_artifacts = ctx.storage.ephemeral / "fabric" / "artifacts"
+    stale_artifacts.mkdir(parents=True)
+    (stale_artifacts / "stale.txt").write_text("stale\n")
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        assert not (request.base_dir / "artifacts" / "stale.txt").exists()
+        (request.base_dir / "artifacts" / "fresh.txt").write_text("fresh\n")
+        return FabricRuntimeResult(status="succeeded")
+
+    with patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke):
+        result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert result["status"] == "completed"
+    saved_artifacts = ctx.storage.persistent / "results" / "output_artifacts"
+    assert not (saved_artifacts / "stale.txt").exists()
+    assert (saved_artifacts / "fresh.txt").read_text() == "fresh\n"
 
 
 def test_run_failed_download_does_not_register_partial_result(ctx: JobContext) -> None:
@@ -426,6 +586,83 @@ def test_run_failed_download_does_not_register_partial_result(ctx: JobContext) -
         AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx, sdk=sdk)
 
     assert not (ctx.storage.persistent / "results" / "input_workdir").exists()
+
+
+def test_run_failed_fabric_result_saves_results_and_marks_job_failed(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        (request.base_dir / "workspace" / "partial.txt").write_text("partial\n")
+        return FabricRuntimeResult(
+            status="failed",
+            error={"stage": "invoke", "message": "adapter failed"},
+        )
+
+    with patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke):
+        result = AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert result["status"] == "failed"
+    assert result["fabric_status"] == "failed"
+    assert (ctx.storage.persistent / "results" / OUTPUT_WORKDIR_RESULT_NAME / "partial.txt").read_text() == "partial\n"
+    payload = json.loads((ctx.storage.persistent / "results" / FABRIC_RUN_RESULT_NAME).read_text())
+    assert payload["status"] == "failed"
+    assert payload["error"] == {"stage": "invoke", "message": "adapter failed"}
+    assert not (ctx.storage.persistent / "results" / FABRIC_ERROR_RESULT_NAME).exists()
+
+
+def test_run_fabric_exception_saves_best_effort_error_results(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        (request.base_dir / "workspace" / "partial.txt").write_text("partial\n")
+        raise RuntimeError("fabric exploded")
+
+    with (
+        patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke),
+        pytest.raises(RuntimeError, match="fabric exploded"),
+    ):
+        AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert (ctx.storage.persistent / "results" / INPUT_WORKDIR_RESULT_NAME).is_dir()
+    assert (ctx.storage.persistent / "results" / OUTPUT_WORKDIR_RESULT_NAME / "partial.txt").read_text() == "partial\n"
+    assert (ctx.storage.persistent / "results" / OUTPUT_ARTIFACTS_RESULT_NAME).is_dir()
+    payload = json.loads((ctx.storage.persistent / "results" / FABRIC_ERROR_RESULT_NAME).read_text())
+    assert payload["type"] == "RuntimeError"
+    assert payload["message"] == "fabric exploded"
+    assert payload["fabric_status"] == "error"
+
+
+def test_run_fabric_exception_preserves_original_error_if_result_save_fails(ctx: JobContext) -> None:
+    spec = AgentInvocationStepConfig(
+        request=AgentInvocationJobConfig(agent="calc", input="hello"),
+        agent=_resolved_agent(),
+    )
+    original_save = ctx.results.save
+
+    async def _invoke(request: Any) -> FabricRuntimeResult:
+        (request.base_dir / "workspace" / "partial.txt").write_text("partial\n")
+        raise RuntimeError("fabric exploded")
+
+    def _save(name: str, local_path: str | Path, **kwargs: Any) -> Any:
+        if name == OUTPUT_WORKDIR_RESULT_NAME:
+            raise RuntimeError("save failed")
+        return original_save(name, local_path, **kwargs)
+
+    cast(Any, ctx.results).save = _save
+
+    with (
+        patch("nemo_agents_plugin.jobs.invoke.invoke_agent_config_request_once", _invoke),
+        pytest.raises(RuntimeError, match="fabric exploded"),
+    ):
+        AgentInvocationJob().run(spec.model_dump(mode="json"), ctx=ctx)
+
+    assert (ctx.storage.persistent / "results" / FABRIC_ERROR_RESULT_NAME).exists()
 
 
 def test_invoke_job_create_route_stores_canonical_step_config() -> None:
@@ -474,12 +711,19 @@ def test_invoke_job_create_route_stores_canonical_step_config() -> None:
     assert response.status_code == 201, response.text
     body = captured_body["body"]
     assert body.source == "nemo-agents-plugin"
-    assert body.spec["agent"] == {
-        "name": "calc",
-        "workspace": "default",
-        "config": {"workflow": {}},
-        "config_format": "nat-workflow-v1",
+    assert body.spec["agent"]["name"] == "calc"
+    assert body.spec["agent"]["workspace"] == "default"
+    assert body.spec["agent"]["config_format"] == "nemo-agents-spec-v1"
+    assert body.spec["agent"]["config"]["environment"] == {
+        "provider": "local",
+        "workspace": "./workspace",
+        "artifacts": "./artifacts",
+        "settings": {},
     }
+    assert (
+        body.spec["agent"]["config"]["models"]["default"]["base_url"]
+        == "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1"
+    )
     assert body.spec["request"] == {
         "agent": "calc",
         "input": "hello",

--- a/plugins/nemo-agents/tests/unit/test_service.py
+++ b/plugins/nemo-agents/tests/unit/test_service.py
@@ -9,6 +9,7 @@ from fastapi.routing import APIRoute
 from nemo_agents_plugin.jobs.analyze_batch import AnalyzeBatchJob
 from nemo_agents_plugin.jobs.evaluate_agent import EvaluateAgentJob
 from nemo_agents_plugin.jobs.evaluate_suite import EvaluateSuiteJob
+from nemo_agents_plugin.jobs.invoke import AgentInvocationJob
 from nemo_agents_plugin.jobs.optimize_skills import OptimizeSkillsJob
 from nemo_agents_plugin.service import AgentsService
 from nemo_optimization.jobs.optimize import OptimizeJob
@@ -23,7 +24,8 @@ def _mounted_routes() -> dict[str, set[str]]:
             if not isinstance(route, APIRoute):
                 continue
             path = f"/apis/agents{spec.prefix}{route.path}".replace("{trailing_uri:path}", "{trailing_uri}")
-            routes.setdefault(path, set()).update(route.methods)
+            if route.methods is not None:
+                routes.setdefault(path, set()).update(route.methods)
     return routes
 
 
@@ -42,6 +44,10 @@ def test_evaluate_job_route_matches_generated_submit_path() -> None:
 
 def test_evaluate_suite_job_route_matches_generated_submit_path() -> None:
     assert submit_path_for(EvaluateSuiteJob, workspace="{workspace}") in _mounted_post_paths()
+
+
+def test_invoke_job_route_matches_generated_submit_path() -> None:
+    assert submit_path_for(AgentInvocationJob, workspace="{workspace}") in _mounted_post_paths()
 
 
 def test_optimize_skills_job_route_matches_generated_submit_path() -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Building on https://github.com/NVIDIA-NeMo/nemo-platform/pull/1365, this PR adds the meat of the `AgentInvocationJob`: calling Fabric and persisting the output results.


## Changes
- Updates the job implementation to call Fabric and persist results after Fabric finishes
- Updates some common `nemo_agents_plugin.fabric.invocation` helpers
- Adds e2e tests

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included
