### PR TITLE
feat(studio): create Fabric agents by uploading their directory [ASTD-448]

### DIFF
--- a/web/packages/common/src/api/common/utils.ts
+++ b/web/packages/common/src/api/common/utils.ts
@@ -49,6 +49,12 @@ export const isValidationErrorArray = (detail: unknown): detail is ValidationErr
 export const isVersionConflictError = (error: unknown): boolean =>
   error instanceof AxiosError && error.response?.status === 409;
 
+/** A 404 from the platform API. Duck-typed: some callers see a plain object, not an AxiosError. */
+export const isNotFoundError = (error: unknown): boolean => {
+  const candidate = error as { response?: { status?: number }; status?: number };
+  return candidate?.response?.status === 404 || candidate?.status === 404;
+};
+
 /**
  * Extracts a user-friendly error message from an error object.
  * Handles both ValidationError arrays and simple string errors from the backend.

--- a/web/packages/common/src/api/common/utils.ts
+++ b/web/packages/common/src/api/common/utils.ts
@@ -49,7 +49,7 @@ export const isValidationErrorArray = (detail: unknown): detail is ValidationErr
 export const isVersionConflictError = (error: unknown): boolean =>
   error instanceof AxiosError && error.response?.status === 409;
 
-/** A 404 from the platform API. Duck-typed: some callers see a plain object, not an AxiosError. */
+/** A 404 from the platform API. */
 export const isNotFoundError = (error: unknown): boolean => {
   const candidate = error as { response?: { status?: number }; status?: number };
   return candidate?.response?.status === 404 || candidate?.status === 404;

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { agentsCreateAgent, agentsDeleteAgent } from '@nemo/sdk/generated/agents/api';
+import {
+  filesCreateFileset,
+  filesDeleteFileset,
+  filesRetrieveFileset,
+  filesUploadFile,
+} from '@nemo/sdk/generated/platform/api';
+import {
+  AgentSpecFilesetConflictError,
+  createAgentFromUpload,
+} from '@studio/api/agents/useCreateAgentFromUpload';
+import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+
+vi.mock('@nemo/sdk/generated/agents/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@nemo/sdk/generated/agents/api')>()),
+  agentsCreateAgent: vi.fn(),
+  agentsDeleteAgent: vi.fn(),
+}));
+
+vi.mock('@nemo/sdk/generated/platform/api', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@nemo/sdk/generated/platform/api')>()),
+  filesRetrieveFileset: vi.fn(),
+  filesCreateFileset: vi.fn(),
+  filesUploadFile: vi.fn(),
+  filesDeleteFileset: vi.fn(),
+}));
+
+const FABRIC_YAML = 'config_format: nemo-agents-spec-v1\nname: calc\ndescription: Adds numbers\n';
+
+const entryFor = (path: string, contents: string): UploadAgentEntry => ({
+  path,
+  file: new File([contents], path.split('/').pop() ?? path),
+});
+
+const entries = (): UploadAgentEntry[] => [
+  entryFor('agent.yaml', FABRIC_YAML),
+  entryFor('mcps/calculator.py', 'print(1)\n'),
+];
+
+const params = () => ({ workspace: 'ws', name: 'calc', entries: entries() });
+
+beforeEach(() => {
+  vi.mocked(filesRetrieveFileset).mockRejectedValue(new Error('404'));
+  vi.mocked(filesCreateFileset).mockResolvedValue({ name: 'calc-spec' } as never);
+  vi.mocked(filesUploadFile).mockResolvedValue({ path: 'agent.yaml' } as never);
+  vi.mocked(filesDeleteFileset).mockResolvedValue(undefined as never);
+  vi.mocked(agentsCreateAgent).mockResolvedValue({ name: 'calc' } as never);
+  vi.mocked(agentsDeleteAgent).mockResolvedValue(undefined as never);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('createAgentFromUpload', () => {
+  it('creates the agent, then uploads every file into the {agent}-spec fileset', async () => {
+    await createAgentFromUpload(params());
+
+    expect(agentsCreateAgent).toHaveBeenCalledWith('ws', {
+      name: 'calc',
+      description: 'Adds numbers',
+      config: expect.objectContaining({ config_format: 'nemo-agents-spec-v1' }),
+      config_format: 'nemo-agents-spec-v1',
+    });
+    expect(filesCreateFileset).toHaveBeenCalledWith('ws', expect.objectContaining({ name: 'calc-spec' }));
+    expect(vi.mocked(filesUploadFile).mock.calls.map((call) => [call[1], call[2]])).toEqual([
+      ['calc-spec', 'agent.yaml'],
+      ['calc-spec', 'mcps/calculator.py'],
+    ]);
+  });
+
+  it('refuses to touch an existing spec fileset', async () => {
+    vi.mocked(filesRetrieveFileset).mockResolvedValue({ name: 'calc-spec' } as never);
+
+    await expect(createAgentFromUpload(params())).rejects.toThrow(AgentSpecFilesetConflictError);
+    expect(agentsCreateAgent).not.toHaveBeenCalled();
+    expect(filesCreateFileset).not.toHaveBeenCalled();
+  });
+
+  it('deletes the agent and the fileset when an upload fails', async () => {
+    vi.mocked(filesUploadFile)
+      .mockResolvedValueOnce({ path: 'agent.yaml' } as never)
+      .mockRejectedValueOnce(new Error('network down'));
+
+    await expect(createAgentFromUpload(params())).rejects.toThrow('network down');
+    expect(agentsDeleteAgent).toHaveBeenCalledWith('ws', 'calc');
+    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-spec');
+  });
+
+  it('rejects a non-Fabric config before creating anything', async () => {
+    const natEntries = [entryFor('agent.yaml', 'config_format: nat-workflow-v1\n')];
+
+    await expect(
+      createAgentFromUpload({ workspace: 'ws', name: 'calc', entries: natEntries })
+    ).rejects.toThrow(/config_format/);
+    expect(agentsCreateAgent).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
@@ -76,7 +76,9 @@ describe('createAgentFromUpload', () => {
 
     await createAgentFromUpload(params());
 
-    expect(order).toEqual(['upload:agent.yaml', 'upload:mcps/calculator.py', 'createAgent']);
+    // Uploads run concurrently, so only their completion before the create is guaranteed.
+    expect(order.at(-1)).toBe('createAgent');
+    expect(order.slice(0, -1).sort()).toEqual(['upload:agent.yaml', 'upload:mcps/calculator.py']);
     expect(agentsCreateAgent).toHaveBeenCalledWith('ws', {
       name: 'calc',
       description: 'Adds numbers',

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { agentsCreateAgent, agentsDeleteAgent } from '@nemo/sdk/generated/agents/api';
+import { agentsCreateAgent, agentsGetAgent } from '@nemo/sdk/generated/agents/api';
 import {
   filesCreateFileset,
   filesDeleteFileset,
@@ -10,6 +10,7 @@ import {
 } from '@nemo/sdk/generated/platform/api';
 import {
   AgentSpecFilesetConflictError,
+  AgentSpecFilesetOrphanError,
   createAgentFromUpload,
 } from '@studio/api/agents/useCreateAgentFromUpload';
 import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
@@ -17,7 +18,7 @@ import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/Upl
 vi.mock('@nemo/sdk/generated/agents/api', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@nemo/sdk/generated/agents/api')>()),
   agentsCreateAgent: vi.fn(),
-  agentsDeleteAgent: vi.fn(),
+  agentsGetAgent: vi.fn(),
 }));
 
 vi.mock('@nemo/sdk/generated/platform/api', async (importOriginal) => ({
@@ -42,13 +43,19 @@ const entries = (): UploadAgentEntry[] => [
 
 const params = () => ({ workspace: 'ws', name: 'calc', entries: entries() });
 
+const filesetMissing = () => vi.mocked(filesRetrieveFileset).mockRejectedValue(new Error('404'));
+const filesetExists = () =>
+  vi.mocked(filesRetrieveFileset).mockResolvedValue({ name: 'calc-spec' } as never);
+const agentMissing = () => vi.mocked(agentsGetAgent).mockRejectedValue(new Error('404'));
+const agentExists = () => vi.mocked(agentsGetAgent).mockResolvedValue({ name: 'calc' } as never);
+
 beforeEach(() => {
-  vi.mocked(filesRetrieveFileset).mockRejectedValue(new Error('404'));
+  filesetMissing();
+  agentMissing();
   vi.mocked(filesCreateFileset).mockResolvedValue({ name: 'calc-spec' } as never);
   vi.mocked(filesUploadFile).mockResolvedValue({ path: 'agent.yaml' } as never);
   vi.mocked(filesDeleteFileset).mockResolvedValue(undefined as never);
   vi.mocked(agentsCreateAgent).mockResolvedValue({ name: 'calc' } as never);
-  vi.mocked(agentsDeleteAgent).mockResolvedValue(undefined as never);
 });
 
 afterEach(() => {
@@ -56,46 +63,92 @@ afterEach(() => {
 });
 
 describe('createAgentFromUpload', () => {
-  it('creates the agent, then uploads every file into the {agent}-spec fileset', async () => {
+  it('uploads every file before creating the agent', async () => {
+    const order: string[] = [];
+    vi.mocked(filesUploadFile).mockImplementation(async (_ws, _fs, path) => {
+      order.push(`upload:${path}`);
+      return { path } as never;
+    });
+    vi.mocked(agentsCreateAgent).mockImplementation(async () => {
+      order.push('createAgent');
+      return { name: 'calc' } as never;
+    });
+
     await createAgentFromUpload(params());
 
+    expect(order).toEqual(['upload:agent.yaml', 'upload:mcps/calculator.py', 'createAgent']);
     expect(agentsCreateAgent).toHaveBeenCalledWith('ws', {
       name: 'calc',
       description: 'Adds numbers',
       config: expect.objectContaining({ config_format: 'nemo-agents-spec-v1' }),
       config_format: 'nemo-agents-spec-v1',
     });
-    expect(filesCreateFileset).toHaveBeenCalledWith('ws', expect.objectContaining({ name: 'calc-spec' }));
-    expect(vi.mocked(filesUploadFile).mock.calls.map((call) => [call[1], call[2]])).toEqual([
-      ['calc-spec', 'agent.yaml'],
-      ['calc-spec', 'mcps/calculator.py'],
-    ]);
   });
 
-  it('refuses to touch an existing spec fileset', async () => {
-    vi.mocked(filesRetrieveFileset).mockResolvedValue({ name: 'calc-spec' } as never);
+  it('refuses a fileset that an existing agent owns', async () => {
+    filesetExists();
+    agentExists();
 
     await expect(createAgentFromUpload(params())).rejects.toThrow(AgentSpecFilesetConflictError);
-    expect(agentsCreateAgent).not.toHaveBeenCalled();
     expect(filesCreateFileset).not.toHaveBeenCalled();
+    expect(filesDeleteFileset).not.toHaveBeenCalled();
   });
 
-  it('deletes the agent and the fileset when an upload fails', async () => {
+  it('asks before replacing a fileset that no agent owns', async () => {
+    filesetExists();
+
+    await expect(createAgentFromUpload(params())).rejects.toThrow(AgentSpecFilesetOrphanError);
+    expect(filesDeleteFileset).not.toHaveBeenCalled();
+    expect(agentsCreateAgent).not.toHaveBeenCalled();
+  });
+
+  it('replaces an orphaned fileset once confirmed', async () => {
+    filesetExists();
+
+    await createAgentFromUpload({ ...params(), replaceOrphanedFileset: true });
+
+    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-spec');
+    expect(filesCreateFileset).toHaveBeenCalledWith(
+      'ws',
+      expect.objectContaining({ name: 'calc-spec' })
+    );
+    expect(agentsCreateAgent).toHaveBeenCalled();
+  });
+
+  it('does not replace an owned fileset even when confirmed', async () => {
+    filesetExists();
+    agentExists();
+
+    await expect(
+      createAgentFromUpload({ ...params(), replaceOrphanedFileset: true })
+    ).rejects.toThrow(AgentSpecFilesetConflictError);
+    expect(filesDeleteFileset).not.toHaveBeenCalled();
+  });
+
+  it('deletes the fileset when an upload fails', async () => {
     vi.mocked(filesUploadFile)
       .mockResolvedValueOnce({ path: 'agent.yaml' } as never)
       .mockRejectedValueOnce(new Error('network down'));
 
     await expect(createAgentFromUpload(params())).rejects.toThrow('network down');
-    expect(agentsDeleteAgent).toHaveBeenCalledWith('ws', 'calc');
     expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-spec');
   });
 
-  it('rejects a non-Fabric config before creating anything', async () => {
+  it('deletes the fileset when creating the agent fails', async () => {
+    vi.mocked(agentsCreateAgent).mockRejectedValue(new Error('409 conflict'));
+
+    await expect(createAgentFromUpload(params())).rejects.toThrow('409 conflict');
+    expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-spec');
+  });
+
+  it('rejects a non-Fabric config before touching anything', async () => {
     const natEntries = [entryFor('agent.yaml', 'config_format: nat-workflow-v1\n')];
 
     await expect(
       createAgentFromUpload({ workspace: 'ws', name: 'calc', entries: natEntries })
     ).rejects.toThrow(/config_format/);
+    expect(filesRetrieveFileset).not.toHaveBeenCalled();
+    expect(filesCreateFileset).not.toHaveBeenCalled();
     expect(agentsCreateAgent).not.toHaveBeenCalled();
   });
 });

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.test.ts
@@ -43,10 +43,13 @@ const entries = (): UploadAgentEntry[] => [
 
 const params = () => ({ workspace: 'ws', name: 'calc', entries: entries() });
 
-const filesetMissing = () => vi.mocked(filesRetrieveFileset).mockRejectedValue(new Error('404'));
+const httpError = (status: number): Error =>
+  Object.assign(new Error(`HTTP ${status}`), { response: { status } });
+
+const filesetMissing = () => vi.mocked(filesRetrieveFileset).mockRejectedValue(httpError(404));
 const filesetExists = () =>
   vi.mocked(filesRetrieveFileset).mockResolvedValue({ name: 'calc-spec' } as never);
-const agentMissing = () => vi.mocked(agentsGetAgent).mockRejectedValue(new Error('404'));
+const agentMissing = () => vi.mocked(agentsGetAgent).mockRejectedValue(httpError(404));
 const agentExists = () => vi.mocked(agentsGetAgent).mockResolvedValue({ name: 'calc' } as never);
 
 beforeEach(() => {
@@ -141,6 +144,32 @@ describe('createAgentFromUpload', () => {
 
     await expect(createAgentFromUpload(params())).rejects.toThrow('409 conflict');
     expect(filesDeleteFileset).toHaveBeenCalledWith('ws', 'calc-spec');
+  });
+
+  it('does not delete a fileset it failed to create', async () => {
+    vi.mocked(filesCreateFileset).mockRejectedValue(httpError(409));
+
+    await expect(createAgentFromUpload(params())).rejects.toThrow('HTTP 409');
+    expect(filesDeleteFileset).not.toHaveBeenCalled();
+  });
+
+  it('does not claim the name when the fileset lookup fails for any reason but absence', async () => {
+    vi.mocked(filesRetrieveFileset).mockRejectedValue(httpError(503));
+
+    await expect(createAgentFromUpload(params())).rejects.toThrow('HTTP 503');
+    expect(filesCreateFileset).not.toHaveBeenCalled();
+    expect(filesDeleteFileset).not.toHaveBeenCalled();
+  });
+
+  it('does not replace a fileset when the agent lookup fails for any reason but absence', async () => {
+    filesetExists();
+    vi.mocked(agentsGetAgent).mockRejectedValue(httpError(503));
+
+    await expect(
+      createAgentFromUpload({ ...params(), replaceOrphanedFileset: true })
+    ).rejects.toThrow('HTTP 503');
+    expect(filesDeleteFileset).not.toHaveBeenCalled();
+    expect(agentsCreateAgent).not.toHaveBeenCalled();
   });
 
   it('rejects a non-Fabric config before touching anything', async () => {

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
@@ -48,7 +48,7 @@ export class AgentSpecFilesetOrphanError extends Error {
 
 // Files first: the fileset reserves the name, and a create-time validation that needs a
 // base_dir can only see files that are already uploaded. Creating it outside the try keeps
-// rollback to what this call created — a failed create leaves someone else's fileset alone.
+// rollback to what this call created.
 export const createAgentFromUpload = async ({
   workspace,
   name,
@@ -92,8 +92,7 @@ const claimFileset = async (
   try {
     await filesRetrieveFileset(workspace, filesetName);
   } catch (error) {
-    // Only a 404 means the name is free. Anything else and ownership is unknown, so
-    // claiming it could hand a live agent's fileset to this upload.
+    // Only a 404 means the name is free; anything else leaves ownership unknown.
     if (!isNotFoundError(error)) throw error;
     return;
   }

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
@@ -32,18 +32,9 @@ export class AgentSpecFilesetConflictError extends Error {
   }
 }
 
-/**
- * Create a Fabric agent from a picked directory.
- *
- * Two phases, because the platform has no endpoint that takes config and files
- * together: the agent entity is created first so the name is reserved (and a
- * duplicate returns 409), then the directory is uploaded into the conventional
- * `{agent}-spec` fileset that deployments read.
- *
- * Both are rolled back on failure. Deleting the fileset is safe here only
- * because an existing one is refused up front — so anything this flow uploaded
- * into it, this flow created.
- */
+// Two phases: no endpoint takes config and files together. Creating the agent first
+// reserves the name. Deleting the fileset on rollback is safe only because an existing
+// one is refused up front, so anything in it was put there by this flow.
 export const createAgentFromUpload = async ({
   workspace,
   name,
@@ -87,11 +78,6 @@ const assertFilesetAvailable = async (workspace: string, filesetName: string): P
   throw new AgentSpecFilesetConflictError(filesetName);
 };
 
-/**
- * Upload sequentially. The files service takes one file per request, and a
- * directory is bounded at 500 files, so ordered failure beats saturating the
- * browser's connection pool for a marginal speedup.
- */
 const uploadEntries = async (
   workspace: string,
   filesetName: string,

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { isNotFoundError } from '@nemo/common/src/api/common/utils';
 import { agentsCreateAgent, agentsGetAgent } from '@nemo/sdk/generated/agents/api';
 import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
 import {
@@ -46,8 +47,8 @@ export class AgentSpecFilesetOrphanError extends Error {
 }
 
 // Files first: the fileset reserves the name, and a create-time validation that needs a
-// base_dir can only see files that are already uploaded. Deleting the fileset on rollback
-// is safe because an existing one is either refused or replaced deliberately above.
+// base_dir can only see files that are already uploaded. Creating it outside the try keeps
+// rollback to what this call created — a failed create leaves someone else's fileset alone.
 export const createAgentFromUpload = async ({
   workspace,
   name,
@@ -62,11 +63,12 @@ export const createAgentFromUpload = async ({
 
   await claimFileset(workspace, name, filesetName, replaceOrphanedFileset);
 
+  await filesCreateFileset(workspace, {
+    name: filesetName,
+    description: `Agent spec for ${name}`,
+  });
+
   try {
-    await filesCreateFileset(workspace, {
-      name: filesetName,
-      description: `Agent spec for ${name}`,
-    });
     await uploadEntries(workspace, filesetName, entries);
 
     return await agentsCreateAgent(workspace, {
@@ -89,7 +91,10 @@ const claimFileset = async (
 ): Promise<void> => {
   try {
     await filesRetrieveFileset(workspace, filesetName);
-  } catch {
+  } catch (error) {
+    // Only a 404 means the name is free. Anything else and ownership is unknown, so
+    // claiming it could hand a live agent's fileset to this upload.
+    if (!isNotFoundError(error)) throw error;
     return;
   }
 
@@ -107,7 +112,8 @@ const agentExists = async (workspace: string, agentName: string): Promise<boolea
   try {
     await agentsGetAgent(workspace, agentName);
     return true;
-  } catch {
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
     return false;
   }
 };

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { agentsCreateAgent, agentsDeleteAgent } from '@nemo/sdk/generated/agents/api';
+import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
+import {
+  filesCreateFileset,
+  filesDeleteFileset,
+  filesRetrieveFileset,
+  filesUploadFile,
+} from '@nemo/sdk/generated/platform/api';
+import {
+  AGENT_CONFIG_FILENAME,
+  agentSpecFilesetName,
+  FABRIC_CONFIG_FORMAT,
+  parseAgentConfig,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
+import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import { UseMutationOptions, useMutation } from '@tanstack/react-query';
+
+export interface CreateAgentFromUploadParams {
+  workspace: string;
+  name: string;
+  entries: UploadAgentEntry[];
+}
+
+export class AgentSpecFilesetConflictError extends Error {
+  constructor(public readonly filesetName: string) {
+    super(
+      `A fileset named "${filesetName}" already exists. It holds the spec for an agent of this name — possibly one that was deleted, since deleting an agent leaves its fileset behind. Delete it with \`nemo files filesets delete ${filesetName}\`, or choose a different name.`
+    );
+  }
+}
+
+/**
+ * Create a Fabric agent from a picked directory.
+ *
+ * Two phases, because the platform has no endpoint that takes config and files
+ * together: the agent entity is created first so the name is reserved (and a
+ * duplicate returns 409), then the directory is uploaded into the conventional
+ * `{agent}-spec` fileset that deployments read.
+ *
+ * Both are rolled back on failure. Deleting the fileset is safe here only
+ * because an existing one is refused up front — so anything this flow uploaded
+ * into it, this flow created.
+ */
+export const createAgentFromUpload = async ({
+  workspace,
+  name,
+  entries,
+}: CreateAgentFromUploadParams): Promise<Agent> => {
+  const filesetName = agentSpecFilesetName(name);
+
+  await assertFilesetAvailable(workspace, filesetName);
+
+  const configEntry = entries.find((entry) => entry.path === AGENT_CONFIG_FILENAME);
+  if (!configEntry) throw new Error(`No ${AGENT_CONFIG_FILENAME} in the selected directory.`);
+  const config = parseAgentConfig(await configEntry.file.text());
+
+  const agent = await agentsCreateAgent(workspace, {
+    name,
+    description: typeof config.description === 'string' ? config.description : '',
+    config,
+    config_format: FABRIC_CONFIG_FORMAT,
+  });
+
+  try {
+    await filesCreateFileset(workspace, {
+      name: filesetName,
+      description: `Agent spec for ${name}`,
+    });
+    await uploadEntries(workspace, filesetName, entries);
+  } catch (error) {
+    await rollback(workspace, name, filesetName);
+    throw error;
+  }
+
+  return agent;
+};
+
+const assertFilesetAvailable = async (workspace: string, filesetName: string): Promise<void> => {
+  try {
+    await filesRetrieveFileset(workspace, filesetName);
+  } catch {
+    return;
+  }
+  throw new AgentSpecFilesetConflictError(filesetName);
+};
+
+/**
+ * Upload sequentially. The files service takes one file per request, and a
+ * directory is bounded at 500 files, so ordered failure beats saturating the
+ * browser's connection pool for a marginal speedup.
+ */
+const uploadEntries = async (
+  workspace: string,
+  filesetName: string,
+  entries: UploadAgentEntry[]
+): Promise<void> => {
+  for (const entry of entries) {
+    const blob = new Blob([await entry.file.arrayBuffer()], { type: 'application/octet-stream' });
+    await filesUploadFile(workspace, filesetName, entry.path, blob);
+  }
+};
+
+const rollback = async (
+  workspace: string,
+  agentName: string,
+  filesetName: string
+): Promise<void> => {
+  await Promise.allSettled([
+    agentsDeleteAgent(workspace, agentName),
+    filesDeleteFileset(workspace, filesetName),
+  ]);
+};
+
+export type UseCreateAgentFromUploadOptions = Omit<
+  UseMutationOptions<Agent, Error, CreateAgentFromUploadParams>,
+  'mutationFn'
+>;
+
+export const useCreateAgentFromUpload = (options?: UseCreateAgentFromUploadOptions) =>
+  useMutation({ ...options, mutationFn: createAgentFromUpload });

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { agentsCreateAgent, agentsDeleteAgent } from '@nemo/sdk/generated/agents/api';
+import { agentsCreateAgent, agentsGetAgent } from '@nemo/sdk/generated/agents/api';
 import type { Agent } from '@nemo/sdk/generated/agents/schema/Agent';
 import {
   filesCreateFileset,
@@ -22,38 +22,43 @@ export interface CreateAgentFromUploadParams {
   workspace: string;
   name: string;
   entries: UploadAgentEntry[];
+  replaceOrphanedFileset?: boolean;
 }
 
+/** An agent of this name already exists; its spec fileset is not ours to take. */
 export class AgentSpecFilesetConflictError extends Error {
   constructor(public readonly filesetName: string) {
     super(
-      `A fileset named "${filesetName}" already exists. It holds the spec for an agent of this name — possibly one that was deleted, since deleting an agent leaves its fileset behind. Delete it with \`nemo files filesets delete ${filesetName}\`, or choose a different name.`
+      `An agent named "${filesetName.replace(/-spec$/, '')}" already owns the fileset "${filesetName}". Choose a different name.`
     );
   }
 }
 
-// Two phases: no endpoint takes config and files together. Creating the agent first
-// reserves the name. Deleting the fileset on rollback is safe only because an existing
-// one is refused up front, so anything in it was put there by this flow.
+/** A spec fileset with no agent behind it — an abandoned upload, or an agent since deleted. */
+export class AgentSpecFilesetOrphanError extends Error {
+  constructor(public readonly filesetName: string) {
+    super(
+      `A fileset named "${filesetName}" already exists, but no agent owns it — an upload that did not finish, or an agent that was deleted, since deleting an agent leaves its fileset behind. Replacing it discards its current contents.`
+    );
+  }
+}
+
+// Files first: the fileset reserves the name, and a create-time validation that needs a
+// base_dir can only see files that are already uploaded. Deleting the fileset on rollback
+// is safe because an existing one is either refused or replaced deliberately above.
 export const createAgentFromUpload = async ({
   workspace,
   name,
   entries,
+  replaceOrphanedFileset = false,
 }: CreateAgentFromUploadParams): Promise<Agent> => {
   const filesetName = agentSpecFilesetName(name);
-
-  await assertFilesetAvailable(workspace, filesetName);
 
   const configEntry = entries.find((entry) => entry.path === AGENT_CONFIG_FILENAME);
   if (!configEntry) throw new Error(`No ${AGENT_CONFIG_FILENAME} in the selected directory.`);
   const config = parseAgentConfig(await configEntry.file.text());
 
-  const agent = await agentsCreateAgent(workspace, {
-    name,
-    description: typeof config.description === 'string' ? config.description : '',
-    config,
-    config_format: FABRIC_CONFIG_FORMAT,
-  });
+  await claimFileset(workspace, name, filesetName, replaceOrphanedFileset);
 
   try {
     await filesCreateFileset(workspace, {
@@ -61,21 +66,48 @@ export const createAgentFromUpload = async ({
       description: `Agent spec for ${name}`,
     });
     await uploadEntries(workspace, filesetName, entries);
+
+    return await agentsCreateAgent(workspace, {
+      name,
+      description: typeof config.description === 'string' ? config.description : '',
+      config,
+      config_format: FABRIC_CONFIG_FORMAT,
+    });
   } catch (error) {
-    await rollback(workspace, name, filesetName);
+    await rollback(workspace, filesetName);
     throw error;
   }
-
-  return agent;
 };
 
-const assertFilesetAvailable = async (workspace: string, filesetName: string): Promise<void> => {
+const claimFileset = async (
+  workspace: string,
+  agentName: string,
+  filesetName: string,
+  replaceOrphanedFileset: boolean
+): Promise<void> => {
   try {
     await filesRetrieveFileset(workspace, filesetName);
   } catch {
     return;
   }
-  throw new AgentSpecFilesetConflictError(filesetName);
+
+  if (await agentExists(workspace, agentName)) {
+    throw new AgentSpecFilesetConflictError(filesetName);
+  }
+  if (!replaceOrphanedFileset) {
+    throw new AgentSpecFilesetOrphanError(filesetName);
+  }
+
+  await filesDeleteFileset(workspace, filesetName);
+};
+
+const agentExists = async (workspace: string, agentName: string): Promise<boolean> => {
+  try {
+    await agentsGetAgent(workspace, agentName);
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 const uploadEntries = async (
@@ -89,15 +121,8 @@ const uploadEntries = async (
   }
 };
 
-const rollback = async (
-  workspace: string,
-  agentName: string,
-  filesetName: string
-): Promise<void> => {
-  await Promise.allSettled([
-    agentsDeleteAgent(workspace, agentName),
-    filesDeleteFileset(workspace, filesetName),
-  ]);
+const rollback = async (workspace: string, filesetName: string): Promise<void> => {
+  await filesDeleteFileset(workspace, filesetName).catch(() => undefined);
 };
 
 export type UseCreateAgentFromUploadOptions = Omit<

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
@@ -11,11 +11,13 @@ import {
 } from '@nemo/sdk/generated/platform/api';
 import {
   AGENT_CONFIG_FILENAME,
-  agentSpecFilesetName,
   FABRIC_CONFIG_FORMAT,
-  parseAgentConfig,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
 import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import {
+  agentSpecFilesetName,
+  parseAgentConfig,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/utils';
 import { UseMutationOptions, useMutation } from '@tanstack/react-query';
 
 export interface CreateAgentFromUploadParams {

--- a/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
+++ b/web/packages/studio/src/api/agents/useCreateAgentFromUpload.ts
@@ -110,15 +110,27 @@ const agentExists = async (workspace: string, agentName: string): Promise<boolea
   }
 };
 
+// One request per file, so a 500-file agent is 500 round trips. Run a bounded number at
+// once: unbounded Promise.all would queue them all against the browser's per-host limit
+// and lose the first error behind hundreds of in-flight requests.
+const UPLOAD_CONCURRENCY = 6;
+
 const uploadEntries = async (
   workspace: string,
   filesetName: string,
   entries: UploadAgentEntry[]
 ): Promise<void> => {
-  for (const entry of entries) {
-    const blob = new Blob([await entry.file.arrayBuffer()], { type: 'application/octet-stream' });
-    await filesUploadFile(workspace, filesetName, entry.path, blob);
-  }
+  const queue = [...entries];
+  const worker = async (): Promise<void> => {
+    for (let entry = queue.shift(); entry; entry = queue.shift()) {
+      const blob = new Blob([await entry.file.arrayBuffer()], { type: 'application/octet-stream' });
+      await filesUploadFile(workspace, filesetName, entry.path, blob);
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(UPLOAD_CONCURRENCY, entries.length) }, () => worker())
+  );
 };
 
 const rollback = async (workspace: string, filesetName: string): Promise<void> => {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.test.ts
@@ -6,6 +6,7 @@ import {
   agentNameFromConfig,
   agentSpecFilesetName,
   collectAgentEntries,
+  findNonUtf8Path,
   isIgnoredPath,
   MAX_AGENT_SPEC_FILES,
   parseAgentConfig,
@@ -134,5 +135,48 @@ describe('agentNameFromConfig', () => {
 describe('agentSpecFilesetName', () => {
   it('matches the platform convention', () => {
     expect(agentSpecFilesetName('calc')).toBe('calc-spec');
+  });
+});
+
+describe('findNonUtf8Path', () => {
+  const binaryEntry = (path: string, bytes: number[]): UploadAgentEntry => ({
+    path,
+    file: new File([new Uint8Array(bytes)], path.split('/').pop() ?? path),
+  });
+
+  const textEntry = (path: string, contents: string): UploadAgentEntry => ({
+    path,
+    file: new File([contents], path.split('/').pop() ?? path),
+  });
+
+  it('names the first file that is not valid UTF-8', async () => {
+    const entries = [
+      textEntry('agent.yaml', 'name: calc\n'),
+      binaryEntry('logo.bin', [0xff, 0xfe, 0x00, 0x62]),
+    ];
+
+    await expect(findNonUtf8Path(entries)).resolves.toBe('logo.bin');
+  });
+
+  it('accepts multi-byte UTF-8, an empty file, and a BOM', async () => {
+    const entries = [
+      textEntry('agent.yaml', 'description: café ☕ — 名前\n'),
+      textEntry('empty.md', ''),
+      binaryEntry('bom.md', [0xef, 0xbb, 0xbf, 0x68, 0x69]),
+    ];
+
+    await expect(findNonUtf8Path(entries)).resolves.toBeUndefined();
+  });
+
+  it('ignores AGENT-SPEC.md, which container staging never reads', async () => {
+    const entries = [binaryEntry('AGENT-SPEC.md', [0xff, 0xfe, 0x00])];
+
+    await expect(findNonUtf8Path(entries)).resolves.toBeUndefined();
+  });
+
+  it('rejects a lone UTF-16 surrogate sequence', async () => {
+    const entries = [binaryEntry('utf16.md', [0xed, 0xa0, 0x80])];
+
+    await expect(findNonUtf8Path(entries)).resolves.toBe('utf16.md');
   });
 });

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.test.ts
@@ -9,7 +9,9 @@ import {
   findNonUtf8Path,
   isIgnoredPath,
   MAX_AGENT_SPEC_FILES,
+  MAX_PICKED_FILES,
   parseAgentConfig,
+  tooManyPickedFiles,
   validateAgentEntries,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
 import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
@@ -90,7 +92,9 @@ describe('validateAgentEntries', () => {
   });
 
   it('accepts a directory within both limits', () => {
-    expect(validateAgentEntries([entry('agent.yaml'), entry('mcps/calculator.py')])).toBeUndefined();
+    expect(
+      validateAgentEntries([entry('agent.yaml'), entry('mcps/calculator.py')])
+    ).toBeUndefined();
   });
 });
 
@@ -178,5 +182,16 @@ describe('findNonUtf8Path', () => {
     const entries = [binaryEntry('utf16.md', [0xed, 0xa0, 0x80])];
 
     await expect(findNonUtf8Path(entries)).resolves.toBe('utf16.md');
+  });
+});
+
+describe('tooManyPickedFiles', () => {
+  it('rejects a pick far larger than any agent directory', () => {
+    expect(tooManyPickedFiles(880_000)).toMatch(/880,000 files/);
+  });
+
+  it('allows a pick within the inspectable ceiling', () => {
+    expect(tooManyPickedFiles(MAX_PICKED_FILES)).toBeUndefined();
+    expect(tooManyPickedFiles(12)).toBeUndefined();
   });
 });

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.test.ts
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AgentConfigParseError,
+  agentNameFromConfig,
+  agentSpecFilesetName,
+  collectAgentEntries,
+  isIgnoredPath,
+  MAX_AGENT_SPEC_FILES,
+  parseAgentConfig,
+  validateAgentEntries,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
+import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+
+const makeFile = (relativePath: string, contents = 'x'): File => {
+  const file = new File([contents], relativePath.split('/').pop() ?? relativePath);
+  Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+  return file;
+};
+
+const entry = (path: string, size = 1): UploadAgentEntry => ({
+  path,
+  file: { size } as File,
+});
+
+describe('collectAgentEntries', () => {
+  it('strips the picked directory from each path', () => {
+    const entries = collectAgentEntries([
+      makeFile('calculator-agent/agent.yaml'),
+      makeFile('calculator-agent/mcps/calculator.py'),
+    ]);
+
+    expect(entries.map((item) => item.path)).toEqual(['agent.yaml', 'mcps/calculator.py']);
+  });
+
+  it('drops build artifacts that the container path cannot stage', () => {
+    const entries = collectAgentEntries([
+      makeFile('agent/agent.yaml'),
+      makeFile('agent/mcps/__pycache__/calculator.cpython-312.pyc'),
+      makeFile('agent/.DS_Store'),
+      makeFile('agent/.git/config'),
+      makeFile('agent/node_modules/left-pad/index.js'),
+    ]);
+
+    expect(entries.map((item) => item.path)).toEqual(['agent.yaml']);
+  });
+
+  it('falls back to the file name when the picker reports no relative path', () => {
+    const entries = collectAgentEntries([new File(['x'], 'agent.yaml')]);
+
+    expect(entries.map((item) => item.path)).toEqual(['agent.yaml']);
+  });
+});
+
+describe('isIgnoredPath', () => {
+  it.each([
+    ['mcps/__pycache__/calculator.pyc', true],
+    ['.venv/lib/python3.12/site-packages/x.py', true],
+    ['build/libthing.so', true],
+    ['skills/review/SKILL.md', false],
+    ['mcps/calculator.py', false],
+  ])('%s -> %s', (path, expected) => {
+    expect(isIgnoredPath(path)).toBe(expected);
+  });
+});
+
+describe('validateAgentEntries', () => {
+  it('requires agent.yaml at the top level', () => {
+    expect(validateAgentEntries([entry('mcps/calculator.py')])).toMatch(/No agent\.yaml/);
+    expect(validateAgentEntries([entry('nested/agent.yaml')])).toMatch(/No agent\.yaml/);
+  });
+
+  it('rejects an empty directory', () => {
+    expect(validateAgentEntries([])).toMatch(/no uploadable files/);
+  });
+
+  it('rejects a directory over the file-count limit', () => {
+    const entries = [
+      entry('agent.yaml'),
+      ...Array.from({ length: MAX_AGENT_SPEC_FILES }, (_unused, index) => entry(`f${index}.md`)),
+    ];
+
+    expect(validateAgentEntries(entries)).toMatch(/the limit is 500/);
+  });
+
+  it('rejects a directory over the byte limit', () => {
+    expect(validateAgentEntries([entry('agent.yaml', 900_001)])).toMatch(/the limit is 900 KB/);
+  });
+
+  it('accepts a directory within both limits', () => {
+    expect(validateAgentEntries([entry('agent.yaml'), entry('mcps/calculator.py')])).toBeUndefined();
+  });
+});
+
+describe('parseAgentConfig', () => {
+  it('returns the parsed config for the Fabric contract', () => {
+    const config = parseAgentConfig('config_format: nemo-agents-spec-v1\nname: calc\n');
+
+    expect(config.name).toBe('calc');
+  });
+
+  it('rejects a NAT workflow config', () => {
+    expect(() => parseAgentConfig('config_format: nat-workflow-v1\n')).toThrow(
+      AgentConfigParseError
+    );
+  });
+
+  it('rejects a config with no config_format', () => {
+    expect(() => parseAgentConfig('name: calc\n')).toThrow(AgentConfigParseError);
+  });
+
+  it('rejects YAML that is not a mapping', () => {
+    expect(() => parseAgentConfig('- one\n- two\n')).toThrow(/must contain a YAML mapping/);
+  });
+
+  it('rejects malformed YAML', () => {
+    expect(() => parseAgentConfig('a:\n  - b\n c: broken\n')).toThrow(/not valid YAML/);
+  });
+});
+
+describe('agentNameFromConfig', () => {
+  it('reads a non-empty name', () => {
+    expect(agentNameFromConfig({ name: ' calc ' })).toBe('calc');
+  });
+
+  it('ignores a missing or blank name', () => {
+    expect(agentNameFromConfig({})).toBeUndefined();
+    expect(agentNameFromConfig({ name: '   ' })).toBeUndefined();
+    expect(agentNameFromConfig({ name: 7 })).toBeUndefined();
+  });
+});
+
+describe('agentSpecFilesetName', () => {
+  it('matches the platform convention', () => {
+    expect(agentSpecFilesetName('calc')).toBe('calc-spec');
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
@@ -64,6 +64,8 @@ export const isIgnoredPath = (path: string): boolean => {
   return IGNORED_EXTENSIONS.some((extension) => filename.endsWith(extension));
 };
 
+const pathCollator = new Intl.Collator();
+
 /** The fileset holds the directory's contents, so the picked root is stripped from each path. */
 export const collectAgentEntries = (files: File[]): UploadAgentEntry[] => {
   const entries: UploadAgentEntry[] = [];
@@ -75,7 +77,7 @@ export const collectAgentEntries = (files: File[]): UploadAgentEntry[] => {
     entries.push({ path, file });
   }
 
-  return entries.sort((left, right) => left.path.localeCompare(right.path));
+  return entries.sort((left, right) => pathCollator.compare(left.path, right.path));
 };
 
 export const totalEntryBytes = (entries: UploadAgentEntry[]): number =>
@@ -104,16 +106,19 @@ export const validateAgentEntries = (entries: UploadAgentEntry[]): string | unde
 export const findNonUtf8Path = async (entries: UploadAgentEntry[]): Promise<string | undefined> => {
   const decoder = new TextDecoder('utf-8', { fatal: true });
 
-  for (const entry of entries) {
-    if (entry.path.split('/').pop() === AGENT_SPEC_FILENAME) continue;
-    try {
-      decoder.decode(await entry.file.arrayBuffer());
-    } catch {
-      return entry.path;
-    }
-  }
+  const offenders = await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.path.split('/').pop() === AGENT_SPEC_FILENAME) return undefined;
+      try {
+        decoder.decode(await entry.file.arrayBuffer());
+        return undefined;
+      } catch {
+        return entry.path;
+      }
+    })
+  );
 
-  return undefined;
+  return offenders.find((path) => path !== undefined);
 };
 
 export class AgentConfigParseError extends Error {}

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
@@ -8,6 +8,9 @@ import { z } from 'zod';
 export const AGENT_CONFIG_FILENAME = 'agent.yaml';
 export const FABRIC_CONFIG_FORMAT = 'nemo-agents-spec-v1';
 
+// Container staging skips this file, so its bytes never reach a deployment.
+const AGENT_SPEC_FILENAME = 'AGENT-SPEC.md';
+
 // Mirrors MAX_AGENT_SPEC_STAGED_BYTES / _FILES in nemo_agents_plugin.entities. The
 // platform only enforces these when the deployment stages the fileset, which is long
 // after the upload, so the same limits are checked here to fail while the user is looking.
@@ -90,6 +93,32 @@ export const validateAgentEntries = (entries: UploadAgentEntry[]): string | unde
   const bytes = totalEntryBytes(entries);
   if (bytes > MAX_AGENT_SPEC_BYTES) {
     return `That directory is ${Math.round(bytes / 1000)} KB; the limit is ${Math.round(MAX_AGENT_SPEC_BYTES / 1000)} KB. Point at a directory containing only the agent's own files.`;
+  }
+
+  return undefined;
+};
+
+/**
+ * Return the first file that is not valid UTF-8, or undefined.
+ *
+ * Container deployments read every staged file with `read_text(encoding="utf-8")`
+ * and refuse the whole deployment on a decode error, so a binary file uploads
+ * fine and then breaks the agent at deploy time — in docker and k8s only, since
+ * subprocess deployments never read the contents. The ignore list already drops
+ * the usual culprits (`.pyc`, `.so`); this catches the rest.
+ */
+export const findNonUtf8Path = async (
+  entries: UploadAgentEntry[]
+): Promise<string | undefined> => {
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+
+  for (const entry of entries) {
+    if (entry.path.split('/').pop() === AGENT_SPEC_FILENAME) continue;
+    try {
+      decoder.decode(await entry.file.arrayBuffer());
+    } catch {
+      return entry.path;
+    }
   }
 
   return undefined;

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
@@ -16,6 +16,16 @@ const AGENT_SPEC_FILENAME = 'AGENT-SPEC.md';
 export const MAX_AGENT_SPEC_BYTES = 900_000;
 export const MAX_AGENT_SPEC_FILES = 500;
 
+// A directory picker hands over every descendant, so a mistaken pick can arrive with
+// hundreds of thousands of entries. Reject on the raw count before mapping, filtering or
+// sorting any of them — the ignore list cannot be applied without touching every entry.
+export const MAX_PICKED_FILES = 1_000;
+
+export const tooManyPickedFiles = (pickedCount: number): string | undefined =>
+  pickedCount > MAX_PICKED_FILES
+    ? `That directory holds ${pickedCount.toLocaleString()} files, far more than an agent directory should. Point at the agent's own directory.`
+    : undefined;
+
 const IGNORED_DIRECTORIES = new Set([
   '__pycache__',
   '.git',

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
-import YAML from 'yaml';
 import { z } from 'zod';
 
 export const AGENT_CONFIG_FILENAME = 'agent.yaml';
@@ -10,7 +8,7 @@ export const AGENT_CONFIG_FILENAME = 'agent.yaml';
 export const FABRIC_CONFIG_FORMAT = 'nemo-agents-spec-v1';
 
 // Container staging skips this file, so its bytes never reach a deployment.
-const AGENT_SPEC_FILENAME = 'AGENT-SPEC.md';
+export const AGENT_SPEC_FILENAME = 'AGENT-SPEC.md';
 
 // Mirrors MAX_AGENT_SPEC_STAGED_BYTES / _FILES; the platform only enforces them at deploy.
 export const MAX_AGENT_SPEC_BYTES = 900_000;
@@ -21,12 +19,7 @@ export const MAX_AGENT_SPEC_FILES = 500;
 // sorting any of them — the ignore list cannot be applied without touching every entry.
 export const MAX_PICKED_FILES = 1_000;
 
-export const tooManyPickedFiles = (pickedCount: number): string | undefined =>
-  pickedCount > MAX_PICKED_FILES
-    ? `That directory holds ${pickedCount.toLocaleString()} files, far more than an agent directory should. Point at the agent's own directory.`
-    : undefined;
-
-const IGNORED_DIRECTORIES = new Set([
+export const IGNORED_DIRECTORIES = new Set([
   '__pycache__',
   '.git',
   '.venv',
@@ -39,9 +32,9 @@ const IGNORED_DIRECTORIES = new Set([
   '.vscode',
 ]);
 
-const IGNORED_FILENAMES = new Set(['.DS_Store', 'Thumbs.db']);
+export const IGNORED_FILENAMES = new Set(['.DS_Store', 'Thumbs.db']);
 
-const IGNORED_EXTENSIONS = ['.pyc', '.pyo', '.pyd', '.so', '.dylib', '.dll'];
+export const IGNORED_EXTENSIONS = ['.pyc', '.pyo', '.pyd', '.so', '.dylib', '.dll'];
 
 export const uploadAgentFormSchema = z.object({
   name: z
@@ -50,105 +43,3 @@ export const uploadAgentFormSchema = z.object({
     .min(1, 'Name is required')
     .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Use lowercase letters, numbers, and hyphens'),
 });
-
-/** Convention only — the Agent entity stores no reference to it. */
-export const agentSpecFilesetName = (agentName: string): string => `${agentName}-spec`;
-
-export const isIgnoredPath = (path: string): boolean => {
-  const segments = path.split('/');
-  if (segments.some((segment) => IGNORED_DIRECTORIES.has(segment))) return true;
-
-  const filename = segments[segments.length - 1] ?? '';
-  if (IGNORED_FILENAMES.has(filename)) return true;
-
-  return IGNORED_EXTENSIONS.some((extension) => filename.endsWith(extension));
-};
-
-const pathCollator = new Intl.Collator();
-
-/** The fileset holds the directory's contents, so the picked root is stripped from each path. */
-export const collectAgentEntries = (files: File[]): UploadAgentEntry[] => {
-  const entries: UploadAgentEntry[] = [];
-
-  for (const file of files) {
-    const relativePath = file.webkitRelativePath || file.name;
-    const path = relativePath.split('/').slice(1).join('/') || file.name;
-    if (!path || isIgnoredPath(path)) continue;
-    entries.push({ path, file });
-  }
-
-  return entries.sort((left, right) => pathCollator.compare(left.path, right.path));
-};
-
-export const totalEntryBytes = (entries: UploadAgentEntry[]): number =>
-  entries.reduce((total, entry) => total + entry.file.size, 0);
-
-export const validateAgentEntries = (entries: UploadAgentEntry[]): string | undefined => {
-  if (entries.length === 0) return 'That directory has no uploadable files.';
-
-  if (!entries.some((entry) => entry.path === AGENT_CONFIG_FILENAME)) {
-    return `No ${AGENT_CONFIG_FILENAME} at the top level of that directory.`;
-  }
-
-  if (entries.length > MAX_AGENT_SPEC_FILES) {
-    return `That directory holds ${entries.length} files; the limit is ${MAX_AGENT_SPEC_FILES}. Point at a directory containing only the agent's own files.`;
-  }
-
-  const bytes = totalEntryBytes(entries);
-  if (bytes > MAX_AGENT_SPEC_BYTES) {
-    return `That directory is ${Math.round(bytes / 1000)} KB; the limit is ${Math.round(MAX_AGENT_SPEC_BYTES / 1000)} KB. Point at a directory containing only the agent's own files.`;
-  }
-
-  return undefined;
-};
-
-// Container deployments read every staged file as text and fail on a decode error.
-export const findNonUtf8Path = async (entries: UploadAgentEntry[]): Promise<string | undefined> => {
-  const decoder = new TextDecoder('utf-8', { fatal: true });
-
-  const offenders = await Promise.all(
-    entries.map(async (entry) => {
-      if (entry.path.split('/').pop() === AGENT_SPEC_FILENAME) return undefined;
-      try {
-        decoder.decode(await entry.file.arrayBuffer());
-        return undefined;
-      } catch {
-        return entry.path;
-      }
-    })
-  );
-
-  return offenders.find((path) => path !== undefined);
-};
-
-export class AgentConfigParseError extends Error {}
-
-export const parseAgentConfig = (text: string): Record<string, unknown> => {
-  let parsed: unknown;
-  try {
-    parsed = YAML.parse(text);
-  } catch (error) {
-    throw new AgentConfigParseError(
-      `${AGENT_CONFIG_FILENAME} is not valid YAML: ${(error as Error).message}`
-    );
-  }
-
-  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-    throw new AgentConfigParseError(`${AGENT_CONFIG_FILENAME} must contain a YAML mapping.`);
-  }
-
-  const config = parsed as Record<string, unknown>;
-  const configFormat = config.config_format;
-  if (configFormat !== FABRIC_CONFIG_FORMAT) {
-    throw new AgentConfigParseError(
-      `${AGENT_CONFIG_FILENAME} must set config_format: ${FABRIC_CONFIG_FORMAT}${
-        typeof configFormat === 'string' ? ` (found ${configFormat})` : ''
-      }.`
-    );
-  }
-
-  return config;
-};
-
-export const agentNameFromConfig = (config: Record<string, unknown>): string | undefined =>
-  typeof config.name === 'string' && config.name.trim() ? config.name.trim() : undefined;

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
@@ -6,6 +6,14 @@ import YAML from 'yaml';
 import { z } from 'zod';
 
 export const AGENT_CONFIG_FILENAME = 'agent.yaml';
+
+/** Copy shown on the coding-agent tab, per the Figma design. */
+export const AGENT_INTEGRATION_PROMPT =
+  'Integrate my agent with NeMo Platform using the agent integration skill and connect it to platform.';
+
+/** The command the CLI tab offers; mirrors what `nemo agents create` takes. */
+export const agentCreateCliCommand = (agentName?: string): string =>
+  `nemo agents create \\\n  --name ${agentName?.trim() || '<agent-name>'} \\\n  --agent-config ./${AGENT_CONFIG_FILENAME}`;
 export const FABRIC_CONFIG_FORMAT = 'nemo-agents-spec-v1';
 
 // Container staging skips this file, so its bytes never reach a deployment.

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
@@ -7,13 +7,6 @@ import { z } from 'zod';
 
 export const AGENT_CONFIG_FILENAME = 'agent.yaml';
 
-/** Copy shown on the coding-agent tab, per the Figma design. */
-export const AGENT_INTEGRATION_PROMPT =
-  'Integrate my agent with NeMo Platform using the agent integration skill and connect it to platform.';
-
-/** The command the CLI tab offers; mirrors what `nemo agents create` takes. */
-export const agentCreateCliCommand = (agentName?: string): string =>
-  `nemo agents create \\\n  --name ${agentName?.trim() || '<agent-name>'} \\\n  --agent-config ./${AGENT_CONFIG_FILENAME}`;
 export const FABRIC_CONFIG_FORMAT = 'nemo-agents-spec-v1';
 
 // Container staging skips this file, so its bytes never reach a deployment.
@@ -98,9 +91,7 @@ export const validateAgentEntries = (entries: UploadAgentEntry[]): string | unde
 };
 
 // Container deployments read every staged file as text and fail on a decode error.
-export const findNonUtf8Path = async (
-  entries: UploadAgentEntry[]
-): Promise<string | undefined> => {
+export const findNonUtf8Path = async (entries: UploadAgentEntry[]): Promise<string | undefined> => {
   const decoder = new TextDecoder('utf-8', { fatal: true });
 
   for (const entry of entries) {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
@@ -11,9 +11,7 @@ export const FABRIC_CONFIG_FORMAT = 'nemo-agents-spec-v1';
 // Container staging skips this file, so its bytes never reach a deployment.
 const AGENT_SPEC_FILENAME = 'AGENT-SPEC.md';
 
-// Mirrors MAX_AGENT_SPEC_STAGED_BYTES / _FILES in nemo_agents_plugin.entities. The
-// platform only enforces these when the deployment stages the fileset, which is long
-// after the upload, so the same limits are checked here to fail while the user is looking.
+// Mirrors MAX_AGENT_SPEC_STAGED_BYTES / _FILES; the platform only enforces them at deploy.
 export const MAX_AGENT_SPEC_BYTES = 900_000;
 export const MAX_AGENT_SPEC_FILES = 500;
 
@@ -42,7 +40,7 @@ export const uploadAgentFormSchema = z.object({
     .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Use lowercase letters, numbers, and hyphens'),
 });
 
-/** Fileset holding an agent's spec. Convention only — the Agent entity stores no reference. */
+/** Convention only — the Agent entity stores no reference to it. */
 export const agentSpecFilesetName = (agentName: string): string => `${agentName}-spec`;
 
 export const isIgnoredPath = (path: string): boolean => {
@@ -55,13 +53,7 @@ export const isIgnoredPath = (path: string): boolean => {
   return IGNORED_EXTENSIONS.some((extension) => filename.endsWith(extension));
 };
 
-/**
- * Map picked files to fileset-relative paths, dropping build artifacts.
- *
- * A directory picker reports `webkitRelativePath` rooted at the chosen directory
- * (`calculator-agent/mcps/calculator.py`); the fileset holds the contents, not the
- * directory itself, so the first segment is stripped.
- */
+/** The fileset holds the directory's contents, so the picked root is stripped from each path. */
 export const collectAgentEntries = (files: File[]): UploadAgentEntry[] => {
   const entries: UploadAgentEntry[] = [];
 
@@ -78,7 +70,6 @@ export const collectAgentEntries = (files: File[]): UploadAgentEntry[] => {
 export const totalEntryBytes = (entries: UploadAgentEntry[]): number =>
   entries.reduce((total, entry) => total + entry.file.size, 0);
 
-/** Returns the first blocking problem with the picked directory, or undefined. */
 export const validateAgentEntries = (entries: UploadAgentEntry[]): string | undefined => {
   if (entries.length === 0) return 'That directory has no uploadable files.';
 
@@ -98,15 +89,7 @@ export const validateAgentEntries = (entries: UploadAgentEntry[]): string | unde
   return undefined;
 };
 
-/**
- * Return the first file that is not valid UTF-8, or undefined.
- *
- * Container deployments read every staged file with `read_text(encoding="utf-8")`
- * and refuse the whole deployment on a decode error, so a binary file uploads
- * fine and then breaks the agent at deploy time — in docker and k8s only, since
- * subprocess deployments never read the contents. The ignore list already drops
- * the usual culprits (`.pyc`, `.so`); this catches the rest.
- */
+// Container deployments read every staged file as text and fail on a decode error.
 export const findNonUtf8Path = async (
   entries: UploadAgentEntry[]
 ): Promise<string | undefined> => {
@@ -126,7 +109,6 @@ export const findNonUtf8Path = async (
 
 export class AgentConfigParseError extends Error {}
 
-/** Parse `agent.yaml` and confirm it is the Platform-owned Fabric contract. */
 export const parseAgentConfig = (text: string): Record<string, unknown> => {
   let parsed: unknown;
   try {
@@ -154,6 +136,5 @@ export const parseAgentConfig = (text: string): Record<string, unknown> => {
   return config;
 };
 
-/** The config's own name, used to prefill the form. */
 export const agentNameFromConfig = (config: Record<string, unknown>): string | undefined =>
   typeof config.name === 'string' && config.name.trim() ? config.name.trim() : undefined;

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/const.ts
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import YAML from 'yaml';
+import { z } from 'zod';
+
+export const AGENT_CONFIG_FILENAME = 'agent.yaml';
+export const FABRIC_CONFIG_FORMAT = 'nemo-agents-spec-v1';
+
+// Mirrors MAX_AGENT_SPEC_STAGED_BYTES / _FILES in nemo_agents_plugin.entities. The
+// platform only enforces these when the deployment stages the fileset, which is long
+// after the upload, so the same limits are checked here to fail while the user is looking.
+export const MAX_AGENT_SPEC_BYTES = 900_000;
+export const MAX_AGENT_SPEC_FILES = 500;
+
+const IGNORED_DIRECTORIES = new Set([
+  '__pycache__',
+  '.git',
+  '.venv',
+  'venv',
+  'node_modules',
+  '.mypy_cache',
+  '.pytest_cache',
+  '.ruff_cache',
+  '.idea',
+  '.vscode',
+]);
+
+const IGNORED_FILENAMES = new Set(['.DS_Store', 'Thumbs.db']);
+
+const IGNORED_EXTENSIONS = ['.pyc', '.pyo', '.pyd', '.so', '.dylib', '.dll'];
+
+export const uploadAgentFormSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, 'Name is required')
+    .regex(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/, 'Use lowercase letters, numbers, and hyphens'),
+});
+
+/** Fileset holding an agent's spec. Convention only — the Agent entity stores no reference. */
+export const agentSpecFilesetName = (agentName: string): string => `${agentName}-spec`;
+
+export const isIgnoredPath = (path: string): boolean => {
+  const segments = path.split('/');
+  if (segments.some((segment) => IGNORED_DIRECTORIES.has(segment))) return true;
+
+  const filename = segments[segments.length - 1] ?? '';
+  if (IGNORED_FILENAMES.has(filename)) return true;
+
+  return IGNORED_EXTENSIONS.some((extension) => filename.endsWith(extension));
+};
+
+/**
+ * Map picked files to fileset-relative paths, dropping build artifacts.
+ *
+ * A directory picker reports `webkitRelativePath` rooted at the chosen directory
+ * (`calculator-agent/mcps/calculator.py`); the fileset holds the contents, not the
+ * directory itself, so the first segment is stripped.
+ */
+export const collectAgentEntries = (files: File[]): UploadAgentEntry[] => {
+  const entries: UploadAgentEntry[] = [];
+
+  for (const file of files) {
+    const relativePath = file.webkitRelativePath || file.name;
+    const path = relativePath.split('/').slice(1).join('/') || file.name;
+    if (!path || isIgnoredPath(path)) continue;
+    entries.push({ path, file });
+  }
+
+  return entries.sort((left, right) => left.path.localeCompare(right.path));
+};
+
+export const totalEntryBytes = (entries: UploadAgentEntry[]): number =>
+  entries.reduce((total, entry) => total + entry.file.size, 0);
+
+/** Returns the first blocking problem with the picked directory, or undefined. */
+export const validateAgentEntries = (entries: UploadAgentEntry[]): string | undefined => {
+  if (entries.length === 0) return 'That directory has no uploadable files.';
+
+  if (!entries.some((entry) => entry.path === AGENT_CONFIG_FILENAME)) {
+    return `No ${AGENT_CONFIG_FILENAME} at the top level of that directory.`;
+  }
+
+  if (entries.length > MAX_AGENT_SPEC_FILES) {
+    return `That directory holds ${entries.length} files; the limit is ${MAX_AGENT_SPEC_FILES}. Point at a directory containing only the agent's own files.`;
+  }
+
+  const bytes = totalEntryBytes(entries);
+  if (bytes > MAX_AGENT_SPEC_BYTES) {
+    return `That directory is ${Math.round(bytes / 1000)} KB; the limit is ${Math.round(MAX_AGENT_SPEC_BYTES / 1000)} KB. Point at a directory containing only the agent's own files.`;
+  }
+
+  return undefined;
+};
+
+export class AgentConfigParseError extends Error {}
+
+/** Parse `agent.yaml` and confirm it is the Platform-owned Fabric contract. */
+export const parseAgentConfig = (text: string): Record<string, unknown> => {
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(text);
+  } catch (error) {
+    throw new AgentConfigParseError(
+      `${AGENT_CONFIG_FILENAME} is not valid YAML: ${(error as Error).message}`
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new AgentConfigParseError(`${AGENT_CONFIG_FILENAME} must contain a YAML mapping.`);
+  }
+
+  const config = parsed as Record<string, unknown>;
+  const configFormat = config.config_format;
+  if (configFormat !== FABRIC_CONFIG_FORMAT) {
+    throw new AgentConfigParseError(
+      `${AGENT_CONFIG_FILENAME} must set config_format: ${FABRIC_CONFIG_FORMAT}${
+        typeof configFormat === 'string' ? ` (found ${configFormat})` : ''
+      }.`
+    );
+  }
+
+  return config;
+};
+
+/** The config's own name, used to prefill the form. */
+export const agentNameFromConfig = (config: Record<string, unknown>): string | undefined =>
+  typeof config.name === 'string' && config.name.trim() ? config.name.trim() : undefined;

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
@@ -184,3 +184,56 @@ describe('UploadAgentModal oversized pick', () => {
     expect(within(dialog).getByRole('button', { name: 'Create' })).toBeDisabled();
   });
 });
+
+describe('UploadAgentModal folder drop', () => {
+  const dirEntry = (name: string, fullPath: string, children: FileSystemEntry[]) =>
+    ({
+      name,
+      fullPath,
+      isFile: false,
+      isDirectory: true,
+      createReader: () => {
+        let drained = false;
+        return {
+          readEntries: (resolve: (entries: FileSystemEntry[]) => void) => {
+            resolve(drained ? [] : children);
+            drained = true;
+          },
+        };
+      },
+    }) as unknown as FileSystemEntry;
+
+  const fileEntry = (name: string, fullPath: string, contents: string) =>
+    ({
+      name,
+      fullPath,
+      isFile: true,
+      isDirectory: false,
+      file: (resolve: (file: File) => void) => resolve(new File([contents], name)),
+    }) as unknown as FileSystemEntry;
+
+  it('accepts a dropped folder, walking it into nested paths', async () => {
+    const user = userEvent.setup();
+    const { uploaded, created } = mockPlatform();
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+
+    const root = dirEntry('calc-agent', '/calc-agent', [
+      fileEntry('agent.yaml', '/calc-agent/agent.yaml', FABRIC_YAML),
+      dirEntry('mcps', '/calc-agent/mcps', [
+        fileEntry('calculator.py', '/calc-agent/mcps/calculator.py', 'print(1)\n'),
+      ]),
+    ]);
+
+    fireEvent.drop(within(dialog).getByTestId('agent-directory-dropzone'), {
+      dataTransfer: { items: [{ kind: 'file', webkitGetAsEntry: () => root }], files: [] },
+    });
+
+    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
+    await submit(dialog, user);
+
+    await waitFor(() => expect(created).toHaveLength(1));
+    expect([...uploaded].sort()).toEqual(['agent.yaml', 'mcps/calculator.py']);
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
@@ -170,3 +170,33 @@ describe('UploadAgentModal', () => {
     expect(await within(dialog).findByText(/is not a text file/)).toBeInTheDocument();
   });
 });
+
+describe('UploadAgentModal tabs', () => {
+  it('offers the designed coding-agent prompt', async () => {
+    const user = userEvent.setup();
+    mockPlatform();
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    await user.click(within(dialog).getByRole('tab', { name: 'Coding agent prompt' }));
+
+    expect(
+      await within(dialog).findByText(/Integrate my agent with NeMo Platform/)
+    ).toBeInTheDocument();
+  });
+
+  it('shows a CLI command carrying the entered name', async () => {
+    const user = userEvent.setup();
+    mockPlatform();
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog);
+    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
+
+    await user.click(within(dialog).getByRole('tab', { name: 'CLI command' }));
+
+    await waitFor(() => expect(dialog).toHaveTextContent('nemo agents create'));
+    expect(dialog).toHaveTextContent('--name calc');
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { ROUTES } from '@studio/constants/routes';
+import { workspace1 } from '@studio/mocks/entity-store/projects';
+import { server } from '@studio/mocks/node';
+import { UploadAgentModal } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal';
+import { getAgentsListRoute } from '@studio/routes/utils';
+import { renderRoute, screen, waitFor } from '@studio/tests/util/render';
+import { fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+
+const workspace = workspace1.workspace;
+const FILESETS_URL = `${PLATFORM_BASE_URL}/apis/files/v2/workspaces/:workspace/filesets`;
+const FILESET_URL = `${FILESETS_URL}/:name`;
+const UPLOAD_URL = `${FILESET_URL}/-/*`;
+const AGENTS_URL = `${PLATFORM_BASE_URL}/apis/agents/v2/workspaces/:workspace/agents`;
+const AGENT_URL = `${AGENTS_URL}/:name`;
+
+const FABRIC_YAML = `config_format: nemo-agents-spec-v1
+name: calc
+description: Adds numbers
+`;
+
+const makeFile = (relativePath: string, contents: string): File => {
+  const file = new File([contents], relativePath.split('/').pop() ?? relativePath, {
+    type: 'text/plain',
+  });
+  Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+  return file;
+};
+
+const DEFAULT_FILES = [
+  makeFile('calc-agent/agent.yaml', FABRIC_YAML),
+  makeFile('calc-agent/mcps/calculator.py', 'print(1)\n'),
+];
+
+interface Scenario {
+  filesetExists?: boolean;
+  agentExists?: boolean;
+}
+
+const mockPlatform = ({ filesetExists = false, agentExists = false }: Scenario = {}) => {
+  const uploaded: string[] = [];
+  const created: { name?: string }[] = [];
+
+  server.use(
+    http.get(FILESET_URL, ({ params }) =>
+      filesetExists
+        ? HttpResponse.json({ name: params['name'], workspace })
+        : HttpResponse.json({ detail: 'not found' }, { status: 404 })
+    ),
+    http.get(AGENT_URL, ({ params }) =>
+      agentExists
+        ? HttpResponse.json({ name: params['name'], workspace })
+        : HttpResponse.json({ detail: 'not found' }, { status: 404 })
+    ),
+    http.delete(FILESET_URL, () => HttpResponse.json({ name: 'deleted' })),
+    http.post(FILESETS_URL, async ({ request }) =>
+      HttpResponse.json(await request.json())
+    ),
+    http.put(UPLOAD_URL, ({ request }) => {
+      uploaded.push(decodeURIComponent(new URL(request.url).pathname.split('/-/')[1] ?? ''));
+      return HttpResponse.json({ path: 'ok' });
+    }),
+    http.post(AGENTS_URL, async ({ request }) => {
+      const body = (await request.json()) as { name?: string };
+      created.push(body);
+      return HttpResponse.json({ ...body, workspace }, { status: 201 });
+    })
+  );
+
+  return { uploaded, created };
+};
+
+const renderModal = () =>
+  renderRoute(undefined, {
+    history: getAgentsListRoute(workspace),
+    routes: [
+      {
+        path: ROUTES.workspace.agentsList,
+        element: <UploadAgentModal open onClose={vi.fn()} workspace={workspace} />,
+      },
+      { path: ROUTES.workspace.agentDetail, element: <div>Agent detail page</div> },
+    ],
+  });
+
+const pickDirectory = (dialog: HTMLElement, files: File[] = DEFAULT_FILES) => {
+  fireEvent.change(within(dialog).getByTestId('agent-directory-input'), { target: { files } });
+};
+
+const submit = async (dialog: HTMLElement, user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(within(dialog).getByRole('button', { name: /^(Create|Replace and create)$/ }));
+};
+
+describe('UploadAgentModal', () => {
+  it('uploads the picked directory, then creates the agent', async () => {
+    const user = userEvent.setup();
+    const { uploaded, created } = mockPlatform();
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog);
+    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
+
+    await submit(dialog, user);
+
+    await waitFor(() => expect(created).toHaveLength(1));
+    expect(uploaded).toEqual(['agent.yaml', 'mcps/calculator.py']);
+    expect(created[0]?.name).toBe('calc');
+  });
+
+  it('shows why an owned name is refused instead of a generic failure', async () => {
+    const user = userEvent.setup();
+    const { created } = mockPlatform({ filesetExists: true, agentExists: true });
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog);
+    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
+
+    await submit(dialog, user);
+
+    expect(await within(dialog).findByText(/already owns the fileset/)).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Create' })).toBeInTheDocument();
+    expect(created).toHaveLength(0);
+  });
+
+  it('offers to replace an orphaned fileset, and replaces it on the next submit', async () => {
+    const user = userEvent.setup();
+    const { created } = mockPlatform({ filesetExists: true });
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog);
+    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
+
+    await submit(dialog, user);
+    expect(await within(dialog).findByText(/no agent owns it/)).toBeInTheDocument();
+
+    const replace = await within(dialog).findByRole('button', { name: 'Replace and create' });
+    await user.click(replace);
+
+    await waitFor(() => expect(created).toHaveLength(1));
+  });
+
+  it('rejects a directory with no agent.yaml at the top level', async () => {
+    mockPlatform();
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog, [makeFile('calc-agent/mcps/calculator.py', 'print(1)\n')]);
+
+    expect(await within(dialog).findByText(/No agent\.yaml/)).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('rejects a directory holding a file that is not text', async () => {
+    mockPlatform();
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog, [
+      makeFile('calc-agent/agent.yaml', FABRIC_YAML),
+      new File([new Uint8Array([0xff, 0xfe, 0x00])], 'logo.bin'),
+    ]);
+
+    expect(await within(dialog).findByText(/is not a text file/)).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
@@ -106,7 +106,7 @@ describe('UploadAgentModal', () => {
     await submit(dialog, user);
 
     await waitFor(() => expect(created).toHaveLength(1));
-    expect(uploaded).toEqual(['agent.yaml', 'mcps/calculator.py']);
+    expect([...uploaded].sort()).toEqual(['agent.yaml', 'mcps/calculator.py']);
     expect(created[0]?.name).toBe('calc');
   });
 

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
@@ -32,7 +32,7 @@ const makeFile = (relativePath: string, contents: string): File => {
   return file;
 };
 
-/** A file whose reads block until released, so two selections can be resolved out of order. */
+/** Blocks its reads until released, so selections can resolve out of order. */
 const deferredFile = (relativePath: string, contents: string) => {
   const file = makeFile(relativePath, contents);
   const bytes = new TextEncoder().encode(contents);
@@ -201,6 +201,30 @@ describe('UploadAgentModal', () => {
 
     expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument();
     expect(within(dialog).getByText(/calc-agent — 2 files/)).toBeInTheDocument();
+  });
+
+  it('cannot submit the previous directory while a new one is validated', async () => {
+    mockPlatform();
+    const gate = deferredFile(
+      'slow-agent/agent.yaml',
+      'config_format: nemo-agents-spec-v1\nname: slow\n'
+    );
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog);
+    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
+    expect(within(dialog).getByRole('button', { name: 'Create' })).toBeEnabled();
+
+    pickDirectory(dialog, [gate.file]);
+
+    await waitFor(() =>
+      expect(within(dialog).getByRole('button', { name: 'Create' })).toBeDisabled()
+    );
+
+    gate.release();
+    await waitFor(() => expect(within(dialog).getByDisplayValue('slow')).toBeInTheDocument());
+    expect(within(dialog).getByRole('button', { name: 'Create' })).toBeEnabled();
   });
 
   it('clears the previous failure when a new directory is picked', async () => {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
@@ -58,9 +58,7 @@ const mockPlatform = ({ filesetExists = false, agentExists = false }: Scenario =
         : HttpResponse.json({ detail: 'not found' }, { status: 404 })
     ),
     http.delete(FILESET_URL, () => HttpResponse.json({ name: 'deleted' })),
-    http.post(FILESETS_URL, async ({ request }) =>
-      HttpResponse.json(await request.json())
-    ),
+    http.post(FILESETS_URL, async ({ request }) => HttpResponse.json(await request.json())),
     http.put(UPLOAD_URL, ({ request }) => {
       uploaded.push(decodeURIComponent(new URL(request.url).pathname.split('/-/')[1] ?? ''));
       return HttpResponse.json({ path: 'ok' });
@@ -168,35 +166,5 @@ describe('UploadAgentModal', () => {
     ]);
 
     expect(await within(dialog).findByText(/is not a text file/)).toBeInTheDocument();
-  });
-});
-
-describe('UploadAgentModal tabs', () => {
-  it('offers the designed coding-agent prompt', async () => {
-    const user = userEvent.setup();
-    mockPlatform();
-
-    renderModal();
-    const dialog = await screen.findByRole('dialog');
-    await user.click(within(dialog).getByRole('tab', { name: 'Coding agent prompt' }));
-
-    expect(
-      await within(dialog).findByText(/Integrate my agent with NeMo Platform/)
-    ).toBeInTheDocument();
-  });
-
-  it('shows a CLI command carrying the entered name', async () => {
-    const user = userEvent.setup();
-    mockPlatform();
-
-    renderModal();
-    const dialog = await screen.findByRole('dialog');
-    pickDirectory(dialog);
-    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
-
-    await user.click(within(dialog).getByRole('tab', { name: 'CLI command' }));
-
-    await waitFor(() => expect(dialog).toHaveTextContent('nemo agents create'));
-    expect(dialog).toHaveTextContent('--name calc');
   });
 });

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
@@ -32,6 +32,34 @@ const makeFile = (relativePath: string, contents: string): File => {
   return file;
 };
 
+/** A file whose reads block until released, so two selections can be resolved out of order. */
+const deferredFile = (relativePath: string, contents: string) => {
+  const file = makeFile(relativePath, contents);
+  const bytes = new TextEncoder().encode(contents);
+  let release = () => {};
+  let read = false;
+  const open = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  Object.defineProperty(file, 'arrayBuffer', {
+    value: async () => {
+      await open;
+      read = true;
+      return bytes.buffer;
+    },
+  });
+  Object.defineProperty(file, 'text', {
+    value: async () => {
+      await open;
+      read = true;
+      return contents;
+    },
+  });
+
+  return { file, release: () => release(), read: () => read };
+};
+
 const DEFAULT_FILES = [
   makeFile('calc-agent/agent.yaml', FABRIC_YAML),
   makeFile('calc-agent/mcps/calculator.py', 'print(1)\n'),
@@ -153,6 +181,44 @@ describe('UploadAgentModal', () => {
 
     expect(await within(dialog).findByText(/No agent\.yaml/)).toBeInTheDocument();
     expect(within(dialog).getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+
+  it('ignores a slower selection that a newer one replaced', async () => {
+    mockPlatform();
+    const gate = deferredFile(
+      'slow-agent/agent.yaml',
+      'config_format: nemo-agents-spec-v1\nname: slow\n'
+    );
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog, [gate.file]);
+    pickDirectory(dialog, DEFAULT_FILES);
+    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
+
+    gate.release();
+    await waitFor(() => expect(gate.read()).toBe(true));
+
+    expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument();
+    expect(within(dialog).getByText(/calc-agent — 2 files/)).toBeInTheDocument();
+  });
+
+  it('clears the previous failure when a new directory is picked', async () => {
+    const user = userEvent.setup();
+    mockPlatform({ filesetExists: true, agentExists: true });
+
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+    pickDirectory(dialog);
+    await waitFor(() => expect(within(dialog).getByDisplayValue('calc')).toBeInTheDocument());
+    await submit(dialog, user);
+    expect(await within(dialog).findByText(/already owns the fileset/)).toBeInTheDocument();
+
+    pickDirectory(dialog, DEFAULT_FILES);
+
+    await waitFor(() =>
+      expect(within(dialog).queryByText(/already owns the fileset/)).not.toBeInTheDocument()
+    );
   });
 
   it('rejects a directory holding a file that is not text', async () => {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.test.tsx
@@ -168,3 +168,19 @@ describe('UploadAgentModal', () => {
     expect(await within(dialog).findByText(/is not a text file/)).toBeInTheDocument();
   });
 });
+
+describe('UploadAgentModal oversized pick', () => {
+  it('rejects a directory far larger than an agent, naming the count', async () => {
+    mockPlatform();
+    renderModal();
+    const dialog = await screen.findByRole('dialog');
+
+    // A real accidental pick was 880k files; only length is read before the guard fires.
+    fireEvent.change(within(dialog).getByTestId('agent-directory-input'), {
+      target: { files: { length: 880_000 } },
+    });
+
+    expect(await within(dialog).findByText(/880,000 files/)).toBeInTheDocument();
+    expect(within(dialog).getByRole('button', { name: 'Create' })).toBeDisabled();
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -20,20 +20,22 @@ import {
 } from '@studio/api/agents/useCreateAgentFromUpload';
 import {
   AGENT_CONFIG_FILENAME,
-  agentNameFromConfig,
-  collectAgentEntries,
-  findNonUtf8Path,
-  parseAgentConfig,
-  tooManyPickedFiles,
-  totalEntryBytes,
   uploadAgentFormSchema,
-  validateAgentEntries,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
 import type {
   UploadAgentEntry,
   UploadAgentFormData,
   UploadAgentModalProps,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import {
+  agentNameFromConfig,
+  collectAgentEntries,
+  findNonUtf8Path,
+  parseAgentConfig,
+  tooManyPickedFiles,
+  totalEntryBytes,
+  validateAgentEntries,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/utils';
 import { getAgentDetailRoute } from '@studio/routes/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { type ChangeEventHandler, type FC, useCallback, useMemo, useRef, useState } from 'react';

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -40,7 +40,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
   const [directoryName, setDirectoryName] = useState('');
   const [selectionError, setSelectionError] = useState<string | undefined>(undefined);
 
-  // webkitdirectory is not in React's input attribute types; set it on the node instead.
+  // webkitdirectory is absent from React's input attribute types.
   useEffect(() => {
     inputRef.current?.setAttribute('webkitdirectory', '');
   }, [open]);
@@ -111,7 +111,9 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
       setValue('name', agentNameFromConfig(config) ?? '', { shouldValidate: true });
     } catch (error) {
       setEntries([]);
-      setSelectionError(getErrorMessage(error as Error, `Could not read ${AGENT_CONFIG_FILENAME}`));
+      setSelectionError(
+        getErrorMessage(error as Error) || `Could not read ${AGENT_CONFIG_FILENAME}`
+      );
       return;
     }
 
@@ -127,9 +129,10 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     }
   };
 
+  // No fallback argument: getErrorMessage prefers one over a plain Error's own message.
   const errorMessage =
     selectionError ??
-    (createError ? getErrorMessage(createError as Error, 'Failed to create agent') : undefined);
+    (createError ? getErrorMessage(createError as Error) || 'Failed to create agent' : undefined);
 
   return (
     <FormModal

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -36,7 +36,7 @@ import type {
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
 import { getAgentDetailRoute } from '@studio/routes/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { type ChangeEventHandler, type FC, useCallback, useEffect, useRef, useState } from 'react';
+import { type ChangeEventHandler, type FC, useCallback, useRef, useState } from 'react';
 import { type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
@@ -54,7 +54,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
   const [entries, setEntries] = useState<UploadAgentEntry[]>([]);
   const [directoryName, setDirectoryName] = useState('');
   const [selectionError, setSelectionError] = useState<string | undefined>(undefined);
-  const [replaceOrphan, setReplaceOrphan] = useState(false);
+  const [replaceArmedFor, setReplaceArmedFor] = useState<string | null>(null);
 
   const {
     mutateAsync: createAgent,
@@ -84,11 +84,9 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
   });
 
   const watchedName = useWatch({ control, name: 'name' });
-
-  // The armed replace targets one fileset; a different name must re-confirm.
-  useEffect(() => {
-    setReplaceOrphan(false);
-  }, [watchedName]);
+  // Derived, not stored: an armed replace targets one fileset, so editing the name
+  // disarms it in the same render rather than one render later.
+  const replaceOrphan = replaceArmedFor !== null && replaceArmedFor === watchedName?.trim();
 
   const resetAndClose = () => {
     resetMutation();
@@ -96,7 +94,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     setEntries([]);
     setDirectoryName('');
     setSelectionError(undefined);
-    setReplaceOrphan(false);
+    setReplaceArmedFor(null);
     onClose();
   };
 
@@ -155,16 +153,12 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
   };
 
   const onSubmit: SubmitHandler<UploadAgentFormData> = async (formData) => {
+    const name = formData.name.trim();
     try {
-      await createAgent({
-        workspace,
-        name: formData.name.trim(),
-        entries,
-        replaceOrphanedFileset: replaceOrphan,
-      });
+      await createAgent({ workspace, name, entries, replaceOrphanedFileset: replaceOrphan });
     } catch (error) {
       // An orphaned fileset is recoverable, so the next submit replaces it.
-      setReplaceOrphan(error instanceof AgentSpecFilesetOrphanError);
+      setReplaceArmedFor(error instanceof AgentSpecFilesetOrphanError ? name : null);
     }
   };
 

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -166,7 +166,14 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
       errorText={errorMessage}
     >
       <Stack gap="density-md">
-        <input ref={inputRef} type="file" multiple hidden onChange={onDirectoryPicked} />
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          hidden
+          data-testid="agent-directory-input"
+          onChange={onDirectoryPicked}
+        />
         <Button kind="secondary" onClick={() => inputRef.current?.click()} disabled={isPending}>
           {directoryName ? 'Choose a different directory' : 'Choose directory'}
         </Button>

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -13,6 +13,7 @@ import {
   AGENT_CONFIG_FILENAME,
   agentNameFromConfig,
   collectAgentEntries,
+  findNonUtf8Path,
   parseAgentConfig,
   totalEntryBytes,
   uploadAgentFormSchema,
@@ -92,6 +93,15 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     if (problem) {
       setEntries([]);
       setSelectionError(problem);
+      return;
+    }
+
+    const binaryPath = await findNonUtf8Path(collected);
+    if (binaryPath) {
+      setEntries([]);
+      setSelectionError(
+        `${binaryPath} is not a text file. Agent files are delivered to container deployments as text, so the agent would fail to deploy. Remove it and try again.`
+      );
       return;
     }
 

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -7,13 +7,26 @@ import { ControlledTextInput } from '@nemo/common/src/components/form/Controlled
 import { FormModal } from '@nemo/common/src/components/FormModal';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { getAgentsListAgentsQueryKey } from '@nemo/sdk/generated/agents/api';
-import { Button, Stack, Text } from '@nvidia/foundations-react-core';
+import {
+  CodeSnippet,
+  Stack,
+  TabsContent,
+  TabsList,
+  TabsRoot,
+  TabsTrigger,
+  Text,
+  UploadInputElement,
+  UploadRoot,
+  UploadTrigger,
+} from '@nvidia/foundations-react-core';
 import {
   AgentSpecFilesetOrphanError,
   useCreateAgentFromUpload,
 } from '@studio/api/agents/useCreateAgentFromUpload';
 import {
   AGENT_CONFIG_FILENAME,
+  AGENT_INTEGRATION_PROMPT,
+  agentCreateCliCommand,
   agentNameFromConfig,
   collectAgentEntries,
   findNonUtf8Path,
@@ -29,7 +42,7 @@ import type {
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
 import { getAgentDetailRoute } from '@studio/routes/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { type ChangeEventHandler, type FC, useEffect, useRef, useState } from 'react';
+import { type ChangeEventHandler, type FC, useCallback, useEffect, useRef, useState } from 'react';
 import { type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
@@ -39,15 +52,15 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
   const queryClient = useQueryClient();
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const setDirectoryInput = useCallback((node: HTMLInputElement | null) => {
+    inputRef.current = node;
+    // webkitdirectory is absent from React's input attribute types.
+    node?.setAttribute('webkitdirectory', '');
+  }, []);
   const [entries, setEntries] = useState<UploadAgentEntry[]>([]);
   const [directoryName, setDirectoryName] = useState('');
   const [selectionError, setSelectionError] = useState<string | undefined>(undefined);
   const [replaceOrphan, setReplaceOrphan] = useState(false);
-
-  // webkitdirectory is absent from React's input attribute types.
-  useEffect(() => {
-    inputRef.current?.setAttribute('webkitdirectory', '');
-  }, [open]);
 
   const {
     mutateAsync: createAgent,
@@ -156,8 +169,9 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     <FormModal
       open={open}
       onClose={resetAndClose}
-      title="Upload Agent"
-      instruction={`Select a directory containing ${AGENT_CONFIG_FILENAME}. Its skills, MCP servers, and prompts are uploaded with it.`}
+      className="w-[720px] max-w-[90vw]"
+      title="Integrate an agent with NeMo Platform"
+      instruction="Integrated agents allow users to evaluate, optimize, and deploy agents."
       submitButtonText={replaceOrphan ? 'Replace and create' : 'Create'}
       onSubmit={handleSubmit(onSubmit)}
       disabled={isPending}
@@ -165,29 +179,67 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
       submitDisabled={entries.length === 0}
       errorText={errorMessage}
     >
-      <Stack gap="density-md">
-        <input
-          ref={inputRef}
-          type="file"
-          multiple
-          hidden
-          data-testid="agent-directory-input"
-          onChange={onDirectoryPicked}
-        />
-        <Button kind="secondary" onClick={() => inputRef.current?.click()} disabled={isPending}>
-          {directoryName ? 'Choose a different directory' : 'Choose directory'}
-        </Button>
-        {entries.length > 0 ? (
-          <Text kind="body/regular/sm">
-            {`${directoryName} — ${entries.length} files, ${Math.max(1, Math.round(totalEntryBytes(entries) / 1000))} KB`}
-          </Text>
-        ) : null}
-      </Stack>
-      <ControlledTextInput
-        useControllerProps={{ control, name: 'name' }}
-        label="Name"
-        formFieldProps={{ slotError: errors.name?.message }}
-      />
+      <TabsRoot defaultValue="upload" className="w-full min-w-0">
+        <TabsList>
+          <TabsTrigger value="prompt">Coding agent prompt</TabsTrigger>
+          <TabsTrigger value="cli">CLI command</TabsTrigger>
+          <TabsTrigger value="upload">Upload agent configuration</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="prompt" className="px-0 w-full">
+          <Stack gap="density-xs">
+            <Text kind="label/semibold/md">Agent prompt</Text>
+            <CodeSnippet
+              className="min-w-full"
+              value={AGENT_INTEGRATION_PROMPT}
+              language="text"
+              kind="block"
+            />
+          </Stack>
+        </TabsContent>
+
+        <TabsContent value="cli" className="px-0 w-full">
+          <Stack gap="density-xs">
+            <Text kind="label/semibold/md">CLI command</Text>
+            <CodeSnippet
+              className="min-w-full"
+              value={agentCreateCliCommand(watchedName)}
+              language="bash"
+              kind="block"
+            />
+          </Stack>
+        </TabsContent>
+
+        <TabsContent value="upload" className="px-0 w-full">
+          <Stack gap="density-md">
+            <Text kind="label/semibold/md">Select agent config files</Text>
+            <UploadRoot multiple disabled={isPending}>
+              <UploadTrigger
+                className="w-full"
+                slotAnchor={directoryName ? 'Choose a different directory' : 'Choose a directory'}
+                slotHeaderText=" containing agent.yaml."
+              >
+                <UploadInputElement
+                  ref={setDirectoryInput}
+                  data-testid="agent-directory-input"
+                  multiple
+                  onChange={onDirectoryPicked}
+                />
+              </UploadTrigger>
+            </UploadRoot>
+            {entries.length > 0 ? (
+              <Text kind="body/regular/sm">
+                {`${directoryName} — ${entries.length} files, ${Math.max(1, Math.round(totalEntryBytes(entries) / 1000))} KB`}
+              </Text>
+            ) : null}
+            <ControlledTextInput
+              useControllerProps={{ control, name: 'name' }}
+              label="Name"
+              formFieldProps={{ slotError: errors.name?.message }}
+            />
+          </Stack>
+        </TabsContent>
+      </TabsRoot>
     </FormModal>
   );
 };

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -23,6 +23,7 @@ import {
   uploadAgentFormSchema,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
 import type {
+  PickedFile,
   UploadAgentEntry,
   UploadAgentFormData,
   UploadAgentModalProps,
@@ -32,13 +33,23 @@ import {
   collectAgentEntries,
   findNonUtf8Path,
   parseAgentConfig,
+  pickedFromDataTransfer,
+  pickedFromFileList,
   tooManyPickedFiles,
   totalEntryBytes,
   validateAgentEntries,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/utils';
 import { getAgentDetailRoute } from '@studio/routes/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { type ChangeEventHandler, type FC, useCallback, useMemo, useRef, useState } from 'react';
+import {
+  type ChangeEventHandler,
+  type DragEventHandler,
+  type FC,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
@@ -109,26 +120,9 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     onClose();
   };
 
-  const onDirectoryPicked: ChangeEventHandler<HTMLInputElement> = async (event) => {
-    // Read the count off the FileList before materialising it: an accidental pick can
-    // carry hundreds of thousands of files, and Array.from on that is itself the stall.
-    const fileList = event.target.files;
-    const pickedCount = fileList?.length ?? 0;
-    if (pickedCount === 0) return;
-
-    const oversized = tooManyPickedFiles(pickedCount);
-    if (oversized) {
-      event.target.value = '';
-      setEntries([]);
-      setDirectoryName('');
-      setSelectionError(oversized);
-      return;
-    }
-
-    const picked = Array.from(fileList ?? []);
-    event.target.value = '';
-    setDirectoryName(picked[0]?.webkitRelativePath.split('/')[0] ?? '');
-
+  // Both entry points land here so a drop is validated exactly like a pick.
+  const acceptPicked = async (picked: PickedFile[]) => {
+    setDirectoryName(picked[0]?.relativePath.split('/')[0] ?? '');
     const collected = collectAgentEntries(picked);
 
     const problem = validateAgentEntries(collected);
@@ -161,6 +155,48 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
 
     setEntries(collected);
     setSelectionError(undefined);
+  };
+
+  const rejectOversized = (count: number): boolean => {
+    const oversized = tooManyPickedFiles(count);
+    if (!oversized) return false;
+    setEntries([]);
+    setDirectoryName('');
+    setSelectionError(oversized);
+    return true;
+  };
+
+  const onDirectoryPicked: ChangeEventHandler<HTMLInputElement> = async (event) => {
+    const fileList = event.target.files;
+    const pickedCount = fileList?.length ?? 0;
+    if (pickedCount === 0) return;
+
+    if (rejectOversized(pickedCount)) {
+      event.target.value = '';
+      return;
+    }
+
+    const picked = pickedFromFileList(Array.from(fileList ?? []));
+    event.target.value = '';
+    await acceptPicked(picked);
+  };
+
+  const onDirectoryDropped: DragEventHandler<HTMLLabelElement> = async (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (isPending) return;
+
+    const items = Array.from(event.dataTransfer.items);
+    if (items.length === 0) return;
+
+    const picked = await pickedFromDataTransfer(items);
+    if (picked.length === 0) {
+      setSelectionError('That drop contained no readable files.');
+      return;
+    }
+    if (rejectOversized(picked.length)) return;
+
+    await acceptPicked(picked);
   };
 
   const onSubmit: SubmitHandler<UploadAgentFormData> = async (formData) => {
@@ -197,6 +233,8 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
         <UploadRoot multiple disabled={isPending}>
           <UploadTrigger
             className="w-full"
+            data-testid="agent-directory-dropzone"
+            onDrop={onDirectoryDropped}
             slotAnchor={directoryName ? 'Choose a different directory' : 'Choose a directory'}
             slotHeaderText=" containing agent.yaml."
           >

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -24,6 +24,7 @@ import {
   collectAgentEntries,
   findNonUtf8Path,
   parseAgentConfig,
+  tooManyPickedFiles,
   totalEntryBytes,
   uploadAgentFormSchema,
   validateAgentEntries,
@@ -100,11 +101,25 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
   };
 
   const onDirectoryPicked: ChangeEventHandler<HTMLInputElement> = async (event) => {
-    const picked = Array.from(event.target.files ?? []);
-    event.target.value = '';
-    if (picked.length === 0) return;
+    // Read the count off the FileList before materialising it: an accidental pick can
+    // carry hundreds of thousands of files, and Array.from on that is itself the stall.
+    const fileList = event.target.files;
+    const pickedCount = fileList?.length ?? 0;
+    if (pickedCount === 0) return;
 
+    const oversized = tooManyPickedFiles(pickedCount);
+    if (oversized) {
+      event.target.value = '';
+      setEntries([]);
+      setDirectoryName('');
+      setSelectionError(oversized);
+      return;
+    }
+
+    const picked = Array.from(fileList ?? []);
+    event.target.value = '';
     setDirectoryName(picked[0]?.webkitRelativePath.split('/')[0] ?? '');
+
     const collected = collectAgentEntries(picked);
 
     const problem = validateAgentEntries(collected);

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -120,12 +120,14 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     onClose();
   };
 
-  // Reading a directory is async, so a newer selection has to win however the reads finish.
+  // Directory reads finish out of order, so the newest selection has to win.
   const selectionSeq = useRef(0);
   const beginSelection = (): (() => boolean) => {
     const selection = ++selectionSeq.current;
-    // A new selection replaces whatever the last attempt reported.
+    // Dropping the entries disables submit until this selection validates.
     resetMutation();
+    setEntries([]);
+    setSelectionError(undefined);
     setReplaceArmedFor(null);
     return () => selection !== selectionSeq.current;
   };
@@ -167,7 +169,6 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     }
 
     setEntries(collected);
-    setSelectionError(undefined);
   };
 
   const rejectOversized = (count: number): boolean => {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -8,7 +8,10 @@ import { FormModal } from '@nemo/common/src/components/FormModal';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { getAgentsListAgentsQueryKey } from '@nemo/sdk/generated/agents/api';
 import { Button, Stack, Text } from '@nvidia/foundations-react-core';
-import { useCreateAgentFromUpload } from '@studio/api/agents/useCreateAgentFromUpload';
+import {
+  AgentSpecFilesetOrphanError,
+  useCreateAgentFromUpload,
+} from '@studio/api/agents/useCreateAgentFromUpload';
 import {
   AGENT_CONFIG_FILENAME,
   agentNameFromConfig,
@@ -27,7 +30,7 @@ import type {
 import { getAgentDetailRoute } from '@studio/routes/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { type ChangeEventHandler, type FC, useEffect, useRef, useState } from 'react';
-import { type SubmitHandler, useForm } from 'react-hook-form';
+import { type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
 export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, workspace }) => {
@@ -39,6 +42,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
   const [entries, setEntries] = useState<UploadAgentEntry[]>([]);
   const [directoryName, setDirectoryName] = useState('');
   const [selectionError, setSelectionError] = useState<string | undefined>(undefined);
+  const [replaceOrphan, setReplaceOrphan] = useState(false);
 
   // webkitdirectory is absent from React's input attribute types.
   useEffect(() => {
@@ -72,12 +76,20 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     mode: 'onChange',
   });
 
+  const watchedName = useWatch({ control, name: 'name' });
+
+  // The armed replace targets one fileset; a different name must re-confirm.
+  useEffect(() => {
+    setReplaceOrphan(false);
+  }, [watchedName]);
+
   const resetAndClose = () => {
     resetMutation();
     resetForm({ name: '' });
     setEntries([]);
     setDirectoryName('');
     setSelectionError(undefined);
+    setReplaceOrphan(false);
     onClose();
   };
 
@@ -123,9 +135,15 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
 
   const onSubmit: SubmitHandler<UploadAgentFormData> = async (formData) => {
     try {
-      await createAgent({ workspace, name: formData.name.trim(), entries });
-    } catch {
-      // surfaced via errorText
+      await createAgent({
+        workspace,
+        name: formData.name.trim(),
+        entries,
+        replaceOrphanedFileset: replaceOrphan,
+      });
+    } catch (error) {
+      // An orphaned fileset is recoverable, so the next submit replaces it.
+      setReplaceOrphan(error instanceof AgentSpecFilesetOrphanError);
     }
   };
 
@@ -140,7 +158,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
       onClose={resetAndClose}
       title="Upload Agent"
       instruction={`Select a directory containing ${AGENT_CONFIG_FILENAME}. Its skills, MCP servers, and prompts are uploaded with it.`}
-      submitButtonText="Create"
+      submitButtonText={replaceOrphan ? 'Replace and create' : 'Create'}
       onSubmit={handleSubmit(onSubmit)}
       disabled={isPending}
       loading={isPending}

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { getErrorMessage } from '@nemo/common/src/api/common/utils';
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { FormModal } from '@nemo/common/src/components/FormModal';
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import { getAgentsListAgentsQueryKey } from '@nemo/sdk/generated/agents/api';
+import { Button, Stack, Text } from '@nvidia/foundations-react-core';
+import { useCreateAgentFromUpload } from '@studio/api/agents/useCreateAgentFromUpload';
+import {
+  AGENT_CONFIG_FILENAME,
+  agentNameFromConfig,
+  collectAgentEntries,
+  parseAgentConfig,
+  totalEntryBytes,
+  uploadAgentFormSchema,
+  validateAgentEntries,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
+import type {
+  UploadAgentEntry,
+  UploadAgentFormData,
+  UploadAgentModalProps,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import { getAgentDetailRoute } from '@studio/routes/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { type ChangeEventHandler, type FC, useEffect, useRef, useState } from 'react';
+import { type SubmitHandler, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router';
+
+export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, workspace }) => {
+  const toast = useToast();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [entries, setEntries] = useState<UploadAgentEntry[]>([]);
+  const [directoryName, setDirectoryName] = useState('');
+  const [selectionError, setSelectionError] = useState<string | undefined>(undefined);
+
+  // webkitdirectory is not in React's input attribute types; set it on the node instead.
+  useEffect(() => {
+    inputRef.current?.setAttribute('webkitdirectory', '');
+  }, [open]);
+
+  const {
+    mutateAsync: createAgent,
+    error: createError,
+    isPending,
+    reset: resetMutation,
+  } = useCreateAgentFromUpload({
+    onSuccess: (agent) => {
+      toast.success(`Agent "${agent.name}" created`);
+      void queryClient.invalidateQueries({ queryKey: getAgentsListAgentsQueryKey(workspace) });
+      resetAndClose();
+      if (agent.name) navigate(getAgentDetailRoute(workspace, agent.name));
+    },
+  });
+
+  const {
+    control,
+    setValue,
+    handleSubmit,
+    reset: resetForm,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(uploadAgentFormSchema),
+    defaultValues: { name: '' },
+    disabled: isPending,
+    mode: 'onChange',
+  });
+
+  const resetAndClose = () => {
+    resetMutation();
+    resetForm({ name: '' });
+    setEntries([]);
+    setDirectoryName('');
+    setSelectionError(undefined);
+    onClose();
+  };
+
+  const onDirectoryPicked: ChangeEventHandler<HTMLInputElement> = async (event) => {
+    const picked = Array.from(event.target.files ?? []);
+    event.target.value = '';
+    if (picked.length === 0) return;
+
+    setDirectoryName(picked[0]?.webkitRelativePath.split('/')[0] ?? '');
+    const collected = collectAgentEntries(picked);
+
+    const problem = validateAgentEntries(collected);
+    if (problem) {
+      setEntries([]);
+      setSelectionError(problem);
+      return;
+    }
+
+    const configEntry = collected.find((item) => item.path === AGENT_CONFIG_FILENAME);
+    try {
+      const config = parseAgentConfig((await configEntry?.file.text()) ?? '');
+      setValue('name', agentNameFromConfig(config) ?? '', { shouldValidate: true });
+    } catch (error) {
+      setEntries([]);
+      setSelectionError(getErrorMessage(error as Error, `Could not read ${AGENT_CONFIG_FILENAME}`));
+      return;
+    }
+
+    setEntries(collected);
+    setSelectionError(undefined);
+  };
+
+  const onSubmit: SubmitHandler<UploadAgentFormData> = async (formData) => {
+    try {
+      await createAgent({ workspace, name: formData.name.trim(), entries });
+    } catch {
+      // surfaced via errorText
+    }
+  };
+
+  const errorMessage =
+    selectionError ??
+    (createError ? getErrorMessage(createError as Error, 'Failed to create agent') : undefined);
+
+  return (
+    <FormModal
+      open={open}
+      onClose={resetAndClose}
+      title="Upload Agent"
+      instruction={`Select a directory containing ${AGENT_CONFIG_FILENAME}. Its skills, MCP servers, and prompts are uploaded with it.`}
+      submitButtonText="Create"
+      onSubmit={handleSubmit(onSubmit)}
+      disabled={isPending}
+      loading={isPending}
+      submitDisabled={entries.length === 0}
+      errorText={errorMessage}
+    >
+      <Stack gap="density-md">
+        <input ref={inputRef} type="file" multiple hidden onChange={onDirectoryPicked} />
+        <Button kind="secondary" onClick={() => inputRef.current?.click()} disabled={isPending}>
+          {directoryName ? 'Choose a different directory' : 'Choose directory'}
+        </Button>
+        {entries.length > 0 ? (
+          <Text kind="body/regular/sm">
+            {`${directoryName} — ${entries.length} files, ${Math.max(1, Math.round(totalEntryBytes(entries) / 1000))} KB`}
+          </Text>
+        ) : null}
+      </Stack>
+      <ControlledTextInput
+        useControllerProps={{ control, name: 'name' }}
+        label="Name"
+        formFieldProps={{ slotError: errors.name?.message }}
+      />
+    </FormModal>
+  );
+};

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -8,12 +8,7 @@ import { FormModal } from '@nemo/common/src/components/FormModal';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { getAgentsListAgentsQueryKey } from '@nemo/sdk/generated/agents/api';
 import {
-  CodeSnippet,
   Stack,
-  TabsContent,
-  TabsList,
-  TabsRoot,
-  TabsTrigger,
   Text,
   UploadInputElement,
   UploadRoot,
@@ -25,8 +20,6 @@ import {
 } from '@studio/api/agents/useCreateAgentFromUpload';
 import {
   AGENT_CONFIG_FILENAME,
-  AGENT_INTEGRATION_PROMPT,
-  agentCreateCliCommand,
   agentNameFromConfig,
   collectAgentEntries,
   findNonUtf8Path,
@@ -170,7 +163,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
       open={open}
       onClose={resetAndClose}
       className="w-[720px] max-w-[90vw]"
-      title="Integrate an agent with NeMo Platform"
+      title="Upload agent configuration"
       instruction="Integrated agents allow users to evaluate, optimize, and deploy agents."
       submitButtonText={replaceOrphan ? 'Replace and create' : 'Create'}
       onSubmit={handleSubmit(onSubmit)}
@@ -179,67 +172,33 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
       submitDisabled={entries.length === 0}
       errorText={errorMessage}
     >
-      <TabsRoot defaultValue="upload" className="w-full min-w-0">
-        <TabsList>
-          <TabsTrigger value="prompt">Coding agent prompt</TabsTrigger>
-          <TabsTrigger value="cli">CLI command</TabsTrigger>
-          <TabsTrigger value="upload">Upload agent configuration</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="prompt" className="px-0 w-full">
-          <Stack gap="density-xs">
-            <Text kind="label/semibold/md">Agent prompt</Text>
-            <CodeSnippet
-              className="min-w-full"
-              value={AGENT_INTEGRATION_PROMPT}
-              language="text"
-              kind="block"
+      <Stack gap="density-md">
+        <Text kind="label/semibold/md">Select agent config files</Text>
+        <UploadRoot multiple disabled={isPending}>
+          <UploadTrigger
+            className="w-full"
+            slotAnchor={directoryName ? 'Choose a different directory' : 'Choose a directory'}
+            slotHeaderText=" containing agent.yaml."
+          >
+            <UploadInputElement
+              ref={setDirectoryInput}
+              data-testid="agent-directory-input"
+              multiple
+              onChange={onDirectoryPicked}
             />
-          </Stack>
-        </TabsContent>
-
-        <TabsContent value="cli" className="px-0 w-full">
-          <Stack gap="density-xs">
-            <Text kind="label/semibold/md">CLI command</Text>
-            <CodeSnippet
-              className="min-w-full"
-              value={agentCreateCliCommand(watchedName)}
-              language="bash"
-              kind="block"
-            />
-          </Stack>
-        </TabsContent>
-
-        <TabsContent value="upload" className="px-0 w-full">
-          <Stack gap="density-md">
-            <Text kind="label/semibold/md">Select agent config files</Text>
-            <UploadRoot multiple disabled={isPending}>
-              <UploadTrigger
-                className="w-full"
-                slotAnchor={directoryName ? 'Choose a different directory' : 'Choose a directory'}
-                slotHeaderText=" containing agent.yaml."
-              >
-                <UploadInputElement
-                  ref={setDirectoryInput}
-                  data-testid="agent-directory-input"
-                  multiple
-                  onChange={onDirectoryPicked}
-                />
-              </UploadTrigger>
-            </UploadRoot>
-            {entries.length > 0 ? (
-              <Text kind="body/regular/sm">
-                {`${directoryName} — ${entries.length} files, ${Math.max(1, Math.round(totalEntryBytes(entries) / 1000))} KB`}
-              </Text>
-            ) : null}
-            <ControlledTextInput
-              useControllerProps={{ control, name: 'name' }}
-              label="Name"
-              formFieldProps={{ slotError: errors.name?.message }}
-            />
-          </Stack>
-        </TabsContent>
-      </TabsRoot>
+          </UploadTrigger>
+        </UploadRoot>
+        {entries.length > 0 ? (
+          <Text kind="body/regular/sm">
+            {`${directoryName} — ${entries.length} files, ${Math.max(1, Math.round(totalEntryBytes(entries) / 1000))} KB`}
+          </Text>
+        ) : null}
+        <ControlledTextInput
+          useControllerProps={{ control, name: 'name' }}
+          label="Name"
+          formFieldProps={{ slotError: errors.name?.message }}
+        />
+      </Stack>
     </FormModal>
   );
 };

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -120,8 +120,18 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     onClose();
   };
 
+  // Reading a directory is async, so a newer selection has to win however the reads finish.
+  const selectionSeq = useRef(0);
+  const beginSelection = (): (() => boolean) => {
+    const selection = ++selectionSeq.current;
+    // A new selection replaces whatever the last attempt reported.
+    resetMutation();
+    setReplaceArmedFor(null);
+    return () => selection !== selectionSeq.current;
+  };
+
   // Both entry points land here so a drop is validated exactly like a pick.
-  const acceptPicked = async (picked: PickedFile[]) => {
+  const acceptPicked = async (picked: PickedFile[], superseded: () => boolean) => {
     setDirectoryName(picked[0]?.relativePath.split('/')[0] ?? '');
     const collected = collectAgentEntries(picked);
 
@@ -133,6 +143,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     }
 
     const binaryPath = await findNonUtf8Path(collected);
+    if (superseded()) return;
     if (binaryPath) {
       setEntries([]);
       setSelectionError(
@@ -144,8 +155,10 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     const configEntry = collected.find((item) => item.path === AGENT_CONFIG_FILENAME);
     try {
       const config = parseAgentConfig((await configEntry?.file.text()) ?? '');
+      if (superseded()) return;
       setValue('name', agentNameFromConfig(config) ?? '', { shouldValidate: true });
     } catch (error) {
+      if (superseded()) return;
       setEntries([]);
       setSelectionError(
         getErrorMessage(error as Error) || `Could not read ${AGENT_CONFIG_FILENAME}`
@@ -171,6 +184,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     const pickedCount = fileList?.length ?? 0;
     if (pickedCount === 0) return;
 
+    const superseded = beginSelection();
     if (rejectOversized(pickedCount)) {
       event.target.value = '';
       return;
@@ -178,7 +192,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
 
     const picked = pickedFromFileList(Array.from(fileList ?? []));
     event.target.value = '';
-    await acceptPicked(picked);
+    await acceptPicked(picked, superseded);
   };
 
   const onDirectoryDropped: DragEventHandler<HTMLLabelElement> = async (event) => {
@@ -189,14 +203,17 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     const items = Array.from(event.dataTransfer.items);
     if (items.length === 0) return;
 
+    const superseded = beginSelection();
     const picked = await pickedFromDataTransfer(items);
+    if (superseded()) return;
+
     if (picked.length === 0) {
       setSelectionError('That drop contained no readable files.');
       return;
     }
     if (rejectOversized(picked.length)) return;
 
-    await acceptPicked(picked);
+    await acceptPicked(picked, superseded);
   };
 
   const onSubmit: SubmitHandler<UploadAgentFormData> = async (formData) => {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/index.tsx
@@ -36,7 +36,7 @@ import type {
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
 import { getAgentDetailRoute } from '@studio/routes/utils';
 import { useQueryClient } from '@tanstack/react-query';
-import { type ChangeEventHandler, type FC, useCallback, useRef, useState } from 'react';
+import { type ChangeEventHandler, type FC, useCallback, useMemo, useRef, useState } from 'react';
 import { type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 
@@ -82,6 +82,15 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
     disabled: isPending,
     mode: 'onChange',
   });
+
+  // useWatch re-renders this modal on every keystroke; the summary depends only on entries.
+  const entriesSummary = useMemo(
+    () =>
+      entries.length === 0
+        ? undefined
+        : `${directoryName} — ${entries.length} files, ${Math.max(1, Math.round(totalEntryBytes(entries) / 1000))} KB`,
+    [directoryName, entries]
+  );
 
   const watchedName = useWatch({ control, name: 'name' });
   // Derived, not stored: an armed replace targets one fileset, so editing the name
@@ -197,11 +206,7 @@ export const UploadAgentModal: FC<UploadAgentModalProps> = ({ open, onClose, wor
             />
           </UploadTrigger>
         </UploadRoot>
-        {entries.length > 0 ? (
-          <Text kind="body/regular/sm">
-            {`${directoryName} — ${entries.length} files, ${Math.max(1, Math.round(totalEntryBytes(entries) / 1000))} KB`}
-          </Text>
-        ) : null}
+        {entriesSummary ? <Text kind="body/regular/sm">{entriesSummary}</Text> : null}
         <ControlledTextInput
           useControllerProps={{ control, name: 'name' }}
           label="Name"

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/type.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/type.ts
@@ -9,14 +9,14 @@ export type UploadAgentFormData = z.infer<typeof uploadAgentFormSchema>;
 
 /** A file plus the path it was picked or dropped under, still including the root directory. */
 export interface PickedFile {
-  file: File;
-  relativePath: string;
+  readonly file: File;
+  readonly relativePath: string;
 }
 
 /** A picked file paired with its path inside the agent spec fileset. */
 export interface UploadAgentEntry {
-  path: string;
-  file: File;
+  readonly path: string;
+  readonly file: File;
 }
 
 export interface UploadAgentModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/type.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/type.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FormModalProps } from '@nemo/common/src/components/FormModal';
+import type { uploadAgentFormSchema } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
+import type { z } from 'zod';
+
+export type UploadAgentFormData = z.infer<typeof uploadAgentFormSchema>;
+
+/** A picked file paired with its path inside the agent spec fileset. */
+export interface UploadAgentEntry {
+  path: string;
+  file: File;
+}
+
+export interface UploadAgentModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
+  workspace: string;
+}

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/type.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/type.ts
@@ -7,6 +7,12 @@ import type { z } from 'zod';
 
 export type UploadAgentFormData = z.infer<typeof uploadAgentFormSchema>;
 
+/** A file plus the path it was picked or dropped under, still including the root directory. */
+export interface PickedFile {
+  file: File;
+  relativePath: string;
+}
+
 /** A picked file paired with its path inside the agent spec fileset. */
 export interface UploadAgentEntry {
   path: string;

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.test.ts
@@ -2,19 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  MAX_AGENT_SPEC_FILES,
+  MAX_PICKED_FILES,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
+import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import {
   AgentConfigParseError,
   agentNameFromConfig,
   agentSpecFilesetName,
   collectAgentEntries,
   findNonUtf8Path,
   isIgnoredPath,
-  MAX_AGENT_SPEC_FILES,
-  MAX_PICKED_FILES,
   parseAgentConfig,
   tooManyPickedFiles,
   validateAgentEntries,
-} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
-import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/utils';
 
 const makeFile = (relativePath: string, contents = 'x'): File => {
   const file = new File([contents], relativePath.split('/').pop() ?? relativePath);

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.test.ts
@@ -85,6 +85,15 @@ describe('validateAgentEntries', () => {
     expect(validateAgentEntries([])).toMatch(/no uploadable files/);
   });
 
+  it('rejects two roots that contribute the same path', () => {
+    const entries = collectAgentEntries([
+      makeFile('calc-agent/agent.yaml'),
+      makeFile('other-agent/agent.yaml'),
+    ]);
+
+    expect(validateAgentEntries(entries)).toMatch(/more than one agent\.yaml/);
+  });
+
   it('rejects a directory over the file-count limit', () => {
     const entries = [
       entry('agent.yaml'),

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.test.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.test.ts
@@ -5,7 +5,10 @@ import {
   MAX_AGENT_SPEC_FILES,
   MAX_PICKED_FILES,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
-import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import type {
+  PickedFile,
+  UploadAgentEntry,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
 import {
   AgentConfigParseError,
   agentNameFromConfig,
@@ -14,15 +17,15 @@ import {
   findNonUtf8Path,
   isIgnoredPath,
   parseAgentConfig,
+  pickedFromDataTransfer,
   tooManyPickedFiles,
   validateAgentEntries,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/utils';
 
-const makeFile = (relativePath: string, contents = 'x'): File => {
-  const file = new File([contents], relativePath.split('/').pop() ?? relativePath);
-  Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
-  return file;
-};
+const makeFile = (relativePath: string, contents = 'x'): PickedFile => ({
+  file: new File([contents], relativePath.split('/').pop() ?? relativePath),
+  relativePath,
+});
 
 const entry = (path: string, size = 1): UploadAgentEntry => ({
   path,
@@ -52,7 +55,9 @@ describe('collectAgentEntries', () => {
   });
 
   it('falls back to the file name when the picker reports no relative path', () => {
-    const entries = collectAgentEntries([new File(['x'], 'agent.yaml')]);
+    const entries = collectAgentEntries([
+      { file: new File(['x'], 'agent.yaml'), relativePath: 'agent.yaml' },
+    ]);
 
     expect(entries.map((item) => item.path)).toEqual(['agent.yaml']);
   });
@@ -195,5 +200,87 @@ describe('tooManyPickedFiles', () => {
   it('allows a pick within the inspectable ceiling', () => {
     expect(tooManyPickedFiles(MAX_PICKED_FILES)).toBeUndefined();
     expect(tooManyPickedFiles(12)).toBeUndefined();
+  });
+});
+
+describe('pickedFromDataTransfer', () => {
+  interface FakeTree {
+    [name: string]: FakeTree | string;
+  }
+
+  const makeEntry = (name: string, fullPath: string, node: FakeTree | string): FileSystemEntry => {
+    if (typeof node === 'string') {
+      return {
+        name,
+        fullPath,
+        isFile: true,
+        isDirectory: false,
+        file: (resolve: (file: File) => void) => resolve(new File([node], name)),
+      } as unknown as FileSystemEntry;
+    }
+
+    const children = Object.entries(node).map(([child, value]) =>
+      makeEntry(child, `${fullPath}/${child}`, value)
+    );
+    let drained = false;
+    return {
+      name,
+      fullPath,
+      isFile: false,
+      isDirectory: true,
+      createReader: () => ({
+        readEntries: (resolve: (entries: FileSystemEntry[]) => void) => {
+          resolve(drained ? [] : children);
+          drained = true;
+        },
+      }),
+    } as unknown as FileSystemEntry;
+  };
+
+  const drop = (tree: FakeTree, root = 'calc-agent'): DataTransferItem[] => [
+    {
+      kind: 'file',
+      webkitGetAsEntry: () => makeEntry(root, `/${root}`, tree),
+    } as unknown as DataTransferItem,
+  ];
+
+  it('walks a dropped directory into files with their paths', async () => {
+    const picked = await pickedFromDataTransfer(
+      drop({ 'agent.yaml': 'name: calc', mcps: { 'calculator.py': 'print(1)' } })
+    );
+
+    expect(picked.map((item) => item.relativePath).sort()).toEqual([
+      'calc-agent/agent.yaml',
+      'calc-agent/mcps/calculator.py',
+    ]);
+  });
+
+  it('feeds collectAgentEntries the same shape a picked directory does', async () => {
+    const picked = await pickedFromDataTransfer(
+      drop({ 'agent.yaml': 'name: calc', mcps: { 'calculator.py': 'print(1)' } })
+    );
+
+    expect(collectAgentEntries(picked).map((entry) => entry.path)).toEqual([
+      'agent.yaml',
+      'mcps/calculator.py',
+    ]);
+  });
+
+  it('does not descend into ignored directories', async () => {
+    const picked = await pickedFromDataTransfer(
+      drop({
+        'agent.yaml': 'name: calc',
+        __pycache__: { 'calculator.cpython-312.pyc': 'binary-ish' },
+        node_modules: { 'left-pad': { 'index.js': 'x' } },
+      })
+    );
+
+    expect(picked.map((item) => item.relativePath)).toEqual(['calc-agent/agent.yaml']);
+  });
+
+  it('ignores non-file drag items', async () => {
+    const items = [{ kind: 'string', webkitGetAsEntry: () => null } as unknown as DataTransferItem];
+
+    await expect(pickedFromDataTransfer(items)).resolves.toEqual([]);
   });
 });

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.ts
@@ -118,6 +118,16 @@ export const totalEntryBytes = (entries: UploadAgentEntry[]): number =>
 export const validateAgentEntries = (entries: UploadAgentEntry[]): string | undefined => {
   if (entries.length === 0) return 'That directory has no uploadable files.';
 
+  // Dropping two directories at once merges them, and the fileset would take whichever
+  // upload of a shared path landed last.
+  const seen = new Set<string>();
+  for (const { path } of entries) {
+    if (seen.has(path)) {
+      return `That selection holds more than one ${path}. Select a single agent directory.`;
+    }
+    seen.add(path);
+  }
+
   if (!entries.some((entry) => entry.path === AGENT_CONFIG_FILENAME)) {
     return `No ${AGENT_CONFIG_FILENAME} at the top level of that directory.`;
   }

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.ts
@@ -12,7 +12,10 @@ import {
   MAX_AGENT_SPEC_FILES,
   MAX_PICKED_FILES,
 } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
-import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import type {
+  PickedFile,
+  UploadAgentEntry,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
 import YAML from 'yaml';
 
 /** Convention only — the Agent entity stores no reference to it. */
@@ -36,17 +39,77 @@ export const isIgnoredPath = (path: string): boolean => {
 const pathCollator = new Intl.Collator();
 
 /** The fileset holds the directory's contents, so the picked root is stripped from each path. */
-export const collectAgentEntries = (files: File[]): UploadAgentEntry[] => {
+export const collectAgentEntries = (picked: PickedFile[]): UploadAgentEntry[] => {
   const entries: UploadAgentEntry[] = [];
 
-  for (const file of files) {
-    const relativePath = file.webkitRelativePath || file.name;
+  for (const { file, relativePath } of picked) {
     const path = relativePath.split('/').slice(1).join('/') || file.name;
     if (!path || isIgnoredPath(path)) continue;
     entries.push({ path, file });
   }
 
   return entries.sort((left, right) => pathCollator.compare(left.path, right.path));
+};
+
+/** A directory picker reports the path on the File itself; a drop does not. */
+export const pickedFromFileList = (files: File[]): PickedFile[] =>
+  files.map((file) => ({ file, relativePath: file.webkitRelativePath || file.name }));
+
+/**
+ * Walk dropped directories into files.
+ *
+ * `dataTransfer.files` flattens a dropped folder to a useless zero-byte entry, so the
+ * directory has to be traversed through `webkitGetAsEntry`. Paths are built during the
+ * walk because a File produced this way has an empty `webkitRelativePath`.
+ *
+ * Traversal stops once the ceiling is passed: a mistaken drop of a large tree is the
+ * same hazard as the equivalent pick, and here the reading is ours to abandon.
+ */
+export const pickedFromDataTransfer = async (items: DataTransferItem[]): Promise<PickedFile[]> => {
+  const roots = items
+    .map((item) => (item.kind === 'file' ? item.webkitGetAsEntry() : null))
+    .filter((entry): entry is FileSystemEntry => entry !== null);
+
+  const picked: PickedFile[] = [];
+  const pending: FileSystemEntry[] = [...roots];
+
+  while (pending.length > 0 && picked.length <= MAX_PICKED_FILES) {
+    const entry = pending.shift();
+    if (!entry) break;
+
+    if (entry.isFile) {
+      const file = await readEntryFile(entry as FileSystemFileEntry);
+      if (file) picked.push({ file, relativePath: entry.fullPath.replace(/^\//, '') });
+      continue;
+    }
+
+    if (entry.isDirectory) {
+      if (isIgnoredPath(entry.name)) continue;
+      pending.push(...(await readDirectoryEntries(entry as FileSystemDirectoryEntry)));
+    }
+  }
+
+  return picked;
+};
+
+const readEntryFile = (entry: FileSystemFileEntry): Promise<File | undefined> =>
+  new Promise((resolve) => entry.file(resolve, () => resolve(undefined)));
+
+const readDirectoryEntries = async (
+  directory: FileSystemDirectoryEntry
+): Promise<FileSystemEntry[]> => {
+  const reader = directory.createReader();
+  const all: FileSystemEntry[] = [];
+
+  // readEntries yields a batch at a time and signals completion with an empty batch.
+  for (;;) {
+    const batch = await new Promise<FileSystemEntry[]>((resolve) =>
+      reader.readEntries(resolve, () => resolve([]))
+    );
+    if (batch.length === 0) return all;
+    all.push(...batch);
+    if (all.length > MAX_PICKED_FILES) return all;
+  }
 };
 
 export const totalEntryBytes = (entries: UploadAgentEntry[]): number =>

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.ts
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AGENT_CONFIG_FILENAME,
+  AGENT_SPEC_FILENAME,
+  FABRIC_CONFIG_FORMAT,
+  IGNORED_DIRECTORIES,
+  IGNORED_EXTENSIONS,
+  IGNORED_FILENAMES,
+  MAX_AGENT_SPEC_BYTES,
+  MAX_AGENT_SPEC_FILES,
+  MAX_PICKED_FILES,
+} from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/const';
+import type { UploadAgentEntry } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal/type';
+import YAML from 'yaml';
+
+/** Convention only — the Agent entity stores no reference to it. */
+export const agentSpecFilesetName = (agentName: string): string => `${agentName}-spec`;
+
+export const tooManyPickedFiles = (pickedCount: number): string | undefined =>
+  pickedCount > MAX_PICKED_FILES
+    ? `That directory holds ${pickedCount.toLocaleString()} files, far more than an agent directory should. Point at the agent's own directory.`
+    : undefined;
+
+export const isIgnoredPath = (path: string): boolean => {
+  const segments = path.split('/');
+  if (segments.some((segment) => IGNORED_DIRECTORIES.has(segment))) return true;
+
+  const filename = segments[segments.length - 1] ?? '';
+  if (IGNORED_FILENAMES.has(filename)) return true;
+
+  return IGNORED_EXTENSIONS.some((extension) => filename.endsWith(extension));
+};
+
+const pathCollator = new Intl.Collator();
+
+/** The fileset holds the directory's contents, so the picked root is stripped from each path. */
+export const collectAgentEntries = (files: File[]): UploadAgentEntry[] => {
+  const entries: UploadAgentEntry[] = [];
+
+  for (const file of files) {
+    const relativePath = file.webkitRelativePath || file.name;
+    const path = relativePath.split('/').slice(1).join('/') || file.name;
+    if (!path || isIgnoredPath(path)) continue;
+    entries.push({ path, file });
+  }
+
+  return entries.sort((left, right) => pathCollator.compare(left.path, right.path));
+};
+
+export const totalEntryBytes = (entries: UploadAgentEntry[]): number =>
+  entries.reduce((total, entry) => total + entry.file.size, 0);
+
+export const validateAgentEntries = (entries: UploadAgentEntry[]): string | undefined => {
+  if (entries.length === 0) return 'That directory has no uploadable files.';
+
+  if (!entries.some((entry) => entry.path === AGENT_CONFIG_FILENAME)) {
+    return `No ${AGENT_CONFIG_FILENAME} at the top level of that directory.`;
+  }
+
+  if (entries.length > MAX_AGENT_SPEC_FILES) {
+    return `That directory holds ${entries.length} files; the limit is ${MAX_AGENT_SPEC_FILES}. Point at a directory containing only the agent's own files.`;
+  }
+
+  const bytes = totalEntryBytes(entries);
+  if (bytes > MAX_AGENT_SPEC_BYTES) {
+    return `That directory is ${Math.round(bytes / 1000)} KB; the limit is ${Math.round(MAX_AGENT_SPEC_BYTES / 1000)} KB. Point at a directory containing only the agent's own files.`;
+  }
+
+  return undefined;
+};
+
+// Container deployments read every staged file as text and fail on a decode error.
+export const findNonUtf8Path = async (entries: UploadAgentEntry[]): Promise<string | undefined> => {
+  const decoder = new TextDecoder('utf-8', { fatal: true });
+
+  const offenders = await Promise.all(
+    entries.map(async (entry) => {
+      if (entry.path.split('/').pop() === AGENT_SPEC_FILENAME) return undefined;
+      try {
+        decoder.decode(await entry.file.arrayBuffer());
+        return undefined;
+      } catch {
+        return entry.path;
+      }
+    })
+  );
+
+  return offenders.find((path) => path !== undefined);
+};
+
+export class AgentConfigParseError extends Error {}
+
+export const parseAgentConfig = (text: string): Record<string, unknown> => {
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(text);
+  } catch (error) {
+    throw new AgentConfigParseError(
+      `${AGENT_CONFIG_FILENAME} is not valid YAML: ${(error as Error).message}`
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new AgentConfigParseError(`${AGENT_CONFIG_FILENAME} must contain a YAML mapping.`);
+  }
+
+  const config = parsed as Record<string, unknown>;
+  const configFormat = config.config_format;
+  if (configFormat !== FABRIC_CONFIG_FORMAT) {
+    throw new AgentConfigParseError(
+      `${AGENT_CONFIG_FILENAME} must set config_format: ${FABRIC_CONFIG_FORMAT}${
+        typeof configFormat === 'string' ? ` (found ${configFormat})` : ''
+      }.`
+    );
+  }
+
+  return config;
+};
+
+export const agentNameFromConfig = (config: Record<string, unknown>): string | undefined =>
+  typeof config.name === 'string' && config.name.trim() ? config.name.trim() : undefined;

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.ts
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/UploadAgentModal/utils.ts
@@ -118,8 +118,7 @@ export const totalEntryBytes = (entries: UploadAgentEntry[]): number =>
 export const validateAgentEntries = (entries: UploadAgentEntry[]): string | undefined => {
   if (entries.length === 0) return 'That directory has no uploadable files.';
 
-  // Dropping two directories at once merges them, and the fileset would take whichever
-  // upload of a shared path landed last.
+  // Two directories dropped at once merge, and a path they share would upload twice.
   const seen = new Set<string>();
   for (const { path } of entries) {
     if (seen.has(path)) {

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
@@ -68,7 +68,7 @@ export const AgentsListRoute: FC = () => {
           slotActions={
             <Stack direction="row" gap="density-md">
               <Button kind="secondary" onClick={() => setUploadOpen(true)}>
-                Integrate agent
+                Upload agent
               </Button>
               <Button color="brand" onClick={() => setCreateExampleOpen(true)}>
                 Create Example Agent

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
@@ -15,6 +15,7 @@ import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { CreateDeploymentModal } from '@studio/routes/agents/AgentDeploymentsListRoute/CreateDeploymentModal';
 import { CloneAgentModal } from '@studio/routes/agents/AgentsListRoute/CloneAgentModal';
 import { CreateExampleAgentModal } from '@studio/routes/agents/AgentsListRoute/CreateExampleAgentModal';
+import { UploadAgentModal } from '@studio/routes/agents/AgentsListRoute/UploadAgentModal';
 import { getAgentDetailRoute } from '@studio/routes/utils';
 import { CircleAlert } from 'lucide-react';
 import { type FC, useState } from 'react';
@@ -28,6 +29,7 @@ export const AgentsListRoute: FC = () => {
   const navigate = useNavigate();
   const [createDeploymentAgent, setCreateDeploymentAgent] = useState<string | null>(null);
   const [isCreateExampleOpen, setCreateExampleOpen] = useState(false);
+  const [isUploadOpen, setUploadOpen] = useState(false);
   const [cloneSource, setCloneSource] = useState<AgentTableRow | null>(null);
   const [loadedAgents, setLoadedAgents] = useState<Agent[]>([]);
 
@@ -64,9 +66,14 @@ export const AgentsListRoute: FC = () => {
           slotHeading="Agents"
           slotDescription="View and manage AI agents and their deployments."
           slotActions={
-            <Button color="brand" onClick={() => setCreateExampleOpen(true)}>
-              Create Example Agent
-            </Button>
+            <Stack direction="row" gap="density-md">
+              <Button kind="secondary" onClick={() => setUploadOpen(true)}>
+                Upload Agent
+              </Button>
+              <Button color="brand" onClick={() => setCreateExampleOpen(true)}>
+                Create Example Agent
+              </Button>
+            </Stack>
           }
         />
         <AgentsTable
@@ -81,6 +88,11 @@ export const AgentsListRoute: FC = () => {
         onClose={() => setCreateExampleOpen(false)}
         workspace={workspace}
         existingAgents={loadedAgents}
+      />
+      <UploadAgentModal
+        open={isUploadOpen}
+        onClose={() => setUploadOpen(false)}
+        workspace={workspace}
       />
       <CloneAgentModal
         open={cloneSource !== null}

--- a/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentsListRoute/index.tsx
@@ -68,7 +68,7 @@ export const AgentsListRoute: FC = () => {
           slotActions={
             <Stack direction="row" gap="density-md">
               <Button kind="secondary" onClick={() => setUploadOpen(true)}>
-                Upload Agent
+                Integrate agent
               </Button>
               <Button color="brand" onClick={() => setCreateExampleOpen(true)}>
                 Create Example Agent


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Studio could only create Fabric agents from a bundled sample config, so an agent's skills, MCP servers, and prompts had no way in. This adds an Upload agent flow: pick the directory holding `agent.yaml`, and it is uploaded into the conventional `{agent}-spec` fileset that deployments read.

The server-side validation leg of the ticket is not included, and the harness is not restricted. See Limitations.

## Related Issue

Tracked in Linear as ASTD-448. Depends on #1409, which taught subprocess deployments to stage that fileset — without it, uploaded artifacts are invisible in the default deploy mode.

## Changes

- Add `UploadAgentModal`: a KUI `Upload` dropzone plus a name field, wired into the agents list beside Create Example Agent. A folder can be picked or dropped; a dropped directory is walked through `webkitGetAsEntry`, since `dataTransfer.files` reduces it to a zero-byte entry.
- Add `useCreateAgentFromUpload`: upload the directory into `{agent}-spec`, then create the agent entity. The platform has no endpoint taking config and files together, so this runs in two phases; the fileset is deleted if either fails.
- Files go up before the entity. The fileset reserves the name just as the entity would, and it leaves the files in place for a create-time validation that needs a `base_dir` — which is what the server-side leg will want.
- An existing spec fileset is two different situations. If an agent of that name owns it, the name is taken. If nothing owns it — an abandoned upload, or an agent since deleted, since deletion leaves the fileset behind — the next submit offers to replace it.
- Validate the picked directory before anything is created: `agent.yaml` present at the top level, `config_format: nemo-agents-spec-v1`, at most 500 files, at most 900 KB, and every file valid UTF-8.
- Reject a pick above 1,000 raw files on the count alone, before mapping, filtering, or sorting any of it. A directory picker hands over every descendant, and an accidental pick of a large tree otherwise did all that work only to be rejected.
- Drop build artifacts (`__pycache__`, `.pyc`, `.git`, `node_modules`, `.DS_Store`) before the count and byte checks, so junk cannot push an otherwise valid agent over a limit.
- Upload six files at a time rather than one, bounded rather than unbounded so the first failure surfaces promptly for rollback.

The limits mirror `MAX_AGENT_SPEC_STAGED_BYTES` / `_FILES` and the UTF-8 read in `nemo_agents_plugin.runner.fabric_artifact_staging`. The platform only enforces them when a deployment stages the fileset, long after the upload; checking here fails while the user is still looking at the directory they picked. The UTF-8 check matters most: container deployments read every staged file as text and fail the deployment on a decode error, while subprocess deployments never read the contents — so a binary file would otherwise upload cleanly, run locally, and only break on docker or k8s.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no existing docs describe creating an agent from Studio.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/routes/agents/AgentsListRoute/UploadAgentModal src/api/agents/useCreateAgentFromUpload.test.ts` — 46 passed, across the directory/validation helpers (including dropped-directory traversal), the create-and-upload flow, and the modal itself.
- `pnpm --filter nemo-studio-ui test` — full package suite passes.
- `pnpm --filter nemo-studio-ui typecheck` — clean for the files this PR touches.
- `pnpm lint:fix` — clean.
- `uv run pre-commit run -a` — passed.
- Browser run against a local platform, driven with Playwright: selecting the calculator agent directory issued `GET /filesets/<name>-spec` (404, name free), `POST /filesets`, a `PUT` per file including `mcps%2Fcalculator.py`, then `POST /agents` (201), and navigated to the agent detail route. Server-side the fileset held `mcps/calculator.py` with its path intact. Deploying that agent `--mode subprocess` staged `agent.yaml`, `mcps/calculator.py`, and `README.md` into the deployment directory.
- Both conflict paths exercised in the browser: with an agent owning the fileset, nothing was created and the name was refused; with the fileset orphaned, the second submit deleted and replaced it, then created the agent.

Two bugs the browser run caught that the unit tests could not:

- `getErrorMessage` prefers its fallback argument over a plain `Error`'s own message, so the modal showed "Failed to create agent" instead of naming the colliding fileset and how to remove it.
- Switching tabs unmounted the file input, and `webkitdirectory` was applied by an effect keyed on the modal's open state, so returning to the upload view left a plain file picker that silently flattened `mcps/calculator.py`. It is now set through a callback ref.

## Limitations

- Server-side validation, the ticket's third leg, is not included. `POST /agents` still validates config shape only, so a config referencing a `skills.paths` entry that was not uploaded is accepted at create time and fails later, at deploy.
- The config file must be named `agent.yaml`. The CLI accepts any path via `--agent-config`, so an agent whose config is named otherwise is uploadable by CLI but not here.
- The harness is not restricted. `deepagents` is the only one with no host-side prerequisite; claude and codex need the Relay CLI plus an interactive login on the deploy host, and that failure currently appears at deploy.
- Docker and k8s deployments need a container image, which only `nemo agents package` produces. An agent created here has none, so subprocess is the only mode that works end to end from Studio. Tracked as ASTD-459: this PR removes the main obstacle by putting the build context in the `{agent}-spec` fileset, but a platform-side build still needs a daemon-less builder, registry configuration, and somewhere to record the resulting tag.
- Playwright cannot populate `webkitRelativePath` or synthesise `webkitGetAsEntry`, so the browser runs constructed the `File` objects a directory picker would hand the change handler, and the dropped-folder path is covered by unit tests with fake filesystem entries rather than a real drop. Everything after selection — upload, path encoding, API, staging — was exercised for real.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Upload agent” action to the agents list.
  * Upload agent directories through file selection or drag-and-drop, including nested folders.
  * Added validation for supported files, configuration formats, file counts, duplicate paths, encoding, and size limits.
  * Automatically creates the agent after a successful upload.
  * Supports replacing orphaned upload data and provides clear conflict or validation errors.

* **Bug Fixes**
  * Cleans up incomplete uploads when agent creation fails.
  * Prevents outdated file selections from overwriting newer selections or validation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->