### PR TITLE
feat(evaluator): Add manual gym e2e test matrix

### DIFF
--- a/e2e/test_gym_resource_server_matrix.py
+++ b/e2e/test_gym_resource_server_matrix.py
@@ -1,0 +1,390 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Manual NMP job matrix for Gym's declared agent/resources-server pairs."""
+
+from __future__ import annotations
+
+import json
+import os
+import tarfile
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+from nemo_evaluator.jobs.agent_spec import GymRunnerTarget
+from nemo_evaluator.shared.metric_bundles.bundles import bundle_metric
+from nemo_evaluator.shared.metric_bundles.cloudpickle import CloudpickleMetricBundlePackager
+from nemo_evaluator_sdk.agent_eval.runtimes.gym import GymRewardMetric, discover_gym_tasks
+from nemo_platform import NeMoPlatform
+from nmp.testing import short_unique_name
+from nmp.testing.e2e import wait_for_platform_job
+
+from e2e.test_evaluator_plugin import (
+    _chat_completion,
+    _cleanup_evaluator_job,
+    _create_ready_mock_model,
+    _internal_model_route,
+    _post_evaluator_payload,
+    _require_job_name,
+)
+
+# Checked-in source of the Gym agent/resource-server pairs exercised by this matrix.
+GYM_MATRIX_MANIFEST = (
+    Path(__file__).resolve().parents[1]
+    / "packages/nemo_evaluator_sdk/tests/agent_eval/fixtures/gym_test_matrix_resource_servers.json"
+)
+
+# Opt-in switch that prevents normal E2E and CI runs from collecting this manual matrix.
+GYM_MATRIX_RUN_ENV = "NEMO_GYM_RUN_PLATFORM_MATRIX"
+
+# Optional comma-separated filter of resource servers, agents, or exact pair IDs.
+GYM_MATRIX_CASES_ENV = "NEMO_GYM_MATRIX_CASES"
+
+# Directory containing the example datasets extracted from the Gym task image.
+GYM_MATRIX_RESOURCES_ROOT_ENV = "NEMO_GYM_RESOURCES_ROOT"
+
+# Maximum time, in seconds, to wait for each submitted NMP job.
+GYM_MATRIX_JOB_TIMEOUT_ENV = "NEMO_GYM_MATRIX_JOB_TIMEOUT"
+
+# This matrix must remain explicitly enabled because a full run takes hours.
+if os.environ.get(GYM_MATRIX_RUN_ENV) != "1":
+    pytest.skip(
+        "manual-only matrix; invoke through plugins/nemo-evaluator/scripts/gym-matrix/run.py "
+        f"or set {GYM_MATRIX_RUN_ENV}=1",
+        allow_module_level=True,
+    )
+
+pytestmark = [
+    pytest.mark.container_only,
+    pytest.mark.gym_matrix,
+]
+
+
+@dataclass(frozen=True)
+class GymPlatformMatrixCase:
+    """One agent/resource-server pair stored in the checked-in Gym matrix fixture.
+
+    Attributes:
+        resources_server: Resource-server package directory and matrix selection name.
+        agent: Agent implementation connected to the resource server.
+        agent_server: Composed Gym agent-server component name from the source config.
+        resource_server: Gym resource-server component referenced by the agent.
+        agent_config: Gym YAML path that declares the composed pair.
+        selector: Optional Gym CLI selector for a specific configuration variant.
+        model_servers: Additional model-server components required by the configuration.
+        needs_gpu: Whether the pair requires a local GPU-backed component.
+        rollout_skip_reason: Reason the pair cannot run in this local matrix, if any.
+    """
+
+    resources_server: str
+    agent: str
+    agent_server: str
+    resource_server: str
+    agent_config: str
+    selector: str | None = None
+    model_servers: tuple[str, ...] = ()
+    needs_gpu: bool = False
+    rollout_skip_reason: str | None = None
+
+    @property
+    def id(self) -> str:
+        """Return the stable pytest ID for this pair."""
+        return f"{self.resources_server}+{self.agent}"
+
+
+@pytest.fixture(scope="module")
+def evaluator_workspace(sdk: NeMoPlatform) -> Iterator[str]:
+    """Create an isolated workspace shared by one matrix worker."""
+    name = short_unique_name("e2e-gym-matrix")
+    try:
+        sdk.workspaces.create(name=name)
+        yield name
+    finally:
+        # Workspace cleanup should not hide the original test failure.
+        with suppress(Exception):
+            sdk.workspaces.delete(name)
+
+
+@pytest.fixture(scope="module")
+def evaluator_sdk(sdk: NeMoPlatform, evaluator_workspace: str) -> Iterator[NeMoPlatform]:
+    """Provide an SDK client scoped to the matrix workspace."""
+    yield sdk.copy(workspace=evaluator_workspace, max_retries=2, timeout=900.0)
+
+
+@pytest.fixture(scope="module")
+def matrix_model_name(sdk: NeMoPlatform, evaluator_workspace: str) -> str:
+    """Register the mock policy model reused by all cases in one worker."""
+    model_name = short_unique_name("gym-matrix")
+    _create_ready_mock_model(
+        sdk,
+        workspace=evaluator_workspace,
+        name=model_name,
+        mock_response_body=_chat_completion("NeMo Platform Gym matrix smoke response."),
+    )
+    return model_name
+
+
+def _load_gym_matrix_cases() -> tuple[GymPlatformMatrixCase, ...]:
+    """Load, validate, and optionally filter the checked-in matrix fixture."""
+    raw = json.loads(GYM_MATRIX_MANIFEST.read_text(encoding="utf-8"))
+    cases = tuple(
+        GymPlatformMatrixCase(
+            **{key: value for key, value in item.items() if key != "model_servers"},
+            model_servers=tuple(item.get("model_servers", ())),
+        )
+        for item in raw
+    )
+
+    # Pair IDs are the stable identity used by pytest and the command-line filter.
+    case_id_counts = Counter(case.id for case in cases)
+    duplicate_ids = sorted(case_id for case_id, count in case_id_counts.items() if count > 1)
+    if duplicate_ids:
+        raise ValueError(f"{GYM_MATRIX_MANIFEST} contains duplicate pair IDs: {duplicate_ids}")
+
+    requested = {value.strip() for value in os.environ.get(GYM_MATRIX_CASES_ENV, "").split(",") if value.strip()}
+    if not requested:
+        return cases
+
+    # A filter can select one exact pair or every pair for an agent or resource server.
+    valid_filters = {value for case in cases for value in (case.id, case.resources_server, case.agent)}
+    unknown = requested - valid_filters
+    if unknown:
+        raise ValueError(
+            f"Unknown {GYM_MATRIX_CASES_ENV} values: {sorted(unknown)}. "
+            f"Valid resource servers: {sorted({case.resources_server for case in cases})}"
+        )
+
+    return tuple(case for case in cases if requested.intersection((case.id, case.resources_server, case.agent)))
+
+
+def _gym_matrix_resources_root() -> Path:
+    """Resolve the directory containing Gym resource-server example datasets."""
+    configured = os.environ.get(GYM_MATRIX_RESOURCES_ROOT_ENV)
+    if not configured:
+        raise RuntimeError(
+            f"{GYM_MATRIX_RESOURCES_ROOT_ENV} is not set; invoke the matrix through "
+            "plugins/nemo-evaluator/scripts/gym-matrix/run.py"
+        )
+
+    root = Path(configured).expanduser().resolve()
+    if not root.is_dir():
+        raise FileNotFoundError(f"{GYM_MATRIX_RESOURCES_ROOT_ENV}={configured!r} is not a directory")
+
+    return root
+
+
+def _gym_task_payloads(dataset: Path) -> list[dict[str, object]]:
+    """Convert one bundled Gym example into an Evaluator task payload."""
+    # One example is sufficient to prove the NMP job can exercise the resource server.
+    tasks = discover_gym_tasks(dataset)[:1]
+    if not tasks:
+        raise ValueError(f"Gym discovered no tasks in {dataset}")
+
+    bundled_reward = bundle_metric(GymRewardMetric(), CloudpickleMetricBundlePackager()).model_dump(mode="json")
+    return [
+        {
+            "id": task.id,
+            "intent": task.intent,
+            "inputs": task.inputs or {},
+            "reference": task.reference or {},
+            "metrics": [bundled_reward],
+            "metadata": [{"key": key, "value": value} for key, value in (task.metadata or {}).items()],
+        }
+        for task in tasks
+    ]
+
+
+def _gym_matrix_target(
+    case: GymPlatformMatrixCase,
+    *,
+    workspace: str,
+    model_name: str,
+) -> GymRunnerTarget:
+    """Build a Gym target from the exact pair configuration stored in the fixture."""
+    hydra_params: dict[str, Any] = {
+        "policy_base_url": _internal_model_route(workspace, model_name),
+        "policy_api_key": "not-used-mock-provider",
+        "policy_model_name": model_name,
+    }
+
+    # Judge and reward models use the same deterministic mock route for this launch smoke test.
+    for model_server in case.model_servers:
+        if case.resources_server == "genrm_compare" and model_server == "genrm_model":
+            hydra_params["genrm_model_name"] = "stub-model"
+            continue
+
+        hydra_params[model_server] = {
+            "responses_api_models": {
+                "inference_provider": {
+                    "entrypoint": "app.py",
+                    "base_url": "${policy_base_url}",
+                    "api_key": "${policy_api_key}",
+                    "model": "${policy_model_name}",
+                }
+            }
+        }
+
+    return GymRunnerTarget(
+        agent=case.agent_server,
+        agent_config=case.agent_config,
+        resources_server=case.selector or case.resources_server,
+        bind_resources_server=False,
+        num_repeats=1,
+        concurrency=1,
+        startup_timeout_s=300,
+        collection_timeout_s=300,
+        hydra_params=hydra_params,
+    )
+
+
+def _submit_gym_matrix_job(
+    sdk: NeMoPlatform,
+    workspace: str,
+    case: GymPlatformMatrixCase,
+    *,
+    model_name: str,
+    resources_root: Path,
+) -> str:
+    """Submit one matrix pair through the NMP Evaluator API."""
+    dataset = resources_root / case.resources_server / "data" / "example.jsonl"
+    if not dataset.is_file():
+        raise FileNotFoundError(f"{case.id} has no bundled example dataset at {dataset}")
+
+    target = _gym_matrix_target(case, workspace=workspace, model_name=model_name)
+    payload = _post_evaluator_payload(
+        sdk,
+        workspace,
+        "agent-evaluate/jobs",
+        {"spec": {"tasks": _gym_task_payloads(dataset), "target": target.model_dump(mode="json")}},
+    )
+    return _require_job_name(payload)
+
+
+def _validate_gym_matrix_result(
+    sdk: NeMoPlatform,
+    workspace: str,
+    job_name: str,
+    case: GymPlatformMatrixCase,
+    output_dir: Path,
+) -> None:
+    """Validate that a completed job persisted one successful Gym trial."""
+    # Download and unpack the first-party result bundle produced by the Evaluator job.
+    case_dir = output_dir / case.id.replace("/", "_")
+    case_dir.mkdir(parents=True, exist_ok=True)
+
+    archive_path = case_dir / "agent-eval-results.tar.gz"
+    sdk.jobs.results.download("agent-eval-results", job=job_name, workspace=workspace).write_to_file(archive_path)
+
+    extract_dir = case_dir / "results"
+    with tarfile.open(archive_path) as archive:
+        archive.extractall(extract_dir)  # noqa: S202 - trusted first-party job artifact, not user input
+
+    # A single input and one repeat must produce exactly one persisted trial.
+    trials_files = list(extract_dir.rglob("trials.jsonl"))
+    if not trials_files:
+        raise AssertionError(f"{case.id}: trials.jsonl missing from job {job_name}")
+
+    trials = [json.loads(line) for line in trials_files[0].read_text(encoding="utf-8").splitlines() if line.strip()]
+    if len(trials) != 1:
+        raise AssertionError(f"{case.id}: expected one trial from job {job_name}, got {len(trials)}")
+
+    # Completion and a numeric Gym reward prove that the resource server handled the rollout.
+    trial = trials[0]
+    if trial.get("status") != "completed":
+        raise AssertionError(f"{case.id}: trial ended {trial.get('status')!r}: {trial}")
+
+    reward = (trial.get("metadata") or {}).get("reward")
+    if reward is None:
+        raise AssertionError(f"{case.id}: completed trial has no Gym reward")
+    if not isinstance(reward, int | float):
+        raise AssertionError(f"{case.id}: Gym reward is not numeric: {reward!r}")
+
+
+def _gym_matrix_job_diagnostics(sdk: NeMoPlatform, workspace: str, job_name: str) -> str:
+    """Collect bounded job status and log diagnostics for an assertion failure."""
+    details: list[str] = []
+
+    # Diagnostics are best-effort, but retrieval failures should remain visible.
+    try:
+        status = sdk.jobs.get_status(workspace=workspace, name=job_name)
+        details.append(status.model_dump_json(indent=2))
+    except Exception as error:
+        details.append(f"Could not retrieve job status: {error}")
+
+    try:
+        logs = sdk.jobs.get_logs(workspace=workspace, name=job_name)
+        details.extend(f"[{entry.job_step}] {entry.message}" for entry in (logs.data or [])[-20:])
+    except Exception as error:
+        details.append(f"Could not retrieve job logs: {error}")
+
+    return "\n".join(details)[-8000:]
+
+
+def _matrix_skip_reason(case: GymPlatformMatrixCase) -> str | None:
+    """Return why a case cannot run against the local CPU and mock-policy setup."""
+    if case.needs_gpu:
+        return "requires a GPU-backed Gym model server"
+
+    if case.rollout_skip_reason:
+        return case.rollout_skip_reason
+
+    return None
+
+
+# Cases loaded at import time become the pytest parameter source.
+GYM_MATRIX_CASES = _load_gym_matrix_cases()
+
+# Parameters attach skip marks before fixtures can submit any unsupported job.
+GYM_MATRIX_PARAMETERS = [
+    pytest.param(case, id=case.id, marks=pytest.mark.skip(reason=reason))
+    if (reason := _matrix_skip_reason(case))
+    else pytest.param(case, id=case.id)
+    for case in GYM_MATRIX_CASES
+]
+
+
+@pytest.mark.parametrize("case", GYM_MATRIX_PARAMETERS)
+@pytest.mark.timeout(1800)
+def test_gym_resource_server_job_matrix(
+    evaluator_sdk: NeMoPlatform,
+    evaluator_workspace: str,
+    matrix_model_name: str,
+    tmp_path: Path,
+    case: GymPlatformMatrixCase,
+) -> None:
+    """Run one declared Gym pair as an NMP job and validate its persisted trial."""
+    job_timeout = float(os.environ.get(GYM_MATRIX_JOB_TIMEOUT_ENV, "900"))
+    if job_timeout <= 0:
+        raise ValueError(f"{GYM_MATRIX_JOB_TIMEOUT_ENV} must be positive")
+
+    # Submission must use the pair-specific config and example dataset from the fixture.
+    job_name = _submit_gym_matrix_job(
+        evaluator_sdk,
+        evaluator_workspace,
+        case,
+        model_name=matrix_model_name,
+        resources_root=_gym_matrix_resources_root(),
+    )
+
+    try:
+        # Platform completion alone is insufficient; the persisted Gym trial must also be valid.
+        job = wait_for_platform_job(evaluator_sdk, job_name, evaluator_workspace, timeout=job_timeout)
+        assert job.status.lower() == "completed", (
+            f"{case.id}: job {job_name} ended {job.status!r}\n"
+            f"{_gym_matrix_job_diagnostics(evaluator_sdk, evaluator_workspace, job_name)}"
+        )
+        _validate_gym_matrix_result(
+            evaluator_sdk,
+            evaluator_workspace,
+            job_name,
+            case,
+            tmp_path,
+        )
+    finally:
+        # Always release the job container before the next sequential matrix case starts.
+        _cleanup_evaluator_job(evaluator_sdk, job_name)

--- a/e2e/test_gym_resource_server_matrix.py
+++ b/e2e/test_gym_resource_server_matrix.py
@@ -3,8 +3,6 @@
 
 """Manual NMP job matrix for Gym's declared agent/resources-server pairs."""
 
-from __future__ import annotations
-
 import json
 import os
 import tarfile
@@ -282,7 +280,7 @@ def _validate_gym_matrix_result(
 
     extract_dir = case_dir / "results"
     with tarfile.open(archive_path) as archive:
-        archive.extractall(extract_dir)  # noqa: S202 - trusted first-party job artifact, not user input
+        archive.extractall(extract_dir, filter="data")
 
     # A single input and one repeat must produce exactly one persisted trial.
     trials_files = list(extract_dir.rglob("trials.jsonl"))

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/fixtures/gym_test_matrix_resource_servers.json
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/fixtures/gym_test_matrix_resource_servers.json
@@ -1,0 +1,366 @@
+[
+  {
+    "resources_server": "aalcr",
+    "agent": "simple_agent",
+    "agent_server": "aalcr_simple_agent",
+    "resource_server": "aalcr_resources_server",
+    "agent_config": "resources_servers/aalcr/configs/aalcr.yaml",
+    "model_servers": [
+      "Qwen3-235B-A22B-Instruct-2507-FP8"
+    ]
+  },
+  {
+    "resources_server": "abstention",
+    "agent": "simple_agent",
+    "agent_server": "abstention_simple_agent",
+    "resource_server": "abstention",
+    "agent_config": "resources_servers/abstention/configs/abstention.yaml",
+    "model_servers": [
+      "genrm_model"
+    ]
+  },
+  {
+    "resources_server": "arc_agi",
+    "agent": "simple_agent",
+    "agent_server": "arc_agi_simple_agent",
+    "resource_server": "arc_agi_resources_server",
+    "agent_config": "resources_servers/arc_agi/configs/arc_agi.yaml"
+  },
+  {
+    "resources_server": "bird_sql",
+    "agent": "simple_agent",
+    "agent_server": "bird_sql_simple_agent",
+    "resource_server": "bird_sql_resources_server",
+    "agent_config": "resources_servers/bird_sql/configs/bird_sql.yaml"
+  },
+  {
+    "resources_server": "blackjack",
+    "agent": "gymnasium_agent",
+    "agent_server": "blackjack_gymnasium_agent",
+    "resource_server": "blackjack",
+    "agent_config": "resources_servers/blackjack/configs/blackjack.yaml"
+  },
+  {
+    "resources_server": "bunsenbench_chemistry_mcq",
+    "agent": "simple_agent",
+    "agent_server": "bunsenbench_chemistry_mcq_simple_agent",
+    "resource_server": "bunsenbench_chemistry_mcq",
+    "agent_config": "resources_servers/bunsenbench_chemistry_mcq/configs/bunsenbench_chemistry_mcq.yaml"
+  },
+  {
+    "resources_server": "circle_click",
+    "agent": "simple_agent",
+    "agent_server": "circle_click_simple_agent",
+    "resource_server": "circle_click",
+    "agent_config": "resources_servers/circle_click/configs/circle_click.yaml"
+  },
+  {
+    "resources_server": "circle_count",
+    "agent": "simple_agent",
+    "agent_server": "circle_count_simple_agent",
+    "resource_server": "circle_count",
+    "agent_config": "resources_servers/circle_count/configs/circle_count.yaml"
+  },
+  {
+    "resources_server": "code_fim",
+    "agent": "simple_agent",
+    "agent_server": "code_fim_simple_agent",
+    "resource_server": "code_fim",
+    "agent_config": "resources_servers/code_fim/configs/code_fim.yaml"
+  },
+  {
+    "resources_server": "critpt",
+    "agent": "critpt_agent",
+    "agent_server": "critpt_agent",
+    "resource_server": "critpt_resources_server",
+    "agent_config": "resources_servers/critpt/configs/critpt.yaml",
+    "rollout_skip_reason": "critpt verification requires an Artificial Analysis API key and external service"
+  },
+  {
+    "resources_server": "equivalence_rule",
+    "agent": "simple_agent",
+    "agent_server": "lc_equivalence_rule_simple_agent",
+    "resource_server": "lc_equivalence_rule",
+    "agent_config": "resources_servers/equivalence_rule/configs/lc.yaml",
+    "selector": "equivalence_rule/lc"
+  },
+  {
+    "resources_server": "example_multi_step",
+    "agent": "simple_agent",
+    "agent_server": "example_multi_step_simple_agent",
+    "resource_server": "example_multi_step_resources_server",
+    "agent_config": "resources_servers/example_multi_step/configs/example_multi_step.yaml"
+  },
+  {
+    "resources_server": "example_multi_turn_gymnasium",
+    "agent": "gymnasium_agent",
+    "agent_server": "example_multi_turn_gymnasium_agent",
+    "resource_server": "example_multi_turn_gymnasium",
+    "agent_config": "resources_servers/example_multi_turn_gymnasium/configs/example_multi_turn_gymnasium.yaml"
+  },
+  {
+    "resources_server": "example_session_state_mgmt",
+    "agent": "simple_agent",
+    "agent_server": "example_session_state_mgmt_simple_agent",
+    "resource_server": "example_session_state_mgmt_resources_server",
+    "agent_config": "resources_servers/example_session_state_mgmt/configs/example_session_state_mgmt.yaml"
+  },
+  {
+    "resources_server": "example_single_tool_call",
+    "agent": "simple_agent",
+    "agent_server": "example_single_tool_call_simple_agent",
+    "resource_server": "example_single_tool_call",
+    "agent_config": "resources_servers/example_single_tool_call/configs/example_single_tool_call.yaml"
+  },
+  {
+    "resources_server": "example_tool_call_multireward",
+    "agent": "simple_agent",
+    "agent_server": "example_tool_call_multireward_simple_agent",
+    "resource_server": "example_tool_call_multireward",
+    "agent_config": "resources_servers/example_tool_call_multireward/configs/example_tool_call_multireward.yaml"
+  },
+  {
+    "resources_server": "format_verification",
+    "agent": "simple_agent",
+    "agent_server": "citation_format_simple_agent",
+    "resource_server": "citation_format",
+    "agent_config": "resources_servers/format_verification/configs/citation_format.yaml",
+    "selector": "format_verification/citation_format"
+  },
+  {
+    "resources_server": "frontierscience_judge",
+    "agent": "simple_agent",
+    "agent_server": "frontierscience_judge_simple_agent",
+    "resource_server": "frontierscience_judge",
+    "agent_config": "resources_servers/frontierscience_judge/configs/frontierscience_judge.yaml",
+    "model_servers": [
+      "judge_model"
+    ]
+  },
+  {
+    "resources_server": "genrm_compare",
+    "agent": "simple_agent",
+    "agent_server": "genrm_simple_agent",
+    "resource_server": "genrm_compare_resources_server",
+    "agent_config": "resources_servers/genrm_compare/configs/genrm_compare.yaml",
+    "model_servers": [
+      "genrm_model",
+      "policy_model_reasoning_off"
+    ],
+    "needs_gpu": true
+  },
+  {
+    "resources_server": "gpqa_diamond",
+    "agent": "simple_agent",
+    "agent_server": "gpqa_diamond_simple_agent",
+    "resource_server": "gpqa_diamond",
+    "agent_config": "resources_servers/gpqa_diamond/configs/gpqa_diamond.yaml"
+  },
+  {
+    "resources_server": "gymnasium",
+    "agent": "gymnasium_agent",
+    "agent_server": "gymnasium_agent",
+    "resource_server": "gymnasium",
+    "agent_config": "resources_servers/gymnasium/configs/gymnasium.yaml"
+  },
+  {
+    "resources_server": "hotpotqa_qa",
+    "agent": "simple_agent",
+    "agent_server": "hotpotqa_qa_simple_agent",
+    "resource_server": "hotpotqa_qa",
+    "agent_config": "resources_servers/hotpotqa_qa/configs/hotpotqa_qa.yaml"
+  },
+  {
+    "resources_server": "imo_gradingbench",
+    "agent": "simple_agent",
+    "agent_server": "imo_gradingbench_simple_agent",
+    "resource_server": "imo_gradingbench",
+    "agent_config": "resources_servers/imo_gradingbench/configs/imo_gradingbench.yaml"
+  },
+  {
+    "resources_server": "indirect_prompt_injection",
+    "agent": "simple_agent",
+    "agent_server": "indirect_prompt_injection_simple_agent",
+    "resource_server": "indirect_prompt_injection_resources_server",
+    "agent_config": "resources_servers/indirect_prompt_injection/configs/indirect_prompt_injection.yaml"
+  },
+  {
+    "resources_server": "inverse_if",
+    "agent": "simple_agent",
+    "agent_server": "inverse_if_simple_agent",
+    "resource_server": "inverse_if",
+    "agent_config": "resources_servers/inverse_if/configs/inverse_if.yaml",
+    "model_servers": [
+      "judge_model"
+    ]
+  },
+  {
+    "resources_server": "jailbreak_detection",
+    "agent": "simple_agent",
+    "agent_server": "jailbreak_detection_simple_agent",
+    "resource_server": "jailbreak_detection",
+    "agent_config": "resources_servers/jailbreak_detection/configs/jailbreak_detection_nemotron_combined_reward_tp8.yaml",
+    "selector": "jailbreak_detection/jailbreak_detection_nemotron_combined_reward_tp8",
+    "model_servers": [
+      "safety_judge_model"
+    ]
+  },
+  {
+    "resources_server": "lc_niah",
+    "agent": "simple_agent",
+    "agent_server": "lc_niah_simple_agent",
+    "resource_server": "lc_niah",
+    "agent_config": "resources_servers/lc_niah/configs/lc_niah.yaml"
+  },
+  {
+    "resources_server": "math_advanced_calculations",
+    "agent": "simple_agent",
+    "agent_server": "math_advanced_calculations_simple_agent",
+    "resource_server": "math_advanced_calculations",
+    "agent_config": "resources_servers/math_advanced_calculations/configs/math_advanced_calculations.yaml"
+  },
+  {
+    "resources_server": "math_proof_judgement",
+    "agent": "simple_agent",
+    "agent_server": "math_proof_judgement_simple_agent",
+    "resource_server": "math_proof_judgement",
+    "agent_config": "resources_servers/math_proof_judgement/configs/math_proof_judgement.yaml"
+  },
+  {
+    "resources_server": "multichallenge",
+    "agent": "simple_agent",
+    "agent_server": "multichallenge_simple_agent",
+    "resource_server": "multichallenge",
+    "agent_config": "resources_servers/multichallenge/configs/multichallenge.yaml"
+  },
+  {
+    "resources_server": "nvarc",
+    "agent": "simple_agent",
+    "agent_server": "nvarc_inductive_simple_agent",
+    "resource_server": "nvarc_inductive_resources_server",
+    "agent_config": "resources_servers/nvarc/configs/inductive.yaml",
+    "selector": "nvarc/inductive"
+  },
+  {
+    "resources_server": "omniscience",
+    "agent": "simple_agent",
+    "agent_server": "omniscience_simple_agent",
+    "resource_server": "omniscience",
+    "agent_config": "resources_servers/omniscience/configs/omniscience.yaml",
+    "model_servers": [
+      "genrm_model"
+    ]
+  },
+  {
+    "resources_server": "proof_genselect",
+    "agent": "simple_agent",
+    "agent_server": "proof_genselect_simple_agent",
+    "resource_server": "proof_genselect",
+    "agent_config": "resources_servers/proof_genselect/configs/proof_genselect.yaml"
+  },
+  {
+    "resources_server": "proof_judge",
+    "agent": "simple_agent",
+    "agent_server": "proof_simple_agent",
+    "resource_server": "proof_judge",
+    "agent_config": "resources_servers/proof_judge/configs/proof_judge.yaml"
+  },
+  {
+    "resources_server": "proof_verification",
+    "agent": "simple_agent",
+    "agent_server": "proof_verification_simple_agent",
+    "resource_server": "proof_verification",
+    "agent_config": "resources_servers/proof_verification/configs/proof_verification.yaml"
+  },
+  {
+    "resources_server": "ragtruth",
+    "agent": "simple_agent",
+    "agent_server": "ragtruth_simple_agent",
+    "resource_server": "ragtruth",
+    "agent_config": "resources_servers/ragtruth/configs/ragtruth.yaml"
+  },
+  {
+    "resources_server": "ruler",
+    "agent": "simple_agent",
+    "agent_server": "ruler_simple_agent",
+    "resource_server": "ruler_resources_server",
+    "agent_config": "resources_servers/ruler/configs/ruler.yaml"
+  },
+  {
+    "resources_server": "simpleqa",
+    "agent": "simple_agent",
+    "agent_server": "simpleqa_simple_agent",
+    "resource_server": "simpleqa",
+    "agent_config": "resources_servers/simpleqa/configs/simpleqa.yaml",
+    "model_servers": [
+      "genrm_model"
+    ]
+  },
+  {
+    "resources_server": "single_step_tool_use_with_argument_comparison",
+    "agent": "tool_simulation_agent",
+    "agent_server": "single_step_tool_use_with_argument_comparison_agent",
+    "resource_server": "single_step_tool_use_with_argument_comparison_resources_server",
+    "agent_config": "resources_servers/single_step_tool_use_with_argument_comparison/configs/single_step_tool_use_with_argument_comparison.yaml"
+  },
+  {
+    "resources_server": "speed_bench",
+    "agent": "speed_bench_agent",
+    "agent_server": "speed_bench_simple_agent",
+    "resource_server": "speed_bench_resources_server",
+    "agent_config": "resources_servers/speed_bench/configs/speed_bench.yaml",
+    "rollout_skip_reason": "speed_bench requires a real policy model instead of the fixed mock response"
+  },
+  {
+    "resources_server": "spider2_lite",
+    "agent": "simple_agent",
+    "agent_server": "spider2_lite_simple_agent",
+    "resource_server": "spider2_lite_resources_server",
+    "agent_config": "resources_servers/spider2_lite/configs/spider2_lite.yaml"
+  },
+  {
+    "resources_server": "swe_pivot",
+    "agent": "tool_simulation_agent",
+    "agent_server": "swe_pivot_tool_simulation_agent",
+    "resource_server": "swe_pivot",
+    "agent_config": "resources_servers/swe_pivot/configs/swe_pivot.yaml"
+  },
+  {
+    "resources_server": "text_to_sql",
+    "agent": "simple_agent",
+    "agent_server": "text_to_sql_simple_agent",
+    "resource_server": "text_to_sql_resources_server",
+    "agent_config": "resources_servers/text_to_sql/configs/text_to_sql.yaml"
+  },
+  {
+    "resources_server": "vlm_eval_kit",
+    "agent": "simple_agent",
+    "agent_server": "vlm_eval_kit_simple_agent",
+    "resource_server": "vlm_eval_kit_resources_server",
+    "agent_config": "resources_servers/vlm_eval_kit/configs/vlm_eval_kit.yaml"
+  },
+  {
+    "resources_server": "workplace_assistant",
+    "agent": "simple_agent",
+    "agent_server": "workplace_assistant_simple_agent",
+    "resource_server": "workplace_assistant",
+    "agent_config": "resources_servers/workplace_assistant/configs/workplace_assistant.yaml"
+  },
+  {
+    "resources_server": "xlam_fc",
+    "agent": "simple_agent",
+    "agent_server": "xlam_fc_simple_agent",
+    "resource_server": "xlam_fc",
+    "agent_config": "resources_servers/xlam_fc/configs/xlam_fc.yaml"
+  },
+  {
+    "resources_server": "xstest",
+    "agent": "simple_agent",
+    "agent_server": "xstest_simple_agent",
+    "resource_server": "xstest_resources_server",
+    "agent_config": "resources_servers/xstest/configs/xstest.yaml",
+    "model_servers": [
+      "allenai_wildguard_model_server"
+    ]
+  }
+]

--- a/plugins/nemo-evaluator/scripts/gym-matrix/README.md
+++ b/plugins/nemo-evaluator/scripts/gym-matrix/README.md
@@ -1,0 +1,104 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Run the Gym resource-server matrix
+
+Use this manual test to verify that NeMo Platform can launch and complete a Gym evaluation job for each resource server in the checked-in test matrix. Normal E2E and CI runs skip this matrix.
+
+## Matrix scope
+
+The 47 pairs were derived from the agent configurations shipped with NeMo Gym v0.5.0. An explicitly composed pair means that Gym provides a Hydra configuration that connects that particular agent to that resource server. The matrix tests those known pairings; it does not assume that every agent can work with every resource server. BigCodeBench is excluded because it dynamically installs a separate evaluation environment with system dependencies such as GDAL.
+
+## Prerequisites
+
+- Docker is running.
+- The repository is bootstrapped with `make bootstrap`.
+
+## Build the Gym task image
+
+Build and load the local image into Docker:
+
+```bash
+IMAGE_REGISTRY=my-registry \
+BAKE_TAG=local \
+make docker-load TARGET=nmp-gym-tasks-docker
+```
+
+Build the image's smoke-test stage to verify the Gym, Ray, and tokenizer imports:
+
+```bash
+IMAGE_REGISTRY=my-registry \
+BAKE_TAG=local \
+make docker-build TARGET=nmp-gym-tasks-smoke-test
+```
+
+The matrix and the running Evaluator must both use `my-registry/nmp-gym-tasks:local`.
+
+## Create the Python 3.13 test environment
+
+Synchronize the repository development environment into a Python 3.13 virtual environment:
+
+```bash
+uv python install 3.13
+uv venv --python 3.13 --clear /tmp/nemo-platform-e2e-client-py313
+env -u VIRTUAL_ENV \
+  UV_PROJECT_ENVIRONMENT=/tmp/nemo-platform-e2e-client-py313 \
+  uv sync --frozen --all-packages
+```
+
+## Start NeMo Platform
+
+Start all services and controllers from the Python 3.13 environment:
+
+```bash
+NMP_BASE_URL=http://localhost:8080 \
+NMP_INFERENCE_GATEWAY_MOCK_PROVIDER_PREFIX=igw-mock- \
+NEMO_EVALUATOR_GYM_TASKS_IMAGE=my-registry/nmp-gym-tasks:local \
+/tmp/nemo-platform-e2e-client-py313/bin/nemo services run \
+  --service-group all \
+  --controller-group all \
+  --host 0.0.0.0 \
+  --port 8080
+```
+
+These environment variables select the local platform, enable the mock inference provider used by the tests, and force Gym jobs to use the locally built image. `NMP_JOBS_EXECUTORS`, `NMP_JOBS_ENABLE_SUBPROCESS_EXECUTOR`, `NMP_IMAGE_REGISTRY`, and `NMP_IMAGE_TAG` are not required for this test setup.
+
+Leave this process running while executing the matrix.
+
+## Run one resource server
+
+Start with one job:
+
+```bash
+/tmp/nemo-platform-e2e-client-py313/bin/python \
+  plugins/nemo-evaluator/scripts/gym-matrix/run.py \
+  --image my-registry/nmp-gym-tasks:local \
+  --server arc_agi \
+  --workers 1
+```
+
+## Run the complete matrix
+
+The worker count limits concurrent pytest workers and NMP jobs. Use one worker locally so that Gym jobs and their Ray clusters run sequentially:
+
+```bash
+/tmp/nemo-platform-e2e-client-py313/bin/python \
+  plugins/nemo-evaluator/scripts/gym-matrix/run.py \
+  --image my-registry/nmp-gym-tasks:local \
+  --workers 1
+```
+
+The complete sequential run takes approximately two to three hours. More than one worker starts multiple Ray clusters concurrently and can exhaust Docker Desktop's CPU and memory allocation.
+
+## How it works
+
+The script:
+
+1. Extracts bundled `example.jsonl` datasets from the Gym task image into a temporary directory.
+2. Sets the opt-in environment variable that enables the manual-only pytest module.
+3. Runs the matrix with the current Python 3.13 interpreter and pytest-xdist.
+4. Deletes the temporary datasets when pytest exits.
+
+Each parameterized test submits one Evaluator job to NMP, waits for completion, validates the persisted Gym trial and reward, and cleans up the job and temporary workspace.
+
+Matrix entries that require a GPU, an external service, or a real policy model are skipped before an NMP job is submitted.

--- a/plugins/nemo-evaluator/scripts/gym-matrix/run.py
+++ b/plugins/nemo-evaluator/scripts/gym-matrix/run.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the manual Gym resource-server matrix against a local NeMo Platform."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+TEST = "e2e/test_gym_resource_server_matrix.py::test_gym_resource_server_job_matrix"
+
+
+def worker_count(value: str) -> int:
+    workers = int(value)
+    if not 1 <= workers <= 16:
+        raise argparse.ArgumentTypeError("must be between 1 and 16")
+    return workers
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--image",
+        default=os.environ.get("NMP_GYM_TASKS_IMAGE", "nmp-gym-tasks:latest"),
+        help="task image used by NMP and as the Gym dataset source",
+    )
+    parser.add_argument(
+        "--workers",
+        type=worker_count,
+        default=worker_count(os.environ.get("NEMO_GYM_MATRIX_WORKERS", "1")),
+        help="concurrent pytest workers and NMP jobs (default: 1)",
+    )
+    parser.add_argument("--server", help="resource server, agent, or exact pair ID to run")
+    return parser.parse_args()
+
+
+def extract_example_datasets(image: str, destination: Path) -> Path:
+    archive = destination / "examples.tar"
+    export_command = """
+set -eu
+for site_packages in /opt/gym-venv/lib/python*/site-packages; do
+  if [ -d "$site_packages/resources_servers" ]; then
+    cd "$site_packages"
+    tar -cf - resources_servers/*/data/example.jsonl
+    exit 0
+  fi
+done
+echo "Gym resources_servers package not found in task image" >&2
+exit 1
+"""
+    with archive.open("wb") as output:
+        subprocess.run(
+            ["docker", "run", "--rm", "--entrypoint", "/bin/sh", image, "-c", export_command],
+            check=True,
+            stdout=output,
+        )
+    with tarfile.open(archive) as examples:
+        examples.extractall(destination, filter="data")
+    resources_root = destination / "resources_servers"
+    if not resources_root.is_dir():
+        raise RuntimeError(f"Gym example datasets were not extracted from {image}")
+    return resources_root
+
+
+def main() -> int:
+    args = parse_args()
+    if sys.version_info[:2] != (3, 13):
+        raise RuntimeError(f"Run this script with Python 3.13, not {sys.version.split()[0]}")
+
+    internal_base_url = os.environ.get("NMP_E2E_INTERNAL_BASE_URL", "http://host.docker.internal:8080")
+    internal_base_url = internal_base_url.replace("://localhost", "://host.docker.internal")
+    internal_base_url = internal_base_url.replace("://127.0.0.1", "://host.docker.internal")
+
+    with tempfile.TemporaryDirectory(prefix="nemo-gym-matrix-") as temporary_directory:
+        resources_root = extract_example_datasets(args.image, Path(temporary_directory))
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "NMP_BASE_URL": os.environ.get("NMP_BASE_URL", "http://localhost:8080"),
+                "NMP_E2E_INTERNAL_BASE_URL": internal_base_url,
+                "NEMO_GYM_RUN_PLATFORM_MATRIX": "1",
+                "NEMO_GYM_MATRIX_CASES": args.server or "",
+                "NEMO_GYM_RESOURCES_ROOT": str(resources_root),
+            }
+        )
+        pytest_args = [
+            sys.executable,
+            "-m",
+            "pytest",
+            TEST,
+            "--run-e2e",
+            "-n",
+            str(args.workers),
+            "--dist",
+            "load",
+            "-v",
+            "-ra",
+        ]
+        return subprocess.run(pytest_args, cwd=REPO_ROOT, env=environment, check=False).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/nemo-evaluator/scripts/gym-matrix/run.py
+++ b/plugins/nemo-evaluator/scripts/gym-matrix/run.py
@@ -4,8 +4,6 @@
 
 """Run the manual Gym resource-server matrix against a local NeMo Platform."""
 
-from __future__ import annotations
-
 import argparse
 import os
 import subprocess

--- a/pytest.ini
+++ b/pytest.ini
@@ -70,6 +70,7 @@ markers =
     smoke_nmp_automodel_training: Import smoke tests for the nmp-automodel-training image
     e2e: End-to-end tests - test complete customer workflows on deployed infrastructure (Helm/Docker Compose)
     gym_e2e: Gym agent-evaluate E2E tests that require the dedicated nmp-gym-tasks image
+    gym_matrix: Manual NeMo Gym declared agent/resource-server compatibility sweep
     auth_idp: Auth IdP e2e tests - provider-backed auth compose coverage through the gateway
     auth_idp_runtime: Auth IdP tests that require a provider runtime; optional marker args list matching runtime ids
     auth_idp_docker: Auth IdP tests for the Docker Compose reference deployment


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Adds an opt-in manual E2E matrix for verifying that NeMo Platform can launch Gym evaluation jobs against explicitly configured resource-server and agent pairs that **do not require additional dependencies**. The matrix remains excluded from normal E2E and CI runs because each case starts a Ray cluster and the complete sequential sweep takes several hours.

With Claude's assistance, defined the specific resource server + agent server combinations to test in `gym_test_matrix_resources_servers.json`.

## Changes

- Add a manual pytest matrix covering 47 Gym v0.5.0 agent/resource-server pair configurations.
- The test suite submits an NMP Evaluator job using the pair-specific Gym config and one bundled example task, validates job succeeds, and asserts the Gym reward output looks expected.
- **NOTE:** Skip configurations requiring a GPU, external service, or real policy model.
- Add a Python launcher supporting sequential execution and targeted resource-server selection.
- Add developer documentation covering image builds, platform setup, execution, resource constraints, and matrix scope.
- Register the `gym_matrix` pytest marker while retaining an explicit environment-variable gate so CI collection skips the module.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --no-sync ruff check e2e/test_gym_resource_server_matrix.py` - passed.
- `uv run --no-sync ruff format e2e/test_gym_resource_server_matrix.py` - passed.
- `uv run --no-sync ty check e2e/test_gym_resource_server_matrix.py` - passed.
- `uv run pre-commit run` - passed
- Manual matrix with `--workers 1` — partial run so far; the complete matrix has not finished yet at time of writing this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in compatibility matrix for testing Gym agent and resource-server pairings.
  * Added support for running individual pairings or the full matrix with configurable filters and parallel workers.
  * Added validation of completed evaluation jobs, persisted trials, rewards, and diagnostic results.
  * Added cleanup and safe result handling for matrix runs.

* **Documentation**
  * Added setup and usage instructions, prerequisites, supported pairings, and troubleshooting guidance.

* **Tests**
  * Added a dedicated pytest marker for manually running Gym matrix evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->