### PR TITLE
fix(evaluator): carry trial cost through to Intake

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from collections.abc import Mapping
 from typing import Any
 
@@ -31,7 +32,7 @@ from nemo_evaluator_sdk.metrics.protocol import (
 )
 from nemo_evaluator_sdk.values.atif import Trajectory
 from nemo_evaluator_sdk.values.evidence import EVIDENCE_TRACE
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -204,8 +205,22 @@ class TrialMeasurements(BaseModel):
     cache_creation_tokens: int | None = None
     cache_read_tokens: int | None = None
     runtime_sec: float | None = None
+    cost_usd: float | None = Field(default=None, allow_inf_nan=False)
     reward: float | None = None
     passed: bool | None = None
+
+    @field_validator("cost_usd", mode="before")
+    @classmethod
+    def _reject_boolean_cost(cls, value: Any) -> Any:
+        """Refuse a ``bool`` cost, which coercion would otherwise hide.
+
+        ``bool`` is an ``int`` subclass, so ``True`` would validate as a cost of 1.0. Every other
+        unusable value is already refused: ``allow_inf_nan=False`` covers NaN and the infinities
+        however they were spelled, and float coercion covers an int too large to represent.
+        """
+        if isinstance(value, bool):
+            raise ValueError("cost_usd must be a number, not a bool")
+        return value
 
     @classmethod
     def from_metadata(cls, metadata: Mapping[str, Any] | None) -> TrialMeasurements:
@@ -225,6 +240,7 @@ class TrialMeasurements(BaseModel):
         return cls(
             **tokens,
             runtime_sec=_runtime_sec(metadata),
+            cost_usd=_as_float(metadata.get("cost_usd")),
             reward=_reward(metadata, passed),
             passed=passed,
         )
@@ -255,6 +271,19 @@ def _as_int(value: Any) -> int | None:
     if isinstance(value, bool):
         return None
     return value if isinstance(value, int) else None
+
+
+def _as_float(value: Any) -> float | None:
+    # bool is an int subclass; never treat True/False as a measurement. NaN, the infinities, and
+    # integers too large to represent are rejected too: none can be serialised onto the wire, so
+    # recording one would fail the publish of an otherwise good trial.
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    try:
+        number = float(value)
+    except OverflowError:
+        return None
+    return number if math.isfinite(number) else None
 
 
 def _runtime_sec(metadata: Mapping[str, Any]) -> float | None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -85,6 +85,7 @@ async def test_harbor_runner_scores_through_agent_evaluator_and_adapts_legacy_pa
     assert trials["pass-task"].status == AgentEvalTrialStatus.COMPLETED
     assert trials["pass-task"].metadata["reward"] == 1.0
     assert trials["pass-task"].metadata["prompt_tokens"] == 100
+    assert trials["pass-task"].metadata["cost_usd"] == 0.25
     assert trials["pass-task"].evidence is not None
     assert trials["fail-task"].status == AgentEvalTrialStatus.PARTIAL
     assert trials["fail-task"].error is not None

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_metrics.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_metrics.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ from nemo_evaluator_sdk.agent_eval.metrics import (
 from nemo_evaluator_sdk.agent_eval.trials import standard_evidence_descriptors
 from nemo_evaluator_sdk.metrics.protocol import CandidateOutput, DatasetRow, MetricInput
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence
+from pydantic import ValidationError
 
 
 @pytest.mark.asyncio
@@ -65,12 +67,14 @@ def test_from_metadata_reads_tokens_runtime_reward() -> None:
             "prompt_tokens": 80,
             "completion_tokens": 40,
             "runtime_sec": 4.5,
+            "cost_usd": 0.134,
             "reward": 1,
             "passed": True,
         }
     )
     assert measurements.total_tokens == 120
     assert measurements.runtime_sec == 4.5
+    assert measurements.cost_usd == 0.134
     assert measurements.reward == 1.0
     assert measurements.passed is True
 
@@ -83,4 +87,38 @@ def test_from_metadata_applies_fallbacks_and_ignores_bad_types() -> None:
     assert measurements.total_tokens is None
 
     empty = TrialMeasurements.from_metadata(None)
-    assert empty.reward is None and empty.runtime_sec is None
+    assert empty.reward is None and empty.runtime_sec is None and empty.cost_usd is None
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf"), True, 10**1000])
+def test_from_metadata_rejects_unserialisable_cost(bad: object) -> None:
+    # A cost the wire cannot carry would fail the publish of an otherwise good trial. 10**1000 is
+    # an int no float can represent, which reaches here from any harness that reports JSON numbers.
+    assert TrialMeasurements.from_metadata({"cost_usd": bad}).cost_usd is None
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        True,
+        10**1000,
+        # These reach a float only through coercion, so they slip past any check made before it.
+        "nan",
+        "inf",
+        Decimal("NaN"),
+        Decimal("Infinity"),
+    ],
+)
+def test_direct_construction_rejects_unserialisable_cost(bad: object) -> None:
+    # from_metadata is not the only way in, so the model itself has to hold the invariant.
+    with pytest.raises(ValidationError):
+        TrialMeasurements(cost_usd=bad)
+
+
+@pytest.mark.parametrize("good", [0.134, 0, "0.5", Decimal("1.25")])
+def test_direct_construction_still_accepts_a_finite_cost(good: object) -> None:
+    # Rejecting non-finite values must not cost the ordinary coercion of a finite one.
+    assert TrialMeasurements(cost_usd=good).cost_usd == float(good)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
@@ -101,8 +101,9 @@ def _token_final_metrics(measurements: TrialMeasurements) -> AtifFinalMetricsPar
 
     Intake promotes these root totals onto the trajectory's root span, where the evaluation rollup
     reads them — so publishing them is what makes token counts show up under the Evaluation. Only the
-    token fields the trial actually recorded are set; a trial whose harness recorded no usage yields
-    ``None`` (no ``final_metrics`` block). Cost is not captured here.
+    fields the trial actually recorded are set; a trial that recorded neither token counts nor a
+    cost yields ``None`` (no ``final_metrics`` block). A recorded cost alone is enough to produce
+    one.
     """
     final_metrics: AtifFinalMetricsParam = {}
     if measurements.prompt_tokens is not None:
@@ -111,6 +112,8 @@ def _token_final_metrics(measurements: TrialMeasurements) -> AtifFinalMetricsPar
         final_metrics["total_completion_tokens"] = measurements.completion_tokens
     if measurements.cache_read_tokens is not None:
         final_metrics["total_cached_tokens"] = measurements.cache_read_tokens
+    if measurements.cost_usd is not None:
+        final_metrics["total_cost_usd"] = measurements.cost_usd
     return final_metrics or None
 
 

--- a/plugins/nemo-evaluator/tests/intake/test_publish.py
+++ b/plugins/nemo-evaluator/tests/intake/test_publish.py
@@ -131,12 +131,18 @@ def _result(trials: list[AgentEvalTrial], scores: list[AgentEvalTaskScore]) -> A
 
 def test_token_final_metrics_projects_recorded_token_usage() -> None:
     # Recorded token usage becomes ATIF final_metrics, which Intake promotes onto the root span.
-    measurements = TrialMeasurements(prompt_tokens=120, completion_tokens=45, cache_read_tokens=30)
+    measurements = TrialMeasurements(prompt_tokens=120, completion_tokens=45, cache_read_tokens=30, cost_usd=0.134)
     assert _token_final_metrics(measurements) == {
         "total_prompt_tokens": 120,
         "total_completion_tokens": 45,
         "total_cached_tokens": 30,
+        "total_cost_usd": 0.134,
     }
+
+
+def test_token_final_metrics_carries_cost_without_token_counts() -> None:
+    # A harness that reports spend but not usage still gets its cost onto the root span.
+    assert _token_final_metrics(TrialMeasurements(cost_usd=0.5)) == {"total_cost_usd": 0.5}
 
 
 def test_token_final_metrics_is_none_without_recorded_usage() -> None:

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/metrics.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/metrics.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from collections.abc import Mapping
 from typing import Any
 
@@ -31,7 +32,7 @@ from nemo_platform.beta.evaluator.metrics.protocol import (
 )
 from nemo_platform.beta.evaluator.values.atif import Trajectory
 from nemo_platform.beta.evaluator.values.evidence import EVIDENCE_TRACE
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -204,8 +205,22 @@ class TrialMeasurements(BaseModel):
     cache_creation_tokens: int | None = None
     cache_read_tokens: int | None = None
     runtime_sec: float | None = None
+    cost_usd: float | None = Field(default=None, allow_inf_nan=False)
     reward: float | None = None
     passed: bool | None = None
+
+    @field_validator("cost_usd", mode="before")
+    @classmethod
+    def _reject_boolean_cost(cls, value: Any) -> Any:
+        """Refuse a ``bool`` cost, which coercion would otherwise hide.
+
+        ``bool`` is an ``int`` subclass, so ``True`` would validate as a cost of 1.0. Every other
+        unusable value is already refused: ``allow_inf_nan=False`` covers NaN and the infinities
+        however they were spelled, and float coercion covers an int too large to represent.
+        """
+        if isinstance(value, bool):
+            raise ValueError("cost_usd must be a number, not a bool")
+        return value
 
     @classmethod
     def from_metadata(cls, metadata: Mapping[str, Any] | None) -> TrialMeasurements:
@@ -225,6 +240,7 @@ class TrialMeasurements(BaseModel):
         return cls(
             **tokens,
             runtime_sec=_runtime_sec(metadata),
+            cost_usd=_as_float(metadata.get("cost_usd")),
             reward=_reward(metadata, passed),
             passed=passed,
         )
@@ -255,6 +271,19 @@ def _as_int(value: Any) -> int | None:
     if isinstance(value, bool):
         return None
     return value if isinstance(value, int) else None
+
+
+def _as_float(value: Any) -> float | None:
+    # bool is an int subclass; never treat True/False as a measurement. NaN, the infinities, and
+    # integers too large to represent are rejected too: none can be serialised onto the wire, so
+    # recording one would fail the publish of an otherwise good trial.
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    try:
+        number = float(value)
+    except OverflowError:
+        return None
+    return number if math.isfinite(number) else None
 
 
 def _runtime_sec(metadata: Mapping[str, Any]) -> float | None:


### PR DESCRIPTION
## Summary

A trial's cost was recorded and then silently dropped, so evaluations in Intake reported no cost even though every Harbor run measures it. The Harbor runtime already reads `cost_usd` from Harbor's `agent_result` onto trial metadata, but `TrialMeasurements` had no field for it — the typed contract discarded it and the publisher had nothing left to send. After this change, cost reaches the evaluation rollup.

## Changes

- `agent_eval/metrics.py`: add `TrialMeasurements.cost_usd`, projected in `from_metadata` via a new `_as_float` coercion helper
- `intake/publish.py`: `_token_final_metrics` emits ATIF `total_cost_usd`
- Vendored SDK mirror regenerated via `tools/lint/lint-sdk-vendored.sh`
- Tests for the new field, the publisher projection, and a regression guard on the runtime's existing `cost_usd` extraction

No Intake-side change is needed: `atif_mapping` already maps `total_cost_usd` onto the root span's `cost_total_usd` and aggregates it per evaluation.

### On `_as_float`

It refuses two kinds of value that are numeric but are not measurements:

- **`bool`** — an `int` subclass, so a stray `True` would be recorded as a cost of 1.0. This mirrors the guard `_as_int` already applies.
- **NaN / ±Infinity** — the platform client serialises with `allow_nan=False`, so a non-finite cost would raise and fail the publish of an otherwise good trial. The sibling path in `intake/mapping.py` already drops non-finite metric values for exactly this reason; this keeps the two consistent.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing API or CLI surface changes; the new field is internal to the trial-measurement contract

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest packages/nemo_evaluator_sdk/tests plugins/nemo-evaluator/tests` — **2511 passed, 37 skipped**
- `ruff check` / `ruff format --check` on all changed files — pass
- **Mutation-checked**, since a test that passes against a broken implementation proves nothing. Each layer was broken on purpose and the corresponding test confirmed red:
  - drop `cost_usd` from `from_metadata` → `test_from_metadata_reads_tokens_runtime_reward` fails
  - drop `total_cost_usd` from `_token_final_metrics` → both `_token_final_metrics` tests fail
  - drop the `math.isfinite` guard → `test_from_metadata_rejects_unserialisable_cost` fails for `nan`/`inf`/`-inf`
- **End-to-end against a live Harbor run** (2 tasks, codex agent): the evaluation's rollup returned `cost_usd = {'sum': 0.058139, 'mean': 0.029069, 'count': 2}`, matching the sum of the trials' recorded spend.
- `uv run pre-commit run -a` — all hooks passed **except two blocked in my local environment, not by this change**:
  - **Helm Docs** — `helm-docs` is not installed locally. This diff touches no `k8s/` or `helm/` files.
  - **Run uv lock with platform uv** — the `uv` on PATH in the hook env is 0.9.30, repo requires 0.9.14. This diff changes no dependency; `Check for uv.lock drift` passed.

  Left unchecked rather than claimed — CI has both tools.

### Note on a flaky unrelated test

`test_symlink_loop_degrades_the_stamp_instead_of_killing_the_run` failed when I ran a narrow subset, and **also fails on pristine `origin/main`** with none of my changes applied; it passes in the full-suite run. It looks order- or filesystem-state-dependent. Unrelated to this change, but flagging it rather than staying quiet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trial measurements now expose recorded evaluation costs in USD.
  * Final metrics publish total cost alongside token usage.
  * Cost data is retained even when token counts are unavailable.

* **Bug Fixes**
  * Invalid or unsupported cost values, including booleans, non-finite numbers, and oversized integers, are safely handled.
  * Cost metadata is preserved when importing trial results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->