### PR TITLE
docs(home): link Harbor first-use to harborframework.com

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -16,7 +16,7 @@ NeMo Platform exposes the same local services through the CLI, Python SDK, Studi
 ## What You Can Do
 
 - **Secure agents.** Guardrails (content safety, jailbreak detection, PII redaction), Auditor (red-teaming via garak), Anonymizer (PII handling for training data).
-- **Evaluate agents.** LLM-as-judge, deterministic, agentic, and RAG benchmarks. Harbor-backed eval suites for regression testing.
+- **Evaluate agents.** LLM-as-judge, deterministic, agentic, and RAG benchmarks. [Harbor](https://www.harborframework.com/)-backed eval suites for regression testing.
 - **Tune agents.** Skill optimization, prompt and hyperparameter tuning, Switchyard model routing.
 - **Build agents.** Create platform-managed agents with agent.yaml, with legacy support for NAT-based LangGraph agents. Shared infrastructure: Inference Gateway, Secrets, Files, Entity Store, Jobs.
 - **Generate synthetic data.** Generate synthetic data for training or evaluation purposes using Data Designer.


### PR DESCRIPTION
## Summary

The landing page (`docs/index.mdx`) introduces "Harbor-backed eval suites" without defining Harbor or linking to a concept page. Readers unfamiliar with Harbor cannot orient themselves — the nightly [NMP_Docs_Review](http://infra.nth.nvidia.com:8081/view/NMP%20CI/view/Usability/job/NMP_Docs_Review/) build flags this as a high-severity terminology_first_use defect.

Link the first use to the official Harbor website: [https://www.harborframework.com/](https://www.harborframework.com/) — title "Harbor", tagline "A framework for evaluating and optimizing sandboxed agents and models", which matches its role in the NeMo Platform evaluation flow.

## Diff

```diff
-- **Evaluate agents.** LLM-as-judge, deterministic, agentic, and RAG benchmarks. Harbor-backed eval suites for regression testing.
++ **Evaluate agents.** LLM-as-judge, deterministic, agentic, and RAG benchmarks. [Harbor](https://www.harborframework.com/)-backed eval suites for regression testing.
```

## Test plan
- [ ] `mkdocs`/`fern` build renders the link.
- [ ] Nightly docs-review no longer flags `terminology_first_use: Harbor` on `documentation/home`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the agent evaluation description so the Harbor reference links directly to the Harbor website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->