### PR TITLE
feat(evaluator): keep Harbor identity and evidence on SDK trials

### DIFF
--- a/docs/evaluator/agent-eval/index.mdx
+++ b/docs/evaluator/agent-eval/index.mdx
@@ -42,7 +42,7 @@ One run flows through five pieces:
   agent over HTTP, and container/harness backends; you can supply your own. Scoring never depends on
   which runner produced a trial.
 - **Trial** (`AgentEvalTrial`) — the durable record of one attempt: the agent's final `output`, the
-  `evidence` it produced (an [Agent Trajectory Interchange Format (ATIF)](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) trace of steps and tool calls, final filesystem state, logs), a
+  `evidence` it produced (an [ATIF](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) trace of steps and tool calls or OTLP resource spans, final filesystem state, logs), a
   `status` (`completed` / `partial` / `failed`), and arbitrary metadata. The trial — not the runner — is what
   gets scored, and it can be re-scored offline later.
 - **Metrics** (`Metric`) — each task's metrics score its trials through

--- a/docs/evaluator/agent-eval/score-by-component.mdx
+++ b/docs/evaluator/agent-eval/score-by-component.mdx
@@ -47,10 +47,10 @@ class KeywordMatchMetric:
 ## 2. A trajectory metric
 
 A metric can read more than the final output. `input.candidate.evidence` exposes the trial's
-**evidence** — for the trajectory, an [Agent Trajectory Interchange Format (ATIF)](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) trace of the
-agent's steps. `evidence.trace(...)` gives a handle whose `tool_calls()` returns the tool calls in
-order; each `ToolCall` has a `function_name` and `arguments`. This metric scores `1.0` when the agent
-used the tool you expected and `0.0` otherwise:
+**evidence**. This guide produces an [ATIF](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md)
+trace, whose handle returns modeled tool calls in order. Each `ToolCall` has a
+`function_name` and `arguments`. This metric scores `1.0` when the agent used the tool you expected
+and `0.0` otherwise:
 
 ```python
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
@@ -73,13 +73,17 @@ class UsedExpectedToolMetric:
         used = False
         evidence = input.candidate.evidence
         if evidence is not None and evidence.get(EVIDENCE_TRACE) is not None:
-            calls = await (await evidence.trace(EVIDENCE_TRACE)).tool_calls()
+            handle = await evidence.trace(EVIDENCE_TRACE)
+            if handle.format != "atif":
+                raise ValueError("UsedExpectedToolMetric requires ATIF trace evidence")
+            calls = await handle.tool_calls()
             used = any(call.function_name == self._expected for call in calls)
         return MetricResult(outputs=[MetricOutput(name="tool_use", value=1.0 if used else 0.0)])
 ```
 
-The metric checks for evidence first — a trial without a trace simply scores `0.0` rather than
-erroring.
+The metric scores a missing trace as `0.0`, but rejects OTLP rather than treating unsupported evidence
+as proof that the tool was not used. An OTLP metric must narrow on `handle.format` and inspect
+`resource_spans()` with exporter-specific logic.
 
 ## 3. Produce a trajectory
 
@@ -167,14 +171,15 @@ from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
 from nemo_evaluator_sdk.agent_eval.runtimes.callable_runtime import CallableAgentTaskRunner
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig
 
-result = await AgentEvaluator().run(
-    tasks=make_tasks(),
-    target=CallableAgentTaskRunner(my_agent),
-    config=AgentEvalRunConfig(parallelism=2),
-)
+async def run_evaluation() -> None:
+    result = await AgentEvaluator().run(
+        tasks=make_tasks(),
+        target=CallableAgentTaskRunner(my_agent),
+        config=AgentEvalRunConfig(parallelism=2),
+    )
 
-for aggregate in result.summary.scores.scores:
-    print(f"{aggregate.name}: {aggregate.mean}")
+    for aggregate in result.summary.scores.scores:
+        print(f"{aggregate.name}: {aggregate.mean}")
 ```
 
 Output:
@@ -245,7 +250,10 @@ class UsedExpectedToolMetric:
         used = False
         evidence = input.candidate.evidence
         if evidence is not None and evidence.get(EVIDENCE_TRACE) is not None:
-            calls = await (await evidence.trace(EVIDENCE_TRACE)).tool_calls()
+            handle = await evidence.trace(EVIDENCE_TRACE)
+            if handle.format != "atif":
+                raise ValueError("UsedExpectedToolMetric requires ATIF trace evidence")
+            calls = await handle.tool_calls()
             used = any(call.function_name == self._expected for call in calls)
         return MetricResult(outputs=[MetricOutput(name="tool_use", value=1.0 if used else 0.0)])
 

--- a/docs/evaluator/agent-eval/writing-metrics.mdx
+++ b/docs/evaluator/agent-eval/writing-metrics.mdx
@@ -13,18 +13,21 @@ however simple or elaborate, implements the same small protocol.
 ## The protocol
 
 ```python
-from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutputSpec, MetricResult
+from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
 
 class MyMetric:
     @property
     def type(self) -> str:
         """A unique name for this metric within a task (also the summary key prefix)."""
+        return "my_metric"
 
     def output_spec(self) -> list[MetricOutputSpec]:
         """The named values this metric emits, and their types."""
+        return [MetricOutputSpec.continuous_score("score")]
 
     async def compute_scores(self, input: MetricInput) -> MetricResult:
         """Score one trial and return its outputs."""
+        return MetricResult(outputs=[MetricOutput(name="score", value=1.0)])
 ```
 
 No base class — a metric is any object with these three members (a structural `Metric` protocol).
@@ -69,6 +72,8 @@ A metric may emit **several** outputs — for example an efficiency metric retur
 count:
 
 ```python
+from nemo_evaluator_sdk.metrics.protocol import MetricOutputSpec
+
 def output_spec(self) -> list[MetricOutputSpec]:
     return [
         MetricOutputSpec.boolean("efficient_tool_use"),
@@ -108,21 +113,36 @@ class KeywordMatchMetric:
 ## Reading evidence
 
 `candidate.evidence` (a `CandidateEvidence`) holds named descriptors, each exposed through a typed
-handle. Always guard first — a trial may not carry a given descriptor:
+handle. `trace()` returns an `ATIFTraceHandle | OTLPTraceHandle` union. Always guard for missing
+evidence, then narrow on `handle.format` before using format-specific methods:
 
 ```python
+from nemo_evaluator_sdk.metrics.protocol import MetricInput
 from nemo_evaluator_sdk.values.evidence import EVIDENCE_TRACE
 
-evidence = input.candidate.evidence
-if evidence is not None and evidence.get(EVIDENCE_TRACE) is not None:
-    calls = await (await evidence.trace(EVIDENCE_TRACE)).tool_calls()
+async def read_trace(input: MetricInput) -> None:
+    evidence = input.candidate.evidence
+    if evidence is None or evidence.get(EVIDENCE_TRACE) is None:
+        return
+
+    handle = await evidence.trace(EVIDENCE_TRACE)
+    if handle.format == "otlp":
+        resource_spans = await handle.resource_spans()
+        # extract tool calls based on the OTLP exporter specific logic
+        # calls = await extract_tool_calls(resource_spans)
+    else:
+        calls = await handle.tool_calls()
 ```
 
 | Evidence | Handle | Reads |
 |---|---|---|
-| **trace** (`EVIDENCE_TRACE`) | `await evidence.trace(name)` | `.tool_calls()`, `.steps()`, `.token_usage()` — the [Agent Trajectory Interchange Format (ATIF)](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) trajectory |
+| **trace** (`EVIDENCE_TRACE`) | `ATIFTraceHandle` (`format == "atif"`) | `.trace()`, `.tool_calls()`, `.steps()`, `.token_usage()` |
+| **trace** (`EVIDENCE_TRACE`) | `OTLPTraceHandle` (`format == "otlp"`) | `.resource_spans()` |
 | **filesystem** (`EVIDENCE_FINAL_STATE`, `EVIDENCE_INITIAL_STATE`) | `await evidence.filesystem(name)` | `.run_verifier(command)`, `.diff(other)` — run a check or diff two snapshots |
 | **logs** | `await evidence.logs(name)` | `.read_text(file)`, `.tail(file)` |
+
+OTLP exposes the unflattened `resourceSpans` tree; it does not provide a generic `tool_calls()` method.
+It's a responsibility of consumer to parse `resourceSpans` tree specific to OTLP exporter to extract the searched data.
 
 The [Score by Component](/documentation/evaluate-models/agent-eval/score-by-component) guide has a
 complete, runnable trajectory metric; the SDK's `example_metrics.py` (under

--- a/docs/evaluator/evaluation-approaches.mdx
+++ b/docs/evaluator/evaluation-approaches.mdx
@@ -45,9 +45,10 @@ Entry point: [Evaluation Metrics](/documentation/evaluate-models/metrics).
 
 You start from **tasks**. Each task gives an agent an instruction and any inputs it needs; the agent
 performs the task through a **runner**, producing a **trial** — the agent's final output plus
-evidence such as its trajectory (an [Agent Trajectory Interchange Format (ATIF)](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md) trace of steps and tool calls), final filesystem state, and
-logs. Container-based runners also provide an environment (and its final state) the agent works in.
-Metrics then score the trial. Because the trajectory is part of the trial, you can score not
+evidence such as [Agent Trajectory Interchange Format (ATIF)](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md)
+steps and tool calls or OTLP resource spans, final filesystem state, and logs. Container-based runners
+also provide an environment (and its final state) the agent works in. Metrics then score the trial.
+Because trace evidence is part of the trial, you can score not
 just *whether the answer is right* but *how the agent worked* — for example, whether it used the
 expected tool.
 
@@ -70,13 +71,13 @@ Entry point: [Agent Evaluation](/documentation/evaluate-models/agent-eval).
 |---|---|---|
 | **Unit of evaluation** | a dataset row | a task, and the trial it produces |
 | **What produces the candidate** | a model/pipeline generates an output per row | an agent performs the task (via a runner) |
-| **What you score** | the output, against a reference | the trial: final output **and** trajectory/evidence |
-| **Evidence available to the scorer** | the output (and row fields) | ATIF trace, tool calls, final state, logs |
+| **What you score** | the output, against a reference | the trial: final output **and** trace/evidence |
+| **Evidence available to the scorer** | the output (and row fields) | ATIF steps/tool calls or OTLP resource spans, final state, logs |
 | **Metric assignment** | one metric set applied to every row | each task defines its own metrics (heterogeneous suites) |
-| **Scoring granularity** | per-row metric + aggregate | task · trajectory · component (views) · session |
+| **Scoring granularity** | per-row metric + aggregate | task · trace/evidence · component (views) · session |
 | **Target** | a `Model` or `Agent` (plus the dataset) | a `Model`, a deployed `Agent` (HTTP), or a custom runner |
 | **Entry point** | metrics (`RunConfig`, dataset rows) | `AgentEvaluator` + `AgentEvalTask` |
-| **Result** | metric results + aggregates | an `AgentEvalResult` bundle (trials incl. ATIF trajectory & file evidence, scores, summary, report) |
+| **Result** | metric results + aggregates | an `AgentEvalResult` bundle (trials incl. ATIF trajectory, OTLP traces & file evidence, scores, summary, report) |
 | **Best for** | model quality, RAG, regression on labeled data | agents, tool use, multi-step behavior, skills, model/skill A/B |
 
 ## Which should I use?
@@ -92,7 +93,7 @@ does it matters — use **task-driven**.
 - **Dataset-driven** — you have (or can produce) a labeled dataset and want to score outputs against
   references: LLM quality, RAG, or a regression suite.
 - **Task-driven** — the system under test is an agent that uses tools or takes multiple steps, you
-  want to score the trajectory as well as the outcome, your suite is **heterogeneous** so different
+  want to score trace evidence as well as the outcome, your suite is **heterogeneous** so different
   tasks need different metrics (e.g. a coding agent producing docs, Q&A, tests, and net-new code), or
   you're running a skills / model A/B on agentic tasks.
 - **Both** — the two compose. It's common to track base model quality with dataset-driven metrics

--- a/docs/evaluator/experiments.mdx
+++ b/docs/evaluator/experiments.mdx
@@ -234,12 +234,12 @@ session with the Evaluation's identity:
 - For Agent Trajectory Interchange Format (ATIF) and chat-completions, add a **top-level**
   `evaluation_context` object to the ingest payload
   carrying `evaluation_name` and `test_case_name`.
-- For OpenTelemetry Protocol (OTLP), set the `nemo.evaluation.name` and
-  `nemo.test_case.name` root-span attributes.
+- For OpenTelemetry Protocol (OTLP), set `nemo.evaluation.name` and
+  `nemo.test_case.name` on each trace's root span.
 
 The per-evaluator scores on the leaderboard come from **evaluator results** captured on those
-sessions, either automatically from ATIF verifier rewards or explicitly through the evaluator-results
-endpoint. Refer to
+sessions. Intake can derive them from ATIF verifier rewards. OTLP traces carry session telemetry, so
+the framework or caller must publish their scores through the evaluator-results endpoint. Refer to
 [Capture Evaluator Results](/documentation/agents/observe-agents#capture-evaluator-results) for both
 paths, and [Observe Agents](/documentation/agents/observe-agents) for the ingestion paths themselves.
 The `nemo-experiments-upload` skill walks this through end to end.
@@ -446,8 +446,8 @@ You typically do not create Evaluations manually. Common producers include:
 
 - **Optimizer**: records each run as an Experiment and its candidates as Evaluations, so results land
   automatically. Refer to [Optimize Agents](/documentation/agents/optimize-agents).
-- **Evaluation framework**: a framework like Harbor sends complete trajectories through Intake's ATIF
-  ingest, and each run becomes an Evaluation with its final metrics as evaluator results. Refer to
+- **Evaluation framework**: a framework like Harbor sends trajectories through Intake's ATIF or OTLP
+  ingest, publishes its scores as evaluator results, and records each run as an Evaluation. Refer to
   [Observe Agents](/documentation/agents/observe-agents).
 - **Direct API**: create the Experiment and Evaluations, then ingest their sessions, for a custom
   evaluation pipeline.

--- a/packages/nemo_evaluator_sdk/examples/run_agent_eval/example_metrics.py
+++ b/packages/nemo_evaluator_sdk/examples/run_agent_eval/example_metrics.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
+from typing import Any
 
 from nemo_evaluator_sdk.agent_eval.trials import EVIDENCE_FINAL_STATE, EVIDENCE_INITIAL_STATE, EVIDENCE_TRACE
 from nemo_evaluator_sdk.metrics.protocol import MetricInput, MetricOutput, MetricOutputSpec, MetricResult
@@ -109,7 +110,14 @@ class InefficientRetryLoopMetric:
         max_repeats = 0
         evidence = input.candidate.evidence
         if evidence is not None and evidence.get(EVIDENCE_TRACE) is not None:
-            calls = await (await evidence.trace(EVIDENCE_TRACE)).tool_calls()
+            handle = await evidence.trace(EVIDENCE_TRACE)
+            if handle.format == "otlp":
+                calls = _otlp_tool_calls(await handle.resource_spans())
+            else:
+                calls = [
+                    {"function_name": call.function_name, "arguments": call.arguments or {}}
+                    for call in await handle.tool_calls()
+                ]
             # Count the longest run of *consecutive* identical calls (a retry loop), not the
             # global frequency, so legitimate reuse separated by other work isn't flagged.
             previous_key: str | None = None
@@ -118,7 +126,7 @@ class InefficientRetryLoopMetric:
                 # Canonicalize for comparison only (sorted keys): semantically identical calls
                 # match regardless of argument insertion order; execution order is untouched.
                 key = json.dumps(
-                    {"function_name": call.function_name, "arguments": call.arguments or {}},
+                    {"function_name": call["function_name"], "arguments": call["arguments"]},
                     sort_keys=True,
                     separators=(",", ":"),
                 )
@@ -131,3 +139,112 @@ class InefficientRetryLoopMetric:
                 MetricOutput(name="max_repeated_tool_calls", value=max_repeats),
             ]
         )
+
+
+def _otlp_tool_calls(resource_spans: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract fully identified OTLP tool calls in start-time order.
+
+    Args:
+        resource_spans: OTLP resource-span export units.
+
+    Returns:
+        Tool name and argument mappings ordered by span start time.
+    """
+    found: list[tuple[int, int, dict[str, Any]]] = []
+    index = 0
+    for resource_span in resource_spans:
+        for scope_span in _otlp_dict_items(resource_span.get("scopeSpans")):
+            for span in _otlp_dict_items(scope_span.get("spans")):
+                call = _otlp_tool_call(span)
+                if call is None:
+                    continue
+                found.append((_otlp_start_ns(span), index, call))
+                index += 1
+    found.sort(key=lambda item: (item[0], item[1]))
+    return [item[2] for item in found]
+
+
+def _otlp_tool_call(span: dict[str, Any]) -> dict[str, Any] | None:
+    """Project one recognized OTLP tool span into retry-comparison fields.
+
+    Args:
+        span: Decoded OTLP span object.
+
+    Returns:
+        Tool name and arguments, or ``None`` when the span is not a tool call.
+    """
+    attrs = _otlp_attr_map(span.get("attributes"))
+    kind = attrs.get("openinference.span.kind")
+    operation = attrs.get("gen_ai.operation.name")
+    if kind != "TOOL" and operation != "execute_tool":
+        return None
+    name = attrs.get("tool.name") or attrs.get("gen_ai.tool.name") or span.get("name") or "tool"
+    function_name = str(name)
+    argument_keys = ("input.value", "tool.parameters", "gen_ai.tool.call.arguments")
+    raw = next((attrs[key] for key in argument_keys if key in attrs), None)
+    if raw is None:
+        raise ValueError(f"OTLP tool call {function_name!r} has no arguments; retry identity is unavailable")
+    arguments: dict[str, Any]
+    if isinstance(raw, dict):
+        arguments = raw
+    elif isinstance(raw, str):
+        try:
+            parsed = json.loads(raw)
+        except ValueError:
+            parsed = {"_raw": raw}
+        arguments = parsed if isinstance(parsed, dict) else {"_raw": parsed}
+    else:
+        arguments = {"_raw": raw}
+    return {"function_name": function_name, "arguments": arguments}
+
+
+def _otlp_start_ns(span: dict[str, Any]) -> int:
+    """Coerce an OTLP span start timestamp for stable tool-call ordering.
+
+    Args:
+        span: Decoded OTLP span object.
+
+    Returns:
+        Nanosecond timestamp, or zero when missing or malformed.
+    """
+    raw = span.get("startTimeUnixNano") or 0
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _otlp_attr_map(attributes: Any) -> dict[str, Any]:
+    """Decode scalar string and integer OTLP attributes by key.
+
+    Args:
+        attributes: Candidate OTLP key-value attribute list.
+
+    Returns:
+        Supported attribute values keyed by attribute name.
+    """
+    out: dict[str, Any] = {}
+    for item in _otlp_dict_items(attributes):
+        key = item.get("key")
+        value = item.get("value")
+        if not isinstance(key, str):
+            continue
+        if isinstance(value, dict) and "stringValue" in value:
+            out[key] = value["stringValue"]
+        elif isinstance(value, dict) and "intValue" in value:
+            out[key] = value["intValue"]
+    return out
+
+
+def _otlp_dict_items(value: Any) -> list[dict[str, Any]]:
+    """Return only dictionary elements from an OTLP repeated field.
+
+    Args:
+        value: Candidate decoded repeated field.
+
+    Returns:
+        Dictionary elements, or an empty list for malformed containers.
+    """
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/metrics.py
@@ -167,7 +167,11 @@ class SkillUsedMetric(MetricBase):
         if evidence is None or evidence.get(self.trace_evidence) is None:
             return False
         try:
-            trajectory = await (await evidence.trace(self.trace_evidence)).trace()
+            handle = await evidence.trace(self.trace_evidence)
+            if handle.format == "otlp":
+                resource_spans = await handle.resource_spans()
+                return any(_otlp_references(resource_spans, loc) for loc in locations)
+            trajectory = await handle.trace()
         except (KeyError, ValueError, ValidationError, OSError) as exc:
             # Best-effort: a missing/malformed/invalid trajectory must score skill_used=False, not raise.
             # ValidationError covers Trajectory.model_validate; OSError covers the underlying file read.
@@ -252,6 +256,97 @@ def _trajectory_references(trajectory: Trajectory, needle: str) -> bool:
                 if result.content is not None and needle in json.dumps(result.content, default=str):
                     return True
     return False
+
+
+def _otlp_references(resource_spans: list[dict[str, Any]], needle: str) -> bool:
+    """Check whether an OTLP string payload references ``needle``.
+
+    Args:
+        resource_spans: OTLP resource-span export units.
+        needle: Staged skill location to find.
+
+    Returns:
+        Whether any span or span-event string attribute contains ``needle``.
+    """
+    return any(needle in blob for blob in _otlp_string_blobs(resource_spans))
+
+
+def _otlp_string_blobs(resource_spans: list[dict[str, Any]]) -> list[str]:
+    """Collect searchable string attributes from OTLP spans and events.
+
+    Args:
+        resource_spans: OTLP resource-span export units.
+
+    Returns:
+        String values found beneath span and event attributes.
+    """
+    blobs: list[str] = []
+    for resource_span in resource_spans:
+        for scope_span in _otlp_dict_items(resource_span.get("scopeSpans")):
+            for span in _otlp_dict_items(scope_span.get("spans")):
+                blobs.extend(_otlp_attr_strings(span.get("attributes")))
+                for event in _otlp_dict_items(span.get("events")):
+                    blobs.extend(_otlp_attr_strings(event.get("attributes")))
+    return blobs
+
+
+def _otlp_dict_items(value: Any) -> list[dict[str, Any]]:
+    """Return only dictionary elements from an OTLP repeated field.
+
+    Args:
+        value: Candidate decoded repeated field.
+
+    Returns:
+        Dictionary elements, or an empty list for malformed containers.
+    """
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _otlp_attr_strings(attributes: Any) -> list[str]:
+    """Collect string leaves from decoded OTLP attributes.
+
+    Args:
+        attributes: Candidate OTLP key-value attribute list.
+
+    Returns:
+        String leaves contained in each attribute value.
+    """
+    blobs: list[str] = []
+    for item in _otlp_dict_items(attributes):
+        blobs.extend(_otlp_any_strings(item.get("value")))
+    return blobs
+
+
+def _otlp_any_strings(value: Any) -> list[str]:
+    """Collect string leaves from one decoded OTLP ``AnyValue``.
+
+    Args:
+        value: Candidate OTLP ``AnyValue`` object.
+
+    Returns:
+        Recursively nested string values.
+    """
+    if isinstance(value, str):
+        return [value]
+    if not isinstance(value, dict):
+        return []
+    if (text := value.get("stringValue")) is not None:
+        return [str(text)]
+    if isinstance(array := value.get("arrayValue"), dict):
+        blobs: list[str] = []
+        values = array.get("values")
+        if isinstance(values, list):
+            for item in values:
+                blobs.extend(_otlp_any_strings(item))
+        return blobs
+    if isinstance(kvlist := value.get("kvlistValue"), dict):
+        blobs = []
+        for item in _otlp_dict_items(kvlist.get("values")):
+            blobs.extend(_otlp_any_strings(item.get("value")))
+        return blobs
+    return []
 
 
 def _as_int(value: Any) -> int | None:

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_runtime.py
@@ -51,32 +51,23 @@ from collections.abc import Awaitable, Callable, Iterator, Mapping, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
-from typing import Any
+from typing import Any, Literal
 
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
+from nemo_evaluator_sdk.agent_eval.runtimes.harbor_trial_adapter import _trial_from_harbor_result
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask, AgentEvalTaskset
-from nemo_evaluator_sdk.agent_eval.trials import (
-    UNKNOWN_ERROR_TYPE,
-    AgentEvalTrial,
-    AgentEvalTrialStatus,
-    AgentOutput,
-    RunnerInfo,
-    TrialError,
-    standard_evidence_descriptors,
-)
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, RunnerInfo
 from nemo_evaluator_sdk.metrics.protocol import Metric
-from nemo_evaluator_sdk.values.evidence import (
-    EVIDENCE_FORMAT_ATIF,
-    CandidateEvidence,
-    read_atif,
-)
+from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_ATIF, EVIDENCE_FORMAT_OTLP
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
 # Default reward key inside Harbor's ``verifier_result.rewards`` mapping.
 DEFAULT_REWARD_KEY = "reward"
+# Harbor trace format selected as the trial's standard trace evidence.
+_TRACE_FORMATS = frozenset({EVIDENCE_FORMAT_OTLP, EVIDENCE_FORMAT_ATIF})
 # Filename that marks a directory as a Harbor task, and the template dir to skip.
 _TASK_CONFIG_FILENAME = "task.toml"
 _TASK_TEMPLATE_DIRNAME = "task_template"
@@ -123,8 +114,6 @@ _SPDX_HTML_COMMENT_RE = re.compile(r"<!--\s*SPDX-(?:FileCopyrightText|License-Id
 # deliverable — the Harbor wrapper does not upload them into the task container.
 _DIGEST_SKIP_DIRS = frozenset({".git", "__pycache__", ".venv", ".uv", ".mypy_cache", ".pytest_cache"})
 _DIGEST_CHUNK_BYTES = 1 << 20
-
-_MAX_TRACEBACK_CHARS = 8192
 
 RunJob = Callable[[], Awaitable[None]]
 
@@ -229,15 +218,18 @@ class HarborAgentTaskRunner:
         job_dir: str | Path | None = None,
         run_job: RunJob | None = None,
         reward_key: str = DEFAULT_REWARD_KEY,
+        trace_format: Literal["otlp", "atif"] = EVIDENCE_FORMAT_ATIF,
     ) -> None:
         if config is None and job_dir is None:
             raise ValueError("provide either a HarborRuntimeConfig or an explicit job_dir")
+        _validate_trace_format(trace_format)
         self._config = config
         self._dataset_path = Path(dataset_path) if dataset_path is not None else None
         self._task_names = task_names
         self._job_dir = Path(job_dir) if job_dir is not None else None
         self._run_job = run_job
         self._reward_key = config.reward_key if config is not None else reward_key
+        self._trace_format: Literal["otlp", "atif"] = trace_format
 
     def runner_info(self) -> RunnerInfo:
         """Identify this runner and the Harbor settings that shape its results.
@@ -262,6 +254,7 @@ class HarborAgentTaskRunner:
                 "jobs_dir": str(config.jobs_dir) if config is not None else None,
                 "job_name": config.job_name if config is not None else None,
                 "reward_key": self._reward_key,
+                "trace_format": self._trace_format,
             },
         )
 
@@ -352,13 +345,23 @@ class HarborAgentTaskRunner:
                             "so the next run re-executes rather than trusting these results.",
                             job_dir,
                         )
-            return build_trials_from_job_dir(job_dir, tasks, reward_key=self._reward_key)
+            return build_trials_from_job_dir(
+                job_dir,
+                tasks,
+                reward_key=self._reward_key,
+                trace_format=self._trace_format,
+            )
 
         if self._job_dir is None:  # unreachable: __init__ guarantees config or job_dir
             raise ValueError("no job_dir configured")
         if self._run_job is not None:
             await self._run_job()
-        return build_trials_from_job_dir(self._job_dir, tasks, reward_key=self._reward_key)
+        return build_trials_from_job_dir(
+            self._job_dir,
+            tasks,
+            reward_key=self._reward_key,
+            trace_format=self._trace_format,
+        )
 
 
 def _dataset_path_from_tasks(tasks: Sequence[AgentEvalTask]) -> Path:
@@ -746,6 +749,23 @@ def _write_cache_stamp(job_dir: Path, stamp: Mapping[str, Any]) -> None:
         logger.warning("Could not stamp Harbor job dir %s with its cache key: %s", job_dir, exc)
 
 
+def _validated_job_dir(jobs_dir: Path, job_name: str) -> Path:
+    """Resolve ``jobs_dir / job_name`` and require it stay under ``jobs_dir``.
+
+    Harbor deletes this path on ``force_rerun`` (and again if it refuses to resume).
+    ``job_name='..'``, ``'.'``, or an absolute path would otherwise ``rmtree``
+    directories the caller did not name as the jobs root.
+    """
+    resolved_jobs_dir = jobs_dir.expanduser().resolve()
+    candidate = (jobs_dir / job_name).expanduser().resolve()
+    if candidate == resolved_jobs_dir or not candidate.is_relative_to(resolved_jobs_dir):
+        raise ValueError(
+            f"Resolved job directory {candidate} is not a strict descendant of "
+            f"{resolved_jobs_dir} (job_name={job_name!r})"
+        )
+    return candidate
+
+
 def _resolve_job_dir(config: HarborRuntimeConfig) -> tuple[str, Path]:
     """Resolve ``(job_name, job_dir)`` without importing Harbor.
 
@@ -753,9 +773,12 @@ def _resolve_job_dir(config: HarborRuntimeConfig) -> tuple[str, Path]:
     directory *before* deciding whether to run: an unpinned ``job_name`` is a
     timestamp with microsecond precision, so resolving it twice would yield two
     different directories and the cache decision would be made about the wrong one.
+
+    The resolved directory must be a strict descendant of ``jobs_dir``; see
+    :func:`_validated_job_dir`.
     """
     job_name = config.job_name or datetime.now(timezone.utc).strftime("%Y-%m-%d__%H-%M-%S__%f")
-    return job_name, config.jobs_dir / job_name
+    return job_name, _validated_job_dir(config.jobs_dir, job_name)
 
 
 def _build_native_job(
@@ -783,7 +806,7 @@ def _build_native_job(
             and the job name stays fixed.
     """
     resolved_name = job_name if job_name is not None else _resolve_job_dir(config)[0]
-    job_dir = config.jobs_dir / resolved_name
+    job_dir = _validated_job_dir(config.jobs_dir, resolved_name)
     effective_force_rerun = config.force_rerun if force_rerun is None else force_rerun
 
     async def run_job() -> None:
@@ -1099,6 +1122,7 @@ def build_trials_from_job_dir(
     tasks: Sequence[AgentEvalTask],
     *,
     reward_key: str = DEFAULT_REWARD_KEY,
+    trace_format: Literal["otlp", "atif"] = EVIDENCE_FORMAT_ATIF,
 ) -> list[AgentEvalTrial]:
     """Adapt Harbor's per-trial ``result.json`` files into :class:`AgentEvalTrial` objects.
 
@@ -1109,6 +1133,7 @@ def build_trials_from_job_dir(
     ``metadata`` and standard evidence descriptors pointing at the trial's
     on-disk artifacts.
     """
+    _validate_trace_format(trace_format)
     job_path = Path(job_dir)
     known_task_ids = {task.id for task in tasks}
     trials: list[AgentEvalTrial] = []
@@ -1122,7 +1147,14 @@ def build_trials_from_job_dir(
         if task_id not in known_task_ids:
             # Trial for a task we weren't asked to score (e.g. a wider dataset run).
             continue
-        trials.append(_trial_from_harbor_result(result_path.parent, data, reward_key=reward_key))
+        trials.append(
+            _trial_from_harbor_result(
+                result_path.parent,
+                data,
+                reward_key=reward_key,
+                trace_format=trace_format,
+            )
+        )
 
     # Surface tasks that produced no trial loudly: a mis-pointed job_dir or a
     # crashed run would otherwise silently score fewer tasks than requested.
@@ -1136,162 +1168,20 @@ def build_trials_from_job_dir(
     return trials
 
 
-def _trial_from_harbor_result(trial_dir: Path, data: Mapping[str, Any], *, reward_key: str) -> AgentEvalTrial:
-    task_id = str(data["task_name"])
-    trial_id = str(data.get("trial_name") or trial_dir.name)
-    rewards = _rewards_mapping(data)
-    reward = _primary_reward(rewards, reward_key)
-    error = _trial_error(data.get("exception_info"))
+def _validate_trace_format(trace_format: str) -> None:
+    """Validate the trace format accepted by Harbor trial adaptation.
 
-    metadata: dict[str, Any] = {
-        "reward": reward,
-        "reward_details": dict(rewards),
-        "harbor_trial_dir": str(trial_dir),
-    }
-    metadata.update(_token_measurements(data.get("agent_result")))
+    Args:
+        trace_format: Requested standard trace encoding.
 
-    # An errored trial (or one with no reward) stays PARTIAL so it is still scored
-    # as 0 and counted in the summary; FAILED would exclude it from scoring.
-    status = AgentEvalTrialStatus.COMPLETED if error is None and reward is not None else AgentEvalTrialStatus.PARTIAL
+    Returns:
+        None when ``trace_format`` is supported.
 
-    trace_path = trial_dir / "agent" / "trajectory.json"
-    # Only agents with SUPPORTS_ATIF write this file, so its absence is normal: oracle and nop
-    # never produce one.
-    trajectory = read_atif(trace_path)
-    descriptors = standard_evidence_descriptors(
-        logs_dir=trial_dir / "agent",
-        final_state_dir=trial_dir / "artifacts",
-        trace_path=trace_path if trace_path.exists() else None,
-        trace_format=EVIDENCE_FORMAT_ATIF if trajectory is not None else None,
-        verifier_logs_dir=trial_dir / "verifier",
-    )
-
-    return AgentEvalTrial(
-        id=trial_id,
-        task_id=task_id,
-        status=status,
-        output=AgentOutput(metadata={"harbor_trial_dir": str(trial_dir)}),
-        evidence=CandidateEvidence(descriptors=descriptors),
-        error=error,
-        metadata=metadata,
-    )
-
-
-def _rewards_mapping(data: Mapping[str, Any]) -> dict[str, float]:
-    verifier_result = data.get("verifier_result")
-    if not isinstance(verifier_result, Mapping):
-        return {}
-    rewards = verifier_result.get("rewards")
-    if not isinstance(rewards, Mapping):
-        return {}
-    out: dict[str, float] = {}
-    for key, value in rewards.items():
-        try:
-            out[str(key)] = float(value)
-        except (TypeError, ValueError):
-            continue
-    return out
-
-
-def _primary_reward(rewards: Mapping[str, float], reward_key: str) -> float | None:
-    """Return the single reward a trial is scored on.
-
-    Returns the reward named by ``reward_key`` when the verifier emitted it.
-    Returns ``None`` otherwise (the trial is treated as having no reward, so it
-    stays PARTIAL rather than scoring a misleading 0.0): if the verifier emitted
-    rewards but none matches ``reward_key`` a warning is logged, since we do not
-    guess among the emitted rewards (point ``reward_key`` at the intended one, or
-    score the others with additional metrics over ``reward_details``).
+    Raises:
+        ValueError: If ``trace_format`` is not one of the supported encodings.
     """
-    if reward_key in rewards:
-        return rewards[reward_key]
-    if rewards:
-        logger.warning(
-            "Harbor trial emitted rewards %s but none matches reward_key=%r; treating the trial as having no reward",
-            sorted(rewards),
-            reward_key,
-        )
-    return None
-
-
-def _trial_error(exception_info: Any) -> TrialError | None:
-    """Harbor's ``exception_info`` as a :class:`TrialError`, for any shape it can arrive in.
-
-    **Total by construction.** :func:`_trial_from_harbor_result` is called outside the only
-    ``try``/``except`` in :func:`build_trials_from_job_dir` (which guards ``json.loads`` alone), so a
-    ``ValidationError`` raised here would abort adaptation of the *whole job dir* over one malformed
-    trial. Every field is therefore normalised rather than trusted:
-
-    - ``type`` -- first non-empty string of ``exception_type``/``type``/``name``/``class``; for a
-      non-mapping, ``str(value)``; anything left empty becomes :data:`UNKNOWN_ERROR_TYPE`
-    - ``message``/``traceback`` -- kept only when actually strings; the traceback is truncated
-    - ``occurred_at`` -- kept only when it parses; never raises
-
-    Returns ``None`` only for a genuinely absent ``exception_info``, which is what marks a trial as
-    not having errored.
-    """
-    if exception_info is None:
-        return None
-    if not isinstance(exception_info, Mapping):
-        return TrialError(type=str(exception_info).strip() or UNKNOWN_ERROR_TYPE)
-
-    error_type = ""
-    for key in ("exception_type", "type", "name", "class"):
-        value = exception_info.get(key)
-        if isinstance(value, str) and value.strip():
-            error_type = value
-            break
-
-    traceback = _first_string(exception_info, ("exception_traceback", "traceback"))
-    return TrialError(
-        type=error_type or UNKNOWN_ERROR_TYPE,
-        message=_first_string(exception_info, ("exception_message", "message")),
-        traceback=traceback[:_MAX_TRACEBACK_CHARS] if traceback is not None else None,
-        occurred_at=_error_timestamp(exception_info.get("occurred_at")),
-    )
-
-
-def _first_string(payload: Mapping[str, Any], keys: tuple[str, ...]) -> str | None:
-    """The first value under ``keys`` that is actually a string. Harbor's spelling is tried first."""
-    for key in keys:
-        value = payload.get(key)
-        if isinstance(value, str):
-            return value
-    return None
-
-
-def _error_timestamp(value: Any) -> datetime | None:
-    """``value`` as a datetime when it plausibly is one, else ``None`` -- never raising.
-
-    Deliberately not normalized to UTC: Harbor writes a naive local wall-clock time here while
-    stamping trial start/finish in UTC, and inventing an offset would fabricate precision.
-    """
-    if isinstance(value, datetime):
-        return value
-    if isinstance(value, str):
-        with contextlib.suppress(ValueError):
-            return datetime.fromisoformat(value)
-    return None
-
-
-def _token_measurements(agent_result: Any) -> dict[str, int | float]:
-    """Map Harbor's ``agent_result`` token counts onto SDK ``TrialMeasurements`` keys."""
-    if not isinstance(agent_result, Mapping):
-        return {}
-    mapping = {
-        "prompt_tokens": "n_input_tokens",
-        "completion_tokens": "n_output_tokens",
-        "cache_read_tokens": "n_cache_tokens",
-    }
-    out: dict[str, int | float] = {}
-    for sdk_key, harbor_key in mapping.items():
-        value = agent_result.get(harbor_key)
-        if isinstance(value, int) and not isinstance(value, bool):
-            out[sdk_key] = value
-    cost = agent_result.get("cost_usd")
-    if isinstance(cost, (int, float)) and not isinstance(cost, bool):
-        out["cost_usd"] = float(cost)
-    return out
+    if trace_format not in _TRACE_FORMATS:
+        raise ValueError(f"trace_format must be one of {sorted(_TRACE_FORMATS)}, got {trace_format!r}")
 
 
 def _harbor_task_dirs(dataset_path: Path) -> list[Path]:
@@ -1396,6 +1286,7 @@ async def run_harbor_eval(
     task_names: Sequence[str] | None = None,
     metrics: Sequence[Metric] | None = None,
     run_config: AgentEvalRunConfig | None = None,
+    trace_format: Literal["otlp", "atif"] = EVIDENCE_FORMAT_ATIF,
 ) -> AgentEvalResult:
     """Run a Harbor dataset natively and score it — the minimal-plumbing entry point.
 
@@ -1413,7 +1304,7 @@ async def run_harbor_eval(
     if metrics is not None:
         tasks = [task.model_copy(update={"metrics": list(metrics)}) for task in tasks]
 
-    runner = HarborAgentTaskRunner(config=config, task_names=task_names)
+    runner = HarborAgentTaskRunner(config=config, task_names=task_names, trace_format=trace_format)
     return await AgentEvaluator().run(
         tasks=tasks,
         target=runner,

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/runtimes/harbor_trial_adapter.py
@@ -1,0 +1,591 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adapt one Harbor result directory into an SDK :class:`AgentEvalTrial`.
+
+This module owns the complete Harbor trial-data seam: identity, reward and error
+normalization, measurements, and collision-safe evidence discovery. Harbor job
+execution and result-file discovery remain in :mod:`harbor_runtime`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import math
+from collections.abc import Mapping
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from nemo_evaluator_sdk.agent_eval.trials import (
+    UNKNOWN_ERROR_TYPE,
+    AgentEvalTrial,
+    AgentEvalTrialStatus,
+    AgentOutput,
+    TrialError,
+    standard_evidence_descriptors,
+)
+from nemo_evaluator_sdk.values.evidence import (
+    EVIDENCE_FORMAT_ATIF,
+    EVIDENCE_FORMAT_JSON,
+    EVIDENCE_FORMAT_OTLP,
+    EVIDENCE_FORMAT_TEXT,
+    EVIDENCE_TRACE,
+    CandidateEvidence,
+    EvidenceDescriptor,
+    read_atif,
+)
+
+logger = logging.getLogger(__name__)
+
+_ATIF_TRACE_SUFFIX = ".atif.json"
+_TRIAL_DIR_DESCRIPTION = (
+    "Harbor trial output directory for one task attempt. Contains config.json, result.json, "
+    "trial.log, agent logs, verifier logs, and collected artifacts."
+)
+_TRIAL_CONFIG_DESCRIPTION = (
+    "Harbor trial configuration snapshot. Records the task, agent, environment, verifier, "
+    "artifact collection, and job id used for this attempt."
+)
+_TRIAL_RESULT_DESCRIPTION = (
+    "Harbor trial result JSON. Contains task and trial identifiers, agent info, verifier rewards, "
+    "exception info, phase timings, and token or cost usage."
+)
+_TRIAL_LOG_DESCRIPTIONS = {
+    "agent/oracle.txt": "Oracle-agent log captured when Harbor runs the reference solution.",
+    "agent/setup/stdout.txt": "Agent setup stdout captured while Harbor uploads the agent and installs dependencies.",
+    "exception.txt": "Exception traceback captured by Harbor for a failed trial.",
+    "trial.log": (
+        "Harbor trial orchestration log covering environment setup, agent execution, verifier execution, "
+        "artifact collection, and cleanup."
+    ),
+    "verifier/reward.json": (
+        "Verifier reward JSON written under /logs/verifier. Harbor parses numeric entries from this file "
+        "as trial metrics."
+    ),
+    "verifier/reward.txt": (
+        "Verifier scalar reward file written under /logs/verifier. Harbor parses this file as the reward metric."
+    ),
+    "verifier/test-stderr.txt": "Verifier stderr captured while Harbor runs the task tests from the /tests directory.",
+    "verifier/test-stdout.txt": "Verifier stdout captured while Harbor runs the task tests from the /tests directory.",
+}
+_MAX_TRACEBACK_CHARS = 8192
+
+
+def _trial_from_harbor_result(
+    trial_dir: Path,
+    data: Mapping[str, Any],
+    *,
+    reward_key: str,
+    trace_format: Literal["otlp", "atif"] = EVIDENCE_FORMAT_ATIF,
+) -> AgentEvalTrial:
+    """Normalize one completed Harbor attempt into an SDK trial.
+
+    Args:
+        trial_dir: Directory containing the Harbor attempt result and evidence files.
+        data: Parsed contents of the attempt's ``result.json`` file.
+        reward_key: Verifier reward name to expose as the trial's primary reward.
+        trace_format: Trace format whose first discovered artifact should be exposed
+            under the standard ``trace`` evidence key.
+
+    Returns:
+        The normalized trial, including its identity, reward, error, measurements,
+        and evidence descriptors.
+    """
+    task_id = str(data["task_name"])
+    trial_id = str(data.get("trial_name") or trial_dir.name)
+    rewards = _rewards_mapping(data)
+    reward = _primary_reward(rewards, reward_key)
+    error = _trial_error(data.get("exception_info"))
+
+    metadata: dict[str, Any] = {
+        "reward": reward,
+        "reward_details": dict(rewards),
+        "harbor_trial_dir": str(trial_dir),
+    }
+    metadata.update(_trial_measurements(data))
+
+    # An errored trial (or one with no reward) stays PARTIAL so it is still scored
+    # as 0 and counted in the summary; FAILED would exclude it from scoring.
+    status = AgentEvalTrialStatus.COMPLETED if error is None and reward is not None else AgentEvalTrialStatus.PARTIAL
+
+    extension_descriptors, selected_trace = _harbor_extension_evidence(trial_dir, trace_format=trace_format)
+    descriptors = standard_evidence_descriptors(
+        logs_dir=(trial_dir / "agent").resolve(),
+        final_state_dir=(trial_dir / "artifacts").resolve(),
+        verifier_logs_dir=(trial_dir / "verifier").resolve(),
+    )
+    descriptors.update(extension_descriptors)
+    if selected_trace is not None:
+        descriptors[EVIDENCE_TRACE] = selected_trace
+
+    return AgentEvalTrial(
+        id=trial_id,
+        task_id=task_id,
+        status=status,
+        output=AgentOutput(metadata={"harbor_trial_dir": str(trial_dir)}),
+        evidence=CandidateEvidence(descriptors=descriptors),
+        error=error,
+        metadata=metadata,
+    )
+
+
+def _add_extension_descriptor(
+    descriptors: dict[str, EvidenceDescriptor],
+    *,
+    family: str,
+    relative_path: Path,
+    descriptor: EvidenceDescriptor,
+) -> None:
+    """Register an extension descriptor under canonical and compatible keys.
+
+    The canonical key includes the complete trial-relative path, for example
+    ``artifact:artifacts/output.txt``. This keeps the mapping injective when a
+    trial contains both ``output.txt`` and ``artifacts/output.txt``.
+
+    Experimentalist consumers remove the leading ``artifacts/`` directory
+    while naming collected artifacts, so they look up the same file through the
+    legacy alias ``artifact:output.txt``. The alias is retained during migration
+    to avoid breaking those consumers. ``setdefault`` ensures that an alias never
+    replaces an exact key belonging to another file.
+
+    Args:
+        descriptors: Mutable evidence mapping to update.
+        family: Evidence key prefix, such as ``artifact``, ``log``, or ``trace``.
+        relative_path: Artifact path relative to the Harbor trial directory.
+        descriptor: Descriptor that points to the artifact.
+
+    Returns:
+        None. The supplied ``descriptors`` mapping is updated in place.
+    """
+    descriptors[f"{family}:{relative_path.as_posix()}"] = descriptor
+    if relative_path.parts and relative_path.parts[0] == "artifacts" and len(relative_path.parts) > 1:
+        legacy_path = Path(*relative_path.parts[1:]).as_posix()
+        descriptors.setdefault(f"{family}:{legacy_path}", descriptor)
+
+
+def _is_trial_log_path(relative_path: str) -> bool:
+    """Determine whether a trial-relative path is a known Harbor log.
+
+    Args:
+        relative_path: POSIX-style path relative to the Harbor trial directory.
+
+    Returns:
+        ``True`` for a known Harbor log or agent command stdout file; otherwise
+        ``False``.
+    """
+    if relative_path in _TRIAL_LOG_DESCRIPTIONS:
+        return True
+    parts = relative_path.split("/")
+    return len(parts) == 3 and parts[0] == "agent" and parts[1].startswith("command-") and parts[2] == "stdout.txt"
+
+
+def _trace_format_from_path(relative_path: Path) -> Literal["otlp", "atif"] | None:
+    """Identify the trace format declared by Harbor's artifact path convention.
+
+    This classifies evidence without reading it: Harbor's path convention is the
+    contract, so discovery stays a catalog rather than a full ingest.
+    ``EvidenceDescriptor.format`` is a parser hint; ATIF content is validated
+    lazily when a consumer materializes the trace.
+
+    Args:
+        relative_path: Artifact path relative to the Harbor trial directory.
+
+    Returns:
+        ``"atif"`` or ``"otlp"`` for a supported file below a ``traces``
+        directory, or ``None`` when the path does not declare a recognized trace
+        format.
+    """
+    if "traces" not in relative_path.parts[:-1]:
+        return None
+    if relative_path.as_posix().endswith(_ATIF_TRACE_SUFFIX):
+        return EVIDENCE_FORMAT_ATIF
+    if relative_path.suffix == ".jsonl":
+        return EVIDENCE_FORMAT_OTLP
+    return None
+
+
+def _display_artifact_path(relative_path: Path) -> Path:
+    """Produce the historical display path for a Harbor artifact.
+
+    Args:
+        relative_path: Artifact path relative to the Harbor trial directory.
+
+    Returns:
+        The path without a leading ``artifacts/`` component when present, or the
+        original relative path otherwise.
+    """
+    if relative_path.parts and relative_path.parts[0] == "artifacts" and len(relative_path.parts) > 1:
+        return Path(*relative_path.parts[1:])
+    return relative_path
+
+
+def _harbor_extension_evidence(
+    trial_dir: Path,
+    *,
+    trace_format: Literal["otlp", "atif"],
+) -> tuple[dict[str, EvidenceDescriptor], EvidenceDescriptor | None]:
+    """Describe every Harbor trial file and select the standard trace.
+
+    Every discovered file remains available through an extension evidence key.
+    The first trace matching ``trace_format`` is additionally returned for the
+    standard ``trace`` key. Harbor's built-in ATIF dump ``agent/trajectory.json``
+    is used as a fallback when no path-declared ATIF file is present.
+
+    Args:
+        trial_dir: Harbor attempt directory to inspect recursively.
+        trace_format: Trace encoding to expose through the standard ``trace`` key.
+
+    Returns:
+        A pair containing all discovered extension descriptors and the selected
+        standard trace descriptor, or ``None`` when no matching trace exists.
+    """
+    descriptors: dict[str, EvidenceDescriptor] = {
+        "trial_dir": EvidenceDescriptor(
+            kind="filesystem",
+            format="dir",
+            ref=str(trial_dir.resolve()),
+            description=_TRIAL_DIR_DESCRIPTION,
+        )
+    }
+    collected_traces: dict[str, EvidenceDescriptor | None] = {
+        EVIDENCE_FORMAT_OTLP: None,
+        EVIDENCE_FORMAT_ATIF: None,
+    }
+    # ATIF from Harbor's older dump path ``agent/trajectory.json``. Used only when
+    # no canonical ATIF trace is found under ``traces/*.atif.json``.
+    legacy_atif: EvidenceDescriptor | None = None
+
+    try:
+        files = sorted(path for path in trial_dir.rglob("*") if path.is_file())
+    except OSError as exc:
+        logger.warning("Could not enumerate Harbor trial evidence under %s: %s", trial_dir, exc)
+        files = []
+
+    for path in files:
+        relative_path = path.relative_to(trial_dir)
+        relative_name = relative_path.as_posix()
+        try:
+            ref = str(path.resolve())
+        except OSError as exc:
+            logger.warning("Skipping unreadable Harbor trial evidence %s: %s", path, exc)
+            continue
+
+        if relative_name == "config.json":
+            descriptor = EvidenceDescriptor(
+                kind="json",
+                format=EVIDENCE_FORMAT_JSON,
+                ref=ref,
+                description=_TRIAL_CONFIG_DESCRIPTION,
+            )
+            descriptors["config"] = descriptor
+            _add_extension_descriptor(
+                descriptors,
+                family="json",
+                relative_path=relative_path,
+                descriptor=descriptor,
+            )
+            continue
+        if relative_name == "result.json":
+            descriptor = EvidenceDescriptor(
+                kind="json",
+                format=EVIDENCE_FORMAT_JSON,
+                ref=ref,
+                description=_TRIAL_RESULT_DESCRIPTION,
+            )
+            descriptors["result"] = descriptor
+            _add_extension_descriptor(
+                descriptors,
+                family="json",
+                relative_path=relative_path,
+                descriptor=descriptor,
+            )
+            continue
+
+        discovered_format = _trace_format_from_path(relative_path)
+        if discovered_format is not None:
+            display_path = _display_artifact_path(relative_path).as_posix()
+            description = (
+                f"Agent execution ATIF trajectory for {display_path}."
+                if discovered_format == EVIDENCE_FORMAT_ATIF
+                else f"Agent execution trace JSONL for {display_path}."
+            )
+            descriptor = EvidenceDescriptor(
+                kind=EVIDENCE_TRACE,
+                format=discovered_format,
+                ref=ref,
+                description=description,
+            )
+            _add_extension_descriptor(
+                descriptors,
+                family=EVIDENCE_TRACE,
+                relative_path=relative_path,
+                descriptor=descriptor,
+            )
+            if collected_traces[discovered_format] is None:
+                collected_traces[discovered_format] = descriptor
+            continue
+
+        if relative_name == "agent/trajectory.json" and read_atif(path) is not None:
+            descriptor = EvidenceDescriptor(
+                kind=EVIDENCE_TRACE,
+                format=EVIDENCE_FORMAT_ATIF,
+                ref=ref,
+                description="Collected Harbor artifact agent/trajectory.json.",
+            )
+            _add_extension_descriptor(
+                descriptors,
+                family=EVIDENCE_TRACE,
+                relative_path=relative_path,
+                descriptor=descriptor,
+            )
+            legacy_atif = descriptor
+            continue
+
+        if _is_trial_log_path(relative_name):
+            description = _TRIAL_LOG_DESCRIPTIONS.get(relative_name)
+            if description is None and relative_name.startswith("agent/command-"):
+                description = "Agent command stdout captured while Harbor runs the benchmark agent."
+            descriptor = EvidenceDescriptor(
+                kind="log",
+                format=EVIDENCE_FORMAT_JSON if path.suffix == ".json" else EVIDENCE_FORMAT_TEXT,
+                ref=ref,
+                description=description or f"Harbor trial log {relative_name}.",
+            )
+            _add_extension_descriptor(
+                descriptors,
+                family="log",
+                relative_path=relative_path,
+                descriptor=descriptor,
+            )
+            continue
+
+        display_path = _display_artifact_path(relative_path).as_posix()
+        description = f"Collected Harbor artifact {display_path}."
+        if relative_path.parts[0] == "artifacts" and display_path == "manifest.json":
+            description = (
+                "Harbor artifact manifest. Lists collected artifact files and the environment paths they were "
+                "copied from."
+            )
+        descriptor = EvidenceDescriptor(
+            kind="artifact",
+            ref=ref,
+            description=description,
+        )
+        _add_extension_descriptor(
+            descriptors,
+            family="artifact",
+            relative_path=relative_path,
+            descriptor=descriptor,
+        )
+
+    selected = collected_traces[trace_format]
+    if selected is None and trace_format == EVIDENCE_FORMAT_ATIF:
+        selected = legacy_atif
+    other_format = EVIDENCE_FORMAT_OTLP if trace_format == EVIDENCE_FORMAT_ATIF else EVIDENCE_FORMAT_ATIF
+    other = collected_traces[other_format]
+    if other is None and other_format == EVIDENCE_FORMAT_ATIF:
+        other = legacy_atif
+    if selected is None and other is not None:
+        logger.warning(
+            "Trial %s: configured trace_format='%s' matched no trace artifact, but %s artifacts are present. "
+            "This trial will have no trace — set trace_format='%s' if the agent under test emits %s.",
+            trial_dir.name,
+            trace_format,
+            other_format,
+            other_format,
+            other_format.upper(),
+        )
+    return descriptors, selected
+
+
+def _rewards_mapping(data: Mapping[str, Any]) -> dict[str, float]:
+    """Normalize Harbor verifier rewards into numeric SDK values.
+
+    Args:
+        data: Parsed Harbor ``result.json`` payload.
+
+    Returns:
+        A string-keyed mapping of rewards that can be converted to ``float``.
+        Missing, malformed, and non-numeric reward entries are omitted.
+    """
+    verifier_result = data.get("verifier_result")
+    if not isinstance(verifier_result, Mapping):
+        return {}
+    rewards = verifier_result.get("rewards")
+    if not isinstance(rewards, Mapping):
+        return {}
+    out: dict[str, float] = {}
+    for key, value in rewards.items():
+        try:
+            out[str(key)] = float(value)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def _primary_reward(rewards: Mapping[str, float], reward_key: str) -> float | None:
+    """Select the configured primary reward.
+
+    Args:
+        rewards: Normalized verifier rewards keyed by reward name.
+        reward_key: Reward name selected by the runtime configuration.
+
+    Returns:
+        The selected reward, or ``None`` when ``reward_key`` is absent. A warning
+        is emitted when other rewards exist but none matches the configured key.
+    """
+    if reward_key in rewards:
+        return rewards[reward_key]
+    if rewards:
+        logger.warning(
+            "Harbor trial emitted rewards %s but none matches reward_key=%r; treating the trial as having no reward",
+            sorted(rewards),
+            reward_key,
+        )
+    return None
+
+
+def _trial_error(exception_info: Any) -> TrialError | None:
+    """Normalize any Harbor ``exception_info`` shape without raising.
+
+    Args:
+        exception_info: Exception payload emitted by Harbor, which may be a
+            mapping, scalar value, or ``None``.
+
+    Returns:
+        A normalized trial error with a bounded traceback, or ``None`` when Harbor
+        reported no exception.
+    """
+    if exception_info is None:
+        return None
+    if not isinstance(exception_info, Mapping):
+        return TrialError(type=str(exception_info).strip() or UNKNOWN_ERROR_TYPE)
+
+    error_type = ""
+    for key in ("exception_type", "type", "name", "class"):
+        value = exception_info.get(key)
+        if isinstance(value, str) and value.strip():
+            error_type = value
+            break
+
+    traceback = _first_string(exception_info, ("exception_traceback", "traceback"))
+    return TrialError(
+        type=error_type or UNKNOWN_ERROR_TYPE,
+        message=_first_string(exception_info, ("exception_message", "message")),
+        traceback=traceback[:_MAX_TRACEBACK_CHARS] if traceback is not None else None,
+        occurred_at=_error_timestamp(exception_info.get("occurred_at")),
+    )
+
+
+def _first_string(payload: Mapping[str, Any], keys: tuple[str, ...]) -> str | None:
+    """Find the first string value among candidate mapping keys.
+
+    Args:
+        payload: Mapping to inspect.
+        keys: Candidate keys in lookup order.
+
+    Returns:
+        The first string value found, including an empty string, or ``None`` when
+        no candidate contains a string.
+    """
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _error_timestamp(value: Any) -> datetime | None:
+    """Parse an error timestamp without inventing a timezone.
+
+    Args:
+        value: Harbor timestamp value, typically a ``datetime`` or ISO-formatted
+            string.
+
+    Returns:
+        The supplied ``datetime`` or a parsed ISO timestamp. Returns ``None`` for
+        unsupported or invalid values and preserves whether the timestamp is
+        timezone-aware or naive.
+    """
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            return datetime.fromisoformat(value)
+    return None
+
+
+def _token_measurements(agent_result: Any) -> dict[str, int | float]:
+    """Extract valid token counts and cost from one Harbor agent result.
+
+    Args:
+        agent_result: Harbor agent-result payload to inspect.
+
+    Returns:
+        SDK measurement keys for integer token counts and finite numeric cost.
+        Missing, malformed, boolean, and non-finite values are omitted.
+    """
+    if not isinstance(agent_result, Mapping):
+        return {}
+    mapping = {
+        "prompt_tokens": "n_input_tokens",
+        "completion_tokens": "n_output_tokens",
+        "cache_read_tokens": "n_cache_tokens",
+    }
+    out: dict[str, int | float] = {}
+    for sdk_key, harbor_key in mapping.items():
+        value = agent_result.get(harbor_key)
+        if isinstance(value, int) and not isinstance(value, bool):
+            out[sdk_key] = value
+    cost = agent_result.get("cost_usd")
+    if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+        try:
+            numeric_cost = float(cost)
+        except (OverflowError, TypeError, ValueError):
+            numeric_cost = None
+        if numeric_cost is not None and math.isfinite(numeric_cost):
+            out["cost_usd"] = numeric_cost
+    return out
+
+
+def _trial_measurements(data: Mapping[str, Any]) -> dict[str, int | float]:
+    """Extract Harbor token and cost metadata from one result source.
+
+    A top-level ``agent_result`` takes precedence. When it is absent, valid
+    measurements from step-level agent results are aggregated exactly once.
+
+    Args:
+        data: Parsed Harbor ``result.json`` payload.
+
+    Returns:
+        SDK measurement keys for token counts and finite cost. Returns an empty
+        mapping when neither result source contains valid measurements.
+    """
+    top_level = data.get("agent_result")
+    if isinstance(top_level, Mapping):
+        return _token_measurements(top_level)
+
+    step_results = data.get("step_results")
+    if not isinstance(step_results, list):
+        return {}
+
+    totals: dict[str, int | float] = {}
+    costs: list[float] = []
+    for step in step_results:
+        if not isinstance(step, Mapping):
+            continue
+        for key, value in _token_measurements(step.get("agent_result")).items():
+            if key == "cost_usd":
+                costs.append(float(value))
+            else:
+                totals[key] = int(totals.get(key, 0)) + int(value)
+    if costs:
+        try:
+            total_cost = math.fsum(costs)
+        except OverflowError:
+            total_cost = None
+        if total_cost is not None and math.isfinite(total_cost):
+            totals["cost_usd"] = total_cost
+    return totals

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/tasks.py
@@ -11,7 +11,7 @@ from typing import Any, Protocol, runtime_checkable
 
 from nemo_evaluator_sdk.metrics.protocol import Metric
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
-from nemo_evaluator_sdk.values import RunConfig, RunConfigOnline, RunConfigOnlineModel
+from nemo_evaluator_sdk.values.params import RunConfig, RunConfigOnline, RunConfigOnlineModel
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
 
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/agent_eval/trials.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Annotated, Any, Protocol, runtime_checkable
 
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
-from nemo_evaluator_sdk.values import Agent, Model
+from nemo_evaluator_sdk.values.agents import Agent
 from nemo_evaluator_sdk.values.evidence import (
     EVIDENCE_FINAL_STATE,
     EVIDENCE_FORMAT_ATIF,
@@ -26,6 +26,7 @@ from nemo_evaluator_sdk.values.evidence import (
     CandidateEvidence,
     EvidenceDescriptor,
 )
+from nemo_evaluator_sdk.values.models import Model
 from nemo_evaluator_sdk.values.results import AggregateScore
 from pydantic import (
     BaseModel,
@@ -172,6 +173,20 @@ class AgentEvalTrial(BaseModel):
             raise ValueError("completed trial requires output")
         return self
 
+    def get_evidence(self, name: str) -> EvidenceDescriptor | None:
+        """Look up a named evidence descriptor for this trial.
+
+        Args:
+            name: Evidence key to retrieve.
+
+        Returns:
+            The matching descriptor, or ``None`` when the trial has no evidence or
+            the key is not present.
+        """
+        if self.evidence is None:
+            return None
+        return self.evidence.get(name)
+
 
 @runtime_checkable
 class AgentTaskRunner(Protocol):
@@ -285,8 +300,12 @@ def standard_evidence_descriptors(
     dir), ``final_state`` (workspace), and ``verifier_logs`` (only when present).
     Callers may add their own extension keys to the returned mapping.
 
-    ``trace_format`` declares the trace's format; without it the format is inferred from the
-    filename, which misreads an ATIF trajectory that is not named for it.
+    ``trace_format`` is the producer's parser hint. Without it, the hint is
+    inferred from the trace basename without reading the file: ``atif`` when the
+    name starts with ``atif`` or contains ``.atif.`` (for example
+    ``atif-trace.json`` or ``trajectory.atif.json``), otherwise ``json``.
+    Producers whose filenames do not follow that pattern can call
+    ``read_atif()`` first and pass ``trace_format`` only when parsing succeeds.
     """
     descriptors: dict[str, EvidenceDescriptor] = {}
 

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/__init__.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     )
     from nemo_evaluator_sdk.values.datasets import DatasetInput, DatasetRows
     from nemo_evaluator_sdk.values.evidence import (
+        ATIFTraceHandle,
         CandidateEvidence,
         CommandResult,
         EvidenceDescriptor,
@@ -50,6 +51,7 @@ if TYPE_CHECKING:
         FilesystemEntry,
         LocalFilesystemEvidence,
         LogHandle,
+        OTLPTraceHandle,
         TraceHandle,
         WellKnownEvidenceKey,
         parse_atif,
@@ -157,6 +159,7 @@ _LAZY_ATTRS: dict[str, str] = {
     "InputSchema": ".dataset_schemas",
     "DatasetInput": ".datasets",
     "DatasetRows": ".datasets",
+    "ATIFTraceHandle": ".evidence",
     "CandidateEvidence": ".evidence",
     "CommandResult": ".evidence",
     "EvidenceDescriptor": ".evidence",
@@ -164,6 +167,7 @@ _LAZY_ATTRS: dict[str, str] = {
     "FilesystemEntry": ".evidence",
     "LocalFilesystemEvidence": ".evidence",
     "LogHandle": ".evidence",
+    "OTLPTraceHandle": ".evidence",
     "TraceHandle": ".evidence",
     "WellKnownEvidenceKey": ".evidence",
     "parse_atif": ".evidence",
@@ -251,6 +255,7 @@ __all__ = [
     "AggregateRubricScore",
     "AggregateScore",
     "AggregateScoreBase",
+    "ATIFTraceHandle",
     "BenchmarkEvaluationResult",
     "BooleanValue",
     "CandidateEvidence",
@@ -264,6 +269,7 @@ __all__ = [
     "Metrics",
     "Observation",
     "ObservationResult",
+    "OTLPTraceHandle",
     "Step",
     "ToolCall",
     "Trajectory",

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -16,7 +16,7 @@ import signal
 import tempfile
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias, cast
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, PrivateAttr, model_validator
@@ -38,6 +38,7 @@ EVIDENCE_TRANSLATION_ERROR = "translation_error"
 
 EVIDENCE_FORMAT_ATIF = "atif"
 EVIDENCE_FORMAT_JSON = "json"
+EVIDENCE_FORMAT_OTLP = "otlp"
 EVIDENCE_FORMAT_TEXT = "text"
 
 # Well-known evidence keys used by the core agent-eval artifact contract.
@@ -318,6 +319,10 @@ class EvidenceDescriptor(BaseModel):
         default=None,
         description="Small inline evidence payload; at least one of ref or data must be set.",
     )
+    description: str | None = Field(
+        default=None,
+        description="Human-readable description of this evidence artifact.",
+    )
     metadata: dict[str, Any] = Field(
         default_factory=dict,
         description="Free-form metadata associated with the evidence descriptor.",
@@ -356,8 +361,99 @@ def read_atif(path: Path) -> Trajectory | None:
         return None
 
 
-class TraceHandle:
+class OTLPTraceHandle:
+    """Lazily loaded read handle over OTLP/JSON (JSONL or a single object)."""
+
+    format: Literal["otlp"] = "otlp"
+
+    def __init__(self, descriptor: EvidenceDescriptor) -> None:
+        self._descriptor = descriptor
+        self._resource_spans: list[dict[str, Any]] | None = None
+
+    async def resource_spans(self) -> list[dict[str, Any]]:
+        """Return concatenated OTLP ``resourceSpans``, loading and validating once.
+
+        Returns:
+            Resource-span objects in request and file order.
+        """
+        if self._resource_spans is None:
+            self._resource_spans = await asyncio.to_thread(self._load_resource_spans)
+        return self._resource_spans
+
+    def _load_resource_spans(self) -> list[dict[str, Any]]:
+        """Load inline or local OTLP evidence into its resource-span export units.
+
+        Returns:
+            Validated resource-span objects from every request.
+        """
+        descriptor = self._descriptor
+        if descriptor.data is not None:
+            if isinstance(descriptor.data, list):
+                return self._validate_resource_spans(descriptor.data)
+            return self._resource_spans_from_request(descriptor.data)
+        if descriptor.ref is None:
+            raise ValueError("trace evidence descriptor requires ref or data")
+
+        raw = _local_filesystem_ref(descriptor.ref).read_text(encoding="utf-8")
+        if not raw.strip():
+            return []
+        try:
+            requests = [json.loads(raw)]
+        except json.JSONDecodeError:
+            requests = []
+            for line_number, line in enumerate(raw.splitlines(), start=1):
+                if not line.strip():
+                    continue
+                try:
+                    requests.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"invalid OTLP JSON on line {line_number}") from exc
+
+        resource_spans: list[dict[str, Any]] = []
+        for request in requests:
+            resource_spans.extend(self._resource_spans_from_request(request))
+        return resource_spans
+
+    @classmethod
+    def _resource_spans_from_request(cls, request: Any) -> list[dict[str, Any]]:
+        """Extract validated ``resourceSpans`` from one OTLP request object.
+
+        Args:
+            request: Decoded OTLP/JSON request value.
+
+        Returns:
+            The request's validated resource-span objects.
+        """
+        if not isinstance(request, dict):
+            raise ValueError("OTLP trace request must be an object")
+        if "resourceSpans" not in request:
+            raise ValueError("OTLP trace request requires a resourceSpans list")
+        return cls._validate_resource_spans(request["resourceSpans"])
+
+    @staticmethod
+    def _validate_resource_spans(value: Any) -> list[dict[str, Any]]:
+        """Validate the list shape exposed by :meth:`resource_spans`.
+
+        Args:
+            value: Candidate resource-span list.
+
+        Returns:
+            Resource-span objects in their original order.
+        """
+        if not isinstance(value, list):
+            raise ValueError("OTLP resourceSpans must be a list")
+        resource_spans: list[dict[str, Any]] = []
+        for index, resource_span in enumerate(value):
+            if not isinstance(resource_span, dict):
+                raise ValueError(f"OTLP resourceSpans[{index}] must be an object")
+            resource_spans.append(cast(dict[str, Any], resource_span))
+        return resource_spans
+
+
+class ATIFTraceHandle:
     """Lazily validated read handle exposing a trace descriptor as an ATIF :class:`Trajectory`."""
+
+    format: Literal["atif"] = "atif"
 
     def __init__(self, descriptor: EvidenceDescriptor) -> None:
         self._descriptor = descriptor
@@ -397,6 +493,9 @@ class TraceHandle:
         prompt = sum((step.metrics.prompt_tokens or 0) for step in trajectory.steps if step.metrics is not None)
         completion = sum((step.metrics.completion_tokens or 0) for step in trajectory.steps if step.metrics is not None)
         return FinalMetrics(total_prompt_tokens=prompt or None, total_completion_tokens=completion or None)
+
+
+TraceHandle: TypeAlias = ATIFTraceHandle | OTLPTraceHandle
 
 
 class LogHandle:
@@ -484,7 +583,14 @@ class CandidateEvidence(BaseModel):
         cached = self._trace_cache.get(name)
         if cached is not None:
             return cached
-        handle = TraceHandle(self.require(name, kind="trace"))
+        descriptor = self.require(name, kind="trace")
+        handle: TraceHandle
+        if descriptor.format is None or descriptor.format == EVIDENCE_FORMAT_ATIF:
+            handle = ATIFTraceHandle(descriptor)
+        elif descriptor.format == EVIDENCE_FORMAT_OTLP:
+            handle = OTLPTraceHandle(descriptor)
+        else:
+            raise ValueError(f"unknown trace evidence format {descriptor.format!r}")
         self._trace_cache[name] = handle
         return handle
 

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py
@@ -11,11 +11,15 @@ from pathlib import Path
 import pytest
 from nemo_evaluator_sdk.execution.samples import build_metric_input
 from nemo_evaluator_sdk.values.evidence import (
+    EVIDENCE_FORMAT_ATIF,
+    EVIDENCE_FORMAT_OTLP,
+    ATIFTraceHandle,
     CandidateEvidence,
     EvidenceDescriptor,
     LocalFilesystemEvidence,
+    OTLPTraceHandle,
 )
-from pydantic import ValidationError
+from pydantic import JsonValue, ValidationError
 
 
 def test_metric_input_preserves_candidate_evidence_out_of_metadata() -> None:
@@ -316,6 +320,8 @@ async def test_trace_handle_reads_atif(tmp_path: Path) -> None:
         descriptors={"trace": EvidenceDescriptor(kind="trace", ref=str(trace_path), format="atif")}
     )
     handle = await evidence.trace("trace")
+    assert isinstance(handle, ATIFTraceHandle)
+    assert handle.format == "atif"
     assert handle is await evidence.trace("trace")  # cached
     trajectory = await handle.trace()
     assert trajectory.schema_version == "ATIF-v1.7"
@@ -327,8 +333,116 @@ async def test_trace_handle_reads_atif(tmp_path: Path) -> None:
     bad = CandidateEvidence(
         descriptors={"trace": EvidenceDescriptor(kind="trace", format="atif", data={"steps": "not-a-list"})}
     )
+    bad_handle = await bad.trace("trace")
+    assert isinstance(bad_handle, ATIFTraceHandle)
     with pytest.raises(ValidationError):
-        await (await bad.trace("trace")).trace()
+        await bad_handle.trace()
+
+
+@pytest.mark.asyncio
+async def test_trace_handle_reads_atif_when_optional_format_is_absent() -> None:
+    evidence = CandidateEvidence(descriptors={"trace": EvidenceDescriptor(kind="trace", data=_ATIF_TRAJECTORY)})
+
+    handle = await evidence.trace("trace")
+    assert isinstance(handle, ATIFTraceHandle)
+    assert handle.format == "atif"
+    trajectory = await handle.trace()
+
+    assert trajectory.schema_version == "ATIF-v1.7"
+
+
+@pytest.mark.asyncio
+async def test_trace_handle_reads_otlp_jsonl_and_inline_data(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    trace_path.write_text(
+        json.dumps({"resourceSpans": [{"schemaUrl": "keep-me", "scopeSpans": []}]})
+        + "\n"
+        + json.dumps({"resourceSpans": [{"scopeSpans": [{"spans": [{"name": "child"}]}]}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    evidence = CandidateEvidence(
+        descriptors={"trace": EvidenceDescriptor(kind="trace", format=EVIDENCE_FORMAT_OTLP, ref=str(trace_path))}
+    )
+
+    assert EVIDENCE_FORMAT_ATIF == "atif"
+    assert EVIDENCE_FORMAT_OTLP == "otlp"
+    handle = await evidence.trace("trace")
+    assert isinstance(handle, OTLPTraceHandle)
+    assert handle.format == "otlp"
+    assert handle is await evidence.trace("trace")
+
+    resource_spans = await handle.resource_spans()
+    assert len(resource_spans) == 2
+    assert resource_spans[0]["schemaUrl"] == "keep-me"
+    assert resource_spans[1]["scopeSpans"][0]["spans"][0]["name"] == "child"
+
+    inline = CandidateEvidence(
+        descriptors={"trace": EvidenceDescriptor(kind="trace", format="otlp", data=[{"scopeSpans": []}])}
+    )
+    inline_handle = await inline.trace("trace")
+    assert isinstance(inline_handle, OTLPTraceHandle)
+    assert await inline_handle.resource_spans() == [{"scopeSpans": []}]
+
+
+@pytest.mark.asyncio
+async def test_trace_handle_reads_pretty_printed_otlp_object(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.json"
+    trace_path.write_text(
+        json.dumps({"resourceSpans": [{"scopeSpans": []}]}, indent=2),
+        encoding="utf-8",
+    )
+    evidence = CandidateEvidence(
+        descriptors={"trace": EvidenceDescriptor(kind="trace", format="otlp", ref=str(trace_path))}
+    )
+
+    handle = await evidence.trace()
+    assert isinstance(handle, OTLPTraceHandle)
+    assert await handle.resource_spans() == [{"scopeSpans": []}]
+
+
+@pytest.mark.asyncio
+async def test_trace_handle_caches_empty_otlp_after_first_read(tmp_path: Path) -> None:
+    trace_path = tmp_path / "empty.jsonl"
+    trace_path.write_text('{"resourceSpans": []}\n', encoding="utf-8")
+    evidence = CandidateEvidence(
+        descriptors={"trace": EvidenceDescriptor(kind="trace", format="otlp", ref=str(trace_path))}
+    )
+
+    handle = await evidence.trace()
+    assert isinstance(handle, OTLPTraceHandle)
+    assert await handle.resource_spans() == []
+    trace_path.unlink()
+    assert await handle.resource_spans() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "not-an-object",
+        {},
+        {"resourceSpans": "not-a-list"},
+        {"resourceSpans": ["not-an-object"]},
+    ],
+)
+async def test_trace_handle_rejects_malformed_otlp(payload: JsonValue) -> None:
+    evidence = CandidateEvidence(descriptors={"trace": EvidenceDescriptor(kind="trace", format="otlp", data=payload)})
+
+    handle = await evidence.trace()
+    assert isinstance(handle, OTLPTraceHandle)
+    with pytest.raises(ValueError):
+        await handle.resource_spans()
+
+
+@pytest.mark.asyncio
+async def test_trace_handle_rejects_unknown_format() -> None:
+    evidence = CandidateEvidence(
+        descriptors={"trace": EvidenceDescriptor(kind="trace", format="json", data={"resourceSpans": []})}
+    )
+
+    with pytest.raises(ValueError, match="unknown trace evidence format 'json'"):
+        await evidence.trace()
 
 
 @pytest.mark.asyncio
@@ -337,7 +451,9 @@ async def test_trace_handle_exposes_typed_tool_evidence_and_retains_modeled_fiel
         descriptors={"trace": EvidenceDescriptor(kind="trace", format="atif", data=_ATIF_TRAJECTORY)}
     )
 
-    trajectory = await (await evidence.trace("trace")).trace()
+    handle = await evidence.trace("trace")
+    assert isinstance(handle, ATIFTraceHandle)
+    trajectory = await handle.trace()
     assert trajectory.agent is not None
     assert trajectory.agent.name == "demo"
     assert trajectory.session_id == "session-1"

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_example_metrics.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_example_metrics.py
@@ -9,7 +9,12 @@ from pathlib import Path
 
 import pytest
 from nemo_evaluator_sdk.execution.samples import build_metric_input
-from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+from nemo_evaluator_sdk.values.evidence import (
+    EVIDENCE_FORMAT_ATIF,
+    EVIDENCE_FORMAT_OTLP,
+    CandidateEvidence,
+    EvidenceDescriptor,
+)
 
 _MODULE_PATH = Path(__file__).resolve().parents[2] / "examples" / "run_agent_eval" / "example_metrics.py"
 _spec = importlib.util.spec_from_file_location("example_metrics", _MODULE_PATH)
@@ -20,6 +25,39 @@ _spec.loader.exec_module(example_metrics)
 
 def _input_with_evidence(evidence: CandidateEvidence):
     return build_metric_input({"prompt": "q"}, {"evidence": evidence}, index=0)
+
+
+def _otlp_evidence(spans: list[object], *extra_resource_spans: object) -> CandidateEvidence:
+    return CandidateEvidence(
+        descriptors={
+            "trace": EvidenceDescriptor(
+                kind="trace",
+                format=EVIDENCE_FORMAT_OTLP,
+                data={
+                    "resourceSpans": [
+                        {"scopeSpans": [{"spans": spans}]},
+                        *extra_resource_spans,
+                    ]
+                },
+            )
+        }
+    )
+
+
+def _otlp_tool_span(
+    name: str,
+    arguments: dict[str, object] | None,
+    start_ns: int,
+    *,
+    kind: str = "TOOL",
+) -> dict[str, object]:
+    attributes: list[dict[str, object]] = [
+        {"key": "openinference.span.kind", "value": {"stringValue": kind}},
+        {"key": "tool.name", "value": {"stringValue": name}},
+    ]
+    if arguments is not None:
+        attributes.append({"key": "input.value", "value": {"stringValue": json.dumps(arguments)}})
+    return {"name": name, "startTimeUnixNano": str(start_ns), "attributes": attributes}
 
 
 @pytest.mark.asyncio
@@ -79,13 +117,75 @@ async def test_inefficient_retry_loop(tmp_path: Path) -> None:
 
     loop_result = await metric.compute_scores(
         _input_with_evidence(
-            CandidateEvidence(descriptors={"trace": EvidenceDescriptor(kind="trace", ref=str(looping))})
+            CandidateEvidence(
+                descriptors={"trace": EvidenceDescriptor(kind="trace", format=EVIDENCE_FORMAT_ATIF, ref=str(looping))}
+            )
         )
     )
     assert loop_result.outputs[0].value is False
     assert loop_result.outputs[1].value == 5
 
     clean_result = await metric.compute_scores(
-        _input_with_evidence(CandidateEvidence(descriptors={"trace": EvidenceDescriptor(kind="trace", ref=str(clean))}))
+        _input_with_evidence(
+            CandidateEvidence(
+                descriptors={"trace": EvidenceDescriptor(kind="trace", format=EVIDENCE_FORMAT_ATIF, ref=str(clean))}
+            )
+        )
     )
     assert clean_result.outputs[0].value is True
+
+
+@pytest.mark.asyncio
+async def test_inefficient_retry_loop_reads_time_ordered_otlp_tool_spans() -> None:
+    evidence = _otlp_evidence(
+        [
+            _otlp_tool_span("search", {"q": "same"}, 30),
+            _otlp_tool_span("search", {"q": "same"}, 10),
+            _otlp_tool_span("search", {"q": "same"}, 20),
+        ]
+    )
+
+    result = await example_metrics.InefficientRetryLoopMetric(threshold=2).compute_scores(
+        _input_with_evidence(evidence)
+    )
+
+    assert result.outputs[0].value is False
+    assert result.outputs[1].value == 3
+
+
+@pytest.mark.asyncio
+async def test_inefficient_retry_loop_ignores_non_tool_and_malformed_otlp_spans() -> None:
+    evidence = _otlp_evidence(
+        [
+            _otlp_tool_span("search", {"q": "same"}, 10),
+            _otlp_tool_span("search", {"q": "same"}, 20, kind="CHAIN"),
+            "not-a-span",
+            _otlp_tool_span("search", {"q": "different"}, 30),
+        ],
+        {"scopeSpans": "not-a-list"},
+    )
+
+    result = await example_metrics.InefficientRetryLoopMetric(threshold=1).compute_scores(
+        _input_with_evidence(evidence)
+    )
+
+    assert result.outputs[0].value is True
+    assert result.outputs[1].value == 1
+
+
+@pytest.mark.asyncio
+async def test_inefficient_retry_loop_rejects_otlp_tool_without_arguments() -> None:
+    evidence = _otlp_evidence(
+        [
+            {
+                "name": "search",
+                "attributes": [
+                    {"key": "gen_ai.operation.name", "value": {"stringValue": "execute_tool"}},
+                    {"key": "gen_ai.tool.name", "value": {"stringValue": "search"}},
+                ],
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="retry identity is unavailable"):
+        await example_metrics.InefficientRetryLoopMetric().compute_scores(_input_with_evidence(evidence))

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -13,32 +13,35 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from types import ModuleType
+from typing import Literal
 
 import pytest
 from nemo_evaluator_sdk.agent_eval.evaluator import AgentEvaluator
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalSummary
 from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import (
-    _MAX_TRACEBACK_CHARS,
     HarborAgentTaskRunner,
     HarborRewardMetric,
     HarborRuntimeConfig,
     HarborTasksetLoader,
     _build_native_job,
-    _trial_error,
     build_trials_from_job_dir,
     discover_harbor_tasks,
     reward_payload_from_result,
+    run_harbor_eval,
     scoped_harbor_agent_import,
 )
+from nemo_evaluator_sdk.agent_eval.runtimes.harbor_trial_adapter import _trial_from_harbor_result
 from nemo_evaluator_sdk.agent_eval.tasks import AgentEvalRunConfig, AgentEvalTask
-from nemo_evaluator_sdk.agent_eval.trials import UNKNOWN_ERROR_TYPE, AgentEvalTrial, AgentEvalTrialStatus, TrialError
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, TrialError
 from nemo_evaluator_sdk.metrics.utils import metric_type_name
+from nemo_evaluator_sdk.values.evidence import ATIFTraceHandle
 from pydantic import BaseModel, ValidationError
 
 _HELLO_WORLD_DATASET = Path(__file__).resolve().parents[2] / "examples" / "harbor" / "hello_world_dataset"
 _FIXTURES = Path(__file__).parent / "fixtures"
 # A verbatim Harbor result.json from a real agent-timeout run, host paths scrubbed.
 _HARBOR_ERROR_RESULT = _FIXTURES / "harbor_error_result.json"
+_EXPECTED_MAX_TRACEBACK_CHARS = 8192
 
 
 def _write_trial(
@@ -414,6 +417,56 @@ async def test_native_runner_uses_job_dir_as_cache(tmp_path: Path, monkeypatch: 
     assert imported == [], f"a cache hit must not import harbor, but imported {imported}"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["native", "offline"])
+async def test_runner_forwards_trace_format_in_both_modes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+) -> None:
+    from nemo_evaluator_sdk.agent_eval.runtimes import harbor_runtime
+
+    config, job_dir, task = _seed_cached_job(tmp_path)
+    observed: list[str] = []
+    real_build_trials = harbor_runtime.build_trials_from_job_dir
+
+    def recording_build_trials(job_dir, tasks, *, reward_key="reward", trace_format="atif"):
+        observed.append(trace_format)
+        return real_build_trials(job_dir, tasks, reward_key=reward_key, trace_format=trace_format)
+
+    monkeypatch.setattr(harbor_runtime, "build_trials_from_job_dir", recording_build_trials)
+    runner = (
+        HarborAgentTaskRunner(config=config, trace_format="otlp")
+        if mode == "native"
+        else HarborAgentTaskRunner(job_dir=job_dir, trace_format="otlp")
+    )
+
+    await runner.run_tasks([task])
+
+    assert observed == ["otlp"]
+
+
+@pytest.mark.asyncio
+async def test_run_harbor_eval_forwards_trace_format_to_the_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    observed: list[str] = []
+    sentinel = object()
+
+    async def recording_run(self, *, tasks, target, config):
+        observed.append(target.runner_info().config["trace_format"])
+        return sentinel
+
+    monkeypatch.setattr(AgentEvaluator, "run", recording_run)
+
+    result = await run_harbor_eval(
+        HarborRuntimeConfig(jobs_dir=tmp_path / "jobs"),
+        _HELLO_WORLD_DATASET,
+        trace_format="otlp",
+    )
+
+    assert result is sentinel
+    assert observed == ["otlp"]
+
+
 def _stamp_for(config: HarborRuntimeConfig, task: AgentEvalTask, job_dir: Path) -> None:
     """Stamp ``job_dir`` as though ``config`` had just produced it."""
     from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import _cache_stamp, _write_cache_stamp
@@ -580,6 +633,60 @@ def test_unpinned_job_name_writes_no_stamp_and_reads_no_files(tmp_path: Path) ->
     assert not list((tmp_path / "jobs").glob("**/.nemo-eval-harbor-cache.json"))
 
 
+@pytest.mark.parametrize("job_name", ["..", "../outside", "/tmp/harbor-escape", "."])
+def test_resolve_job_dir_rejects_paths_outside_jobs_dir(tmp_path: Path, job_name: str) -> None:
+    # force_rerun shutil.rmtree's this path. A job_name that escapes jobs_dir would
+    # delete arbitrary directories; Harbor's native evaluator already refuses that.
+    from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import _resolve_job_dir
+
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    config = HarborRuntimeConfig(jobs_dir=jobs_dir, job_name=job_name)
+
+    with pytest.raises(ValueError, match="strict descendant"):
+        _resolve_job_dir(config)
+
+
+def test_resolve_job_dir_accepts_a_nested_descendant(tmp_path: Path) -> None:
+    from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import _resolve_job_dir
+
+    jobs_dir = tmp_path / "jobs"
+    config = HarborRuntimeConfig(jobs_dir=jobs_dir, job_name="debug-rerun")
+
+    name, job_dir = _resolve_job_dir(config)
+
+    assert name == "debug-rerun"
+    assert job_dir == (jobs_dir / "debug-rerun").resolve()
+    assert job_dir.is_relative_to(jobs_dir.resolve())
+    assert job_dir != jobs_dir.resolve()
+
+
+def test_build_native_job_rejects_escaping_job_name_before_rmtree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # _build_native_job concatenates jobs_dir/job_name independently of _resolve_job_dir.
+    # The containment check must live here too, or force_rerun still rmtree's the escape.
+    jobs_dir = tmp_path / "jobs"
+    jobs_dir.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "keep.txt"
+    marker.write_text("do not delete", encoding="utf-8")
+
+    rmtree_calls: list[Path] = []
+    monkeypatch.setattr(
+        "nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime.shutil.rmtree",
+        lambda path, **kwargs: rmtree_calls.append(Path(path)),
+    )
+
+    config = HarborRuntimeConfig(jobs_dir=jobs_dir, job_name="../outside", force_rerun=True)
+    with pytest.raises(ValueError, match="strict descendant"):
+        _build_native_job(config, tmp_path / "dataset", None, job_name="../outside", force_rerun=True)
+
+    assert rmtree_calls == []
+    assert marker.read_text(encoding="utf-8") == "do not delete"
+
+
 def test_cache_stamp_survives_harbors_stray_directory_sweep(tmp_path: Path) -> None:
     # Harbor rmtree's any *directory* in a job dir lacking result.json. The stamp must
     # therefore be a file, or it would be silently deleted on the next Harbor run.
@@ -621,12 +728,14 @@ def test_multiple_attempts_map_to_one_trial_each(tmp_path: Path) -> None:
     # distinct trial for the same task id (so the summary can aggregate over attempts).
     job_dir = tmp_path / "job"
     job_dir.mkdir()
-    _write_trial(job_dir, "t__aaa", "t", reward=1.0)
-    _write_trial(job_dir, "t__bbb", "t", reward=0.0)
+    _write_trial(job_dir, "t__a1B2", "t", reward=1.0)
+    _write_trial(job_dir, "t__Z9y8", "t", reward=0.0)
     tasks = [AgentEvalTask(id="t", intent="x", inputs={"instruction": "p"}, metrics=[HarborRewardMetric()])]
 
     trials = build_trials_from_job_dir(job_dir, tasks)
     assert [trial.task_id for trial in trials] == ["t", "t"]
+    assert [trial.id for trial in trials] == ["t__Z9y8", "t__a1B2"]
+    assert all("harbor_attempt" not in trial.metadata for trial in trials)
     assert sorted(trial.metadata["reward"] for trial in trials) == [0.0, 1.0]
 
 
@@ -1617,7 +1726,10 @@ def test_an_oversized_traceback_is_truncated(tmp_path: Path) -> None:
         "t__aaa",
         "t",
         reward=1.0,
-        exception={"exception_type": "RuntimeError", "exception_traceback": "x" * (_MAX_TRACEBACK_CHARS * 3)},
+        exception={
+            "exception_type": "RuntimeError",
+            "exception_traceback": "x" * (_EXPECTED_MAX_TRACEBACK_CHARS * 3),
+        },
     )
 
     [trial] = build_trials_from_job_dir(
@@ -1626,7 +1738,7 @@ def test_an_oversized_traceback_is_truncated(tmp_path: Path) -> None:
 
     assert trial.error is not None
     assert trial.error.traceback is not None
-    assert len(trial.error.traceback) == _MAX_TRACEBACK_CHARS
+    assert len(trial.error.traceback) == _EXPECTED_MAX_TRACEBACK_CHARS
 
 
 def test_absent_exception_info_leaves_the_trial_completed(tmp_path: Path) -> None:
@@ -1663,12 +1775,6 @@ def test_the_typed_error_is_the_only_carrier(tmp_path: Path) -> None:
     assert fresh.error is not None and fresh.error.type == "RuntimeError"
     assert "exception_type" not in fresh.metadata
     assert legacy.error is None  # free-form metadata is never promoted to a typed error
-
-
-def test_a_degenerate_exception_type_normalises_to_the_fallback() -> None:
-    error = _trial_error({"exception_type": ""})
-    assert error is not None
-    assert error.type == UNKNOWN_ERROR_TYPE
 
 
 def test_occurred_at_is_not_advertised_as_rfc_3339() -> None:
@@ -1723,6 +1829,13 @@ def test_a_real_harbor_error_payload_reaches_the_summary_rollup(tmp_path: Path) 
     # Errored, but still scored -- FAILED would exclude it from scoring entirely.
     assert trial.status is AgentEvalTrialStatus.PARTIAL
     assert trial.metadata["reward"] == 0.0
+    assert "exception_info" not in trial.metadata
+
+    result_evidence = trial.get_evidence("result")
+    assert result_evidence is not None
+    assert result_evidence.ref is not None
+    raw_result = json.loads(Path(result_evidence.ref).read_text(encoding="utf-8"))
+    assert raw_result["exception_info"] == payload["exception_info"]
 
     summary = AgentEvalSummary.from_scores([], trials=[trial])
     assert summary.error_trial_ids == {"AgentTimeoutError": [trial_name]}
@@ -1743,9 +1856,9 @@ def _atif_trajectory_payload() -> dict[str, object]:
     }
 
 
-def _trial_with_trajectory(tmp_path: Path, payload: object) -> AgentEvalTrial:
-    from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import _trial_from_harbor_result
-
+def _trial_with_trajectory(
+    tmp_path: Path, payload: object, *, trace_format: Literal["otlp", "atif"] = "atif"
+) -> AgentEvalTrial:
     job_dir = tmp_path / "job"
     _write_trial(job_dir, "t__1", "t", reward=1.0)
     trial_dir = job_dir / "t__1"
@@ -1754,23 +1867,362 @@ def _trial_with_trajectory(tmp_path: Path, payload: object) -> AgentEvalTrial:
     else:
         (trial_dir / "agent" / "trajectory.json").write_text(json.dumps(payload))
     data = json.loads((trial_dir / "result.json").read_text())
-    return _trial_from_harbor_result(trial_dir, data, reward_key="reward")
+    return _trial_from_harbor_result(trial_dir, data, reward_key="reward", trace_format=trace_format)
 
 
 def test_atif_trajectory_is_labelled_atif(tmp_path: Path) -> None:
     trial = _trial_with_trajectory(tmp_path, _atif_trajectory_payload())
 
     # Harbor names the file trajectory.json, so only its contents identify it as ATIF.
-    assert trial.evidence.descriptors["trace"].format == "atif"
+    trace = trial.get_evidence("trace")
+    assert trace is not None
+    assert trace.format == "atif"
+    assert trace.description == "Collected Harbor artifact agent/trajectory.json."
+    assert trace.metadata == {}
 
 
 def test_absent_trajectory_leaves_no_trace_evidence(tmp_path: Path) -> None:
     trial = _trial_with_trajectory(tmp_path, None)
 
-    assert trial.evidence.descriptors.get("trace") is None
+    assert trial.get_evidence("trace") is None
 
 
-def test_non_atif_trajectory_is_kept_as_json_evidence(tmp_path: Path) -> None:
+def test_non_atif_trajectory_is_an_artifact_not_standard_trace(tmp_path: Path) -> None:
     trial = _trial_with_trajectory(tmp_path, {"not": "atif"})
 
-    assert trial.evidence.descriptors["trace"].format == "json"
+    assert trial.get_evidence("trace") is None
+    artifact = trial.get_evidence("artifact:agent/trajectory.json")
+    assert artifact is not None
+    assert artifact.kind == "artifact"
+
+
+def _adapted_measurements(tmp_path: Path, result_data: dict[str, object]) -> dict[str, int | float]:
+    trial_dir = tmp_path / "measurement-trial"
+    trial_dir.mkdir(exist_ok=True)
+    payload: dict[str, object] = {
+        "task_name": "task",
+        "trial_name": "task__1",
+        "verifier_result": {"rewards": {"reward": 1.0}},
+        "exception_info": None,
+    }
+    payload.update(result_data)
+    trial = _trial_from_harbor_result(trial_dir, payload, reward_key="reward")
+    keys = ("prompt_tokens", "completion_tokens", "cache_read_tokens", "cost_usd")
+    return {key: trial.metadata[key] for key in keys if key in trial.metadata}
+
+
+def test_trial_measurements_use_one_source_and_are_total(tmp_path: Path) -> None:
+    assert _adapted_measurements(
+        tmp_path,
+        {
+            "agent_result": {"n_input_tokens": 2, "cost_usd": 0.25},
+            "step_results": [{"agent_result": {"n_input_tokens": 100, "n_output_tokens": 3}}],
+        },
+    ) == {"prompt_tokens": 2, "cost_usd": 0.25}
+    assert _adapted_measurements(
+        tmp_path,
+        {
+            "step_results": [
+                {"agent_result": {"n_input_tokens": 2, "n_output_tokens": 1, "cost_usd": 0.1}},
+                {"agent_result": {"n_input_tokens": 3, "n_cache_tokens": 4, "cost_usd": 0.2}},
+            ]
+        },
+    ) == {
+        "prompt_tokens": 5,
+        "completion_tokens": 1,
+        "cache_read_tokens": 4,
+        "cost_usd": pytest.approx(0.3),
+    }
+    assert _adapted_measurements(
+        tmp_path, {"agent_result": {"n_input_tokens": 0, "n_output_tokens": 0, "n_cache_tokens": 0, "cost_usd": 0}}
+    ) == {"prompt_tokens": 0, "completion_tokens": 0, "cache_read_tokens": 0, "cost_usd": 0.0}
+    assert (
+        _adapted_measurements(tmp_path, {"agent_result": {}, "step_results": [{"agent_result": {"n_input_tokens": 9}}]})
+        == {}
+    )
+    assert _adapted_measurements(tmp_path, {"step_results": 7}) == {}
+    assert _adapted_measurements(
+        tmp_path, {"step_results": [None, "bad", {"agent_result": 7}, {"agent_result": {"n_input_tokens": -2}}]}
+    ) == {"prompt_tokens": -2}
+
+
+@pytest.mark.parametrize("bad", [True, "12", float("nan"), float("inf"), float("-inf")])
+def test_trial_measurements_reject_malformed_values(tmp_path: Path, bad: object) -> None:
+    assert _adapted_measurements(
+        tmp_path,
+        {"agent_result": {"n_input_tokens": bad, "n_output_tokens": 2, "cost_usd": bad}},
+    ) == {"completion_tokens": 2}
+
+
+def test_trial_measurements_omit_numeric_and_aggregate_cost_overflow(tmp_path: Path) -> None:
+    assert _adapted_measurements(tmp_path, {"agent_result": {"n_input_tokens": 1, "cost_usd": 10**1000}}) == {
+        "prompt_tokens": 1
+    }
+    assert _adapted_measurements(
+        tmp_path,
+        {
+            "step_results": [
+                {"agent_result": {"n_input_tokens": 1, "cost_usd": 1e308}},
+                {"agent_result": {"n_input_tokens": 2, "cost_usd": 1e308}},
+            ]
+        },
+    ) == {"prompt_tokens": 3}
+
+
+def _write_evidence_trial(job_dir: Path, trial_name: str = "task__A1b2") -> Path:
+    _write_trial(job_dir, trial_name, "task", reward=1.0)
+    trial_dir = job_dir / trial_name
+    (trial_dir / "config.json").write_text("{}", encoding="utf-8")
+    (trial_dir / "trial.log").write_text("run", encoding="utf-8")
+    (trial_dir / "verifier" / "reward.json").write_text('{"reward": 1}', encoding="utf-8")
+    return trial_dir
+
+
+def _adapt_evidence_trial(job_dir: Path, *, trace_format: Literal["otlp", "atif"] = "atif") -> AgentEvalTrial:
+    task = AgentEvalTask(id="task", intent="x", inputs={"instruction": "p"}, metrics=[HarborRewardMetric()])
+    return build_trials_from_job_dir(job_dir, [task], trace_format=trace_format)[0]
+
+
+def test_harbor_evidence_descriptors_are_typed_absolute_and_described(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    trial_dir = _write_evidence_trial(job_dir)
+    (trial_dir / "artifacts" / "output.txt").parent.mkdir(parents=True)
+    (trial_dir / "artifacts" / "output.txt").write_text("done", encoding="utf-8")
+
+    trial = _adapt_evidence_trial(job_dir)
+
+    expected = {
+        "trial_dir": ("filesystem", "dir", trial_dir.resolve()),
+        "config": ("json", "json", (trial_dir / "config.json").resolve()),
+        "json:config.json": ("json", "json", (trial_dir / "config.json").resolve()),
+        "result": ("json", "json", (trial_dir / "result.json").resolve()),
+        "json:result.json": ("json", "json", (trial_dir / "result.json").resolve()),
+        "log:trial.log": ("log", "text", (trial_dir / "trial.log").resolve()),
+        "log:verifier/reward.json": ("log", "json", (trial_dir / "verifier" / "reward.json").resolve()),
+        "artifact:artifacts/output.txt": ("artifact", None, (trial_dir / "artifacts" / "output.txt").resolve()),
+        "artifact:output.txt": ("artifact", None, (trial_dir / "artifacts" / "output.txt").resolve()),
+    }
+    for name, (kind, evidence_format, path) in expected.items():
+        descriptor = trial.get_evidence(name)
+        assert descriptor is not None
+        assert (descriptor.kind, descriptor.format, descriptor.ref) == (kind, evidence_format, str(path))
+        assert isinstance(descriptor.description, str)
+
+    logs = trial.get_evidence("logs")
+    final_state = trial.get_evidence("final_state")
+    verifier_logs = trial.get_evidence("verifier_logs")
+    assert logs is not None
+    assert final_state is not None
+    assert verifier_logs is not None
+    assert (logs.kind, logs.format, logs.ref) == ("logs", "dir", str((trial_dir / "agent").resolve()))
+    assert (final_state.kind, final_state.format, final_state.ref) == (
+        "filesystem",
+        "dir",
+        str((trial_dir / "artifacts").resolve()),
+    )
+    assert (verifier_logs.kind, verifier_logs.format, verifier_logs.ref) == (
+        "logs",
+        "dir",
+        str((trial_dir / "verifier").resolve()),
+    )
+    assert set(trial.evidence.descriptors if trial.evidence is not None else ()) == {
+        "logs",
+        "final_state",
+        "verifier_logs",
+        "trial_dir",
+        "config",
+        "json:config.json",
+        "result",
+        "json:result.json",
+        "log:trial.log",
+        "log:verifier/reward.json",
+        "artifact:agent/trajectory.json",
+        "artifact:artifacts/output.txt",
+        "artifact:output.txt",
+    }
+
+
+def test_harbor_manifest_descriptions_preserve_their_original_paths(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    trial_dir = _write_evidence_trial(job_dir)
+    artifacts_manifest = trial_dir / "artifacts" / "manifest.json"
+    artifacts_manifest.parent.mkdir(parents=True)
+    artifacts_manifest.write_text("{}", encoding="utf-8")
+    root_manifest = trial_dir / "manifest.json"
+    root_manifest.write_text("{}", encoding="utf-8")
+
+    trial = _adapt_evidence_trial(job_dir)
+
+    artifact_descriptor = trial.get_evidence("artifact:artifacts/manifest.json")
+    root_descriptor = trial.get_evidence("artifact:manifest.json")
+    assert artifact_descriptor is not None
+    assert root_descriptor is not None
+    assert artifact_descriptor.description == (
+        "Harbor artifact manifest. Lists collected artifact files and the environment paths they were copied from."
+    )
+    assert root_descriptor.description == "Collected Harbor artifact manifest.json."
+
+
+def test_harbor_evidence_keys_preserve_colliding_files_and_noncolliding_aliases(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    trial_dir = _write_evidence_trial(job_dir)
+    paths = [
+        "artifacts/traces/x.jsonl",
+        "traces/x.jsonl",
+        "artifacts/traces/y.jsonl",
+        "artifacts/foo.txt",
+        "foo.txt",
+        "artifacts/only.txt",
+    ]
+    for relative in paths:
+        path = trial_dir / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"resourceSpans": []}\n' if path.suffix == ".jsonl" else relative, encoding="utf-8")
+
+    trial = _adapt_evidence_trial(job_dir, trace_format="otlp")
+
+    expected_refs = {
+        "trace:artifacts/traces/x.jsonl": trial_dir / "artifacts/traces/x.jsonl",
+        "trace:traces/x.jsonl": trial_dir / "traces/x.jsonl",
+        "trace:artifacts/traces/y.jsonl": trial_dir / "artifacts/traces/y.jsonl",
+        "trace:traces/y.jsonl": trial_dir / "artifacts/traces/y.jsonl",
+        "artifact:artifacts/foo.txt": trial_dir / "artifacts/foo.txt",
+        "artifact:foo.txt": trial_dir / "foo.txt",
+        "artifact:artifacts/only.txt": trial_dir / "artifacts/only.txt",
+        "artifact:only.txt": trial_dir / "artifacts/only.txt",
+    }
+    for name, path in expected_refs.items():
+        descriptor = trial.get_evidence(name)
+        assert descriptor is not None
+        assert descriptor.ref == str(path.resolve())
+
+
+def test_configured_trace_format_selects_one_standard_trace_and_keeps_all_extensions(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    trial_dir = _write_evidence_trial(job_dir)
+    traces = trial_dir / "nested" / "traces"
+    traces.mkdir(parents=True)
+    otlp = traces / "trace.jsonl"
+    atif = traces / "trajectory.atif.json"
+    otlp.write_text('{"resourceSpans": []}\n', encoding="utf-8")
+    atif.write_text(json.dumps(_atif_trajectory_payload()), encoding="utf-8")
+
+    otlp_trial = _adapt_evidence_trial(job_dir, trace_format="otlp")
+    atif_trial = _adapt_evidence_trial(job_dir, trace_format="atif")
+
+    otlp_trace = otlp_trial.get_evidence("trace")
+    atif_trace = atif_trial.get_evidence("trace")
+    assert otlp_trace is not None
+    assert atif_trace is not None
+    assert otlp_trace.ref == str(otlp.resolve())
+    assert otlp_trace.format == "otlp"
+    assert otlp_trace.description == "Agent execution trace JSONL for nested/traces/trace.jsonl."
+    assert otlp_trace.metadata == {}
+    assert atif_trace.ref == str(atif.resolve())
+    assert atif_trace.format == "atif"
+    assert atif_trace.description == "Agent execution ATIF trajectory for nested/traces/trajectory.atif.json."
+    assert atif_trace.metadata == {}
+    assert otlp_trial.get_evidence("trace:nested/traces/trajectory.atif.json") is not None
+    assert atif_trial.get_evidence("trace:nested/traces/trace.jsonl") is not None
+    assert "matched no trace" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_named_atif_trace_keeps_its_identity_and_validates_lazily(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    trial_dir = _write_evidence_trial(job_dir)
+    traces = trial_dir / "traces"
+    traces.mkdir()
+    atif = traces / "broken.atif.json"
+    atif.write_text(json.dumps({"schema_version": "ATIF-v1.7", "steps": []}), encoding="utf-8")
+
+    trial = _adapt_evidence_trial(job_dir, trace_format="atif")
+
+    extension = trial.get_evidence("trace:traces/broken.atif.json")
+    selected = trial.get_evidence("trace")
+    assert extension is not None
+    assert selected is not None
+    assert (extension.kind, extension.format, extension.ref) == ("trace", "atif", str(atif.resolve()))
+    assert extension.description == "Agent execution ATIF trajectory for traces/broken.atif.json."
+    assert extension.metadata == {}
+    assert selected.ref == extension.ref
+    assert trial.evidence is not None
+    handle = await trial.evidence.trace()
+    assert isinstance(handle, ATIFTraceHandle)
+    with pytest.raises(ValidationError):
+        await handle.trace()
+
+
+def test_trace_selection_warns_only_when_opposite_format_exists(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    trial_dir = _write_evidence_trial(job_dir)
+    (trial_dir / "agent" / "trajectory.json").unlink()
+    traces = trial_dir / "traces"
+    traces.mkdir()
+    atif = traces / "trajectory.atif.json"
+    atif.write_text(json.dumps(_atif_trajectory_payload()), encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        trial = _adapt_evidence_trial(job_dir, trace_format="otlp")
+
+    assert trial.get_evidence("trace") is None
+    assert "trace_format='otlp'" in caplog.text
+    assert "atif" in caplog.text
+
+    caplog.clear()
+    atif.unlink()
+    with caplog.at_level(logging.WARNING):
+        no_trace = _adapt_evidence_trial(job_dir, trace_format="otlp")
+    assert no_trace.get_evidence("trace") is None
+    assert "matched no trace" not in caplog.text
+
+
+def test_invalid_trace_format_is_rejected_at_public_boundaries(tmp_path: Path) -> None:
+    job_dir = tmp_path / "job"
+    job_dir.mkdir()
+    task = AgentEvalTask(id="task", intent="x", inputs={"instruction": "p"}, metrics=[HarborRewardMetric()])
+
+    with pytest.raises(ValueError, match="trace_format"):
+        HarborAgentTaskRunner(job_dir=job_dir, trace_format="json")  # ty: ignore[invalid-argument-type]
+    with pytest.raises(ValueError, match="trace_format"):
+        build_trials_from_job_dir(job_dir, [task], trace_format="json")  # ty: ignore[invalid-argument-type]
+    with pytest.raises(ValueError, match="trace_format"):
+        asyncio.run(
+            run_harbor_eval(
+                HarborRuntimeConfig(jobs_dir=tmp_path / "jobs"),
+                _HELLO_WORLD_DATASET,
+                trace_format="json",  # ty: ignore[invalid-argument-type]
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    ("source_name", "legacy_name"),
+    [
+        (
+            "nemo_evaluator_sdk.agent_eval.runtimes.harbor_trial_adapter",
+            "nemo_platform.beta.evaluator.agent_eval.runtimes.harbor_trial_adapter",
+        ),
+        (
+            "nemo_evaluator_sdk.agent_eval.trials",
+            "nemo_platform.beta.evaluator.agent_eval.trials",
+        ),
+    ],
+)
+def test_legacy_harbor_trial_contract_import_resolves_to_source_module(source_name: str, legacy_name: str) -> None:
+    source = importlib.import_module(source_name)
+    legacy = importlib.import_module(legacy_name)
+    assert source.__file__ is not None
+    assert legacy.__file__ is not None
+
+    assert Path(legacy.__file__).resolve() == Path(source.__file__).resolve()

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_run_metadata.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_run_metadata.py
@@ -100,7 +100,15 @@ def test_every_shipped_runner_reports_a_stable_name_and_result_shaping_config() 
         (
             HarborAgentTaskRunner(config=HarborRuntimeConfig(jobs_dir=Path("/jobs"))),
             "harbor",
-            {"agent_name", "agent_import_path", "effective_agent", "n_attempts", "jobs_dir", "reward_key"},
+            {
+                "agent_name",
+                "agent_import_path",
+                "effective_agent",
+                "n_attempts",
+                "jobs_dir",
+                "reward_key",
+                "trace_format",
+            },
         ),
     ]
 
@@ -181,6 +189,17 @@ def test_harbor_records_the_effective_agent_when_a_custom_import_path_overrides_
     # Built-in agents still resolve through agent_name, defaulting to Harbor's oracle.
     assert _info(agent_name="oracle")["effective_agent"] == "oracle"
     assert _info()["effective_agent"] == "oracle"
+
+
+def test_harbor_records_the_result_shaping_trace_format() -> None:
+    from pathlib import Path
+
+    from nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime import HarborAgentTaskRunner, HarborRuntimeConfig
+
+    config = HarborRuntimeConfig(jobs_dir=Path("/jobs"))
+
+    assert HarborAgentTaskRunner(config=config).runner_info().config["trace_format"] == "atif"
+    assert HarborAgentTaskRunner(config=config, trace_format="otlp").runner_info().config["trace_format"] == "otlp"
 
 
 def test_gym_redacts_credential_looking_hydra_params() -> None:

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_skill_used_metric.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_skill_used_metric.py
@@ -42,6 +42,26 @@ def _evidence(atif: dict[str, Any]) -> CandidateEvidence:
     return CandidateEvidence(descriptors={EVIDENCE_TRACE: EvidenceDescriptor(kind="trace", format="atif", data=atif)})
 
 
+def _otlp_evidence(payload: str) -> CandidateEvidence:
+    return CandidateEvidence(
+        descriptors={
+            EVIDENCE_TRACE: EvidenceDescriptor(
+                kind="trace",
+                format="otlp",
+                data={
+                    "resourceSpans": [
+                        {
+                            "scopeSpans": [
+                                {"spans": [{"attributes": [{"key": "input.value", "value": {"stringValue": payload}}]}]}
+                            ]
+                        }
+                    ]
+                },
+            )
+        }
+    )
+
+
 async def _score(sample: dict[str, Any]) -> dict[str, Any]:
     result = await SkillUsedMetric().compute_scores(build_metric_input({}, sample, 0))
     return {output.name: output.value for output in result.outputs}
@@ -66,6 +86,21 @@ async def test_present_and_used_when_trajectory_reads_the_skill() -> None:
 @pytest.mark.asyncio
 async def test_present_not_used_when_trajectory_ignores_the_skill() -> None:
     sample = {"skills": [_PROV], "evidence": _evidence(_atif(tool_path="README.md"))}
+    assert await _score(sample) == {"skill_present": True, "skill_used": False}
+
+
+@pytest.mark.asyncio
+async def test_present_and_used_when_otlp_payload_reads_the_skill() -> None:
+    sample = {
+        "skills": [_PROV],
+        "evidence": _otlp_evidence(f'{{"path": "{_LOCATION}/SKILL.md"}}'),
+    }
+    assert await _score(sample) == {"skill_present": True, "skill_used": True}
+
+
+@pytest.mark.asyncio
+async def test_present_not_used_when_otlp_payload_ignores_the_skill() -> None:
+    sample = {"skills": [_PROV], "evidence": _otlp_evidence('{"path": "README.md"}')}
     assert await _score(sample) == {"skill_present": True, "skill_used": False}
 
 

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_trial_error_rollup.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_trial_error_rollup.py
@@ -158,3 +158,4 @@ def test_vendored_module_exposes_the_error_rollup_surface() -> None:
 
     assert summary.error_trial_ids == {"RuntimeError": ["t0"]}
     assert summary.error_count == 1
+    assert trial.get_evidence("result") is None

--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_trials.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_trials.py
@@ -12,6 +12,7 @@ from nemo_evaluator_sdk.agent_eval.trials import (
     resolve_trial_status,
     standard_evidence_descriptors,
 )
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 from pydantic import ValidationError
 
 
@@ -40,6 +41,7 @@ def test_trial_accepts_mapping_shaped_evidence_and_serializes_descriptors() -> N
                 "ref": "runs/local/final-state",
                 "format": None,
                 "data": None,
+                "description": None,
                 "metadata": {},
             },
             "trace": {
@@ -47,6 +49,7 @@ def test_trial_accepts_mapping_shaped_evidence_and_serializes_descriptors() -> N
                 "ref": "runs/local/trace.atif.json",
                 "format": "atif",
                 "data": None,
+                "description": None,
                 "metadata": {},
             },
         },
@@ -59,6 +62,20 @@ def test_completed_trial_requires_output() -> None:
         AgentEvalTrial(id="trial-1", task_id="task-1", status=AgentEvalTrialStatus.COMPLETED)
 
 
+def test_trial_get_evidence_is_named_and_null_safe() -> None:
+    descriptor = EvidenceDescriptor(kind="json", format="json", ref="/tmp/result.json")
+    trial = AgentEvalTrial(
+        id="trial-1",
+        task_id="task-1",
+        status=AgentEvalTrialStatus.PARTIAL,
+        evidence=CandidateEvidence(descriptors={"result": descriptor}),
+    )
+
+    assert trial.get_evidence("result") is descriptor
+    assert trial.get_evidence("missing") is None
+    assert trial.model_copy(update={"evidence": None}).get_evidence("result") is None
+
+
 def test_resolve_trial_status_maps_ran_but_failed_to_partial() -> None:
     assert resolve_trial_status(True) == AgentEvalTrialStatus.COMPLETED
     # A ran-but-unsuccessful agent stays scorable (PARTIAL), not dropped (FAILED).
@@ -68,6 +85,8 @@ def test_resolve_trial_status_maps_ran_but_failed_to_partial() -> None:
 def test_standard_evidence_descriptors_builds_documented_keys(tmp_path: Path) -> None:
     verifier_dir = tmp_path / "verifier"
     verifier_dir.mkdir()
+    # The trace does not need to exist: the fallback is a parser hint inferred from
+    # its name, not an eager content-validation step.
     descriptors = standard_evidence_descriptors(
         logs_dir=tmp_path / "agent",
         final_state_dir=tmp_path / "workspace",

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -3540,6 +3540,10 @@ components:
           - $ref: '#/components/schemas/JsonValue'
           description: Small inline evidence payload; at least one of ref or data
             must be set.
+        description:
+          title: Description
+          description: Human-readable description of this evidence artifact.
+          type: string
         metadata:
           additionalProperties: true
           type: object

--- a/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor_evaluator.py
+++ b/plugins/nemo-experimentalist/tests/experimentalist/test_evaluator_harbor_evaluator.py
@@ -538,6 +538,35 @@ async def test_wrong_options_type_is_rejected(tmp_path: Path, dataset: HarborDat
         await HarborRunnerOutcomeEvaluator(experiment_dir=tmp_path)._run(agent_dir, dataset, EvaluatorConfig())
 
 
+async def test_force_rerun_rejects_job_name_outside_jobs_dir(
+    tmp_path: Path,
+    dataset: HarborDataset,
+    agent_dir: Path,
+    fake_job: type[_FakeJob],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    marker = outside / "keep.txt"
+    marker.write_text("do not delete", encoding="utf-8")
+    rmtree_calls: list[Path] = []
+    monkeypatch.setattr(
+        "nemo_evaluator_sdk.agent_eval.runtimes.harbor_runtime.shutil.rmtree",
+        lambda path, **kwargs: rmtree_calls.append(Path(path)),
+    )
+
+    with pytest.raises(ValueError, match="strict descendant"):
+        await HarborRunnerOutcomeEvaluator(experiment_dir=tmp_path)._run(
+            agent_dir,
+            dataset,
+            HarborRunnerConfig(jobs_dir=Path("jobs"), job_name="../outside", force_rerun=True),
+        )
+
+    assert fake_job.calls == []
+    assert rmtree_calls == []
+    assert marker.read_text(encoding="utf-8") == "do not delete"
+
+
 # --------------------------------------------------------------------------
 # Result parity with the plain Harbor evaluator
 # --------------------------------------------------------------------------


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

- Preserve complete Harbor trial identity, measurements, and evidence when adapting results into evaluator SDK trials.
- Support explicit ATIF or OTLP trace selection while retaining every discovered trial artifact.
- Fix: fix path traversal on re-run

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

- Linear: [AALGO-442](https://linear.app/nvidia/issue/AALGO-442)
- Follow ups: 
  - [AALGO-556](https://linear.app/nvidia/issue/AALGO-556)
  - [AALGO-557](https://linear.app/nvidia/issue/AALGO-557)

## Changes
<!-- List the concrete changes included in this pull request. -->

- Extract Harbor trial shaping into a dedicated adapter with lossless identity and robust token, cost, reward, and error normalization.
- Add typed, described, collision-safe evidence descriptors with legacy aliases and configurable standard trace selection.
- Add named trial evidence lookup, guard ATIF-only trace parsing, sync vendored SDK sources, and expand regression coverage.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Beta SDK behavior is documented by the updated type signatures and docstrings; no user guide changes are needed.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox -q activate -- uv run pre-commit run -a`: passed all hooks.
- `flox -q activate -- uv run --frozen pytest packages/nemo_evaluator_sdk/tests/agent_eval/test_evidence.py packages/nemo_evaluator_sdk/tests/agent_eval/test_example_metrics.py packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py packages/nemo_evaluator_sdk/tests/agent_eval/test_run_metadata.py packages/nemo_evaluator_sdk/tests/agent_eval/test_trial_error_rollup.py packages/nemo_evaluator_sdk/tests/agent_eval/test_trials.py -q`: 154 passed.
- `flox -q activate -- make test-package PACKAGE=nemo_evaluator_sdk`: 1,696 passed, 10 skipped.
- `git diff --check origin/main...HEAD`: passed.
- DCO audit for `origin/main..HEAD`: passed for 1 commit.

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Harbor evaluations support configurable ATIF and OTLP trace formats, defaulting to ATIF.
* Evaluation results provide richer evidence, including traces, logs, artifacts, measurements, timestamps, rewards, errors, and descriptions.
* Added named-evidence retrieval for evaluation trials.
* Metrics can analyze OTLP traces for tool activity and skill usage.
* Harbor results preserve trial identities and support nested job paths.

## Bug Fixes
* Improved validation and fallback handling for unsupported or malformed evidence.
* Prevented unsafe job paths from accessing files outside the configured jobs directory.

## Documentation
* Updated guidance for ATIF and OTLP evidence formats and trace-based metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->