### PR TITLE
chore: Update deprecated fastapi status imports

### DIFF
--- a/packages/nmp_common/src/nmp/common/api/utils.py
+++ b/packages/nmp_common/src/nmp/common/api/utils.py
@@ -655,7 +655,7 @@ def parse_deep_object_query(field_name: str, value_type: Type[T]) -> Callable[[R
                 return None
             return value_type(**parsed)
         except ValidationError as e:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
 
     return _dep
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/metrics.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/metrics.py
@@ -112,7 +112,7 @@ async def create_metric(
         return await service.create_metric(name, metric, workspace=workspace, project=project)
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during metric creation: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except ValueError as e:
         if "already exists" in str(e).lower():
             logger.warning(f"Metric already exists: {safe_workspace}/{safe_name}")

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/tasks.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/tasks.py
@@ -108,10 +108,10 @@ async def create_task(
         return created
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during task creation: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except MetricRefNotFoundError as e:
         logger.warning(f"Task has an invalid metric reference: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except ValueError as e:
         if "already exists" in str(e).lower():
             logger.warning(f"Task already exists: {safe_workspace}/{safe_name}")
@@ -165,10 +165,10 @@ async def replace_task(
         replaced, published = await service.replace_task(name, task, workspace=workspace, project=project)
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during task replace: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except MetricRefNotFoundError as e:
         logger.warning(f"Task has an invalid metric reference: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except RevisionConflictError as e:
         logger.warning(f"Task revision allocation contended: {e}")
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
@@ -261,7 +261,7 @@ async def get_task_revision(
     status_code=status.HTTP_200_OK,
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Task or revision not found"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Tag is reserved"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Tag is reserved"},
     },
 )
 @scope.write
@@ -283,7 +283,7 @@ async def tag_task_revision(
     try:
         tagged = await service.tag_revision(workspace, name, tag, revision)
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except RevisionNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     if tagged is None:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/tasksets.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/api/v2/tasksets.py
@@ -112,11 +112,11 @@ async def create_taskset(
         return created
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during taskset creation: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except (TaskRefNotFoundError, DuplicateTaskRefError) as e:
         # A bad member reference (missing task, or two refs to the same task) — a client error.
         logger.warning(f"Taskset has an invalid task reference: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except TasksetExistsError:
         logger.warning(f"Taskset already exists: {safe_workspace}/{safe_name}")
         raise HTTPException(
@@ -168,10 +168,10 @@ async def replace_taskset(
         replaced, published = await service.replace_taskset(name, taskset, workspace=workspace, project=project)
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during taskset replace: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except (TaskRefNotFoundError, DuplicateTaskRefError) as e:
         logger.warning(f"Taskset has an invalid task reference: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except RevisionConflictError as e:
         logger.warning(f"Taskset revision allocation contended: {e}")
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
@@ -259,7 +259,7 @@ async def get_taskset_revision(
     status_code=status.HTTP_200_OK,
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Taskset or revision not found"},
-        status.HTTP_422_UNPROCESSABLE_ENTITY: {"description": "Tag is reserved"},
+        status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Tag is reserved"},
     },
 )
 @scope.write
@@ -275,7 +275,7 @@ async def tag_taskset_revision(
     try:
         tagged = await service.tag_revision(workspace, name, tag, revision)
     except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except RevisionNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     if tagged is None:

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -876,7 +876,7 @@ async def virtual_model_proxy(
             modified_model_ref = parse_model_entity_ref(json_body["model"])
         except (KeyError, TypeError, ValueError) as exc:
             raise HTTPException(
-                http_status.HTTP_422_UNPROCESSABLE_ENTITY,
+                http_status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=f"Could not resolve model entity from body['model'] after request middleware: {exc}",
             ) from exc
 

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/validation.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/validation.py
@@ -27,7 +27,7 @@ def validate_entity_name(value: str, *, field_name: str = "name") -> None:
     """
     if not _ENTITY_NAME_PATTERN.match(value):
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Invalid {field_name}: {NAME_PATTERN_DESCRIPTION}",
         )
 

--- a/services/core/models/src/nmp/core/models/api/v2/adapters.py
+++ b/services/core/models/src/nmp/core/models/api/v2/adapters.py
@@ -58,7 +58,7 @@ async def create_adapter(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during adapter creation: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except PermissionError as e:
@@ -198,7 +198,7 @@ async def update_adapter(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during adapter update: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except PermissionError as e:

--- a/services/core/models/src/nmp/core/models/api/v2/deployment_configs.py
+++ b/services/core/models/src/nmp/core/models/api/v2/deployment_configs.py
@@ -120,7 +120,7 @@ async def create_deployment_config(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during deployment config creation: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except Exception:
@@ -253,7 +253,7 @@ async def update_deployment_config(
     deployment_config_name = name
     logger.info(f"Updating deployment config: {workspace}/{deployment_config_name}")
     if not deployments_enabled():
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
     try:
         if config_input.model_entity_id:
             await check_model_entity_access(auth_client, config_input.model_entity_id, workspace)
@@ -270,7 +270,7 @@ async def update_deployment_config(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during deployment config update: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except Exception:
@@ -304,7 +304,7 @@ async def delete_all_deployment_config_versions(
     dependent deployments to reach DELETED status before deleting the config.
     """
     if not deployments_enabled():
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
     deployment_config_name = name
     logger.info(f"Deleting all versions of deployment config: {workspace}/{deployment_config_name}")
 
@@ -358,7 +358,7 @@ async def delete_deployment_config_version(
     dependent deployments to reach DELETED status before deleting the config version.
     """
     if not deployments_enabled():
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
     deployment_config_name = config
     logger.info(f"Deleting deployment config version: {workspace}/{deployment_config_name} version {name}")
 

--- a/services/core/models/src/nmp/core/models/api/v2/deployments.py
+++ b/services/core/models/src/nmp/core/models/api/v2/deployments.py
@@ -98,7 +98,7 @@ async def create_deployment(
     Create a new ModelDeployment (version 1).
     """
     if not deployments_enabled():
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
 
     logger.debug(f"Creating deployment: {workspace}/{deployment_input.name}")
 
@@ -123,7 +123,7 @@ async def create_deployment(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during deployment creation: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except Exception:
@@ -290,7 +290,7 @@ async def update_deployment(
     Update a ModelDeployment (creates a new immutable version).
     """
     if not deployments_enabled():
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
     deployment_name = name
     logger.debug(f"Updating deployment: {workspace}/{deployment_name}")
 
@@ -310,7 +310,7 @@ async def update_deployment(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during deployment update: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except Exception:
@@ -336,7 +336,7 @@ async def update_deployment_status(
     If version is not specified, updates the latest version.
     """
     if not deployments_enabled():
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
     deployment_name = name
     logger.debug(
         f"Updating deployment status: {workspace}/{deployment_name}"
@@ -370,7 +370,7 @@ async def update_deployment_status(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during deployment status update: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except DeploymentStatusConflictError as e:
@@ -419,7 +419,7 @@ async def delete_all_deployment_versions(
     - 404 Not Found: Deployment doesn't exist
     """
     if not deployments_enabled():
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
     deployment_name = name
     logger.debug(f"Deleting all versions of deployment: {workspace}/{deployment_name}")
 
@@ -488,7 +488,7 @@ async def delete_deployment_version(
     - 404 Not Found: Deployment version doesn't exist
     """
     if not deployments_enabled():
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=ERR_DEPLOYMENTS_NOT_ENABLED)
     deployment_name = deployment
     logger.debug(f"Deleting deployment version: {workspace}/{deployment_name} version {name}")
 

--- a/services/core/models/src/nmp/core/models/api/v2/models.py
+++ b/services/core/models/src/nmp/core/models/api/v2/models.py
@@ -138,7 +138,7 @@ async def create_model(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during model creation: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except ValueError as e:
@@ -402,7 +402,7 @@ async def update_model(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during model update: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except PermissionError as e:
@@ -506,7 +506,7 @@ async def create_model_adapter(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during adapter creation: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except PermissionError as e:
@@ -628,7 +628,7 @@ async def update_model_adapter(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during adapter update: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except PermissionError as e:

--- a/services/core/models/src/nmp/core/models/api/v2/prompts.py
+++ b/services/core/models/src/nmp/core/models/api/v2/prompts.py
@@ -89,7 +89,7 @@ async def create_prompt(
         return await service.create_prompt(request, workspace)
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during prompt creation: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except ValueError as e:
         if "already exists" in str(e).lower():
             logger.warning(f"Prompt already exists: {safe_workspace}/{safe_request_name}")
@@ -157,7 +157,7 @@ async def update_prompt(
         return prompt
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during prompt update: {e}")
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e))
     except HTTPException:
         raise
     except Exception:

--- a/services/core/models/src/nmp/core/models/api/v2/providers.py
+++ b/services/core/models/src/nmp/core/models/api/v2/providers.py
@@ -104,7 +104,7 @@ async def create_provider(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during model provider creation: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except ModelProviderValidationError as e:
@@ -157,7 +157,7 @@ async def upsert_provider(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during model provider upsert: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except ModelProviderValidationError as e:
@@ -210,7 +210,7 @@ async def update_provider_status(
     except EntityValidationError as e:
         logger.warning(f"Entity store validation error during model provider status update: {e}")
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(e),
         )
     except HTTPException:

--- a/services/guardrails/src/nmp/guardrails/app/handlers/checks.py
+++ b/services/guardrails/src/nmp/guardrails/app/handlers/checks.py
@@ -88,7 +88,7 @@ class CheckRequestHandler:
         try:
             config_ids, config = self.get_guardrails_config()
         except ValueError as e:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)) from e
 
         if config_ids:
             log.info("Got request for config(s) %s", config_ids)

--- a/services/guardrails/src/nmp/guardrails/app/handlers/completion.py
+++ b/services/guardrails/src/nmp/guardrails/app/handlers/completion.py
@@ -115,7 +115,7 @@ class CompletionRequestHandler:
         try:
             config_ids, config = self.get_guardrails_config()
         except ValueError as e:
-            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)) from e
         prompt, messages = self._get_prompt_or_messages(self.body)
 
         if config_ids:

--- a/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
@@ -467,7 +467,7 @@ async def list_evaluations(
             exc.limit,
         )
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=(
                 f"This query selects {exc.selected} evaluations, exceeding the maximum of "
                 f"{exc.limit} that can be sorted in one request. Narrow the result with a "
@@ -799,7 +799,7 @@ async def list_evaluation_sessions(
         ) from exc
     except MetricSortTooLargeError as exc:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=(
                 f"This query selects {exc.total} sessions, exceeding the maximum of "
                 f"{exc.limit} that can be sorted by cost or tokens in one request. "

--- a/services/intake/src/nmp/intake/spans/ingest/otlp.py
+++ b/services/intake/src/nmp/intake/spans/ingest/otlp.py
@@ -76,7 +76,7 @@ async def ingest_otlp_traces(
     max_bytes = _otlp_max_body_bytes(request)
     if content_length is not None and content_length > max_bytes:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"OTLP body of {content_length} bytes exceeds limit of {max_bytes} bytes",
         )
 
@@ -140,7 +140,7 @@ async def _read_limited_body(request: Request, *, max_bytes: int) -> bytes:
         size += len(chunk)
         if size > max_bytes:
             raise HTTPException(
-                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
                 detail=f"OTLP body exceeds limit of {max_bytes} bytes",
             )
         chunks.append(chunk)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
When starting NMP, the terminal emits warnings because Evaluator uses deprecated imports from `fastapi`:
```
StarletteDeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.
```

This PR updates all occurrences of deprecated status imports (422 and 413 status codes).

## Changes
- Swap fastapi status imports from deprecated -> current

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: simply swapping imports
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation error responses to use the standardized HTTP 422 “Unprocessable Content” status.
  * Updated oversized request responses to use HTTP 413 “Content Too Large.”
  * Applied consistent status codes across model, deployment, task, evaluation, guardrail, inference, and data-ingestion APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->