### PR TITLE
fix(studio): rename "Guarded" verdict label to "Blocked" (ASTD-469)

### DIFF
--- a/web/packages/studio/src/api/guardrail-checks/types.ts
+++ b/web/packages/studio/src/api/guardrail-checks/types.ts
@@ -12,7 +12,7 @@ import type {
 /** Entity type discriminator used in the entity-store for guardrail checks. */
 export const GUARDRAIL_CHECKS_ENTITY_TYPE = 'guardrail_checks';
 
-/** Verdict of a check or an individual rail. UI: success -> "Allowed", blocked -> "Guarded". */
+/** Verdict of a check or an individual rail. UI: success -> "Allowed", blocked -> "Blocked". */
 export type Verdict = StatusEnum;
 
 /** A single message in a check's conversation (user input, optional assistant output, etc.). */

--- a/web/packages/studio/src/components/dataViews/GuardrailChecksDataView/ResultIndicator.tsx
+++ b/web/packages/studio/src/components/dataViews/GuardrailChecksDataView/ResultIndicator.tsx
@@ -6,13 +6,13 @@ import type { Verdict } from '@studio/api/guardrail-checks/types';
 import { ArrowRight, Clock, ShieldCheck } from 'lucide-react';
 import type { FC } from 'react';
 
-/** Solid status badge for a check's latest-run verdict (yellow guarded / green allowed). */
+/** Solid status badge for a check's latest-run verdict (yellow blocked / green allowed). */
 export const ResultIndicator: FC<{ status: Verdict | undefined }> = ({ status }) => {
   if (status === 'blocked') {
     return (
       <Badge color="yellow" kind="solid">
         <ShieldCheck size={14} />
-        Guarded
+        Blocked
       </Badge>
     );
   }

--- a/web/packages/studio/src/components/dataViews/GuardrailChecksDataView/ResultSummary.tsx
+++ b/web/packages/studio/src/components/dataViews/GuardrailChecksDataView/ResultSummary.tsx
@@ -10,14 +10,14 @@ interface ResultSummaryProps {
   checks: GuardrailCheckEntity[];
 }
 
-const GUARDED_BG = 'bg-[var(--text-color-feedback-warning)]';
+const BLOCKED_BG = 'bg-[var(--text-color-feedback-warning)]';
 const ALLOWED_BG = 'bg-[var(--text-color-brand)]';
 const NOTRUN_BG = 'bg-[var(--color-gray-200)]';
 
-/** Count of checks by their latest-run verdict: allowed, guarded, or never run. */
+/** Count of checks by their latest-run verdict: allowed, blocked, or never run. */
 const summarizeResults = (checks: GuardrailCheckEntity[]) => {
   let allowed = 0;
-  let guarded = 0;
+  let blocked = 0;
   let notRun = 0;
 
   for (const check of checks) {
@@ -25,13 +25,13 @@ const summarizeResults = (checks: GuardrailCheckEntity[]) => {
     if (status === 'success') {
       allowed += 1;
     } else if (status === 'blocked') {
-      guarded += 1;
+      blocked += 1;
     } else {
       notRun += 1;
     }
   }
 
-  return { allowed, guarded, notRun };
+  return { allowed, blocked, notRun };
 };
 
 /** One proportional segment of the summary bar; renders nothing when its share is zero. */
@@ -61,10 +61,10 @@ const LegendRow: FC<{ dotClassName: string; label: string; value: number }> = ({
 
 /** Proportional bar + legend breaking down a set of checks by their latest-run verdict. */
 export const ResultSummary: FC<ResultSummaryProps> = ({ checks }) => {
-  const { allowed, guarded, notRun } = summarizeResults(checks);
+  const { allowed, blocked, notRun } = summarizeResults(checks);
 
-  // Bar proportions span every check: guarded, then allowed, then not-run at the end.
-  const total = guarded + allowed + notRun;
+  // Bar proportions span every check: blocked, then allowed, then not-run at the end.
+  const total = blocked + allowed + notRun;
   const pct = (n: number) => (total > 0 ? (n / total) * 100 : 0);
 
   return (
@@ -74,14 +74,14 @@ export const ResultSummary: FC<ResultSummaryProps> = ({ checks }) => {
           className=" h-3 overflow-hidden rounded-full bg-surface-sunken"
           role="img"
           gap="0.5"
-          aria-label={`${guarded} guarded, ${allowed} allowed, ${notRun} not run`}
+          aria-label={`${blocked} blocked, ${allowed} allowed, ${notRun} not run`}
         >
-          <BarSegment colorClassName={GUARDED_BG} pct={pct(guarded)} />
+          <BarSegment colorClassName={BLOCKED_BG} pct={pct(blocked)} />
           <BarSegment colorClassName={ALLOWED_BG} pct={pct(allowed)} />
           <BarSegment colorClassName={NOTRUN_BG} pct={pct(notRun)} />
         </Flex>
         <Stack gap="density-sm">
-          <LegendRow dotClassName={GUARDED_BG} label="Guarded" value={guarded} />
+          <LegendRow dotClassName={BLOCKED_BG} label="Blocked" value={blocked} />
           <LegendRow dotClassName={ALLOWED_BG} label="Allowed" value={allowed} />
           <LegendRow dotClassName={NOTRUN_BG} label="Not run" value={notRun} />
         </Stack>

--- a/web/packages/studio/src/components/dataViews/GuardrailChecksDataView/checkStatus.ts
+++ b/web/packages/studio/src/components/dataViews/GuardrailChecksDataView/checkStatus.ts
@@ -15,14 +15,14 @@ export const getLatestRunStatus = (check: GuardrailCheckEntity): Verdict | undef
 
 /** The three result buckets the UI presents, keyed by their filter value. */
 const RESULT_FILTER_VALUES = {
-  guarded: 'blocked',
+  blocked: 'blocked',
   allowed: 'success',
   notRun: 'not-run',
 } as const;
 
 /** Options for the "Result" single-select column filter. */
 export const RESULT_FILTER_OPTIONS: FilterItem[] = [
-  { value: RESULT_FILTER_VALUES.guarded, label: 'Guarded' },
+  { value: RESULT_FILTER_VALUES.blocked, label: 'Blocked' },
   { value: RESULT_FILTER_VALUES.allowed, label: 'Allowed' },
   { value: RESULT_FILTER_VALUES.notRun, label: 'Not run' },
 ];
@@ -32,8 +32,8 @@ export const RESULT_FILTER_OPTIONS: FilterItem[] = [
  * that has never run — is presented as "Not run" rather than as its own result.
  */
 export const getResultFilterValue = (status: Verdict | undefined): string => {
-  if (status === RESULT_FILTER_VALUES.guarded) {
-    return RESULT_FILTER_VALUES.guarded;
+  if (status === RESULT_FILTER_VALUES.blocked) {
+    return RESULT_FILTER_VALUES.blocked;
   }
   if (status === RESULT_FILTER_VALUES.allowed) {
     return RESULT_FILTER_VALUES.allowed;
@@ -41,9 +41,9 @@ export const getResultFilterValue = (status: Verdict | undefined): string => {
   return RESULT_FILTER_VALUES.notRun;
 };
 
-/** Ascending sort order for the Result column: guarded first, never-run last. */
+/** Ascending sort order for the Result column: blocked first, never-run last. */
 const RESULT_SORT_RANK: Record<string, number> = {
-  [RESULT_FILTER_VALUES.guarded]: 0,
+  [RESULT_FILTER_VALUES.blocked]: 0,
   [RESULT_FILTER_VALUES.allowed]: 1,
   [RESULT_FILTER_VALUES.notRun]: 2,
 };

--- a/web/packages/studio/src/components/dataViews/GuardrailChecksDataView/index.test.tsx
+++ b/web/packages/studio/src/components/dataViews/GuardrailChecksDataView/index.test.tsx
@@ -52,8 +52,8 @@ const makeCheck = ({
   },
 });
 
-const GUARDED = makeCheck({
-  id: 'chk-guarded',
+const BLOCKED = makeCheck({
+  id: 'chk-blocked',
   input: 'My SSN is 123-45-6789',
   output: 'I cannot help with that',
   status: 'blocked',
@@ -66,16 +66,16 @@ const ALLOWED = makeCheck({
 });
 const NOT_RUN = makeCheck({ id: 'chk-not-run', input: 'Hello there' });
 
-const CHECKS = [GUARDED, ALLOWED, NOT_RUN];
+const CHECKS = [BLOCKED, ALLOWED, NOT_RUN];
 
-/** Straddles ALLOWED, so filtering to Guarded leaves a gap in the underlying array. */
-const SECOND_GUARDED = makeCheck({
-  id: 'chk-guarded-2',
+/** Straddles ALLOWED, so filtering to Blocked leaves a gap in the underlying array. */
+const SECOND_BLOCKED = makeCheck({
+  id: 'chk-blocked-2',
   input: 'My card number is 4111 1111 1111 1111',
   output: 'I cannot help with that either',
   status: 'blocked',
 });
-const CHECKS_WITH_GAP = [GUARDED, ALLOWED, SECOND_GUARDED];
+const CHECKS_WITH_GAP = [BLOCKED, ALLOWED, SECOND_BLOCKED];
 
 /** Renders the detail context as text, so assertions can read it off the DOM. */
 const DetailProbe: FC<GuardrailCheckDetail> = ({
@@ -118,10 +118,10 @@ const renderComponent = (
 const renderWithDetail = (checks: GuardrailCheckEntity[] = CHECKS) =>
   renderComponent(checks, (detail) => <DetailProbe {...detail} />);
 
-const filterToGuarded = async () => {
+const filterToBlocked = async () => {
   fireEvent.click(screen.getByTestId('open-filters-button'));
   fireEvent.click(await screen.findByTestId('column-filter-status'));
-  fireEvent.click(await screen.findByRole('option', { name: 'Guarded' }));
+  fireEvent.click(await screen.findByRole('option', { name: 'Blocked' }));
 };
 
 describe('GuardrailChecksDataView', () => {
@@ -153,7 +153,7 @@ describe('GuardrailChecksDataView', () => {
 
     const rowFor = (input: string) => screen.getByRole('row', { name: new RegExp(input) });
 
-    expect(rowFor('My SSN is 123-45-6789')).toHaveTextContent('Guarded');
+    expect(rowFor('My SSN is 123-45-6789')).toHaveTextContent('Blocked');
     expect(rowFor('What is the weather today')).toHaveTextContent('Allowed');
     // A check with no runs has never been evaluated — it must not read as a passing test.
     expect(rowFor('Hello there')).toHaveTextContent('Not run');
@@ -201,7 +201,7 @@ describe('GuardrailChecksDataView', () => {
 
     fireEvent.click(screen.getByTestId('open-filters-button'));
     fireEvent.click(await screen.findByTestId('column-filter-status'));
-    fireEvent.click(await screen.findByRole('option', { name: 'Guarded' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'Blocked' }));
 
     await waitFor(() => expect(screen.queryByText('Hello there')).not.toBeInTheDocument(), {
       timeout: XL_SELECTOR_TIMEOUT,
@@ -255,7 +255,7 @@ describe('GuardrailChecksDataView', () => {
       await screen.findByText('What is the weather today', undefined, {
         timeout: XL_SELECTOR_TIMEOUT,
       });
-      await filterToGuarded();
+      await filterToBlocked();
       await waitFor(
         () => expect(screen.queryByText('What is the weather today')).not.toBeInTheDocument(),
         { timeout: XL_SELECTOR_TIMEOUT }
@@ -274,20 +274,20 @@ describe('GuardrailChecksDataView', () => {
       await screen.findByText('What is the weather today', undefined, {
         timeout: XL_SELECTOR_TIMEOUT,
       });
-      await filterToGuarded();
+      await filterToBlocked();
       await waitFor(
         () => expect(screen.queryByText('What is the weather today')).not.toBeInTheDocument(),
         { timeout: XL_SELECTOR_TIMEOUT }
       );
 
       fireEvent.click(screen.getByText('My SSN is 123-45-6789'));
-      expect(screen.getByTestId('detail-id')).toHaveTextContent('chk-guarded');
+      expect(screen.getByTestId('detail-id')).toHaveTextContent('chk-blocked');
       expect(screen.getByTestId('detail-position')).toHaveTextContent('1 of 2');
 
       fireEvent.click(screen.getByRole('button', { name: 'next' }));
 
       // The next *visible* row, not checks[1] (chk-allowed) — which the filter hid.
-      expect(screen.getByTestId('detail-id')).toHaveTextContent('chk-guarded-2');
+      expect(screen.getByTestId('detail-id')).toHaveTextContent('chk-blocked-2');
       expect(screen.getByTestId('detail-position')).toHaveTextContent('2 of 2');
     });
 
@@ -300,7 +300,7 @@ describe('GuardrailChecksDataView', () => {
       fireEvent.click(screen.getByText('What is the weather today'));
       expect(screen.getByTestId('detail-position')).toHaveTextContent('2 of 3');
 
-      await filterToGuarded();
+      await filterToBlocked();
 
       // The check leaves the table but stays on screen; only its position is gone.
       await waitFor(
@@ -338,7 +338,7 @@ describe('GuardrailChecksDataView', () => {
         const [checks, setChecks] = useState(CHECKS);
         return (
           <>
-            <button type="button" onClick={() => setChecks([NOT_RUN, GUARDED, ALLOWED])}>
+            <button type="button" onClick={() => setChecks([NOT_RUN, BLOCKED, ALLOWED])}>
               refetch
             </button>
             <GuardrailChecksDataView
@@ -358,13 +358,13 @@ describe('GuardrailChecksDataView', () => {
 
       await screen.findByText('Hello there', undefined, { timeout: XL_SELECTOR_TIMEOUT });
       fireEvent.click(screen.getByText('My SSN is 123-45-6789'));
-      expect(screen.getByTestId('detail-id')).toHaveTextContent('chk-guarded');
+      expect(screen.getByTestId('detail-id')).toHaveTextContent('chk-blocked');
       expect(screen.getByTestId('detail-number')).toHaveTextContent('Test 1');
 
       fireEvent.click(screen.getByRole('button', { name: 'refetch' }));
 
       // Same check, renumbered — not whatever slid into the position it held.
-      expect(screen.getByTestId('detail-id')).toHaveTextContent('chk-guarded');
+      expect(screen.getByTestId('detail-id')).toHaveTextContent('chk-blocked');
       expect(screen.getByTestId('detail-number')).toHaveTextContent('Test 2');
     });
   });

--- a/web/packages/studio/src/components/sidePanels/GuardrailCheckDetailSidePanel/GuardrailCheckDetailSidePanel.stories.tsx
+++ b/web/packages/studio/src/components/sidePanels/GuardrailCheckDetailSidePanel/GuardrailCheckDetailSidePanel.stories.tsx
@@ -48,7 +48,7 @@ const CONFIG: RailsConfig = {
   },
 } as RailsConfig;
 
-const GUARDED_CHECK = makeCheck('leaks-ssn', {
+const BLOCKED_CHECK = makeCheck('leaks-ssn', {
   messages: [{ role: 'user', content: 'My SSN is 123-45-6789, can you store it for me?' }],
   runs: [
     {
@@ -137,8 +137,8 @@ type Story = StoryObj<typeof meta>;
  * twice — distinguished as "(input)" and "(output)" — while Activated Guardrails
  * counts it once and dims the Jailbreak Detection that never ran.
  */
-export const Guarded: Story = {
-  args: { check: GUARDED_CHECK },
+export const Blocked: Story = {
+  args: { check: BLOCKED_CHECK },
 };
 
 /**
@@ -156,7 +156,7 @@ export const WithSystemPrompt: Story = {
 
 /** Last of the visible rows, so Next is disabled and Previous is not. */
 export const LastCheck: Story = {
-  args: { check: GUARDED_CHECK, checkIndex: 2, visibleIndex: 2 },
+  args: { check: BLOCKED_CHECK, checkIndex: 2, visibleIndex: 2 },
 };
 
 /**
@@ -164,10 +164,10 @@ export const LastCheck: Story = {
  * with no visible sequence to step through, so the controls are gone.
  */
 export const NotInVisibleRows: Story = {
-  args: { check: GUARDED_CHECK, checkIndex: 2, visibleIndex: null, visibleCount: 0 },
+  args: { check: BLOCKED_CHECK, checkIndex: 2, visibleIndex: null, visibleCount: 0 },
 };
 
 /** No config loaded: the rail table still renders, Activated Guardrails is omitted. */
 export const WithoutConfigCoverage: Story = {
-  args: { check: GUARDED_CHECK, configData: undefined },
+  args: { check: BLOCKED_CHECK, configData: undefined },
 };

--- a/web/packages/studio/src/components/sidePanels/GuardrailCheckDetailSidePanel/RailStatusBadge.tsx
+++ b/web/packages/studio/src/components/sidePanels/GuardrailCheckDetailSidePanel/RailStatusBadge.tsx
@@ -23,7 +23,7 @@ export const RailStatusBadge: FC<RailStatusBadgeProps> = ({ status }) => {
     return (
       <Badge color="yellow" kind="solid">
         <ShieldCheck size={10} />
-        Guarded
+        Blocked
       </Badge>
     );
   }

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.test.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.test.tsx
@@ -114,7 +114,7 @@ describe('GuardrailChecksTab', () => {
     expect(
       await screen.findByText('Result Summary', undefined, { timeout: XL_SELECTOR_TIMEOUT })
     ).toBeInTheDocument();
-    expect(screen.getByRole('row', { name: /My SSN is 123-45-6789/ })).toHaveTextContent('Guarded');
+    expect(screen.getByRole('row', { name: /My SSN is 123-45-6789/ })).toHaveTextContent('Blocked');
     expect(screen.getByRole('row', { name: /Hello there/ })).toHaveTextContent('Not run');
     expect(screen.getByTestId('checks-location')).toHaveTextContent(
       getGuardrailChecksSubTabRoute(WORKSPACE, 'pii-filter', GuardrailChecksSubTab.Results)


### PR DESCRIPTION
## Summary

A guardrail check whose verdict is `blocked` was shown to users as "Guarded" — in the result badge, the rail status badge, the Result column filter, and the summary bar legend. That wording did not match the API value it represents. This renames the user-facing label to "Blocked" and renames the local identifiers that mirrored the old wording. It is a presentation-layer rename: the wire value is unchanged.

<img width="1260" height="661" alt="image" src="https://github.com/user-attachments/assets/b1dc860b-47eb-4047-bc8a-b393c0144f76" />

## Changes

- `ResultIndicator.tsx`, `RailStatusBadge.tsx`: badge text `Guarded` → `Blocked`.
- `checkStatus.ts`: `RESULT_FILTER_VALUES.guarded` → `.blocked` and the Result filter option label → `Blocked`. The mapped value is still `'blocked'`, so filter values and sort ranking are byte-for-byte unchanged.
- `ResultSummary.tsx`: `GUARDED_BG` → `BLOCKED_BG`, the `guarded` counter → `blocked`, the legend row label, and the bar's `aria-label` (`"N blocked, N allowed, N not run"`).
- `types.ts`: corrected the `Verdict` doc comment.
- `GuardrailCheckDetailSidePanel.stories.tsx`: `GUARDED_CHECK` → `BLOCKED_CHECK` and the `Guarded` story → `Blocked`.
- `GuardrailChecksDataView/index.test.tsx`, `GuardrailChecksTab/index.test.tsx`: updated assertions to the new label.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no docs reference this label. `docs/agents/security.mdx` does use the word "Guarded", but for a *guarded VirtualModel* — a different concept that is intentionally left alone.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm --filter nemo-studio-ui typecheck` — passes, which is the check that matters most for an identifier rename.
- `pnpm --filter nemo-studio-ui test src/components/dataViews/GuardrailChecksDataView` — 1 file, 15 tests passed.
- `uv run pre-commit run -a` — all hooks pass except two blocked by the local environment, neither of which inspects these files:
  - `Helm Docs` — `helm-docs` is not installed on this machine.
  - `Run uv lock with platform uv` — requires uv 0.9.14; this machine has uv 0.9.28. The related `Check for uv.lock drift` hook **passed**.
- `grep -rni guarded web/packages/studio/src web/packages/common/src` — no remaining occurrences of the old label; the only hits are ordinary English in unrelated files ("unguarded by the archbishop" in SQuAD fixture data, "guarded by `expected_db_version`" in a mock comment).

Pre-existing test failures, disclosed rather than claimed as passing:

- `pnpm --filter nemo-studio-ui test src/routes/guardrails` — 4 files failed, 5 passed (34 tests passed, 28 skipped, **0 test failures**).
- `pnpm --filter nemo-studio-ui test src/components/sidePanels/GuardrailCheckDetailSidePanel` — 1 file failed, 2 passed (7 passed, 17 skipped, **0 test failures**).

  Both fail in a `beforeAll` MSW setup hook in `vitest.setup.tsx:76` that times out, not on any assertion. I re-ran both suites with this branch stashed, on a clean `origin/main` tree, and got byte-identical failure counts — so these are pre-existing and unrelated to this change. I have not attempted a fix here to keep the rename self-contained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated guardrail result terminology from “Guarded” to “Blocked” across summaries, filters, badges, details, and test result displays.
  * Blocked results now use consistent labels, accessibility text, sorting, and visual indicators throughout the Studio.
* **Tests**
  * Updated coverage and examples to reflect the new “Blocked” terminology and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->