### PR TITLE
docs: expand NGC Helm chart overview

### DIFF
--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -18,7 +18,7 @@ Inference, evaluation, guardrails, jobs, observability, and CPU/GPU orchestratio
 Shared agent platform; pre-production evaluation and red-teaming; GPU-backed customization and synthetic-data jobs.
 
 ### System Requirements
-Kubernetes, Helm 3, kubectl, ReadWriteMany storage, NGC API key, and an image pull secret.
+Kubernetes, Helm, kubectl, ReadWriteMany storage, NGC API key, and an image pull secret.
 GPU workloads need NVIDIA GPU nodes and the GPU Operator or device plugin.
 See the [support matrix](https://docs.nvidia.com/nemo-platform/documentation/reference/support-matrix).
 

--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -21,7 +21,7 @@ Shared agent platform; pre-production evaluation and red-teaming; GPU-backed cus
 
 ### System Requirements
 
-Kubernetes 1.33+, kubectl, ReadWriteMany storage, and an NGC API key.
+Kubernetes 1.33+.
 GPU workloads need NVIDIA GPU nodes and the GPU Operator or device plugin.
 See the [support matrix](https://docs.nvidia.com/nemo-platform/documentation/reference/support-matrix).
 

--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -1,15 +1,26 @@
-<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Deploy NeMo Platform on Kubernetes to build, evaluate, harden, and optimize AI agents
+---
 
 ## NeMo Platform Helm Chart
 
-NVIDIA NeMo Platform Helm Chart for the deployment of NeMo Platform on Kubernetes.
+NeMo Platform is a toolkit for building, evaluating, hardening, and optimizing
+AI agents through a REST API, Python SDK, CLI, and web UI. This chart deploys
+those services on Kubernetes.
 
-### Resources
+### Features
+Inference, evaluation, guardrails, jobs, observability, and CPU/GPU orchestration.
 
-[Documentation](https://docs.nvidia.com/nemo-platform)
+### Use Cases
+Shared agent platform; pre-production evaluation and red-teaming; GPU-backed customization and synthetic-data jobs.
+
+### System Requirements
+Kubernetes, Helm 3, kubectl, ReadWriteMany storage, NGC API key, and an image pull secret.
+GPU workloads need NVIDIA GPU nodes and the GPU Operator or device plugin.
+See the [support matrix](https://docs.nvidia.com/nemo-platform/documentation/reference/support-matrix).
 
 ### License
-
 This chart is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).
-

--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -21,7 +21,7 @@ Shared agent platform; pre-production evaluation and red-teaming; GPU-backed cus
 
 ### System Requirements
 
-Kubernetes, Helm, kubectl, ReadWriteMany storage, and an NGC API key.
+Kubernetes 1.33+, kubectl, ReadWriteMany storage, and an NGC API key.
 GPU workloads need NVIDIA GPU nodes and the GPU Operator or device plugin.
 See the [support matrix](https://docs.nvidia.com/nemo-platform/documentation/reference/support-matrix).
 

--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -18,7 +18,7 @@ Inference, evaluation, guardrails, jobs, observability, and CPU/GPU orchestratio
 Shared agent platform; pre-production evaluation and red-teaming; GPU-backed customization and synthetic-data jobs.
 
 ### System Requirements
-Kubernetes, Helm, kubectl, ReadWriteMany storage, NGC API key, and an image pull secret.
+Kubernetes, Helm, kubectl, ReadWriteMany storage, and an NGC API key.
 GPU workloads need NVIDIA GPU nodes and the GPU Operator or device plugin.
 See the [support matrix](https://docs.nvidia.com/nemo-platform/documentation/reference/support-matrix).
 

--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -25,6 +25,10 @@ Kubernetes 1.33+.
 GPU workloads need NVIDIA GPU nodes and the GPU Operator or device plugin.
 See the [support matrix](https://docs.nvidia.com/nemo-platform/documentation/reference/support-matrix).
 
+### Resources
+
+[Documentation](https://docs.nvidia.com/nemo-platform)
+
 ### License
 
 This chart is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).

--- a/.github/assets/ngc/charts/nemo-platform.md
+++ b/.github/assets/ngc/charts/nemo-platform.md
@@ -12,15 +12,19 @@ AI agents through a REST API, Python SDK, CLI, and web UI. This chart deploys
 those services on Kubernetes.
 
 ### Features
+
 Inference, evaluation, guardrails, jobs, observability, and CPU/GPU orchestration.
 
 ### Use Cases
+
 Shared agent platform; pre-production evaluation and red-teaming; GPU-backed customization and synthetic-data jobs.
 
 ### System Requirements
+
 Kubernetes, Helm, kubectl, ReadWriteMany storage, and an NGC API key.
 GPU workloads need NVIDIA GPU nodes and the GPU Operator or device plugin.
 See the [support matrix](https://docs.nvidia.com/nemo-platform/documentation/reference/support-matrix).
 
 ### License
+
 This chart is licensed under the [Apache License 2.0](https://github.com/NVIDIA-NeMo/nemo-platform/blob/main/LICENSE).


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
The NGC catalog completeness review rejected the Helm chart overview because it only said the chart deploys NeMo Platform on Kubernetes. This expands the overview with what the platform is, plus Features, Use Cases, and System Requirements, using public documentation links.

## Changes
- Expand `.github/assets/ngc/charts/nemo-platform.md` with a short product description, features, use cases, and system requirements.
- Keep the NGC short description in YAML front matter.
- Link to the public support matrix and the Apache 2.0 license.
- Require Kubernetes 1.33+. Do not list Helm, kubectl, ReadWriteMany storage, an NGC API key, or an image pull secret.
- Add blank lines after section headings (markdownlint MD022). Keep `##` headings and do not restore extra docs links.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `test_repository_assets_are_valid` still loads the chart overview; no loader or sync behavior changed.
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run --files .github/assets/ngc/charts/nemo-platform.md`: copyright headers and merge-conflict hooks passed; other hooks skipped as unrelated.
- `uv run pre-commit run -a`: blocked locally by missing `helm-docs` and host `uv` 0.11.26 versus the required 0.9.14. Those hooks do not apply to this markdown file.
- `uv run --frozen pytest .github/scripts/tests/test_ngc_metadata.py -v -k 'repository_assets or load_asset or discover'`: 4 passed, 10 deselected.
- DCO audit of `origin/main..HEAD`: DCO OK (`smuley@nvidia.com`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the NeMo Platform chart documentation with a concise product overview.
  - Added key features, use cases, system requirements, and GPU prerequisites.
  - Clarified supported Kubernetes versions and linked to the support matrix.
  - Restored the Resources section with a documentation link.
  - Added SPDX licensing headers and retained Apache 2.0 license information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->