### PR TITLE
fix(deployments): inject VIRTUAL_ENV into openshell sandboxes

### DIFF
--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/backend.py
@@ -359,6 +359,8 @@ class OpenShellDeploymentBackend(DeploymentBackend):
             )
         if "PATH" not in env:
             env["PATH"] = self._executor_config.serve_path
+        if "VIRTUAL_ENV" not in env and self._executor_config.serve_virtual_env:
+            env["VIRTUAL_ENV"] = self._executor_config.serve_virtual_env
         all_labels = {
             **labels,
             **config.labels,

--- a/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/config.py
+++ b/plugins/nemo-deployments/src/nemo_deployments_plugin/backends/openshell/config.py
@@ -121,6 +121,16 @@ class OpenShellExecutorConfig(BaseModel):
             "config already declares PATH."
         ),
     )
+    serve_virtual_env: str = Field(
+        default="/workspace/.venv",
+        description=(
+            "VIRTUAL_ENV injected into the sandbox environment. PATH alone only fixes the "
+            "processes the supervisor execs directly; a child that re-launches an interpreter "
+            "from sys.base_prefix (Fabric spawns its adapter host this way) escapes the venv "
+            "and loses site-packages. Ignored when the deployment config already declares "
+            "VIRTUAL_ENV; empty string disables the injection."
+        ),
+    )
     landlock_compatibility: Literal["best_effort", "hard_requirement"] = Field(
         default="best_effort",
         description=(

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_backend.py
@@ -466,6 +466,63 @@ async def test_create_injects_serve_path_into_sandbox_environment(
     assert spec.template.environment["PATH"] == expected
 
 
+async def test_create_injects_serve_virtual_env_into_sandbox_environment(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    """PATH alone does not keep a re-launched interpreter inside the venv.
+
+    Fabric starts its adapter host from ``sys.base_prefix``, which resolves to the
+    uv-managed interpreter rather than the venv and so cannot import the adapter
+    packages. VIRTUAL_ENV is what keeps that child in the venv.
+    """
+    mock_entities.get.return_value = _config()
+    mock_stub.GetSandbox.side_effect = _not_found()
+    mock_stub.CreateSandbox.return_value = MagicMock()
+
+    update = await openshell_backend.create_deployment(
+        workspace="default", name="srv", config_name="cfg1", labels={}, backend_config={}
+    )
+
+    assert update.status == "STARTING"
+    spec = mock_stub.CreateSandbox.call_args.args[0].spec
+    expected = openshell_backend._executor_config.serve_virtual_env
+    assert spec.environment["VIRTUAL_ENV"] == expected
+    assert spec.template.environment["VIRTUAL_ENV"] == expected
+
+
+async def test_create_respects_a_container_declared_virtual_env(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    mock_entities.get.return_value = _config_with_env([EnvVar(name="VIRTUAL_ENV", value="/opt/other-venv")])
+    mock_stub.GetSandbox.side_effect = _not_found()
+    mock_stub.CreateSandbox.return_value = MagicMock()
+
+    update = await openshell_backend.create_deployment(
+        workspace="default", name="srv", config_name="cfg1", labels={}, backend_config={}
+    )
+
+    assert update.status == "STARTING"
+    spec = mock_stub.CreateSandbox.call_args.args[0].spec
+    assert spec.environment["VIRTUAL_ENV"] == "/opt/other-venv"
+
+
+async def test_create_omits_virtual_env_when_disabled(
+    openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
+) -> None:
+    openshell_backend._executor_config.serve_virtual_env = ""
+    mock_entities.get.return_value = _config()
+    mock_stub.GetSandbox.side_effect = _not_found()
+    mock_stub.CreateSandbox.return_value = MagicMock()
+
+    update = await openshell_backend.create_deployment(
+        workspace="default", name="srv", config_name="cfg1", labels={}, backend_config={}
+    )
+
+    assert update.status == "STARTING"
+    spec = mock_stub.CreateSandbox.call_args.args[0].spec
+    assert "VIRTUAL_ENV" not in spec.environment
+
+
 async def test_create_respects_a_container_declared_path(
     openshell_backend: OpenShellDeploymentBackend, mock_stub: MagicMock, mock_entities: AsyncMock
 ) -> None:

--- a/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_executor_config.py
+++ b/plugins/nemo-deployments/tests/unit/backends/openshell/test_openshell_executor_config.py
@@ -97,3 +97,13 @@ def test_serve_path_defaults_to_venv_bin_prepended_to_system_path() -> None:
 def test_serve_path_is_overridable() -> None:
     config = OpenShellExecutorConfig.model_validate({"serve_path": "/opt/bin:/usr/bin"})
     assert config.serve_path == "/opt/bin:/usr/bin"
+
+
+def test_serve_virtual_env_defaults_to_the_packaged_venv() -> None:
+    config = OpenShellExecutorConfig.model_validate({})
+    assert config.serve_virtual_env == "/workspace/.venv"
+
+
+def test_serve_virtual_env_is_overridable_and_can_be_disabled() -> None:
+    assert OpenShellExecutorConfig.model_validate({"serve_virtual_env": "/opt/venv"}).serve_virtual_env == "/opt/venv"
+    assert OpenShellExecutorConfig.model_validate({"serve_virtual_env": ""}).serve_virtual_env == ""


### PR DESCRIPTION
## Summary

Every Fabric-backed agent deployed into an OpenShell sandbox failed on its first invoke with `ModuleNotFoundError: No module named 'nemo_fabric_adapters'`. The packaged agent image sets `ENV VIRTUAL_ENV=/workspace/.venv`, but the ExecSandbox drops image ENV and the backend re-injected only `PATH`. After this change the adapter host loads and the harness runs.

`PATH` covers the processes the supervisor execs directly, which is why `python -m nemo_agents_plugin.fabric.server` started and `/health` passed — readiness gating never caught this. It does not cover a grandchild that re-launches an interpreter: Fabric starts its adapter host from `sys.base_prefix`, landing on the uv-managed interpreter rather than the venv, where site-packages is absent.

## Related Issue

AIRCORE-1054

## Changes

- `backends/openshell/backend.py`: inject `VIRTUAL_ENV` alongside the existing `PATH` injection.
- `backends/openshell/config.py`: new `serve_virtual_env` executor field (default `/workspace/.venv`; empty string disables; a container-declared `VIRTUAL_ENV` wins).
- Tests: injection into both `spec.environment` and `spec.template.environment`, container-declared override, and the disable path.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the new config field is self-documenting via its `Field(description=...)`, which is how every other executor option in this file is described.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
uv run --frozen pytest plugins/nemo-deployments/tests/unit/backends/openshell -q
  → 121 passed (includes the 5 new tests)

uv run pre-commit run ruff --all-files        → Passed
uv run pre-commit run ruff-format --all-files → Passed
uv run pre-commit run ty --all-files          → Passed
```

`uv run pre-commit run -a` is **not** fully green on my machine. Every failure is a missing local tool, unrelated to this change, and none of them modified any file (working tree stayed clean):

- `helm-docs` — binary not installed locally
- `uv-lock` — requires uv 0.9.14; local uv is 0.9.30 (`uv-lock-check` for drift **Passed**)
- `uv-version-consistency`, `python-version-consistency`, `node-version-consistency` — all exit 127, `yq: command not found`

Live verification on the docker driver (OpenShell gateway `:17670`): a Fabric codex-harness agent deployed via `nemo agents deploy --mode docker` onto an `openshell-local` executor reached `running` at a gateway URL. Before the fix, `nemo agents invoke` returned the `ModuleNotFoundError` above. After it, the adapter host loads and the harness executes a real model call, leaving only a separate missing-credential error that is tracked on its own.

Inside a live sandbox, confirming the mechanism:

```
$ /opt/uv/python/cpython-3.13.9-linux-aarch64-gnu/bin/python -c "import nemo_fabric_adapters"
ModuleNotFoundError: No module named 'nemo_fabric_adapters'

$ VIRTUAL_ENV=/workspace/.venv /workspace/.venv/bin/python -c "import nemo_fabric_adapters"
adapters OK
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable virtual-environment support for OpenShell deployments.
  * Deployments now use `/workspace/.venv` by default when setting the runtime environment.
  * Custom virtual-environment paths are supported, and the setting can be disabled.
  * Existing deployment-level virtual-environment settings take precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->