### PR TITLE
docs(plugins-and-skills): drop version literal from opening sentence

### DIFF
--- a/docs/agents/plugins.mdx
+++ b/docs/agents/plugins.mdx
@@ -7,7 +7,7 @@ description: ""
 ---
 <a id="agents-plugins"></a>
 
-NeMo Platform 0.3.0 is extended through Python plugins and
+NeMo Platform is extended through Python plugins and
 coding-agent skills. Plugins add runtime capabilities to the local platform.
 Skills teach your coding agent how to operate those capabilities on your behalf.
 


### PR DESCRIPTION
## Summary

`docs/agents/plugins.mdx` opens with:

> NeMo Platform 0.3.0 is extended through Python plugins and coding-agent skills.

Under 0.4.0 the published page still reads "0.3.0". The version literal has drifted against every release since 0.3.0 and the nightly docs-review agent flags it as a version-claim mismatch on every build.

Drop the version literal. The sentence is release-agnostic and stays correct across future releases, eliminating this class of drift entirely.

## Diff

```diff
-NeMo Platform 0.3.0 is extended through Python plugins and
+NeMo Platform is extended through Python plugins and
 coding-agent skills. Plugins add runtime capabilities to the local platform.
```

## Test plan
- [ ] Nightly docs-review no longer flags `doc_claims_match_target: documentation/agents/plugins-and-skills`.
- [ ] Reads cleanly for both current and future releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the NeMo Platform extensions documentation to remove an outdated hard-coded version reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->