### PR TITLE
fix(sdk): add [project.urls] to nemo-platform wrapper distribution

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
 Homepage = "https://github.com/NVIDIA-NeMo/nemo-platform"
 Documentation = "https://docs.nvidia.com/nemo-platform"
 Source = "https://github.com/NVIDIA-NeMo/nemo-platform"
-"Bug Tracker" = "https://github.com/NVIDIA-NeMo/nemo-platform/issues"
 
 # Base install: SDK + shared runtime (nmp-common) + plugin contract.
 # Keep the true workspace deps here for editable installs and local tooling.

--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -33,6 +33,12 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
+[project.urls]
+Homepage = "https://github.com/NVIDIA-NeMo/nemo-platform"
+Documentation = "https://docs.nvidia.com/nemo-platform"
+Source = "https://github.com/NVIDIA-NeMo/nemo-platform"
+"Bug Tracker" = "https://github.com/NVIDIA-NeMo/nemo-platform/issues"
+
 # Base install: SDK + shared runtime (nmp-common) + plugin contract.
 # Keep the true workspace deps here for editable installs and local tooling.
 # Wheel builds rewrite bundled workspace deps to self-referencing extras.


### PR DESCRIPTION
## Summary

Published PyPI wheel currently has `info.project_urls == null` and no `home_page`, so the [pypi.org/project/nemo-platform/](https://pypi.org/project/nemo-platform/) sidebar shows no **Project links** section (Homepage / Documentation / Source / Bug Tracker). Users landing on PyPI cannot navigate to the docs site or the GitHub repo.

Sister distribution [`nemo-platform-plugin`](https://pypi.org/project/nemo-platform-plugin/) already sets these; mirror the same pattern on the main wrapper. `Documentation` points at the public docs site (docs.nvidia.com/nemo-platform), matching where CLI/PyPI users actually land.

## Evidence

```bash
$ curl -s https://pypi.org/pypi/nemo-platform/json | jq '.info | {version, home_page, project_urls}'
{
  "version": "0.4.0",
  "home_page": null,
  "project_urls": null
}

$ curl -s https://pypi.org/pypi/nemo-platform-plugin/json | jq '.info.project_urls'
{
  "Documentation": "…",
  "Homepage": "…",
  "Source": "…"
}
```

## Test plan
- [ ] Build the wheel and inspect metadata: `hatch build` (or `uv build`) then `python -c "import pkginfo; print(pkginfo.Wheel('dist/…').project_urls)"` — should list all four URLs.
- [ ] After the next release, verify [pypi.org/project/nemo-platform/](https://pypi.org/project/nemo-platform/) renders a **Project links** sidebar with Homepage / Documentation / Source / Bug Tracker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated package metadata with links to the homepage, documentation, and source repository.
  * Removed the bug tracker link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->