### PR TITLE
refactor(eval-author)!: split trace reads into list, overview, and spans

### DIFF
--- a/plugins/nemo-eval-author/skills/eval-author-inspect-trace/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-inspect-trace/SKILL.md
@@ -21,8 +21,8 @@ not-for:
   - eval-author-discover (use to establish whether a repository's Harbor suite is runnable)
   - nemo-experimentalist (use for an optimization experiment across many trials)
 compatibility: >-
-  Python 3.12 or later. Each trace source states its own access, authentication,
-  and runtime requirements.
+  Python 3.9 or later, with no third-party packages. Each trace source states its
+  own access, authentication, and runtime requirements.
 maturity: alpha
 license: Apache-2.0
 user-invocable: true
@@ -53,27 +53,34 @@ Select the matching source guide:
 If no guide matches, stop and report the unsupported scheme. Don't reinterpret
 the reference as one of the supported sources.
 
-## Step 1: build the analysis bundle
+When nobody named a trace, don't guess an ID. Run the `list` verb for the source
+the user names. It returns candidates, each with a reference the read verbs accept
+verbatim. Report the candidates, then inspect the one the user picks, or the most
+recent one when the user asks for whatever is there.
 
-Read the selected source guide and run its command exactly. The
+## Step 1: read the trace structure
+
+Read the selected source guide and run its `overview` command exactly. The
 `scripts/inspect_trace.py` entry point validates the URI scheme, invokes the
 matching source adapter, and applies the source-neutral overview.
 
-The command prints one JSON object and writes no files. An exit code of `1`
+Every command prints one JSON object and writes no files. An exit code of `1`
 means that the object contains `error` and `hint` fields. Resolve that error
 before interpreting the trace.
 
-Preserve the complete JSON object. It separates `source` identity and context
-from `trace` evidence and the deterministic `overview`. Span payloads and
-evaluator comments are evidence, and dropping them can change the assessment.
+The `overview` verb reads every span in a compact form, so it stays affordable on
+a trace of any size. It returns `source` identity and context, a `report_path`,
+the deterministic `overview`, and a per-span `timeline`. It carries no span
+payloads, which is what makes it cheap. Step 3 fetches those for the spans you
+choose.
 
 ## Step 2: review the overview
 
-Read the deterministic `overview` before the payloads. It reports structure,
+Read the deterministic `overview` before any payload. It reports structure,
 not an outcome:
 
 - Root and span statuses
-- Timing and span kinds
+- Root duration and span kinds
 - Tools, models, providers, agents, sessions, and projects
 - Error, canceled, and incomplete spans
 - A `root_succeeded_with_errors` recovery signal
@@ -83,9 +90,28 @@ Treat `root_succeeded_with_errors` as a signal, not proof of correct behavior.
 A successful root status can still conflict with the requested result or an
 evaluator score.
 
-## Step 3: analyze the trajectory
+An `error_spans` message keeps only its first characters, and
+`error_message_truncated` marks the cut. When the exact wording decides
+something, read the full text with the `spans` verb in step 3.
 
-Read `trace.spans` in chronological order. For each important transition:
+Then read the `timeline`. It orders every span with `offset_ms` from the first
+start and its own `duration_ms`, which is the only place either appears: span
+payloads carry timestamps but no duration. Use it to find where the time went
+and which spans ran as siblings.
+
+## Step 3: read the spans that matter
+
+The overview and timeline name every span, so you now choose which ones to read
+in full. Run the source guide's `spans` command, selecting by status, kind, or
+span ID. Read the error spans and the transitions the timeline makes look
+decisive, rather than every span in the trace.
+
+Payloads arrive shortened by default, and a shortened field records its full
+length beside it. Ask for a field in full only when the exact text decides the
+assessment. Span payloads and evaluator comments are evidence, so quote them
+rather than paraphrasing.
+
+For each important transition:
 
 1. Identify the span ID.
 2. State what the span received or attempted.
@@ -156,9 +182,10 @@ identity, the deterministic overview, and the command that rebuilds the evidence
 ---
 ```
 
-Copy those two objects verbatim. Don't paste `trace` into the report. Span
-payloads can run to megabytes, retyping them invites corruption, and the command
-rebuilds them exactly when a later reader needs them.
+Copy those two objects verbatim, writing them with a tool instead of retyping
+them. Don't paste the `timeline` or any span payload into the front matter. A
+long timeline rivals the report in size, retyping either invites corruption, and
+the recorded command rebuilds both exactly when a later reader needs them.
 
 Then use this report shape:
 
@@ -206,6 +233,6 @@ user's decision.
 
 | Path | Purpose |
 |---|---|
-| `scripts/inspect_trace.py` | Selects the source adapter and prints the normalized JSON bundle |
-| `scripts/overview.py` | Derives factual trace structure without assigning an outcome |
+| `scripts/inspect_trace.py` | Runs the `list`, `overview`, and `spans` verbs against the source a reference names |
+| `scripts/overview.py` | Derives factual trace structure and the span timeline without assigning an outcome |
 | `references/intake.md` | Provides Intake requirements, invocation, and adapter details |

--- a/plugins/nemo-eval-author/skills/eval-author-inspect-trace/references/intake.md
+++ b/plugins/nemo-eval-author/skills/eval-author-inspect-trace/references/intake.md
@@ -7,28 +7,95 @@ Use this source when the trace reference starts with `intake://`.
 
 ## Requirements
 
-- Python 3.12 or later
+- Python 3.9 or later, and no third-party packages. The bare `python3` works,
+  including the 3.9 that macOS ships.
 - An explicit NeMo Platform workspace
 - `NMP_BASE_URL` set to the Platform origin
 - `NMP_ACCESS_TOKEN` set when the Platform requires authentication
 
 Remote Platform origins must use HTTPS. Loopback origins can use HTTP.
 
-## Read the trace
+Every command prints one JSON object and writes no files. An exit code of `1`
+means that the object contains `error` and `hint` fields. Add `--compact` to any
+verb to print the JSON on one line.
 
-Run:
+In each command, replace `SKILL_DIR` with the installed
+`eval-author-inspect-trace` directory, `WORKSPACE` with the NeMo Platform
+workspace that holds the trace, and `TRACE_ID` with the Intake trace ID.
+
+## List candidate traces
+
+When neither the user nor the preceding workflow named a trace:
 
 ```bash
-python3 "SKILL_DIR/scripts/inspect_trace.py" \
+python3 "SKILL_DIR/scripts/inspect_trace.py" list \
+  --source intake \
+  --workspace "WORKSPACE" \
+  --limit 20
+```
+
+Add `--agent AGENT_NAME` to keep only traces that contain a span from one agent,
+and `--since ISO_TIMESTAMP` to bound the window. Each row carries a `trace_ref`
+that the read verbs accept without edits, alongside `status`, `span_count`,
+`error_count`, and `duration_ms`, so you can choose a trace deliberately.
+
+An empty result carries a `note` and is not an error. Report it and stop rather
+than widening the search on your own.
+
+## Read the trace structure
+
+```bash
+python3 "SKILL_DIR/scripts/inspect_trace.py" overview \
   --trace "intake://traces/TRACE_ID" \
   --workspace "WORKSPACE"
 ```
 
-Replace the following:
+This reads every span in Intake's compact form, which measured 82 times smaller
+than the detailed form. A 605-span trace returns about 154 KB rather than 26 MB,
+so the first read is affordable whatever the trace size. The output carries
+`source`, `report_path`, `overview`, and `timeline`, and no span payloads.
 
-- `SKILL_DIR`: the installed `eval-author-inspect-trace` skill directory
-- `TRACE_ID`: the Intake trace ID
-- `WORKSPACE`: the NeMo Platform workspace that contains the trace
+## Read the spans that matter
+
+```bash
+python3 "SKILL_DIR/scripts/inspect_trace.py" spans \
+  --trace "intake://traces/TRACE_ID" \
+  --workspace "WORKSPACE" \
+  --status error
+```
+
+Select the spans with any combination of these:
+
+| Flag | Selects |
+|---|---|
+| `--status` | Spans with one status, such as `error` |
+| `--kind` | Spans of one kind, such as `LLM`, `TOOL`, `CHAIN`, or `AGENT` |
+| `--parent` | The direct children of one span |
+| `--span-id` | One span, repeatable to name several |
+| `--limit` | At most N spans when you name none, 20 by default |
+
+`--status`, `--kind`, and `--parent` narrow the query on the server. `--span-id`
+is applied after the fetch, because Intake supports no equality operator on a
+span `id`. Reading stops as soon as every named span is found, so pairing
+`--span-id` with `--kind` or `--status` makes the read cheaper on a long trace.
+
+Each of `input`, `output`, and `raw_attributes` is shortened to `--max-chars`
+characters, 2000 by default. A shortened field sets `FIELD_truncated` and records
+the whole length in `FIELD_length`. Pass `--full` to shorten nothing, and expect
+megabytes when you do. The result repeats `max_chars` at the top level, where
+`null` means the payloads are whole.
+
+## Filters Intake accepts
+
+The span endpoint accepts `agent_name`, `kind`, `model`, `name`,
+`parent_span_id`, `project`, `provider`, `session_id`, `source`, `started_at`,
+`status`, `tool_name`, and `trace_id`. It rejects both `$eq` and `$in` on `id`,
+so no query selects spans by span ID. The trace endpoint does accept
+`id` with `$in`, which is how a batch of trace summaries is fetched.
+
+A rejected filter returns HTTP 400 with the valid field names in `detail`.
+
+## Adapter details
 
 The Intake adapter makes read-only `GET` requests under
 `/apis/intake/v2/workspaces/WORKSPACE`. It rejects redirects and sends
@@ -36,15 +103,12 @@ credentials only to the validated Platform origin.
 
 The adapter lives under `scripts/sources/intake/`:
 
-- `scripts/sources/intake/adapter.py` validates source arguments and returns the
-  normalized source identity and trace evidence.
+- `scripts/sources/intake/adapter.py` owns the Intake flags for all three verbs
+  and returns the normalized source identity beside the result.
 - `scripts/sources/intake/_http.py` validates the Platform origin,
   authenticates, encodes filters, and drains pages.
-- `scripts/sources/intake/traces.py` builds Intake span and trace queries. Trace
-  inspection reaches only the trace-summary query. The span and agent-corpus
-  queries wait on the audit flow that consumes them.
-- `scripts/sources/intake/reader.py` loads detailed spans and related evaluator
-  results.
-
-The command prints one JSON object and writes no files. An exit code of `1`
-means that the object contains `error` and `hint` fields.
+- `scripts/sources/intake/traces.py` builds Intake span and trace queries, and
+  owns the one canonical `intake://traces/ID` reference form.
+- `scripts/sources/intake/reader.py` reads structure compactly, joins evaluator
+  results through the sessions the spans belong to, and fetches detailed
+  payloads only for a named selection.

--- a/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/inspect_trace.py
+++ b/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/inspect_trace.py
@@ -1,30 +1,63 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Print one source-qualified trace analysis bundle as JSON."""
+"""Read one trace source as JSON, in the three steps an inspection actually takes.
+
+``list`` finds a trace worth reading. ``overview`` reports the whole shape of one
+trace cheaply. ``spans`` spends detail only on the spans you name. Splitting the read
+this way keeps the first look affordable on a trace of any size, and it leaves the
+choice of what to read in full with the caller rather than with this script.
+"""
 
 import argparse
 import json
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 from urllib.parse import urlsplit
 
 _SCRIPTS = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPTS))
 
-from overview import build_overview  # noqa: E402
-from sources.intake.adapter import read_source as read_intake_source  # noqa: E402
+from overview import build_overview, build_timeline  # noqa: E402
+from sources.intake.adapter import list_traces as list_intake  # noqa: E402
+from sources.intake.adapter import overview as overview_intake  # noqa: E402
+from sources.intake.adapter import spans as spans_intake  # noqa: E402
 
-SOURCE_READERS = {"intake": read_intake_source}
+# One entry per trace source, kept in two maps because discovery takes no trace
+# reference and a read takes nothing else. A new source is added to both, beside its
+# own package under sources/.
+LIST_SOURCES = {"intake": list_intake}
+READ_SOURCES = {
+    "overview": {"intake": overview_intake},
+    "spans": {"intake": spans_intake},
+}
 _UNSAFE_NAME = re.compile(r"[^A-Za-z0-9._-]+")
 
 
+class _ArgumentParser(argparse.ArgumentParser):
+    """Raise instead of exiting, so a usage error reports the documented error object."""
+
+    def error(self, message: str) -> NoReturn:
+        raise ValueError(f"Arguments are invalid: {message}")
+
+
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Read one source-qualified trace for evidence-based analysis.")
-    parser.add_argument("--trace", required=True, help="Source-qualified trace reference, such as intake://traces/ID.")
-    parser.add_argument("--compact", action="store_true", help="Print the JSON on one line.")
+    parser = _ArgumentParser(description="Read one source-qualified trace for evidence-based analysis.")
+    verbs = parser.add_subparsers(dest="verb", required=True)
+
+    listing = verbs.add_parser("list", help="List candidate traces from one source.")
+    listing.add_argument("--source", required=True, choices=sorted(LIST_SOURCES), help="Trace source to search.")
+    listing.add_argument("--compact", action="store_true", help="Print the JSON on one line.")
+
+    for verb, help_text in (
+        ("overview", "Report one trace's structure, timeline, and evaluator signals."),
+        ("spans", "Read detailed payloads for the spans you name."),
+    ):
+        read = verbs.add_parser(verb, help=help_text)
+        read.add_argument("--trace", required=True, help="Source-qualified reference, such as intake://traces/ID.")
+        read.add_argument("--compact", action="store_true", help="Print the JSON on one line.")
     return parser
 
 
@@ -37,9 +70,9 @@ def _source_kind(trace_ref: str) -> str:
         raise ValueError(f"Trace reference is invalid: {exc}") from exc
     if not source_kind:
         raise ValueError("Trace reference must be source-qualified, for example intake://traces/TRACE_ID.")
-    if source_kind not in SOURCE_READERS:
+    if source_kind not in LIST_SOURCES:
         raise ValueError(
-            f"Trace source '{source_kind}' is not supported. Supported sources: {', '.join(SOURCE_READERS)}."
+            f"Trace source '{source_kind}' is not supported. Supported sources: {', '.join(LIST_SOURCES)}."
         )
     return source_kind
 
@@ -52,35 +85,47 @@ def _report_name(source: dict[str, Any]) -> str:
     return slug[:96] or "trace"
 
 
-def inspect(trace_ref: str, source_args: list[str]) -> dict[str, Any]:
-    """Build the deterministic input for the skill's trace assessment."""
+def read(verb: str, trace_ref: str, source_args: list[str]) -> dict[str, Any]:
+    """Run one verb against the source named by the trace reference."""
     source_kind = _source_kind(trace_ref)
     _, _, locator = trace_ref.partition("://")
-    source, trace = SOURCE_READERS[source_kind](f"{source_kind}://{locator}", source_args)
-    return {
-        "schema_version": "1",
-        "source": source,
-        "report_path": f".eval-author/traces/{_report_name(source)}.md",
-        "trace": trace,
-        "overview": build_overview(trace),
-    }
+    source, payload = READ_SOURCES[verb][source_kind](f"{source_kind}://{locator}", source_args)
+    report: dict[str, Any] = {"schema_version": "1", "source": source}
+    if verb == "overview":
+        report["report_path"] = f".eval-author/traces/{_report_name(source)}.md"
+        report["overview"] = build_overview(payload)
+        report["timeline"] = build_timeline(payload)
+        return report
+    report.update({key: value for key, value in payload.items() if key != "trace_ref"})
+    return report
+
+
+def find(source_kind: str, source_args: list[str]) -> dict[str, Any]:
+    """List the traces one source can offer for inspection."""
+    if source_kind not in LIST_SOURCES:
+        raise ValueError(
+            f"Trace source '{source_kind}' is not supported. Supported sources: {', '.join(LIST_SOURCES)}."
+        )
+    source, found = LIST_SOURCES[source_kind](source_args)
+    return {"schema_version": "1", "source": source, **found}
 
 
 def main() -> int:
-    args, source_args = _parser().parse_known_args()
+    compact = False
     try:
-        report = inspect(args.trace, source_args)
+        args, source_args = _parser().parse_known_args()
+        compact = args.compact
+        report = find(args.source, source_args) if args.verb == "list" else read(args.verb, args.trace, source_args)
         code = 0
     except ValueError as exc:
         report = {
             "schema_version": "1",
-            "trace_ref": args.trace,
-            "supported_sources": list(SOURCE_READERS),
+            "supported_sources": list(LIST_SOURCES),
             "error": str(exc),
             "hint": "Read the selected source guide and check its requirements, trace reference, and source arguments.",
         }
         code = 1
-    json.dump(report, sys.stdout, indent=None if args.compact else 2, sort_keys=True)
+    json.dump(report, sys.stdout, indent=None if compact else 2, sort_keys=True)
     sys.stdout.write("\n")
     return code
 

--- a/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/overview.py
+++ b/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/overview.py
@@ -5,7 +5,11 @@
 
 from collections import Counter
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
+
+# A provider traceback can repeat verbatim across every retry, so the overview keeps
+# only enough to identify the failure. The trace payload keeps the full text.
+MAX_ERROR_MESSAGE = 600
 
 
 def _values(rows: list[dict[str, Any]], field: str) -> list[str]:
@@ -16,7 +20,7 @@ def _counts(rows: list[dict[str, Any]], field: str) -> dict[str, int]:
     return dict(sorted(Counter(str(row[field]) for row in rows if row.get(field) not in {None, ""}).items()))
 
 
-def _timestamp(value: Any) -> datetime | None:
+def _timestamp(value: Any) -> Optional[datetime]:
     if not isinstance(value, str):
         return None
     try:
@@ -25,7 +29,7 @@ def _timestamp(value: Any) -> datetime | None:
         return None
 
 
-def _duration_ms(start: datetime | None, end: datetime | None) -> float | None:
+def _duration_ms(start: Optional[datetime], end: Optional[datetime]) -> Optional[float]:
     if start is None or end is None:
         return None
     try:
@@ -34,7 +38,7 @@ def _duration_ms(start: datetime | None, end: datetime | None) -> float | None:
         return None
 
 
-def _trace_duration_ms(spans: list[dict[str, Any]]) -> float | None:
+def _trace_duration_ms(spans: list[dict[str, Any]]) -> Optional[float]:
     starts = [_timestamp(span.get("started_at")) for span in spans]
     ends = [_timestamp(span.get("ended_at")) for span in spans]
     valid_starts = [value for value in starts if value is not None]
@@ -43,6 +47,50 @@ def _trace_duration_ms(spans: list[dict[str, Any]]) -> float | None:
         return _duration_ms(min(valid_starts), max(valid_ends)) if valid_starts and valid_ends else None
     except TypeError:
         return None
+
+
+def _error_span(span: dict[str, Any]) -> dict[str, Any]:
+    """Identify one error span without carrying its whole traceback."""
+    entry: dict[str, Any] = {
+        field: span[field]
+        for field in ("span_id", "parent_span_id", "name", "kind", "error_type")
+        if span.get(field) is not None
+    }
+    message = span.get("error_message")
+    if message is None:
+        return entry
+    text = message if isinstance(message, str) else str(message)
+    entry["error_message"] = text[:MAX_ERROR_MESSAGE]
+    if len(text) > MAX_ERROR_MESSAGE:
+        entry["error_message_truncated"] = True
+        entry["error_message_length"] = len(text)
+    return entry
+
+
+def build_timeline(bundle: dict[str, Any]) -> list[dict[str, Any]]:
+    """Place every span in order with its offset from the first start and its duration.
+
+    This is kept beside the overview rather than inside it, because a long trace
+    would otherwise bloat the report front matter that copies the overview.
+    """
+    paired = [(span, _timestamp(span.get("started_at"))) for span in bundle.get("spans", []) if isinstance(span, dict)]
+    valid_starts = [start for _, start in paired if start is not None]
+    try:
+        origin = min(valid_starts) if valid_starts else None
+    except TypeError:
+        origin = None
+    return [
+        {
+            "span_id": span.get("span_id"),
+            "parent_span_id": span.get("parent_span_id"),
+            "name": span.get("name"),
+            "kind": span.get("kind"),
+            "status": span.get("status"),
+            "offset_ms": _duration_ms(origin, start),
+            "duration_ms": _duration_ms(start, _timestamp(span.get("ended_at"))),
+        }
+        for span, start in paired
+    ]
 
 
 def _evaluator_signal(result: dict[str, Any]) -> dict[str, Any]:
@@ -67,14 +115,7 @@ def build_overview(bundle: dict[str, Any]) -> dict[str, Any]:
     summary: dict[str, Any] = raw_summary if isinstance(raw_summary, dict) else {}
     evaluator_results = [result for result in bundle.get("evaluator_results", []) if isinstance(result, dict)]
     errors = [span for span in spans if span.get("status") == "error"]
-    error_spans = [
-        {
-            field: span[field]
-            for field in ("span_id", "parent_span_id", "name", "kind", "error_type", "error_message")
-            if span.get(field) is not None
-        }
-        for span in errors
-    ]
+    error_spans = [_error_span(span) for span in errors]
     root_status = summary.get("status", "unknown")
     duration_ms = summary.get("duration_ms")
     if duration_ms is None and spans:

--- a/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/sources/intake/_http.py
+++ b/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/sources/intake/_http.py
@@ -6,8 +6,8 @@
 import ipaddress
 import json
 import os
-from collections.abc import Iterator, Mapping
-from typing import Any
+from collections.abc import Callable, Iterator, Mapping
+from typing import Any, Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode, urlsplit, urlunsplit
 from urllib.request import HTTPRedirectHandler, Request, build_opener
@@ -64,7 +64,7 @@ def _deep_items(name: str, value: Any) -> Iterator[tuple[str, str]]:
         for key, child in value.items():
             yield from _deep_items(f"{name}[{key}]", child)
         return
-    if isinstance(value, list | tuple):
+    if isinstance(value, (list, tuple)):
         if not value:
             raise ValueError(f"{name} must not be empty because omitting it would broaden the query.")
         for child in value:
@@ -85,7 +85,7 @@ def encode_query(params: Mapping[str, Any]) -> str:
     for name, value in params.items():
         if isinstance(value, Mapping):
             items.extend(_deep_items(name, value))
-        elif isinstance(value, list | tuple):
+        elif isinstance(value, (list, tuple)):
             items.extend(_deep_items(name, value))
         elif value is not None:
             items.append((name, str(value)))
@@ -100,7 +100,7 @@ class IntakeClient:
         base_url: str,
         workspace: str,
         *,
-        access_token: str | None = None,
+        access_token: Optional[str] = None,
         timeout: float = 30.0,
     ) -> None:
         if not workspace:
@@ -128,7 +128,7 @@ class IntakeClient:
         query = encode_query(params)
         return f"{self.base_url}{path}" + (f"?{query}" if query else "")
 
-    def get(self, endpoint: str, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    def get(self, endpoint: str, params: Optional[Mapping[str, Any]] = None) -> dict[str, Any]:
         """Return one decoded JSON object from a read-only Intake endpoint."""
         headers = {"Accept": "application/json"}
         if self.access_token:
@@ -143,6 +143,13 @@ class IntakeClient:
             raise IntakeError(
                 f"Reading Intake failed: the Platform is unreachable at {self.base_url}. "
                 "Check NMP_BASE_URL and that the services are running."
+            ) from exc
+        except OSError as exc:
+            # A timeout while draining the response body arrives as a bare OSError
+            # rather than a URLError, so it needs its own guidance.
+            raise IntakeError(
+                f"Reading Intake failed after {self.timeout:g}s while reading {endpoint}: {exc}. "
+                "Retry, or narrow the query with a smaller limit."
             ) from exc
         try:
             decoded = json.loads(payload)
@@ -177,11 +184,18 @@ class IntakeClient:
     def drain(
         self,
         endpoint: str,
-        params: Mapping[str, Any] | None = None,
+        params: Optional[Mapping[str, Any]] = None,
         *,
-        limit: int | None,
+        limit: Optional[int],
+        stop_when: Optional[Callable[[list[dict[str, Any]]], bool]] = None,
     ) -> tuple[list[dict[str, Any]], bool]:
-        """Read page-based results, preserving the caller's row limit."""
+        """Read page-based results, preserving the caller's row limit.
+
+        ``stop_when`` receives each page as it is kept and ends the read once the
+        caller has what it asked for. It is how a search for named rows avoids paying
+        for every remaining page. The returned flag then reports only whether a row
+        limit cut the result, so a caller that stops early owns that judgement itself.
+        """
         rows: list[dict[str, Any]] = []
         page = 1
         truncated = False
@@ -196,7 +210,10 @@ class IntakeClient:
                 raise IntakeError(f"Intake returned a non-object row while reading {endpoint}.")
 
             remaining = len(data) if limit is None else max(0, limit - len(rows))
-            rows.extend(data[:remaining])
+            kept = data[:remaining]
+            rows.extend(kept)
+            if stop_when is not None and stop_when(kept):
+                break
             total_results = pagination.get("total_results")
             total_pages = pagination.get("total_pages", page)
             if limit is not None and len(rows) >= limit:

--- a/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/sources/intake/adapter.py
+++ b/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/sources/intake/adapter.py
@@ -1,38 +1,105 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Adapt an Intake trace to the generic inspection bundle."""
+"""Adapt Intake to the three reads an inspection makes: list, overview, and spans.
+
+The entry point stays free of Intake's flags, credentials, and client. Everything
+source-specific lives here, so a second trace source can be added beside this module
+without changing the entry point.
+"""
 
 import argparse
 from typing import Any, NoReturn
 
 from sources.intake._http import IntakeClient, IntakeError
-from sources.intake.reader import read_trace
+from sources.intake.reader import DEFAULT_MAX_CHARS, DEFAULT_SPAN_LIMIT, read_overview, read_spans
+from sources.intake.traces import DEFAULT_TRACE_LIMIT, find_agent_traces, recent_traces
 
 
 class _ArgumentParser(argparse.ArgumentParser):
+    """Raise instead of exiting, so a usage error reports the documented error object."""
+
     def error(self, message: str) -> NoReturn:
         raise ValueError(f"Intake source arguments are invalid: {message}")
 
 
-def read_source(trace_ref: str, arguments: list[str]) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Read one Intake trace and return its source identity and evidence."""
+def _client(arguments: list[str], build: Any) -> tuple[IntakeClient, argparse.Namespace]:
     parser = _ArgumentParser(add_help=False)
     parser.add_argument("--workspace", required=True)
+    build(parser)
     args = parser.parse_args(arguments)
-
     try:
-        client = IntakeClient.from_env(args.workspace)
-        trace = read_trace(client, trace_ref)
+        return IntakeClient.from_env(args.workspace), args
     except IntakeError as exc:
         raise ValueError(str(exc)) from exc
 
-    source = {
-        "kind": "intake",
-        "trace_ref": trace["trace_ref"],
-        "context": {
-            "platform_origin": client.base_url,
-            "workspace": client.workspace,
-        },
+
+def _source(client: IntakeClient, **context: Any) -> dict[str, Any]:
+    identity: dict[str, Any] = {
+        "platform_origin": client.base_url,
+        "workspace": client.workspace,
     }
+    identity.update({key: value for key, value in context.items() if value is not None})
+    return {"kind": "intake", "context": identity}
+
+
+def list_traces(arguments: list[str]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """List candidate Intake traces so an inspection can name a real one."""
+
+    def build(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--agent")
+        parser.add_argument("--since")
+        parser.add_argument("--limit", type=int, default=DEFAULT_TRACE_LIMIT)
+
+    client, args = _client(arguments, build)
+    try:
+        if args.agent:
+            found = find_agent_traces(client, args.agent, since=args.since, limit=args.limit)
+        else:
+            found = recent_traces(client, since=args.since, limit=args.limit)
+    except IntakeError as exc:
+        raise ValueError(str(exc)) from exc
+    return _source(client, agent=args.agent, since=args.since), found
+
+
+def overview(trace_ref: str, arguments: list[str]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Read one Intake trace's structure without paying for its span payloads."""
+    client, _ = _client(arguments, lambda parser: None)
+    try:
+        trace = read_overview(client, trace_ref)
+    except IntakeError as exc:
+        raise ValueError(str(exc)) from exc
+    source = _source(client)
+    source["trace_ref"] = trace["trace_ref"]
     return source, trace
+
+
+def spans(trace_ref: str, arguments: list[str]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Read detailed payloads for a named slice of one Intake trace's spans."""
+
+    def build(parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--status")
+        parser.add_argument("--kind")
+        parser.add_argument("--parent")
+        parser.add_argument("--span-id", action="append", default=[], dest="span_ids")
+        parser.add_argument("--limit", type=int, default=DEFAULT_SPAN_LIMIT)
+        parser.add_argument("--max-chars", type=int, default=DEFAULT_MAX_CHARS)
+        parser.add_argument("--full", action="store_true")
+
+    client, args = _client(arguments, build)
+    try:
+        selected = read_spans(
+            client,
+            trace_ref,
+            status=args.status,
+            kind=args.kind,
+            parent_span_id=args.parent,
+            span_ids=args.span_ids,
+            limit=args.limit,
+            max_chars=None if args.full else args.max_chars,
+        )
+    except IntakeError as exc:
+        raise ValueError(str(exc)) from exc
+    source = _source(client)
+    source["trace_ref"] = selected["trace_ref"]
+    return source, selected

--- a/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/sources/intake/reader.py
+++ b/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/sources/intake/reader.py
@@ -1,12 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Load one complete Intake trace as a lossless JSON analysis bundle."""
+"""Read an Intake trace in two passes: cheap structure first, span payloads on request.
 
-from typing import Any
+Intake serves spans in two modes. ``summary`` carries every structural field an
+overview needs; ``detailed`` adds ``input``, ``output``, and ``raw_attributes``, which
+measured 82x larger on a real trace. Reading structure in ``summary`` mode keeps the
+first look affordable, so ``detailed`` is only ever spent on spans the caller names.
+"""
+
+import json
+from collections.abc import Callable, Sequence
+from typing import Any, Optional
 
 from sources.intake._http import IntakeClient, IntakeError
-from sources.intake.traces import query_traces
+from sources.intake.traces import query_traces, trace_ref
+
+PAGE_SIZE = 100
+DEFAULT_SPAN_LIMIT = 20
+DEFAULT_MAX_CHARS = 2000
+
+# Only these three fields are absent from summary mode, so only these need bounding.
+PAYLOAD_FIELDS = ("input", "output", "raw_attributes")
 
 
 def _trace_id(ref: str) -> str:
@@ -16,25 +31,41 @@ def _trace_id(ref: str) -> str:
     return trace_id
 
 
-def read_trace(client: IntakeClient, ref: str) -> dict[str, Any]:
-    """Fetch a trace summary, every detailed span, and related evaluator results."""
+def _sorted_spans(spans: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    spans.sort(key=lambda span: (span.get("started_at") or "", span.get("span_id") or ""))
+    return spans
+
+
+def _evaluator_results(client: IntakeClient, spans: Sequence[dict[str, Any]]) -> tuple[list[str], list[dict[str, Any]]]:
+    """Join evaluator results onto a trace through the sessions its spans belong to.
+
+    Evaluator results are not addressable by trace. They hang off a session, and one
+    session can outlive the trace, so the rows have to be filtered back down to the
+    spans this trace actually contains.
+    """
+    span_ids = {span["span_id"] for span in spans if span.get("span_id")}
+    session_ids = sorted({span["session_id"] for span in spans if span.get("session_id")})
+    results: list[dict[str, Any]] = []
+    for session_id in session_ids:
+        rows, _ = client.drain(
+            "evaluator-results",
+            {"filter": {"session_id": session_id}, "sort": "created_at", "page_size": PAGE_SIZE},
+            limit=None,
+        )
+        results.extend(row for row in rows if row.get("span_id") in span_ids)
+    results.sort(key=lambda result: (result.get("created_at") or "", result.get("evaluator_result_id") or ""))
+    return session_ids, results
+
+
+def read_overview(client: IntakeClient, ref: str) -> dict[str, Any]:
+    """Fetch the trace summary, every span in summary mode, and its evaluator results."""
     trace_id = _trace_id(ref)
-    summary_page = query_traces(
-        client,
-        filter={"id": {"$in": [trace_id]}},
-        mode="detailed",
-        limit=1,
-    )
+    summary_page = query_traces(client, filter={"id": {"$in": [trace_id]}}, mode="detailed", limit=1)
     summary = next((row for row in summary_page["traces"] if row.get("id") == trace_id), None)
 
     spans, _ = client.drain(
         "spans",
-        {
-            "filter": {"trace_id": trace_id},
-            "sort": "started_at",
-            "mode": "detailed",
-            "page_size": 100,
-        },
+        {"filter": {"trace_id": trace_id}, "sort": "started_at", "mode": "summary", "page_size": PAGE_SIZE},
         limit=None,
     )
     if not spans:
@@ -42,29 +73,116 @@ def read_trace(client: IntakeClient, ref: str) -> dict[str, Any]:
             f"No spans matched trace '{trace_id}' in workspace '{client.workspace}'. "
             "Confirm the trace ID and workspace."
         )
-    spans.sort(key=lambda span: (span.get("started_at") or "", span.get("span_id") or ""))
-
-    span_ids = {span["span_id"] for span in spans if span.get("span_id")}
-    session_ids = sorted({span["session_id"] for span in spans if span.get("session_id")})
-    evaluator_results: list[dict[str, Any]] = []
-    for session_id in session_ids:
-        rows, _ = client.drain(
-            "evaluator-results",
-            {
-                "filter": {"session_id": session_id},
-                "sort": "created_at",
-                "page_size": 100,
-            },
-            limit=None,
-        )
-        evaluator_results.extend(row for row in rows if row.get("span_id") in span_ids)
-    evaluator_results.sort(key=lambda result: (result.get("created_at") or "", result.get("evaluator_result_id") or ""))
-
+    spans = _sorted_spans(spans)
+    session_ids, evaluator_results = _evaluator_results(client, spans)
     return {
-        "trace_ref": f"intake://traces/{trace_id}",
+        "trace_ref": trace_ref(trace_id),
         "trace_id": trace_id,
         "summary": summary,
         "session_ids": session_ids,
         "spans": spans,
         "evaluator_results": evaluator_results,
     }
+
+
+def _bounded(span: dict[str, Any], max_chars: Optional[int]) -> dict[str, Any]:
+    """Cap the payload fields, recording the full length of anything shortened.
+
+    A shortened field becomes the leading JSON text of the original value rather than
+    the value itself. That keeps one predictable rule for objects and strings alike,
+    and the recorded length tells the caller when to ask for the field in full.
+    """
+    if max_chars is None:
+        return span
+    bounded = dict(span)
+    for field in PAYLOAD_FIELDS:
+        value = bounded.get(field)
+        if value is None:
+            continue
+        text = value if isinstance(value, str) else json.dumps(value, sort_keys=True)
+        if len(text) <= max_chars:
+            continue
+        bounded[field] = text[:max_chars]
+        bounded[field + "_truncated"] = True
+        bounded[field + "_length"] = len(text)
+    return bounded
+
+
+def read_spans(
+    client: IntakeClient,
+    ref: str,
+    *,
+    status: Optional[str] = None,
+    kind: Optional[str] = None,
+    parent_span_id: Optional[str] = None,
+    span_ids: Sequence[str] = (),
+    limit: int = DEFAULT_SPAN_LIMIT,
+    max_chars: Optional[int] = DEFAULT_MAX_CHARS,
+) -> dict[str, Any]:
+    """Fetch detailed payloads for a named slice of one trace's spans.
+
+    Intake accepts neither ``$eq`` nor ``$in`` on a span ``id``, so an explicit
+    ``span_ids`` selection is applied here rather than server-side. Pairing it with
+    ``status`` or ``kind`` narrows the fetch before it reaches this filter.
+    """
+    trace_id = _trace_id(ref)
+    query: dict[str, Any] = {"trace_id": trace_id}
+    if status:
+        query["status"] = status
+    if kind:
+        query["kind"] = kind
+    if parent_span_id:
+        query["parent_span_id"] = parent_span_id
+
+    wanted = list(dict.fromkeys(span_ids))
+    stop_when: Optional[Callable[[list[dict[str, Any]]], bool]] = None
+    if wanted:
+        remaining = set(wanted)
+
+        def stop_when(rows: list[dict[str, Any]]) -> bool:
+            remaining.difference_update(row.get("span_id") for row in rows)
+            return not remaining
+
+    rows, truncated = client.drain(
+        "spans",
+        {"filter": query, "sort": "started_at", "mode": "detailed", "page_size": PAGE_SIZE},
+        limit=None if wanted else limit,
+        stop_when=stop_when,
+    )
+    if wanted:
+        by_id = {row.get("span_id"): row for row in rows}
+        selected = [by_id[span_id] for span_id in wanted if span_id in by_id]
+        missing = [span_id for span_id in wanted if span_id not in by_id]
+        truncated = False
+    else:
+        selected = _sorted_spans(rows)
+        missing = []
+
+    result: dict[str, Any] = {
+        "trace_ref": trace_ref(trace_id),
+        "trace_id": trace_id,
+        "selection": {
+            key: value
+            for key, value in (
+                ("status", status),
+                ("kind", kind),
+                ("parent_span_id", parent_span_id),
+                ("span_ids", wanted or None),
+            )
+            if value is not None
+        },
+        # Always reported, because null is the difference between "payloads are whole"
+        # and "payloads were shortened", and a caller quoting evidence needs to know.
+        "max_chars": max_chars,
+        "spans": [_bounded(span, max_chars) for span in selected],
+        "count": len(selected),
+        "truncated": truncated,
+    }
+    if missing:
+        result["missing_span_ids"] = missing
+    if not selected:
+        result["note"] = (
+            f"No spans in trace '{trace_id}' matched this selection. An empty result is not an error. "
+            "Read the overview to see which span IDs, kinds, and statuses the trace contains."
+        )
+    return result

--- a/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/sources/intake/traces.py
+++ b/plugins/nemo-eval-author/skills/eval-author-inspect-trace/scripts/sources/intake/traces.py
@@ -4,7 +4,7 @@
 """JSON-returning Intake span and trace queries."""
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional, Union
 
 from sources.intake._http import IntakeClient
 
@@ -24,53 +24,40 @@ def _page_size(limit: int) -> int:
     return max(1, min(limit, _MAX_PAGE_SIZE))
 
 
-def _with_trace_ref(row: dict[str, Any]) -> dict[str, Any]:
-    result = dict(row)
-    group = result.get("group")
-    trace_id = result.get("trace_id") or (group.get("trace_id") if isinstance(group, dict) else None)
-    if trace_id:
-        result["trace_ref"] = f"intake://{trace_id}"
-    return result
+def trace_ref(trace_id: str) -> str:
+    """Build the one canonical Intake trace reference that every caller emits."""
+    return f"intake://traces/{trace_id}"
 
 
-def query_spans(
+def _since_filter(since: Optional[Union[datetime, str]]) -> Optional[dict[str, Any]]:
+    if since is None:
+        return None
+    return {"gte": since.isoformat() if isinstance(since, datetime) else since}
+
+
+def group_spans(
     client: IntakeClient,
     *,
-    filter: dict[str, Any] | None = None,
-    group_by: str | None = None,
-    sort: str | None = None,
-    mode: str = "summary",
+    by: str,
+    filter: Optional[dict[str, Any]] = None,
+    sort: Optional[str] = None,
     limit: int = DEFAULT_ROW_LIMIT,
 ) -> dict[str, Any]:
-    """Query Intake spans, either flat or grouped."""
+    """Roll spans up by one field, so a search can rank whole traces rather than spans."""
     limit = _limit(limit, MAX_ROW_LIMIT)
-    params: dict[str, Any] = {
-        "filter": filter,
-        "sort": sort or "-started_at",
-        "page_size": _page_size(limit),
-    }
-    if group_by is not None:
-        params["by"] = group_by
-        rows, truncated = client.drain("spans/groups", params, limit=limit)
-        groups = [_with_trace_ref(row) for row in rows]
-        return {
-            "groups": groups,
-            "grouped_by": group_by,
-            "count": len(groups),
-            "truncated": truncated,
-        }
-
-    params["mode"] = mode
-    rows, truncated = client.drain("spans", params, limit=limit)
-    spans = [_with_trace_ref(row) for row in rows]
-    return {"spans": spans, "count": len(spans), "truncated": truncated}
+    rows, truncated = client.drain(
+        "spans/groups",
+        {"filter": filter, "sort": sort or "-started_at", "by": by, "page_size": _page_size(limit)},
+        limit=limit,
+    )
+    return {"groups": rows, "count": len(rows), "truncated": truncated}
 
 
 def query_traces(
     client: IntakeClient,
     *,
-    filter: dict[str, Any] | None = None,
-    sort: str | None = None,
+    filter: Optional[dict[str, Any]] = None,
+    sort: Optional[str] = None,
     mode: str = "preview",
     limit: int = DEFAULT_ROW_LIMIT,
 ) -> dict[str, Any]:
@@ -89,23 +76,55 @@ def query_traces(
     return {"traces": rows, "count": len(rows), "truncated": truncated}
 
 
+def recent_traces(
+    client: IntakeClient,
+    *,
+    since: Optional[Union[datetime, str]] = None,
+    limit: int = DEFAULT_TRACE_LIMIT,
+) -> dict[str, Any]:
+    """List the most recent traces in one workspace, newest first."""
+    limit = _limit(limit, MAX_TRACE_LIMIT)
+    started_at = _since_filter(since)
+    page = query_traces(
+        client,
+        filter={"started_at": started_at} if started_at else None,
+        sort="-started_at",
+        mode="preview",
+        limit=limit,
+    )
+    traces = [_trace_entry(row["id"], row) for row in page["traces"] if row.get("id")]
+    result: dict[str, Any] = {
+        "traces": traces,
+        "count": len(traces),
+        "truncated": page["truncated"],
+    }
+    if not traces:
+        window = f" since {started_at['gte']}" if started_at else ""
+        result["note"] = (
+            f"No traces were recorded in workspace '{client.workspace}'{window}. "
+            "An empty result is not an error. Confirm the workspace and that the agent reports to Intake."
+        )
+    return result
+
+
 def find_agent_traces(
     client: IntakeClient,
     agent: str,
     *,
-    since: datetime | str | None = None,
+    since: Optional[Union[datetime, str]] = None,
     limit: int = DEFAULT_TRACE_LIMIT,
 ) -> dict[str, Any]:
     """Find recent traces that contain a span from one agent."""
     limit = _limit(limit, MAX_TRACE_LIMIT)
     span_filter: dict[str, Any] = {"agent_name": agent}
-    if since is not None:
-        span_filter["started_at"] = {"gte": since.isoformat() if isinstance(since, datetime) else since}
+    started_at = _since_filter(since)
+    if started_at is not None:
+        span_filter["started_at"] = started_at
 
-    grouped = query_spans(
+    grouped = group_spans(
         client,
+        by="trace_id",
         filter=span_filter,
-        group_by="trace_id",
         sort="-started_at",
         limit=limit,
     )
@@ -135,7 +154,7 @@ def find_agent_traces(
         "truncated": grouped["truncated"],
     }
     if not traces:
-        window = f" since {span_filter['started_at']['gte']}" if since is not None else ""
+        window = f" since {started_at['gte']}" if started_at else ""
         result["note"] = (
             f"No spans matched agent_name='{agent}' in workspace '{client.workspace}'{window}. "
             "An empty result is not an error. Confirm the agent_name value reported to Intake."
@@ -143,10 +162,10 @@ def find_agent_traces(
     return result
 
 
-def _trace_entry(trace_id: str, summary: dict[str, Any] | None) -> dict[str, Any]:
+def _trace_entry(trace_id: str, summary: Optional[dict[str, Any]]) -> dict[str, Any]:
     summary = summary or {}
     return {
-        "trace_ref": f"intake://{trace_id}",
+        "trace_ref": trace_ref(trace_id),
         "trace_id": trace_id,
         "started_at": summary.get("started_at"),
         "status": summary.get("status", "unknown"),

--- a/plugins/nemo-eval-author/tests/test_intake_scripts.py
+++ b/plugins/nemo-eval-author/tests/test_intake_scripts.py
@@ -3,12 +3,14 @@
 
 """Behavior tests for the Eval Author Intake trace source."""
 
+import ast
 import importlib
 import json
 import os
 import subprocess
 import sys
 import threading
+import time
 from collections import deque
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -28,6 +30,9 @@ _MODULE_PATHS = (
     *(_INTAKE_DIR / name for name in ("_http.py", "traces.py", "reader.py")),
     _INSPECT_SCRIPTS / "overview.py",
 )
+# The scripts run on whatever interpreter the agent's machine offers, and macOS still
+# ships 3.9. Anything newer in the syntax turns a trace read into a SyntaxError.
+_OLDEST_SUPPORTED_PYTHON = (3, 9)
 
 
 def _modules() -> tuple[ModuleType, ModuleType, ModuleType, ModuleType]:
@@ -65,14 +70,21 @@ def _page(
 
 class _Scenario:
     def __init__(self) -> None:
-        self.responses: deque[tuple[int, dict | None, dict[str, str]]] = deque()
+        self.responses: deque[tuple[int, dict | None, dict[str, str], float]] = deque()
         self.requests: list[dict] = []
 
-    def respond(self, body: dict, *, status: int = 200, headers: dict[str, str] | None = None) -> None:
-        self.responses.append((status, body, headers or {}))
+    def respond(
+        self,
+        body: dict,
+        *,
+        status: int = 200,
+        headers: dict[str, str] | None = None,
+        body_delay: float = 0.0,
+    ) -> None:
+        self.responses.append((status, body, headers or {}, body_delay))
 
     def redirect(self, location: str) -> None:
-        self.responses.append((302, None, {"Location": location}))
+        self.responses.append((302, None, {"Location": location}, 0.0))
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -81,7 +93,7 @@ class _Handler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:  # noqa: N802
         scenario = self.server.scenario
         scenario.requests.append({"path": self.path, "authorization": self.headers.get("Authorization")})
-        status, body, headers = scenario.responses.popleft()
+        status, body, headers, body_delay = scenario.responses.popleft()
         payload = b"" if body is None else json.dumps(body).encode()
         self.send_response(status)
         for name, value in headers.items():
@@ -90,6 +102,10 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(payload)))
         self.end_headers()
+        if body_delay:
+            # Headers land first so the client stalls while reading the body.
+            self.wfile.flush()
+            time.sleep(body_delay)
         self.wfile.write(payload)
 
     def log_message(self, format: str, *args: object) -> None:
@@ -123,8 +139,10 @@ def test_intake_source_modules_exist_and_import_without_the_platform() -> None:
     http, traces, reader, overview = _modules()
 
     assert http.IntakeClient
-    assert traces.query_spans
-    assert reader.read_trace
+    assert traces.query_traces
+    assert traces.group_spans
+    assert reader.read_overview
+    assert reader.read_spans
     assert overview.build_overview
 
 
@@ -143,15 +161,16 @@ def test_client_rejects_unsafe_platform_origins(base_url: str, message: str) -> 
         http.IntakeClient(base_url, "default")
 
 
-def test_span_query_encodes_nested_filters_and_bearer_auth() -> None:
-    http, traces, *_ = _modules()
+def test_requests_encode_nested_filters_and_carry_bearer_auth() -> None:
+    http, *_ = _modules()
     with _api() as (base_url, scenario):
         scenario.respond(_page([{"span_id": "span-1", "trace_id": "trace-1"}]))
         client = http.IntakeClient(base_url, "space/name", access_token="secret")
 
-        result = traces.query_spans(
-            client,
-            filter={"agent_name": "support", "started_at": {"gte": "2026-01-01T00:00:00+00:00"}},
+        client.drain(
+            "spans",
+            {"filter": {"agent_name": "support", "started_at": {"gte": "2026-01-01T00:00:00+00:00"}}},
+            limit=100,
         )
 
     request = scenario.requests[0]
@@ -159,17 +178,16 @@ def test_span_query_encodes_nested_filters_and_bearer_auth() -> None:
     assert request["authorization"] == "Bearer secret"
     assert _query(request)["filter[agent_name]"] == ["support"]
     assert _query(request)["filter[started_at][gte]"] == ["2026-01-01T00:00:00+00:00"]
-    assert result["spans"][0]["trace_ref"] == "intake://trace-1"
 
 
 def test_authenticated_requests_do_not_follow_redirects() -> None:
-    http, traces, *_ = _modules()
+    http, *_ = _modules()
     with _api() as (base_url, scenario):
         scenario.redirect(f"{base_url}/elsewhere")
         client = http.IntakeClient(base_url, "default", access_token="secret")
 
         with pytest.raises(http.IntakeError, match="redirect"):
-            traces.query_spans(client)
+            client.drain("spans", limit=1)
 
     assert len(scenario.requests) == 1
 
@@ -179,16 +197,16 @@ def test_authenticated_requests_do_not_follow_redirects() -> None:
     [(401, "NMP_ACCESS_TOKEN"), (404, "workspace"), (400, "filter")],
 )
 def test_http_errors_include_actionable_guidance(status: int, guidance: str) -> None:
-    http, traces, *_ = _modules()
+    http, *_ = _modules()
     with _api() as (base_url, scenario):
         scenario.respond({"detail": "bad request"}, status=status)
 
         with pytest.raises(http.IntakeError, match=guidance):
-            traces.query_spans(http.IntakeClient(base_url, "default"))
+            http.IntakeClient(base_url, "default").drain("spans", limit=1)
 
 
-def test_span_query_drains_pages_and_reports_truncation() -> None:
-    http, traces, *_ = _modules()
+def test_paged_reads_drain_every_page_and_report_truncation() -> None:
+    http, *_ = _modules()
     with _api() as (base_url, scenario):
         scenario.respond(
             _page(
@@ -209,22 +227,22 @@ def test_span_query_drains_pages_and_reports_truncation() -> None:
             )
         )
 
-        result = traces.query_spans(http.IntakeClient(base_url, "default"), limit=3)
+        rows, truncated = http.IntakeClient(base_url, "default").drain("spans", limit=3)
 
-    assert [row["span_id"] for row in result["spans"]] == ["span-1", "span-2", "span-3"]
-    assert result["truncated"] is True
+    assert [row["span_id"] for row in rows] == ["span-1", "span-2", "span-3"]
+    assert truncated is True
     assert [_query(request)["page"] for request in scenario.requests] == [["1"], ["2"]]
 
 
-def test_grouped_span_query_preserves_the_server_group() -> None:
+def test_grouped_spans_preserve_the_server_group_verbatim() -> None:
     http, traces, *_ = _modules()
     with _api() as (base_url, scenario):
         scenario.respond(_page([{"group": {"trace_id": "trace-1"}, "span_count": 3}]))
 
-        result = traces.query_spans(
+        result = traces.group_spans(
             http.IntakeClient(base_url, "default"),
+            by="trace_id",
             filter={"tool_name": "search"},
-            group_by="trace_id",
             sort="-span_count",
         )
 
@@ -233,8 +251,7 @@ def test_grouped_span_query_preserves_the_server_group() -> None:
     assert _query(request)["by"] == ["trace_id"]
     assert _query(request)["sort"] == ["-span_count"]
     assert result == {
-        "groups": [{"group": {"trace_id": "trace-1"}, "span_count": 3, "trace_ref": "intake://trace-1"}],
-        "grouped_by": "trace_id",
+        "groups": [{"group": {"trace_id": "trace-1"}, "span_count": 3}],
         "count": 1,
         "truncated": False,
     }
@@ -253,6 +270,57 @@ def test_trace_query_requests_preview_rollups() -> None:
     assert _query(scenario.requests[0])["mode"] == ["preview"]
     assert _query(scenario.requests[0])["filter[id][$in]"] == ["trace-1"]
     assert result["traces"][0]["error_count"] == 1
+
+
+def test_a_stalled_response_body_reports_guidance_instead_of_raising_oserror() -> None:
+    http, *_ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([{"span_id": "span-1"}]), body_delay=2.0)
+        client = http.IntakeClient(base_url, "default", timeout=0.1)
+
+        with pytest.raises(http.IntakeError) as failure:
+            client.drain("spans", limit=1)
+
+    assert "spans" in str(failure.value)
+
+
+def test_recent_traces_lists_newest_first_with_a_reference_per_row() -> None:
+    http, traces, *_ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(
+            _page(
+                [
+                    {"id": "trace-new", "started_at": "2026-01-03T00:00:00Z", "status": "success", "span_count": 7},
+                    {"id": "trace-old", "started_at": "2026-01-01T00:00:00Z", "status": "error", "span_count": 2},
+                ]
+            )
+        )
+
+        result = traces.recent_traces(http.IntakeClient(base_url, "default"), limit=10)
+
+    assert _query(scenario.requests[0])["sort"] == ["-started_at"]
+    assert _query(scenario.requests[0])["mode"] == ["preview"]
+    assert [row["trace_ref"] for row in result["traces"]] == [
+        "intake://traces/trace-new",
+        "intake://traces/trace-old",
+    ]
+    assert result["count"] == 2
+    assert "note" not in result
+
+
+def test_recent_traces_bounds_the_window_and_notes_an_empty_workspace() -> None:
+    http, traces, *_ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([]))
+
+        result = traces.recent_traces(
+            http.IntakeClient(base_url, "default"),
+            since="2026-01-01T00:00:00+00:00",
+        )
+
+    assert _query(scenario.requests[0])["filter[started_at][gte]"] == ["2026-01-01T00:00:00+00:00"]
+    assert result["count"] == 0
+    assert "2026-01-01T00:00:00+00:00" in result["note"]
 
 
 @pytest.mark.parametrize("values", [[], [None], [{}]], ids=("empty", "null-only", "empty-object"))
@@ -322,7 +390,7 @@ def test_an_empty_agent_query_does_not_request_trace_summaries() -> None:
 
 
 @pytest.mark.parametrize("ref", ["trace-1", "intake://trace-1", "intake://traces/trace-1"])
-def test_read_trace_normalizes_refs_and_fetches_all_evidence(ref: str) -> None:
+def test_read_overview_normalizes_refs_and_joins_evaluator_results(ref: str) -> None:
     http, _, reader, _ = _modules()
     with _api() as (base_url, scenario):
         scenario.respond(_page([{"id": "trace-1", "status": "success", "error_count": 1}]))
@@ -358,25 +426,116 @@ def test_read_trace_normalizes_refs_and_fetches_all_evidence(ref: str) -> None:
         )
         scenario.respond(_page([{"evaluator_result_id": "eval-2", "span_id": "span-2", "session_id": "session-2"}]))
 
-        result = reader.read_trace(http.IntakeClient(base_url, "default"), ref)
+        result = reader.read_overview(http.IntakeClient(base_url, "default"), ref)
 
     assert result["trace_id"] == "trace-1"
     assert result["trace_ref"] == "intake://traces/trace-1"
     assert result["session_ids"] == ["session-1", "session-2"]
     assert [span["span_id"] for span in result["spans"]] == ["span-1", "span-2"]
     assert [item["evaluator_result_id"] for item in result["evaluator_results"]] == ["eval-1", "eval-2"]
-    assert _query(scenario.requests[1])["mode"] == ["detailed"]
     assert _query(scenario.requests[1])["sort"] == ["started_at"]
 
 
-def test_read_trace_rejects_a_trace_with_no_spans() -> None:
+def test_read_overview_reads_structure_without_paying_for_payloads() -> None:
+    """Summary mode measured 82x smaller than detailed, and carries every field it needs."""
+    http, _, reader, _ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([{"id": "trace-1", "status": "success"}]))
+        scenario.respond(_page([{"span_id": "span-1", "session_id": "s", "status": "error", "error_message": "boom"}]))
+        scenario.respond(_page([]))
+
+        result = reader.read_overview(http.IntakeClient(base_url, "default"), "trace-1")
+
+    assert _query(scenario.requests[1])["mode"] == ["summary"]
+    assert result["spans"][0]["error_message"] == "boom"
+
+
+def test_read_overview_rejects_a_trace_with_no_spans() -> None:
     http, _, reader, _ = _modules()
     with _api() as (base_url, scenario):
         scenario.respond(_page([]))
         scenario.respond(_page([]))
 
         with pytest.raises(http.IntakeError, match="No spans"):
-            reader.read_trace(http.IntakeClient(base_url, "default"), "missing")
+            reader.read_overview(http.IntakeClient(base_url, "default"), "missing")
+
+
+def test_read_spans_narrows_the_fetch_server_side_and_bounds_each_payload() -> None:
+    http, _, reader, _ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([{"span_id": "span-1", "status": "error", "input": "x" * 50, "output": "short"}]))
+
+        result = reader.read_spans(
+            http.IntakeClient(base_url, "default"),
+            "trace-1",
+            status="error",
+            kind="LLM",
+            max_chars=10,
+        )
+
+    query = _query(scenario.requests[0])
+    assert query["mode"] == ["detailed"]
+    assert query["filter[status]"] == ["error"]
+    assert query["filter[kind]"] == ["LLM"]
+    assert query["filter[trace_id]"] == ["trace-1"]
+    span = result["spans"][0]
+    assert span["input"] == "x" * 10
+    assert span["input_truncated"] is True
+    assert span["input_length"] == 50
+    assert "output_truncated" not in span, "a payload under the cap is left alone"
+    assert result["max_chars"] == 10
+
+
+def test_read_spans_stops_paging_once_the_named_spans_are_found() -> None:
+    """Naming a span must not cost every remaining page of a long trace."""
+    http, _, reader, _ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([{"span_id": "span-1"}], page=1, total_pages=9, total_results=900))
+        scenario.respond(_page([{"span_id": "span-2"}], page=2, total_pages=9, total_results=900))
+
+        result = reader.read_spans(http.IntakeClient(base_url, "default"), "trace-1", span_ids=["span-1"])
+
+    assert [span["span_id"] for span in result["spans"]] == ["span-1"]
+    assert len(scenario.requests) == 1, "found on page 1, so pages 2 through 9 were never fetched"
+    assert result["truncated"] is False
+    assert "missing_span_ids" not in result
+
+
+def test_read_spans_names_the_span_ids_it_could_not_find() -> None:
+    http, _, reader, _ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([{"span_id": "span-1"}]))
+
+        result = reader.read_spans(
+            http.IntakeClient(base_url, "default"),
+            "trace-1",
+            span_ids=["span-1", "span-404"],
+        )
+
+    assert result["missing_span_ids"] == ["span-404"]
+    assert result["count"] == 1
+
+
+def test_read_spans_keeps_payloads_whole_when_no_cap_is_given() -> None:
+    http, _, reader, _ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([{"span_id": "span-1", "input": {"messages": ["x" * 5000]}}]))
+
+        result = reader.read_spans(http.IntakeClient(base_url, "default"), "trace-1", max_chars=None)
+
+    assert result["spans"][0]["input"] == {"messages": ["x" * 5000]}
+    assert result["max_chars"] is None
+
+
+def test_read_spans_treats_an_empty_selection_as_a_fact_not_a_failure() -> None:
+    http, _, reader, _ = _modules()
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([]))
+
+        result = reader.read_spans(http.IntakeClient(base_url, "default"), "trace-1", kind="TOOL")
+
+    assert result["count"] == 0
+    assert "not an error" in result["note"]
 
 
 @pytest.mark.parametrize(
@@ -513,6 +672,129 @@ def test_overview_separates_cancelled_spans_from_incomplete_telemetry() -> None:
     assert result["incomplete_span_ids"] == []
 
 
+def test_overview_keeps_an_error_span_identifiable_without_its_whole_traceback() -> None:
+    *_, overview = _modules()
+    traceback = "BadRequestError: " + "stack frame\n" * 400
+    bundle = {
+        "trace_id": "trace-1",
+        "summary": {"status": "success"},
+        "session_ids": ["session-1"],
+        "spans": [
+            {
+                "span_id": f"span-{index}",
+                "parent_span_id": "parent-1",
+                "session_id": "session-1",
+                "status": "error",
+                "kind": "LLM",
+                "error_message": traceback,
+            }
+            for index in range(3)
+        ],
+        "evaluator_results": [],
+    }
+
+    result = overview.build_overview(bundle)
+
+    assert len(result["error_spans"]) == 3
+    for entry in result["error_spans"]:
+        assert len(entry["error_message"]) == overview.MAX_ERROR_MESSAGE
+        assert entry["error_message_truncated"] is True
+        assert entry["error_message_length"] == len(traceback)
+    assert len(json.dumps(result["error_spans"])) < len(traceback)
+
+
+def test_overview_leaves_a_short_error_message_whole() -> None:
+    *_, overview = _modules()
+    bundle = {
+        "trace_id": "trace-1",
+        "summary": {"status": "error"},
+        "session_ids": ["session-1"],
+        "spans": [
+            {
+                "span_id": "span-1",
+                "session_id": "session-1",
+                "status": "error",
+                "kind": "TOOL",
+                "error_message": "connection refused",
+            }
+        ],
+        "evaluator_results": [],
+    }
+
+    entry = overview.build_overview(bundle)["error_spans"][0]
+
+    assert entry["error_message"] == "connection refused"
+    assert "error_message_truncated" not in entry
+
+
+def test_timeline_reports_an_offset_and_a_duration_for_every_span() -> None:
+    *_, overview = _modules()
+    bundle = {
+        "spans": [
+            {
+                "span_id": "root",
+                "name": "LangGraph",
+                "kind": "CHAIN",
+                "status": "success",
+                "started_at": "2026-01-01T00:00:00Z",
+                "ended_at": "2026-01-01T00:00:10Z",
+            },
+            {
+                "span_id": "child",
+                "parent_span_id": "root",
+                "name": "ChatOpenAI",
+                "kind": "LLM",
+                "status": "error",
+                "started_at": "2026-01-01T00:00:04Z",
+                "ended_at": "2026-01-01T00:00:06Z",
+            },
+            {"span_id": "unfinished", "parent_span_id": "root", "started_at": "2026-01-01T00:00:07Z"},
+        ]
+    }
+
+    timeline = overview.build_timeline(bundle)
+
+    assert [row["span_id"] for row in timeline] == ["root", "child", "unfinished"]
+    assert [row["offset_ms"] for row in timeline] == [0.0, 4000.0, 7000.0]
+    assert [row["duration_ms"] for row in timeline] == [10_000.0, 2000.0, None]
+    assert timeline[1]["parent_span_id"] == "root"
+    assert timeline[1]["status"] == "error"
+
+
+def test_timeline_is_kept_out_of_the_overview_that_front_matter_copies() -> None:
+    *_, overview = _modules()
+    bundle = {
+        "summary": {"status": "success"},
+        "session_ids": [],
+        "spans": [{"span_id": "one", "status": "success", "kind": "AGENT"}],
+        "evaluator_results": [],
+    }
+
+    assert "timeline" not in overview.build_overview(bundle)
+
+
+def test_every_bundled_script_parses_on_the_oldest_supported_interpreter() -> None:
+    """The scripts stay readable to an old interpreter instead of guarding against it.
+
+    An agent runs these with whatever ``python3`` its machine has, and macOS still
+    ships 3.9. Syntax from a later version turns the first read into a SyntaxError
+    before any of the skill's own error handling can report it.
+    """
+    offenders: dict[str, str] = {}
+    for path in sorted(_INSPECT_SCRIPTS.rglob("*.py")):
+        try:
+            ast.parse(
+                path.read_text(encoding="utf-8"),
+                filename=str(path),
+                feature_version=_OLDEST_SUPPORTED_PYTHON,
+            )
+        except SyntaxError as exc:
+            offenders[path.name] = f"line {exc.lineno}: {exc.msg}"
+
+    version = ".".join(str(part) for part in _OLDEST_SUPPORTED_PYTHON)
+    assert not offenders, f"scripts use syntax newer than Python {version}: {offenders}"
+
+
 @pytest.mark.parametrize("trace_ref", ["trace-1", "intake:trace-1"], ids=("bare", "missing-slashes"))
 def test_inspect_entry_point_rejects_an_unqualified_trace_reference(trace_ref: str) -> None:
     env = {key: value for key, value in os.environ.items() if key not in {"NMP_BASE_URL", "NMP_ACCESS_TOKEN"}}
@@ -522,11 +804,12 @@ def test_inspect_entry_point_rejects_an_unqualified_trace_reference(trace_ref: s
             sys.executable,
             "-S",
             str(_INSPECT),
-            "--workspace",
-            "default",
+            "overview",
             "--trace",
             trace_ref,
             "--compact",
+            "--workspace",
+            "default",
         ],
         env=env,
         capture_output=True,
@@ -546,11 +829,12 @@ def test_inspect_entry_point_rejects_an_unknown_trace_source() -> None:
             sys.executable,
             "-S",
             str(_INSPECT),
-            "--workspace",
-            "default",
+            "overview",
             "--trace",
             "langfuse://project/trace-1",
             "--compact",
+            "--workspace",
+            "default",
         ],
         capture_output=True,
         text=True,
@@ -612,11 +896,12 @@ def test_inspect_entry_point_emits_json_and_writes_nothing(
                 sys.executable,
                 "-S",
                 str(_INSPECT),
-                "--workspace",
-                workspace,
+                "overview",
                 "--trace",
                 f"intake://traces/{trace_id}",
                 "--compact",
+                "--workspace",
+                workspace,
             ],
             cwd=tmp_path,
             env=env,
@@ -628,7 +913,7 @@ def test_inspect_entry_point_emits_json_and_writes_nothing(
     assert result.returncode == 0, result.stderr
     report = json.loads(result.stdout)
     assert report["schema_version"] == "1"
-    assert report["trace"]["trace_id"] == trace_id
+    assert report["overview"]["trace_id"] == trace_id
     assert report["source"] == {
         "kind": "intake",
         "trace_ref": f"intake://traces/{trace_id}",
@@ -640,3 +925,50 @@ def test_inspect_entry_point_emits_json_and_writes_nothing(
     assert report["overview"]["root_status"] == "success"
     assert scenario.requests[0]["authorization"] == "Bearer secret"
     assert list(tmp_path.iterdir()) == before
+
+
+def _run_verb(base_url: str, *arguments: str) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-S", str(_INSPECT), *arguments, "--compact"],
+        env={**os.environ, "NMP_BASE_URL": base_url},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout)
+
+
+def test_the_list_verb_offers_references_the_read_verbs_accept() -> None:
+    """Discovery has to hand back something the next command can take verbatim."""
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([{"id": "trace-1", "status": "error", "span_count": 4, "error_count": 2}]))
+
+        report = _run_verb(base_url, "list", "--source", "intake", "--workspace", "default")
+
+    assert report["traces"][0]["trace_ref"] == "intake://traces/trace-1"
+    assert report["traces"][0]["error_count"] == 2
+    assert report["source"]["context"]["workspace"] == "default"
+
+
+def test_the_spans_verb_reports_the_selection_it_was_given() -> None:
+    with _api() as (base_url, scenario):
+        scenario.respond(_page([{"span_id": "span-1", "status": "error", "input": "y" * 40}]))
+
+        report = _run_verb(
+            base_url,
+            "spans",
+            "--trace",
+            "intake://traces/trace-1",
+            "--workspace",
+            "default",
+            "--status",
+            "error",
+            "--max-chars",
+            "8",
+        )
+
+    assert report["selection"] == {"status": "error"}
+    assert report["max_chars"] == 8
+    assert report["spans"][0]["input_length"] == 40
+    assert report["source"]["trace_ref"] == "intake://traces/trace-1"

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -272,7 +272,16 @@ def test_the_entry_point_owns_no_source_specific_arguments_or_internals() -> Non
     """The entry point names one adapter function; the source owns its own flags and client."""
     entry_point = (_INSPECT_SCRIPTS_DIR / "inspect_trace.py").read_text(encoding="utf-8")
 
-    for detail in ("--workspace", "NMP_BASE_URL", "NMP_ACCESS_TOKEN", "IntakeClient", "IntakeError", "read_trace"):
+    forbidden = (
+        "--workspace",
+        "NMP_BASE_URL",
+        "NMP_ACCESS_TOKEN",
+        "IntakeClient",
+        "IntakeError",
+        "read_overview",
+        "read_spans",
+    )
+    for detail in forbidden:
         assert detail not in entry_point
 
 
@@ -350,6 +359,27 @@ def test_every_bundled_path_the_skill_names_exists() -> None:
         for relative in paths:
             assert relative in body, f"{document.relative_to(skill_dir)} no longer documents {relative}"
             assert (skill_dir / relative).exists(), f"{document.relative_to(skill_dir)} names missing {relative}"
+
+
+def test_no_document_names_a_script_that_was_deleted() -> None:
+    """Catch the other direction of drift: a document naming a file that no longer exists.
+
+    Listing the expected paths only proves the ones we remembered to list. A script
+    that gets folded into another one leaves its name behind in the prose, and the
+    agent then runs a command that cannot work.
+    """
+    named = re.compile(r"`(scripts/[A-Za-z0-9_/]+\.py)`")
+    missing: dict[str, set[str]] = {}
+    for skill_dir in _SKILL_DIRS:
+        for document in sorted(skill_dir.rglob("*.md")):
+            absent = {
+                relative
+                for relative in named.findall(document.read_text(encoding="utf-8"))
+                if not (skill_dir / relative).exists()
+            }
+            if absent:
+                missing[str(document.relative_to(skill_dir.parent))] = absent
+    assert not missing, f"documents name scripts that do not exist: {missing}"
 
 
 def test_bundled_scripts_respect_each_flow_dependency_boundary() -> None:


### PR DESCRIPTION
Stacked on `eval-author-intake-trace-understanding/akhoury`.

## Why

I ran the `eval-author-inspect-trace` skill end to end against a live platform and then reported the defects. The root problem was not any single bug: reading a trace was one command that returned everything, so on a real trace it was unusable and I fell back to ad-hoc `curl`, skipping the skill's page draining and its evaluator join. This reshapes the scripts around the three reads an inspection actually makes.

## What changed

**One entry point, three verbs.** `inspect_trace.py` now takes `list`, `overview`, and `spans`. Discovery folds into `list`, retiring a second entry point.

**Structure is read compactly.** Intake serves spans in a `summary` form that measured 82x smaller than `detailed` and carries every structural field the overview and timeline need. Detail is spent only on spans the caller names, selected by `--status`, `--kind`, `--parent`, or `--span-id`.

| Trace | Before | After |
|---|---|---|
| 67 spans | 1.9 MB | 24 KB |
| 605 spans | 26.3 MB | 154 KB |

**A named span stops the read early.** Intake accepts no equality operator on a span `id`, so `--span-id` is applied after the fetch, and reading stops once every named span is found. On a 605-span trace that is 0.29s for a span on page 1 against 1.84s to drain all seven pages.

**Payloads are bounded honestly.** `input` alone was 85% of a detailed payload. Each of `input`, `output`, and `raw_attributes` is capped at `--max-chars` (2000 by default), and a shortened field records its full length beside it. `--full` opts out. The result always reports `max_chars`, because `null` is the difference between whole and shortened evidence.

**Python 3.9 instead of a guard against it.** The original crash was a `TypeError` from 3.12-only syntax under the 3.9 that macOS ships. Rather than keep a guard file, the scripts target 3.9, and a test parses every script with `feature_version=(3, 9)` so it stays that way.

**Dead code removed.** The flat span query and its reference shaping had no caller; the four tests that reached through it now exercise `IntakeClient.drain` directly, which is where the behavior lives.

Fixes carried in from the defect report: error messages in the overview are bounded, a per-span `timeline` supplies `offset_ms` and `duration_ms`, `trace_ref` has one canonical form, read-phase `OSError` becomes a structured error, and argument errors report the documented `{error, hint}` object instead of an argparse exit.

## Honest note on scope

This does not reduce line count. The scripts go from 699 to 1006 lines, because capability I had been hand-rolling with `curl` now lives in them. What went down is the number of files (8 to 6 in the working tree), entry points (2 to 1), dead code, and output size. Further deletion is possible; say the word and I will take another pass.

## Test plan

- [x] `uv run --frozen pytest plugins/nemo-eval-author/tests` — 89 passed
- [x] `uv run ruff check`, `ruff format --check`, `uv run --frozen ty check` — clean
- [x] `uv run pre-commit run --files ...` — passed
- [x] All six scripts compile under `/usr/bin/python3` (3.9.6)
- [x] All three verbs run against a live platform on 3.9.6
- [x] Eight failure modes return structured JSON with exit 1
- [x] New doc-rot test confirmed to fail when a document names a deleted script