### PR TITLE
fix(studio): stop cross-tab workspace write loop

### DIFF
--- a/web/packages/studio/src/providers/workspace/WorkspaceProvider.test.tsx
+++ b/web/packages/studio/src/providers/workspace/WorkspaceProvider.test.tsx
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { WorkspaceProvider } from '@studio/providers/workspace/WorkspaceProvider';
+import { SELECTED_WORKSPACE_KEY } from '@studio/util/localStorage';
+import { act, render, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+
+vi.mock('@nemo/sdk/generated/platform/api', () => ({
+  useEntitiesGetWorkspace: () => ({
+    error: undefined,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@studio/providers/auth/useAuthProfile', () => ({
+  useAuthProfile: () => ({ workspace: 'profile-workspace' }),
+}));
+
+vi.mock('@studio/providers/auth/useAuthTokenStatus', () => ({
+  useAuthTokenStatus: () => ({ isTokenActive: true }),
+}));
+
+const renderWorkspaceProvider = (workspace: string) =>
+  render(
+    <MemoryRouter initialEntries={[`/workspaces/${workspace}`]}>
+      <Routes>
+        <Route
+          path="/workspaces/:workspace"
+          element={
+            <WorkspaceProvider>
+              <div>Workspace content</div>
+            </WorkspaceProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('WorkspaceProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists the route workspace', async () => {
+    renderWorkspaceProvider('workspace-a');
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(SELECTED_WORKSPACE_KEY)).toBe(
+        JSON.stringify('workspace-a')
+      );
+    });
+  });
+
+  it('does not counter-write when another tab changes the stored workspace', () => {
+    window.localStorage.setItem(SELECTED_WORKSPACE_KEY, JSON.stringify('workspace-a'));
+    renderWorkspaceProvider('workspace-a');
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+    window.localStorage.setItem(SELECTED_WORKSPACE_KEY, JSON.stringify('workspace-b'));
+    setItemSpy.mockClear();
+
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: SELECTED_WORKSPACE_KEY }));
+    });
+
+    expect(setItemSpy).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(SELECTED_WORKSPACE_KEY)).toBe(JSON.stringify('workspace-b'));
+  });
+});

--- a/web/packages/studio/src/providers/workspace/WorkspaceProvider.tsx
+++ b/web/packages/studio/src/providers/workspace/WorkspaceProvider.tsx
@@ -30,12 +30,13 @@ export const WorkspaceProvider: FC<WorkspaceProviderProps> = ({ children }) => {
     }
   }, [profile?.workspace, storedWorkspace, setStoredWorkspace]);
 
-  // Sync URL namespace to localStorage when on a project route (for persistence)
+  // Persist route changes, but do not react to storedWorkspace changes. Otherwise, tabs on
+  // different workspace routes continuously overwrite each other's shared localStorage value.
   useEffect(() => {
-    if (workspaceParam && workspaceParam !== storedWorkspace) {
+    if (workspaceParam) {
       setStoredWorkspace(workspaceParam);
     }
-  }, [workspaceParam, storedWorkspace, setStoredWorkspace]);
+  }, [workspaceParam, setStoredWorkspace]);
 
   const { isPending: isWorkspaceLoading, error: workspaceError } = useEntitiesGetWorkspace(
     selectedWorkspace ?? '',


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Stop Studio tabs on different workspace routes from continuously overwriting the shared `selected-workspace` localStorage entry. Route changes are still persisted, but a cross-tab storage update no longer causes an idle tab to counter-write its own route workspace.

## Changes

- Make workspace persistence depend only on the route workspace, not reactive localStorage updates.
- Add a regression test that dispatches the cross-tab `storage` event and verifies the idle tab does not write back.
- Preserve the existing behavior that the most recently navigated workspace becomes the remembered default.

### Reproduction and trace evidence

1. Open Studio in two Chrome tabs on the same origin.
2. Navigate each tab to a different `/workspaces/<workspace>` route.
3. Leave both tabs idle. Chrome Task Manager shows sustained renderer CPU; closing either tab causes it to drop.

In the provided 5.14-second idle Chrome trace, the affected renderer main thread consumed 3.11 CPU-seconds (60.6% of one logical core), with 240,289 top-level tasks. It scheduled 52,780 storage tasks (about 10.3k/second). The hot path was `storage` event -> `useLocalStorage` subscription -> `WorkspaceProvider` effect -> `localStorage.setItem`.

The two tabs were ping-ponging `selected-workspace`: tab A observed tab B's write and restored workspace A, then tab B observed that write and restored workspace B, indefinitely.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Internal state synchronization fix with no user-facing workflow or API change.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui test src/providers/workspace/WorkspaceProvider.test.tsx` — passed (2 tests).
- `pnpm --filter nemo-studio-ui test:ci` — passed (319 files, 2,970 tests).
- `pnpm --filter nemo-studio-ui typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm format` — passed.
- `pnpm deps:studio` — passed.
- `pnpm --filter @nemo/sdk gen:all-force` — passed; no generated SDK drift.
- `pnpm --filter @nemo/common types:plugin` — passed; no generated plugin-type drift.
- `SKIP=helm-docs uv run pre-commit run -a` — all applicable hooks passed. The unskipped all-files run is blocked by pre-existing Helm README drift on `origin/main`: `helm-docs` rewrites `k8s/helm/README.md` even though this PR does not touch any Helm input. That unrelated generated rewrite was restored and is not included here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workspace selection synchronization across browser tabs.
  - Prevented one tab from repeatedly overwriting another tab’s selected workspace.
  - Workspace route changes now persist more reliably.

- **Tests**
  - Added coverage for workspace persistence and cross-tab storage updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->