### PR TITLE
feat(studio): support RL (DPO) customization jobs

### DIFF
--- a/web/packages/studio/src/components/CustomizationOverview/index.tsx
+++ b/web/packages/studio/src/components/CustomizationOverview/index.tsx
@@ -13,6 +13,7 @@ import { useCustomizationFilesAsRows } from '@studio/hooks/useCustomizationFiles
 import { useCustomizationJob } from '@studio/hooks/useCustomizationJob';
 import { useCustomizationJobStatus } from '@studio/hooks/useCustomizationJobStatus';
 import { hasMetrics } from '@studio/types/customization';
+import { isRlJob } from '@studio/util/customizationBackend';
 import {
   getCustomizationTrainingSteps,
   getDatasetUri,
@@ -67,7 +68,11 @@ export const CustomizationOverview: FC<Props> = ({ customizationJobName, workspa
     fileset: getDatasetUri(customization) || undefined,
   });
 
-  const epochs = customization?.spec?.schedule?.epochs;
+  const epochs = customization
+    ? isRlJob(customization)
+      ? customization.spec?.training?.epochs
+      : customization.spec?.schedule?.epochs
+    : undefined;
   const batchSize = getTrainingBatchSize(customization);
   const maxXAxisValue = getCustomizationTrainingSteps({
     epochs: epochs ?? 0,

--- a/web/packages/studio/src/components/NewCustomizationForm/BackendSelectionSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/BackendSelectionSection.tsx
@@ -20,6 +20,12 @@ const BACKENDS = [
     description:
       'Single-GPU, memory-efficient training via 4-bit quantization. Ideal for smaller hardware with fast iteration.',
   },
+  {
+    value: 'rl' as const,
+    title: 'RL',
+    description:
+      'Reinforcement learning via Direct Preference Optimization on chosen/rejected pairs. Full-weight only.',
+  },
 ];
 
 export const BackendSelectionSection = () => {

--- a/web/packages/studio/src/components/NewCustomizationForm/ComputeResourcesSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ComputeResourcesSection.tsx
@@ -92,6 +92,68 @@ const AutomodelParallelism = ({ disabled }: { disabled: boolean }) => {
   );
 };
 
+const RlParallelism = ({ disabled }: { disabled: boolean }) => {
+  const { control } = useFormContext<CustomizationFormFields>();
+  return (
+    <Stack gap="density-lg">
+      <ControlledSliderWithTextInput
+        useControllerProps={{ name: 'rl.training.parallelism.num_nodes', control }}
+        formFieldProps={{ slotLabel: 'Nodes' }}
+        defaultValue={1}
+        min={1}
+        max={16}
+        step={1}
+        disabled={disabled}
+      />
+      <ControlledSliderWithTextInput
+        useControllerProps={{ name: 'rl.training.parallelism.num_gpus_per_node', control }}
+        formFieldProps={{ slotLabel: 'GPUs per Node' }}
+        defaultValue={1}
+        min={1}
+        max={8}
+        step={1}
+        disabled={disabled}
+      />
+      <Text kind="label/bold/md">Parallelism</Text>
+      <ControlledSliderWithTextInput
+        useControllerProps={{ name: 'rl.training.parallelism.tensor_parallel_size', control }}
+        formFieldProps={{ slotLabel: 'Tensor (TP)' }}
+        defaultValue={1}
+        min={1}
+        max={8}
+        step={1}
+        disabled={disabled}
+      />
+      <ControlledSliderWithTextInput
+        useControllerProps={{ name: 'rl.training.parallelism.pipeline_parallel_size', control }}
+        formFieldProps={{ slotLabel: 'Pipeline (PP)' }}
+        defaultValue={1}
+        min={1}
+        max={8}
+        step={1}
+        disabled={disabled}
+      />
+      <ControlledSliderWithTextInput
+        useControllerProps={{ name: 'rl.training.parallelism.context_parallel_size', control }}
+        formFieldProps={{
+          slotLabel: 'Context (CP)',
+          slotInfo: 'Splits the sequence dimension across GPUs, for long-sequence runs.',
+        }}
+        defaultValue={1}
+        min={1}
+        max={8}
+        step={1}
+        disabled={disabled}
+      />
+      <ControlledSwitch
+        useControllerProps={{ name: 'rl.training.parallelism.sequence_parallel', control }}
+        formFieldProps={{ slotLabel: 'Sequence Parallel', labelPosition: 'left' }}
+        disabled={disabled}
+      />
+    </Stack>
+  );
+};
+
 const UnslothHardware = ({ disabled }: { disabled: boolean }) => {
   const { control } = useFormContext<CustomizationFormFields>();
   return (
@@ -121,6 +183,8 @@ export const ComputeResourcesSection = () => {
     <FormSection title="Compute Resources">
       {backend === 'automodel' ? (
         <AutomodelParallelism disabled={disabled} />
+      ) : backend === 'rl' ? (
+        <RlParallelism disabled={disabled} />
       ) : (
         <UnslothHardware disabled={disabled} />
       )}

--- a/web/packages/studio/src/components/NewCustomizationForm/DpoParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/DpoParametersSection.tsx
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledSliderWithTextInput } from '@nemo/common/src/components/form/ControlledSliderWithTextInput';
+import { ControlledSwitch } from '@nemo/common/src/components/form/ControlledSwitch';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionRoot,
+  AccordionTrigger,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useFormContext } from 'react-hook-form';
+
+export const DpoParametersSection = () => {
+  const { control, formState } = useFormContext<CustomizationFormFields>();
+  const disabled = formState.isSubmitting;
+
+  return (
+    <FormSection title="DPO Parameters">
+      <Stack gap="density-lg">
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'rl.training.ref_policy_kl_penalty', control }}
+          formFieldProps={{
+            slotLabel: 'KL Penalty',
+            slotInfo:
+              'Beta in the DPO paper. Higher values keep the tuned model closer to the reference policy.',
+          }}
+          defaultValue={0.05}
+          min={0}
+          max={1}
+          step={0.01}
+          disabled={disabled}
+        />
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'rl.training.preference_loss_weight', control }}
+          formFieldProps={{
+            slotLabel: 'Preference Loss Weight',
+            slotInfo: 'Weight applied to the preference (DPO) loss term.',
+          }}
+          defaultValue={1}
+          min={0}
+          max={10}
+          step={0.1}
+          disabled={disabled}
+        />
+        <ControlledSliderWithTextInput
+          useControllerProps={{ name: 'rl.training.sft_loss_weight', control }}
+          formFieldProps={{
+            slotLabel: 'SFT Loss Weight',
+            slotInfo:
+              'Weight for the SFT regularization loss on the chosen response. 0 disables it.',
+          }}
+          defaultValue={0}
+          min={0}
+          max={10}
+          step={0.1}
+          disabled={disabled}
+        />
+        <AccordionRoot multiple>
+          <AccordionItem value="advanced-dpo" className="border-b-0">
+            <AccordionTrigger>
+              <Text kind="label/bold/md">Advanced</Text>
+            </AccordionTrigger>
+            <AccordionContent>
+              <Stack gap="density-md" className="pt-density-md">
+                <ControlledSliderWithTextInput
+                  useControllerProps={{ name: 'rl.training.max_grad_norm', control }}
+                  formFieldProps={{ slotLabel: 'Max Gradient Norm' }}
+                  defaultValue={1.0}
+                  min={0}
+                  max={10}
+                  step={0.1}
+                  disabled={disabled}
+                />
+                <ControlledSwitch
+                  useControllerProps={{ name: 'rl.training.preference_average_log_probs', control }}
+                  formFieldProps={{
+                    slotLabel: 'Average Log-Probs (Preference)',
+                    labelPosition: 'left',
+                    slotInfo:
+                      'Average log-probabilities across tokens for the preference loss instead of summing.',
+                  }}
+                  disabled={disabled}
+                />
+                <ControlledSwitch
+                  useControllerProps={{ name: 'rl.training.sft_average_log_probs', control }}
+                  formFieldProps={{
+                    slotLabel: 'Average Log-Probs (SFT)',
+                    labelPosition: 'left',
+                    slotInfo:
+                      'Average log-probabilities across tokens for the SFT regularization loss.',
+                  }}
+                  disabled={disabled}
+                />
+              </Stack>
+            </AccordionContent>
+          </AccordionItem>
+        </AccordionRoot>
+      </Stack>
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
@@ -12,6 +12,7 @@ import {
   Stack,
   Text,
 } from '@nvidia/foundations-react-core';
+import { OPTIMIZER_TYPE_ITEMS } from '@studio/components/NewCustomizationForm/constants';
 import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
@@ -21,6 +22,106 @@ export const GeneralParametersSection = () => {
   const { control, watch, formState } = useFormContext<CustomizationFormFields>();
   const backend = watch('backend');
   const disabled = formState.isSubmitting;
+
+  if (backend === 'rl') {
+    return (
+      <FormSection title="Training Parameters">
+        <Stack gap="density-lg">
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'rl.training.epochs', control }}
+            formFieldProps={{ slotLabel: 'Epochs' }}
+            defaultValue={1}
+            min={1}
+            max={100}
+            step={1}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'rl.training.learning_rate', control }}
+            formFieldProps={{ slotLabel: 'Learning Rate' }}
+            defaultValue={1e-4}
+            min={1e-6}
+            max={1e-3}
+            step={1e-6}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'rl.training.batch_size', control }}
+            formFieldProps={{ slotLabel: 'Global Batch Size' }}
+            defaultValue={32}
+            min={1}
+            max={256}
+            step={1}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'rl.training.max_seq_length', control }}
+            formFieldProps={{ slotLabel: 'Max Sequence Length' }}
+            defaultValue={2048}
+            min={128}
+            max={131072}
+            step={128}
+            disabled={disabled}
+          />
+          <AccordionRoot multiple>
+            <AccordionItem value="advanced" className="border-b-0">
+              <AccordionTrigger>
+                <Text kind="label/bold/md">Advanced</Text>
+              </AccordionTrigger>
+              <AccordionContent>
+                <Stack gap="density-md" className="pt-density-md">
+                  {/* No Max Steps: epochs drives DPO length, and a slider's reset target would override it. */}
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'rl.training.micro_batch_size', control }}
+                    formFieldProps={{ slotLabel: 'Micro Batch Size' }}
+                    defaultValue={1}
+                    min={1}
+                    max={64}
+                    step={1}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'rl.training.warmup_steps', control }}
+                    formFieldProps={{ slotLabel: 'Warmup Steps' }}
+                    defaultValue={0}
+                    min={0}
+                    max={1000}
+                    step={1}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'rl.training.weight_decay', control }}
+                    formFieldProps={{ slotLabel: 'Weight Decay' }}
+                    defaultValue={0.01}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    disabled={disabled}
+                  />
+                  <ControlledSwitch
+                    useControllerProps={{ name: 'rl.training.activation_checkpointing', control }}
+                    formFieldProps={{
+                      slotLabel: 'Activation Checkpointing',
+                      labelPosition: 'left',
+                      slotInfo:
+                        'Recompute activations during the backward pass to reduce memory at the cost of compute.',
+                    }}
+                    disabled={disabled}
+                  />
+                  <ControlledSelect
+                    useControllerProps={{ name: 'rl.training.optimizer_type', control }}
+                    formFieldProps={{ slotLabel: 'Optimizer Type' }}
+                    items={OPTIMIZER_TYPE_ITEMS}
+                    disabled={disabled}
+                  />
+                </Stack>
+              </AccordionContent>
+            </AccordionItem>
+          </AccordionRoot>
+        </Stack>
+      </FormSection>
+    );
+  }
 
   if (backend === 'automodel') {
     return (

--- a/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
@@ -7,7 +7,10 @@ import { ModelSelectV2, type ModelSelection } from '@nemo/common/src/components/
 import { FormField, Stack } from '@nvidia/foundations-react-core';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
-import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import {
+  MODEL_FIELD_BY_BACKEND,
+  type CustomizationFormFields,
+} from '@studio/util/forms/customization';
 import { useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 
@@ -17,7 +20,7 @@ export const ModelSelectionSection = () => {
   const backend = watch('backend');
   const disabled = formState.isSubmitting;
 
-  const modelFieldName = backend === 'automodel' ? 'automodel.model' : 'unsloth.model.name';
+  const modelFieldName = MODEL_FIELD_BY_BACKEND[backend];
 
   const { field: modelField, fieldState: modelFieldState } = useController({
     control,

--- a/web/packages/studio/src/components/NewCustomizationForm/constants.ts
+++ b/web/packages/studio/src/components/NewCustomizationForm/constants.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { OptimizerType } from '@nemo/sdk/generated/customizer/schema';
+
+/** Optimizer + LR-scheduler pairs the RL backend accepts. */
+export const OPTIMIZER_TYPE_ITEMS = [
+  { value: OptimizerType.adamw_with_cosine_annealing, children: 'AdamW + Cosine Annealing' },
+  { value: OptimizerType.adam_with_cosine_annealing, children: 'Adam + Cosine Annealing' },
+  { value: OptimizerType.adamw_with_flat_lr, children: 'AdamW + Flat LR' },
+  { value: OptimizerType.adam_with_flat_lr, children: 'Adam + Flat LR' },
+];

--- a/web/packages/studio/src/components/NewCustomizationForm/index.test.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.test.tsx
@@ -14,10 +14,12 @@ import userEvent from '@testing-library/user-event';
 
 const mutateAutomodel = vi.fn();
 const mutateUnsloth = vi.fn();
+const mutateRl = vi.fn();
 
 vi.mock('@nemo/sdk/generated/customizer/api', () => ({
   useCustomizationCreateAutomodelJob: () => ({ mutateAsync: mutateAutomodel, isPending: false }),
   useCustomizationCreateUnslothJob: () => ({ mutateAsync: mutateUnsloth, isPending: false }),
+  useCustomizationCreateRlJob: () => ({ mutateAsync: mutateRl, isPending: false }),
 }));
 
 vi.mock('@studio/hooks/useCustomizationDatasetValidation', async (importOriginal) => {

--- a/web/packages/studio/src/components/NewCustomizationForm/index.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.tsx
@@ -8,6 +8,7 @@ import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import {
   useCustomizationCreateAutomodelJob,
+  useCustomizationCreateRlJob,
   useCustomizationCreateUnslothJob,
 } from '@nemo/sdk/generated/customizer/api';
 import {
@@ -22,6 +23,7 @@ import {
 import { CustomizationFilesetSelect } from '@studio/components/customizer/CustomizationFilesetSelect';
 import { BackendSelectionSection } from '@studio/components/NewCustomizationForm/BackendSelectionSection';
 import { ComputeResourcesSection } from '@studio/components/NewCustomizationForm/ComputeResourcesSection';
+import { DpoParametersSection } from '@studio/components/NewCustomizationForm/DpoParametersSection';
 import { GeneralParametersSection } from '@studio/components/NewCustomizationForm/GeneralParametersSection';
 import { LoraParametersSection } from '@studio/components/NewCustomizationForm/LoraParametersSection';
 import { ModelSelectionSection } from '@studio/components/NewCustomizationForm/ModelSelectionSection';
@@ -31,6 +33,7 @@ import {
   FORM_DEFAULTS,
   customizationFormSchema,
   formToAutomodelCreate,
+  formToRlCreate,
   formToUnslothCreate,
   type CustomizationFormFields,
 } from '@studio/util/forms/customization';
@@ -64,6 +67,7 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
         ...FORM_DEFAULTS.unsloth,
         model: { ...FORM_DEFAULTS.unsloth.model, name: initialModel ?? '' },
       },
+      rl: { ...FORM_DEFAULTS.rl, model: initialModel ?? '' },
     };
   }, [initialModel, initialValues]);
 
@@ -84,7 +88,9 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
     name: 'unsloth.training.finetuning_type',
   });
   const finetuningType = backend === 'automodel' ? automodelFinetuningType : unslothFinetuningType;
-  const isLora = finetuningType === 'lora' || finetuningType === 'lora_merged';
+  // RL is DPO-only and full-weight, so it has neither a finetuning type nor LoRA params.
+  const isLora =
+    backend !== 'rl' && (finetuningType === 'lora' || finetuningType === 'lora_merged');
 
   const { mutateAsync: createAutomodel, isPending: isPendingAutomodel } =
     useCustomizationCreateAutomodelJob({
@@ -112,7 +118,19 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
       },
     });
 
-  const isPending = isPendingAutomodel || isPendingUnsloth;
+  const { mutateAsync: createRl, isPending: isPendingRl } = useCustomizationCreateRlJob({
+    mutation: {
+      onSuccess: (job) => {
+        toast.success('Fine-tuning job started');
+        navigate(getWorkspaceCustomizationJobDetailsRoute(workspace, job.name));
+      },
+      onError: (error: Error) => {
+        toast.error(getErrorMessage(error, 'Failed to create fine-tuning job'));
+      },
+    },
+  });
+
+  const isPending = isPendingAutomodel || isPendingUnsloth || isPendingRl;
 
   const onSubmit = async (fields: CustomizationFormFields) => {
     setValidationErrors([]);
@@ -120,6 +138,8 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
       await createAutomodel({ workspace, data: formToAutomodelCreate(fields) }).catch(
         () => undefined
       );
+    } else if (fields.backend === 'rl') {
+      await createRl({ workspace, data: formToRlCreate(fields) }).catch(() => undefined);
     } else {
       await createUnsloth({ workspace, data: formToUnslothCreate(fields) }).catch(() => undefined);
     }
@@ -180,11 +200,22 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
                     <Divider />
                     <ModelSelectionSection />
                     <Divider />
-                    <TrainingMethodSection />
-                    <Divider />
+                    {/* RL exposes no fine-tuning or training type: it is DPO, full-weight. */}
+                    {backend !== 'rl' && (
+                      <>
+                        <TrainingMethodSection />
+                        <Divider />
+                      </>
+                    )}
                     <CustomizationFilesetSelect disabled={isPending} />
                     <Divider />
                     <GeneralParametersSection />
+                    {backend === 'rl' && (
+                      <>
+                        <Divider />
+                        <DpoParametersSection />
+                      </>
+                    )}
                     {isLora && (
                       <>
                         <Divider />

--- a/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
+++ b/web/packages/studio/src/components/customizer/CustomizationFilesetSelect/index.tsx
@@ -39,14 +39,15 @@ import { useCustomizationDatasetValidation } from '@studio/hooks/useCustomizatio
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import type { TrainingType } from '@studio/util/customizerSchema';
 import { inferJsonContentType, isJsonFile } from '@studio/util/files';
-import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import {
+  DATASET_FIELD_BY_BACKEND,
+  type CustomizationFormFields,
+} from '@studio/util/forms/customization';
 import { Database, FolderOpen } from 'lucide-react';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useController, useFormContext, useWatch } from 'react-hook-form';
 
 const NEW_DATASET_VALUE = '__new_dataset__';
-
-type DatasetFieldName = 'automodel.dataset.training' | 'unsloth.dataset.path';
 
 export interface CustomizationFilesetSelectProps {
   disabled?: boolean;
@@ -59,11 +60,12 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
   const { control, setValue } = useFormContext<CustomizationFormFields>();
   const backend = useWatch({ control, name: 'backend' });
 
-  const fieldName: DatasetFieldName =
-    backend === 'automodel' ? 'automodel.dataset.training' : 'unsloth.dataset.path';
   const automodelTrainingType = useWatch({ control, name: 'automodel.training.training_type' });
+
+  const fieldName = DATASET_FIELD_BY_BACKEND[backend];
+  // Unsloth is SFT-only; RL is DPO-only; automodel carries its own selector.
   const trainingType: TrainingType =
-    backend === 'automodel' ? (automodelTrainingType ?? 'sft') : 'sft';
+    backend === 'rl' ? 'dpo' : backend === 'automodel' ? (automodelTrainingType ?? 'sft') : 'sft';
 
   const {
     field: { value: selectedRef, onChange: setSelectedRef, onBlur },
@@ -153,6 +155,12 @@ export const CustomizationFilesetSelect: FC<CustomizationFilesetSelectProps> = (
   return (
     <Stack gap="density-2xl">
       <Text kind="body/bold/lg">Training Data</Text>
+      {trainingType === 'dpo' && (
+        <Text kind="body/regular/md" color="secondary">
+          DPO datasets hold preference pairs — chosen and rejected responses for the same prompt.
+          BinaryPreference, Tulu3, HelpSteer3 and native Preference formats are all accepted.
+        </Text>
+      )}
       <Text kind="body/regular/md">
         Datasets should be in JSONL format and split into separate, representative training and
         validation sets. For formatting guidelines, refer to the{' '}

--- a/web/packages/studio/src/components/sidePanels/CustomizationConfigSidePanel/index.tsx
+++ b/web/packages/studio/src/components/sidePanels/CustomizationConfigSidePanel/index.tsx
@@ -8,6 +8,7 @@ import { Loading } from '@studio/components/Layouts/Loading';
 import { useCustomizationJob } from '@studio/hooks/useCustomizationJob';
 import {
   isAutomodelJob,
+  isRlJob,
   isUnslothJob,
   type CustomizationJob,
 } from '@studio/util/customizationBackend';
@@ -21,13 +22,35 @@ import { ComponentProps, FC, ReactNode } from 'react';
 /** Hyperparameter rows specific to each backend. */
 const HyperparameterRows: FC<{ job: CustomizationJob }> = ({ job }) => {
   const rows: ReactNode[] = [];
-  const { schedule, optimizer, training } = job.spec;
+  const { training } = job.spec;
 
-  rows.push(<KVPair key="epochs" label="Epochs" value={schedule?.epochs} />);
-  rows.push(<KVPair key="max-steps" label="Max Steps" value={schedule?.max_steps} />);
-  rows.push(<KVPair key="seed" label="Seed" value={schedule?.seed} />);
-  rows.push(<KVPair key="lr" label="Learning Rate" value={optimizer?.learning_rate} />);
-  rows.push(<KVPair key="wd" label="Weight Decay" value={optimizer?.weight_decay} />);
+  const rl = isRlJob(job) ? job.spec.training : undefined;
+  const schedule = isRlJob(job) ? undefined : job.spec.schedule;
+  const optimizer = isRlJob(job) ? undefined : job.spec.optimizer;
+
+  rows.push(<KVPair key="epochs" label="Epochs" value={rl ? rl.epochs : schedule?.epochs} />);
+  rows.push(
+    <KVPair key="max-steps" label="Max Steps" value={rl ? rl.max_steps : schedule?.max_steps} />
+  );
+  rows.push(<KVPair key="seed" label="Seed" value={rl ? rl.seed : schedule?.seed} />);
+  rows.push(
+    <KVPair
+      key="lr"
+      label="Learning Rate"
+      value={rl ? rl.learning_rate : optimizer?.learning_rate}
+    />
+  );
+  rows.push(
+    <KVPair key="wd" label="Weight Decay" value={rl ? rl.weight_decay : optimizer?.weight_decay} />
+  );
+
+  if (rl) {
+    rows.push(<KVPair key="gbs" label="Global Batch Size" value={rl.batch_size} />);
+    rows.push(<KVPair key="mbs" label="Micro Batch Size" value={rl.micro_batch_size} />);
+    rows.push(<KVPair key="warmup" label="Warmup Steps" value={rl.warmup_steps} />);
+    rows.push(<KVPair key="max-seq" label="Max Sequence Length" value={rl.max_seq_length} />);
+    rows.push(<KVPair key="kl" label="KL Penalty" value={rl.ref_policy_kl_penalty} />);
+  }
 
   if (isAutomodelJob(job)) {
     const { batch } = job.spec;
@@ -55,7 +78,8 @@ const HyperparameterRows: FC<{ job: CustomizationJob }> = ({ job }) => {
     rows.push(<KVPair key="precision" label="Precision" value={job.spec.hardware?.precision} />);
   }
 
-  const lora = training?.lora;
+  // DPO is full-weight only, so RlDPOTraining carries no `lora` to narrow to.
+  const lora = training && 'lora' in training ? training.lora : undefined;
   if (lora) {
     rows.push(<KVPair key="lora-rank" label="LoRA / Rank" value={lora.rank} />);
     rows.push(<KVPair key="lora-alpha" label="LoRA / Alpha" value={lora.alpha} />);
@@ -91,17 +115,23 @@ export const CustomizationConfigSidePanel: FC<Props> = ({
     content = <Loading />;
   } else if (job) {
     const { training } = job.spec;
+    // RL discriminates on `type`; the other backends use `training_type`.
+    const trainingType =
+      training && 'training_type' in training
+        ? training.training_type
+        : isRlJob(job)
+          ? job.spec.training.type
+          : undefined;
+    const finetuningType =
+      training && 'finetuning_type' in training ? training.finetuning_type : undefined;
     content = (
       <Stack className="w-full overflow-y-auto" gap="density-xl">
         <KVPair label="Name" value={job.spec.output?.name} />
         <Stack gap="density-sm">
           <Text kind="body/semibold/md">Configuration Snapshot</Text>
           <KVPair label="Base Model" value={getBaseModel(job)} />
-          <KVPair label="Training Type" value={getFormattedTrainingType(training?.training_type)} />
-          <KVPair
-            label="Finetuning Type"
-            value={getFormattedTrainingType(training?.finetuning_type)}
-          />
+          <KVPair label="Training Type" value={getFormattedTrainingType(trainingType)} />
+          <KVPair label="Finetuning Type" value={getFormattedTrainingType(finetuningType)} />
           <KVPair
             label="Training Options"
             value={

--- a/web/packages/studio/src/hooks/useCustomizationJobStatus/index.ts
+++ b/web/packages/studio/src/hooks/useCustomizationJobStatus/index.ts
@@ -4,8 +4,10 @@
 import { getJobRefetchInterval } from '@nemo/common/src/utils/query';
 import {
   customizationGetAutomodelJobStatus,
+  customizationGetRlJobStatus,
   customizationGetUnslothJobStatus,
   getCustomizationGetAutomodelJobStatusQueryKey,
+  getCustomizationGetRlJobStatusQueryKey,
   getCustomizationGetUnslothJobStatusQueryKey,
 } from '@nemo/sdk/generated/customizer/api';
 import type {
@@ -33,6 +35,10 @@ const STATUS_ENDPOINTS: Record<CustomizationBackend, StatusEndpoint> = {
   unsloth: {
     fetchStatus: customizationGetUnslothJobStatus,
     getQueryKey: getCustomizationGetUnslothJobStatusQueryKey,
+  },
+  rl: {
+    fetchStatus: customizationGetRlJobStatus,
+    getQueryKey: getCustomizationGetRlJobStatusQueryKey,
   },
 };
 

--- a/web/packages/studio/src/routes/CustomizationJobDetailsRoute/DetailActions.tsx
+++ b/web/packages/studio/src/routes/CustomizationJobDetailsRoute/DetailActions.tsx
@@ -7,6 +7,7 @@ import { CJobCancellableStatuses, CJobLaunchableStatuses } from '@nemo/common/sr
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import {
   useCustomizationCancelAutomodelJob,
+  useCustomizationCancelRlJob,
   useCustomizationCancelUnslothJob,
 } from '@nemo/sdk/generated/customizer/api';
 import { getJobsGetJobQueryKey } from '@nemo/sdk/generated/platform/api';
@@ -62,17 +63,22 @@ export const DetailActions: FC<DetailActionsProps> = ({ model, status, backend, 
   };
   const automodelCancel = useCustomizationCancelAutomodelJob({ mutation: cancelMutation });
   const unslothCancel = useCustomizationCancelUnslothJob({ mutation: cancelMutation });
-  const isPending = automodelCancel.isPending || unslothCancel.isPending;
+  const rlCancel = useCustomizationCancelRlJob({ mutation: cancelMutation });
+  const isPending = automodelCancel.isPending || unslothCancel.isPending || rlCancel.isPending;
+
+  type CancelJob = (vars: { workspace: string; name: string }) => Promise<unknown>;
+  const cancelByBackend: Record<CustomizationBackend, CancelJob> = {
+    [CustomizationBackend.automodel]: automodelCancel.mutateAsync,
+    [CustomizationBackend.unsloth]: unslothCancel.mutateAsync,
+    [CustomizationBackend.rl]: rlCancel.mutateAsync,
+  };
 
   const cancelJob = async () => {
     if (!backend) {
       toast.error('Unable to determine the training backend for this job.');
       return;
     }
-    const cancel =
-      backend === CustomizationBackend.automodel
-        ? automodelCancel.mutateAsync
-        : unslothCancel.mutateAsync;
+    const cancel = cancelByBackend[backend];
     try {
       await cancel({ workspace, name });
     } catch (e) {

--- a/web/packages/studio/src/routes/NewCustomizationRoute/index.tsx
+++ b/web/packages/studio/src/routes/NewCustomizationRoute/index.tsx
@@ -7,6 +7,7 @@ import { useBreadcrumbs } from '@studio/providers/breadcrumbs/useBreadcrumbs';
 import { getWorkspaceCustomizationJobListRoute } from '@studio/routes/utils';
 import {
   isAutomodelSpec,
+  isRlSpec,
   isUnslothSpec,
   type CustomizationJob,
 } from '@studio/util/customizationBackend';
@@ -19,7 +20,7 @@ const isCloneFromJobState = (value: unknown): value is { cloneFromJob: Customiza
   const candidate = (value as Record<string, unknown>).cloneFromJob;
   if (typeof candidate !== 'object' || candidate === null) return false;
   const spec = (candidate as Record<string, unknown>).spec;
-  return isAutomodelSpec(spec) || isUnslothSpec(spec);
+  return isAutomodelSpec(spec) || isUnslothSpec(spec) || isRlSpec(spec);
 };
 
 export const NewCustomizationRoute = () => {

--- a/web/packages/studio/src/util/customizationBackend.ts
+++ b/web/packages/studio/src/util/customizationBackend.ts
@@ -4,6 +4,9 @@
 import type {
   AutomodelJobOutput,
   AutomodelJobsJob,
+  RlDPOTraining,
+  RlJobOutput,
+  RlJobsJob,
   UnslothJobOutput,
   UnslothJobsJob,
 } from '@nemo/sdk/generated/customizer/schema';
@@ -11,13 +14,15 @@ import type {
 export const CustomizationBackend = {
   automodel: 'automodel',
   unsloth: 'unsloth',
+  rl: 'rl',
 } as const;
 export type CustomizationBackend = (typeof CustomizationBackend)[keyof typeof CustomizationBackend];
 
-export type CustomizationJobSpec = AutomodelJobOutput | UnslothJobOutput;
+export type CustomizationJobSpec = AutomodelJobOutput | UnslothJobOutput | RlJobOutput;
 export type AutomodelJob = AutomodelJobsJob;
 export type UnslothJob = UnslothJobsJob;
-export type CustomizationJob = AutomodelJobsJob | UnslothJobsJob;
+export type RlJob = RlJobsJob;
+export type CustomizationJob = AutomodelJobsJob | UnslothJobsJob | RlJobsJob;
 export type CustomizationJobStatusDetails = Record<string, unknown>;
 
 const isObject = (value: unknown): value is Record<string, unknown> =>
@@ -29,9 +34,24 @@ export const isAutomodelSpec = (spec: unknown): spec is AutomodelJobOutput =>
 export const isUnslothSpec = (spec: unknown): spec is UnslothJobOutput =>
   isObject(spec) && 'hardware' in spec;
 
+// Orval inlines discriminator literals, so there is no generated enum to import;
+// `satisfies` pins these to the SDK type instead.
+const RL_TRAINING_TYPES: readonly string[] = ['dpo' satisfies RlDPOTraining['type']];
+
+// RL has no top-level marker key like automodel's `parallelism` or unsloth's
+// `hardware` — its parallelism sits under `training` — so it matches on the discriminator.
+export const isRlSpec = (spec: unknown): spec is RlJobOutput =>
+  isObject(spec) &&
+  !('parallelism' in spec) &&
+  !('hardware' in spec) &&
+  'training' in spec &&
+  isObject(spec.training) &&
+  RL_TRAINING_TYPES.includes((spec.training as { type?: string }).type ?? '');
+
 export const getCustomizationBackend = (spec: unknown): CustomizationBackend | undefined => {
   if (isAutomodelSpec(spec)) return CustomizationBackend.automodel;
   if (isUnslothSpec(spec)) return CustomizationBackend.unsloth;
+  if (isRlSpec(spec)) return CustomizationBackend.rl;
   return undefined;
 };
 
@@ -39,3 +59,5 @@ export const isAutomodelJob = (job: CustomizationJob): job is AutomodelJob =>
   isAutomodelSpec(job.spec);
 
 export const isUnslothJob = (job: CustomizationJob): job is UnslothJob => isUnslothSpec(job.spec);
+
+export const isRlJob = (job: CustomizationJob): job is RlJob => isRlSpec(job.spec);

--- a/web/packages/studio/src/util/customizations.tsx
+++ b/web/packages/studio/src/util/customizations.tsx
@@ -13,6 +13,7 @@ import type {
 } from '@studio/types/customization';
 import {
   isAutomodelJob,
+  isRlJob,
   isUnslothJob,
   type CustomizationJob,
   type CustomizationJobStatusDetails,
@@ -47,6 +48,9 @@ export const getFormattedTrainingType = (type?: string) => {
     case 'distillation': {
       return 'Distillation';
     }
+    case 'dpo': {
+      return 'DPO';
+    }
     default: {
       return type;
     }
@@ -78,8 +82,8 @@ export const getFormattedCustomizationStatus = (
 };
 
 /**
- * Returns the base model reference for a customization job. Automodel stores it as a string;
- * unsloth stores it as a `ModelLoadSpec` whose `name` is the reference.
+ * Returns the base model reference for a customization job. Automodel and RL store it
+ * as a string; unsloth stores it as a `ModelLoadSpec` whose `name` is the reference.
  */
 export const getBaseModel = (customizationJob?: CustomizationJob): string => {
   if (!customizationJob) {
@@ -89,6 +93,9 @@ export const getBaseModel = (customizationJob?: CustomizationJob): string => {
     return customizationJob.spec.model.name ?? '';
   }
   if (isAutomodelJob(customizationJob)) {
+    return customizationJob.spec.model ?? '';
+  }
+  if (isRlJob(customizationJob)) {
     return customizationJob.spec.model ?? '';
   }
   return '';
@@ -109,7 +116,8 @@ export const getFinetuningType = (customizationJob?: CustomizationJob): string =
 
 /**
  * Returns the training dataset URI for a customization job. Automodel stores it under
- * `dataset.training`; unsloth stores it under `dataset.path`.
+ * `dataset.training` and unsloth under `dataset.path`; RL's `dataset` is the reference
+ * itself, a plain string, so it has no sub-field to read.
  */
 export const getDatasetUri = (customizationJob?: CustomizationJob): string => {
   if (!customizationJob) {
@@ -121,12 +129,16 @@ export const getDatasetUri = (customizationJob?: CustomizationJob): string => {
   if (isUnslothJob(customizationJob)) {
     return customizationJob.spec.dataset.path ?? '';
   }
+  if (isRlJob(customizationJob)) {
+    return customizationJob.spec.dataset ?? '';
+  }
   return '';
 };
 
 /**
  * Effective training batch size, used to compute the loss-chart x-axis. Automodel uses
- * `batch.global_batch_size`; unsloth uses `batch.per_device_train_batch_size`.
+ * `batch.global_batch_size` and unsloth `batch.per_device_train_batch_size`; RL has no
+ * `batch` block and keeps `batch_size` on `training`.
  */
 export const getTrainingBatchSize = (customizationJob?: CustomizationJob): number => {
   if (!customizationJob) {
@@ -137,6 +149,9 @@ export const getTrainingBatchSize = (customizationJob?: CustomizationJob): numbe
   }
   if (isUnslothJob(customizationJob)) {
     return customizationJob.spec.batch?.per_device_train_batch_size ?? 0;
+  }
+  if (isRlJob(customizationJob)) {
+    return customizationJob.spec.training.batch_size ?? 0;
   }
   return 0;
 };
@@ -172,7 +187,9 @@ export const getCustomizationTrainingProgress = (customization: CustomizationJob
     return '';
   }
 
-  const epochs = customization.spec?.schedule?.epochs;
+  const epochs = isRlJob(customization)
+    ? customization.spec?.training?.epochs
+    : customization.spec?.schedule?.epochs;
 
   const { epoch, percentage_done: percentageDone } = customization.status_details || {};
 
@@ -441,6 +458,29 @@ export const getTrainingOptionBadges = (job: CustomizationJob | null | undefined
       badges.push(badge('gpus', <Gpu />, getTextWithCount('GPU', gpuCount)));
     }
     badges.push(badge('precision', undefined, `Precision: ${precision}`));
+    return badges;
+  }
+
+  if (isRlJob(job)) {
+    const p = job.spec.training.parallelism;
+    if (!p) return [];
+    const badges: ReactNode[] = [
+      badge('num_gpus_per_node', <Gpu />, getTextWithCount('GPU', p.num_gpus_per_node ?? 0)),
+      badge('num_nodes', <Circle />, getTextWithCount('Node', p.num_nodes ?? 0)),
+    ];
+    // Only shown when engaged; RL defaults every degree to 1 and a "1 Tensor Parallel" badge says nothing.
+    if (p.tensor_parallel_size && p.tensor_parallel_size > 1) {
+      badges.push(
+        badge(
+          'tensor_parallel_size',
+          <Gpu />,
+          getTextWithCount('Tensor Parallel', p.tensor_parallel_size)
+        )
+      );
+    }
+    if (p.sequence_parallel) {
+      badges.push(badge('sequence_parallel', undefined, 'Sequence Parallel'));
+    }
     return badges;
   }
 

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -5,21 +5,48 @@ import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName'
 import type {
   AutomodelJobInput,
   AutomodelJobsJobRequest,
+  RlJobInput,
+  RlJobsJobRequest,
   UnslothJobInput,
   UnslothJobsJobRequest,
 } from '@nemo/sdk/generated/customizer/schema';
 import { CustomizationCreateAutomodelJobBody } from '@nemo/sdk/generated/customizer/zod/automodel-jobs';
+import { CustomizationCreateRlJobBody } from '@nemo/sdk/generated/customizer/zod/rl-jobs';
 import { CustomizationCreateUnslothJobBody } from '@nemo/sdk/generated/customizer/zod/unsloth-jobs';
-import { isAutomodelJob, type CustomizationJob } from '@studio/util/customizationBackend';
+import {
+  CustomizationBackend,
+  isAutomodelJob,
+  isRlJob,
+  type CustomizationJob,
+} from '@studio/util/customizationBackend';
 import { z } from 'zod';
 
 export interface CustomizationFormFields {
-  backend: 'automodel' | 'unsloth';
+  backend: CustomizationBackend;
   outputName: string;
   description: string;
   automodel: AutomodelJobInput;
   unsloth: UnslothJobInput;
+  rl: RlJobInput;
 }
+
+type DatasetFieldName = 'automodel.dataset.training' | 'unsloth.dataset.path' | 'rl.dataset';
+
+/** Each backend keeps the training dataset reference under a different path. */
+export const DATASET_FIELD_BY_BACKEND: Record<CustomizationBackend, DatasetFieldName> = {
+  automodel: 'automodel.dataset.training',
+  unsloth: 'unsloth.dataset.path',
+  rl: 'rl.dataset',
+};
+
+type ModelFieldName = 'automodel.model' | 'unsloth.model.name' | 'rl.model';
+
+/** Likewise for the base model reference. */
+export const MODEL_FIELD_BY_BACKEND: Record<CustomizationBackend, ModelFieldName> = {
+  automodel: 'automodel.model',
+  unsloth: 'unsloth.model.name',
+  rl: 'rl.model',
+};
 
 const UNSLOTH_DEFAULT_TARGET_MODULES = [
   'q_proj',
@@ -30,6 +57,37 @@ const UNSLOTH_DEFAULT_TARGET_MODULES = [
   'up_proj',
   'down_proj',
 ];
+
+// Every value here is sent on each submit, so these must match the backend defaults
+// (services/rl/src/nmp/rl/schemas.py); `max_steps` stays unset so `epochs` drives length.
+const RL_DPO_DEFAULTS: RlJobInput = {
+  model: '',
+  dataset: '',
+  training: {
+    type: 'dpo',
+    epochs: 1,
+    learning_rate: 1e-4,
+    batch_size: 32,
+    micro_batch_size: 1,
+    max_seq_length: 2048,
+    warmup_steps: 0,
+    weight_decay: 0.01,
+    ref_policy_kl_penalty: 0.05,
+    preference_loss_weight: 1,
+    sft_loss_weight: 0,
+    preference_average_log_probs: false,
+    sft_average_log_probs: false,
+    max_grad_norm: 1.0,
+    parallelism: {
+      num_nodes: 1,
+      num_gpus_per_node: 1,
+      tensor_parallel_size: 1,
+      pipeline_parallel_size: 1,
+      context_parallel_size: 1,
+      sequence_parallel: false,
+    },
+  },
+};
 
 export const FORM_DEFAULTS: CustomizationFormFields = {
   backend: 'automodel',
@@ -106,6 +164,7 @@ export const FORM_DEFAULTS: CustomizationFormFields = {
     optimizer: { learning_rate: 2e-4, weight_decay: 0, optim: 'adamw_8bit' },
     hardware: { precision: 'bf16' },
   },
+  rl: RL_DPO_DEFAULTS,
 };
 
 const automodelBodySpec = CustomizationCreateAutomodelJobBody.shape.spec;
@@ -137,17 +196,28 @@ const unslothSpecSchema = unslothBodySpec.omit({ output: true }).extend({
   }),
 });
 
+const rlBodySpec = CustomizationCreateRlJobBody.shape.spec;
+const rlSpecSchema = rlBodySpec.omit({ output: true }).extend({
+  model: z.string().min(1, 'Please select a model'),
+  dataset: z.string().min(1, 'Training dataset is required'),
+});
+
 export const customizationFormSchema = z
   .object({
-    backend: z.enum(['automodel', 'unsloth']),
+    backend: z.nativeEnum(CustomizationBackend),
     outputName: z.string().min(1, 'Output model name is required'),
     description: z.string(),
     automodel: z.unknown(),
     unsloth: z.unknown(),
+    rl: z.unknown(),
   })
   .superRefine((data, ctx) => {
-    const spec = data.backend === 'automodel' ? automodelSpecSchema : unslothSpecSchema;
-    const value = data.backend === 'automodel' ? data.automodel : data.unsloth;
+    const specByBackend = {
+      automodel: [automodelSpecSchema, data.automodel],
+      unsloth: [unslothSpecSchema, data.unsloth],
+      rl: [rlSpecSchema, data.rl],
+    } as const;
+    const [spec, value] = specByBackend[data.backend];
     const result = spec.safeParse(value);
     if (!result.success) {
       for (const issue of result.error.issues) {
@@ -175,6 +245,15 @@ export const formToAutomodelCreate = (f: CustomizationFormFields): AutomodelJobs
     },
   };
 };
+
+export const formToRlCreate = (f: CustomizationFormFields): RlJobsJobRequest => ({
+  name: f.outputName || undefined,
+  description: f.description || undefined,
+  spec: {
+    ...f.rl,
+    output: { name: f.outputName || undefined },
+  },
+});
 
 export const formToUnslothCreate = (f: CustomizationFormFields): UnslothJobsJobRequest => {
   const { training } = f.unsloth;
@@ -213,6 +292,15 @@ export const jobToFormFields = (job: CustomizationJob): CustomizationFormFields 
       description: job.description ?? '',
       backend: 'automodel',
       automodel: stripNulls(job.spec) as AutomodelJobInput,
+    };
+  }
+  if (isRlJob(job)) {
+    return {
+      ...FORM_DEFAULTS,
+      outputName: generateDefaultName(),
+      description: job.description ?? '',
+      backend: 'rl',
+      rl: stripNulls(job.spec) as RlJobInput,
     };
   }
   return {

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
-import type {
-  AutomodelJobInput,
-  AutomodelJobsJobRequest,
-  RlJobInput,
-  RlJobsJobRequest,
-  UnslothJobInput,
-  UnslothJobsJobRequest,
+import {
+  type AutomodelJobInput,
+  type AutomodelJobsJobRequest,
+  OptimizerType,
+  type RlJobInput,
+  type RlJobsJobRequest,
+  type UnslothJobInput,
+  type UnslothJobsJobRequest,
 } from '@nemo/sdk/generated/customizer/schema';
 import { CustomizationCreateAutomodelJobBody } from '@nemo/sdk/generated/customizer/zod/automodel-jobs';
 import { CustomizationCreateRlJobBody } from '@nemo/sdk/generated/customizer/zod/rl-jobs';
@@ -66,6 +67,9 @@ const RL_DPO_DEFAULTS: RlJobInput = {
   training: {
     type: 'dpo',
     epochs: 1,
+    // Schema default is null; the service resolves that to AdamW + cosine annealing.
+    // Seeded so the optimizer select renders with a selection rather than blank.
+    optimizer_type: OptimizerType.adamw_with_cosine_annealing,
     learning_rate: 1e-4,
     batch_size: 32,
     micro_batch_size: 1,


### PR DESCRIPTION
- <img width="1410" height="808" alt="image" src="https://github.com/user-attachments/assets/74c8a634-6079-4ccc-bc12-121bd79d5a43" />
- <img width="1248" height="663" alt="image" src="https://github.com/user-attachments/assets/504b9085-498f-4075-89b9-2a84589eda2e" />
- <img width="1303" height="439" alt="image" src="https://github.com/user-attachments/assets/5179e936-de41-4bea-a0d8-a6ea82413173" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reinforcement learning (RL) customization with Direct Preference Optimization (DPO).
  * Added RL-specific model, dataset, compute, training, optimizer, and DPO parameter controls.
  * Added RL job creation, cloning, status tracking, cancellation, and configuration details.
  * Added guidance for supported preference-pair dataset formats.
* **Bug Fixes**
  * Corrected epoch and hyperparameter display for RL jobs.
  * Improved backend-specific model and dataset field handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->