### PR TITLE
docs(manage-files): add client init block before Python SDK examples

### DIFF
--- a/docs/get-started/concepts/manage-files.mdx
+++ b/docs/get-started/concepts/manage-files.mdx
@@ -80,6 +80,20 @@ nemo files filesets list --workspace my-workspace
 ```
 
 </Tip>
+
+All Python SDK examples that follow assume this client initialization:
+
+```python
+import os
+
+from nemo_platform import NeMoPlatform
+
+client = NeMoPlatform(
+    base_url=os.environ.get("NMP_BASE_URL", "http://localhost:8080"),
+    workspace="default",
+)
+```
+
 ### Creating Filesets
 
 Creating a fileset involves specifying a name and workspace. You can optionally provide a description, purpose, and custom storage configuration.

--- a/docs/get-started/concepts/manage-files.mdx
+++ b/docs/get-started/concepts/manage-files.mdx
@@ -89,7 +89,7 @@ import os
 from nemo_platform import NeMoPlatform
 
 client = NeMoPlatform(
-    base_url=os.environ.get("NMP_BASE_URL", "http://localhost:8080"),
+    base_url=os.environ.get("NMP_BASE_URL") or "http://localhost:8080",
     workspace="default",
 )
 ```


### PR DESCRIPTION
## Summary

Most Python SDK snippets on `docs/get-started/concepts/manage-files.mdx` use `client.files....` without any prior `client = NeMoPlatform(...)` construction. Copy-pasting any of them into a fresh interpreter raises:

```
NameError: name 'client' is not defined
```

The nightly [NMP_Docs_Review](http://infra.nth.nvidia.com:8081/view/NMP%20CI/view/Usability/job/NMP_Docs_Review/) build flags this as a high-severity snippet defect on every run.

Follow the pattern used on the [Manage Secrets](../get-started/concepts/manage-secrets) page: place the standard initialization block at the top of the Python SDK examples section (right after the "Managing Filesets" H2's CLI tip), so readers landing on the anchor can copy any subsequent snippet with confidence.

Existing per-snippet init blocks (Creating Filesets, RichProgressCallback, S3 credential chain, etc.) are left intact — they're standalone snippets that legitimately re-declare setup.

## Diff (added block)

```python
import os

from nemo_platform import NeMoPlatform

client = NeMoPlatform(
    base_url=os.environ.get("NMP_BASE_URL", "http://localhost:8080"),
    workspace="default",
)
```

## Test plan
- [ ] `fern` build renders the added block.
- [ ] Nightly docs-review no longer flags `snippet: client` on `get-started/core-concepts/manage-files`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Python SDK client initialization example to the file management guide.
  * Documented configurable base URL and default workspace settings, including a localhost fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->