### PR TITLE
feat(studio): rename "Use Example" eval mode to "Create experiment" (ASTD-465)

### DIFF
--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -62,7 +62,7 @@ import { useNavigate } from 'react-router';
 import { z } from 'zod';
 
 const EVAL_CONFIG_MODE_ITEMS = [
-  { value: MODE_DEFAULT, children: 'Use Example' },
+  { value: MODE_DEFAULT, children: 'Create experiment' },
   { value: MODE_EXPERIMENT, children: 'Use existing evaluation' },
 ];
 
@@ -84,7 +84,7 @@ const submitEvaluationBaseSchema = z.object({
   judgeModel: z.string(),
   mode: z.enum([MODE_DEFAULT, MODE_EXPERIMENT]),
   exampleKey: z.string(),
-  /** Name of the experiment to create in "Use Example" mode. */
+  /** Name of the experiment to create in "Create experiment" mode. */
   newName: z.string(),
   /** Fileset created alongside it, holding eval-config.json and any data artifacts. */
   filesetName: z.string(),
@@ -200,7 +200,7 @@ const discardSeeded = async (
   );
 };
 
-/** Resolves the persisted yardstick spec for this submission. In "Use Example" mode
+/** Resolves the persisted yardstick spec for this submission. In "Create experiment" mode
  *  it builds the spec from the sample template (fanning the metric onto every task with
  *  the picked judge baked in) and seeds it into a new fileset; in "Use existing evaluation"
  *  mode it reads the saved spec back verbatim (no re-fan, no judge re-pick). */
@@ -472,7 +472,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       const seeded: SeededEntities = isNew ? { filesetName } : {};
 
       try {
-        // "Use Example" creates a fresh ExperimentGroup to hold this run; "Use existing
+        // "Create experiment" creates a fresh ExperimentGroup to hold this run; "Use existing
         // evaluation" reuses the picked evaluation's group(s) and records the lineage.
         let experimentIds: string[];
         let nameStem: string;

--- a/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AGENTS.md
+++ b/web/packages/studio/src/routes/agents/AgentEvaluationsRoute/AGENTS.md
@@ -12,7 +12,7 @@ How Studio runs agent evaluations.
   nemo-evaluator team — it is purpose-built for agent tasks with extensive artifact + trace
   collection. (A legacy row-based `evaluate/jobs` endpoint also exists — see the bottom.)
 - **Sample agents:** `public/sample-agents/<agent>/` is the seed repository (agent config +
-  an `eval-config.json`). Studio reads these for the "use example" flow.
+  an `eval-config.json`). Studio reads these for the "Create experiment" flow.
 - **Metrics:** Studio creates metrics **only** as `InlineMetricPayload` — a built-in metric
   serialized to JSON, reconstructed at runtime. No `CloudPickleMetricPayload` (no Python, no
   pickled code).
@@ -66,7 +66,7 @@ Persisted `eval-config.json` shape (the yardstick):
 }
 ```
 
-**Create ("Use Example"):** Studio reads the example template, **fans the shared `metric` onto
+**Create ("Create experiment" mode):** Studio reads the example template, **fans the shared `metric` onto
 each task** and **injects the chosen judge model** (`buildPersistedSpec`), then writes that
 persisted spec into a new Fileset. The judge is now part of the stored yardstick.
 


### PR DESCRIPTION
<img width="1780" height="1103" alt="Screenshot 2026-08-21 at 12 58 35" src="https://github.com/user-attachments/assets/441cbe7e-09ba-4975-ab49-fbc74f6cf3a8" />

## Summary

The Run Agent Evaluation modal (`SubmitEvaluationModal`) has a segmented-control mode labeled "Use Example" that already runs the full create chain (Experiment → Evaluation → Fileset → Job), just seeded from the sample template. The label described the *input source* rather than *what it does*. This renames the segment to "Create experiment" so it reads as the create action alongside the sibling "Use existing evaluation" mode. Behavior is unchanged.

## Changes

- `SubmitEvaluationModal.tsx`: `EVAL_CONFIG_MODE_ITEMS` `MODE_DEFAULT` label `Use Example` → `Create experiment`. Synced three stale `"Use Example"`-mode references in comments. Internal `MODE_DEFAULT` constant value unchanged.
- `AgentEvaluationsRoute/AGENTS.md`: synced two dev-doc references to the new label.

Deferred to ASTD-442 / ASTD-376 (not in this PR): supplying an agent prompt that triggers a create-experiment skill, and mirroring the CLI "create evaluation" flow.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: label-only rename, no behavioral/contract change; `SubmitEvaluationModal.test.tsx` renders the modal and passes. No test asserts the segment label.
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: only an internal dev `AGENTS.md` reference was synced to the new label; no end-user docs reference this UI string.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui exec vitest run src/components/evaluation/SubmitEvaluationModal.test.tsx` → 1 file, 1 test passed (re-run after rebase onto current `main`).
- `pnpm --filter nemo-studio-ui run check` (full studio suite) → 318 files, 2968 tests passed.
- `uv run pre-commit run --files SubmitEvaluationModal.tsx AGENTS.md` → copyright headers, UI lint-staged, merge-conflict check passed; Python/Helm/OPA/uv-lock hooks skipped (no matching files). Scoped to the changed files rather than `-a`; the change is web-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated evaluation workflow terminology from “Use Example” to “Create experiment” in the interface and related guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->