### PR TITLE
fix(rl): record GRPO's reward and off-policy metrics as time series

### DIFF
--- a/services/rl/src/nmp/rl/app/jobs/compiler.py
+++ b/services/rl/src/nmp/rl/app/jobs/compiler.py
@@ -360,6 +360,7 @@ def _build_grpo_training_step_config(job_spec: RlJobOutput, *, trust_remote_code
             val_at_start=t.val_at_start,
             val_at_end=t.val_at_end,
             keep_top_k=t.keep_top_k,
+            progress_reporting=t.progress_reporting,
         ),
         batch=TrainingStepConfig.BatchConfig(global_batch_size=t.batch_size, micro_batch_size=t.micro_batch_size),
         optimizer=TrainingStepConfig.OptimizerConfig(

--- a/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/dpo_driver.py
+++ b/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/dpo_driver.py
@@ -25,7 +25,10 @@ from nemo_rl.distributed.virtual_cluster import init_ray
 from nemo_rl.utils.config import load_config, parse_hydra_overrides
 from nemo_rl.utils.logger import get_next_experiment_dir
 from nmp.customization_common.service.context import NMPJobContext
-from nmp.rl.tasks.training.backends.nemo_rl.nemo_rl_logger import NemoRLLogger
+from nmp.rl.tasks.training.backends.nemo_rl.nemo_rl_logger import (
+    DPO_DEFAULT_TIME_SERIES_METRICS,
+    NemoRLLogger,
+)
 from nmp.rl.tasks.training.backends.nemo_rl.preference_datasets import register_preference_datasets
 from omegaconf import OmegaConf
 
@@ -124,6 +127,7 @@ def main():
             steps_per_epoch=getattr(config.dpo, "steps_per_epoch", None),
             time_series_metrics=getattr(config.dpo, "progress_time_series_metrics", None),
             min_report_interval_seconds=getattr(config.dpo, "progress_min_report_interval_seconds", None),
+            default_time_series_metrics=DPO_DEFAULT_TIME_SERIES_METRICS,
         )
         # The setup() logger is a composite with a `.loggers` list; guard in case
         # that internal shape changes.

--- a/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/grpo_config.py
+++ b/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/grpo_config.py
@@ -339,6 +339,13 @@ def compile_grpo_config(
         "max_val_samples": val_samples if val_samples else None,
         "val_batch_size": val_samples if val_samples else num_prompts,
         "seed": customizer_config.seed,
+        # These three are the only transforms NeMo-RL applies between the rollout's
+        # reward and the one the loss sees. With all three off, grpo.py's `reward`
+        # metric and the NeMo-Gym aggregator's `total_reward/mean` are the same
+        # number, which is why nemo_rl_logger's GRPO series set keeps only the
+        # former. Exposing any of these as a knob should add `*total_reward/mean`
+        # back alongside it -- that is when raw-verifier and post-transform reward
+        # stop coinciding and two curves start saying different things.
         "use_dynamic_sampling": False,
         "batch_multiplier": 1,
         "reward_shaping": {"enabled": False},

--- a/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/grpo_driver.py
+++ b/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/grpo_driver.py
@@ -19,7 +19,10 @@ from nemo_rl.models.generation import configure_generation_config
 from nemo_rl.utils.config import load_config, parse_hydra_overrides
 from nemo_rl.utils.logger import get_next_experiment_dir
 from nmp.customization_common.service.context import NMPJobContext
-from nmp.rl.tasks.training.backends.nemo_rl.nemo_rl_logger import NemoRLLogger
+from nmp.rl.tasks.training.backends.nemo_rl.nemo_rl_logger import (
+    GRPO_DEFAULT_TIME_SERIES_METRICS,
+    NemoRLLogger,
+)
 from nmp.rl.tasks.training.backends.nemo_rl.sandbox_config import assemble_master_egress_allow
 from omegaconf import OmegaConf
 
@@ -153,6 +156,7 @@ def main() -> None:
             steps_per_epoch=getattr(config.grpo, "steps_per_epoch", None),
             time_series_metrics=getattr(config.grpo, "progress_time_series_metrics", None),
             min_report_interval_seconds=getattr(config.grpo, "progress_min_report_interval_seconds", None),
+            default_time_series_metrics=GRPO_DEFAULT_TIME_SERIES_METRICS,
         )
         if hasattr(logger_inst, "loggers"):
             logger_inst.loggers.append(customizer_logger)

--- a/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/nemo_rl_logger.py
+++ b/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/nemo_rl_logger.py
@@ -35,22 +35,108 @@ _logger = logging.getLogger(__name__)
 # What remains is an adapter: route by prefix, qualify validation metrics by
 # dataloader, derive the epoch, and dedupe the rollout log.
 
-#: Which of NeMo-RL's metrics get a stored series by default: the shared
-#: diagnostic set, plus the quantities a preference-learning run is actually read
-#: on. DPO reports eleven metrics on the train path and nine on validation, and
-#: the ones left out are accounting counters -- ``num_valid_samples``,
-#: ``global_valid_seqs``, ``global_valid_toks`` -- whose current value is all
-#: anyone reads. Twenty series become fourteen.
+#: What a preference-learning run is read on, beyond the shared diagnostics.
+#: Together with :data:`DIAGNOSTIC_TIME_SERIES` these select fourteen of the twenty
+#: metrics DPO reports (eleven on the train path, nine on validation); the six left
+#: out are accounting counters -- ``num_valid_samples``, ``global_valid_seqs``,
+#: ``global_valid_toks`` on both phases -- whose current value is all anyone reads.
 #:
-#: Patterns rather than literal names so each entry covers both phases and the
-#: whole family: ``*_loss`` picks up ``train_sft_loss`` and ``val_preference_loss``
-#: as well as the two plain losses, and picks them up for a second validation
-#: dataloader too, whose names NeMo-RL qualifies with the dataset.
-DEFAULT_TIME_SERIES_METRICS = DIAGNOSTIC_TIME_SERIES + (
+#: Patterns rather than literal names so each entry covers both phases and the whole
+#: family. That is mostly load-bearing over in ``DIAGNOSTIC_TIME_SERIES``, whose
+#: ``*_loss`` picks up ``train_sft_loss`` and ``val_preference_loss`` as well as the
+#: two plain losses -- and picks them up for a second validation dataloader too,
+#: whose names NeMo-RL qualifies with the dataset (``val_heldout_loss``).
+DPO_TIME_SERIES_METRICS = (
     "*_accuracy",
     "*_rewards_chosen_mean",
     "*_rewards_rejected_mean",
 )
+
+#: GRPO's own read-on set. The DPO list is preference-learning shaped -- its one
+#: reward entry, ``*_rewards_chosen_mean``, matches nothing GRPO emits -- so before
+#: this a GRPO run stored four curves out of roughly eighty metrics, and the reward
+#: was not among them. A policy-gradient run is read on reward first and on the
+#: off-policy diagnostics second; those are the two things a stored history answers
+#: and a current value cannot.
+#:
+#: Names carry ``/`` (``advantages/mean``), which ``*`` matches like any other
+#: character, so a family is reachable with one entry.
+#: Left out deliberately, as current values only: the ``/max /min /median /stddev``
+#: siblings of every rollout family, the accounting counters
+#: (``global_valid_toks``, ``num_valid_samples``, ``total_num_tokens``), and the
+#: ratio-clipping bounds, which are read as "where is it now", not as a curve.
+#:
+#: Three more are left out for reasons particular to this service, since each looks
+#: like an obvious inclusion:
+#:
+#: ``train_filtered_reward`` is unreachable, not merely inert. ``grpo.py`` sets
+#: ``metrics["filtered_reward"]`` only under ``use_dynamic_sampling``, which
+#: ``grpo_config.py`` hardcodes to False with no knob on ``GRPOTraining``.
+#:
+#: ``*total_reward/mean`` is the NeMo-Gym aggregator's reward, and on this service
+#: it is the same number as ``train_reward`` -- both are the arithmetic mean of the
+#: same ``full_result["reward"]`` values, because the three transforms that could
+#: separate them (``reward_scaling``, ``reward_shaping``, ``use_dynamic_sampling``)
+#: are all hardcoded off. Its validation half is worse than redundant: ``validate()``
+#: reassigns ``additional_metrics_to_report`` per batch, so ``val_total_reward/mean``
+#: is the *last batch only*, while ``val_accuracy`` below is the whole-pass mean of
+#: the same quantity. If those three transforms are ever exposed, add it back --
+#: that is exactly when raw-verifier and post-transform reward stop coinciding.
+#:
+#: ``*_rewards_chosen_mean``/``_rejected_mean`` are DPO's, and match nothing here.
+GRPO_TIME_SERIES_METRICS = (
+    # Reward: the mean over the step's batch, which is what the loss optimized.
+    "train_reward",
+    # GRPO's validation reward. `validate()` reports no loss at all, so this is the
+    # only curve a validation pass contributes -- and it is the whole-pass mean,
+    # unlike the per-batch rollout metrics beside it. Shares a spelling with DPO's
+    # entry; both lists carry it because both algorithms report one.
+    "*_accuracy",
+    # Off-policy drift. `token_mult_prob_error` is the canonical rollout-vs-training
+    # logprob mismatch signal (the loop plots a sample above 1.05); the KL pair is
+    # how far the policy has walked from the reference.
+    #
+    # `kl_penalty` is a flat zero under the default `ref_policy_kl_penalty=0.0` --
+    # the loss function only computes `kl` when the coefficient is nonzero. Kept
+    # anyway, because the coefficient is a user-facing knob: a run with KL
+    # regularization on wants the curve, and storing zeros for the runs that don't
+    # is cheaper than having no history for the runs that do.
+    "*_token_mult_prob_error",
+    "*_gen_kl_error",
+    "*_kl_penalty",
+    # Advantage centering: should sit near zero, and drift means a broken baseline.
+    "*advantages/mean",
+    # Entropy collapse -- the failure that looks fine on the reward curve right up
+    # until generations degenerate.
+    "*_approx_entropy",
+    # Length and termination behaviour, on both phases. `*_avg_length` is
+    # validation's whole-pass mean; `*gen_tokens_per_sample/mean` is the train
+    # rollout's. Truncation rising is usually why reward stopped moving.
+    "*gen_tokens_per_sample/mean",
+    "*_avg_length",
+    "*_truncation_rate",
+    # Multi-turn agent health for NeMo-Gym rollouts.
+    "*turns_per_sample/mean",
+)
+
+#: What each driver passes as its ``default_time_series_metrics``: the shared
+#: diagnostic set plus its own algorithm's.
+#:
+#: One list per algorithm rather than a union of all of them, because
+#: ``TrainingProgressCallback.close()`` warns about patterns that matched no metric,
+#: and that warning exists to catch a user's typo -- most often an unqualified name
+#: like ``loss``, which selects nothing. A union makes it fire on every healthy run
+#: (a DPO run would name every GRPO pattern and vice versa), and a warning that
+#: always fires cannot distinguish the typo it was built for. The union also made
+#: each algorithm carry the other's payload for nothing.
+#:
+#: Adding an algorithm means adding its tuple and passing it from its driver. There
+#: is deliberately no combined constant to fall back on: a new driver that forgets
+#: gets :data:`DIAGNOSTIC_TIME_SERIES` and loses its own metrics' history, which is
+#: recoverable and visible in the log, rather than silently inheriting two other
+#: algorithms' patterns.
+DPO_DEFAULT_TIME_SERIES_METRICS = DIAGNOSTIC_TIME_SERIES + DPO_TIME_SERIES_METRICS
+GRPO_DEFAULT_TIME_SERIES_METRICS = DIAGNOSTIC_TIME_SERIES + GRPO_TIME_SERIES_METRICS
 
 # NeMo-RL's metric dicts are forwarded whole. There is no allow-list on *reporting*: the
 # callback keeps the finite scalars and drops everything else, so a metric
@@ -105,6 +191,7 @@ class NemoRLLogger(LoggerInterface):
         num_epochs: int | None = None,
         time_series_metrics: Collection[str] | None = None,
         min_report_interval_seconds: float | None = None,
+        default_time_series_metrics: Collection[str] = DIAGNOSTIC_TIME_SERIES,
     ):
         """Initialize the NemoRL logger.
 
@@ -114,11 +201,19 @@ class NemoRLLogger(LoggerInterface):
             max_steps: Total number of training steps (optional, used for progress reporting).
             num_epochs: Total number of epochs (optional, used for progress reporting).
             time_series_metrics: Qualified metric names or glob patterns to
-                record as a series. None takes
-                :data:`DEFAULT_TIME_SERIES_METRICS` -- absent means "the
-                backend's default", not "everything"; ``["*"]`` is how a caller
-                asks for every metric. An empty list means no series at all and
-                is honoured as written.
+                record as a series, from the job config. None takes
+                ``default_time_series_metrics`` -- absent means "the algorithm's
+                default", not "everything"; ``["*"]`` is how a caller asks for
+                every metric. An empty list means no series at all and is
+                honoured as written, which is why the substitution tests
+                ``is None`` rather than truthiness.
+            default_time_series_metrics: What an unstated ``time_series_metrics``
+                falls back to. The driver supplies its algorithm's list
+                (:data:`GRPO_DEFAULT_TIME_SERIES_METRICS`,
+                :data:`DPO_DEFAULT_TIME_SERIES_METRICS`); the default here is the
+                algorithm-agnostic diagnostic set, so a driver that forgets loses
+                its own metrics' history rather than inheriting another
+                algorithm's patterns.
 
         Raises:
             ValueError: If ``steps_per_epoch`` is < 1. It divides in
@@ -136,7 +231,7 @@ class NemoRLLogger(LoggerInterface):
 
         self._callback = TrainingProgressCallback(
             JobsServiceProgressReporter(self._job_ctx),
-            time_series_metrics=(DEFAULT_TIME_SERIES_METRICS if time_series_metrics is None else time_series_metrics),
+            time_series_metrics=(default_time_series_metrics if time_series_metrics is None else time_series_metrics),
             min_report_interval_seconds=(
                 DEFAULT_MIN_REPORT_INTERVAL_SECONDS
                 if min_report_interval_seconds is None
@@ -164,6 +259,7 @@ class NemoRLLogger(LoggerInterface):
         steps_per_epoch: int | None = None,
         time_series_metrics: Collection[str] | None = None,
         min_report_interval_seconds: float | None = None,
+        default_time_series_metrics: Collection[str] = DIAGNOSTIC_TIME_SERIES,
         job_ctx: NMPJobContext | None = None,
     ) -> Self:
         """Build a logger from a NeMo-RL training schedule.
@@ -171,8 +267,11 @@ class NemoRLLogger(LoggerInterface):
         Args:
             steps_per_epoch: Authoritative value when the algorithm config carries
                 one (DPO does); otherwise derived from max_steps and num_epochs.
-            time_series_metrics: Names or patterns from the job config. None
-                takes :data:`DEFAULT_TIME_SERIES_METRICS`.
+            time_series_metrics: Names or patterns from the job config. None takes
+                ``default_time_series_metrics``.
+            default_time_series_metrics: The calling driver's algorithm list --
+                :data:`GRPO_DEFAULT_TIME_SERIES_METRICS` or
+                :data:`DPO_DEFAULT_TIME_SERIES_METRICS`.
             val_period: Accepted and unused. It used to set the validation report
                 cadence, and before that the training one; both now follow from
                 run length in the shared callback. Kept in the signature so the
@@ -186,6 +285,7 @@ class NemoRLLogger(LoggerInterface):
             num_epochs=num_epochs,
             time_series_metrics=time_series_metrics,
             min_report_interval_seconds=min_report_interval_seconds,
+            default_time_series_metrics=default_time_series_metrics,
         )
 
     def log_metrics(

--- a/services/rl/tests/test_compiler.py
+++ b/services/rl/tests/test_compiler.py
@@ -41,6 +41,24 @@ def _make_model_entity(fileset: str | None = "default/base-model") -> ModelEntit
     )
 
 
+@pytest.fixture
+def sandbox_capable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cluster that can run sandboxed Gym, which GRPO compilation requires.
+
+    `_build_grpo_training_step_config` refuses to compile without these, so any
+    test that reaches the GRPO branch for some *other* reason has to set them.
+    Collected here so that setup is stated once. The negative tests override the
+    single value they are about and keep the rest.
+
+    `raising=False` throughout: these are read off the module-level `config`
+    object, which the compiler imports directly, and a test run without the RL
+    service settings loaded may not have every attribute present.
+    """
+    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.sandboxed_gym_default", True, raising=False)
+    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.sandbox_cluster_capable", True, raising=False)
+    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.job_storage_pvc_claim", "nmp-job-storage", raising=False)
+
+
 def _make_job_output(
     training: DPOTraining | GRPOTraining | None = None,
     integrations: IntegrationsSpec | None = None,
@@ -127,6 +145,38 @@ def test_the_reporting_budget_reaches_the_training_step_config() -> None:
     sc = _build_training_step_config(_make_job_output(t), trust_remote_code=False)
 
     assert sc.schedule.progress_reporting.time_series_metrics == ["*_loss", "*_accuracy"]
+
+
+def test_the_reporting_budget_reaches_the_training_step_config_for_grpo(sandbox_capable: None) -> None:
+    """The same chain from GRPOTraining, which is a separate branch of the compiler.
+
+    Written because it was broken: ``_build_grpo_training_step_config`` built its
+    ``ScheduleConfig`` without ``progress_reporting`` while the DPO branch passed it,
+    so the field was accepted and validated on the public spec and then dropped. The
+    only symptom was a GRPO run reporting under the backend defaults no matter what
+    was asked for -- nothing raised, and the two knobs still reached the compiled
+    config because ``ProgressReportingConfig()`` supplies them.
+
+    So this asserts the *value*, not the presence of the key: presence is what
+    test_grpo_config's equivalent checks, and presence is exactly what stayed true
+    while the wiring was gone.
+    """
+    from nmp.customization_common.training.reporting import ProgressReportingConfig
+
+    t = GRPOTraining(
+        type="grpo",
+        progress_reporting=ProgressReportingConfig(
+            time_series_metrics=["train_reward"],
+            min_report_interval_seconds=30.0,
+        ),
+    )
+    # environment is required for GRPO -- validate_for_training rejects None -- so
+    # compiling without it would exercise a spec the service cannot produce, even
+    # though _build_training_step_config is reached directly here and would not care.
+    sc = _build_training_step_config(_make_job_output(t, environment="default/env"), trust_remote_code=False)
+
+    assert sc.schedule.progress_reporting.time_series_metrics == ["train_reward"]
+    assert sc.schedule.progress_reporting.min_report_interval_seconds == 30.0
 
 
 def test_the_reporting_budget_defaults_when_unstated() -> None:
@@ -275,10 +325,7 @@ def test_grpo_download_includes_environment() -> None:
     assert len(cfg.download) == 3
 
 
-def test_grpo_training_step_config_sandboxed(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.sandboxed_gym_default", True, raising=False)
-    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.sandbox_cluster_capable", True, raising=False)
-    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.job_storage_pvc_claim", "nmp-job-storage", raising=False)
+def test_grpo_training_step_config_sandboxed(sandbox_capable: None) -> None:
     sc = _build_training_step_config(
         _make_job_output(GRPOTraining(type="grpo"), environment="default/env"),
         trust_remote_code=False,
@@ -293,10 +340,7 @@ def test_grpo_training_step_config_sandboxed(monkeypatch: pytest.MonkeyPatch) ->
     assert sc.training.lora is None
 
 
-def test_grpo_lora_training_step_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.sandboxed_gym_default", True, raising=False)
-    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.sandbox_cluster_capable", True, raising=False)
-    monkeypatch.setattr("nmp.rl.app.jobs.compiler.config.job_storage_pvc_claim", "nmp-job-storage", raising=False)
+def test_grpo_lora_training_step_config(sandbox_capable: None) -> None:
     from nmp.rl.schemas import LoRAParams
 
     job = RlJobOutput(
@@ -318,7 +362,7 @@ def test_grpo_lora_training_step_config(monkeypatch: pytest.MonkeyPatch) -> None
     assert sc.training.lora.alpha == 64
 
 
-def test_grpo_lora_model_entity_peft(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_grpo_lora_model_entity_peft(sandbox_capable: None) -> None:
     from nmp.rl.app.jobs.compiler import _build_model_entity_config
     from nmp.rl.schemas import LoRAParams
 

--- a/services/rl/tests/test_nemo_rl_logger.py
+++ b/services/rl/tests/test_nemo_rl_logger.py
@@ -24,6 +24,7 @@ import types
 from typing import Any
 
 import pytest
+from nmp.customization_common.training.reporting import DIAGNOSTIC_TIME_SERIES
 
 # NeMo-RL is only installed inside the training image, so the LoggerInterface import
 # at nemo_rl_logger module scope fails in a plain repo checkout. Stub just enough to
@@ -129,6 +130,50 @@ def _driver_steps(max_steps: int) -> range:
     directly would validate against a convention no caller uses.
     """
     return range(1, max_steps + 1)
+
+
+class _RecordingReporter:
+    """A JobsServiceProgressReporter that keeps every report instead of sending it.
+
+    Lets a test drive the real TrainingProgressCallback, so what gets recorded as a
+    series is decided by the production `_records_history`/`_qualify_metric_names`
+    rather than by the test restating the matching rule.
+
+    `fetch_current_metrics` returns `{}` -- nothing stored -- which is the first-run
+    case. Returning None would mean the seed *read failed*, which suppresses the
+    `metrics` payload entirely and would make every assertion here vacuous.
+    """
+
+    def __init__(self) -> None:
+        self.reports: list[dict[str, Any]] = []
+
+    def fetch_current_metrics(self) -> dict[str, list[dict[str, float]]]:
+        return {}
+
+    def configure_progress_tracking(self, max_steps: int, num_epochs: int) -> None:
+        pass
+
+    def report_running(self, phase: str, **details: Any) -> None:
+        self.reports.append(details)
+
+    def close(self) -> None:
+        pass
+
+
+def _recording_callback(time_series_metrics: Any) -> tuple[Any, _RecordingReporter]:
+    """A real TrainingProgressCallback over a _RecordingReporter."""
+    from typing import cast
+
+    from nmp.customization_common.training.callbacks import TrainingProgressCallback
+    from nmp.customization_common.training.progress import JobsServiceProgressReporter
+
+    reporter = _RecordingReporter()
+    callback = TrainingProgressCallback(
+        cast(JobsServiceProgressReporter, reporter),
+        time_series_metrics=time_series_metrics,
+        min_report_interval_seconds=0,
+    )
+    return callback, reporter
 
 
 class _Histogram:
@@ -366,15 +411,33 @@ def test_an_absent_report_interval_takes_the_shared_default(callback: _Recording
     assert callback.min_report_interval_seconds == nemo_rl_logger.DEFAULT_MIN_REPORT_INTERVAL_SECONDS
 
 
-def test_an_absent_list_takes_the_backend_default(callback: _RecordingCallback) -> None:
-    """Absent means NeMo-RL's default set, not everything.
+def test_an_absent_list_takes_the_callers_default(callback: _RecordingCallback) -> None:
+    """Absent means the calling driver's algorithm set, not everything.
 
     A config compiled before this knob existed omits it, and a user who wants
-    every metric asks with ``["*"]`` -- the two are now different requests.
+    every metric asks with ``["*"]`` -- the two are different requests.
+    """
+    NemoRLLogger.for_schedule(
+        max_steps=20_000,
+        num_epochs=1,
+        val_period=100,
+        default_time_series_metrics=nemo_rl_logger.GRPO_DEFAULT_TIME_SERIES_METRICS,
+    )
+
+    assert callback.time_series_metrics == nemo_rl_logger.GRPO_DEFAULT_TIME_SERIES_METRICS
+
+
+def test_a_caller_that_states_no_default_gets_the_diagnostics_only(callback: _RecordingCallback) -> None:
+    """A driver that forgets its algorithm list loses history, not reporting.
+
+    The fallback is deliberately the algorithm-agnostic diagnostic set rather than
+    any one algorithm's: a new driver wired up without a default keeps the loss/lr/
+    grad_norm curves and drops its own metrics' history, which shows up in the log,
+    instead of silently inheriting patterns belonging to a different algorithm.
     """
     NemoRLLogger.for_schedule(max_steps=20_000, num_epochs=1, val_period=100)
 
-    assert callback.time_series_metrics == nemo_rl_logger.DEFAULT_TIME_SERIES_METRICS
+    assert callback.time_series_metrics == DIAGNOSTIC_TIME_SERIES
 
 
 def test_an_empty_list_is_honoured_rather_than_defaulted(callback: _RecordingCallback) -> None:
@@ -392,27 +455,6 @@ def test_the_default_set_covers_dpos_diagnostics_and_drops_its_counters() -> Non
     `fnmatchcase` over the same hardcoded list and asserted against the module
     constant, executing no production code at all.
     """
-    from typing import cast
-
-    from nmp.customization_common.training.callbacks import TrainingProgressCallback
-    from nmp.customization_common.training.progress import JobsServiceProgressReporter
-
-    class _Reporter:
-        def __init__(self) -> None:
-            self.reports: list[dict[str, Any]] = []
-
-        def fetch_current_metrics(self) -> dict[str, list[dict[str, float]]]:
-            return {}
-
-        def configure_progress_tracking(self, max_steps: int, num_epochs: int) -> None:
-            pass
-
-        def report_running(self, phase: str, **details: Any) -> None:
-            self.reports.append(details)
-
-        def close(self) -> None:
-            pass
-
     train = {
         "loss": 0.69,
         "grad_norm": 1.2,
@@ -428,12 +470,7 @@ def test_the_default_set_covers_dpos_diagnostics_and_drops_its_counters() -> Non
     }
     val = {k: v for k, v in train.items() if k not in ("grad_norm", "lr")}
 
-    reporter = _Reporter()
-    callback = TrainingProgressCallback(
-        cast(JobsServiceProgressReporter, reporter),
-        time_series_metrics=nemo_rl_logger.DEFAULT_TIME_SERIES_METRICS,
-        min_report_interval_seconds=0,
-    )
+    callback, reporter = _recording_callback(nemo_rl_logger.DPO_DEFAULT_TIME_SERIES_METRICS)
     callback.report_train_step(step=1, epoch=1, metrics=train)
     callback.report_validation(step=1, epoch=1, metrics=val)
 
@@ -451,6 +488,87 @@ def test_the_default_set_covers_dpos_diagnostics_and_drops_its_counters() -> Non
         "val_num_valid_samples",
     }
     assert reporter.reports[0]["train_global_valid_toks"] == 16384.0, "still a latest value"
+
+
+def test_the_default_set_covers_grpos_reward_and_off_policy_diagnostics() -> None:
+    """Pinned against GRPO's real metric names, the same way as DPO's above.
+
+    Names taken from `grpo.py`'s train dict at the `prefix="train"` log: the loss
+    function's `all_mb_metrics`, the NeMo-Gym rollout aggregate (whose families
+    carry `/mean` and friends), and `validate()`'s `accuracy`/`avg_length`.
+
+    Before the GRPO entries existed this recorded four series out of eighty-odd
+    metrics and none of them was a reward, which is the one curve a policy-gradient
+    run is read on. The `/max /min /median /stddev` siblings staying out is the
+    other half of the intent: a family costs one series, not six.
+    """
+    train = {
+        "loss": -0.041,
+        "grad_norm": 0.87,
+        "lr": 8.4e-07,
+        "reward": 0.617,
+        "kl_penalty": 0.0031,
+        "approx_entropy": 0.49,
+        "token_mult_prob_error": 1.011,
+        "gen_kl_error": 0.0041,
+        "advantages/mean": 0.003,
+        "advantages/max": 2.49,
+        "total_reward/mean": 0.617,
+        "total_reward/stddev": 0.486,
+        "gen_tokens_per_sample/mean": 689.3,
+        "gen_tokens_per_sample/max": 2048.0,
+        "turns_per_sample/mean": 3.41,
+        "turns_per_sample/p95": 7.0,
+        "truncation_rate": 0.039,
+        "natural_termination_rate": 0.961,
+        "mean_prompt_length": 753.8,
+        "global_valid_toks": 176432.0,
+    }
+    val = {
+        "accuracy": 0.703,
+        "avg_length": 604.2,
+        "total_reward/mean": 0.703,
+        "truncation_rate": 0.023,
+    }
+
+    callback, reporter = _recording_callback(nemo_rl_logger.GRPO_DEFAULT_TIME_SERIES_METRICS)
+    callback.report_train_step(step=1, epoch=1, metrics=train)
+    callback.report_validation(step=1, epoch=1, metrics=val)
+
+    recorded = {name for name, points in reporter.reports[-1]["metrics"].items() if points}
+
+    assert recorded == {
+        # Shared diagnostics.
+        "train_loss",
+        "train_grad_norm",
+        "train_lr",
+        # Reward, on both phases -- the point of the change. `*total_reward/mean`
+        # is deliberately not here: on this service it is the same number as
+        # `train_reward`, and `val_total_reward/mean` is the last-batch-only
+        # version of `val_accuracy`. Both arrive in the dicts above and are
+        # reported as current values; neither keeps a history.
+        "train_reward",
+        "val_accuracy",
+        # Off-policy drift and advantage centering.
+        "train_kl_penalty",
+        "train_gen_kl_error",
+        "train_token_mult_prob_error",
+        "train_advantages/mean",
+        "train_approx_entropy",
+        # Length and termination behaviour.
+        "train_gen_tokens_per_sample/mean",
+        "train_truncation_rate",
+        "train_turns_per_sample/mean",
+        "val_avg_length",
+        "val_truncation_rate",
+    }
+    # Excluded from the series, still reported as a current value -- dropping a
+    # metric's history never drops the metric.
+    assert reporter.reports[-1]["train_total_reward/mean"] == 0.617
+    assert reporter.reports[-1]["train_total_reward/stddev"] == 0.486
+    assert reporter.reports[-1]["train_global_valid_toks"] == 176432.0
+    # The redundancy the exclusion rests on: same number, two names.
+    assert reporter.reports[-1]["train_total_reward/mean"] == reporter.reports[-1]["train_reward"]
 
 
 def test_the_run_length_reaches_the_callback_that_gates_on_it(callback: _RecordingCallback) -> None:


### PR DESCRIPTION
## Summary

The GRPO branch of the job compiler built its `ScheduleConfig` without `progress_reporting`, so the field was accepted and validated on the public `GRPOTraining` spec and then dropped -- a GRPO job could not set `time_series_metrics` or `min_report_interval_seconds` at all. Separately, the default time-series set was DPO shaped, so a GRPO run stored a handful of curves out of roughly eighty metrics (the loss family, `lr`, `grad_norm`, `val_accuracy`), but the reward -- the curve a policy-gradient run is actually read on -- was not among them. After this change a GRPO job's reporting config is honoured and the default set stores ~15 curves covering reward, off-policy drift, and generation-length behaviour.

<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GRPO reinforcement-learning support alongside DPO, including LoRA training and configurable rollout, validation, and backend settings.
  * Added environment filesets with metadata, validation, and CLI support.
  * Added environment conversion and packaging workflows for NeMo Gym datasets.
  * Added sandboxed Gym execution with shared storage and runtime configuration.
  * Added OpenSandbox deployment profiles, installation, and verification tooling.
* **Documentation**
  * Expanded RL, environment, sandbox, and customization documentation.
* **Bug Fixes**
  * Improved checkpoint publishing for LoRA adapters and tokenizer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->