### PR TITLE
fix(studio): stop inactive Nebula animations

### DIFF
--- a/web/packages/common/src/components/Nebula/animate.ts
+++ b/web/packages/common/src/components/Nebula/animate.ts
@@ -25,6 +25,7 @@ export interface NebulaState {
   canvas: HTMLCanvasElement | null;
   ctx: CanvasRenderingContext2D | null;
   appearance: NebulaAppearance;
+  animationFrameId: number | null;
 }
 
 const CONNECTION_OPACITY = 0.15;
@@ -129,7 +130,21 @@ export const animate = (nebulaState: RefObject<NebulaState>) => (): void => {
     particle.update(nebulaState.current.lastSphereSize);
     particle.draw(ctx);
   });
-  requestAnimationFrame(animate(nebulaState));
+  nebulaState.current.animationFrameId = requestAnimationFrame(animate(nebulaState));
+};
+
+export const destroy = (nebulaState: RefObject<NebulaState>): void => {
+  if (!nebulaState.current) return;
+
+  if (nebulaState.current.animationFrameId !== null) {
+    cancelAnimationFrame(nebulaState.current.animationFrameId);
+  }
+
+  nebulaState.current.animationFrameId = null;
+  nebulaState.current.initialized = false;
+  nebulaState.current.particles = [];
+  nebulaState.current.canvas = null;
+  nebulaState.current.ctx = null;
 };
 
 export const initialize = (
@@ -159,5 +174,5 @@ export const initialize = (
         : new AmbientParticle(canvas, appearance);
     nebulaState.current.particles.push(particle);
   }
-  requestAnimationFrame(animate(nebulaState));
+  nebulaState.current.animationFrameId = requestAnimationFrame(animate(nebulaState));
 };

--- a/web/packages/common/src/components/Nebula/index.test.tsx
+++ b/web/packages/common/src/components/Nebula/index.test.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Nebula } from '@nemo/common/src/components/Nebula';
+import { render } from '@testing-library/react';
+
+const makeCanvasContext = (): CanvasRenderingContext2D =>
+  ({
+    arc: vi.fn(),
+    beginPath: vi.fn(),
+    clearRect: vi.fn(),
+    closePath: vi.fn(),
+    fill: vi.fn(),
+    lineTo: vi.fn(),
+    moveTo: vi.fn(),
+    restore: vi.fn(),
+    rotate: vi.fn(),
+    save: vi.fn(),
+    stroke: vi.fn(),
+    translate: vi.fn(),
+  }) as unknown as CanvasRenderingContext2D;
+
+describe('Nebula', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not retain animation frames across remounts', () => {
+    const pendingFrames = new Set<number>();
+    let nextFrameId = 0;
+
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => {
+      nextFrameId += 1;
+      pendingFrames.add(nextFrameId);
+      return nextFrameId;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((frameId) => {
+      pendingFrames.delete(frameId);
+    });
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() =>
+      makeCanvasContext()
+    );
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      const { unmount } = render(<Nebula variant="sphere" />);
+
+      unmount();
+    }
+
+    expect(pendingFrames.size).toBe(0);
+    expect(window.cancelAnimationFrame).toHaveBeenCalledTimes(3);
+  });
+});

--- a/web/packages/common/src/components/Nebula/index.tsx
+++ b/web/packages/common/src/components/Nebula/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { initialize, type NebulaState } from '@nemo/common/src/components/Nebula/animate';
+import { destroy, initialize, type NebulaState } from '@nemo/common/src/components/Nebula/animate';
 import type { NebulaProps } from '@nemo/common/src/components/Nebula/types';
 import { useCallback, useEffect, useRef } from 'react';
 
@@ -42,6 +42,7 @@ export const Nebula = ({
     canvas: null,
     ctx: null,
     appearance: { color, shape },
+    animationFrameId: null,
   });
 
   useEffect(() => {
@@ -66,7 +67,11 @@ export const Nebula = ({
 
   const handleRef = useCallback(
     (canvasElement: HTMLCanvasElement | null) => {
-      initialize(nebulaState, canvasElement, variant);
+      if (canvasElement) {
+        initialize(nebulaState, canvasElement, variant);
+      } else {
+        destroy(nebulaState);
+      }
     },
     [variant]
   );

--- a/web/packages/studio/src/routes/agents/AssistantChatRoute/AssistantTopBarChat.test.tsx
+++ b/web/packages/studio/src/routes/agents/AssistantChatRoute/AssistantTopBarChat.test.tsx
@@ -83,7 +83,9 @@ describe('AssistantTopBarChat', () => {
     expect(await screen.findByTestId('compact-chat-thread')).toBeVisible();
 
     await user.click(screen.getByRole('button', { name: 'Close NeMo Assistant chat' }));
-    await waitFor(() => expect(screen.getByTestId('compact-chat-thread')).not.toBeVisible());
+    await waitFor(() =>
+      expect(screen.queryByTestId('compact-chat-thread')).not.toBeInTheDocument()
+    );
   });
 
   it('darkens the screen with a backdrop and closes the chat when it is clicked', async () => {
@@ -129,7 +131,9 @@ describe('AssistantTopBarChat', () => {
     expect(await screen.findByTestId('compact-chat-thread')).toBeVisible();
 
     await user.click(screen.getByRole('link', { name: 'Job details' }));
-    await waitFor(() => expect(screen.getByTestId('compact-chat-thread')).not.toBeVisible());
+    await waitFor(() =>
+      expect(screen.queryByTestId('compact-chat-thread')).not.toBeInTheDocument()
+    );
   });
 
   it('shows a thinking indicator while the agent is running', () => {

--- a/web/packages/studio/src/routes/agents/AssistantChatRoute/AssistantTopBarChat.tsx
+++ b/web/packages/studio/src/routes/agents/AssistantChatRoute/AssistantTopBarChat.tsx
@@ -180,7 +180,7 @@ const AssistantTopBarChatPopout: FC<{ workspace: string }> = ({ workspace }) => 
               </Flex>
             </Flex>
             <Stack className="min-h-0 flex-1 overflow-hidden">
-              {hasOpened ? (
+              {isOpen && hasOpened ? (
                 <ChatThreadErrorBoundary onRetry={retryChatThread}>
                   <Suspense fallback={chatThreadFallback}>
                     <ChatThread


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
NeMo Studio kept the empty-chat `Nebula` animation running after the compact Assistant popover closed and after other empty-chat canvases unmounted. A single open and close of the top-bar Assistant was enough to leave the hidden animation consuming sustained renderer CPU; repeated chat lifecycles could additionally retain detached animation loops.

This change unmounts the compact Assistant thread when its popover closes, cancels the active animation frame during `Nebula` ref cleanup, and releases the retained animation state.

## Changes
- Unmount the compact Assistant thread when its popover closes instead of leaving its canvas hidden and active.
- Track and cancel the currently scheduled `requestAnimationFrame` when `Nebula` unmounts or reinitializes.
- Release the canvas, context, and particle references during cleanup.
- Add regression coverage for both the Assistant close behavior and repeated `Nebula` mount/unmount cycles.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the fix changes internal animation lifecycle behavior without changing a documented workflow or API.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

### Actual Studio reproduction

On `main`, with NeMo Assistant enabled:

1. Open a workspace route that shows the top-bar NeMo Assistant button, such as **Agents**.
2. Open NeMo Assistant once with an empty thread.
3. Close the Assistant popover once. Repeated opening or navigation is not required.
4. Leave the Studio tab open and inspect the renderer in Chrome Task Manager or DevTools Performance Monitor.

The KUI popover hides its content without unmounting it. Before this fix, the compact Assistant thread and its `Nebula` canvas therefore remained mounted after close, and `requestAnimationFrame` continued processing 250 particles plus 31,125 particle-pair connection checks every frame while the UI was hidden.

The actual bundled Studio frontend was run against its configured development backend in system Chrome. Chrome DevTools Protocol sampled five-second `TaskDuration` and `ScriptDuration` deltas on the Agents route.

| Actual Studio state | Mounted Nebulas | Renderer task CPU | JavaScript CPU |
| --- | ---: | ---: | ---: |
| Before opening Assistant (`main`) | 0 | 0.056% | 0% |
| Empty Assistant visible (`main`) | 1 | 12.79% | 8.66% |
| After closing Assistant once (`main`) | 1 | 8.94% | 7.21% |
| After closing Assistant once (this fix) | 0 | 0.0069–0.0153% across three runs | 0% |

With this fix, closing the popover unmounts the compact thread; the shared `Nebula` cleanup cancels its frame, and the renderer returns to idle.

### Detached-loop reproduction

The same shared empty state is used by model chat and full Assistant chat. On `main`, sending the first message or navigating away unmounts the empty state but leaves its frame loop active. A Playwright lifecycle harness automated ten mount/unmount cycles against the `origin/main` source and this branch:

| Build | Pending animation frames | Renderer task CPU after unmount |
| --- | ---: | ---: |
| `origin/main` | 10 | 48.47–51.70% across three runs |
| This fix | 0 | 0.011–0.019% across three runs |

An unminified baseline CPU profile identified quadratic `drawConnections` as the dominant function, followed by canvas `stroke`, particle `draw`, and garbage collection. The fixed profile was idle.

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/routes/agents/AssistantChatRoute/AssistantTopBarChat.test.tsx` — passed (8 tests).
- `pnpm --filter @nemo/common test src/components/Nebula/index.test.tsx` — passed (1 test).
- `pnpm --filter nemo-studio-ui test` — passed (315 files, 2,933 tests).
- `pnpm --filter @nemo/common test` — passed (121 files, 1,496 tests).
- `pnpm --filter nemo-studio-ui typecheck` — passed.
- `pnpm --filter nemo-studio-ui lint` — passed.
- Targeted Prettier check for all five changed files — passed.
- `VITE_FF_ASSISTANT_STUDIO_ENABLED=true pnpm --filter nemo-studio-ui build:dev` — passed; this build was used for the actual-app Chrome measurements.
- `pnpm --filter='...[origin/main]' run --parallel --if-present typecheck` — passed for affected Common and Studio packages.
- `pnpm --filter='...[origin/main]' run --parallel --if-present test:ci` — passed with coverage before the Assistant-specific regression was added (Common: 1,496 tests; Studio: 2,898 tests); the updated full Studio suite above passed afterward.
- `uv run pre-commit run -a` — code-related hooks passed, including Ruff, Ruff format, `ty`, config-reference validation, lock checks, copyright headers, UI lint-staged, merge-conflict detection, and Flox-lock validation. The overall command is blocked on host prerequisites unrelated to this change: `helm-docs` is not installed, and `yq` is unavailable to three toolchain-version consistency hooks.

Local pnpm commands ran with pnpm 10.34.5 under Node 24.18.0 because Flox is not installed on this host; the repository requests Node 22.23.2, so pnpm emitted an engine warning. All listed web checks still passed.
