### PR TITLE
fix(evaluator): publish the real ATIF trajectory to Intake

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
@@ -145,12 +145,16 @@ def _agent_trajectory(trial_dir: Path, selected_trace: EvidenceDescriptor | None
 
 
 def _final_agent_message(trajectory: Trajectory | None) -> str | None:
-    """The agent's last message, which is its user-visible answer for the trial."""
+    """The agent's last message, which is its user-visible answer for the trial.
+
+    Only the *last* agent step can be the answer. An earlier one is intermediate reasoning, so an
+    agent that ends on an empty message has produced no answer rather than the previous one.
+    """
     if trajectory is None:
         return None
     for step in reversed(trajectory.steps):
-        if step.source == "agent" and isinstance(step.message, str) and step.message:
-            return step.message
+        if step.source == "agent":
+            return step.message or None
     return None
 
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
@@ -34,6 +34,7 @@ from nemo_evaluator_sdk.values.evidence import (
     EVIDENCE_TRACE,
     CandidateEvidence,
     EvidenceDescriptor,
+    Trajectory,
     read_atif,
 )
 
@@ -124,11 +125,33 @@ def _trial_from_harbor_result(
         id=trial_id,
         task_id=task_id,
         status=status,
-        output=AgentOutput(metadata={"harbor_trial_dir": str(trial_dir)}),
+        output=AgentOutput(
+            output_text=_final_agent_message(_agent_trajectory(trial_dir, selected_trace)),
+            metadata={"harbor_trial_dir": str(trial_dir)},
+        ),
         evidence=CandidateEvidence(descriptors=descriptors),
         error=error,
         metadata=metadata,
     )
+
+
+def _agent_trajectory(trial_dir: Path, selected_trace: EvidenceDescriptor | None) -> Trajectory | None:
+    """The trial's ATIF trajectory, from the selected trace or Harbor's built-in dump."""
+    if selected_trace is not None and selected_trace.format == EVIDENCE_FORMAT_ATIF:
+        return read_atif(Path(selected_trace.ref))
+    # Only agents with SUPPORTS_ATIF write this file, so its absence is normal: oracle and nop
+    # never produce one.
+    return read_atif(trial_dir / "agent" / "trajectory.json")
+
+
+def _final_agent_message(trajectory: Trajectory | None) -> str | None:
+    """The agent's last message, which is its user-visible answer for the trial."""
+    if trajectory is None:
+        return None
+    for step in reversed(trajectory.steps):
+        if step.source == "agent" and isinstance(step.message, str) and step.message:
+            return step.message
+    return None
 
 
 def _add_extension_descriptor(

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -2226,3 +2226,26 @@ def test_legacy_harbor_trial_contract_import_resolves_to_source_module(source_na
     assert legacy.__file__ is not None
 
     assert Path(legacy.__file__).resolve() == Path(source.__file__).resolve()
+
+
+def test_atif_trajectory_supplies_the_final_answer(tmp_path: Path) -> None:
+    trial = _trial_with_trajectory(tmp_path, _atif_trajectory_payload())
+
+    assert trial.output.output_text == "204"
+
+
+def test_non_atif_trajectory_yields_no_final_answer(tmp_path: Path) -> None:
+    trial = _trial_with_trajectory(tmp_path, {"not": "atif"})
+
+    assert trial.output.output_text is None
+
+
+def test_final_answer_ignores_trailing_non_agent_steps(tmp_path: Path) -> None:
+    payload = _atif_trajectory_payload()
+    payload["steps"].append(  # type: ignore[attr-defined]
+        {"step_id": 4, "source": "system", "message": "cleanup", "timestamp": "2026-01-01T00:00:03+00:00"}
+    )
+
+    trial = _trial_with_trajectory(tmp_path, payload)
+
+    assert trial.output.output_text == "204"

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -2249,3 +2249,15 @@ def test_final_answer_ignores_trailing_non_agent_steps(tmp_path: Path) -> None:
     trial = _trial_with_trajectory(tmp_path, payload)
 
     assert trial.output.output_text == "204"
+
+
+def test_empty_final_agent_message_is_not_backfilled_from_earlier_reasoning(tmp_path: Path) -> None:
+    # Only the last agent step can be the answer; an earlier one is intermediate reasoning.
+    payload = _atif_trajectory_payload()
+    payload["steps"].append(  # type: ignore[attr-defined]
+        {"step_id": 4, "source": "agent", "message": "", "timestamp": "2026-01-01T00:00:03+00:00"}
+    )
+
+    trial = _trial_with_trajectory(tmp_path, payload)
+
+    assert trial.output.output_text is None

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -29,13 +29,16 @@ Design constraints (see AALGO-289):
 
 from __future__ import annotations
 
+import logging
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import Literal, cast
 
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
+from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_ATIF, EVIDENCE_TRACE
 from nemo_platform.types.intake.evaluation_context_param import EvaluationContextParam
 from nemo_platform.types.intake.evaluator_result_create_params import EvaluatorResultCreateParams
 from nemo_platform.types.intake.evaluator_result_data_type import EvaluatorResultDataType
@@ -43,6 +46,9 @@ from nemo_platform.types.intake.ingest.atif_agent_param import AtifAgentParam
 from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParams
 from nemo_platform.types.intake.ingest.atif_final_metrics_param import AtifFinalMetricsParam
 from nemo_platform.types.intake.ingest.atif_step_agent_param import AtifStepAgentParam
+from nemo_platform.types.intake.ingest.atif_step_param import AtifStepParam
+
+logger = logging.getLogger(__name__)
 
 # --- Shared conventions -----------------------------------------------------
 
@@ -52,12 +58,6 @@ ATIF_SCHEMA_VERSION: Literal["ATIF-v1.7"] = "ATIF-v1.7"
 #: Default ``agent.version`` when the run target carries none. Neither Model nor
 #: Agent has a version field today, and ATIF requires one (design doc §3.9 #6).
 DEFAULT_AGENT_VERSION = "unknown"
-
-# Evidence-descriptor keys. ATIF is carried as a ``format`` on ``kind="trace"``,
-# *not* as a distinct ``kind``. These are string literals until D1 (AALGO-281)
-# promotes them to shared descriptor-key constants on the SDK evidence types.
-EVIDENCE_KIND_TRACE = "trace"
-TRACE_FORMAT_ATIF = "atif"
 
 
 def session_id_for(run_id: str, trial_id: str) -> str:
@@ -80,6 +80,41 @@ def run_task_to_evaluation_context(trial: AgentEvalTrial, *, evaluation_name: st
     return {"evaluation_name": evaluation_name, "test_case_name": trial.task_id}
 
 
+async def atif_steps_from_trial(trial: AgentEvalTrial, *, started_at: datetime) -> list[AtifStepParam] | None:
+    """Return the trial's real ATIF steps, or None when it carries no ATIF trajectory.
+
+    Only runners whose agent emits ATIF attach one; Harbor's ``oracle`` and ``nop`` never do, and
+    an unreadable or malformed trajectory is treated the same as an absent one so a publish is
+    never lost to bad evidence.
+
+    The SDK's read model is deliberately more permissive than Intake's ingest schema, so steps that
+    parse here can still be rejected there; :func:`nemo_evaluator.intake.publish.publish_to_intake`
+    retries without them rather than enumerating every divergence.
+    """
+    evidence = trial.evidence
+    if evidence is None:
+        return None
+    descriptor = evidence.get(EVIDENCE_TRACE)
+    if descriptor is None or descriptor.format != EVIDENCE_FORMAT_ATIF:
+        return None
+    try:
+        steps = await (await evidence.trace(EVIDENCE_TRACE)).steps()
+    except (OSError, ValueError, KeyError) as error:
+        logger.warning("Ignoring unreadable ATIF trace for trial %s: %s", trial.id, error)
+        return None
+
+    payload: list[AtifStepParam] = []
+    for index, step in enumerate(steps):
+        dumped = step.model_dump(mode="json", exclude_none=True)
+        # Ingest requires one-based sequential ids, while the SDK read model leaves step_id optional.
+        dumped["step_id"] = index + 1
+        # Intake keys spans on start_time and falls back to its own ingest clock for a step with
+        # no timestamp, which would make re-publish duplicate instead of replace.
+        dumped.setdefault("timestamp", started_at.isoformat())
+        payload.append(cast(AtifStepParam, dumped))
+    return payload
+
+
 def trial_to_atif_ingest(
     trial: AgentEvalTrial,
     *,
@@ -91,16 +126,17 @@ def trial_to_atif_ingest(
     model_name: str | None = None,
     final_metrics: AtifFinalMetricsParam | None = None,
     ended_at: datetime | None = None,
+    steps: Sequence[AtifStepParam] | None = None,
 ) -> AtifCreateParams:
     """Build the ATIF ingest params for a single Trial.
 
-    Until ATIF normalization of trace evidence lands (D2, AALGO-282), this emits
-    a minimal single-step trajectory carrying the trial's final output text, so
-    the session/score path works end to end. Real ``steps[]`` reconstructed from
-    ``trial.evidence`` arrive with D2.
+    ``steps`` carries the trial's real ATIF trajectory when it has one (see
+    :func:`atif_steps_from_trial`). Without it this falls back to a minimal single-step
+    trajectory holding the trial's final output text, which is all a runner that emits no
+    trajectory — Harbor's ``oracle``, for one — can offer.
 
-    ``started_at`` (the run's start time) is stamped on the step because it is what
-    makes re-ingest idempotent. Intake's ``spans`` table is a ``ReplacingMergeTree``
+    ``started_at`` (the run's start time) stamps any step that carries no timestamp of its own,
+    because that is what makes re-ingest idempotent. Intake's ``spans`` table is a ``ReplacingMergeTree``
     keyed on ``(workspace, session_id, start_time, id)``, and a step with no timestamp
     falls back to the server's per-request ingest clock — so the same trajectory sent
     twice lands as two rows that never collapse. An explicit timestamp makes the root
@@ -131,7 +167,7 @@ def trial_to_atif_ingest(
         "schema_version": ATIF_SCHEMA_VERSION,
         "session_id": session_id_for(run_id, trial.id),
         "agent": agent,
-        "steps": [step],
+        "steps": list(steps) if steps else [step],
         "evaluation_context": run_task_to_evaluation_context(trial, evaluation_name=evaluation_name),
     }
     if trial.error is not None:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
@@ -18,7 +18,9 @@ HTTP calls go through the generated platform SDK's ``intake`` resources.
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections import defaultdict
+from collections.abc import Sequence
 from datetime import timedelta
 
 from nemo_evaluator.intake import mapping
@@ -27,10 +29,14 @@ from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
-from nemo_platform import AsyncNeMoPlatform
+from nemo_platform import AsyncNeMoPlatform, UnprocessableEntityError
+from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParams
 from nemo_platform.types.intake.ingest.atif_final_metrics_param import AtifFinalMetricsParam
+from nemo_platform.types.intake.ingest.atif_step_param import AtifStepParam
 from nemo_platform.types.intake.trace_filter_param import TraceFilterParam
 from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
 
 #: Default ceiling on concurrent per-trial publishes.
 DEFAULT_MAX_CONCURRENCY = 8
@@ -186,19 +192,39 @@ async def publish_to_intake(
                 if measurements.runtime_sec is not None
                 else None
             )
-            body = mapping.trial_to_atif_ingest(
-                trial,
-                run_id=result.run_id,
-                evaluation_name=experiment_id,
-                agent_name=agent_name,
-                started_at=started_at,
-                agent_version=agent_version,
-                model_name=model_name,
-                final_metrics=_token_final_metrics(measurements),
-                ended_at=ended_at,
-            )
-            body["workspace"] = resolved_workspace
-            await platform.intake.ingest.atif.create(**body)
+
+            def build_body(steps: Sequence[AtifStepParam] | None) -> AtifCreateParams:
+                body = mapping.trial_to_atif_ingest(
+                    trial,
+                    run_id=result.run_id,
+                    evaluation_name=experiment_id,
+                    agent_name=agent_name,
+                    started_at=started_at,
+                    agent_version=agent_version,
+                    model_name=model_name,
+                    final_metrics=_token_final_metrics(measurements),
+                    ended_at=ended_at,
+                    steps=steps,
+                )
+                body["workspace"] = resolved_workspace
+                return body
+
+            recorded_steps = await mapping.atif_steps_from_trial(trial, started_at=started_at)
+            try:
+                await platform.intake.ingest.atif.create(**build_body(recorded_steps))
+            except UnprocessableEntityError as error:
+                # The SDK's ATIF read model accepts shapes ingest does not, so a trajectory that
+                # parsed locally can still be refused. Losing the trial's scores over a trace
+                # detail is the wrong trade — fall back to the single-step trajectory a runner
+                # with no trace would have sent.
+                if recorded_steps is None:
+                    raise
+                logger.warning(
+                    "Intake rejected the recorded trajectory for trial %s (%s); publishing its final output instead.",
+                    trial.id,
+                    error,
+                )
+                await platform.intake.ingest.atif.create(**build_body(None))
 
             session_id = mapping.session_id_for(result.run_id, trial.id)
             span_id = await _resolve_root_span_id(platform, workspace=resolved_workspace, session_id=session_id)

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
@@ -216,8 +216,9 @@ async def publish_to_intake(
                 # The SDK's ATIF read model accepts shapes ingest does not, so a trajectory that
                 # parsed locally can still be refused. Losing the trial's scores over a trace
                 # detail is the wrong trade — fall back to the single-step trajectory a runner
-                # with no trace would have sent.
-                if recorded_steps is None:
+                # with no trace would have sent. Guard on emptiness rather than ``is None``: with no
+                # steps to drop, the retry would resend the body ingest just refused.
+                if not recorded_steps:
                     raise
                 logger.warning(
                     "Intake rejected the recorded trajectory for trial %s (%s); publishing its final output instead.",

--- a/plugins/nemo-evaluator/tests/intake/test_mapping.py
+++ b/plugins/nemo-evaluator/tests/intake/test_mapping.py
@@ -5,13 +5,17 @@
 
 from __future__ import annotations
 
+import json
 import math
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
 
 import pytest
 from nemo_evaluator.intake.mapping import (
     ATIF_SCHEMA_VERSION,
     DEFAULT_AGENT_VERSION,
+    atif_steps_from_trial,
     run_task_to_evaluation_context,
     score_to_evaluator_results,
     session_id_for,
@@ -31,6 +35,7 @@ from nemo_evaluator_sdk.metrics.protocol import (
     Label,
     MetricOutput,
 )
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 from nemo_platform.types.intake.evaluator_result_create_params import EvaluatorResultCreateParams
 
 STARTED_AT = datetime(2026, 1, 2, 3, 4, 5, tzinfo=UTC)
@@ -296,3 +301,136 @@ def test_failed_score_yields_no_rows_and_skips_every_output() -> None:
         ("accuracy.score", "scoring failed"),
         ("accuracy.passed", "scoring failed"),
     ]
+
+
+def _atif_document() -> dict[str, Any]:
+    """An ATIF trajectory shaped like the one Harbor's ATIF-capable agents write."""
+    return {
+        "schema_version": "ATIF-v1.7",
+        "session_id": "harbor-session",
+        "agent": {"name": "codex", "version": "1.0"},
+        "steps": [
+            {"step_id": 1, "source": "user", "message": "solve it", "timestamp": "2026-01-01T00:00:00+00:00"},
+            {"step_id": 2, "source": "agent", "message": "204", "timestamp": "2026-01-01T00:00:01+00:00"},
+        ],
+    }
+
+
+def _trial_with_trace(tmp_path: Path, *, document: object, evidence_format: str = "atif") -> AgentEvalTrial:
+    trace_path = tmp_path / "trajectory.json"
+    trace_path.write_text(json.dumps(document))
+    return AgentEvalTrial(
+        id="trial-1",
+        task_id="task-1",
+        status=AgentEvalTrialStatus.COMPLETED,
+        output=AgentOutput(output_text="204"),
+        evidence=CandidateEvidence(
+            descriptors={"trace": EvidenceDescriptor(kind="trace", format=evidence_format, ref=str(trace_path))}
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_atif_trace_evidence_supplies_the_real_steps(tmp_path: Path) -> None:
+    trial = _trial_with_trace(tmp_path, document=_atif_document())
+
+    steps = await atif_steps_from_trial(trial, started_at=STARTED_AT)
+
+    assert steps is not None
+    assert [step["source"] for step in steps] == ["user", "agent"]
+    assert [step["message"] for step in steps] == ["solve it", "204"]
+
+
+@pytest.mark.asyncio
+async def test_steps_without_a_timestamp_fall_back_to_the_run_start(tmp_path: Path) -> None:
+    document = _atif_document()
+    del document["steps"][1]["timestamp"]
+
+    steps = await atif_steps_from_trial(_trial_with_trace(tmp_path, document=document), started_at=STARTED_AT)
+
+    # Intake keys spans on start_time; a step with no timestamp would take the ingest clock and
+    # duplicate on re-publish instead of replacing.
+    assert steps is not None
+    assert steps[1]["timestamp"] == STARTED_AT.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_trace_evidence_that_is_not_atif_is_ignored(tmp_path: Path) -> None:
+    trial = _trial_with_trace(tmp_path, document=_atif_document(), evidence_format="json")
+
+    assert await atif_steps_from_trial(trial, started_at=STARTED_AT) is None
+
+
+@pytest.mark.asyncio
+async def test_unreadable_trace_evidence_does_not_fail_the_publish(tmp_path: Path) -> None:
+    trial = _trial_with_trace(tmp_path, document=_atif_document())
+    (tmp_path / "trajectory.json").unlink()
+
+    assert await atif_steps_from_trial(trial, started_at=STARTED_AT) is None
+
+
+@pytest.mark.asyncio
+async def test_a_trial_with_no_evidence_has_no_steps() -> None:
+    assert await atif_steps_from_trial(_trial(), started_at=STARTED_AT) is None
+
+
+def test_supplied_steps_replace_the_synthetic_single_step() -> None:
+    real_steps = [
+        {"step_id": 1, "source": "user", "message": "solve it"},
+        {"step_id": 2, "source": "agent", "message": "204"},
+    ]
+
+    body = trial_to_atif_ingest(
+        _trial(),
+        run_id="run-1",
+        evaluation_name="eval-1",
+        agent_name="codex",
+        started_at=STARTED_AT,
+        steps=real_steps,  # type: ignore[arg-type]
+    )
+
+    assert body["steps"] == real_steps
+
+
+def test_no_supplied_steps_still_emits_the_final_output_text() -> None:
+    body = trial_to_atif_ingest(
+        _trial(output_text="only answer"),
+        run_id="run-1",
+        evaluation_name="eval-1",
+        agent_name="oracle",
+        started_at=STARTED_AT,
+    )
+
+    assert [step["message"] for step in body["steps"]] == ["only answer"]
+
+
+@pytest.mark.asyncio
+async def test_step_ids_are_renumbered_to_the_sequence_ingest_requires(tmp_path: Path) -> None:
+    document = _atif_document()
+    for step in document["steps"]:
+        del step["step_id"]
+
+    steps = await atif_steps_from_trial(_trial_with_trace(tmp_path, document=document), started_at=STARTED_AT)
+
+    # Ingest rejects a trajectory whose ids are not one-based and sequential.
+    assert steps is not None
+    assert [step["step_id"] for step in steps] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_a_trajectory_with_no_steps_falls_back_to_the_synthetic_step(tmp_path: Path) -> None:
+    document = _atif_document()
+    document["steps"] = []
+
+    trial = _trial_with_trace(tmp_path, document=document)
+    body = trial_to_atif_ingest(
+        trial,
+        run_id="run-1",
+        evaluation_name="eval-1",
+        agent_name="codex",
+        started_at=STARTED_AT,
+        steps=await atif_steps_from_trial(trial, started_at=STARTED_AT),
+    )
+
+    # Ingest needs at least one step, so an empty trajectory must not empty the request.
+    assert [step["message"] for step in body["steps"]] == ["204"]

--- a/plugins/nemo-evaluator/tests/intake/test_publish.py
+++ b/plugins/nemo-evaluator/tests/intake/test_publish.py
@@ -5,12 +5,15 @@
 
 from __future__ import annotations
 
+import json
 import math
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 
+import httpx
 import pytest
 from nemo_evaluator.intake.publish import PublishError, _token_final_metrics, publish_to_intake
 from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
@@ -18,7 +21,8 @@ from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSumm
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
 from nemo_evaluator_sdk.metrics.protocol import MetricOutput
-from nemo_platform import AsyncNeMoPlatform
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+from nemo_platform import AsyncNeMoPlatform, UnprocessableEntityError
 
 # --- fakes ------------------------------------------------------------------
 
@@ -71,12 +75,13 @@ class _FakeClient:
         root_span_id: str | None = "span",
         atif_fail: bool = False,
         fail_eval_session: str | None = None,
+        atif: Any | None = None,
     ) -> None:
         self.workspace = workspace
         self.atif_calls: list[dict[str, Any]] = []
         self.eval_calls: list[dict[str, Any]] = []
         self.intake = SimpleNamespace(
-            ingest=SimpleNamespace(atif=_FakeAtif(self.atif_calls, fail=atif_fail)),
+            ingest=SimpleNamespace(atif=atif or _FakeAtif(self.atif_calls, fail=atif_fail)),
             evaluator_results=_FakeEvaluatorResults(self.eval_calls, fail_session=fail_eval_session),
             traces=_FakeTraces(root_span_id=root_span_id),
         )
@@ -297,3 +302,63 @@ async def test_one_trial_failure_does_not_block_others_and_is_reported() -> None
     message = str(excinfo.value).lower()
     assert "t-2" in message
     assert "re-run" in message or "cached" in message or "publish" in message
+
+
+class _RejectRichTrajectoryAtif:
+    """Ingest that refuses any multi-step trajectory, the way a schema mismatch would."""
+
+    def __init__(self, calls: list[dict[str, Any]]) -> None:
+        self._calls = calls
+
+    async def create(self, **kwargs: Any) -> None:
+        self._calls.append(kwargs)
+        if len(kwargs["steps"]) > 1:
+            raise UnprocessableEntityError(
+                "steps: rejected",
+                response=httpx.Response(422, request=httpx.Request("POST", "http://test/atif")),
+                body=None,
+            )
+
+
+def _trial_with_atif_trace(tmp_path: Path, trial_id: str = "t-1") -> AgentEvalTrial:
+    trace = tmp_path / "trajectory.json"
+    trace.write_text(
+        json.dumps(
+            {
+                "schema_version": "ATIF-v1.7",
+                "session_id": "s",
+                "agent": {"name": "codex", "version": "1.0"},
+                "steps": [
+                    {"step_id": 1, "source": "user", "message": "q", "timestamp": "2026-01-01T00:00:00+00:00"},
+                    {"step_id": 2, "source": "agent", "message": "a", "timestamp": "2026-01-01T00:00:01+00:00"},
+                ],
+            }
+        )
+    )
+    return AgentEvalTrial(
+        id=trial_id,
+        task_id="task-1",
+        status=AgentEvalTrialStatus.COMPLETED,
+        output=AgentOutput(output_text="a"),
+        evidence=CandidateEvidence(
+            descriptors={"trace": EvidenceDescriptor(kind="trace", format="atif", ref=str(trace))}
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_trajectory_falls_back_instead_of_failing_the_trial(tmp_path: Path) -> None:
+    calls: list[dict[str, Any]] = []
+    client = _client(atif=_RejectRichTrajectoryAtif(calls))
+    trial = _trial_with_atif_trace(tmp_path)
+
+    report = await publish_to_intake(
+        _result([trial], [_score("t-1", "m", [MetricOutput(name="score", value=1.0)])]),
+        platform=client,
+        experiment_id="eval-1",
+        workspace="ws-1",
+    )
+
+    # The rich attempt is refused, the single-step retry lands, and the trial still publishes.
+    assert [len(call["steps"]) for call in calls] == [2, 1]
+    assert report.trial_count == 1


### PR DESCRIPTION
## Summary

Intake received **one synthetic step per trial**, so a trace showed no input and no output in Studio no matter which agent ran. Harbor's ATIF-capable agents already write an ATIF-v1.7 trajectory to `agent/trajectory.json`, and Intake ingests that same schema — so the trajectory now flows end to end. A codex run lands as ~10 spans carrying the task prompt, the agent's reasoning, its tool calls and their results, and the final answer.

> **Stacked on [#1450](https://github.com/NVIDIA-NeMo/nemo-platform/pull/1450)** (`fix(evaluator): let a producer declare its trace format`) — based on that branch, not `main`. Intake can only read the trajectory as ATIF once it's labelled correctly. Review #1450 first.

## Changes

- `intake/mapping.py`: `atif_steps_from_trial` reads the trial's trace evidence into ATIF steps
- `intake/publish.py`: sends the recorded steps, with a fallback (below)
- `agent_eval/runtimes/harbor_runtime.py`: `_final_agent_message` supplies the trial's `output_text`
- Vendored SDK mirror regenerated
- Tests for step mapping, the fallback, and final-answer extraction

### The fallback, and why it isn't an enumeration

The SDK's ATIF read model is deliberately **more permissive** than Intake's ingest schema — `step_id` and `tool_call_id` are optional there and required here — so a trajectory that parses locally can still be refused with a 422.

Rather than enumerating those divergences (and drifting out of sync with them as either side evolves), publish catches `UnprocessableEntityError`, retries without the recorded steps, and keeps the trial's scores. Losing a run's measurements over a detail of its trace is the wrong trade. The retry is logged at warning level so it isn't silent.

### Idempotency

`step_id` is normalised to the one-based sequence ingest validates, and a step with no timestamp takes the run's start. This matters because Intake's spans table is a `ReplacingMergeTree` keyed on `(workspace, session_id, start_time, id)` — unstable timestamps would make re-publishing duplicate rather than replace.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing API or CLI surface change; the user-visible effect is richer trace content in Studio for runs that already publish

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest plugins/nemo-evaluator/tests/intake packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py` — **173 passed**
- `ruff check` / `ruff format --check` — pass
- **Mutation-checked** — each behaviour was broken on purpose and the matching test confirmed red:
  - send no recorded steps → `test_a_rejected_trajectory_falls_back_instead_of_failing_the_trial` fails
  - remove the `UnprocessableEntityError` fallback → same test fails
  - drop `_final_agent_message` → `test_atif_trajectory_supplies_the_final_answer` and `test_final_answer_ignores_trailing_non_agent_steps` fail
- **End to end against a live Harbor run**: a trial published 72 ATIF steps (versus the single synthetic step before), and the trace renders with real content in Studio.
- `uv run pre-commit run -a` — all hooks passed **except two blocked locally, not by this change**: **Helm Docs** (not installed; no `k8s/`/`helm/` files here) and **Run uv lock with platform uv** (PATH `uv` 0.9.30 vs required 0.9.14; no dependency change here, and `Check for uv.lock drift` passed).

## Known limitations (deliberately not addressed here)

Two Intake-side schema gaps surfaced while building this. Both are filed rather than worked around, because the producer side has the information and ATIF has nowhere to put it:

- **ASE-880** — ATIF `step_id` is validated at ingest then discarded, so Studio orders spans by `start_time`. Two steps sharing a timestamp render out of order. A publish-side timestamp nudge was implemented and then **reverted**: it writes a time the producer never recorded, into a store whose purpose is being the record of what happened, and only fixes traces published through this one path.
- **ASE-881** — ATIF has no field for terminal status or error, so a timed-out run is indistinguishable from a genuine reward-0.0 failure.


## Independent review

An independent model (Codex) was run over this branch. Two findings, both reproduced.

**Fixed — intermediate reasoning reported as the trial's answer.** `_final_agent_message` scanned backwards for the last *non-empty* agent message, so a trajectory ending on an empty agent step returned the one before it (`_final_agent_message -> 'working'` where the last agent message was `''`). Fixed in the follow-up commit; only the last agent step can be the answer, and an empty one means no answer. Mutation-checked — reverting the fix turns the new test red.

**Not fixed here — a mode-switching re-publish can leave two trace roots.** Verified as real, but it is an Intake-side design question rather than something this PR should decide.

If a trial is published once *with* recorded steps and later *without* them (or vice versa), the two publishes disagree about the root span's `start_time`:

- the root span ID is stable, derived from workspace + session only (`atif_mapping.py:217-224`)
- but the root's `start_time` comes from the trajectory's own steps (`_trajectory_started_at`, `atif_mapping.py:287-301`)
- and the spans table is `ORDER BY (workspace, session_id, start_time, id)` (`clickhouse_migrations.py:142`)

Same ID plus a different `start_time` is a different sort key, so the `ReplacingMergeTree` keeps **both** rows rather than replacing. Two roots for one session.

This requires a mode switch between publishes — the trace file disappearing, or a 422 that stops happening — so it is off the normal path. Flagged rather than fixed because the general fix is a decision about whether `start_time` belongs in that sort key, which is the same question ASE-880 raises about `step_id` being validated at ingest and then discarded. Better decided together than papered over here. Stable rich-to-rich and degraded-to-degraded re-publishes replace correctly.

**Cleared by that review:** step-ID renumbering across absent/duplicate/non-sequential source IDs; `None` timestamps (removed by `exclude_none=True` before `setdefault`); empty step arrays (the SDK parser requires at least one step); tool calls without `tool_call_id` (rejected by Intake, triggering the intended fallback); and that the 422 retry cannot double-publish through the current endpoint, since validation and mapping both run before the first persistence call (`spans/ingest/atif.py:114-138`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Harbor evaluations now report the final agent message from available trajectories.
  - ATIF trial data can include complete recorded trajectories rather than only a final output.
- **Bug Fixes**
  - Trajectory processing now ignores trailing non-agent steps and preserves intentionally empty final messages.
  - Unsupported, malformed, or unavailable trajectory data is handled safely.
  - Publishing retries with a simplified trajectory when a complete trajectory is rejected, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->