### PR TITLE
fix: dedupe copyright header in helm-docs markdown templates

### DIFF
--- a/k8s/helm/README.md
+++ b/k8s/helm/README.md
@@ -1,5 +1,3 @@
-
-
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
@@ -128,21 +126,16 @@ controller, and managed job pods. A top-level switch enables all default
 policies, and each subpolicy can be disabled independently for cluster-specific
 exceptions.
 
-For a Calico-backed Kind smoke test that verifies allowed and denied in-cluster
-traffic with Chainsaw, see
-[NetworkPolicy Smoke Test](https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test).
-The generated `networkPolicies` values reference remains in the table below.
-
 ## Values
 
 For the complete default values, see [values.yaml](values.yaml).
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| api | object | [See values.yaml](values.yaml#L637) | API configuration settings for the api deployment |
+| api | object | [See values.yaml](values.yaml#L732) | API configuration settings for the api deployment |
 | api.affinity | object | `{}` | Affinity configuration for the API service. |
 | api.annotations | object | `{}` | Annotations to add to the API service deployment. |
-| api.autoscaling | object | [See values.yaml](values.yaml#L761) | Specifies autoscaling configurations for the deployment. |
+| api.autoscaling | object | [See values.yaml](values.yaml#L856) | Specifies autoscaling configurations for the deployment. |
 | api.autoscaling.annotations | object | `{}` | Annotations for the HorizontalPodAutoscaler. |
 | api.autoscaling.enabled | bool | `false` | Whether to enable horizontal pod autoscaler. |
 | api.autoscaling.maxReplicas | int | `10` | The maximum number of replicas for the deployment. |
@@ -153,25 +146,25 @@ For the complete default values, see [values.yaml](values.yaml).
 | api.extraArgs | list | `[]` | Additional arguments to pass to the Platform API service |
 | api.extraVolumeMounts | list | `[]` | Additional volume mounts to add to the Platform API container. |
 | api.extraVolumes | list | `[]` | Additional volumes to add to the Platform API pod. |
-| api.image | object | [See values.yaml](values.yaml#L643) | Container image configuration for the api deployment. |
+| api.image | object | [See values.yaml](values.yaml#L738) | Container image configuration for the api deployment. |
 | api.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy determining when to pull new images. |
 | api.image.repository | string | `"nvcr.io/nvidia/nemo-platform/nmp-api"` | The registry where the NeMo Platform image is located. |
 | api.image.tag | string | `""` | The image tag to use. |
-| api.livenessProbe | object | [See values.yaml](values.yaml#L720) | Liveness probe configuration for the api service. |
+| api.livenessProbe | object | [See values.yaml](values.yaml#L815) | Liveness probe configuration for the api service. |
 | api.livenessProbe.failureThreshold | int | `3` | The failure threshold for the liveness probe. |
 | api.livenessProbe.httpGet | object | `{"path":"/health/live","port":"http"}` | The HTTP GET request to use for the liveness probe. |
 | api.livenessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the liveness probe. |
 | api.livenessProbe.timeoutSeconds | int | `5` | The timeout in seconds for the liveness probe. |
 | api.nodeSelector | object | `{}` | Node selector configuration for the API service. |
 | api.podAnnotations | object | `{}` | Annotations to add to the API service pod. |
-| api.podDisruptionBudget | object | [See values.yaml](values.yaml#L748) | PodDisruptionBudget configuration for the API service. |
+| api.podDisruptionBudget | object | [See values.yaml](values.yaml#L843) | PodDisruptionBudget configuration for the API service. |
 | api.podDisruptionBudget.annotations | object | `{}` | Annotations for the PodDisruptionBudget. |
 | api.podDisruptionBudget.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the API pods. |
 | api.podDisruptionBudget.minAvailable | int | `1` | Minimum number of API pods that must remain available during voluntary disruptions. Only one of minAvailable or maxUnavailable may be set. |
 | api.podLabels | object | `{}` | Labels for the API service pod. |
-| api.podSecurityContext | object | [See values.yaml](values.yaml#L685) | Pod-level security context settings for the API service. |
+| api.podSecurityContext | object | [See values.yaml](values.yaml#L780) | Pod-level security context settings for the API service. |
 | api.podSecurityContext.fsGroup | int | `1000` | The file system group ID to use for all containers. |
-| api.readinessProbe | object | [See values.yaml](values.yaml#L734) | Readiness probe configuration for the api service. |
+| api.readinessProbe | object | [See values.yaml](values.yaml#L829) | Readiness probe configuration for the api service. |
 | api.readinessProbe.failureThreshold | int | `3` | The failure threshold for the readiness probe. |
 | api.readinessProbe.httpGet | object | `{"path":"/health/ready","port":"http"}` | The HTTP GET request to use for the readiness probe. |
 | api.readinessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the readiness probe. |
@@ -181,11 +174,11 @@ For the complete default values, see [values.yaml](values.yaml).
 | api.securityContext | object | `{}` | Container-level security context settings for the API service. |
 | api.server | object | `{"keepAliveTimeoutSeconds":5}` | Platform API server settings. |
 | api.server.keepAliveTimeoutSeconds | int | `5` | Seconds Uvicorn keeps idle HTTP connections open. Must be greater than envoyProxy.timeouts.upstreamIdle when Envoy is enabled. |
-| api.service | object | [See values.yaml](values.yaml#L692) | Service configuration for the API service. |
+| api.service | object | [See values.yaml](values.yaml#L787) | Service configuration for the API service. |
 | api.service.annotations | object | `{}` | Annotations for the API service. |
 | api.service.port | int | `8080` | The port number to expose for the service. |
 | api.service.type | string | `"ClusterIP"` | The Kubernetes service type to create. |
-| api.serviceAccount | object | [See values.yaml](values.yaml#L668) | Service account configuration for the API service. |
+| api.serviceAccount | object | [See values.yaml](values.yaml#L763) | Service account configuration for the API service. |
 | api.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | api.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | api.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
@@ -195,7 +188,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | api.serviceMonitor.interval | string | `"30s"` | Scrape interval for the ServiceMonitor |
 | api.serviceMonitor.labels | object | `{}` | Additional labels to add to the ServiceMonitor |
 | api.serviceMonitor.scheme | string | `"http"` | Scheme to use for scraping metrics (http or https) |
-| api.startupProbe | object | [See values.yaml](values.yaml#L704) | Startup probe configuration for the api service. |
+| api.startupProbe | object | [See values.yaml](values.yaml#L799) | Startup probe configuration for the api service. |
 | api.startupProbe.failureThreshold | int | `24` | The failure threshold for the startup probe. |
 | api.startupProbe.httpGet | object | `{"path":"/health/ready","port":"http"}` | The HTTP GET request to use for the startup probe. |
 | api.startupProbe.initialDelaySeconds | int | `10` | Number of seconds to wait before the first startup probe. Allows time for DB connection retries (e.g. Postgres pod booting). |
@@ -204,8 +197,8 @@ For the complete default values, see [values.yaml](values.yaml).
 | api.telemetry | object | `{}` | OpenTelemetry configuration overrides for the api deployment. |
 | api.tolerations | list | `[]` | Tolerations configuration for the API service. |
 | api.topologySpreadConstraints | list | `[]` | Topology spread constraints for the API service pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
-| basePlatformConfig | string | [See values.yaml](values.yaml#L379) | Base platform configuration settings |
-| clickhouse | object | [See values.yaml](values.yaml#L253) | Embedded ClickHouse configuration for Intake. The embedded deployment is a single-node convenience topology. Use an external, replicated ClickHouse deployment for production environments that require high availability. These values are used only when `clickhouse.enabled` is true. |
+| basePlatformConfig | string | [See values.yaml](values.yaml#L474) | Base platform configuration settings |
+| clickhouse | object | [See values.yaml](values.yaml#L348) | Embedded ClickHouse configuration for Intake. The embedded deployment is a single-node convenience topology. Use an external, replicated ClickHouse deployment for production environments that require high availability. These values are used only when `clickhouse.enabled` is true. |
 | clickhouse.affinity | object | `{}` | Affinity for the ClickHouse pod. |
 | clickhouse.annotations | object | `{}` | Annotations to add to the ClickHouse StatefulSet. |
 | clickhouse.auth.database | string | `"intake"` | ClickHouse database used by Intake. |
@@ -217,7 +210,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | clickhouse.image.pullPolicy | string | `"IfNotPresent"` | ClickHouse image pull policy. |
 | clickhouse.image.repository | string | `"docker.io/clickhouse/clickhouse-server"` | ClickHouse image repository. Intake is tested against the 26.3 LTS release line. |
 | clickhouse.image.tag | string | `"26.3"` | ClickHouse image tag. |
-| clickhouse.livenessProbe | object | [See values.yaml](values.yaml#L304) | Liveness probe configuration for the ClickHouse container. |
+| clickhouse.livenessProbe | object | [See values.yaml](values.yaml#L399) | Liveness probe configuration for the ClickHouse container. |
 | clickhouse.nodeSelector | object | `{}` | Node selector for the ClickHouse pod. |
 | clickhouse.persistence.enabled | bool | `true` | Whether to persist embedded ClickHouse data. |
 | clickhouse.persistence.size | string | `"20Gi"` | PersistentVolumeClaim size. See the Intake and ClickHouse sizing guidance in the chart README. |
@@ -225,50 +218,50 @@ For the complete default values, see [values.yaml](values.yaml).
 | clickhouse.podAnnotations | object | `{}` | Annotations to add to the ClickHouse pod. |
 | clickhouse.podLabels | object | `{}` | Additional labels to add to the ClickHouse pod. |
 | clickhouse.podSecurityContext | object | `{}` | Optional pod security context for the ClickHouse pod. |
-| clickhouse.readinessProbe | object | [See values.yaml](values.yaml#L313) | Readiness probe configuration for the ClickHouse container. |
+| clickhouse.readinessProbe | object | [See values.yaml](values.yaml#L408) | Readiness probe configuration for the ClickHouse container. |
 | clickhouse.resources | object | `{"requests":{"cpu":"2","memory":"8Gi"}}` | Resource requests and limits for the ClickHouse container. The defaults are the supported small-volume starting point. |
 | clickhouse.securityContext | object | `{}` | Optional container security context for the ClickHouse container. |
 | clickhouse.service.annotations | object | `{}` | Annotations to add to the ClickHouse Service. |
 | clickhouse.service.httpPort | int | `8123` | ClickHouse HTTP interface port used by Intake. |
 | clickhouse.service.nativePort | int | `9000` | ClickHouse native protocol port exposed inside the cluster for administration. |
-| clickhouse.serviceAccount | object | [See values.yaml](values.yaml#L326) | Service account for the ClickHouse pod. |
+| clickhouse.serviceAccount | object | [See values.yaml](values.yaml#L421) | Service account for the ClickHouse pod. |
 | clickhouse.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | clickhouse.serviceAccount.automount | bool | `false` | Automatically mount the ServiceAccount's API credentials. |
 | clickhouse.serviceAccount.create | bool | `true` | Specifies whether a service account should be created for the ClickHouse pod. |
 | clickhouse.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated from the release fullname. |
-| clickhouse.startupProbe | object | [See values.yaml](values.yaml#L295) | Startup probe configuration for the ClickHouse container. |
+| clickhouse.startupProbe | object | [See values.yaml](values.yaml#L390) | Startup probe configuration for the ClickHouse container. |
 | clickhouse.tolerations | list | `[]` | Tolerations for the ClickHouse pod. |
-| core | object | [See values.yaml](values.yaml#L831) | Core deployment configuration settings |
+| core | object | [See values.yaml](values.yaml#L926) | Core deployment configuration settings |
 | core.controller.affinity | object | `{}` | Affinity configuration for the controller service. |
 | core.controller.annotations | object | `{}` | Annotations to add to the controller service deployment. |
 | core.controller.env | object | `{}` | Additional environment variables to pass to containers. This is an object formatted like NAME: value or NAME: valueFrom: {object}. |
 | core.controller.extraArgs | list | `[]` | Additional arguments to pass to the Core Controller service |
-| core.controller.livenessProbe | object | [See values.yaml](values.yaml#L935) | Liveness probe configuration for the controller service. |
-| core.controller.livenessProbe.failureThreshold | int | `3` | The failure threshold for the readiness probe. |
-| core.controller.livenessProbe.httpGet | object | `{"path":"/health/live","port":"http"}` | The HTTP GET request to use for the readiness probe. |
-| core.controller.livenessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the readiness probe. |
-| core.controller.livenessProbe.timeoutSeconds | int | `5` | The timeout in seconds for the readiness probe. |
+| core.controller.livenessProbe | object | [See values.yaml](values.yaml#L1030) | Liveness probe configuration for the controller service. |
+| core.controller.livenessProbe.failureThreshold | int | `3` | The failure threshold for the liveness probe. |
+| core.controller.livenessProbe.httpGet | object | `{"path":"/health/live","port":"http"}` | The HTTP GET request to use for the liveness probe. |
+| core.controller.livenessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the liveness probe. |
+| core.controller.livenessProbe.timeoutSeconds | int | `5` | The timeout in seconds for the liveness probe. |
 | core.controller.nodeSelector | object | `{}` | Node selector configuration for the controller service. |
 | core.controller.podAnnotations | object | `{}` | Annotations to add to the controller service pod. |
 | core.controller.podLabels | object | `{}` | Labels for the controller service pod. |
-| core.controller.podSecurityContext | object | [See values.yaml](values.yaml#L909) | Pod-level security context settings for the controller service. |
+| core.controller.podSecurityContext | object | [See values.yaml](values.yaml#L1004) | Pod-level security context settings for the controller service. |
 | core.controller.podSecurityContext.fsGroup | int | `1000` | The file system group ID to use for all containers. |
-| core.controller.readinessProbe | object | [See values.yaml](values.yaml#L949) | Readiness probe configuration for the controller service. |
+| core.controller.readinessProbe | object | [See values.yaml](values.yaml#L1044) | Readiness probe configuration for the controller service. |
 | core.controller.readinessProbe.failureThreshold | int | `3` | The failure threshold for the readiness probe. |
 | core.controller.readinessProbe.httpGet | object | `{"path":"/health/ready","port":"http"}` | The HTTP GET request to use for the readiness probe. |
 | core.controller.readinessProbe.periodSeconds | int | `10` | The frequency in seconds to perform the readiness probe. |
 | core.controller.readinessProbe.timeoutSeconds | int | `5` | The timeout in seconds for the readiness probe. |
 | core.controller.resources | object | `{}` | Kubernetes deployment resources configuration for the controller service. |
 | core.controller.securityContext | object | `{}` | Container-level security context settings for the controller service. |
-| core.controller.service | object | [See values.yaml](values.yaml#L896) | Service configuration for the controller service. This only configures a headless service for DNS resolution. |
+| core.controller.service | object | [See values.yaml](values.yaml#L991) | Service configuration for the controller service. This only configures a headless service for DNS resolution. |
 | core.controller.service.annotations | object | `{}` | Annotations for the headless controller service. |
 | core.controller.service.port | int | `8080` | The port for the service. |
-| core.controller.serviceAccount | object | [See values.yaml](values.yaml#L882) | Service account configuration for the controller service. |
+| core.controller.serviceAccount | object | [See values.yaml](values.yaml#L977) | Service account configuration for the controller service. |
 | core.controller.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | core.controller.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | core.controller.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
 | core.controller.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template. |
-| core.controller.startupProbe | object | [See values.yaml](values.yaml#L919) | Startup probe configuration for the core service. |
+| core.controller.startupProbe | object | [See values.yaml](values.yaml#L1014) | Startup probe configuration for the core service. |
 | core.controller.startupProbe.failureThreshold | int | `24` | The failure threshold for the startup probe. |
 | core.controller.startupProbe.httpGet | object | `{"path":"/health/ready","port":"http"}` | The HTTP GET request to use for the startup probe. |
 | core.controller.startupProbe.initialDelaySeconds | int | `10` | Number of seconds to wait before the first startup probe. Allows time for DB connection retries (e.g. Postgres pod booting). |
@@ -277,11 +270,11 @@ For the complete default values, see [values.yaml](values.yaml).
 | core.controller.tolerations | list | `[]` | Tolerations configuration for the controller service. |
 | core.controller.topologySpreadConstraints | list | `[]` | Topology spread constraints for the controller service pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | core.enabled | bool | `true` | Specifies whether to enable the core deployment. |
-| core.image | object | [See values.yaml](values.yaml#L837) | Container image configuration for the core deployment. |
+| core.image | object | [See values.yaml](values.yaml#L932) | Container image configuration for the core deployment. |
 | core.image.pullPolicy | string | `"IfNotPresent"` | The image pull policy determining when to pull new images. |
 | core.image.repository | string | `"nvcr.io/nvidia/nemo-platform/nmp-api"` | The registry where the NeMo Platform image is located. |
 | core.image.tag | string | `""` | The image tag to use. |
-| core.jobs | object | [See values.yaml](values.yaml#L867) | Service account configuration for pods created by the jobs controller (Kubernetes/Volcano job pods). |
+| core.jobs | object | [See values.yaml](values.yaml#L962) | Service account configuration for pods created by the jobs controller (Kubernetes/Volcano job pods). |
 | core.jobs.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | core.jobs.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | core.jobs.serviceAccount.create | bool | `true` | Specifies whether a service account should be created for job pods. |
@@ -300,11 +293,11 @@ For the complete default values, see [values.yaml](values.yaml).
 | core.telemetry | object | `{}` | OpenTelemetry configuration overrides for the platform deployment. |
 | env | object | `{}` | Environment variables that will be applied to every deployment pod. Uses a simple key value map structure like MY_ENV_VAR: the-key and works with valueFrom as well. |
 | envFromSecret | string | `""` | Optional. Name of an existing Kubernetes Secret to load as env vars (envFrom) for the API pod. When set, the chart does not create or generate the default api-env Secret; use your own Secret (for example, from Vault or sealed-secrets). |
-| envoyProxy | object | [See values.yaml](values.yaml#L987) | Envoy proxy configuration settings. Resources are created only when platform config has auth.enabled: true (see platformConfig.auth.enabled). |
+| envoyProxy | object | [See values.yaml](values.yaml#L1082) | Envoy proxy configuration settings. Resources are created only when platform config has auth.enabled: true (see platformConfig.auth.enabled). |
 | envoyProxy.adminPort | int | `9901` | Envoy Admin port |
 | envoyProxy.affinity | object | `{}` | Affinity configuration for the Envoy pods. |
 | envoyProxy.annotations | object | `{}` | Annotations to add to the Envoy service deployment. |
-| envoyProxy.autoscaling | object | [See values.yaml](values.yaml#L1112) | Specifies autoscaling configurations for the deployment. |
+| envoyProxy.autoscaling | object | [See values.yaml](values.yaml#L1207) | Specifies autoscaling configurations for the deployment. |
 | envoyProxy.autoscaling.annotations | object | `{}` | Annotations for the HorizontalPodAutoscaler. |
 | envoyProxy.autoscaling.enabled | bool | `false` | Whether to enable horizontal pod autoscaler. |
 | envoyProxy.autoscaling.maxReplicas | int | `10` | The maximum number of replicas for the deployment. |
@@ -317,25 +310,25 @@ For the complete default values, see [values.yaml](values.yaml).
 | envoyProxy.extraVolumeMounts | list | `[]` | Additional volume mounts to add to the Envoy container. |
 | envoyProxy.extraVolumes | list | `[]` | Additional volumes to add to the Envoy pod. |
 | envoyProxy.image.digest | string | `""` | Optional image digest. When set, the Envoy image renders as repository@digest. |
-| envoyProxy.livenessProbe | object | [See values.yaml](values.yaml#L1073) | Liveness probe for the Envoy container (admin interface /ready). |
+| envoyProxy.livenessProbe | object | [See values.yaml](values.yaml#L1168) | Liveness probe for the Envoy container (admin interface /ready). |
 | envoyProxy.nodeSelector | object | `{}` | Node selector configuration for the Envoy pods. |
 | envoyProxy.podAnnotations | object | `{}` | Annotations to add to the Envoy service pod. |
-| envoyProxy.podDisruptionBudget | object | [See values.yaml](values.yaml#L1099) | PodDisruptionBudget configuration for the Envoy service. |
+| envoyProxy.podDisruptionBudget | object | [See values.yaml](values.yaml#L1194) | PodDisruptionBudget configuration for the Envoy service. |
 | envoyProxy.podDisruptionBudget.annotations | object | `{}` | Annotations for the PodDisruptionBudget. |
 | envoyProxy.podDisruptionBudget.enabled | bool | `false` | Whether to create a PodDisruptionBudget for the Envoy pods. |
 | envoyProxy.podDisruptionBudget.minAvailable | int | `1` | Minimum number of Envoy pods that must remain available during voluntary disruptions. Only one of minAvailable or maxUnavailable may be set. |
 | envoyProxy.podLabels | object | `{}` | Labels for the Envoy service pod. |
-| envoyProxy.podSecurityContext | object | [See values.yaml](values.yaml#L1033) | Pod-level security context settings for the Envoy service. |
+| envoyProxy.podSecurityContext | object | [See values.yaml](values.yaml#L1128) | Pod-level security context settings for the Envoy service. |
 | envoyProxy.podSecurityContext.fsGroup | int | `1000` | The file system group ID to use for all containers. |
-| envoyProxy.readinessProbe | object | [See values.yaml](values.yaml#L1081) | Readiness probe for the Envoy container (admin interface /ready). |
+| envoyProxy.readinessProbe | object | [See values.yaml](values.yaml#L1176) | Readiness probe for the Envoy container (admin interface /ready). |
 | envoyProxy.resources | object | `{}` | Kubernetes deployment resources configuration for the Envoy service. Utilization-based autoscaling requires a matching resource request. |
 | envoyProxy.securityContext | object | `{}` | Container-level security context settings for the Envoy service. |
-| envoyProxy.service | object | [See values.yaml](values.yaml#L1040) | Service configuration for the Envoy service. |
+| envoyProxy.service | object | [See values.yaml](values.yaml#L1135) | Service configuration for the Envoy service. |
 | envoyProxy.service.annotations | object | `{}` | Annotations for the Envoy service. |
 | envoyProxy.service.exposeAdminPort | bool | `false` | Expose the Envoy admin port through the Kubernetes Service. Enable only for controlled in-cluster scraping or debugging. |
 | envoyProxy.service.port | int | `8080` | The port number to expose for the service. |
 | envoyProxy.service.type | string | `"ClusterIP"` | The Kubernetes service type to create. |
-| envoyProxy.serviceAccount | object | [See values.yaml](values.yaml#L1016) | Service account configuration for the Envoy service. |
+| envoyProxy.serviceAccount | object | [See values.yaml](values.yaml#L1111) | Service account configuration for the Envoy service. |
 | envoyProxy.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | envoyProxy.serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials. |
 | envoyProxy.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
@@ -345,8 +338,8 @@ For the complete default values, see [values.yaml](values.yaml).
 | envoyProxy.serviceMonitor.interval | string | `"30s"` | Scrape interval for the ServiceMonitor |
 | envoyProxy.serviceMonitor.labels | object | `{}` | Additional labels to add to the ServiceMonitor |
 | envoyProxy.serviceMonitor.scheme | string | `"http"` | Scheme to use for scraping metrics (http or https) |
-| envoyProxy.startupProbe | object | [See values.yaml](values.yaml#L1089) | Startup probe for the Envoy container (admin interface /ready). |
-| envoyProxy.timeouts | object | [See values.yaml](values.yaml#L1055) | Timeouts for proxying to long-lived streams (e.g. inference gateway). Use "0s" to disable a timeout. |
+| envoyProxy.startupProbe | object | [See values.yaml](values.yaml#L1184) | Startup probe for the Envoy container (admin interface /ready). |
+| envoyProxy.timeouts | object | [See values.yaml](values.yaml#L1150) | Timeouts for proxying to long-lived streams (e.g. inference gateway). Use "0s" to disable a timeout. |
 | envoyProxy.timeouts.connect | string | `"30s"` | Cluster connect timeout (time to establish connection to backend). |
 | envoyProxy.timeouts.request | string | `"0s"` | Total request timeout. 0 = disabled (required for streaming; not compatible with streaming if set). |
 | envoyProxy.timeouts.requestHeaders | string | `"60s"` | Time to receive full request headers. 0 = disabled. |
@@ -356,7 +349,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | envoyProxy.tolerations | list | `[]` | Tolerations configuration for the Envoy pods. |
 | envoyProxy.topologySpreadConstraints | list | `[]` | Topology spread constraints for the Envoy pods. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | existingSecret | string | `"ngc-api"` | You can use an existing Kubernetes secret for communicating with the NGC API for downloading models. The chart uses the `ngcAPIKey` value to generate the secret if you set this to an empty string. |
-| externalClickhouse | object | [See values.yaml](values.yaml#L350) | External ClickHouse configuration. These values are used when `clickhouse.enabled` is false. |
+| externalClickhouse | object | [See values.yaml](values.yaml#L445) | External ClickHouse configuration. These values are used when `clickhouse.enabled` is false. |
 | externalClickhouse.database | string | `"intake"` | ClickHouse database used by Intake. |
 | externalClickhouse.existingSecret | string | `""` | Name of an existing Secret containing the ClickHouse password. Required when using external ClickHouse. |
 | externalClickhouse.existingSecretPasswordKey | string | `""` | Key in existingSecret containing the ClickHouse password. Required when using external ClickHouse. |
@@ -364,13 +357,13 @@ For the complete default values, see [values.yaml](values.yaml).
 | externalClickhouse.port | int | `8123` | External ClickHouse HTTP interface port. |
 | externalClickhouse.secure | bool | `false` | Whether Intake should connect to ClickHouse over HTTPS. |
 | externalClickhouse.user | string | `"nemo"` | ClickHouse username used by Intake. |
-| externalDatabase | object | [See values.yaml](values.yaml#L227) | External PostgreSQL configuration settings. These values are only used when postgresql.enabled is set to false. |
+| externalDatabase | object | [See values.yaml](values.yaml#L322) | External PostgreSQL configuration settings. These values are only used when postgresql.enabled is set to false. |
 | externalDatabase.database | string | `"nemoplatform"` | Database name. |
 | externalDatabase.existingSecret | string | `""` | Name of an existing secret resource containing the database credentials. |
 | externalDatabase.existingSecretPasswordKey | string | `""` | Name of an existing secret key containing the database credentials. |
 | externalDatabase.host | string | `"localhost"` | External database host address. |
 | externalDatabase.port | int | `5432` | External database port number. |
-| externalDatabase.uriSecret | object | [See values.yaml](values.yaml#L242) | URI secret configuration for external database. |
+| externalDatabase.uriSecret | object | [See values.yaml](values.yaml#L337) | URI secret configuration for external database. |
 | externalDatabase.uriSecret.key | string | `""` | Key in the URI secret containing the database URI. |
 | externalDatabase.uriSecret.name | string | `""` | Name of the URI secret. |
 | externalDatabase.user | string | `"nemo"` | Database username |
@@ -381,13 +374,13 @@ For the complete default values, see [values.yaml](values.yaml).
 | httpRoute.hostnames | list | `[]` | If this has a specific hostname, add the name or names here in an array. |
 | httpRoute.labels | object | `{}` | Extra labels for the HTTP Route object. |
 | httpRoute.parentRefs | list | `[]` | A list of Gateways to enable this route on. This is required if httpRoute.enabled is true. |
-| httpRoute.pathRules | list | [See values.yaml](values.yaml#L568) | Path matches to route queries. |
+| httpRoute.pathRules | list | [See values.yaml](values.yaml#L663) | Path matches to route queries. |
 | imagePullSecrets | list | `[]` | Existing Kubernetes image pull secrets to use for pulling container images from private registries or mirrors. |
 | ingress.annotations | object | `{}` | Annotations for the ingress resource. |
 | ingress.className | string | `""` | The ingress class to use if your cluster has more than one class. |
 | ingress.defaultHost | string | `""` | Optional default hostname. When set, one rule is generated with this host and paths from the first entry in ingress.hosts. |
 | ingress.enabled | bool | `false` | Specifies whether to enable the ingress. |
-| ingress.hosts[0] | object | [See values.yaml](values.yaml#L533) | Hostname used by ingress. If blank, use path-only routing. |
+| ingress.hosts[0] | object | [See values.yaml](values.yaml#L628) | Hostname used by ingress. If blank, use path-only routing. |
 | ingress.tls | list | `[]` | TLS configurations. |
 | multinodeNetworking | object | [See values.yaml](values.yaml#L94) | Multi-node networking configuration for distributed GPU training. These settings control Kyverno policies that inject cloud-specific networking and NCCL configurations.  Requirements: - Kyverno policy engine must be installed in your cluster (required for multi-node networking) - Kyverno is NOT included as a subchart dependency and must be installed separately  To install Kyverno:   helm install kyverno kyverno/kyverno --namespace kyverno --create-namespace --version 3.2.0  Documentation: https://kyverno.io/docs/installation/ Helm chart: https://kyverno.github.io/kyverno/  Note: Only enable ONE cloud provider per cluster deployment. |
 | multinodeNetworking.aws | object | `{"efaDevicesPerGPU":1,"enabled":false}` | AWS-specific configuration for EFA device injection |
@@ -403,58 +396,58 @@ For the complete default values, see [values.yaml](values.yaml).
 | multinodeNetworking.oci.enabled | bool | `false` | Enable OCI-specific Kyverno policy for InfiniBand/SR-IOV configuration |
 | multinodeNetworking.oci.rdmaDevicesPerGPU | int | `8` | Number of RDMA devices (mlnxnics) to request per GPU |
 | nameOverride | string | `""` | Overrides for name and fullname templates |
-| ncclTest | object | [See values.yaml](values.yaml#L126) | NCCL chart test (`helm test`): multi-node allreduce check. Templates use helm.sh/hook: test — they are not created on install/upgrade, only when you run helm test. Requires nodes labeled with gpuNodeLabelKey/gpuNodeLabelValue (default NFD / GPU operator style). See https://helm.sh/docs/topics/chart_tests/ |
-| ncclTest.configMapCleanupJob | object | [See values.yaml](values.yaml#L155) | Post-test hook Job (after orchestrator): deletes the scripts ConfigMap (helm.sh/hook-weight 5). |
+| ncclTest | object | [See values.yaml](values.yaml#L221) | NCCL chart test (`helm test`): multi-node allreduce check. Templates use helm.sh/hook: test — they are not created on install/upgrade, only when you run helm test. Requires nodes labeled with gpuNodeLabelKey/gpuNodeLabelValue (default NFD / GPU operator style). See https://helm.sh/docs/topics/chart_tests/ |
+| ncclTest.configMapCleanupJob | object | [See values.yaml](values.yaml#L250) | Post-test hook Job (after orchestrator): deletes the scripts ConfigMap (helm.sh/hook-weight 5). |
 | ncclTest.gpuNodeLabelKey | string | `"nvidia.com/gpu.present"` | Node label used to discover GPU workers (must match your cluster). |
 | ncclTest.gpuResourceKey | string | `"nvidia.com/gpu"` | Resource name for GPU capacity on worker pods (e.g. nvidia.com/gpu or a MIG device). |
 | ncclTest.gpusPerNode | int | `1` | GPUs per worker pod / per node (torch.distributed nproc_per_node). IMPORTANT: Set this value before testing |
 | ncclTest.iterations | int | `3` | How many times to run the full multinode NCCL test (orchestrator loop; env NCCL_TEST_ITERATIONS). Increase the test timeout on helm test if increasing this variable |
 | ncclTest.validation.minBandwidthMBpsAt1024MB | int | `8000` | Minimum allreduce bandwidth (MB/s) at 1024MB message size; 0 disables the floor check in nccl_test.py. |
 | ncclTest.waitTimeoutSeconds | int | `900` | Max seconds to wait for each worker pod to complete. |
-| networkPolicies | object | This object has the following default values. The top-level switch is disabled by default so chart upgrades do not change cluster connectivity unless explicitly enabled. | NetworkPolicy configuration. Enable the top-level switch to render all default policies, then disable individual policies only for cluster-specific exceptions. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test. |
-| networkPolicies.api | object | This object has the following default values for API pod ingress isolation. | NetworkPolicy configuration for the Platform API pods. |
+| networkPolicies | object | [See values.yaml](values.yaml#L125) | NetworkPolicy configuration. Enable the top-level switch to render all default policies, then disable individual policies only for cluster-specific exceptions. For a Calico-backed smoke test, see https://docs.nvidia.com/nemo-platform/documentation/self-managed-deployment/setup/helm/network-policy-smoke-test. |
+| networkPolicies.api | object | [See values.yaml](values.yaml#L130) | NetworkPolicy configuration for the Platform API pods. |
 | networkPolicies.api.enabled | bool | `true` | Create NetworkPolicy resources that isolate Platform API pod ingress. |
 | networkPolicies.api.extraIngress | list | `[]` | Extra NetworkPolicy ingress rules appended to the API policy, for cluster-specific ingress controllers, gateways, monitoring, or debugging pods. |
-| networkPolicies.api.managedJobs | object | `{"enabled":true,"podSelector":{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}}` | Allow managed job pods to reach the Platform API pods. |
+| networkPolicies.api.managedJobs | object | [See values.yaml](values.yaml#L140) | Allow managed job pods to reach the Platform API pods. |
 | networkPolicies.api.managedJobs.enabled | bool | `true` | Enable ingress from managed job pods. |
-| networkPolicies.api.managedJobs.podSelector | object | `{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}` | Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller. |
+| networkPolicies.api.managedJobs.podSelector | object | [See values.yaml](values.yaml#L144) | Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller. |
 | networkPolicies.api.port | string | `""` | Optional NetworkPolicy port for the Platform API. Empty uses api.service.port. |
 | networkPolicies.api.sameReleasePods | object | `{"enabled":true}` | Allow pods from the same Helm release namespace that carry the chart selector labels to reach the Platform API pods. |
 | networkPolicies.api.sameReleasePods.enabled | bool | `true` | Enable ingress from same-release pods. |
-| networkPolicies.controller | object | This object has the following default values for core controller pod ingress isolation. | NetworkPolicy configuration for the core controller pods. |
+| networkPolicies.controller | object | [See values.yaml](values.yaml#L153) | NetworkPolicy configuration for the core controller pods. |
 | networkPolicies.controller.enabled | bool | `true` | Create NetworkPolicy resources that isolate core controller pod ingress. |
 | networkPolicies.controller.extraIngress | list | `[]` | Extra NetworkPolicy ingress rules appended to the core controller policy, for cluster-specific monitoring or debugging pods. |
 | networkPolicies.controller.port | string | `""` | Optional NetworkPolicy port for the core controller. Empty uses core.controller.service.port. |
 | networkPolicies.controller.sameReleasePods | object | `{"enabled":true}` | Allow pods from the same Helm release namespace that carry the chart selector labels to reach the core controller pods. |
 | networkPolicies.controller.sameReleasePods.enabled | bool | `true` | Enable ingress from same-release pods. |
 | networkPolicies.enabled | bool | `false` | Create NetworkPolicy resources for enabled subpolicies. |
-| networkPolicies.jobs | object | This object has the following default values for managed job pod egress isolation. | NetworkPolicy configuration for pods created by the jobs controller. |
-| networkPolicies.jobs.dns | object | `{"enabled":true,"namespaceSelector":{"matchLabels":{"kubernetes.io/metadata.name":"kube-system"}},"podSelector":{"matchLabels":{"k8s-app":"kube-dns"}},"ports":[{"port":53,"protocol":"UDP"},{"port":53,"protocol":"TCP"}]}` | Allow DNS lookup from managed job pods. |
+| networkPolicies.jobs | object | [See values.yaml](values.yaml#L167) | NetworkPolicy configuration for pods created by the jobs controller. |
+| networkPolicies.jobs.dns | object | [See values.yaml](values.yaml#L182) | Allow DNS lookup from managed job pods. |
 | networkPolicies.jobs.dns.enabled | bool | `true` | Enable egress to DNS pods. |
-| networkPolicies.jobs.dns.namespaceSelector | object | `{"matchLabels":{"kubernetes.io/metadata.name":"kube-system"}}` | Namespace selector for DNS pods. |
+| networkPolicies.jobs.dns.namespaceSelector | object | [See values.yaml](values.yaml#L186) | Namespace selector for DNS pods. |
 | networkPolicies.jobs.dns.podSelector | object | `{"matchLabels":{"k8s-app":"kube-dns"}}` | Pod selector for DNS pods. |
-| networkPolicies.jobs.dns.ports | list | `[{"port":53,"protocol":"UDP"},{"port":53,"protocol":"TCP"}]` | DNS ports to allow. |
+| networkPolicies.jobs.dns.ports | list | [See values.yaml](values.yaml#L194) | DNS ports to allow. |
 | networkPolicies.jobs.enabled | bool | `true` | Create NetworkPolicy resources that isolate managed job pod egress. |
-| networkPolicies.jobs.externalEgress | object | `{"enabled":true,"ipBlocks":[{"cidr":"0.0.0.0/0","except":["10.0.0.0/8","100.64.0.0/10","127.0.0.0/8","169.254.0.0/16","172.16.0.0/12","192.168.0.0/16"]}],"ports":[]}` | Allow egress to external CIDR blocks. The default excludes common private, loopback, and link-local ranges so enabling the policy does not allow direct access to typical in-cluster service and pod networks. |
+| networkPolicies.jobs.externalEgress | object | [See values.yaml](values.yaml#L200) | Allow egress to external CIDR blocks. The default excludes common private, loopback, and link-local ranges so enabling the policy does not allow direct access to typical in-cluster service and pod networks. |
 | networkPolicies.jobs.externalEgress.enabled | bool | `true` | Enable egress to external CIDR blocks. |
-| networkPolicies.jobs.externalEgress.ipBlocks | list | `[{"cidr":"0.0.0.0/0","except":["10.0.0.0/8","100.64.0.0/10","127.0.0.0/8","169.254.0.0/16","172.16.0.0/12","192.168.0.0/16"]}]` | External destination CIDR blocks for managed job pods. |
+| networkPolicies.jobs.externalEgress.ipBlocks | list | [See values.yaml](values.yaml#L204) | External destination CIDR blocks for managed job pods. |
 | networkPolicies.jobs.externalEgress.ports | list | `[]` | Optional list of ports for external egress. Empty allows all ports to the configured ipBlocks. |
 | networkPolicies.jobs.extraEgress | list | `[]` | Extra NetworkPolicy egress rules appended to the managed job policy, for cluster-specific dependencies or additional allowed CIDRs. |
 | networkPolicies.jobs.platformApi | object | `{"enabled":true,"port":""}` | Allow managed job pods to reach the in-namespace Platform API pods. |
 | networkPolicies.jobs.platformApi.enabled | bool | `true` | Enable the default egress exception to the platform API pods. Disable only when managed job pods should not call the in-namespace API, or when API access is supplied through cluster-specific extraEgress rules. |
 | networkPolicies.jobs.platformApi.port | string | `""` | Optional NetworkPolicy port for the platform API. Empty uses api.service.port. |
-| networkPolicies.jobs.podSelector | object | `{"matchLabels":{"app":"nemo-job","nmp.nvidia.com/managed_by":"jobs-controller"}}` | Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller. |
+| networkPolicies.jobs.podSelector | object | [See values.yaml](values.yaml#L171) | Pod selector for managed job pods. The default matches Kubernetes/Volcano pods created by the jobs controller. |
 | ngcAPIKey | string | `"YOUR-NGC-API-KEY"` | Your NVIDIA GPU Cloud (NGC) API key authenticates API calls to NGC services, such as model downloads. The existing secret overrides this key if you provide one to the `existingSecret` key. |
-| openshiftRoute | object | [See values.yaml](values.yaml#L587) | OpenShift Route (route.openshift.io/v1). Use on OpenShift to expose the API via a Route instead of Ingress. |
+| openshiftRoute | object | [See values.yaml](values.yaml#L682) | OpenShift Route (route.openshift.io/v1). Use on OpenShift to expose the API via a Route instead of Ingress. |
 | openshiftRoute.annotations | object | `{}` | Annotations for the route resource. |
 | openshiftRoute.enabled | bool | `false` | Specifies whether to create an OpenShift Route for the API service. |
 | openshiftRoute.host | string | `""` | Hostname for the route. If empty, the OpenShift router may assign a default hostname. |
 | openshiftRoute.labels | object | `{}` | Labels for the route resource. |
-| openshiftRoute.service | string | [See values.yaml](values.yaml#L593) | Service name to route to. Defaults to Envoy when auth+envoy enabled, otherwise API (tpl-evaluated). |
-| openshiftRoute.targetPort | string | [See values.yaml](values.yaml#L595) | Target port on the service. Defaults to Envoy or API port depending on auth (tpl-evaluated). |
+| openshiftRoute.service | string | [See values.yaml](values.yaml#L688) | Service name to route to. Defaults to Envoy when auth+envoy enabled, otherwise API (tpl-evaluated). |
+| openshiftRoute.targetPort | string | [See values.yaml](values.yaml#L690) | Target port on the service. Defaults to Envoy or API port depending on auth (tpl-evaluated). |
 | openshiftRoute.tls | object | `{}` | Optional TLS configuration (termination, certificate, key, etc.). See OpenShift Route spec. |
-| platformConfig | object | [See values.yaml](values.yaml#L372) | Platform-wide configuration settings Set configuration here to apply custom, structured configuration across all services. Applied after the base platform config is evaluated for templates. Enables adding / overriding YAML-based elements in the evaluated platform config. It is usually recommended to use this config section instead of `basePlatformConfig` unless you need to use templating features. For example, you can set the NIM default StorageClass via models.controller.backends.deployments_plugin.default_storage_class. For full configuration reference, see https://docs.nvidia.com/nemo-platform |
-| platformSeedJob | object | [See values.yaml](values.yaml#L803) | Platform seed Job (Helm hook: runs after install/upgrade) Runs the platform-seed task (guardrails configs, evaluator system entities, data designer filesets). Uses post-install,post-upgrade hooks so it runs on fresh installs and can be re-triggered on no-op upgrade. |
+| platformConfig | object | [See values.yaml](values.yaml#L467) | Platform-wide configuration settings Set configuration here to apply custom, structured configuration across all services. Applied after the base platform config is evaluated for templates. Enables adding / overriding YAML-based elements in the evaluated platform config. It is usually recommended to use this config section instead of `basePlatformConfig` unless you need to use templating features. For example, you can set the NIM default StorageClass via models.controller.backends.deployments_plugin.default_storage_class. For full configuration reference, see https://docs.nvidia.com/nemo-platform |
+| platformSeedJob | object | [See values.yaml](values.yaml#L898) | Platform seed Job (Helm hook: runs after install/upgrade) Runs the platform-seed task (guardrails configs, evaluator system entities, data designer filesets). Uses post-install,post-upgrade hooks so it runs on fresh installs and can be re-triggered on no-op upgrade. |
 | platformSeedJob.activeDeadlineSeconds | int | `600` | Maximum time in seconds the Job can run. |
 | platformSeedJob.affinity | object | `{}` | Affinity for the platform seeding Job pod. |
 | platformSeedJob.backoffLimit | int | `6` | Number of retries before considering the Job failed. |
@@ -467,10 +460,10 @@ For the complete default values, see [values.yaml](values.yaml).
 | platformSeedJob.securityContext | object | `{}` | Container-level security context for the platform-seed container. |
 | platformSeedJob.tolerations | list | `[]` | Tolerations for the platform seeding Job pod. |
 | platformSeedJob.ttlSecondsAfterFinished | int | `86400` | Seconds after the Job finishes (success or failure) before it is eligible for automatic deletion. |
-| podSecurityContext | object | [See values.yaml](values.yaml#L628) | Pod security context settings applied to all services by default. These can be overridden in individual service configurations. |
-| postgresql | object | [See values.yaml](values.yaml#L173) | Local PostgreSQL configuration for the NeMo Platform. |
+| podSecurityContext | object | [See values.yaml](values.yaml#L723) | Pod security context settings applied to all services by default. These can be overridden in individual service configurations. |
+| postgresql | object | [See values.yaml](values.yaml#L268) | Local PostgreSQL configuration for the NeMo Platform. |
 | postgresql.affinity | object | `{}` | Affinity for the PostgreSQL pod. |
-| postgresql.auth | object | [See values.yaml](values.yaml#L183) | PostgreSQL authentication configuration. |
+| postgresql.auth | object | [See values.yaml](values.yaml#L278) | PostgreSQL authentication configuration. |
 | postgresql.auth.existingSecret | string | `""` | Name of an existing secret containing a "password" key (or use existingSecretPasswordKey). If set, the chart does not create a secret. |
 | postgresql.enabled | bool | `true` | Whether to deploy the embedded PostgreSQL. If enabled, the chart deploys a single-replica PostgreSQL instance using the official Postgres image. It is NOT recommended to use the built-in PostgreSQL for production deployments. It is enabled in the chart by default for ease of getting started with the platform. If you are using an existing PostgreSQL installation, set this to false and use the "externalDatabase" configuration section. |
 | postgresql.nodeSelector | object | `{}` | Node selector for the PostgreSQL pod. |
@@ -480,7 +473,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | postgresql.resources | object | `{}` | Optional resource limits/requests for the PostgreSQL container. |
 | postgresql.securityContext | object | `{}` | Optional container security context for the PostgreSQL container. |
 | postgresql.service | object | `{"port":5432}` | PostgreSQL service configuration. |
-| postgresql.serviceAccount | object | [See values.yaml](values.yaml#L209) | Service account for the PostgreSQL pod. |
+| postgresql.serviceAccount | object | [See values.yaml](values.yaml#L304) | Service account for the PostgreSQL pod. |
 | postgresql.serviceAccount.annotations | object | `{}` | Annotations to add to the service account. |
 | postgresql.serviceAccount.automount | bool | `true` | Automatically mount the ServiceAccount's API credentials. |
 | postgresql.serviceAccount.create | bool | `true` | Specifies whether a service account should be created for the PostgreSQL pod. |
@@ -509,7 +502,7 @@ For the complete default values, see [values.yaml](values.yaml).
 | secrets.defaultEncryptionKey.generated.tolerations | list | `[]` | Tolerations for the key generation hook. |
 | secrets.defaultEncryptionKey.generated.ttlSecondsAfterFinished | int | `300` | Seconds to keep the key generation hook Job after it finishes, if the hook is not deleted first. |
 | secrets.defaultEncryptionKey.value | string | `""` | Optional base64-encoded key for encrypting platform secrets. The decoded key must be at least 32 bytes. If empty and envFromSecret is not set, a pre-install hook generates a per-install key. |
-| securityContext | object | [See values.yaml](values.yaml#L633) | Container security context settings applied to all services by default. These can be overridden in individual service configurations. |
+| securityContext | object | [See values.yaml](values.yaml#L728) | Container security context settings applied to all services by default. These can be overridden in individual service configurations. |
 | telemetry.OTEL_EXPORTER_OTLP_ENDPOINT | string | `""` | The OpenTelemetry grpc collector endpoint to export traces and metrics to. |
 | telemetry.OTEL_EXPORTER_OTLP_INSECURE | bool | `true` | Whether to use an insecure connection (no TLS) to the OpenTelemetry collector endpoint. |
 | telemetry.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT | string | `nil` | The OpenTelemetry metrics exporter endpoint to use. Defaults to `OTEL_EXPORTER_OTLP_ENDPOINT` if not set. |

--- a/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
+++ b/k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl
@@ -1,9 +1,6 @@
 <!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
-<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
-
 # {{ template "chart.description" . }}
 
 {{ template "chart.typeBadge" . }}

--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -1028,15 +1028,15 @@ core:
     # -- Liveness probe configuration for the controller service.
     # @default -- This object has the following default values for the liveness probe configuration.
     livenessProbe:
-      # -- The HTTP GET request to use for the readiness probe.
+      # -- The HTTP GET request to use for the liveness probe.
       httpGet:
         path: /health/live
         port: http
-      # -- The frequency in seconds to perform the readiness probe.
+      # -- The frequency in seconds to perform the liveness probe.
       periodSeconds: 10
-      # -- The timeout in seconds for the readiness probe.
+      # -- The timeout in seconds for the liveness probe.
       timeoutSeconds: 5
-      # -- The failure threshold for the readiness probe.
+      # -- The failure threshold for the liveness probe.
       failureThreshold: 3
 
     # -- Readiness probe configuration for the controller service.

--- a/tests/test_copyright_fixer.py
+++ b/tests/test_copyright_fixer.py
@@ -63,7 +63,7 @@ def test_add_header_uses_syntax_safe_styles_for_missing_osrb_file_types(tmp_path
 
     files = {
         "test_case.py": ('print("ok")\n', copyright_fixer._HASH_HEADER + "\n"),
-        "nemo-helm-readme.md.gotmpl": ("# title\n", copyright_fixer._HELM_TEMPLATE_HEADER + "\n"),
+        "nemo-helm-readme.md.gotmpl": ("# title\n", copyright_fixer._HTML_HEADER + "\n"),
         "values.yaml": ("apiVersion: v1\n", copyright_fixer._HASH_HEADER + "\n"),
         "chart/templates/serviceaccount.yaml": (
             "{{- if .Values.enabled -}}\napiVersion: v1\n{{- end }}\n",
@@ -100,6 +100,15 @@ def test_fix_style_converts_helm_template_yaml_to_non_rendering_comment(tmp_path
     assert copyright_fixer._needs_style_fix(str(chart_template))
     assert copyright_fixer._fix_header_style(str(chart_template))
     assert chart_template.read_text(encoding="utf-8").startswith(copyright_fixer._HELM_TEMPLATE_HEADER + "\n")
+
+
+def test_fix_style_preserves_markdown_gotmpl_rendered_header(tmp_path: Path) -> None:
+    template = tmp_path / "nemo-helm-readme.md.gotmpl"
+    template.write_text(copyright_fixer._HTML_HEADER + '\n# {{ template "chart.description" . }}\n', encoding="utf-8")
+
+    assert not copyright_fixer._needs_style_fix(str(template))
+    assert not copyright_fixer._fix_header_style(str(template))
+    assert template.read_text(encoding="utf-8").startswith(copyright_fixer._HTML_HEADER + "\n")
 
 
 def test_plain_yaml_keeps_hash_comment_header(tmp_path: Path) -> None:

--- a/tools/lint/copyright_fixer.py
+++ b/tools/lint/copyright_fixer.py
@@ -506,6 +506,10 @@ def _has_frontmatter(content: str) -> bool:
     return content.startswith("---\n") or content.startswith("---\r\n")
 
 
+def _is_markdown_go_template(path: Path) -> bool:
+    return path.name.endswith(".md.gotmpl")
+
+
 def _is_helm_template_yaml(path: Path) -> bool:
     """Return True for YAML files under a Helm chart templates directory."""
     if path.suffix not in {".yaml", ".yml"}:
@@ -553,6 +557,9 @@ def _get_header_for_file(filepath: str, content: str) -> str:
 
     if name in _SPECIAL_FILENAMES or name.startswith("Dockerfile.") or name.endswith(".Dockerfile"):
         return _HASH_HEADER + "\n"
+
+    if _is_markdown_go_template(path):
+        return _HTML_HEADER + "\n"
 
     if ext in {".md", ".mdx"} and _has_frontmatter(content):
         return _HASH_HEADER


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

The copyright fixer treated `.md.gotmpl` files like plain Markdown and inserted its default header, which duplicated the HTML-comment header already emitted by `helm-docs` for `k8s/helm/README.md`. This teaches the fixer to recognize `*.md.gotmpl` templates and use the HTML-comment header style consistently, then regenerates `k8s/helm/README.md` to drop the duplicate header and other stale content.

## Changes

- `tools/lint/copyright_fixer.py`: add `_is_markdown_go_template` and route `.md.gotmpl` files to the HTML-comment header instead of the default Markdown header.
- `k8s/helm/helm-docs-template/nemo-helm-readme.md.gotmpl`: remove the duplicated copyright header block.
- `k8s/helm/README.md`: regenerate via `helm-docs` to pick up the deduplicated header and updated `values.yaml` line references.
- `tests/test_copyright_fixer.py`: update/add coverage for `.md.gotmpl` header selection and style-fix behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Existing tests cover changed behavior — justification: extended `tests/test_copyright_fixer.py` with a case for `.md.gotmpl` header handling.
- [x] Documentation not applicable — justification: `k8s/helm/README.md` is generated output, not authored documentation.

## Verification

Targeted validation:

- `uv run pytest tests/test_copyright_fixer.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Helm chart configuration references to match the current available settings.
  * Simplified NetworkPolicy documentation by linking to the relevant configuration sections.
  * Removed redundant licensing information from the chart README template.

* **Bug Fixes**
  * Corrected the controller probe documentation to identify the liveness probe accurately.

* **Chores**
  * Improved copyright header handling for Markdown-based templates and expanded validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->