### PR TITLE
feat(studio): describe eval runner in submit modal (ASTD-457)

### DIFF
--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -8,8 +8,7 @@ import { FormModal, type FormModalProps } from '@nemo/common/src/components/Form
 import { getURNFromNamedEntityRef } from '@nemo/common/src/namedEntity';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { getEntityNameError } from '@nemo/common/src/utils/entityName';
-import { useAgentsListAgents, useAgentsListDeployments } from '@nemo/sdk/generated/agents/api';
-import type { AgentsListDeploymentsParams } from '@nemo/sdk/generated/agents/schema/AgentsListDeploymentsParams';
+import { useAgentsListAgents } from '@nemo/sdk/generated/agents/api';
 import { evaluatorCreateEvaluateJob } from '@nemo/sdk/generated/evaluator/api';
 import type {
   AgentEvaluateJobRequest,
@@ -26,7 +25,7 @@ import {
   useListEvaluations,
   useListExperiments,
 } from '@nemo/sdk/generated/platform/api';
-import { Anchor, SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
+import { Button, SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
 import { fetchSampleText } from '@studio/api/agents/fetchSampleText';
 import { submitAgentEvalJob } from '@studio/api/evaluation/agent-evaluations';
 import { isConflictError, type EvalSeedFile } from '@studio/api/evaluation/eval-config-fileset';
@@ -52,10 +51,12 @@ import {
   MODE_EXPERIMENT,
   parseEvalConfig,
 } from '@studio/components/evaluation/submitEvaluationJob';
+import { LINK_NEMO_EVALUATOR_DOCS } from '@studio/constants/links';
 import { DATASET_EVAL_CONFIG_KEY, getEvalConfigSample } from '@studio/constants/sampleAgents';
 import { useJudgeModels } from '@studio/hooks/evaluation/useJudgeModels';
 import { getAgentEvaluationsTabRoute } from '@studio/routes/utils';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronRight, File } from 'lucide-react';
 import { type FC, useEffect, useRef, useState } from 'react';
 import { FormProvider, type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -74,10 +75,6 @@ const README_FILENAME = 'README.md';
 
 const NO_EVALUATIONS_MESSAGE =
   'No evaluations with a reusable eval config yet. Create one to run and re-use it.';
-
-const NO_DEPLOYMENT_MESSAGE = 'This agent has no active deployment.';
-const DEPLOYMENT_CHECK_FAILED_MESSAGE =
-  'Could not verify this agent has a running deployment. Try again.';
 
 const submitEvaluationBaseSchema = z.object({
   agent: z.string().min(1, 'Agent is required'),
@@ -129,14 +126,6 @@ const makeSubmitEvaluationSchema = (requiresJudgeModel: () => boolean) =>
       });
     }
   });
-
-/** Narrows the deployments list to one agent's running deployments, so the modal never
- *  pages through a workspace-wide list to answer a per-agent question. The endpoint
- *  accepts these as deepObject query params (``filter[agent]``, ``filter[status]``) and
- *  the fetcher serializes nested objects that way, but the generated params type omits
- *  ``filter`` — the agents plugin never declares it via ``openapi_extra`` — hence the cast. */
-const runningDeploymentsQuery = (agent: string): AgentsListDeploymentsParams =>
-  ({ filter: { agent: bareName(agent), status: 'running' } }) as AgentsListDeploymentsParams;
 
 const makeDefaultValues = (agent?: string): SubmitEvaluationFormData => {
   const newName = generateEvalConfigName();
@@ -331,27 +320,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const mode = useWatch({ control, name: 'mode' });
   const selectedAgent = useWatch({ control, name: 'agent' });
 
-  const {
-    data: runningDeployments,
-    isLoading: isDeploymentsLoading,
-    isError: isDeploymentsError,
-  } = useAgentsListDeployments(workspace, runningDeploymentsQuery(selectedAgent), {
-    query: { enabled: open && Boolean(selectedAgent) },
-  });
-
-  const hasRunningDeployment = (runningDeployments?.data ?? []).length > 0;
-
-  const deploymentVerified =
-    Boolean(selectedAgent) && !isDeploymentsLoading && !isDeploymentsError && hasRunningDeployment;
-
-  const deploymentError = ((): string | undefined => {
-    if (!selectedAgent || isDeploymentsLoading) return undefined;
-    if (isDeploymentsError) return DEPLOYMENT_CHECK_FAILED_MESSAGE;
-    if (!hasRunningDeployment) return NO_DEPLOYMENT_MESSAGE;
-    return undefined;
-  })();
-
-  const agentFieldError = errors.agent?.message ?? deploymentError;
+  const agentFieldError = errors.agent?.message;
   const exampleKey = useWatch({ control, name: 'exampleKey' });
   const evaluationName = useWatch({ control, name: 'evaluationName' });
 
@@ -565,7 +534,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       submitButtonText="Submit"
       onSubmit={handleSubmit(onSubmit)}
       disabled={isPending}
-      submitDisabled={!deploymentVerified || !canRunSelectedEvaluation}
+      submitDisabled={!canRunSelectedEvaluation}
       loading={isPending}
       errorText={errorMessage}
       className="w-[690px]! max-w-[95vw]!"
@@ -573,23 +542,24 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       <FormProvider {...methods}>
         <Stack gap="density-xl">
           {agentProp ? (
-            <Stack gap="density-xs">
-              <Text kind="body/regular/sm">
+            <Stack gap="density-md">
+              <Text kind="body/regular/md">
                 Run evaluation via NeMo evaluator&apos;s built in runner. Evaluator supports
-                Harbor and Gym runners as well.{' '}
-                <Anchor
-                  href="https://docs.nvidia.com/nemo/evaluator/nightly"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  Learn more
-                </Anchor>
+                Harbor and Gym runners as well.
               </Text>
-              {deploymentError && (
-                <Text kind="body/regular/sm" className="text-[var(--text-color-feedback-danger)]">
-                  {deploymentError}
-                </Text>
-              )}
+              <Button
+                asChild
+                color="neutral"
+                kind="tertiary"
+                size="small"
+                className="w-full justify-start"
+              >
+                <a href={LINK_NEMO_EVALUATOR_DOCS} target="_blank" rel="noreferrer">
+                  <File className="!text-brand" />
+                  <Text className="flex-1">NeMo Evaluator docs — learn more</Text>
+                  <ChevronRight />
+                </a>
+              </Button>
             </Stack>
           ) : (
             <ControlledSelect

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -26,7 +26,7 @@ import {
   useListEvaluations,
   useListExperiments,
 } from '@nemo/sdk/generated/platform/api';
-import { SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
+import { Anchor, SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
 import { fetchSampleText } from '@studio/api/agents/fetchSampleText';
 import { submitAgentEvalJob } from '@studio/api/evaluation/agent-evaluations';
 import { isConflictError, type EvalSeedFile } from '@studio/api/evaluation/eval-config-fileset';
@@ -574,7 +574,17 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
         <Stack gap="density-xl">
           {agentProp ? (
             <Stack gap="density-xs">
-              <Text kind="body/semibold/lg">{agentProp}</Text>
+              <Text kind="body/regular/sm">
+                Run evaluation via NeMo evaluator&apos;s built in runner. Evaluator supports
+                Harbor and Gym runners as well.{' '}
+                <Anchor
+                  href="https://docs.nvidia.com/nemo/evaluator/nightly"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Learn more
+                </Anchor>
+              </Text>
               {deploymentError && (
                 <Text kind="body/regular/sm" className="text-[var(--text-color-feedback-danger)]">
                   {deploymentError}

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -25,7 +25,7 @@ import {
   useListEvaluations,
   useListExperiments,
 } from '@nemo/sdk/generated/platform/api';
-import { Button, SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
+import { Anchor, SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
 import { fetchSampleText } from '@studio/api/agents/fetchSampleText';
 import { submitAgentEvalJob } from '@studio/api/evaluation/agent-evaluations';
 import { isConflictError, type EvalSeedFile } from '@studio/api/evaluation/eval-config-fileset';
@@ -56,7 +56,6 @@ import { DATASET_EVAL_CONFIG_KEY, getEvalConfigSample } from '@studio/constants/
 import { useJudgeModels } from '@studio/hooks/evaluation/useJudgeModels';
 import { getAgentEvaluationsTabRoute } from '@studio/routes/utils';
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { ChevronRight, File } from 'lucide-react';
 import { type FC, useEffect, useRef, useState } from 'react';
 import { FormProvider, type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -542,25 +541,20 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       <FormProvider {...methods}>
         <Stack gap="density-xl">
           {agentProp ? (
-            <Stack gap="density-md">
-              <Text kind="body/regular/md">
-                Run evaluation via NeMo evaluator&apos;s built in runner. Evaluator supports Harbor
-                and Gym runners as well.
-              </Text>
-              <Button
-                asChild
-                color="neutral"
-                kind="tertiary"
-                size="small"
-                className="w-full justify-start"
+            <Text kind="body/regular/md">
+              Run evaluation via NeMo Evaluator&apos;s built in runner. Evaluator also supports
+              Harbor and Gym as runners.{' '}
+              <Anchor
+                kind="inline"
+                textKind="body/regular/md"
+                href={LINK_EVAL_DOCS_NEMO_EVALUATOR}
+                target="_blank"
+                rel="noreferrer"
               >
-                <a href={LINK_EVAL_DOCS_NEMO_EVALUATOR} target="_blank" rel="noreferrer">
-                  <File className="!text-brand" />
-                  <Text className="flex-1">NeMo Evaluator docs — learn more</Text>
-                  <ChevronRight />
-                </a>
-              </Button>
-            </Stack>
+                Learn more
+              </Anchor>
+              .
+            </Text>
           ) : (
             <ControlledSelect
               useControllerProps={{ control, name: 'agent' }}

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -51,7 +51,7 @@ import {
   MODE_EXPERIMENT,
   parseEvalConfig,
 } from '@studio/components/evaluation/submitEvaluationJob';
-import { LINK_EVAL_DOCS_NEMO_EVALUATOR } from '@studio/constants/links';
+import { LINK_EVAL_DOCS } from '@studio/constants/links';
 import { DATASET_EVAL_CONFIG_KEY, getEvalConfigSample } from '@studio/constants/sampleAgents';
 import { useJudgeModels } from '@studio/hooks/evaluation/useJudgeModels';
 import { getAgentEvaluationsTabRoute } from '@studio/routes/utils';
@@ -542,12 +542,12 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
         <Stack gap="density-xl">
           {agentProp ? (
             <Text kind="body/regular/md">
-              Run evaluation via NeMo Evaluator&apos;s built in runner. Evaluator also supports
+              Run evaluation via NeMo Evaluator&apos;s built-in runner. Evaluator also supports
               Harbor and Gym as runners.{' '}
               <Anchor
                 kind="inline"
                 textKind="body/regular/md"
-                href={LINK_EVAL_DOCS_NEMO_EVALUATOR}
+                href={LINK_EVAL_DOCS}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -544,8 +544,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
           {agentProp ? (
             <Stack gap="density-md">
               <Text kind="body/regular/md">
-                Run evaluation via NeMo evaluator&apos;s built in runner. Evaluator supports
-                Harbor and Gym runners as well.
+                Run evaluation via NeMo evaluator&apos;s built in runner. Evaluator supports Harbor
+                and Gym runners as well.
               </Text>
               <Button
                 asChild

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -51,7 +51,7 @@ import {
   MODE_EXPERIMENT,
   parseEvalConfig,
 } from '@studio/components/evaluation/submitEvaluationJob';
-import { LINK_NEMO_EVALUATOR_DOCS } from '@studio/constants/links';
+import { LINK_EVAL_DOCS_NEMO_EVALUATOR } from '@studio/constants/links';
 import { DATASET_EVAL_CONFIG_KEY, getEvalConfigSample } from '@studio/constants/sampleAgents';
 import { useJudgeModels } from '@studio/hooks/evaluation/useJudgeModels';
 import { getAgentEvaluationsTabRoute } from '@studio/routes/utils';
@@ -554,7 +554,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                 size="small"
                 className="w-full justify-start"
               >
-                <a href={LINK_NEMO_EVALUATOR_DOCS} target="_blank" rel="noreferrer">
+                <a href={LINK_EVAL_DOCS_NEMO_EVALUATOR} target="_blank" rel="noreferrer">
                   <File className="!text-brand" />
                   <Text className="flex-1">NeMo Evaluator docs — learn more</Text>
                   <ChevronRight />

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -46,7 +46,9 @@ export const LINK_EVAL_DOCS_METRICS = `${DOCS_BASE_URL}evaluate-models/metrics`;
 export const LINK_EVAL_DOCS_APPROACHES = `${DOCS_BASE_URL}evaluate-models/dataset-driven-vs-task-driven-evaluation`;
 export const LINK_EVAL_DOCS_BENCHMARKS = `${DOCS_BASE_URL}evaluate-models`;
 export const LINK_EVAL_DOCS_BENCHMARKS_INDUSTRY = `${DOCS_BASE_URL}evaluate-models`;
-export const LINK_NEMO_EVALUATOR_DOCS = 'https://docs.nvidia.com/nemo/evaluator/nightly';
+// NeMo Evaluator's own docs site — intentionally not DOCS_BASE_URL (platform docs); the
+// built-in-runner / Harbor / Gym details this links to live in the standalone Evaluator docs.
+export const LINK_EVAL_DOCS_NEMO_EVALUATOR = 'https://docs.nvidia.com/nemo/evaluator/nightly';
 
 // Jobs documentation links
 export const LINK_DOCS_JOBS = `${DOCS_BASE_URL}studio#jobs`;

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -46,9 +46,9 @@ export const LINK_EVAL_DOCS_METRICS = `${DOCS_BASE_URL}evaluate-models/metrics`;
 export const LINK_EVAL_DOCS_APPROACHES = `${DOCS_BASE_URL}evaluate-models/dataset-driven-vs-task-driven-evaluation`;
 export const LINK_EVAL_DOCS_BENCHMARKS = `${DOCS_BASE_URL}evaluate-models`;
 export const LINK_EVAL_DOCS_BENCHMARKS_INDUSTRY = `${DOCS_BASE_URL}evaluate-models`;
-// NeMo Evaluator's own docs site — intentionally not DOCS_BASE_URL (platform docs); the
-// built-in-runner / Harbor / Gym details this links to live in the standalone Evaluator docs.
-export const LINK_EVAL_DOCS_NEMO_EVALUATOR = 'https://docs.nvidia.com/nemo/evaluator/nightly';
+// Base evaluation docs landing. (The Gym runner named in the eval modal copy is not yet
+// documented in platform docs — only Harbor is — so this page lags the copy pending a docs update.)
+export const LINK_EVAL_DOCS = `${DOCS_BASE_URL}evaluate-models`;
 
 // Jobs documentation links
 export const LINK_DOCS_JOBS = `${DOCS_BASE_URL}studio#jobs`;

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -46,8 +46,6 @@ export const LINK_EVAL_DOCS_METRICS = `${DOCS_BASE_URL}evaluate-models/metrics`;
 export const LINK_EVAL_DOCS_APPROACHES = `${DOCS_BASE_URL}evaluate-models/dataset-driven-vs-task-driven-evaluation`;
 export const LINK_EVAL_DOCS_BENCHMARKS = `${DOCS_BASE_URL}evaluate-models`;
 export const LINK_EVAL_DOCS_BENCHMARKS_INDUSTRY = `${DOCS_BASE_URL}evaluate-models`;
-// Base evaluation docs landing. (The Gym runner named in the eval modal copy is not yet
-// documented in platform docs — only Harbor is — so this page lags the copy pending a docs update.)
 export const LINK_EVAL_DOCS = `${DOCS_BASE_URL}evaluate-models`;
 
 // Jobs documentation links

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -46,6 +46,7 @@ export const LINK_EVAL_DOCS_METRICS = `${DOCS_BASE_URL}evaluate-models/metrics`;
 export const LINK_EVAL_DOCS_APPROACHES = `${DOCS_BASE_URL}evaluate-models/dataset-driven-vs-task-driven-evaluation`;
 export const LINK_EVAL_DOCS_BENCHMARKS = `${DOCS_BASE_URL}evaluate-models`;
 export const LINK_EVAL_DOCS_BENCHMARKS_INDUSTRY = `${DOCS_BASE_URL}evaluate-models`;
+export const LINK_NEMO_EVALUATOR_DOCS = 'https://docs.nvidia.com/nemo/evaluator/nightly';
 
 // Jobs documentation links
 export const LINK_DOCS_JOBS = `${DOCS_BASE_URL}studio#jobs`;


### PR DESCRIPTION
<img width="1780" height="1103" alt="Screenshot 2026-08-20 at 14 50 44" src="https://github.com/user-attachments/assets/8a0ebbcf-de81-41e7-b3dc-7fabd5543bfb" />

## Summary

Two changes to the Run Agent Evaluation modal (opened from an agent page):

1. **Describe how evals run.** Replaces the duplicative agent-name header (the agent is already the page context) with a sentence — "Run evaluation via NeMo evaluator's built in runner. Evaluator supports Harbor and Gym runners as well." — followed by the standard full-width docs button linking to the NeMo evaluator docs.
2. **Drop the deployment gate.** Removes the "no active deployment" warning and the deployment-verification gate on the Submit button. It was a false-positive precaution: users can run platform-supported evals against custom (non-fabric, non-platform-deployed) agents, so a missing running deployment must not block submission.

## Changes

- `SubmitEvaluationModal.tsx`:
  - Locked-agent (`agentProp`) branch: replace `<Text>{agentProp}</Text>` with a `body/regular/md` runner description + a full-width tertiary docs `Button` (File icon + `ChevronRight`) to `LINK_NEMO_EVALUATOR_DOCS`, matching the `EvaluationSessionsDataView/Empty.tsx` pattern.
  - Remove the deployment-verification query (`useAgentsListDeployments`), derived state (`deploymentVerified`, `deploymentError`, `hasRunningDeployment`), the `NO_DEPLOYMENT_MESSAGE` / `DEPLOYMENT_CHECK_FAILED_MESSAGE` constants, and the `runningDeploymentsQuery` helper.
  - Submit gate is now `submitDisabled={!canRunSelectedEvaluation}` (was `!deploymentVerified || !canRunSelectedEvaluation`).
  - Drop the now-unused `useAgentsListDeployments` / `AgentsListDeploymentsParams` imports.
  - No change to the agent-picker (`ControlledSelect`) branch used when opened without a locked agent.
- `constants/links.ts`: add `LINK_NEMO_EVALUATOR_DOCS = 'https://docs.nvidia.com/nemo/evaluator/nightly'`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: modal header copy/link + removal of a client-side gate; no test asserted the deployment gate. Full Studio suite (317 files / 2946 tests) passes unchanged.
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: in-product copy linking to existing evaluator docs; no docs surface to update.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui run check` (eslint `--max-warnings 0`, `tsc --noEmit`, vitest) → lint 0 warnings, typecheck 0 errors, **2946/2946 tests pass**. This is the suite `studio-ci` enforces for a Studio-only change.
- Live check against the running platform (Studio dev server, chrome-devtools): opened the modal from an agent with **zero running deployments** (`email-security-triage-bcf59v`) → no deployment warning, **Submit enabled** (previously `!deploymentVerified` disabled it), runner description renders at normal size, and the full-width docs button links to `https://docs.nvidia.com/nemo/evaluator/nightly`.
- `uv run pre-commit run -a` not run: whole-repo Python gate (ruff/ty/helm-docs) irrelevant to Studio `.tsx`/`.ts` changes; DCO and merge-conflict pre-commit hooks ran on commit and passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Evaluation submissions are no longer blocked when a running deployment is unavailable or cannot be verified.
  - The submission dialog now displays runner information and provides a direct link to evaluation guidance.
  - Users can continue with evaluations while reviewing runner requirements as needed.

- **Documentation**
  - Added access to platform documentation covering evaluation workflows and available runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->