### PR TITLE
fix(studio): Auth stuff for nemo assistant - ASTD-461

### DIFF
--- a/agents/nemo-studio-assistant/Dockerfile.fabric-local
+++ b/agents/nemo-studio-assistant/Dockerfile.fabric-local
@@ -50,7 +50,7 @@ RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \
     uv venv --python ${PYTHON_VERSION} /workspace/.venv && \
     . /workspace/.venv/bin/activate && \
     uv pip install --no-sources --constraint /workspace/constraints.fabric-local.txt \
-      "/workspace/wheelhouse/nemo_platform-0.3.0.post217.dev0+b6f22880a-py3-none-any.whl[nemo-agents-plugin]" \
+      "/workspace/wheelhouse/nemo_platform-0.3.0.post277.dev0+095b19918-py3-none-any.whl[nemo-agents-plugin]" \
       "nemo-fabric==0.1.1" . && \
     chmod -R a+rX /opt/uv /workspace/.venv
 

--- a/services/studio/src/nmp/studio/assistant.py
+++ b/services/studio/src/nmp/studio/assistant.py
@@ -22,6 +22,7 @@ from urllib.parse import quote, urlencode, urlparse
 import httpx
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from nemo_platform_plugin.authz import CallerKind, path_rule
 from nmp.common.entities.client import EntityClient, EntityConflictError, EntityNotFoundError, EntityStoreError
 from nmp.common.entities.constants import NAME_PATTERN
 from nmp.common.service.dependencies import get_entity_client
@@ -54,6 +55,7 @@ from nmp.studio.assistant_mcp_tools import (
     permission_prompt_tool,
 )
 from nmp.studio.assistant_skills import ClaudeSkillResponse, DuplicateSkillError, list_claude_skill_responses
+from nmp.studio.authz import scope
 from nmp.studio.entities import AssistantConversation, AssistantMessage, LegacyAssistantConversation
 from pydantic import BaseModel, ConfigDict, Field
 from starlette.routing import NoMatchFound
@@ -747,6 +749,8 @@ def _extract_assistant_parts(content: Any) -> list[dict[str, Any]]:
 
 
 @router.post("/sessions", response_model=NewSessionResponse)
+@scope.write
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def create_session(
     request: Request,
     workspace: str = "default",
@@ -767,6 +771,8 @@ async def create_session(
 
 
 @router.get("/history/sessions", response_model=list[HistorySessionResponse])
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def list_history_sessions(
     request: Request,
     workspace: str = "default",
@@ -888,6 +894,8 @@ def _history_user_interaction_texts(
 
 
 @router.get("/history/sessions/{session_id}", response_model=SessionHistoryResponse)
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def get_session_history(
     session_id: str,
     request: Request,
@@ -974,6 +982,8 @@ async def get_session_history(
 
 
 @router.delete("/history/sessions/{session_id}", status_code=204)
+@scope.write
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def delete_session_history(
     session_id: str,
     request: Request,
@@ -1007,6 +1017,8 @@ async def delete_session_history(
 
 
 @router.get("/skills", response_model=list[ClaudeSkillResponse])
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 def list_claude_skills() -> list[ClaudeSkillResponse]:
     """List NeMo skills that the repo's Claude Code installer exposes."""
     try:
@@ -1867,6 +1879,8 @@ async def _stream_assistant(
 
 
 @router.post("/sessions/{session_id}/messages")
+@scope.write
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def send_message(
     session_id: str,
     body: MessageRequest,
@@ -1914,6 +1928,8 @@ async def send_message(
 
 
 @router.post("/sessions/{session_id}/permissions/{request_id}")
+@scope.write
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def resolve_permission(session_id: str, request_id: str, body: PermissionDecision) -> dict[str, bool]:
     """Resolve a pending Claude tool permission request."""
     sid = _validate_session_id(session_id)
@@ -1928,6 +1944,8 @@ async def resolve_permission(session_id: str, request_id: str, body: PermissionD
 
 
 @router.post("/sessions/{session_id}/inputs/{request_id}")
+@scope.write
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def resolve_agent_input(session_id: str, request_id: str, body: AgentInputDecision) -> dict[str, bool]:
     """Resolve a pending Claude UI input request."""
     sid = _validate_session_id(session_id)
@@ -1942,6 +1960,8 @@ async def resolve_agent_input(session_id: str, request_id: str, body: AgentInput
 
 
 @router.post("/mcp/{session_id}", name=MCP_ROUTE_NAME, include_in_schema=False)
+@scope.write
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def mcp_endpoint(session_id: str, request: Request) -> Response:
     """Minimal MCP endpoint used by Claude's permission-prompt tool."""
     sid = _validate_session_id(session_id)
@@ -2096,6 +2116,8 @@ async def mcp_endpoint(session_id: str, request: Request) -> Response:
 
 
 @router.api_route("/mcp/{session_id}", methods=["GET", "DELETE"], include_in_schema=False)
+@scope.write
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[])
 async def mcp_unsupported_method(session_id: str) -> Response:
     """Decline optional MCP SSE/session methods without falling through to Studio HTML."""
     _validate_session_id(session_id)

--- a/services/studio/src/nmp/studio/authz.py
+++ b/services/studio/src/nmp/studio/authz.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorization scope for Studio API routes."""
+
+from nemo_platform_plugin.authz import AuthzScope
+
+scope = AuthzScope("studio")

--- a/services/studio/src/nmp/studio/service.py
+++ b/services/studio/src/nmp/studio/service.py
@@ -13,6 +13,7 @@ from typing import ClassVar
 
 from fastapi import FastAPI, HTTPException, Request, status
 from fastapi.responses import FileResponse, HTMLResponse
+from nemo_platform_plugin.authz import Permission
 from nmp.common.http_clients import shared_async_http_client
 from nmp.common.service import RouterConfig, Service
 from nmp.studio import assistant
@@ -101,6 +102,14 @@ class StudioService(Service[StudioConfig]):
     def description(self) -> str:
         """Service description for OpenAPI docs."""
         return "Serves the NeMo Studio web application and local assistant bridge"
+
+    def extra_permissions(self) -> list[Permission]:
+        """Return permissions not attached to routes."""
+        return []
+
+    def extra_role_permissions(self) -> dict[str, list[Permission]]:
+        """Return role grants beyond the default permission heuristic."""
+        return {}
 
     def get_routers(self) -> list[RouterConfig]:
         """Return routers for the studio service.

--- a/services/studio/tests/unit/test_authz.py
+++ b/services/studio/tests/unit/test_authz.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authorization derivation for the Studio Assistant bridge."""
+
+from nemo_platform_plugin.authz_discovery import _derive_service_contribution
+from nmp.studio.service import StudioService
+
+
+def test_studio_assistant_routes_are_ruled_for_authenticated_principals() -> None:
+    contribution, problems, _warnings = _derive_service_contribution(StudioService())
+
+    assert problems == []
+    skills = contribution.endpoints["/apis/studio/v2/assistant/skills"]["get"]
+    messages = contribution.endpoints["/apis/studio/v2/assistant/sessions/{session_id}/messages"]["post"]
+    assert skills.callers == ["principal"]
+    assert skills.permissions == []
+    assert skills.scopes == ["studio:read", "platform:read"]
+    assert not skills.deny
+    assert messages.callers == ["principal"]
+    assert messages.permissions == []
+    assert messages.scopes == ["studio:write", "platform:write"]
+    assert not messages.deny

--- a/web/packages/studio/src/routes/agents/AssistantChatRoute/api.test.ts
+++ b/web/packages/studio/src/routes/agents/AssistantChatRoute/api.test.ts
@@ -22,7 +22,32 @@ const getExpectedStudioBaseUrl = (): string => {
 
 describe('Assistant API helpers', () => {
   afterEach(() => {
+    localStorage.clear();
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('adds the active OIDC bearer token to Assistant requests', async () => {
+    const authority = 'https://auth.example.test';
+    const clientId = 'studio-client';
+    vi.stubEnv('VITE_AUTH_AUTHORITY', authority);
+    vi.stubEnv('VITE_AUTH_CLIENT_ID', clientId);
+    localStorage.setItem(
+      `oidc.user:${authority}:${clientId}`,
+      JSON.stringify({
+        access_token: 'assistant-token',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        profile: { sub: 'user-1' },
+        token_type: 'Bearer',
+      })
+    );
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await listAssistantSkills();
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(new Headers(requestInit?.headers).get('Authorization')).toBe('Bearer assistant-token');
   });
 
   it('scopes session creation and history requests to the active workspace', async () => {

--- a/web/packages/studio/src/routes/agents/AssistantChatRoute/api.ts
+++ b/web/packages/studio/src/routes/agents/AssistantChatRoute/api.ts
@@ -26,6 +26,7 @@ import type {
   AssistantSkill,
   AssistantStreamHandlers,
 } from '@studio/routes/agents/AssistantChatRoute/types';
+import { User } from 'oidc-client-ts';
 
 const ASSISTANT_API_BASE_PATH = '/apis/studio/v2/assistant';
 
@@ -41,6 +42,33 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const assistantApiUrl = (path: string): string =>
   `${PLATFORM_BASE_URL}${ASSISTANT_API_BASE_PATH}${path}`;
+
+const getAssistantAccessToken = (): string | undefined => {
+  const authority = import.meta.env.VITE_AUTH_AUTHORITY;
+  const clientId = import.meta.env.VITE_AUTH_CLIENT_ID;
+  if (!authority || !clientId || typeof localStorage === 'undefined') return undefined;
+
+  const oidcStorageKey = `oidc.user:${authority}:${clientId}`;
+  const oidcStorage = localStorage.getItem(oidcStorageKey);
+  if (!oidcStorage) return undefined;
+
+  try {
+    const user = User.fromStorageString(oidcStorage);
+    return user?.access_token && !user.expired ? user.access_token : undefined;
+  } catch {
+    localStorage.removeItem(oidcStorageKey);
+    return undefined;
+  }
+};
+
+const assistantFetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const accessToken = getAssistantAccessToken();
+  if (!accessToken) return fetch(input, init);
+
+  const headers = new Headers(init?.headers);
+  headers.set('Authorization', `Bearer ${accessToken}`);
+  return fetch(input, { ...init, headers });
+};
 
 const getStudioBaseUrl = (): string | undefined => {
   if (typeof window === 'undefined') return undefined;
@@ -79,7 +107,7 @@ const getResponseErrorMessage = async (response: Response, fallback: string): Pr
 
 export const createAssistantSession = async (workspace = 'default'): Promise<string> => {
   const params = new URLSearchParams({ workspace });
-  const response = await fetch(assistantApiUrl(`/sessions?${params.toString()}`), {
+  const response = await assistantFetch(assistantApiUrl(`/sessions?${params.toString()}`), {
     method: 'POST',
   });
 
@@ -265,7 +293,7 @@ export const listAssistantHistorySessions = async (
   workspace = 'default'
 ): Promise<AssistantHistorySession[]> => {
   const params = new URLSearchParams({ workspace });
-  const response = await fetch(assistantApiUrl(`/history/sessions?${params.toString()}`));
+  const response = await assistantFetch(assistantApiUrl(`/history/sessions?${params.toString()}`));
 
   if (!response.ok) {
     throw new Error(
@@ -282,7 +310,7 @@ export const listAssistantHistorySessions = async (
 };
 
 export const listAssistantSkills = async (): Promise<AssistantSkill[]> => {
-  const response = await fetch(assistantApiUrl('/skills'));
+  const response = await assistantFetch(assistantApiUrl('/skills'));
 
   if (!response.ok) {
     throw new Error(
@@ -303,7 +331,7 @@ export const getAssistantSessionHistory = async (
   workspace = 'default'
 ): Promise<AssistantSessionHistory> => {
   const params = new URLSearchParams({ workspace });
-  const response = await fetch(
+  const response = await assistantFetch(
     assistantApiUrl(`/history/sessions/${encodeURIComponent(sessionId)}?${params.toString()}`)
   );
 
@@ -344,7 +372,7 @@ export const deleteAssistantSessionHistory = async (
   workspace = 'default'
 ): Promise<void> => {
   const params = new URLSearchParams({ workspace });
-  const response = await fetch(
+  const response = await assistantFetch(
     assistantApiUrl(`/history/sessions/${encodeURIComponent(sessionId)}?${params.toString()}`),
     { method: 'DELETE' }
   );
@@ -459,17 +487,20 @@ export const resolveAssistantPermission = async ({
   requestId: string;
   decision: AssistantPermissionDecision;
 }): Promise<void> => {
-  const response = await fetch(assistantApiUrl(`/sessions/${sessionId}/permissions/${requestId}`), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      approved: decision.approved,
-      reason: decision.reason,
-      updated_input: decision.updatedInput,
-    }),
-  });
+  const response = await assistantFetch(
+    assistantApiUrl(`/sessions/${sessionId}/permissions/${requestId}`),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        approved: decision.approved,
+        reason: decision.reason,
+        updated_input: decision.updatedInput,
+      }),
+    }
+  );
 
   if (!response.ok) {
     throw new Error(
@@ -487,16 +518,19 @@ export const resolveAssistantInput = async ({
   requestId: string;
   sessionId: string;
 }): Promise<void> => {
-  const response = await fetch(assistantApiUrl(`/sessions/${sessionId}/inputs/${requestId}`), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      skipped: decision.skipped,
-      value: decision.value,
-    }),
-  });
+  const response = await assistantFetch(
+    assistantApiUrl(`/sessions/${sessionId}/inputs/${requestId}`),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        skipped: decision.skipped,
+        value: decision.value,
+      }),
+    }
+  );
 
   if (!response.ok) {
     throw new Error(
@@ -522,7 +556,7 @@ export const streamAssistantMessage = async ({
   signal: AbortSignal;
   handlers: AssistantStreamHandlers;
 }): Promise<void> => {
-  const response = await fetch(assistantApiUrl(`/sessions/${sessionId}/messages`), {
+  const response = await assistantFetch(assistantApiUrl(`/sessions/${sessionId}/messages`), {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
Added auth token to requests from the Nemo Assistant so requests will be approved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Assistant API requests now securely include the active sign-in token when available.
  - Added authorization controls for Assistant sessions, history, skills, messaging, permissions, and integrations.
  - Unauthenticated requests continue to work without authorization headers.

- **Bug Fixes**
  - Invalid stored sign-in data is automatically cleared to prevent failed requests.

- **Tests**
  - Added coverage for authorization behavior and authenticated Assistant API requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->