### PR TITLE
fix(evaluator): use `GenericAgent` instead of `Agent`

### DIFF
--- a/docs/evaluator/metrics/agent-configuration.mdx
+++ b/docs/evaluator/metrics/agent-configuration.mdx
@@ -9,7 +9,7 @@ description: ""
 
 Online evaluations can target an **agent** instead of a model. An agent is an HTTP endpoint that accepts a request and returns a response, optionally with a trajectory of intermediate steps. Use agents when you want to evaluate an agentic system end to end rather than a standalone LLM endpoint.
 
-Provide a `GenericAgent` or `NemoAgentToolkitAgent` as `target=...`. `Agent` is the union type alias used in SDK signatures; instantiate one of the concrete classes. The metric, prompt template, target, dataset rows, and runtime parameters are all passed through the Evaluator plugin SDK call.
+Provide a `GenericAgent` or `NemoAgentToolkitAgent` as `target=...`. `Agent` is a union type alias used in SDK signatures, not an instantiable class; instantiate one of the concrete classes instead. The metric, prompt template, target, dataset rows, and runtime parameters are all passed through the Evaluator plugin SDK call.
 
 ## Agent Formats
 

--- a/docs/evaluator/metrics/agent-configuration.mdx
+++ b/docs/evaluator/metrics/agent-configuration.mdx
@@ -9,7 +9,7 @@ description: ""
 
 Online evaluations can target an **agent** instead of a model. An agent is an HTTP endpoint that accepts a request and returns a response, optionally with a trajectory of intermediate steps. Use agents when you want to evaluate an agentic system end to end rather than a standalone LLM endpoint.
 
-Provide an `Agent` as `target=...`. The metric, prompt template, target, dataset rows, and runtime parameters are all passed through the Evaluator plugin SDK call.
+Provide a `GenericAgent` or `NemoAgentToolkitAgent` as `target=...`. `Agent` is the union type alias used in SDK signatures; instantiate one of the concrete classes. The metric, prompt template, target, dataset rows, and runtime parameters are all passed through the Evaluator plugin SDK call.
 
 ## Agent Formats
 
@@ -76,14 +76,15 @@ You control the request shape with `body` and extract values from the response w
 ### Run a Generic Agent Evaluation
 
 ```python
-from nemo_evaluator_sdk import Agent, RunConfigOnline
-from nemo_evaluator_sdk import ExactMatchMetric
+from nemo_evaluator_sdk import ExactMatchMetric, GenericAgent, RunConfigOnline, SecretRef
+from nemo_evaluator_sdk.enums import AgentFormat
+
 metric = ExactMatchMetric(reference="{{item.expected_answer}}")
-agent = Agent(
+agent = GenericAgent(
     url="https://my-agent.example.com/invoke",
     name="qa-agent",
-    format="generic",
-    api_key_secret="MY_AGENT_API_KEY",
+    format=AgentFormat.GENERIC,
+    api_key_secret=SecretRef(root="MY_AGENT_API_KEY"),
     body={"question": "{{ prompt }}"},
     response_path="$.answer",
     trajectory_path="$.reasoning_steps",
@@ -156,15 +157,15 @@ Use the `nemo_agent_toolkit` format when evaluating agents built with the [NeMo 
 ### Run a NAT Agent Evaluation
 
 ```python
-from nemo_evaluator_sdk import Agent, RunConfigOnline
+from nemo_evaluator_sdk import ExactMatchMetric, NemoAgentToolkitAgent, RunConfigOnline, SecretRef
+from nemo_evaluator_sdk.enums import AgentFormat
 
-from nemo_evaluator_sdk import ExactMatchMetric
 metric = ExactMatchMetric(reference="{{item.expected_answer}}")
-agent = Agent(
+agent = NemoAgentToolkitAgent(
     url="https://my-nat-agent.example.com",
     name="nat-research-agent",
-    format="nemo_agent_toolkit",
-    api_key_secret="my-nat-api-key",
+    format=AgentFormat.NEMO_AGENT_TOOLKIT,
+    api_key_secret=SecretRef(root="my-nat-api-key"),
 )
 
 job = evaluator.submit(


### PR DESCRIPTION


<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Corrects the Agent Eval configuration documentation so examples instantiate concrete agent models instead of the non-callable `Agent` union alias. This prevents the documented `TypeError` and aligns the snippets with the SDK's public types.

NVBug: https://nvbugspro.nvidia.com/bug/6658014

## Changes
<!-- List the concrete changes included in this pull request. -->

- Replace generic `Agent(...)` calls with `GenericAgent(...)` and `NemoAgentToolkitAgent(...)`.
- Use `AgentFormat` and `SecretRef` values accepted by the concrete constructor annotations.
- Clarify that `Agent` is a union type alias used in SDK signatures, not an instantiable class.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: The focused Python snippet checker validates the corrected imports and constructor types.
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `flox -q activate --dir . -- uv run pre-commit run -a` — passed.
- `make docs-check-python-snippets DOCS_PATH=docs/evaluator/metrics/agent-configuration.mdx` — passed (5 snippets).
- `make docs-check` — passed (210 MDX files parsed cleanly).
- `make docs-broken-links` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Clarified the distinction between the `Agent` type alias and concrete agent classes.
  - Updated configuration examples to use supported agent classes and format values.
  - Demonstrated secure API-key references through `SecretRef` instead of raw secret strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->