### PR TITLE
fix(agents): reject a contract version no package index can serve

### DIFF
--- a/plugins/nemo-agents/README.md
+++ b/plugins/nemo-agents/README.md
@@ -173,19 +173,21 @@ The packaging command runs locally; Platform services are not required.
 
 `nemo agents package` renders `uv pip install "nemo-platform[nemo-agents-plugin]==<version>"`
 into the Fabric image, where `<version>` is whatever is installed on the build
-host. Working from a checkout, that version carries a local build identifier,
-which PEP 440 keeps off public indexes, so the command fails immediately:
+host. A checkout reports something like `0.3.0.post402.dev0+062f0ac6e8`, which is
+both a developmental release and a local build identifier — neither of which a
+public index serves — so the command fails immediately:
 
 ```text
-Error: The installed nemo-platform version '0.3.0.post402.dev0+062f0ac6e8' is a
-local build identifier, which package indexes do not serve.
+Error: The installed nemo-platform version '0.3.0.post402.dev0+062f0ac6e8' carries
+a local build identifier and is a developmental release, so no package index serves
+it. Fabric packaging pins this exact version inside the image, so the build would
+fail while resolving it. Install a released nemo-platform to package an agent, or
+set NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1 if your index serves this
+version.
 ```
 
-Install a released `nemo-platform` to package a Fabric agent. If you build
-against an index that does serve the version, set
-`NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1` to proceed anyway. Supplying
-your own `--template` also skips the check, since a custom template need not
-pin the contract version at all.
+Supplying your own `--template` also skips the check, since a custom template
+need not pin the contract version at all.
 
 NAT packaging is unaffected — it installs the packaged project plus a published
 `nvidia-nat` release.

--- a/plugins/nemo-agents/README.md
+++ b/plugins/nemo-agents/README.md
@@ -167,6 +167,28 @@ The packaging command runs locally; Platform services are not required.
 |---|---|
 | Docker | A running Docker-compatible daemon |
 | Container dependencies | Install with `uv sync --package nemo-agents-plugin --extra container` from the repository root |
+| A released `nemo-platform` (Fabric only) | Fabric images pin the installed `nemo-platform` version and resolve it from an index. A source checkout reports a setuptools-scm version such as `0.3.0.post402.dev0+062f0ac6e8`, which no index serves, so packaging stops before building. See below. |
+
+##### Packaging a Fabric agent from a source checkout
+
+`nemo agents package` renders `uv pip install "nemo-platform[nemo-agents-plugin]==<version>"`
+into the Fabric image, where `<version>` is whatever is installed on the build
+host. Working from a checkout, that version carries a local build identifier,
+which PEP 440 keeps off public indexes, so the command fails immediately:
+
+```text
+Error: The installed nemo-platform version '0.3.0.post402.dev0+062f0ac6e8' is a
+local build identifier, which package indexes do not serve.
+```
+
+Install a released `nemo-platform` to package a Fabric agent. If you build
+against an index that does serve the version, set
+`NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1` to proceed anyway. Supplying
+your own `--template` also skips the check, since a custom template need not
+pin the contract version at all.
+
+NAT packaging is unaffected — it installs the packaged project plus a published
+`nvidia-nat` release.
 
 #### Progressive pipeline
 
@@ -366,6 +388,12 @@ The old shared environment variables have been replaced:
 | `NAT_BASE_IMAGE_URL` | `NEMO_AGENTS_BASE_IMAGE_URL` |
 | `NAT_BASE_IMAGE_TAG` | `NEMO_AGENTS_BASE_IMAGE_TAG` |
 | `NAT_PYTHON_VERSION` | `NEMO_AGENTS_PYTHON_VERSION` |
+
+Additional environment variables:
+
+| Variable | Effect |
+|---|---|
+| `NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION` | Set to `1` to let Fabric packaging pin an unpublished `nemo-platform` version (a local build identifier or a `.dev` release). Use only when the build's index serves that version. Does not apply when `nemo-platform` is not installed at all. |
 
 There are no compatibility aliases. `NAT_VERSION` remains available only for
 NAT workflow packaging.

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field, fields
 from pathlib import Path
+from typing import Any
 
 import jinja2
 
@@ -39,6 +40,10 @@ import jinja2
 # the next ``nemo agents package`` invocation.
 DOCKERIGNORE_SENTINEL = "# Managed by `nemo agents package` — safe to delete if you take ownership."
 DOCKERFILE_SENTINEL = "# Managed by `nemo agents package` — safe to delete if you take ownership."
+
+UNRESOLVED_CONTRACT_VERSION = "0.0.0"
+
+ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV = "NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION"
 
 
 def is_plugin_managed(path: Path) -> bool:
@@ -425,9 +430,10 @@ def _jinja_env() -> jinja2.Environment:
         undefined=jinja2.StrictUndefined,
     )
     env.filters["dockerfile_escape"] = _dockerfile_escape
-    env.globals["pinned_nemo_relay_cli_version"] = PINNED_NEMO_RELAY_CLI_VERSION
-    env.globals["pinned_nemo_relay_installer_commit"] = PINNED_NEMO_RELAY_INSTALLER_COMMIT
-    env.globals["pinned_nemo_relay_installer_sha256"] = PINNED_NEMO_RELAY_INSTALLER_SHA256
+    template_globals: dict[str, Any] = env.globals
+    template_globals["pinned_nemo_relay_cli_version"] = PINNED_NEMO_RELAY_CLI_VERSION
+    template_globals["pinned_nemo_relay_installer_commit"] = PINNED_NEMO_RELAY_INSTALLER_COMMIT
+    template_globals["pinned_nemo_relay_installer_sha256"] = PINNED_NEMO_RELAY_INSTALLER_SHA256
     return env
 
 
@@ -634,11 +640,10 @@ def render_fabric_dockerfile(
         agent_author=agent_author,
         metadata=metadata,
     )
-    if shared.contract_version == "0.0.0":
-        raise ValueError(
-            "Unable to resolve the installed nemo-platform contract version; "
-            "Fabric packaging requires an installed release version."
-        )
+    require_installable_contract_version(
+        shared.contract_version,
+        pins_contract_version=template_path is None,
+    )
     params = FabricRenderParams(**{f.name: getattr(shared, f.name) for f in fields(shared)})
 
     if template_path:
@@ -660,7 +665,41 @@ def get_contract_version() -> str:
     try:
         return version("nemo-platform")
     except PackageNotFoundError:
-        return "0.0.0"
+        return UNRESOLVED_CONTRACT_VERSION
+
+
+def require_installable_contract_version(contract_version: str, *, pins_contract_version: bool = True) -> None:
+    """Reject a version no index can serve: a local identifier or a ``.dev`` release.
+
+    ``pins_contract_version`` is False for a caller-supplied ``--template``,
+    whose contents may not pin the version at all.
+    """
+    if contract_version == UNRESOLVED_CONTRACT_VERSION:
+        raise ValueError(
+            "Unable to resolve the installed nemo-platform contract version; "
+            "Fabric packaging requires an installed release version."
+        )
+
+    if not pins_contract_version:
+        return
+
+    if os.environ.get(ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV, "").strip().lower() in {"1", "true", "yes"}:
+        return
+
+    reason = ""
+    if "+" in contract_version:
+        reason = "is a local build identifier, which package indexes do not serve"
+    elif ".dev" in contract_version:
+        reason = "is a developmental release, which is not published for this project"
+    if not reason:
+        return
+
+    raise ValueError(
+        f"The installed nemo-platform version '{contract_version}' {reason}. "
+        "Fabric packaging pins this exact version inside the image, so the build would fail "
+        "while resolving it. Install a released nemo-platform to package an agent, or set "
+        f"{ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV}=1 if your index serves this version."
+    )
 
 
 def render_dockerignore(output_dir: Path) -> Path | None:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
@@ -44,9 +44,9 @@ DOCKERFILE_SENTINEL = "# Managed by `nemo agents package` — safe to delete if 
 
 UNRESOLVED_CONTRACT_VERSION = "0.0.0"
 
-#: PEP 440 dev segment. The separator is optional, so ``1.2.3dev0`` is a dev
-#: release too and normalizes to ``1.2.3.dev0``.
-_DEV_SEGMENT = re.compile(r"[-_.]?dev[-_.]?[0-9]*$")
+#: PEP 440 dev segment. The separator is optional and the spelling is case
+#: insensitive, so ``1.2.3dev0`` and ``1.2.3.DEV0`` both normalize to ``1.2.3.dev0``.
+_DEV_SEGMENT = re.compile(r"[-_.]?dev[-_.]?[0-9]*$", re.IGNORECASE)
 
 
 def is_plugin_managed(path: Path) -> bool:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/container/template.py
@@ -27,6 +27,7 @@ Two rendering modes are supported:
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
@@ -43,7 +44,9 @@ DOCKERFILE_SENTINEL = "# Managed by `nemo agents package` — safe to delete if 
 
 UNRESOLVED_CONTRACT_VERSION = "0.0.0"
 
-ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV = "NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION"
+#: PEP 440 dev segment. The separator is optional, so ``1.2.3dev0`` is a dev
+#: release too and normalizes to ``1.2.3.dev0``.
+_DEV_SEGMENT = re.compile(r"[-_.]?dev[-_.]?[0-9]*$")
 
 
 def is_plugin_managed(path: Path) -> bool:
@@ -683,22 +686,23 @@ def require_installable_contract_version(contract_version: str, *, pins_contract
     if not pins_contract_version:
         return
 
-    if os.environ.get(ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV, "").strip().lower() in {"1", "true", "yes"}:
+    if os.environ.get("NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION", "").strip().lower() in {"1", "true", "yes"}:
         return
 
-    reason = ""
-    if "+" in contract_version:
-        reason = "is a local build identifier, which package indexes do not serve"
-    elif ".dev" in contract_version:
-        reason = "is a developmental release, which is not published for this project"
-    if not reason:
+    public, _, local = contract_version.partition("+")
+    reasons = []
+    if local:
+        reasons.append("carries a local build identifier")
+    if _DEV_SEGMENT.search(public):
+        reasons.append("is a developmental release")
+    if not reasons:
         return
 
     raise ValueError(
-        f"The installed nemo-platform version '{contract_version}' {reason}. "
-        "Fabric packaging pins this exact version inside the image, so the build would fail "
-        "while resolving it. Install a released nemo-platform to package an agent, or set "
-        f"{ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV}=1 if your index serves this version."
+        f"The installed nemo-platform version '{contract_version}' {' and '.join(reasons)}, so no "
+        "package index serves it. Fabric packaging pins this exact version inside the image, so the "
+        "build would fail while resolving it. Install a released nemo-platform to package an agent, "
+        "or set NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1 if your index serves this version."
     )
 
 

--- a/plugins/nemo-agents/tests/unit/conftest.py
+++ b/plugins/nemo-agents/tests/unit/conftest.py
@@ -53,3 +53,11 @@ def ctx(tmp_path: Path) -> JobContext:
         storage=StoragePaths(ephemeral=ephemeral, persistent=persistent),
         results=LocalJobResults(root=persistent / "results"),
     )
+
+
+@pytest.fixture(autouse=True)
+def _released_contract_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A source checkout reports a version the packaging guard rejects."""
+    import nemo_agents_plugin.container.template as template
+
+    monkeypatch.setattr(template, "get_contract_version", lambda: "1.0.0")

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -2579,6 +2579,11 @@ class TestInstallableContractVersion:
             "1.2.3dev0",
             "1.2.3-dev0",
             "1.2.3_dev0",
+            # PEP 440 normalizes case, so these are dev releases too.
+            "1.2.3.DEV0",
+            "1.2.3DEV0",
+            "1.2.3-DEV0",
+            "1.2.3_DEV0",
         ],
     )
     def test_unpublishable_versions_are_rejected(self, version: str) -> None:

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -2567,3 +2567,103 @@ class TestFabricTagNamespace:
         build_fabric_agent_image(fabric_agent_config, tag="my-agent:1.0", skip_validation=True)
 
         assert mock_build.call_args.kwargs["tag"] == "my-agent:1.0"
+
+
+class TestInstallableContractVersion:
+    @pytest.mark.parametrize(
+        "version",
+        [
+            "0.3.0.post402.dev0+062f0ac6e8",  # setuptools-scm from a source checkout
+            "0.3.0+local",
+            "1.2.3.dev0",
+        ],
+    )
+    def test_unpublishable_versions_are_rejected(self, version: str) -> None:
+        from nemo_agents_plugin.container.template import require_installable_contract_version
+
+        with pytest.raises(ValueError, match="Fabric packaging pins this exact version"):
+            require_installable_contract_version(version)
+
+    @pytest.mark.parametrize("version", ["0.3.0", "0.4.0", "1.0.0.post1", "0.4.0rc1"])
+    def test_published_versions_are_accepted(self, version: str) -> None:
+        from nemo_agents_plugin.container.template import require_installable_contract_version
+
+        require_installable_contract_version(version)
+
+    def test_missing_install_keeps_its_own_message(self) -> None:
+        from nemo_agents_plugin.container.template import (
+            UNRESOLVED_CONTRACT_VERSION,
+            require_installable_contract_version,
+        )
+
+        with pytest.raises(ValueError, match="Unable to resolve the installed nemo-platform contract version"):
+            require_installable_contract_version(UNRESOLVED_CONTRACT_VERSION)
+
+    @pytest.mark.parametrize("value", ["1", "true", "YES"])
+    def test_env_override_allows_an_unpublished_version(self, value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nemo_agents_plugin.container.template import (
+            ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV,
+            require_installable_contract_version,
+        )
+
+        monkeypatch.setenv(ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV, value)
+        require_installable_contract_version("0.3.0.post402.dev0+062f0ac6e8")
+
+    def test_env_override_ignores_unset_and_falsey(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nemo_agents_plugin.container.template import (
+            ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV,
+            require_installable_contract_version,
+        )
+
+        monkeypatch.setenv(ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV, "0")
+        with pytest.raises(ValueError):
+            require_installable_contract_version("0.3.0+local")
+
+    def test_override_cannot_bypass_an_unresolved_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nemo_agents_plugin.container.template import (
+            ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV,
+            UNRESOLVED_CONTRACT_VERSION,
+            require_installable_contract_version,
+        )
+
+        monkeypatch.setenv(ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV, "1")
+
+        with pytest.raises(ValueError, match="Unable to resolve the installed nemo-platform contract version"):
+            require_installable_contract_version(UNRESOLVED_CONTRACT_VERSION)
+
+    def test_custom_template_may_use_an_unpublished_version(self) -> None:
+        from nemo_agents_plugin.container.template import require_installable_contract_version
+
+        require_installable_contract_version("0.3.0.post402.dev0+062f0ac6e8", pins_contract_version=False)
+
+    def test_custom_template_still_needs_an_installed_platform(self) -> None:
+        from nemo_agents_plugin.container.template import (
+            UNRESOLVED_CONTRACT_VERSION,
+            require_installable_contract_version,
+        )
+
+        with pytest.raises(ValueError, match="Unable to resolve"):
+            require_installable_contract_version(UNRESOLVED_CONTRACT_VERSION, pins_contract_version=False)
+
+    def test_render_with_custom_template_allows_a_checkout_version(
+        self, tmp_path: Path, fabric_agent_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import nemo_agents_plugin.container.template as template
+
+        monkeypatch.setattr(template, "get_contract_version", lambda: "0.3.0.post402.dev0+062f0ac6e8")
+        custom = tmp_path / "custom.j2"
+        custom.write_text("FROM scratch\nLABEL agent={{ agent_name }}\n")
+
+        result = template.render_fabric_dockerfile(fabric_agent_config, template_path=str(custom))
+
+        assert "FROM scratch" in result
+
+    def test_render_rejects_a_source_checkout_version(
+        self, fabric_agent_config: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import nemo_agents_plugin.container.template as template
+
+        monkeypatch.setattr(template, "get_contract_version", lambda: "0.3.0.post402.dev0+062f0ac6e8")
+
+        with pytest.raises(ValueError, match="local build identifier"):
+            template.render_fabric_dockerfile(fabric_agent_config)

--- a/plugins/nemo-agents/tests/unit/test_container.py
+++ b/plugins/nemo-agents/tests/unit/test_container.py
@@ -2576,6 +2576,9 @@ class TestInstallableContractVersion:
             "0.3.0.post402.dev0+062f0ac6e8",  # setuptools-scm from a source checkout
             "0.3.0+local",
             "1.2.3.dev0",
+            "1.2.3dev0",
+            "1.2.3-dev0",
+            "1.2.3_dev0",
         ],
     )
     def test_unpublishable_versions_are_rejected(self, version: str) -> None:
@@ -2583,6 +2586,14 @@ class TestInstallableContractVersion:
 
         with pytest.raises(ValueError, match="Fabric packaging pins this exact version"):
             require_installable_contract_version(version)
+
+    def test_a_checkout_version_reports_both_reasons(self) -> None:
+        from nemo_agents_plugin.container.template import require_installable_contract_version
+
+        with pytest.raises(ValueError) as excinfo:
+            require_installable_contract_version("0.3.0.post402.dev0+062f0ac6e8")
+
+        assert "carries a local build identifier and is a developmental release" in str(excinfo.value)
 
     @pytest.mark.parametrize("version", ["0.3.0", "0.4.0", "1.0.0.post1", "0.4.0rc1"])
     def test_published_versions_are_accepted(self, version: str) -> None:
@@ -2601,32 +2612,25 @@ class TestInstallableContractVersion:
 
     @pytest.mark.parametrize("value", ["1", "true", "YES"])
     def test_env_override_allows_an_unpublished_version(self, value: str, monkeypatch: pytest.MonkeyPatch) -> None:
-        from nemo_agents_plugin.container.template import (
-            ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV,
-            require_installable_contract_version,
-        )
+        from nemo_agents_plugin.container.template import require_installable_contract_version
 
-        monkeypatch.setenv(ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV, value)
+        monkeypatch.setenv("NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION", value)
         require_installable_contract_version("0.3.0.post402.dev0+062f0ac6e8")
 
     def test_env_override_ignores_unset_and_falsey(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        from nemo_agents_plugin.container.template import (
-            ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV,
-            require_installable_contract_version,
-        )
+        from nemo_agents_plugin.container.template import require_installable_contract_version
 
-        monkeypatch.setenv(ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV, "0")
+        monkeypatch.setenv("NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION", "0")
         with pytest.raises(ValueError):
             require_installable_contract_version("0.3.0+local")
 
     def test_override_cannot_bypass_an_unresolved_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from nemo_agents_plugin.container.template import (
-            ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV,
             UNRESOLVED_CONTRACT_VERSION,
             require_installable_contract_version,
         )
 
-        monkeypatch.setenv(ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV, "1")
+        monkeypatch.setenv("NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION", "1")
 
         with pytest.raises(ValueError, match="Unable to resolve the installed nemo-platform contract version"):
             require_installable_contract_version(UNRESOLVED_CONTRACT_VERSION)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## TL;DR

`nemo agents package` on a Fabric agent has never worked from a source checkout. It pins the installed `nemo-platform` version into the image, which from a checkout is something like `0.3.0.post402.dev0+062f0ac6e8` — a PEP 440 local identifier that no package index is allowed to host. You'd wait several minutes for the base image and `apt-get`, then get an opaque uv resolver error.

The guard meant to catch this only tested for `0.0.0` (nemo-platform not installed at all), so every dev build walked past it.

Now it fails in under a second, naming the version and the way out. Release installs are unaffected; NAT packaging is untouched.

## Summary

Fabric packaging pins `nemo-platform[nemo-agents-plugin]=={contract_version}` inside the image and resolves it from a package index, where `contract_version` is whatever `importlib.metadata` reports on the build host. From a source checkout that is a setuptools-scm version like `0.3.0.post402.dev0+062f0ac6e8` — and PEP 440 local version identifiers are not permitted on public indexes, so the pin can never resolve. The build spent minutes pulling a base image and running `apt-get` before failing inside Docker with an opaque uv resolver error.

The existing guard only caught `"0.0.0"`, the sentinel for `nemo-platform` not being installed at all. Every dev build sailed through it — which is the state of anyone working in this repository. This makes the check reject any version an index cannot serve, and fail at render time with a message that names the offending version.

## Related Issue

None.

## Changes

- `template.py`: replace the inline `contract_version == "0.0.0"` check in `render_fabric_dockerfile` with `require_installable_contract_version()`, which rejects PEP 440 local version identifiers (`+062f0ac6e8`) and developmental releases (`.dev0`) in addition to the existing sentinel. Published pre-releases (`0.4.0rc1`) are still accepted — those upload normally. The not-installed case keeps its original message so the two failures stay distinguishable.
- Add `UNRESOLVED_CONTRACT_VERSION` and `ALLOW_UNPUBLISHED_CONTRACT_VERSION_ENV` constants rather than repeating the `"0.0.0"` literal and the env-var name.
- `conftest.py`: autouse fixture pinning `get_contract_version()` to a released version for the unit suite, since a source checkout no longer renders a Fabric Dockerfile by default. Tests that assert on the rejection re-patch it themselves.
- `README.md`: document the released-`nemo-platform` prerequisite next to the existing Docker requirement, explain what a source checkout does and how to proceed, and add the new environment variable to the reference. The packaging section previously told users to `uv sync` from the checkout, which is exactly the state that now fails.
- Widen two `**kwargs` annotations in `test_container.py` and the jinja `globals` assignment in `template.py`, which `ty` rejects when those files are checked on their own (the pre-commit hook checks staged files individually).

### Before and after

Previously, from any source checkout:

```
#9 3.921 Need to get 72.7 MB of archives.
...minutes later...
ERROR: failed to solve: ... we can conclude that your requirements are unsatisfiable
```

Now, immediately, before Docker is invoked:

```
Error: The installed nemo-platform version '0.3.0.post402.dev0+062f0ac6e8' is a local
build identifier, which package indexes do not serve. Fabric packaging pins this exact
version inside the image, so the build would fail while resolving it. Install a released
nemo-platform to package an agent, or set
NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1 if your index serves this version.
```

### Scope of the check

The two conditions are deliberately separate:

| Case | Built-in template | `--template` |
|---|---|---|
| `nemo-platform` not installed (`0.0.0`) | rejected | rejected |
| local identifier / `.dev` release | rejected, override available | allowed |
| released version, including `rc` | allowed | allowed |

`nemo-platform` not being installed is rejected unconditionally — the override cannot bypass it, because there is no version for any index to serve, only the placeholder. A caller-supplied `--template` is exempt from the installability check: it may install a wheel directly or omit the pin entirely, and this module does not get to assume its contents. It is still subject to the unresolved-version check, which is the pre-existing behaviour.

### Note for reviewers

`NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1` is an escape hatch rather than an absolute block, on the assumption that an internal index may legitimately host dev wheels; a hard rejection would break that workflow with no recourse. Happy to drop it and make the rejection unconditional if that assumption is wrong.

Scope note: this only affects the Fabric path. NAT packaging installs `uv pip install .` plus `nvidia-nat[most]==${NAT_VERSION}`, a genuinely published version, and is untouched.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
|---|---|
| `uv run pytest plugins/nemo-agents/tests/unit` | 1170 passed, 2 failed — both `test_port_allocation.py`, which `bind()`s a socket and is blocked by the local sandbox. Verified passing (13/13) with the sandbox disabled; unrelated to this change. |
| `uv run pytest .../test_container.py` | 154 passed (17 new, covering the guard, the override's limits, and the custom-template exemption) |
| `uv run pytest .../test_fabric_package_validation.py` | 26 passed |
| `uv run ruff check plugins/nemo-agents/` | All checks passed |
| `uv run ruff format --check plugins/nemo-agents/` | 198 files already formatted |
| `uv run --frozen ty check` on every changed file | All checks passed — `template.py` went from 3 pre-existing diagnostics to 0 |
| `uv run nemo agents package --agent <fabric>.yaml --tag x:test` | Fails immediately with the new message instead of after a multi-minute Docker build |
| `NEMO_AGENTS_ALLOW_UNPUBLISHED_CONTRACT_VERSION=1 uv run nemo agents package ... --no-build` | Renders, pinning `nemo-platform[nemo-agents-plugin]==0.3.0.post402.dev0+062f0ac6e8` — override path confirmed |

All pre-commit hooks pass on the commit itself, including `ty`. Two hooks are blocked in this environment and were skipped for the `git push` only, neither related to this change:

- **`uv-lock`** — requires exactly uv 0.9.14 on `PATH`; this machine has 0.9.30. No dependency files are touched by this PR and the `uv-lock-check` drift hook passes.
- **`helm-docs`** — the `helm-docs` binary is not installed locally. No Helm files are touched.

Related: PR #1464 also edits the two `**kwargs` annotations in `test_container.py`, so whichever of the two merges second may need a trivial conflict resolution there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fabric agent packaging now verifies that the required `nemo-platform` version is installable.
  * Improved diagnostics identify unpublished, development, or unresolved versions, including checkout-based versions.

* **New Features**
  * Added an opt-in override for unpublished contract versions.
  * Custom templates may omit strict version pinning when appropriate.
  * Development-version detection now handles additional capitalization and version formats.

* **Documentation**
  * Expanded guidance on version requirements, checkout builds, overrides, and related packaging errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->