### PR TITLE
fix(agents): return OpenAI-shaped errors from the gateway proxy

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -20,6 +20,10 @@ used by the Inference Gateway.
 
 Streaming and SSE are supported: the response is streamed back to the client
 chunk by chunk.  ``text/event-stream`` responses bypass buffering.
+
+Failures under the OpenAI-compatible ``/-/v1/*`` surface are rendered with an
+OpenAI ``error`` envelope beside FastAPI's ``detail`` (see ``openai_errors``);
+every other proxied path keeps ``detail`` alone.
 """
 
 from __future__ import annotations
@@ -31,10 +35,15 @@ from typing import AsyncIterator
 from urllib.parse import urljoin, urlparse, urlunparse
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import StreamingResponse
 from nemo_agents_plugin.api.v2._perms import GatewayPerms
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
+from nemo_agents_plugin.api.v2.openai_errors import (
+    UpstreamAgentError,
+    is_openai_compatible_uri,
+    openai_error_response,
+)
 from nemo_agents_plugin.authz import scope
 from nemo_agents_plugin.deployment_routing import get_deployment_endpoint, is_deployment_routable
 from nemo_agents_plugin.entities import Agent, AgentDeployment, AgentSession, SessionStatus
@@ -107,13 +116,29 @@ async def _serve_agent_proxy(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient,
-) -> StreamingResponse:
+) -> Response:
     """Resolve the target deployment for the named agent and forward the request to it.
 
     A persisted session makes its bound deployment authoritative. Without a session, this keeps
     the existing first-routable-deployment behavior. Shared by the read/write route handlers,
     which differ only in their authorization scope (``agents:read`` vs ``agents:write``).
     """
+    try:
+        return await _resolve_and_proxy_agent(workspace, name, trailing_uri, request, entity_client)
+    except HTTPException as exc:
+        if not is_openai_compatible_uri(trailing_uri):
+            raise
+        return openai_error_response(exc)
+
+
+async def _resolve_and_proxy_agent(
+    workspace: str,
+    name: str,
+    trailing_uri: str,
+    request: Request,
+    entity_client: NemoEntitiesClient,
+) -> StreamingResponse:
+    """Pick the deployment for *name* — session-bound if one was supplied — and forward."""
     session = await _resolve_request_session(request, workspace, entity_client)
     if session is None:
         deployment = await _resolve_agent_deployment(name, workspace, entity_client)
@@ -151,7 +176,7 @@ async def proxy_by_agent_name_read(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
-) -> StreamingResponse:
+) -> Response:
     """Read-scoped (GET/HEAD/OPTIONS) proxy to the active deployment for *agent name*."""
     return await _serve_agent_proxy(workspace, name, trailing_uri, request, entity_client)
 
@@ -173,7 +198,7 @@ async def proxy_by_agent_name_write(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
-) -> StreamingResponse:
+) -> Response:
     """Write-scoped (POST/PUT/PATCH/DELETE) proxy to the active deployment for *agent name*."""
     return await _serve_agent_proxy(workspace, name, trailing_uri, request, entity_client)
 
@@ -184,12 +209,28 @@ async def _serve_deployment_proxy(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient,
-) -> StreamingResponse:
+) -> Response:
     """Proxy a request directly to the named deployment.
 
     Returns ``404`` if the deployment doesn't exist, ``503`` if it isn't currently running.
     Shared by the read/write route handlers, which differ only in authorization scope.
     """
+    try:
+        return await _resolve_and_proxy_deployment(workspace, name, trailing_uri, request, entity_client)
+    except HTTPException as exc:
+        if not is_openai_compatible_uri(trailing_uri):
+            raise
+        return openai_error_response(exc)
+
+
+async def _resolve_and_proxy_deployment(
+    workspace: str,
+    name: str,
+    trailing_uri: str,
+    request: Request,
+    entity_client: NemoEntitiesClient,
+) -> StreamingResponse:
+    """Look the deployment up, check it against any supplied session, and forward."""
     try:
         dep = await entity_client.get(AgentDeployment, name=name, workspace=workspace)
     except NemoEntityNotFoundError as exc:
@@ -267,7 +308,7 @@ async def proxy_by_deployment_name_read(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
-) -> StreamingResponse:
+) -> Response:
     """Read-scoped (GET/HEAD/OPTIONS) proxy directly to the named deployment."""
     return await _serve_deployment_proxy(workspace, name, trailing_uri, request, entity_client)
 
@@ -289,7 +330,7 @@ async def proxy_by_deployment_name_write(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
-) -> StreamingResponse:
+) -> Response:
     """Write-scoped (POST/PUT/PATCH/DELETE) proxy directly to the named deployment."""
     return await _serve_deployment_proxy(workspace, name, trailing_uri, request, entity_client)
 
@@ -479,11 +520,7 @@ async def _proxy(
                 # aread() consumes the full body before raising so the connection
                 # is cleanly closed rather than reset mid-stream.
                 if response.status_code >= 500:
-                    error_body = await response.aread()
-                    raise HTTPException(
-                        status_code=502,
-                        detail=(f"Agent returned {response.status_code}: {error_body.decode(errors='replace')[:500]}"),
-                    )
+                    raise UpstreamAgentError(response.status_code, await response.aread())
                 async for chunk in response.aiter_bytes():
                     yield chunk
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -41,6 +41,7 @@ from nemo_agents_plugin.api.v2._perms import GatewayPerms
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.api.v2.openai_errors import (
     UpstreamAgentError,
+    augment_upstream_error_body,
     is_openai_compatible_uri,
     openai_error_response,
 )
@@ -457,7 +458,10 @@ async def _proxy(
     """Forward *request* to ``{endpoint}/{trailing_uri}`` and stream the response.
 
     Error handling policy:
-    - **4xx** from the agent: transparent pass-through (client error, agent's response).
+    - **4xx** from the agent: status and body passed through (client error, agent's
+      response). On the OpenAI-compatible surface a body that no OpenAI client could
+      read gains an ``error`` envelope beside its existing keys; one that already
+      carries ``error.message`` is forwarded untouched.
     - **5xx** from the agent: translated to **502 Bad Gateway** (upstream fault).
     - **Connection failure** (httpx.RequestError): 502 Bad Gateway.
 
@@ -521,6 +525,15 @@ async def _proxy(
                 # is cleanly closed rather than reset mid-stream.
                 if response.status_code >= 500:
                     raise UpstreamAgentError(response.status_code, await response.aread())
+                if response.status_code >= 400 and is_openai_compatible_uri(trailing_uri):
+                    error_body = await response.aread()
+                    reshaped = augment_upstream_error_body(error_body, response.status_code)
+                    if reshaped is None:
+                        yield error_body
+                    else:
+                        response_headers["content-type"] = "application/json"
+                        yield reshaped
+                    return
                 async for chunk in response.aiter_bytes():
                     yield chunk
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/openai_errors.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/openai_errors.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI-shaped error envelopes for the gateway's OpenAI-compatible surface.
+
+Requests proxied under ``/-/v1/*`` are advertised as OpenAI-compatible, and clients
+reach them with the official OpenAI SDKs. Those SDKs read an error body **only**
+through its ``error`` key — the Node SDK's ``APIError.generate`` inspects
+``body["error"]`` and reports ``"<status> status code (no body)"`` when it is absent —
+so FastAPI's ``{"detail": ...}`` arrives as a bare status line with the real message
+discarded before any client code can see it.
+
+Error responses on that surface therefore carry **both** keys: ``error`` for the
+OpenAI contract and ``detail`` for existing readers of the FastAPI shape. OpenAI
+clients ignore unknown top-level keys, so one body serves both. Proxied paths
+outside ``/-/v1/*`` and the CRUD routes are untouched and stay ``detail``-only.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+# Bound the response: upstream bodies can be arbitrarily large.
+UPSTREAM_BODY_MAX_CHARS = 500
+
+_OPENAI_COMPATIBLE_PREFIX = "v1"
+
+# Error codes reach us inside the message text, not as a field: an adapter raises
+# ``AdapterRelayError("claude_relay_unavailable", "...")``, whose rendering is
+# "... failed (claude_relay_unavailable): NeMo Relay CLI executable was not found".
+_EMBEDDED_CODE_PATTERN = re.compile(r"\(([a-z][a-z0-9_]*)\)\s*:")
+
+_ERROR_TYPE_BY_STATUS = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    409: "conflict_error",
+    429: "rate_limit_error",
+}
+
+UPSTREAM_ERROR_TYPE = "upstream_error"
+
+
+def is_openai_compatible_uri(trailing_uri: str) -> bool:
+    """Whether *trailing_uri* addresses the OpenAI-compatible surface (``/-/v1/...``)."""
+    head, _, _ = trailing_uri.lstrip("/").partition("/")
+    return head == _OPENAI_COMPATIBLE_PREFIX
+
+
+def openai_error_body(message: str, *, error_type: str, code: str | None = None) -> dict[str, Any]:
+    """Build the OpenAI error envelope. ``param`` is always null; we never fault a field."""
+    return {"error": {"message": message, "type": error_type, "code": code, "param": None}}
+
+
+def unwrap_upstream_error(body: bytes) -> tuple[str, str | None]:
+    """Lift a human message and a machine code out of an upstream agent's error body.
+
+    Agent servers are FastAPI too, so the body is normally ``{"detail": "..."}``; one
+    that is already OpenAI-shaped is read directly. Falls back to the decoded text when
+    the body is not JSON, or is JSON carrying none of the fields we recognize. The
+    returned message is truncated; the caller can embed it without further bounding.
+    """
+    text = body.decode(errors="replace")
+    try:
+        parsed: Any = json.loads(text)
+    except ValueError:
+        return _truncate(text), None
+
+    message: str | None = None
+    code: str | None = None
+
+    if isinstance(parsed, dict):
+        error = parsed.get("error")
+        if isinstance(error, dict):
+            message = _first_str(error, "message", "detail")
+            code = _first_str(error, "code")
+        elif isinstance(error, str):
+            message = error or None
+        if message is None:
+            message = _first_str(parsed, "detail", "message")
+        if code is None:
+            code = _first_str(parsed, "code")
+    elif isinstance(parsed, str):
+        message = parsed or None
+
+    if message is None:
+        message = text
+    return _truncate(message), code or _embedded_code(message)
+
+
+class UpstreamAgentError(HTTPException):
+    """A proxied agent returned 5xx; the gateway reports 502 Bad Gateway.
+
+    Carries the unwrapped upstream message and code alongside the status so the
+    OpenAI-compatible surface can render them without re-parsing ``detail``, which
+    keeps its historical wrapped form for readers of the FastAPI shape.
+    """
+
+    def __init__(self, upstream_status: int, body: bytes) -> None:
+        self.upstream_status = upstream_status
+        self.openai_message, self.openai_code = unwrap_upstream_error(body)
+        super().__init__(
+            status_code=502,
+            detail=f"Agent returned {upstream_status}: {_truncate(body.decode(errors='replace'))}",
+        )
+
+
+def openai_error_response(exc: HTTPException) -> JSONResponse:
+    """Render *exc* with the OpenAI ``error`` envelope and FastAPI's ``detail`` side by side."""
+    if isinstance(exc, UpstreamAgentError):
+        message, code, error_type = exc.openai_message, exc.openai_code, UPSTREAM_ERROR_TYPE
+    else:
+        message, code, error_type = _detail_message(exc.detail), None, _error_type(exc.status_code)
+
+    content = openai_error_body(message, error_type=error_type, code=code)
+    content["detail"] = exc.detail
+    return JSONResponse(status_code=exc.status_code, content=content, headers=exc.headers)
+
+
+def _error_type(status_code: int) -> str:
+    if (known := _ERROR_TYPE_BY_STATUS.get(status_code)) is not None:
+        return known
+    return "invalid_request_error" if status_code < 500 else "server_error"
+
+
+def _detail_message(detail: Any) -> str:
+    return detail if isinstance(detail, str) else json.dumps(detail, default=str)
+
+
+def _first_str(mapping: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _embedded_code(message: str) -> str | None:
+    match = _EMBEDDED_CODE_PATTERN.search(message)
+    return match.group(1) if match else None
+
+
+def _truncate(text: str) -> str:
+    return text[:UPSTREAM_BODY_MAX_CHARS]

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/openai_errors.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/openai_errors.py
@@ -83,7 +83,7 @@ def unwrap_upstream_error(body: bytes) -> tuple[str, str | None]:
         elif isinstance(error, str):
             message = error or None
         if message is None:
-            message = _first_str(parsed, "detail", "message")
+            message = _first_str(parsed, "detail", "message") or _validation_message(parsed.get("detail"))
         if code is None:
             code = _first_str(parsed, "code")
     elif isinstance(parsed, str):
@@ -92,6 +92,42 @@ def unwrap_upstream_error(body: bytes) -> tuple[str, str | None]:
     if message is None:
         message = text
     return _truncate(message), code or _embedded_code(message)
+
+
+def augment_upstream_error_body(body: bytes, status_code: int) -> bytes | None:
+    """Give an upstream error body an OpenAI ``error`` envelope it is missing.
+
+    Returns ``None`` when the body already carries a usable ``error.message`` and so must
+    be forwarded byte for byte — an agent may itself be an OpenAI-compatible server, and
+    reshaping its envelope would discard the ``type``/``code`` it chose.
+
+    A JSON object keeps every key it arrived with and gains ``error`` beside them, so
+    readers of the upstream shape are unaffected. Any other body is replaced by the
+    envelope alone, with its text carried in ``error.message`` rather than dropped.
+    """
+    try:
+        parsed: Any = json.loads(body.decode(errors="replace"))
+    except ValueError:
+        parsed = None
+
+    if isinstance(parsed, dict) and _has_usable_error(parsed):
+        return None
+
+    message, code = unwrap_upstream_error(body)
+    envelope = openai_error_body(message, error_type=_error_type(status_code), code=code)
+    if isinstance(parsed, dict):
+        return json.dumps({**parsed, **envelope}).encode()
+    return json.dumps(envelope).encode()
+
+
+def _has_usable_error(parsed: dict[str, Any]) -> bool:
+    """Whether an OpenAI client could read a message out of this body.
+
+    Mirrors what the SDKs actually do — the Node client reads ``body.error?.message``
+    and reports "no body" for anything else, so ``error`` alone is not enough.
+    """
+    error = parsed.get("error")
+    return isinstance(error, dict) and bool(_first_str(error, "message"))
 
 
 class UpstreamAgentError(HTTPException):
@@ -131,6 +167,26 @@ def _error_type(status_code: int) -> str:
 
 def _detail_message(detail: Any) -> str:
     return detail if isinstance(detail, str) else json.dumps(detail, default=str)
+
+
+def _validation_message(detail: Any) -> str | None:
+    """Render FastAPI's ``{"detail": [{"loc": [...], "msg": ...}]}`` as one line.
+
+    Agent servers are FastAPI, so a malformed request comes back as a list of
+    validation errors — the most common 4xx on this surface, and unreadable to a
+    user as raw JSON.
+    """
+    if not isinstance(detail, list):
+        return None
+
+    parts: list[str] = []
+    for item in detail:
+        if not isinstance(item, dict) or (msg := _first_str(item, "msg", "message")) is None:
+            continue
+        loc = item.get("loc")
+        where = ".".join(str(x) for x in loc) if isinstance(loc, list) and loc else None
+        parts.append(f"{where}: {msg}" if where else msg)
+    return "; ".join(parts) or None
 
 
 def _first_str(mapping: dict[str, Any], *keys: str) -> str | None:

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -1032,14 +1032,103 @@ class TestOpenAICompatibleErrors:
         assert resp.status_code == 200
         assert resp.content == upstream_body
 
-    def test_4xx_from_agent_is_still_transparent(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
-        """4xx bodies are the agent's own response and must pass through unshaped."""
+    def test_upstream_4xx_keeps_its_status_and_gains_an_envelope(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        """A 4xx body no OpenAI client could read is augmented, not passed through blind."""
         mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
         httpx_mock = _make_httpx_mock(422, b'{"detail": "invalid input"}')
 
         with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
             resp = client.post(
                 "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 422
+        body = resp.json()
+        assert body["detail"] == "invalid input"
+        assert body["error"] == {
+            "message": "invalid input",
+            "type": "invalid_request_error",
+            "code": None,
+            "param": None,
+        }
+
+    def test_unknown_session_404_reaches_the_client(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """The agent server 404s an unknown session (fabric/server.py); the reason must survive."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        detail = "Fabric session 'abc' was not found."
+        httpx_mock = _make_httpx_mock(404, json.dumps({"detail": detail}).encode())
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 404
+        assert resp.json()["error"]["message"] == detail
+        assert resp.json()["error"]["type"] == "not_found_error"
+
+    def test_upstream_validation_error_list_is_enveloped(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        """FastAPI puts a list on ``detail`` for a 422; the list is kept and a message derived."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        upstream = json.dumps({"detail": [{"loc": ["body"], "msg": "field required"}]}).encode()
+        httpx_mock = _make_httpx_mock(422, upstream)
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        body = resp.json()
+        assert body["detail"] == [{"loc": ["body"], "msg": "field required"}]
+        assert body["error"]["message"] == "body: field required"
+
+    def test_openai_shaped_4xx_is_forwarded_untouched(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """An agent that already speaks OpenAI keeps the type and code it chose."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        upstream = json.dumps(
+            {"error": {"message": "bad key", "type": "authentication_error", "code": "invalid_api_key"}}
+        ).encode()
+        httpx_mock = _make_httpx_mock(401, upstream)
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 401
+        assert resp.content == upstream
+
+    def test_non_json_4xx_is_enveloped(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        httpx_mock = _make_httpx_mock(400, b"Bad Request", content_type="text/plain")
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 400
+        assert resp.headers["content-type"].startswith("application/json")
+        assert resp.json()["error"]["message"] == "Bad Request"
+
+    def test_non_openai_path_4xx_is_passed_through_verbatim(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        httpx_mock = _make_httpx_mock(422, b'{"detail": "invalid input"}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/health",
                 json={},
             )
 
@@ -1068,9 +1157,23 @@ class TestUnwrapUpstreamError:
     def test_unrecognized_json_falls_back_to_raw_text(self) -> None:
         assert openai_errors.unwrap_upstream_error(b'{"nope": 1}') == ('{"nope": 1}', None)
 
-    def test_list_detail_falls_back_to_raw_text(self) -> None:
-        """FastAPI validation errors put a list on ``detail``; the raw body is more useful."""
-        body = b'{"detail": [{"loc": ["body"], "msg": "field required"}]}'
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            (b'{"detail": [{"loc": ["body"], "msg": "field required"}]}', "body: field required"),
+            (
+                b'{"detail": [{"loc": ["body", "messages", 0], "msg": "bad"}, {"loc": ["query"], "msg": "nope"}]}',
+                "body.messages.0: bad; query: nope",
+            ),
+            (b'{"detail": [{"msg": "no location"}]}', "no location"),
+        ],
+    )
+    def test_validation_error_list_is_rendered_readably(self, body: bytes, expected: str) -> None:
+        """FastAPI validation errors are the most common 4xx here; raw JSON is unreadable."""
+        assert openai_errors.unwrap_upstream_error(body)[0] == expected
+
+    def test_unrenderable_detail_list_falls_back_to_raw_text(self) -> None:
+        body = b'{"detail": [1, 2]}'
         message, code = openai_errors.unwrap_upstream_error(body)
         assert message == body.decode()
         assert code is None
@@ -1079,6 +1182,39 @@ class TestUnwrapUpstreamError:
         message, code = openai_errors.unwrap_upstream_error(b"\xff\xfe not utf-8")
         assert "not utf-8" in message
         assert code is None
+
+
+class TestAugmentUpstreamErrorBody:
+    def test_existing_keys_are_preserved(self) -> None:
+        out = openai_errors.augment_upstream_error_body(b'{"detail": "boom", "trace": "t"}', 404)
+        assert out is not None
+        assert json.loads(out)["detail"] == "boom"
+        assert json.loads(out)["trace"] == "t"
+
+    def test_usable_openai_body_is_left_alone(self) -> None:
+        body = b'{"error": {"message": "boom", "type": "x", "code": "y"}}'
+        assert openai_errors.augment_upstream_error_body(body, 400) is None
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            b'{"error": {"code": "y"}}',
+            b'{"error": {"message": ""}}',
+            b'{"error": "boom"}',
+        ],
+    )
+    def test_unusable_error_key_is_replaced(self, body: bytes) -> None:
+        """``error`` alone is not enough — the SDK reads ``error.message`` or reports no body."""
+        out = openai_errors.augment_upstream_error_body(body, 400)
+        assert out is not None
+        assert json.loads(out)["error"]["message"]
+
+    def test_non_json_body_text_is_carried_in_the_message(self) -> None:
+        out = openai_errors.augment_upstream_error_body(b"Bad Request", 400)
+        assert out is not None
+        assert json.loads(out) == {
+            "error": {"message": "Bad Request", "type": "invalid_request_error", "code": None, "param": None}
+        }
 
 
 class TestIsOpenAICompatibleURI:

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -30,6 +30,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from nemo_agents_plugin.api.v2 import gateway as gateway_module
+from nemo_agents_plugin.api.v2 import openai_errors
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.entities import (
     Agent,
@@ -834,3 +835,264 @@ class TestContainerModeByAgentName:
         )
 
         assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-shaped errors on the /-/v1/* surface
+# ---------------------------------------------------------------------------
+
+
+RELAY_FAILURE_DETAIL = (
+    "Fabric runtime startup failed: adapter lifecycle start failed "
+    "(claude_relay_unavailable): NeMo Relay CLI executable was not found"
+)
+
+
+class TestOpenAICompatibleErrors:
+    def test_upstream_detail_is_lifted_into_error_message(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        """A FastAPI-shaped upstream body is unwrapped, not embedded as a JSON string."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        httpx_mock = _make_httpx_mock(503, b'{"detail": "boom"}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 502
+        assert resp.json()["error"] == {
+            "message": "boom",
+            "type": "upstream_error",
+            "code": None,
+            "param": None,
+        }
+
+    def test_adapter_error_code_is_preserved(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """The motivating case: the relay message and its code both reach the client."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        httpx_mock = _make_httpx_mock(503, json.dumps({"detail": RELAY_FAILURE_DETAIL}).encode())
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        error = resp.json()["error"]
+        assert error["message"] == RELAY_FAILURE_DETAIL
+        assert error["code"] == "claude_relay_unavailable"
+        assert "NeMo Relay CLI executable was not found" in error["message"]
+
+    def test_openai_shaped_upstream_body_passes_through(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        """An upstream that already speaks OpenAI is read directly rather than re-wrapped."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        upstream = json.dumps({"error": {"message": "rate limited", "code": "slow_down"}}).encode()
+        httpx_mock = _make_httpx_mock(500, upstream)
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.json()["error"]["message"] == "rate limited"
+        assert resp.json()["error"]["code"] == "slow_down"
+
+    def test_non_json_upstream_body_still_yields_an_envelope(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        httpx_mock = _make_httpx_mock(500, b"Internal server error in agent")
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 502
+        assert resp.json()["error"]["message"] == "Internal server error in agent"
+        assert resp.json()["error"]["type"] == "upstream_error"
+
+    def test_oversized_upstream_body_is_truncated(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """The 500-char cap bounds the envelope, not just the legacy detail string."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        long_detail = "x" * 5000
+        httpx_mock = _make_httpx_mock(500, json.dumps({"detail": long_detail}).encode())
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.json()["error"]["message"] == "x" * openai_errors.UPSTREAM_BODY_MAX_CHARS
+
+    def test_gateway_side_failure_is_also_enveloped(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """Errors raised before the request leaves the gateway get an envelope too."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="starting", endpoint=""))
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+            json={},
+        )
+
+        assert resp.status_code == 503
+        error = resp.json()["error"]
+        assert "not routable" in error["message"].lower()
+        assert error["type"] == "server_error"
+
+    def test_connection_failure_is_enveloped(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        client_cm = MagicMock()
+        client_cm.__aenter__ = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        client_cm.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=client_cm):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 502
+        assert "Could not connect" in resp.json()["error"]["message"]
+
+    def test_not_found_is_enveloped_with_a_typed_error(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        mock_entity_client.get = AsyncMock(side_effect=NemoEntityNotFoundError("not found"))
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments/nonexistent/-/v1/chat/completions",
+            json={},
+        )
+
+        assert resp.status_code == 404
+        assert resp.json()["error"]["type"] == "not_found_error"
+
+    def test_agent_name_route_is_enveloped(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """The by-agent-name surface is OpenAI-compatible under /-/v1/* too."""
+        mock_entity_client.get = AsyncMock(return_value=_make_agent("calc"))
+        mock_entity_client.list = AsyncMock(return_value=_list_response([]))
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+            json={},
+        )
+
+        assert resp.status_code == 503
+        assert "No running deployment" in resp.json()["error"]["message"]
+
+    def test_detail_is_retained_for_backwards_compatibility(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        """Existing readers of the FastAPI shape keep working: both keys are present."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        httpx_mock = _make_httpx_mock(503, b'{"detail": "boom"}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        body = resp.json()
+        assert body["detail"] == 'Agent returned 503: {"detail": "boom"}'
+        assert body["error"]["message"] == "boom"
+
+    def test_non_openai_path_keeps_detail_only(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """Only the /-/v1/* surface changes shape."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        httpx_mock = _make_httpx_mock(503, b'{"detail": "boom"}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/health",
+                json={},
+            )
+
+        assert resp.status_code == 502
+        assert resp.json() == {"detail": 'Agent returned 503: {"detail": "boom"}'}
+
+    def test_2xx_response_is_untouched(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """Envelope shaping must not disturb the success path."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        upstream_body = b'{"id": "chatcmpl-1", "model": "calc-dep"}'
+        httpx_mock = _make_httpx_mock(200, upstream_body)
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 200
+        assert resp.content == upstream_body
+
+    def test_4xx_from_agent_is_still_transparent(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
+        """4xx bodies are the agent's own response and must pass through unshaped."""
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(status="running"))
+        httpx_mock = _make_httpx_mock(422, b'{"detail": "invalid input"}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            resp = client.post(
+                "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/v1/chat/completions",
+                json={},
+            )
+
+        assert resp.status_code == 422
+        assert resp.json() == {"detail": "invalid input"}
+
+
+class TestUnwrapUpstreamError:
+    @pytest.mark.parametrize(
+        ("body", "expected"),
+        [
+            (b'{"detail": "boom"}', ("boom", None)),
+            (b'{"message": "boom"}', ("boom", None)),
+            (b'{"error": "boom"}', ("boom", None)),
+            (b'{"error": {"message": "boom", "code": "c"}}', ("boom", "c")),
+            (b'{"detail": "boom", "code": "c"}', ("boom", "c")),
+            (b'"boom"', ("boom", None)),
+            (b"boom", ("boom", None)),
+            (b"", ("", None)),
+            (b'{"detail": "failed (some_code): why"}', ("failed (some_code): why", "some_code")),
+        ],
+    )
+    def test_message_and_code_extraction(self, body: bytes, expected: tuple[str, str | None]) -> None:
+        assert openai_errors.unwrap_upstream_error(body) == expected
+
+    def test_unrecognized_json_falls_back_to_raw_text(self) -> None:
+        assert openai_errors.unwrap_upstream_error(b'{"nope": 1}') == ('{"nope": 1}', None)
+
+    def test_list_detail_falls_back_to_raw_text(self) -> None:
+        """FastAPI validation errors put a list on ``detail``; the raw body is more useful."""
+        body = b'{"detail": [{"loc": ["body"], "msg": "field required"}]}'
+        message, code = openai_errors.unwrap_upstream_error(body)
+        assert message == body.decode()
+        assert code is None
+
+    def test_invalid_utf8_does_not_raise(self) -> None:
+        message, code = openai_errors.unwrap_upstream_error(b"\xff\xfe not utf-8")
+        assert "not utf-8" in message
+        assert code is None
+
+
+class TestIsOpenAICompatibleURI:
+    @pytest.mark.parametrize(
+        ("trailing_uri", "expected"),
+        [
+            ("v1/chat/completions", True),
+            ("/v1/chat/completions", True),
+            ("v1", True),
+            ("v1beta/chat", False),
+            ("health", False),
+            ("", False),
+            ("api/v1/chat", False),
+        ],
+    )
+    def test_only_the_v1_surface_matches(self, trailing_uri: str, expected: bool) -> None:
+        assert openai_errors.is_openai_compatible_uri(trailing_uri) is expected


### PR DESCRIPTION
## Summary

`/-/v1/*` on the agent gateway is advertised as OpenAI-compatible and Studio talks to it with the official `openai` SDK, but its **error** responses were FastAPI-shaped `{"detail": ...}`. The SDK builds its message from `body["error"]` alone (`error.js:43`) and falls back to `"<status> status code (no body)"` when that key is absent, so every upstream failure reached the user with the real message discarded.

Before / after, on a host without the NeMo Relay CLI:

| upstream | before | after |
| --- | --- | --- |
| 503, no NeMo Relay CLI | `503 status code (no body)` | `Fabric runtime startup failed: adapter lifecycle start failed (claude_relay_unavailable): NeMo Relay CLI executable was not found` |
| 404, unknown session | `404 status code (no body)` | `Fabric session 'abc' was not found.` |
| 422, malformed body | `422 status code (no body)` | `body.messages: field required` |

Error responses under `/-/v1/*` now carry **both** keys — `error` for the OpenAI contract and `detail` for existing readers of the FastAPI shape. OpenAI clients ignore unknown top-level keys, so one body serves both and no consumer audit is needed. Everything outside `/-/v1/*` is decided by the trailing URI and stays `detail`-only.

## Changes

- New `plugins/nemo-agents/src/nemo_agents_plugin/api/v2/openai_errors.py` owning the error shape: surface detection, envelope construction, upstream-body unwrapping, and an `UpstreamAgentError` that carries the unwrapped message and code alongside the 502.
- `gateway.py` renders `HTTPException` through that envelope at the two proxy entry points, so **every** failure mode on the OpenAI surface is covered — upstream 5xx, connect errors, timeouts, SSRF rejection, missing/unhealthy deployment, and session conflicts — not just the 5xx path.
- Upstream bodies are **unwrapped, not nested**. The agent server is FastAPI too, so its `{"detail": "..."}` is lifted into `error.message` rather than embedded as a JSON string inside a string. An already-OpenAI-shaped upstream body is read directly; a non-JSON body still yields a well-formed envelope from the decoded text.
- **Upstream 4xx** is augmented, not replaced: every key the agent sent is preserved and `error` is added beside it, so the status code and the original shape both pass through. A body that already carries a usable `error.message` is forwarded byte for byte — an agent may itself be an OpenAI-compatible server, and reshaping would discard the `type`/`code` it chose. `error` alone does not count as usable, since the SDK reads `error.message`.
- FastAPI validation errors (`{"detail": [{"loc": ..., "msg": ...}]}`) are rendered into one line rather than surfaced as raw JSON.
- Adapter error codes are preserved into `error.code`. They arrive inside the message text (`AdapterRelayError("claude_relay_unavailable", ...)` renders as `... failed (claude_relay_unavailable): ...`), so they are recovered from there; a structured `code` field is preferred when the upstream supplies one.
- `error.type` is mapped from the status (`upstream_error` for a proxied 5xx, else `invalid_request_error` / `not_found_error` / `server_error`, …).

Deliberately unchanged: the 502-for-upstream-5xx translation, upstream 4xx status codes, the 500-char body cap, and the `detail` string itself are all what they were.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the wire shape is documented in the new module's docstring and the gateway module docstring; there is no user-facing doc page for the proxy's error contract.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest plugins/nemo-agents/tests/unit/test_gateway.py` — **84 passed**. 39 new tests; the 45 pre-existing ones pass unmodified, which is itself the back-compat check: they assert on `resp.json()["detail"]` under `/-/v1/*` and still hold.
- `pytest plugins/nemo-agents/tests/unit` — **1152 passed, 3 failed**. All 3 fail identically on the unmodified baseline (verified by stashing): 2 in `test_port_allocation.py` are sandbox `socket.bind` denials, and `test_service.py::test_execute_job_route_matches_generated_submit_path` is a pre-existing `agents-plugin` vs `agents` path mismatch. Neither is touched by this change.
- `ruff check` / `ruff format --check` — pass.
- `ty check` — pass.
- Pre-commit ran on the commit (ruff, ruff format, ty, copyright headers, plugin-import guard, merge conflicts) — all passed. `uv run pre-commit run -a` was **not** run repo-wide; the hook set that applies to these files ran via the commit hook instead.
- End-to-end against the pinned `openai@4.104.0` in `web/node_modules`: `APIError.generate` returns `"<status> status code (no body)"` for each old body and the real message for each new one, across the 503, 404 and 422 rows in the table above. `err.code === "claude_relay_unavailable"` on the 503.

Not covered: the integration reproduction (deploying a claude-harness agent on a host with no `nemo-relay` on PATH) was not run — it needs a live platform and a Claude install. The unit tests reproduce that exact upstream body verbatim instead.

## Follow-ups, not done here

- The agent server at `fabric/server.py:296` stringifies `FabricSessionStartError`, discarding the structured `FabricError.code` that the SDK already carries. The gateway recovers it from the message text; propagating it as a real field would make that heuristic unnecessary.
- The open question from the task write-up stands: 502-for-upstream-5xx still masks the agent's own status code. That is a separate decision from the body shape and is left as-is.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible error responses for `/v1` gateway routes.
  * Upstream and gateway failures now return consistent OpenAI-style error envelopes, including readable messages and error codes.
  * Large or malformed upstream error responses are safely handled.

* **Bug Fixes**
  * Preserved existing behavior for non-OpenAI routes and successful responses.
  * Improved handling of connection failures, missing resources, validation errors, and upstream server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->