### PR TITLE
feat(insights): log analyst evaluations to intake

### DIFF
--- a/plugins/nemo-insights/README.md
+++ b/plugins/nemo-insights/README.md
@@ -147,11 +147,10 @@ export NEMO_INSIGHTS_ANALYST='{"run_at_hour": 17, "run_on_weekday": "friday", "j
 
 ### Analyst self-observability
 
-`NEMO_INSIGHTS_ANALYST_OBSERVABILITY` is read directly from the environment
-rather than through `NemoConfig`, and is off unless set to one of `1`, `true`,
-`yes`, or `on` (case-insensitive). When enabled, the analyst exports its own
-traces to Intake's workspace-scoped OTLP endpoint. The endpoint must be HTTPS
-unless it is loopback.
+Whenever a platform base URL is available, the Analyst exports its own traces
+to Intake's workspace-scoped OTLP endpoint. No opt-in flag or environment
+variable is required. Set `NEMO_INSIGHTS_ANALYST_OBSERVABILITY=false` to opt
+out. The endpoint must be HTTPS unless it is loopback.
 
 ## Development
 

--- a/plugins/nemo-insights/evaluation/README.md
+++ b/plugins/nemo-insights/evaluation/README.md
@@ -209,10 +209,14 @@ is that base name. Runs no longer mint a workspace each. Run isolation comes fro
 the per-span `nemo.evaluation.name=<run-id>` tag plus the Analyst's `evaluation_id`
 filter (which AND-pins every span read to that run) — that is what scopes the
 analysis. The matching **Experiment** entity registered on the `-oracle` workspace
-is metadata for the UI (run-picker + leaderboard), not the scoping mechanism. So
-workspaces stop accumulating and each run reads only its own traces. (Old runs'
-spans age out by Intake retention; the Experiment entities are cheap and
-soft-deletable.)
+is metadata for the UI (run-picker + leaderboard), not the scoping mechanism.
+For standard Platform subjects, every `analyze` also creates a separate
+Evaluation under the `nemo-analyst` Experiment and associates the Analyst's own
+OTLP trace with that Evaluation and the subject-derived test case. The source
+Evaluation ID scopes what the Analyst reads; the Analyst Evaluation ID tags what
+the Analyst emits. Workspaces therefore stop accumulating while each source run
+still reads only its own traces. (Old spans age out by Intake retention;
+Experiment and Evaluation entities are soft-deletable.)
 
 Keys come from `evaluation/.env` (see below), so the commands need no inline env. **`doctor`**
 prints a per-subject readiness checklist — on a fresh clone, run it first and it tells you

--- a/plugins/nemo-insights/evaluation/adapters.py
+++ b/plugins/nemo-insights/evaluation/adapters.py
@@ -23,6 +23,7 @@ from evaluation.otlp_build import session_id_for, sim_to_spans
 from evaluation.otlp_ingest import export_spans, post_evaluator_results, trace_id_for
 from evaluation.registry import Subject
 from evaluation.tau2run import load_tasks, policy_version, read_policy, resolve_paths, run_tau2
+from nemo_insights_plugin.analyst.observability import AnalystEvaluationContext
 from nemo_insights_plugin.analyst.run import run_analyst
 from nemo_insights_plugin.client import make_client
 from nemo_platform import AsyncNeMoPlatform
@@ -48,8 +49,9 @@ class EvaluationAdapter(Protocol):
 class IntakeAdapter:
     """Analyze an agent's existing Intake traces (no production step)."""
 
-    def __init__(self, subject: Subject) -> None:
+    def __init__(self, subject: Subject, *, analyst_evaluation: AnalystEvaluationContext | None = None) -> None:
         self.subject = subject
+        self.analyst_evaluation = analyst_evaluation
 
     def check(self) -> list[str]:
         """Unmet prerequisites for this subject (empty list = ready to run)."""
@@ -98,6 +100,7 @@ class IntakeAdapter:
             local_only=True,
             verbose=verbose,
             since=since,
+            analyst_evaluation=self.analyst_evaluation,
         )
 
     def _basic_auth_client(self) -> AsyncNeMoPlatform:
@@ -115,8 +118,9 @@ class IntakeAdapter:
 class BenchmarkAdapter:
     """Run a benchmark to produce traces, ingest them, then analyze."""
 
-    def __init__(self, subject: Subject) -> None:
+    def __init__(self, subject: Subject, *, analyst_evaluation: AnalystEvaluationContext | None = None) -> None:
         self.subject = subject
+        self.analyst_evaluation = analyst_evaluation
 
     def check(self) -> list[str]:
         """Unmet prerequisites for this benchmark (empty list = ready to run)."""
@@ -306,6 +310,7 @@ class BenchmarkAdapter:
             verbose=verbose,
             since=since,
             evaluation_id=evaluation_id,
+            analyst_evaluation=self.analyst_evaluation,
         )
 
 
@@ -315,11 +320,15 @@ _ADAPTERS: dict[str, type[IntakeAdapter] | type[BenchmarkAdapter]] = {
 }
 
 
-def build_adapter(subject: Subject) -> EvaluationAdapter:
+def build_adapter(
+    subject: Subject,
+    *,
+    analyst_evaluation: AnalystEvaluationContext | None = None,
+) -> EvaluationAdapter:
     """Construct the adapter for a subject's ``type``."""
     cls = _ADAPTERS.get(subject.type)
     if cls is None:
         raise SystemExit(
             f"evaluation '{subject.name}' has unknown type '{subject.type}'. Known types: {', '.join(sorted(_ADAPTERS))}."
         )
-    return cls(subject)
+    return cls(subject, analyst_evaluation=analyst_evaluation)

--- a/plugins/nemo-insights/evaluation/adapters.py
+++ b/plugins/nemo-insights/evaluation/adapters.py
@@ -101,6 +101,7 @@ class IntakeAdapter:
             verbose=verbose,
             since=since,
             analyst_evaluation=self.analyst_evaluation,
+            enable_observability=cfg.get("auth") != "basic",
         )
 
     def _basic_auth_client(self) -> AsyncNeMoPlatform:

--- a/plugins/nemo-insights/evaluation/cli.py
+++ b/plugins/nemo-insights/evaluation/cli.py
@@ -52,10 +52,12 @@ import yaml
 from evaluation import artifact, publish, reingest, release
 from evaluation.adapters import build_adapter
 from evaluation.export import EPOCH
+from evaluation.ingest import create_experiment, ensure_experiment_group, mint_agent_id
 from evaluation.registry import Subject, load_registry
 from evaluation.runstore import load_run, save_run
 from evaluation.summary import render_summary_md
 from evaluation.timeparse import parse_since
+from nemo_insights_plugin.analyst.observability import AnalystEvaluationContext
 
 HERE = Path(__file__).parent
 REGISTRY_PATH = HERE / "evaluations.toml"
@@ -66,6 +68,7 @@ ANALYST_LOCKFILE = HERE.parents[2] / "uv.lock"
 ANALYST_LOCK_ROOT = "nemo-insights-plugin"
 ENV_PATH = HERE / ".env"
 LOCAL_URL = artifact.LOCAL_URL  # the local NeMo Platform (the default restore/analyze target)
+ANALYST_EXPERIMENT_NAME = "nemo-analyst"
 _REMOTE_AUTH_KEYS = ("auth", "intake_path_prefix", "auth_user_env", "auth_password_env")
 INSIGHTS_SPDX_HEADER = (
     "# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
@@ -586,6 +589,57 @@ def _analysis_workspace(subject: Subject, record: dict | None) -> str | None:
     if record is None:
         return None
     return str(record.get("realistic_workspace") or "") or None
+
+
+def _register_analysis_evaluation(
+    *,
+    subject: Subject,
+    subject_name: str,
+    record: dict[str, object] | None,
+    state_label: str,
+) -> AnalystEvaluationContext | None:
+    """Create the Experiment/Evaluation that owns one Analyst OTLP trace."""
+    if subject.config.get("auth") == "basic":
+        # Custom Intake routing/auth remains owned by the existing subject client.
+        return None
+    workspace = _analysis_workspace(subject, record)
+    if workspace is None:
+        raise RuntimeError("cannot register Analyst evaluation without an analysis workspace")
+    if subject.type == "benchmark":
+        if record is None or not record.get("base_url"):
+            raise RuntimeError("cannot register benchmark Analyst evaluation without a recorded base URL")
+        base_url = str(record["base_url"])
+        target_agent = str(record.get("agent") or subject_name)
+    else:
+        base_url = str(subject.config.get("base_url") or "")
+        target_agent = str(subject.config.get("agent") or subject_name)
+    if not base_url:
+        raise RuntimeError("cannot register Analyst evaluation without a platform base URL")
+    evaluation_name = mint_agent_id(ANALYST_EXPERIMENT_NAME)
+    experiment_id = ensure_experiment_group(
+        base_url,
+        workspace,
+        ANALYST_EXPERIMENT_NAME,
+    )
+    create_experiment(
+        base_url,
+        workspace,
+        name=evaluation_name,
+        experiment_group_id=experiment_id,
+        dataset_name=f"nemo-analyst:{target_agent}",
+        dataset_version=state_label,
+        metadata={
+            "subject": subject_name,
+            "target_agent": target_agent,
+            "test_case_name": subject_name,
+            "state": state_label,
+        },
+    )
+    print(
+        f"Analyst telemetry: Experiment '{ANALYST_EXPERIMENT_NAME}', Evaluation '{evaluation_name}', "
+        f"test case '{subject_name}' in workspace '{workspace}'"
+    )
+    return AnalystEvaluationContext(evaluation_name=evaluation_name, test_case_name=subject_name)
 
 
 def _warn_insights_workspace_mismatch(subject_name: str, workspace: str | None) -> None:
@@ -1175,8 +1229,23 @@ def main() -> None:
         # remap (state mode) / record load (live) so it compares against the
         # workspace this analysis actually reads.
         _warn_insights_workspace_mismatch(args.name, _analysis_workspace(subject, record))
-    adapter = build_adapter(subject)
-    report = asyncio.run(adapter.analyze(record=record, since=since, verbose=args.verbose, out_path=out))
+    try:
+        analyst_evaluation = _register_analysis_evaluation(
+            subject=subject,
+            subject_name=args.name,
+            record=record,
+            state_label=label,
+        )
+    except RuntimeError as exc:
+        sys.exit(f"could not register Analyst evaluation: {exc}")
+    adapter = build_adapter(subject, analyst_evaluation=analyst_evaluation)
+    analysis = adapter.analyze(
+        record=record,
+        since=since,
+        verbose=args.verbose,
+        out_path=out,
+    )
+    report = asyncio.run(analysis)
     print(report)
     print(f"\n✓ Insights written to {out}")
     if not args.no_baseline_update:

--- a/plugins/nemo-insights/examples/research-agent/tests/test_analyst_e2e.py
+++ b/plugins/nemo-insights/examples/research-agent/tests/test_analyst_e2e.py
@@ -59,10 +59,7 @@ from urllib.parse import urlparse
 
 import httpx
 import pytest
-from nemo_insights_plugin.analyst.observability import (
-    ANALYST_OBSERVABILITY_AGENT_NAME,
-    ANALYST_OBSERVABILITY_ENV,
-)
+from nemo_insights_plugin.analyst.observability import ANALYST_OBSERVABILITY_AGENT_NAME
 
 # Scope every artifact this test produces to a dedicated project/agent name so
 # it is non-destructive to the real `research-agent` data.
@@ -462,8 +459,6 @@ def test_analyst_creates_insight_end_to_end(platform_server: str) -> None:  # no
     assert trace_count >= MIN_TRACES, f"expected >= {MIN_TRACES} traces for {TEST_AGENT}, saw {trace_count}"
 
     # 4. Run the analyst.
-    analyst_env = _subprocess_env()
-    analyst_env[ANALYST_OBSERVABILITY_ENV] = "1"
     result = subprocess.run(
         _cli_cmd(
             "nemo",
@@ -478,7 +473,7 @@ def test_analyst_creates_insight_end_to_end(platform_server: str) -> None:  # no
             BASE_URL,
         ),
         cwd=str(EXAMPLE_DIR),
-        env=analyst_env,
+        env=_subprocess_env(),
         capture_output=True,
         text=True,
         timeout=600,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/observability.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/observability.py
@@ -17,6 +17,14 @@ ANALYST_OBSERVABILITY_SERVICE_NAMESPACE = "nemo-insights"
 OTLP_TRACES_PATH = "/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
 
 
+@dataclass(frozen=True)
+class AnalystEvaluationContext:
+    """Evaluation identity attached to every span in one Analyst run."""
+
+    evaluation_name: str
+    test_case_name: str
+
+
 @dataclass
 class AnalystObservability:
     """Configured Nooa instrumentation for one analyst run."""
@@ -47,12 +55,12 @@ def setup_analyst_observability(
     base_url: str,
     workspace: str,
     target_agent: str,
+    evaluation_context: AnalystEvaluationContext | None = None,
 ) -> AnalystObservability:
     """Configure native Nooa OTel instrumentation for Intake export.
 
-    This path is intended for insights dogfooding and is opt-in at the CLI
-    layer, so it always sends the analyst's own spans to the platform Intake
-    endpoint derived from the active ``--base-url`` and ``--workspace``.
+    By default, the analyst sends its own spans to the platform Intake endpoint
+    derived from the active ``--base-url`` and ``--workspace``.
     """
     endpoint = build_intake_otlp_traces_endpoint(base_url=base_url, workspace=workspace)
     session_id = f"{ANALYST_OBSERVABILITY_AGENT_NAME}-{uuid4()}"
@@ -60,6 +68,7 @@ def setup_analyst_observability(
         workspace=workspace,
         target_agent=target_agent,
         session_id=session_id,
+        evaluation_context=evaluation_context,
     )
 
     otlp_headers = _otlp_auth_headers(base_url)
@@ -92,8 +101,14 @@ def _otlp_auth_headers(base_url: str) -> dict[str, str] | None:
     return {str(k): str(v) for k, v in headers.items()}
 
 
-def _resource_attributes(*, workspace: str, target_agent: str, session_id: str) -> dict[str, str]:
-    return {
+def _resource_attributes(
+    *,
+    workspace: str,
+    target_agent: str,
+    session_id: str,
+    evaluation_context: AnalystEvaluationContext | None,
+) -> dict[str, str]:
+    attributes = {
         "service.name": ANALYST_OBSERVABILITY_AGENT_NAME,
         "service.namespace": ANALYST_OBSERVABILITY_SERVICE_NAMESPACE,
         "gen_ai.agent.name": ANALYST_OBSERVABILITY_AGENT_NAME,
@@ -104,3 +119,7 @@ def _resource_attributes(*, workspace: str, target_agent: str, session_id: str) 
         "nemo.insights.workspace": workspace,
         "nemo.insights.target_agent": target_agent,
     }
+    if evaluation_context is not None:
+        attributes["nemo.evaluation.name"] = evaluation_context.evaluation_name
+        attributes["nemo.test_case.name"] = evaluation_context.test_case_name
+    return attributes

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
@@ -17,6 +17,7 @@ from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
 from nemo_insights_plugin.analyst.deps import AnalystDeps
 from nemo_insights_plugin.analyst.observability import (
     ANALYST_OBSERVABILITY_ENV,
+    AnalystEvaluationContext,
     setup_analyst_observability,
 )
 from nemo_insights_plugin.analyst.result import AnalystResult
@@ -51,6 +52,7 @@ async def run_analyst(
     verbose: bool = False,
     since: datetime | None = None,
     evaluation_id: str | None = None,
+    analyst_evaluation: AnalystEvaluationContext | None = None,
     model_refs: ConfiguredModelRefs | None = None,
 ) -> str:
     """Build and run the analyst agent against an agent's telemetry.
@@ -72,6 +74,8 @@ async def run_analyst(
         verbose: Whether to stream model/tool events to stderr.
         since: Optional incremental lower bound enforced on trace/span reads.
         evaluation_id: Optional run scope; AND-pinned onto every span read.
+        analyst_evaluation: Optional Evaluation and test-case
+            identity attached to the Analyst's own OTLP trace.
         model_refs: Optional explicit default/fast Model Entity IDs. Unset uses
             the active Platform CLI context.
     """
@@ -99,6 +103,7 @@ async def run_analyst(
                 base_url=base_url,
                 workspace=workspace,
                 target_agent=agent,
+                evaluation_context=analyst_evaluation,
             )
         with activate_model_clients(model_clients):
             analyst = build_analyst_agent(
@@ -121,9 +126,9 @@ async def run_analyst(
 
 
 def _analyst_observability_enabled() -> bool:
-    """True when dogfooding analyst self-observability is explicitly enabled."""
-    value = os.environ.get(ANALYST_OBSERVABILITY_ENV, "")
-    return value.strip().lower() in {"1", "true", "yes", "on"}
+    """Return false only when self-observability is explicitly disabled."""
+    value = os.environ.get(ANALYST_OBSERVABILITY_ENV)
+    return value is None or value.strip().lower() not in {"0", "false", "no", "off"}
 
 
 async def _run_agent(

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analyst/run.py
@@ -53,6 +53,7 @@ async def run_analyst(
     since: datetime | None = None,
     evaluation_id: str | None = None,
     analyst_evaluation: AnalystEvaluationContext | None = None,
+    enable_observability: bool = True,
     model_refs: ConfiguredModelRefs | None = None,
 ) -> str:
     """Build and run the analyst agent against an agent's telemetry.
@@ -76,6 +77,8 @@ async def run_analyst(
         evaluation_id: Optional run scope; AND-pinned onto every span read.
         analyst_evaluation: Optional Evaluation and test-case
             identity attached to the Analyst's own OTLP trace.
+        enable_observability: Whether this run may export the Analyst's own
+            OTLP trace. The environment variable can still disable export.
         model_refs: Optional explicit default/fast Model Entity IDs. Unset uses
             the active Platform CLI context.
     """
@@ -98,7 +101,7 @@ async def run_analyst(
             since=since,
             evaluation_id=evaluation_id,
         )
-        if base_url and _analyst_observability_enabled():
+        if base_url and enable_observability and _analyst_observability_enabled():
             observability = setup_analyst_observability(
                 base_url=base_url,
                 workspace=workspace,

--- a/plugins/nemo-insights/tests/evaluation/test_adapters.py
+++ b/plugins/nemo-insights/tests/evaluation/test_adapters.py
@@ -7,6 +7,7 @@ from typing import Any
 import pytest
 from evaluation.adapters import BenchmarkAdapter, IntakeAdapter, build_adapter
 from evaluation.registry import Subject
+from nemo_insights_plugin.analyst.observability import AnalystEvaluationContext
 
 _CFG = {
     "domain": "airline",
@@ -354,7 +355,18 @@ async def test_benchmark_analyze_uses_record(monkeypatch, tmp_path):
     seen: dict[str, object] = {}
 
     async def fake_run_analyst(
-        *, agent, agent_spec, workspace, base_url, client, insights_output, local_only, verbose, since, evaluation_id
+        *,
+        agent,
+        agent_spec,
+        workspace,
+        base_url,
+        client,
+        insights_output,
+        local_only,
+        verbose,
+        since,
+        evaluation_id,
+        analyst_evaluation,
     ):
         seen.update(
             agent=agent,
@@ -363,6 +375,7 @@ async def test_benchmark_analyze_uses_record(monkeypatch, tmp_path):
             base_url=base_url,
             evaluation_id=evaluation_id,
             local_only=local_only,
+            analyst_evaluation=analyst_evaluation,
         )
         return "REPORT-OK"
 
@@ -378,8 +391,19 @@ async def test_benchmark_analyze_uses_record(monkeypatch, tmp_path):
         "base_url": "http://localhost:8080",
         "domain": "airline",
     }
-    out = await BenchmarkAdapter(Subject("tau2-airline", "benchmark", cfg)).analyze(
-        record=record, since=None, verbose=True, out_path=tmp_path / "o.json"
+    analyst_evaluation = AnalystEvaluationContext(
+        evaluation_name="nemo-analyst-run",
+        test_case_name="tau2-airline",
+    )
+    adapter = BenchmarkAdapter(
+        Subject("tau2-airline", "benchmark", cfg),
+        analyst_evaluation=analyst_evaluation,
+    )
+    out = await adapter.analyze(
+        record=record,
+        since=None,
+        verbose=True,
+        out_path=tmp_path / "o.json",
     )
     assert out == "REPORT-OK"
     assert ran_tau2["v"] is False  # analyze never runs tau2
@@ -389,6 +413,7 @@ async def test_benchmark_analyze_uses_record(monkeypatch, tmp_path):
     assert seen["evaluation_id"] == "tau2-airline-20260626-000000-abcd"  # run-scoped
     assert seen["base_url"] == "http://localhost:8080"
     assert seen["local_only"] is True  # benchmark runs capture to file and never write to the platform
+    assert seen["analyst_evaluation"] == analyst_evaluation
 
 
 async def test_benchmark_analyze_without_record_raises(tmp_path):

--- a/plugins/nemo-insights/tests/evaluation/test_adapters.py
+++ b/plugins/nemo-insights/tests/evaluation/test_adapters.py
@@ -112,6 +112,7 @@ async def test_intake_analyze_basic_auth_injects_built_client(monkeypatch: pytes
 
     assert report == "REPORT"
     assert calls["client"] is sentinel
+    assert calls["enable_observability"] is False
     assert built == {
         "base_url": "https://agenthub.aire.nvidia.com",
         "username": "intake",
@@ -147,6 +148,7 @@ async def test_intake_analyze_calls_run_analyst(monkeypatch, tmp_path: Path):
     assert calls["base_url"] == "u"
     assert calls["agent_spec"] is None
     assert calls["client"] is built_client
+    assert calls["enable_observability"] is True
 
 
 async def test_intake_analyze_missing_keys_exits(tmp_path: Path):

--- a/plugins/nemo-insights/tests/evaluation/test_cli.py
+++ b/plugins/nemo-insights/tests/evaluation/test_cli.py
@@ -15,8 +15,10 @@ from pathlib import Path
 import pytest
 import yaml
 from evaluation import cli
+from nemo_insights_plugin.analyst.observability import AnalystEvaluationContext
 
 _REAL_LOAD_REGISTRY = cli.load_registry
+_REAL_REGISTER_ANALYSIS_EVALUATION = cli._register_analysis_evaluation
 
 
 @pytest.fixture(autouse=True)
@@ -43,6 +45,14 @@ def isolate_checked_in_insights(monkeypatch, tmp_path):
     }
     monkeypatch.setattr(cli, "load_registry", load_registry_with_test_intake)
     monkeypatch.setattr(cli, "INSIGHTS_DIR", tmp_path / "checked-in-insights", raising=False)
+    monkeypatch.setattr(
+        cli,
+        "_register_analysis_evaluation",
+        lambda **_kwargs: AnalystEvaluationContext(
+            evaluation_name="nemo-analyst-test",
+            test_case_name="test-subject",
+        ),
+    )
     if helpers["check_in"] is not None:
         monkeypatch.setattr(
             cli,
@@ -221,6 +231,100 @@ def test_analyze_live_happy_path(monkeypatch, tmp_path, capsys):
     out = capsys.readouterr().out
     assert "REPORT-OK" in out
     assert "Insights written" in out
+
+
+def test_analyze_registers_and_tags_analyst_run_by_default(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(cli, "TMP", tmp_path)
+    monkeypatch.setattr(cli, "_register_analysis_evaluation", _REAL_REGISTER_ANALYSIS_EVALUATION)
+    monkeypatch.setattr(cli, "mint_agent_id", lambda _base: "nemo-analyst-run-1")
+    calls: dict[str, object] = {}
+
+    def fake_ensure_experiment_group(base_url, workspace, name):
+        calls["experiment"] = (base_url, workspace, name)
+        return "experiment-1"
+
+    def fake_create_experiment(base_url, workspace, **kwargs):
+        calls["evaluation"] = (base_url, workspace, kwargs)
+
+    async def fake_analyze(self, *, record, since, verbose, out_path):
+        calls["observability"] = self.analyst_evaluation
+        return "REPORT-OK"
+
+    monkeypatch.setattr(cli, "ensure_experiment_group", fake_ensure_experiment_group)
+    monkeypatch.setattr(cli, "create_experiment", fake_create_experiment)
+    monkeypatch.setattr("evaluation.adapters.IntakeAdapter.analyze", fake_analyze)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evaluation",
+            "analyze",
+            "nvq",
+            "--live",
+            "--base",
+            "http://localhost:8080",
+            "--set",
+            "agent=smoke-agent",
+            "--set",
+            "workspace=default",
+            "--no-baseline-update",
+        ],
+    )
+
+    cli.main()
+
+    assert calls["experiment"] == (
+        "http://localhost:8080",
+        "default",
+        "nemo-analyst",
+    )
+    assert calls["evaluation"] == (
+        "http://localhost:8080",
+        "default",
+        {
+            "name": "nemo-analyst-run-1",
+            "experiment_group_id": "experiment-1",
+            "dataset_name": "nemo-analyst:smoke-agent",
+            "dataset_version": "live",
+            "metadata": {
+                "subject": "nvq",
+                "target_agent": "smoke-agent",
+                "test_case_name": "nvq",
+                "state": "live",
+            },
+        },
+    )
+    context = calls["observability"]
+    assert isinstance(context, AnalystEvaluationContext)
+    assert context.evaluation_name == "nemo-analyst-run-1"
+    assert context.test_case_name == "nvq"
+    assert "Experiment 'nemo-analyst', Evaluation 'nemo-analyst-run-1'" in capsys.readouterr().out
+
+
+def test_register_analysis_evaluation_leaves_custom_intake_auth_unchanged(monkeypatch):
+    from evaluation.registry import Subject
+
+    subject = Subject(
+        "custom-intake",
+        "intake",
+        {
+            "agent": "custom-agent",
+            "workspace": "default",
+            "base_url": "https://intake.example",
+            "auth": "basic",
+        },
+    )
+    monkeypatch.setattr(cli, "ensure_experiment_group", lambda *_args, **_kwargs: pytest.fail("must not register"))
+
+    assert (
+        _REAL_REGISTER_ANALYSIS_EVALUATION(
+            subject=subject,
+            subject_name=subject.name,
+            record=None,
+            state_label="live",
+        )
+        is None
+    )
 
 
 def test_analyze_checks_in_insights_with_spdx_and_provenance_by_default(
@@ -1102,6 +1206,7 @@ def test_analyze_glamr_live_base_preserves_remote_auth(monkeypatch, tmp_path):
         },
     )
     monkeypatch.setattr(cli, "load_registry", lambda _path: {"glamr": glamr})
+    monkeypatch.setattr(cli, "_register_analysis_evaluation", _REAL_REGISTER_ANALYSIS_EVALUATION)
     monkeypatch.setattr(cli, "_load_dotenv", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "TMP", tmp_path)
     monkeypatch.setenv("INFERENCE_API_KEY", "sk-test")
@@ -1110,9 +1215,14 @@ def test_analyze_glamr_live_base_preserves_remote_auth(monkeypatch, tmp_path):
     built: dict[str, object] = {}
     real_build_adapter = cli.build_adapter
 
-    def capture_build_adapter(subject: Subject) -> EvaluationAdapter:
+    def capture_build_adapter(
+        subject: Subject,
+        *,
+        analyst_evaluation: AnalystEvaluationContext | None = None,
+    ) -> EvaluationAdapter:
         built.update(subject.config)
-        return real_build_adapter(subject)
+        built["analyst_evaluation"] = analyst_evaluation
+        return real_build_adapter(subject, analyst_evaluation=analyst_evaluation)
 
     async def fake_analyze(
         self: IntakeAdapter,
@@ -1133,6 +1243,8 @@ def test_analyze_glamr_live_base_preserves_remote_auth(monkeypatch, tmp_path):
     )
 
     cli.main()
+
+    assert built["analyst_evaluation"] is None
 
     assert built["base_url"] == "https://override.example"
     assert {key: built[key] for key in cli._REMOTE_AUTH_KEYS} == {

--- a/plugins/nemo-insights/tests/test_analyst_observability.py
+++ b/plugins/nemo-insights/tests/test_analyst_observability.py
@@ -29,6 +29,10 @@ def test_setup_maps_intake_endpoint_auth_resource_and_session(monkeypatch: pytes
         base_url="https://platform.example/",
         workspace="workspace",
         target_agent="target-agent",
+        evaluation_context=observability.AnalystEvaluationContext(
+            evaluation_name="analyst-eval-1",
+            test_case_name="smoke/g1",
+        ),
     )
 
     assert configured.endpoint == ("https://platform.example/apis/intake/v2/workspaces/workspace/ingest/otlp/v1/traces")
@@ -37,6 +41,8 @@ def test_setup_maps_intake_endpoint_auth_resource_and_session(monkeypatch: pytes
     assert enabled_exporters == [exporter]
     assert attributes["gen_ai.agent.name"] == observability.ANALYST_OBSERVABILITY_AGENT_NAME
     assert attributes["nemo.insights.target_agent"] == "target-agent"
+    assert attributes["nemo.evaluation.name"] == "analyst-eval-1"
+    assert attributes["nemo.test_case.name"] == "smoke/g1"
     assert seen["session"] == configured.session_id
 
 

--- a/plugins/nemo-insights/tests/test_analyst_run.py
+++ b/plugins/nemo-insights/tests/test_analyst_run.py
@@ -240,3 +240,25 @@ async def test_evaluation_context_is_forwarded_to_default_on_observability(monke
         "evaluation_context": evaluation_context,
     }
     assert seen["shutdown"] is True
+
+
+async def test_per_run_observability_opt_out_skips_setup(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+    seen: dict[str, object] = {}
+    _stub_pipeline(monkeypatch, seen)
+
+    def fail_setup(**kwargs: object) -> None:
+        raise AssertionError(f"unexpected observability setup: {kwargs}")
+
+    monkeypatch.setattr(run_module, "setup_analyst_observability", fail_setup)
+
+    await run_module.run_analyst(
+        agent="remote-agent",
+        agent_spec=None,
+        workspace="default",
+        base_url="https://remote.example",
+        client=cast(AsyncNeMoPlatform, client),
+        enable_observability=False,
+    )
+
+    assert client.closed

--- a/plugins/nemo-insights/tests/test_analyst_run.py
+++ b/plugins/nemo-insights/tests/test_analyst_run.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import pytest
 from nemo_insights_plugin.analyst import run as run_module
 from nemo_insights_plugin.analyst.deps import AnalystDeps
+from nemo_insights_plugin.analyst.observability import AnalystEvaluationContext
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.nooa_model_client import ConfiguredModelClients
 from nooa.context_blocks import ResultStatus
@@ -66,6 +67,12 @@ def _stub_pipeline(monkeypatch: pytest.MonkeyPatch, seen: dict[str, object]) -> 
 
     monkeypatch.setattr(run_module, "build_analyst_agent", fake_build_agent)
     monkeypatch.setattr(run_module, "_run_agent", fake_run_agent)
+
+    class Observability:
+        def shutdown(self) -> None:
+            seen["shutdown"] = True
+
+    monkeypatch.setattr(run_module, "setup_analyst_observability", lambda **_kwargs: Observability())
 
 
 async def test_injected_client_is_used_and_closed(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -180,7 +187,6 @@ async def test_client_closed_when_observability_shutdown_raises(monkeypatch: pyt
         def shutdown(self) -> None:
             raise RuntimeError("shutdown failed")
 
-    monkeypatch.setattr(run_module, "_analyst_observability_enabled", lambda: True)
     monkeypatch.setattr(
         run_module,
         "setup_analyst_observability",
@@ -197,3 +203,40 @@ async def test_client_closed_when_observability_shutdown_raises(monkeypatch: pyt
         )
 
     assert client.closed
+
+
+async def test_evaluation_context_is_forwarded_to_default_on_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+    seen: dict[str, object] = {}
+    _stub_pipeline(monkeypatch, seen)
+
+    class Observability:
+        def shutdown(self) -> None:
+            seen["shutdown"] = True
+
+    def fake_setup(**kwargs: object) -> Observability:
+        seen["observability"] = kwargs
+        return Observability()
+
+    monkeypatch.setattr(run_module, "setup_analyst_observability", fake_setup)
+    evaluation_context = AnalystEvaluationContext(
+        evaluation_name="nemo-analyst-1",
+        test_case_name="smoke/g1",
+    )
+
+    await run_module.run_analyst(
+        agent="smoke-agent",
+        agent_spec=None,
+        workspace="default",
+        base_url="http://localhost:8080",
+        client=cast(AsyncNeMoPlatform, client),
+        analyst_evaluation=evaluation_context,
+    )
+
+    assert seen["observability"] == {
+        "base_url": "http://localhost:8080",
+        "workspace": "default",
+        "target_agent": "smoke-agent",
+        "evaluation_context": evaluation_context,
+    }
+    assert seen["shutdown"] is True

--- a/plugins/nemo-insights/tests/test_analyst_run.py
+++ b/plugins/nemo-insights/tests/test_analyst_run.py
@@ -182,6 +182,7 @@ async def test_client_closed_when_observability_shutdown_raises(monkeypatch: pyt
     client = FakeClient()
     seen: dict[str, object] = {}
     _stub_pipeline(monkeypatch, seen)
+    monkeypatch.setenv(run_module.ANALYST_OBSERVABILITY_ENV, "true")
 
     class FailingObservability:
         def shutdown(self) -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

The Insights Analyst now exports its own OTLP traces to Intake by default and can be opted out with `NEMO_INSIGHTS_ANALYST_OBSERVABILITY=false`. The evaluation runner creates a separate `nemo-analyst` Evaluation for each standard Platform analysis and tags the Analyst trace with that Evaluation and subject-derived test case, independently of the source agent's Evaluation.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Create or reuse the `nemo-analyst` Experiment and create a unique Evaluation for each analysis run.
- Carry the Analyst Evaluation and test-case identity in a typed `AnalystEvaluationContext` and attach both canonical Intake attributes to every Analyst span.
- Make Analyst self-observability default-on while preserving an explicit environment opt-out.
- Preserve the existing source benchmark Evaluation/filter flow and disable the standard Analyst exporter for custom basic-auth Intake subjects.
- Update Analyst evaluation and observability tests, the research-agent E2E setup, and user-facing documentation.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `uv run --frozen pytest plugins/nemo-insights/tests -q` — 621 passed, 1 skipped.
- `uv run ruff check plugins/nemo-insights` — passed.
- `uv run ruff format --check plugins/nemo-insights` — passed.
- Targeted `uv run --frozen ty check ...` over changed implementation and tests — passed.
- `SKIP=helm-docs uv run pre-commit run -a` — every applicable hook passed. The unskipped repository-wide run rewrites the pre-existing `k8s/helm/README.md` from its checked-in template even on `origin/main`; no Helm files are changed by this PR.
- Focused pre-commit hooks over the CodeRabbit follow-up — passed.
- Live local smoke without an opt-in flag — created Evaluation `nemo-analyst-20260820-202951-372e`; Intake associated one Analyst session and all 23 spans with that Evaluation and test case `nvq`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Analyst self-observability is enabled by default when a platform base URL is available.
  * Analysis runs can create or reuse evaluation records and associate traces with evaluation and test-case details.
  * Added an opt-out setting for Analyst tracing.
* **Bug Fixes**
  * Invalid observability registration now stops analysis with a clear error.
  * Basic-auth and custom intake analyses continue without evaluation registration.
* **Documentation**
  * Updated setup and evaluation guidance, including endpoint security and evaluation ID behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->