### PR TITLE
fix(studio): center row checkbox in pinned data cells (ASTD-470)

### DIFF
--- a/web/packages/common/src/components/DataView/StudioDataView.css
+++ b/web/packages/common/src/components/DataView/StudioDataView.css
@@ -69,15 +69,28 @@
       align-items: center;
     }
 
-    /* Pinned cells hold a single control (select checkbox, row-actions menu).
-       Both th and td need flex centering: `justify-items`/`text-align` below
-       are inert on a block-level td, which left-aligns the row checkbox while
-       the flex header centers the select-all checkbox. */
+    /* Pinned cells switch to flex layout, so `justify-items`/`text-align` below
+       are inert on them (those work on block-level boxes, not flex items).
+       Derive justify-content from the cell's configured alignment
+       (columnDef.meta.alignment, surfaced by KUI as nv-table--align-*) so a
+       custom pinned column keeps its own alignment instead of always
+       centering. Prebuilt controls (select checkbox, row-actions menu) set
+       alignment: 'center', so they fall through to the default below. */
     & th[data-pinned],
     & td[data-pinned] {
       display: flex;
       align-items: center;
       justify-content: center;
+    }
+
+    & th[data-pinned].nv-table--align-left,
+    & td[data-pinned].nv-table--align-left {
+      justify-content: flex-start;
+    }
+
+    & th[data-pinned].nv-table--align-right,
+    & td[data-pinned].nv-table--align-right {
+      justify-content: flex-end;
     }
 
     /* Pinned columns: stay at configured size, don't grow */

--- a/web/packages/common/src/components/DataView/StudioDataView.css
+++ b/web/packages/common/src/components/DataView/StudioDataView.css
@@ -67,9 +67,17 @@
     & th {
       display: flex;
       align-items: center;
-      &[data-pinned] {
-        justify-content: center;
-      }
+    }
+
+    /* Pinned cells hold a single control (select checkbox, row-actions menu).
+       Both th and td need flex centering: `justify-items`/`text-align` below
+       are inert on a block-level td, which left-aligns the row checkbox while
+       the flex header centers the select-all checkbox. */
+    & th[data-pinned],
+    & td[data-pinned] {
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     /* Pinned columns: stay at configured size, don't grow */


### PR DESCRIPTION
## Summary

In a table with pinned columns, the row-selection checkbox was left-aligned in its cell while the select-all checkbox in the header was centered, leaving the column visibly ragged. Pinned cells are stripped to `padding: 0` and the header cell is flex-centered, but the data cell stayed block-level — so `justify-items` and `text-align: center` were inert on it. This gives `td[data-pinned]` the same flex centering as `th[data-pinned]`, so header and row checkboxes line up.

| Before | After |
| --- | --- |
| <img width="1288" height="301" alt="image" src="https://github.com/user-attachments/assets/9adee34b-a022-4475-a592-0839e8a2c055" /> | <img width="1292" height="302" alt="image" src="https://github.com/user-attachments/assets/3e3f96a8-8551-4197-ba95-7f7902071c18" /> |

## Changes

- `StudioDataView.css`: split the pinned-cell centering into a rule that covers both `th[data-pinned]` and `td[data-pinned]` (`display: flex; align-items: center; justify-content: center`), instead of centering only the header cell.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: CSS-only layout change. The repo's jsdom-based unit tests do not evaluate stylesheets, so no unit test can observe this. Verified instead by measuring computed geometry in a real browser (below), with the existing DataView suite run as a regression check.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no documented behavior changes; this corrects cell alignment only.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run -a` — all hooks pass except two that are blocked by the local environment and do not inspect CSS:
  - `Helm Docs` — fails because `helm-docs` is not installed on this machine.
  - `Run uv lock with platform uv` — fails because it requires uv 0.9.14 and this machine has uv 0.9.28. The related `Check for uv.lock drift` hook **passed**, so the lockfile itself is in sync.
- `pnpm --filter @nemo/common test src/components/DataView` — 8 files, 74 tests passed.
- `npx prettier --check packages/common/src/components/DataView/StudioDataView.css` — passes.
- Browser measurement on the Agents table (checkbox `x` in px):

  | | header checkbox | row checkbox |
  |---|---|---|
  | before | 277 | 265 |
  | after | 277 | 277 |

  The 12px gap is exactly `(40 − 16) / 2` — the centering offset the header had and the row cells did not. The right-pinned row-actions button was measured before and after and is unchanged at `x=1500`, so that column does not regress.

Notes for reviewers:

- The defect predates the symptom. It became visible only once #1373 removed the Agents table's `columnPinning` override, letting `row-selection` fall back to `DEFAULT_COLUMN_PINNING` in `useStudioDataViewState` and become pinned-left for the first time. #1373 is not at fault — it removed an accidental shield.
- This rule is shared, so the fix also covers tables that already pinned their selection column explicitly, such as `ExperimentDataView` (`left: ['pin', 'row-selection']`), which had the same misalignment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved alignment for pinned table headers and data cells.
- Pinned cells now center consistently while preserving configured left- or right-alignment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->