### PR TITLE
feat(studio): filter existing-evaluation picker by current agent (ASTD-456)

### DIFF
--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.test.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.test.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { DEFAULT_WORKSPACE } from '@nemo/common/src/models/constants';
+import { SubmitEvaluationModal } from '@studio/components/evaluation/SubmitEvaluationModal';
+import { server } from '@studio/mocks/node';
+import { renderRoute, screen, waitFor } from '@studio/tests/util/render';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+
+const emptyPage = { data: [], pagination: { total: 0, page: 1, page_size: 100 } };
+
+describe('SubmitEvaluationModal', () => {
+  it('scopes the "Use existing evaluation" list to the current agent', async () => {
+    const evaluationsUrls: URL[] = [];
+    server.use(
+      http.get('*/apis/intake/v2/workspaces/:workspace/evaluations', ({ request }) => {
+        evaluationsUrls.push(new URL(request.url));
+        return HttpResponse.json(emptyPage);
+      })
+    );
+
+    const user = userEvent.setup();
+    renderRoute(undefined, {
+      history: `/workspaces/${DEFAULT_WORKSPACE}`,
+      routes: [
+        {
+          path: '/workspaces/:workspace',
+          element: (
+            <SubmitEvaluationModal
+              open
+              onClose={() => {}}
+              workspace={DEFAULT_WORKSPACE}
+              agent="my-agent"
+            />
+          ),
+        },
+      ],
+    });
+
+    // The list query only fires in experiment mode; switch to it.
+    await user.click(await screen.findByRole('radio', { name: 'Use existing evaluation' }));
+
+    await waitFor(() => {
+      const filtered = evaluationsUrls.find((u) => u.searchParams.has('filter[agent_name]'));
+      expect(filtered).toBeDefined();
+      expect(filtered!.searchParams.get('filter[agent_name]')).toBe('my-agent');
+    });
+  });
+});

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -357,7 +357,15 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
 
   const { data: evaluationsResponse, isLoading: isEvaluationsLoading } = useListEvaluations(
     workspace,
-    { page_size: LIST_PAGE_SIZE, sort: '-created_at' },
+    // Scope the "use existing evaluation" list to the current agent. agent_name matches against
+    // the Evaluation's denormalized agent_names (populated from ingested span telemetry), so an
+    // evaluation only appears once it has runs tagged with this agent. selectedAgent is seeded
+    // from the agentProp on the agent detail page and set by the in-modal picker otherwise.
+    {
+      page_size: LIST_PAGE_SIZE,
+      sort: '-created_at',
+      ...(selectedAgent ? { filter: { agent_name: selectedAgent } } : {}),
+    },
     { query: { enabled: open && mode === MODE_EXPERIMENT } }
   );
   const evaluations = evaluationsResponse?.data ?? [];


### PR DESCRIPTION
| w/ prev runs | w/o prev runs |
| --- | --- |
| <img width="1780" height="1103" alt="Screenshot 2026-08-20 at 12 21 21" src="https://github.com/user-attachments/assets/30f067e8-a4bc-4a05-89f2-db11337bde45" /> | <img width="1780" height="1103" alt="Screenshot 2026-08-20 at 12 31 51" src="https://github.com/user-attachments/assets/423a6545-3a2d-456a-a230-511d65994860" /> |

## Summary

The Run Evaluation modal's "Use existing evaluation" dropdown listed every compatible evaluation in the workspace, regardless of which agent you were on. It now scopes the list to the current agent. Before: opening the modal from an agent detail page showed all workspace evaluations. After: it shows only evaluations whose telemetry-derived `agent_names` include that agent.

## Related Issue

Linear ASTD-456 (child of ASTD-360, "Agent evals to experiments"). No GitHub issue.

## Changes

- `web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx`: pass `filter: { agent_name: selectedAgent }` to the `useListEvaluations` query when an agent is selected. `selectedAgent` is seeded from the `agent` prop on the agent detail page and set by the in-modal picker otherwise. Backend already supports this filter (`EvaluationFilter.agent_name` → denormalized `agent_names`), so no API change was needed.
- `web/packages/studio/src/components/evaluation/SubmitEvaluationModal.test.tsx`: new behavioral test asserting the evaluations request carries `filter[agent_name]=<agent>` in experiment mode.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs cover this dropdown; behavior is self-evident in the modal.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `node_modules/.bin/vitest --run src/components/evaluation/SubmitEvaluationModal.test.tsx` (in `web/packages/studio`) → 1 passed.
- `node_modules/.bin/tsc --noEmit --noErrorTruncation` (in `web/packages/studio`) → exit 0.
- `eslint --report-unused-disable-directives --max-warnings 0 <both changed files>` (from `web/`) → exit 0.
- Commit-time pre-commit hooks (UI lint-staged, copyright headers, DCO) passed. Repo-wide `uv run pre-commit run -a` was not run for this FE-only change; the relevant hooks are covered by the targeted commands above and CI will run the full gate.
- Live end-to-end against a running platform (Studio dev server proxying `/apis` → `:8080`): for agent `email-security-triage-dwvz8y` the modal issued `evaluations?...&filter[agent_name]=email-security-triage-dwvz8y` and the dropdown showed only that agent's 6 compatible evaluations; for `email-security-triage-bcf59v` (0 scoped evals) it showed the empty state. API cross-check via the proxy: unfiltered 61, `dwvz8y` → 8, `bcf59v` → 0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing evaluations are now filtered to the currently selected agent, preventing unrelated evaluations from appearing.
  * Evaluation history continues to support pagination and sorting by newest first.
  * Filtering is omitted when no agent is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->