### PR TITLE
fix: remove python shim for already removed codec files

### DIFF
--- a/docker/customizer/removals/files/nmp-automodel-training.txt
+++ b/docker/customizer/removals/files/nmp-automodel-training.txt
@@ -12,3 +12,7 @@
 /usr/local/lib/python*/dist-packages/nvidia/dali/.libs/libopus-*.so*
 /usr/local/lib/python*/dist-packages/nvidia/dali/.libs/libsndfile-*.so*
 /usr/local/lib/python*/dist-packages/nvidia/dali/.libs/libswscale-*.so*
+# The soundfile shim goes with its payload above. transformers gates `import soundfile` on
+# find_spec("soundfile"), so leaving the module behind makes that probe report an audio
+# backend that can no longer dlopen its library.
+/opt/venv/lib/python3.*/site-packages/soundfile.py

--- a/docker/customizer/removals/files/nmp-rl-training.txt
+++ b/docker/customizer/removals/files/nmp-rl-training.txt
@@ -5,3 +5,6 @@
 /opt/nemo_rl_venv/lib/python3.*/site-packages/_soundfile_data/libsndfile_*.so
 /opt/ray_venvs/*/lib/python3.*/site-packages/_soundfile_data/libsndfile_*.so
 /opt/uv_cache/archive-v0/*/_soundfile_data/libsndfile_*.so
+/opt/nemo_rl_venv/lib/python3.*/site-packages/soundfile.py
+/opt/ray_venvs/*/lib/python3.*/site-packages/soundfile.py
+/opt/uv_cache/archive-v0/*/soundfile.py

--- a/docker/rl/Dockerfile.nmp-rl-training
+++ b/docker/rl/Dockerfile.nmp-rl-training
@@ -87,7 +87,13 @@ RUN --mount=type=bind,source=docker/scripts/remove-listed-files.sh,target=/tmp/r
 # Point runtime uv writes at the per-user cache instead, which is already owned by USER_UID above.
 # The prefetched venvs are unaffected: their symlinks are absolute /opt/uv_cache paths resolved at
 # build time, so changing UV_CACHE_DIR only redirects FUTURE uv operations.
+# HOME must follow the runtime user. The base sets HOME=/home/nmp-build for its build user
+# (uid 2000) and that value survives into the published image, but this stage runs as
+# ${USER_UID}, which cannot write there. Anything resolving `~` at import time then dies:
+# swanlab, which nemo_rl.utils.logger imports unconditionally, calls os.mkdir("~/.swanlab")
+# from its module body, so the GRPO driver fails before reading a config.
 ENV PATH="/opt/nemo_rl_venv/bin:${PATH}" \
+    HOME=/home/${USERNAME} \
     UV_CACHE_DIR=/home/${USERNAME}/.cache/uv
 ENTRYPOINT ["/opt/venv/bin/python"]
 CMD ["-m", "nmp.rl.tasks.training", "--help"]

--- a/tests/smoke_gpu/test_customizer_automodel.py
+++ b/tests/smoke_gpu/test_customizer_automodel.py
@@ -21,7 +21,12 @@ from glob import glob
 import pytest
 from python_package_versions import assert_python_package_min_versions
 
-SOUNDFILE_LIBSNDFILE_PATTERN = "/opt/venv/lib/python3.*/site-packages/_soundfile_data/libsndfile_*.so"
+SOUNDFILE_PATTERNS = (
+    "/opt/venv/lib/python3.*/site-packages/_soundfile_data/libsndfile_*.so",
+    # The shim is removed with its payload; see the removals file for why keeping it is
+    # worse than not shipping soundfile at all.
+    "/opt/venv/lib/python3.*/site-packages/soundfile.py",
+)
 MINIMUM_PYTHON_PACKAGE_VERSIONS = {
     "bitsandbytes": "0.49.2",
     "mamba-ssm": "2.3.0",
@@ -68,8 +73,22 @@ def test_nmp_automodel_training_importable():
 
 @pytest.mark.smoke_nmp_automodel_training
 def test_soundfile_libsndfile_removed():
-    remaining = sorted(glob(SOUNDFILE_LIBSNDFILE_PATTERN))
+    remaining = sorted(path for pattern in SOUNDFILE_PATTERNS for path in glob(pattern))
     assert remaining == [], f"file cleanup left scanner-visible libsndfile files: {remaining}"
+
+
+@pytest.mark.smoke_nmp_automodel_training
+def test_transformers_audio_backend_probe_is_off():
+    """The payload and its shim must be removed together.
+
+    ``transformers.audio_utils`` runs ``if is_soundfile_available(): import soundfile``, and
+    that probe is ``find_spec("soundfile")`` -- file presence, not loadability. Removing only
+    the codec leaves the probe answering yes for a backend that then fails to dlopen, which
+    breaks ``from transformers import AutoProcessor`` and everything importing through it.
+    """
+    from transformers.utils.import_utils import is_soundfile_available
+
+    assert not is_soundfile_available()
 
 
 @pytest.mark.smoke_nmp_automodel_training

--- a/tests/smoke_gpu/test_rl_training.py
+++ b/tests/smoke_gpu/test_rl_training.py
@@ -37,6 +37,11 @@ SOUNDFILE_LIBSNDFILE_PATTERNS = (
     "/opt/nemo_rl_venv/lib/python3.*/site-packages/_soundfile_data/libsndfile_*.so",
     "/opt/ray_venvs/*/lib/python3.*/site-packages/_soundfile_data/libsndfile_*.so",
     "/opt/uv_cache/archive-v0/*/_soundfile_data/libsndfile_*.so",
+    # The shim is removed with the codec; see docker/rl/codec-file-removals.txt for why
+    # keeping it is worse than not shipping soundfile at all.
+    "/opt/nemo_rl_venv/lib/python3.*/site-packages/soundfile.py",
+    "/opt/ray_venvs/*/lib/python3.*/site-packages/soundfile.py",
+    "/opt/uv_cache/archive-v0/*/soundfile.py",
 )
 BASE_VENV_MINIMUM_PYTHON_PACKAGE_VERSIONS = {
     "wandb": "0.28.2",
@@ -237,6 +242,27 @@ def test_worker_venvs_symlink_into_shared_cache():
 def test_soundfile_libsndfile_removed():
     remaining = sorted(path for pattern in SOUNDFILE_LIBSNDFILE_PATTERNS for path in glob(pattern))
     assert remaining == [], f"file cleanup left scanner-visible libsndfile files: {remaining}"
+
+
+@pytest.mark.smoke_nmp_rl_training
+def test_transformers_audio_backend_probe_is_off():
+    """Removing the codec must also switch off the probe that guards its import.
+
+    ``transformers.audio_utils`` does ``if is_soundfile_available(): import soundfile``,
+    and that probe is ``find_spec("soundfile")`` -- file presence, not loadability. Delete
+    the codec but keep the module and the probe says yes to a backend that then fails to
+    dlopen, so ``from transformers import AutoProcessor`` raises. That import is at module
+    scope in ``nemo_rl.algorithms.grpo``, so the GRPO driver dies before it reads a config.
+    """
+    from transformers.utils.import_utils import is_soundfile_available
+
+    assert not is_soundfile_available()
+
+
+@pytest.mark.smoke_nmp_rl_training
+def test_grpo_driver_module_imports():
+    """The exact import the GRPO driver performs first, and the one the codec strip broke."""
+    from nemo_rl.algorithms.grpo import MasterConfig  # noqa: F401
 
 
 @pytest.mark.smoke_nmp_rl_training


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
- We removed the `libsndfile .so` for fixing the CVEs, but left `soundfile.py` behind and it caused GRPO training to fail with error
```
  File "/app/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/backend.py", line 196, in execute_training
    raise parsed.to_exception()
nmp.rl.tasks.training.errors.parser.OSError: cannot load library 'libsndfile.so': libsndfile.so: cannot open shared object file: No such file or directory
```
- Call chain - When we run GRPO training we call `grpo.py` and import `AutoProcessor` [here](https://github.com/soluwalana/RL/blob/nmp/customizer/nemo_rl/algorithms/grpo.py#L29) which eventually [call this in `transformers` library](https://github.com/huggingface/transformers/blob/main/src/transformers/audio_utils.py#L48).
- Since the `soundfile.py` exists, it tries to load `'libsndfile.so'` and fails
- Second issue is the base image sets `HOME=/home/nmp-build` for its build user (uid 2000), and that ENV survives into the published image. The training image switches the runtime user to uid 1000 (ubuntu) and creates + chowns /home/ubuntu but never updates HOME. And when running GRPO training I get this error
```
  File "/app/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/backend.py", line 196, in execute_training
    raise parsed.to_exception()
nmp.rl.tasks.training.errors.parser.PermissionError: [Errno 13] Permission denied: '/home/nmp-build/.swanlab'
```

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes

This PR removes the shim along with the codec, so the probe returns False and transformers skips the backend entirely.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unusable audio backends from being detected in customized training environments.
  * Improved cleanup of bundled SoundFile components and related libraries.
  * Ensured runtime initialization uses the correct user home directory.

* **Tests**
  * Added validation for audio backend detection and reinforcement learning training startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->