### PR TITLE
fix(evaluator): let a producer declare its trace format

### DIFF
--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/platform_runtime.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/platform_runtime.py
@@ -42,7 +42,12 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     standard_evidence_descriptors,
 )
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
-from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+from nemo_evaluator_sdk.values.evidence import (
+    EVIDENCE_FORMAT_ATIF,
+    CandidateEvidence,
+    EvidenceDescriptor,
+    read_atif,
+)
 
 from .build_spec import execute_build_plan, plan_task_build
 from .layout import prepare_run_layout, resolve_run_dir
@@ -436,6 +441,7 @@ def build_trial_from_artifacts(
         logs_dir=layout.agent_log_dir,
         final_state_dir=layout.workspace_dir,
         trace_path=trace_path if trace_path.exists() else None,
+        trace_format=EVIDENCE_FORMAT_ATIF if read_atif(trace_path) is not None else None,
         verifier_logs_dir=verifier_log_dir(layout),
         primary_log="nat_agent.log",
     )

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -61,7 +61,11 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     standard_evidence_descriptors,
 )
 from nemo_evaluator_sdk.metrics.protocol import Metric, MetricInput, MetricOutput, MetricOutputSpec, MetricResult
-from nemo_evaluator_sdk.values.evidence import CandidateEvidence
+from nemo_evaluator_sdk.values.evidence import (
+    EVIDENCE_FORMAT_ATIF,
+    CandidateEvidence,
+    read_atif,
+)
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 logger = logging.getLogger(__name__)
@@ -1172,10 +1176,14 @@ def _trial_from_harbor_result(trial_dir: Path, data: Mapping[str, Any], *, rewar
     status = AgentEvalTrialStatus.COMPLETED if error is None and reward is not None else AgentEvalTrialStatus.PARTIAL
 
     trace_path = trial_dir / "agent" / "trajectory.json"
+    # Only agents with SUPPORTS_ATIF write this file, so its absence is normal: oracle and nop
+    # never produce one.
+    trajectory = read_atif(trace_path)
     descriptors = standard_evidence_descriptors(
         logs_dir=trial_dir / "agent",
         final_state_dir=trial_dir / "artifacts",
         trace_path=trace_path if trace_path.exists() else None,
+        trace_format=EVIDENCE_FORMAT_ATIF if trajectory is not None else None,
         verifier_logs_dir=trial_dir / "verifier",
     )
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
@@ -273,6 +273,7 @@ def standard_evidence_descriptors(
     logs_dir: str | Path,
     final_state_dir: str | Path,
     trace_path: str | Path | None = None,
+    trace_format: str | None = None,
     initial_state_ref: str | None = None,
     verifier_logs_dir: str | Path | None = None,
     primary_log: str | None = None,
@@ -283,6 +284,9 @@ def standard_evidence_descriptors(
     ``trace`` (trajectory, ATIF-normalized when available), ``logs`` (agent log
     dir), ``final_state`` (workspace), and ``verifier_logs`` (only when present).
     Callers may add their own extension keys to the returned mapping.
+
+    ``trace_format`` declares the trace's format; without it the format is inferred from the
+    filename, which misreads an ATIF trajectory that is not named for it.
     """
     descriptors: dict[str, EvidenceDescriptor] = {}
 
@@ -299,7 +303,7 @@ def standard_evidence_descriptors(
         is_atif = trace_name.startswith("atif") or ".atif." in trace_name
         descriptors[EVIDENCE_TRACE] = EvidenceDescriptor(
             kind=EVIDENCE_TRACE,
-            format=EVIDENCE_FORMAT_ATIF if is_atif else EVIDENCE_FORMAT_JSON,
+            format=trace_format or (EVIDENCE_FORMAT_ATIF if is_atif else EVIDENCE_FORMAT_JSON),
             ref=str(trace_path),
         )
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -9,6 +9,7 @@ import asyncio
 import difflib
 import hashlib
 import json
+import logging
 import os
 import shutil
 import signal
@@ -333,6 +334,26 @@ class EvidenceDescriptor(BaseModel):
 def parse_atif(payload: Any) -> Trajectory:
     """Validate a payload as a canonical ATIF :class:`Trajectory` (raises ``ValidationError`` if non-conformant)."""
     return payload if isinstance(payload, Trajectory) else Trajectory.model_validate(payload)
+
+
+logger = logging.getLogger(__name__)
+
+
+def read_atif(path: Path) -> Trajectory | None:
+    """The ATIF trajectory at ``path``, or ``None`` if it is absent, unreadable, or not ATIF.
+
+    A producer whose trajectory filename does not identify the format has to read the file to know
+    what it holds: that a file exists says nothing about whether it is ATIF.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    try:
+        return parse_atif(payload)
+    except ValueError:
+        logger.warning("Trajectory at %s is not valid ATIF; ignoring it.", path)
+        return None
 
 
 class TraceHandle:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -1726,3 +1726,50 @@ def test_a_real_harbor_error_payload_reaches_the_summary_rollup(tmp_path: Path) 
     summary = AgentEvalSummary.from_scores([], trials=[trial])
     assert summary.error_trial_ids == {"AgentTimeoutError": [trial_name]}
     assert summary.error_count == 1
+
+
+def _atif_trajectory_payload() -> dict[str, object]:
+    """A minimal ATIF trajectory shaped like the one Harbor's ATIF-capable agents write."""
+    return {
+        "schema_version": "ATIF-v1.7",
+        "session_id": "s1",
+        "agent": {"name": "codex", "version": "1.0"},
+        "steps": [
+            {"step_id": 1, "source": "user", "message": "solve it", "timestamp": "2026-01-01T00:00:00+00:00"},
+            {"step_id": 2, "source": "agent", "message": "thinking", "timestamp": "2026-01-01T00:00:01+00:00"},
+            {"step_id": 3, "source": "agent", "message": "204", "timestamp": "2026-01-01T00:00:02+00:00"},
+        ],
+    }
+
+
+def _trial_with_trajectory(tmp_path: Path, payload: object) -> AgentEvalTrial:
+    from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import _trial_from_harbor_result
+
+    job_dir = tmp_path / "job"
+    _write_trial(job_dir, "t__1", "t", reward=1.0)
+    trial_dir = job_dir / "t__1"
+    if payload is None:
+        (trial_dir / "agent" / "trajectory.json").unlink()
+    else:
+        (trial_dir / "agent" / "trajectory.json").write_text(json.dumps(payload))
+    data = json.loads((trial_dir / "result.json").read_text())
+    return _trial_from_harbor_result(trial_dir, data, reward_key="reward")
+
+
+def test_atif_trajectory_is_labelled_atif(tmp_path: Path) -> None:
+    trial = _trial_with_trajectory(tmp_path, _atif_trajectory_payload())
+
+    # Harbor names the file trajectory.json, so only its contents identify it as ATIF.
+    assert trial.evidence.descriptors["trace"].format == "atif"
+
+
+def test_absent_trajectory_leaves_no_trace_evidence(tmp_path: Path) -> None:
+    trial = _trial_with_trajectory(tmp_path, None)
+
+    assert trial.evidence.descriptors.get("trace") is None
+
+
+def test_non_atif_trajectory_is_kept_as_json_evidence(tmp_path: Path) -> None:
+    trial = _trial_with_trajectory(tmp_path, {"not": "atif"})
+
+    assert trial.evidence.descriptors["trace"].format == "json"

--- a/packages/nemo_evaluator_sdk/tests/values/test_evidence.py
+++ b/packages/nemo_evaluator_sdk/tests/values/test_evidence.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for reading a trace file as ATIF."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nemo_evaluator_sdk.values.evidence import read_atif
+
+ATIF_PAYLOAD = {
+    "schema_version": "ATIF-v1.7",
+    "session_id": "s1",
+    "agent": {"name": "codex", "version": "1.0"},
+    "steps": [
+        {"step_id": 1, "source": "user", "message": "solve it", "timestamp": "2026-01-01T00:00:00+00:00"},
+        {"step_id": 2, "source": "agent", "message": "204", "timestamp": "2026-01-01T00:00:01+00:00"},
+    ],
+}
+
+
+def test_a_valid_atif_file_parses(tmp_path: Path) -> None:
+    path = tmp_path / "trajectory.json"
+    path.write_text(json.dumps(ATIF_PAYLOAD), encoding="utf-8")
+
+    trajectory = read_atif(path)
+
+    assert trajectory is not None
+    assert [step.step_id for step in trajectory.steps] == [1, 2]
+
+
+def test_json_that_is_not_atif_is_not_mistaken_for_it(tmp_path: Path) -> None:
+    # The reason this function exists: a producer names the file, so only its contents identify it.
+    path = tmp_path / "trajectory.json"
+    path.write_text(json.dumps({"not": "atif"}), encoding="utf-8")
+
+    assert read_atif(path) is None
+
+
+def test_a_truncated_file_is_refused_rather_than_raising(tmp_path: Path) -> None:
+    path = tmp_path / "trajectory.json"
+    path.write_text('{"schema_version": "ATIF-v1.7", "steps": [', encoding="utf-8")
+
+    assert read_atif(path) is None
+
+
+def test_an_absent_file_is_refused_rather_than_raising(tmp_path: Path) -> None:
+    assert read_atif(tmp_path / "missing.json") is None
+
+
+def test_a_directory_is_refused_rather_than_raising(tmp_path: Path) -> None:
+    assert read_atif(tmp_path) is None

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/harbor_runtime.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/runtimes/harbor_runtime.py
@@ -61,7 +61,11 @@ from nemo_platform.beta.evaluator.agent_eval.trials import (
     standard_evidence_descriptors,
 )
 from nemo_platform.beta.evaluator.metrics.protocol import Metric, MetricInput, MetricOutput, MetricOutputSpec, MetricResult
-from nemo_platform.beta.evaluator.values.evidence import CandidateEvidence
+from nemo_platform.beta.evaluator.values.evidence import (
+    EVIDENCE_FORMAT_ATIF,
+    CandidateEvidence,
+    read_atif,
+)
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 logger = logging.getLogger(__name__)
@@ -1172,10 +1176,14 @@ def _trial_from_harbor_result(trial_dir: Path, data: Mapping[str, Any], *, rewar
     status = AgentEvalTrialStatus.COMPLETED if error is None and reward is not None else AgentEvalTrialStatus.PARTIAL
 
     trace_path = trial_dir / "agent" / "trajectory.json"
+    # Only agents with SUPPORTS_ATIF write this file, so its absence is normal: oracle and nop
+    # never produce one.
+    trajectory = read_atif(trace_path)
     descriptors = standard_evidence_descriptors(
         logs_dir=trial_dir / "agent",
         final_state_dir=trial_dir / "artifacts",
         trace_path=trace_path if trace_path.exists() else None,
+        trace_format=EVIDENCE_FORMAT_ATIF if trajectory is not None else None,
         verifier_logs_dir=trial_dir / "verifier",
     )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/trials.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/agent_eval/trials.py
@@ -273,6 +273,7 @@ def standard_evidence_descriptors(
     logs_dir: str | Path,
     final_state_dir: str | Path,
     trace_path: str | Path | None = None,
+    trace_format: str | None = None,
     initial_state_ref: str | None = None,
     verifier_logs_dir: str | Path | None = None,
     primary_log: str | None = None,
@@ -283,6 +284,9 @@ def standard_evidence_descriptors(
     ``trace`` (trajectory, ATIF-normalized when available), ``logs`` (agent log
     dir), ``final_state`` (workspace), and ``verifier_logs`` (only when present).
     Callers may add their own extension keys to the returned mapping.
+
+    ``trace_format`` declares the trace's format; without it the format is inferred from the
+    filename, which misreads an ATIF trajectory that is not named for it.
     """
     descriptors: dict[str, EvidenceDescriptor] = {}
 
@@ -299,7 +303,7 @@ def standard_evidence_descriptors(
         is_atif = trace_name.startswith("atif") or ".atif." in trace_name
         descriptors[EVIDENCE_TRACE] = EvidenceDescriptor(
             kind=EVIDENCE_TRACE,
-            format=EVIDENCE_FORMAT_ATIF if is_atif else EVIDENCE_FORMAT_JSON,
+            format=trace_format or (EVIDENCE_FORMAT_ATIF if is_atif else EVIDENCE_FORMAT_JSON),
             ref=str(trace_path),
         )
 

--- a/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/beta/evaluator/values/evidence.py
@@ -9,6 +9,7 @@ import asyncio
 import difflib
 import hashlib
 import json
+import logging
 import os
 import shutil
 import signal
@@ -333,6 +334,26 @@ class EvidenceDescriptor(BaseModel):
 def parse_atif(payload: Any) -> Trajectory:
     """Validate a payload as a canonical ATIF :class:`Trajectory` (raises ``ValidationError`` if non-conformant)."""
     return payload if isinstance(payload, Trajectory) else Trajectory.model_validate(payload)
+
+
+logger = logging.getLogger(__name__)
+
+
+def read_atif(path: Path) -> Trajectory | None:
+    """The ATIF trajectory at ``path``, or ``None`` if it is absent, unreadable, or not ATIF.
+
+    A producer whose trajectory filename does not identify the format has to read the file to know
+    what it holds: that a file exists says nothing about whether it is ATIF.
+    """
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    try:
+        return parse_atif(payload)
+    except ValueError:
+        logger.warning("Trajectory at %s is not valid ATIF; ignoring it.", path)
+        return None
 
 
 class TraceHandle:


### PR DESCRIPTION
## Summary

`standard_evidence_descriptors` inferred a trace's evidence format from its **filename**, so a genuinely-ATIF trajectory that isn't named for it was labelled plain JSON. Harbor writes its ATIF trajectory to `agent/trajectory.json` — a name that says nothing about the contents — so every Harbor trace was mislabelled. Producers can now declare the format explicitly; filename sniffing remains the fallback.

## Changes

- `agent_eval/trials.py`: `standard_evidence_descriptors` accepts an optional `trace_format`; when absent, behaviour is unchanged
- `agent_eval/runtimes/harbor_runtime.py`: new `_atif_trajectory` helper; declares `atif` only when the file actually parses as ATIF
- `examples/run_agent_eval/platform_runtime.py`: the NAT runtime had the identical mislabel, fixed the same way
- Vendored SDK mirror regenerated for both changed modules
- Tests covering all three outcomes: valid ATIF → `atif`, malformed → `json`, absent → no trace evidence

### Why parse rather than trust

`harbor_runtime` declares ATIF only when `_atif_trajectory` successfully parses the file. Agents without `SUPPORTS_ATIF` (`oracle`, `nop`) write no trajectory at all, and a malformed one should stay `json` rather than be mislabelled in the other direction — the bug this PR fixes, pointing the other way.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal evidence-descriptor plumbing; no user-facing API or CLI surface changes

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py` — **88 passed**
- `ruff check` / `ruff format --check` on the changed packages — pass
- **Mutation-checked**: reverting `trials.py` to ignore the declared `trace_format` (falling back to filename sniffing) turns `test_atif_trajectory_is_labelled_atif` red, confirming the test actually pins the new behaviour rather than passing incidentally.
- `uv run pre-commit run -a` — all hooks passed **except two blocked in my local environment, not by this change**: **Helm Docs** (`helm-docs` not installed; this diff touches no `k8s/`/`helm/` files) and **Run uv lock with platform uv** (PATH `uv` is 0.9.30, repo requires 0.9.14; this diff changes no dependency and `Check for uv.lock drift` passed). Left unchecked rather than claimed — CI has both tools.

## Related

Part of a five-PR split. `fix(evaluator): publish the real ATIF trajectory` builds directly on this one — Intake can only read the trajectory as ATIF once it is labelled correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing agent trajectory traces in ATIF format.
  - Evidence records now identify the trace format explicitly when available.
  - Existing JSON trajectory data continues to be supported.

- **Bug Fixes**
  - Missing, invalid, or unreadable trajectory files no longer disrupt trial processing.
  - Trace evidence is omitted when no valid trajectory is available.

- **Tests**
  - Added coverage for ATIF, JSON, missing, and invalid trajectory scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->