### PR TITLE
fix(experimentalist): use native Harbor evaluator in recorder

### DIFF
--- a/plugins/nemo-experimentalist/tests/experimentalist/test_smoke_agent_assets.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_smoke_agent_assets.py
@@ -15,6 +15,7 @@ import hashlib
 import importlib.util
 import re
 import shutil
+import subprocess
 import sys
 import tomllib
 from collections.abc import Iterable
@@ -61,6 +62,19 @@ def _expected_tag() -> str:
 def _template_toml() -> Path:
     """Return the canonical task shape."""
     return _EXAMPLE_DIR / "dataset" / "task-template" / "task.toml"
+
+
+def test_trace_recorder_imports_the_native_harbor_evaluator() -> None:
+    """The recorder must import the evaluator symbols from their public module."""
+    recorder = _EXAMPLE_DIR / "scripts" / "record_traces.py"
+    result = subprocess.run(
+        ["uv", "run", str(recorder), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=_REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 @functools.cache


### PR DESCRIPTION
## Summary
- import the smoke-agent recorder evaluator and configuration from `harbor_native`
- add a regression test that runs the recorder help path and verifies imports resolve

## Testing
- `uv run --project plugins/nemo-experimentalist ruff check plugins/nemo-experimentalist/examples/smoke-agent/scripts/record_traces.py plugins/nemo-experimentalist/tests/experimentalist/test_smoke_agent_assets.py`
- `uv run --project plugins/nemo-experimentalist pytest plugins/nemo-experimentalist/tests/experimentalist/test_smoke_agent_assets.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a smoke test to verify the trace recorder loads successfully.
  * Confirmed the recorder’s help command exits without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->