### PR TITLE
fix(build): restore available Python for RL image

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -115,7 +115,7 @@ variable "NEMO_RL_REPO" {
 # RL pins Gym as a git submodule (-> soluwalana/Gym over https), so Gym rides in with the RL git ADD
 # - no separate Gym pin needed.
 variable "NEMO_RL_REF" {
-  default = "ace40313d474f33cabc9a8fdf13d8dd4dda218c8" # soluwalana/RL nmp/customizer
+  default = "cd42a71d6d4b2eeb6f3d2feef275c5795d2f008c" # soluwalana/RL nmp/customizer
 }
 variable "RL_BASE_CONTEXT" {
   default = ""

--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -31,11 +31,11 @@ ARG BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:26.07-cuda13.3-devel-ubuntu24.04
 ARG NEMO_RL_REPO=https://github.com/soluwalana/RL.git
 ARG NEMO_RL_REF=nmp/customizer
 
-# CVE bumps: uv 0.11.18 bundles a vulnerable quinn-proto (0.12 has breaking changes, so stay on
-# 0.11.x); Python 3.13.15 clears scanner-visible Python 3.13.14 CVEs. Both are scanned at their
-# installed path - see README.md.
+# uv 0.11.18 bundles a vulnerable quinn-proto (0.12 has breaking changes, so stay on 0.11.x).
+# Keep Python at 3.13.14 until uv publishes managed 3.13.15 builds for Linux; unlike the other
+# images, this base installs Python with `uv python install`. See README.md for scanner paths.
 ARG UV_VERSION=0.11.33
-ARG PYTHON_VERSION=3.13.15
+ARG PYTHON_VERSION=3.13.14
 ARG CMAKE_VERSION=4.0.3
 
 # ---- RL source (+ its submodules, incl. Gym) via BuildKit's git ADD ----


### PR DESCRIPTION
## Why

The RL base installs Python with `uv python install`. PR #1351 moved it to Python 3.13.15, but uv does not have managed 3.13.15 builds for Linux. That makes the RL container build fail before PR #1415 can be tested.

## Change

Pin only the RL base back to Python 3.13.14. Other images remain on 3.13.15.

This is temporary and restores the previous RL security finding until uv publishes 3.13.15.

## Validation

- uv lists Python 3.13.14 downloads for Linux AMD64 and ARM64
- `make docker-print TARGET=nmp-rl-base-builder`
- Focused Automodel/Unsloth/RL build: pending


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default Python version used by the runtime image.
  * Clarified documentation around supported Python builds and the uv networking dependency constraint.
  * Updated the NeMo-RL base image to a newer pinned release for improved compatibility and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->