### PR TITLE
feat(agents): adding session ownership rules

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/dependencies.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/dependencies.py
@@ -65,6 +65,18 @@ def get_nemo_client() -> AsyncNemoClient:
     )
 
 
+def get_effective_principal_id() -> str:
+    """FastAPI dependency for getting the request's effective principal ID.
+
+    This is a placeholder — the actual principal ID is injected via
+    app.dependency_overrides in Service.create_app().
+    """
+    raise RuntimeError(
+        "get_effective_principal_id() was called without being overridden. "
+        "Ensure your Service subclass calls super().create_app()."
+    )
+
+
 def get_entity_client() -> "EntityClient":
     """FastAPI dependency for getting the EntityClient.
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/entities/base.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/entities/base.py
@@ -29,7 +29,16 @@ from pydantic import BaseModel, Field, PrivateAttr, TypeAdapter, computed_field
 
 # Regex pattern for valid workspace names
 ID_PATTERN = r"^[\w\-\+.@:]+$"
-BASE_FIELDS = {"id", "name", "workspace", "created_at", "updated_at", "entity_type", "project"}
+BASE_FIELDS = {
+    "id",
+    "name",
+    "workspace",
+    "created_at",
+    "updated_at",
+    "created_by",
+    "entity_type",
+    "project",
+}
 
 # Default workspace when none is specified
 DEFAULT_WORKSPACE = "default"

--- a/packages/nemo_platform_plugin/tests/test_dependencies.py
+++ b/packages/nemo_platform_plugin/tests/test_dependencies.py
@@ -4,9 +4,14 @@
 """Tests for plugin-owned FastAPI dependency placeholders."""
 
 import pytest
-from nemo_platform_plugin.dependencies import get_nemo_client
+from nemo_platform_plugin.dependencies import get_effective_principal_id, get_nemo_client
 
 
 def test_get_nemo_client_requires_platform_override() -> None:
     with pytest.raises(RuntimeError, match=r"get_nemo_client\(\) was called without being overridden"):
         get_nemo_client()
+
+
+def test_get_effective_principal_id_requires_platform_override() -> None:
+    with pytest.raises(RuntimeError, match=r"get_effective_principal_id\(\) was called without being overridden"):
+        get_effective_principal_id()

--- a/packages/nemo_platform_plugin/tests/test_entity_client.py
+++ b/packages/nemo_platform_plugin/tests/test_entity_client.py
@@ -7,12 +7,24 @@ from unittest.mock import AsyncMock, Mock
 import httpx
 import pytest
 from nemo_platform_plugin.client.errors import BadRequestError, NotFoundError
-from nemo_platform_plugin.entities import EntityBase, EntityClient, EntityStoreError
+from nemo_platform_plugin.entities import EntityBase, EntityClient, EntityStoreError, _convert_filter_obj_to_filter_str
 from nemo_platform_plugin.entities.types import Entity
 
 
 class ExperimentGroup:
     __entity_type__ = "experiment_group"
+
+
+def test_filter_obj_keeps_created_by_at_the_entity_root() -> None:
+    assert _convert_filter_obj_to_filter_str(
+        {
+            "created_by": "session-owner",
+            "deployment_id": "deployment-id",
+        }
+    ) == {
+        "created_by": "session-owner",
+        "data.deployment_id": "deployment-id",
+    }
 
 
 def _entities_page(group_counts: dict[str, int] | None = None) -> Mock:

--- a/packages/nmp_common/src/nmp/common/service/base.py
+++ b/packages/nmp_common/src/nmp/common/service/base.py
@@ -14,7 +14,7 @@ from threading import RLock
 from typing import ClassVar, Dict, Generic, List, Optional, Self, Type, TypeVar, cast, get_args, get_origin
 
 import httpx
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.client.client import AsyncNemoClient
@@ -188,9 +188,16 @@ class DependencyProvider:
 
         return get_async_nemo_client(http_client=self.get_http_client())
 
+    def get_effective_principal_id(self, request: Request) -> str:
+        """Return the effective principal ID from the current request auth context."""
+        from nmp.common.auth import get_auth_client
+
+        return get_auth_client(request).principal.effective_id
+
     def setup_dependencies(self, app: FastAPI, service: "Service") -> None:
         """Configure FastAPI dependency overrides."""
         from nmp.common.service.dependencies import (
+            get_effective_principal_id,
             get_entity_client,
             get_nemo_client,
             get_platform_config,
@@ -201,6 +208,7 @@ class DependencyProvider:
         app.dependency_overrides[get_sdk_client] = self.get_request_scoped_sdk
         app.dependency_overrides[get_nemo_client] = self.get_request_scoped_nemo_client
         app.dependency_overrides[get_entity_client] = self.get_entity_client
+        app.dependency_overrides[get_effective_principal_id] = self.get_effective_principal_id
         app.dependency_overrides[get_platform_config] = self.get_platform_config
         if service._service_config is not None:
             app.dependency_overrides[get_service_config] = lambda: service._service_config

--- a/packages/nmp_common/src/nmp/common/service/dependencies.py
+++ b/packages/nmp_common/src/nmp/common/service/dependencies.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Callable, TypeVar
 
 from fastapi import Request
+from nemo_platform_plugin.dependencies import get_effective_principal_id as get_effective_principal_id
 from nemo_platform_plugin.dependencies import get_entity_client as get_entity_client
 from nemo_platform_plugin.dependencies import get_nemo_client as get_nemo_client
 from nemo_platform_plugin.dependencies import get_platform_config as get_platform_config

--- a/packages/nmp_common/tests/nmp_common/test_dependency_provider.py
+++ b/packages/nmp_common/tests/nmp_common/test_dependency_provider.py
@@ -9,9 +9,15 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
+from nmp.common.auth import AuthClient, Principal
 from nmp.common.config import Configuration
 from nmp.common.service import DependencyProvider
-from nmp.common.service.dependencies import get_entity_client, get_platform_config, get_sdk_client
+from nmp.common.service.dependencies import (
+    get_effective_principal_id,
+    get_entity_client,
+    get_platform_config,
+    get_sdk_client,
+)
 
 
 def test_get_http_client_caches_endpoint_client() -> None:
@@ -104,7 +110,23 @@ def test_setup_dependencies_registers_fastapi_overrides() -> None:
 
     assert app.dependency_overrides[get_sdk_client] == provider.get_request_scoped_sdk
     assert app.dependency_overrides[get_entity_client] == provider.get_entity_client
+    assert app.dependency_overrides[get_effective_principal_id] == provider.get_effective_principal_id
     assert app.dependency_overrides[get_platform_config] == provider.get_platform_config
+
+
+def test_get_effective_principal_id_uses_delegated_identity() -> None:
+    provider = DependencyProvider()
+    request = MagicMock()
+    auth_client = MagicMock(spec=AuthClient)
+    auth_client.principal = Principal(
+        id="service:agents",
+        email=None,
+        on_behalf_of="session-owner",
+        on_behalf_of_email=None,
+    )
+
+    with patch("nmp.common.auth.get_auth_client", return_value=auth_client):
+        assert provider.get_effective_principal_id(request) == "session-owner"
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -3470,7 +3470,7 @@ paths:
       tags:
       - Agent Sessions
       summary: List Sessions
-      description: List sessions in a workspace, optionally filtered by deployment
+      description: List the current principal's sessions, optionally filtered by deployment
         ID.
       operationId: list_sessions_apis_agents_v2_workspaces__workspace__sessions_get
       parameters:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -45,11 +45,13 @@ from nemo_agents_plugin.api.v2.openai_errors import (
     is_openai_compatible_uri,
     openai_error_response,
 )
+from nemo_agents_plugin.api.v2.session_access import get_owned_session_by_id
 from nemo_agents_plugin.authz import scope
 from nemo_agents_plugin.deployment_routing import get_deployment_endpoint, is_deployment_routable
 from nemo_agents_plugin.entities import Agent, AgentDeployment, AgentSession, SessionStatus
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 from nemo_platform_plugin.authz import CallerKind, path_rule
+from nemo_platform_plugin.dependencies import get_effective_principal_id
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
 
 logger = logging.getLogger(__name__)
@@ -117,6 +119,7 @@ async def _serve_agent_proxy(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient,
+    effective_principal_id: str,
 ) -> Response:
     """Resolve the target deployment for the named agent and forward the request to it.
 
@@ -125,7 +128,14 @@ async def _serve_agent_proxy(
     which differ only in their authorization scope (``agents:read`` vs ``agents:write``).
     """
     try:
-        return await _resolve_and_proxy_agent(workspace, name, trailing_uri, request, entity_client)
+        return await _resolve_and_proxy_agent(
+            workspace,
+            name,
+            trailing_uri,
+            request,
+            entity_client,
+            effective_principal_id,
+        )
     except HTTPException as exc:
         if not is_openai_compatible_uri(trailing_uri):
             raise
@@ -138,9 +148,10 @@ async def _resolve_and_proxy_agent(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient,
+    effective_principal_id: str,
 ) -> StreamingResponse:
     """Pick the deployment for *name* — session-bound if one was supplied — and forward."""
-    session = await _resolve_request_session(request, workspace, entity_client)
+    session = await _resolve_request_session(request, workspace, entity_client, effective_principal_id)
     if session is None:
         deployment = await _resolve_agent_deployment(name, workspace, entity_client)
     else:
@@ -177,9 +188,17 @@ async def proxy_by_agent_name_read(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> Response:
     """Read-scoped (GET/HEAD/OPTIONS) proxy to the active deployment for *agent name*."""
-    return await _serve_agent_proxy(workspace, name, trailing_uri, request, entity_client)
+    return await _serve_agent_proxy(
+        workspace,
+        name,
+        trailing_uri,
+        request,
+        entity_client,
+        effective_principal_id,
+    )
 
 
 @router.api_route(
@@ -199,9 +218,17 @@ async def proxy_by_agent_name_write(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> Response:
     """Write-scoped (POST/PUT/PATCH/DELETE) proxy to the active deployment for *agent name*."""
-    return await _serve_agent_proxy(workspace, name, trailing_uri, request, entity_client)
+    return await _serve_agent_proxy(
+        workspace,
+        name,
+        trailing_uri,
+        request,
+        entity_client,
+        effective_principal_id,
+    )
 
 
 async def _serve_deployment_proxy(
@@ -210,6 +237,7 @@ async def _serve_deployment_proxy(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient,
+    effective_principal_id: str,
 ) -> Response:
     """Proxy a request directly to the named deployment.
 
@@ -217,7 +245,14 @@ async def _serve_deployment_proxy(
     Shared by the read/write route handlers, which differ only in authorization scope.
     """
     try:
-        return await _resolve_and_proxy_deployment(workspace, name, trailing_uri, request, entity_client)
+        return await _resolve_and_proxy_deployment(
+            workspace,
+            name,
+            trailing_uri,
+            request,
+            entity_client,
+            effective_principal_id,
+        )
     except HTTPException as exc:
         if not is_openai_compatible_uri(trailing_uri):
             raise
@@ -230,6 +265,7 @@ async def _resolve_and_proxy_deployment(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient,
+    effective_principal_id: str,
 ) -> StreamingResponse:
     """Look the deployment up, check it against any supplied session, and forward."""
     try:
@@ -241,7 +277,7 @@ async def _resolve_and_proxy_deployment(
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    session = await _resolve_request_session(request, workspace, entity_client)
+    session = await _resolve_request_session(request, workspace, entity_client, effective_principal_id)
     if session is not None and session.deployment_id != dep.id:
         raise _session_deployment_mismatch(
             session,
@@ -309,9 +345,17 @@ async def proxy_by_deployment_name_read(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> Response:
     """Read-scoped (GET/HEAD/OPTIONS) proxy directly to the named deployment."""
-    return await _serve_deployment_proxy(workspace, name, trailing_uri, request, entity_client)
+    return await _serve_deployment_proxy(
+        workspace,
+        name,
+        trailing_uri,
+        request,
+        entity_client,
+        effective_principal_id,
+    )
 
 
 @router.api_route(
@@ -331,9 +375,17 @@ async def proxy_by_deployment_name_write(
     trailing_uri: str,
     request: Request,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> Response:
     """Write-scoped (POST/PUT/PATCH/DELETE) proxy directly to the named deployment."""
-    return await _serve_deployment_proxy(workspace, name, trailing_uri, request, entity_client)
+    return await _serve_deployment_proxy(
+        workspace,
+        name,
+        trailing_uri,
+        request,
+        entity_client,
+        effective_principal_id,
+    )
 
 
 async def _resolve_agent_deployment(
@@ -368,6 +420,7 @@ async def _resolve_request_session(
     request: Request,
     workspace: str,
     entity_client: NemoEntitiesClient,
+    effective_principal_id: str,
 ) -> AgentSession | None:
     """Resolve and validate the persisted session supplied on a gateway request."""
     session_id = request.headers.get(SESSION_ID_HEADER)
@@ -376,20 +429,12 @@ async def _resolve_request_session(
     if not session_id:
         raise HTTPException(status_code=400, detail=f"Header '{SESSION_ID_HEADER}' must not be empty.")
 
-    try:
-        session = await entity_client.find_one(
-            AgentSession,
-            workspace=workspace,
-            filter_obj={"id": session_id},
-        )
-    except NemoEntityNotFoundError as exc:
-        raise _session_not_found(workspace, session_id) from exc
-    except Exception as exc:
-        logger.exception("Failed to look up session ID '%s'", session_id)
-        raise HTTPException(status_code=500, detail="Failed to look up session.") from exc
-
-    if session.id != session_id or session.workspace != workspace:
-        raise _session_not_found(workspace, session_id)
+    session = await get_owned_session_by_id(
+        entity_client,
+        workspace=workspace,
+        session_id=session_id,
+        effective_principal_id=effective_principal_id,
+    )
     if session.status is not SessionStatus.ACTIVE:
         raise HTTPException(
             status_code=409,
@@ -431,13 +476,6 @@ async def _resolve_session_deployment(
             ),
         )
     return deployment
-
-
-def _session_not_found(workspace: str, session_id: str) -> HTTPException:
-    return HTTPException(
-        status_code=404,
-        detail=f"Session ID '{session_id}' not found in workspace '{workspace}'.",
-    )
 
 
 def _session_deployment_mismatch(session: AgentSession, *, detail: str) -> HTTPException:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/session_access.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/session_access.py
@@ -35,10 +35,50 @@ async def get_owned_session(
         logger.exception("Failed to get session '%s'", name)
         raise HTTPException(status_code=500, detail="Failed to get session.") from exc
 
-    if session.workspace != workspace or session.created_by != effective_principal_id:
+    if not _is_owned_session(session, workspace=workspace, effective_principal_id=effective_principal_id):
         raise session_not_found(workspace, name)
 
     return session
+
+
+async def get_owned_session_by_id(
+    entity_client: NemoEntitiesClient,
+    *,
+    workspace: str,
+    session_id: str,
+    effective_principal_id: str,
+) -> AgentSession:
+    """Resolve a session ID owned by the request's effective principal."""
+    try:
+        session = await entity_client.find_one(
+            AgentSession,
+            workspace=workspace,
+            filter_obj={"id": session_id, "created_by": effective_principal_id},
+        )
+    except NemoEntityNotFoundError as exc:
+        raise session_id_not_found(workspace, session_id) from exc
+    except Exception as exc:
+        logger.exception("Failed to get session ID '%s'", session_id)
+        raise HTTPException(status_code=500, detail="Failed to get session.") from exc
+
+    if session.id != session_id or not _is_owned_session(
+        session,
+        workspace=workspace,
+        effective_principal_id=effective_principal_id,
+    ):
+        raise session_id_not_found(workspace, session_id)
+
+    return session
+
+
+def _is_owned_session(
+    session: AgentSession,
+    *,
+    workspace: str,
+    effective_principal_id: str,
+) -> bool:
+    """Return whether a session belongs to the request workspace and principal."""
+    return session.workspace == workspace and session.created_by == effective_principal_id
 
 
 def session_not_found(workspace: str, name: str) -> HTTPException:
@@ -46,4 +86,12 @@ def session_not_found(workspace: str, name: str) -> HTTPException:
     return HTTPException(
         status_code=404,
         detail=f"Session '{name}' not found in workspace '{workspace}'.",
+    )
+
+
+def session_id_not_found(workspace: str, session_id: str) -> HTTPException:
+    """Return the non-disclosing response for an unavailable session ID."""
+    return HTTPException(
+        status_code=404,
+        detail=f"Session ID '{session_id}' not found in workspace '{workspace}'.",
     )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/session_access.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/session_access.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ownership-aware access helpers for persisted agent sessions."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+from nemo_agents_plugin.entities import AgentSession
+from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+async def get_owned_session(
+    entity_client: NemoEntitiesClient,
+    *,
+    workspace: str,
+    name: str,
+    effective_principal_id: str,
+) -> AgentSession:
+    """Resolve a session owned by the request's effective principal.
+
+    Missing sessions and sessions owned by another principal intentionally have
+    the same response so callers cannot use this endpoint to discover another
+    principal's sessions.
+    """
+    try:
+        session = await entity_client.get(AgentSession, name=name, workspace=workspace)
+    except NemoEntityNotFoundError as exc:
+        raise session_not_found(workspace, name) from exc
+    except Exception as exc:
+        logger.exception("Failed to get session '%s'", name)
+        raise HTTPException(status_code=500, detail="Failed to get session.") from exc
+
+    if session.workspace != workspace or session.created_by != effective_principal_id:
+        raise session_not_found(workspace, name)
+
+    return session
+
+
+def session_not_found(workspace: str, name: str) -> HTTPException:
+    """Return the non-disclosing response for unavailable sessions."""
+    return HTTPException(
+        status_code=404,
+        detail=f"Session '{name}' not found in workspace '{workspace}'.",
+    )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
@@ -21,12 +21,14 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from nemo_agents_plugin.api.v2._perms import SessionPerms
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
+from nemo_agents_plugin.api.v2.session_access import get_owned_session, session_not_found
 from nemo_agents_plugin.authz import scope
 from nemo_agents_plugin.deployment_routing import get_deployment_endpoint
 from nemo_agents_plugin.entities import AgentDeployment, AgentSession, SessionStatus
 from nemo_agents_plugin.schema import CreateSessionRequest, SessionFilter, SessionPage
 from nemo_platform_plugin.api.filters import make_filter_obj_dep
 from nemo_platform_plugin.authz import CallerKind, path_rule
+from nemo_platform_plugin.dependencies import get_effective_principal_id
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityConflictError, NemoEntityNotFoundError
 from nemo_platform_plugin.jobs.openapi_utils import generate_openapi_extra_params
 from nemo_platform_plugin.schema import PaginationData
@@ -139,18 +141,15 @@ async def get_session(
     workspace: str,
     name: str,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> AgentSession:
     """Get a session by name."""
-    try:
-        return await entity_client.get(AgentSession, name=name, workspace=workspace)
-    except NemoEntityNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session '{name}' not found in workspace '{workspace}'.",
-        ) from exc
-    except Exception as exc:
-        logger.exception("Failed to get session '%s'", name)
-        raise HTTPException(status_code=500, detail="Failed to get session.") from exc
+    return await get_owned_session(
+        entity_client,
+        workspace=workspace,
+        name=name,
+        effective_principal_id=effective_principal_id,
+    )
 
 
 @router.post("/sessions/{name}/close", response_model=AgentSession, tags=["Agent Sessions"])
@@ -163,18 +162,15 @@ async def close_session(
     workspace: str,
     name: str,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> AgentSession:
     """Close a session. Closing an already-closed session is idempotent."""
-    try:
-        session = await entity_client.get(AgentSession, name=name, workspace=workspace)
-    except NemoEntityNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session '{name}' not found in workspace '{workspace}'.",
-        ) from exc
-    except Exception as exc:
-        logger.exception("Failed to get session '%s' before closing", name)
-        raise HTTPException(status_code=500, detail="Failed to get session.") from exc
+    session = await get_owned_session(
+        entity_client,
+        workspace=workspace,
+        name=name,
+        effective_principal_id=effective_principal_id,
+    )
 
     if session.status is SessionStatus.CLOSED:
         await _cleanup_fabric_runtime(entity_client, session)
@@ -189,16 +185,12 @@ async def close_session(
             detail=f"Session '{name}' not found in workspace '{workspace}'.",
         ) from exc
     except NemoEntityConflictError as exc:
-        try:
-            latest_session = await entity_client.get(AgentSession, name=name, workspace=workspace)
-        except NemoEntityNotFoundError as get_exc:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Session '{name}' not found in workspace '{workspace}'.",
-            ) from get_exc
-        except Exception as get_exc:
-            logger.exception("Failed to get session '%s' after close conflict", name)
-            raise HTTPException(status_code=500, detail="Failed to get session.") from get_exc
+        latest_session = await get_owned_session(
+            entity_client,
+            workspace=workspace,
+            name=name,
+            effective_principal_id=effective_principal_id,
+        )
 
         if latest_session.status is SessionStatus.CLOSED:
             await _cleanup_fabric_runtime(entity_client, latest_session)
@@ -226,18 +218,15 @@ async def delete_session(
     workspace: str,
     name: str,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> None:
     """Permanently delete a session by name."""
-    try:
-        session = await entity_client.get(AgentSession, name=name, workspace=workspace)
-    except NemoEntityNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session '{name}' not found in workspace '{workspace}'.",
-        ) from exc
-    except Exception as exc:
-        logger.exception("Failed to get session '%s' before deleting", name)
-        raise HTTPException(status_code=500, detail="Failed to get session.") from exc
+    session = await get_owned_session(
+        entity_client,
+        workspace=workspace,
+        name=name,
+        effective_principal_id=effective_principal_id,
+    )
 
     try:
         await entity_client.delete(
@@ -247,10 +236,7 @@ async def delete_session(
             expected_db_version=session.db_version,
         )
     except NemoEntityNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session '{name}' not found in workspace '{workspace}'.",
-        ) from exc
+        raise session_not_found(workspace, name) from exc
     except NemoEntityConflictError as exc:
         raise HTTPException(
             status_code=409,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
@@ -106,9 +106,11 @@ async def list_sessions(
     sort: str = Query(default="-created_at"),
     filter: SessionFilter | dict[str, object] = Depends(_session_filter_dep),
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
+    effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> SessionPage:
-    """List sessions in a workspace, optionally filtered by deployment ID."""
-    filter_dict = filter if isinstance(filter, dict) else filter.model_dump(exclude_none=True)
+    """List the current principal's sessions, optionally filtered by deployment ID."""
+    filter_dict = dict(filter) if isinstance(filter, dict) else filter.model_dump(exclude_none=True)
+    filter_dict["created_by"] = effective_principal_id
     try:
         result = await entity_client.list(
             AgentSession,

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -42,7 +42,10 @@ from nemo_agents_plugin.entities import (
     SessionStatus,
 )
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
+from nemo_platform_plugin.dependencies import get_effective_principal_id
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+
+OWNER_PRINCIPAL_ID = "session-owner"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -74,6 +77,7 @@ def _make_session(
     workspace: str = "default",
     deployment_id: str = "deployment-id",
     status: SessionStatus = SessionStatus.ACTIVE,
+    created_by: str | None = OWNER_PRINCIPAL_ID,
 ) -> AgentSession:
     session = AgentSession(
         name=name,
@@ -82,6 +86,7 @@ def _make_session(
         status=status,
     )
     session._id = session_id
+    session._created_by = created_by
     return session
 
 
@@ -174,6 +179,7 @@ def test_app(mock_entity_client: AsyncMock) -> FastAPI:
         prefix="/apis/agents/v2/workspaces/{workspace}",
     )
     app.dependency_overrides[get_entity_client] = lambda: mock_entity_client
+    app.dependency_overrides[get_effective_principal_id] = lambda: OWNER_PRINCIPAL_ID
     return app
 
 
@@ -463,7 +469,11 @@ class TestSessionAwareRouting:
 
         assert resp.status_code == 200
         assert mock_entity_client.find_one.await_args_list == [
-            call(AgentSession, workspace="default", filter_obj={"id": "session-2"}),
+            call(
+                AgentSession,
+                workspace="default",
+                filter_obj={"id": "session-2", "created_by": OWNER_PRINCIPAL_ID},
+            ),
             call(AgentDeployment, workspace="default", filter_obj={"id": "deployment-2"}),
         ]
         mock_entity_client.get.assert_not_awaited()
@@ -492,7 +502,7 @@ class TestSessionAwareRouting:
         mock_entity_client.find_one.assert_awaited_once_with(
             AgentSession,
             workspace="default",
-            filter_obj={"id": "session-1"},
+            filter_obj={"id": "session-1", "created_by": OWNER_PRINCIPAL_ID},
         )
         stream_call = httpx_mock.__aenter__.return_value.stream.call_args
         assert stream_call.kwargs["headers"][SESSION_ID_HEADER] == "session-1"
@@ -521,6 +531,42 @@ class TestSessionAwareRouting:
         )
 
         assert resp.status_code == 404
+
+    @pytest.mark.parametrize(
+        ("method", "path"),
+        [
+            ("GET", "/apis/agents/v2/workspaces/default/agents/calc/-/health"),
+            ("POST", "/apis/agents/v2/workspaces/default/agents/calc/-/invoke"),
+            ("GET", "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/health"),
+            ("POST", "/apis/agents/v2/workspaces/default/deployments/calc-dep/-/invoke"),
+        ],
+    )
+    def test_foreign_owned_session_returns_404_on_every_gateway_route(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+        method: str,
+        path: str,
+    ) -> None:
+        mock_entity_client.get = AsyncMock(return_value=_make_deployment(deployment_id="deployment-id"))
+        mock_entity_client.find_one = AsyncMock(
+            return_value=_make_session(session_id="session-1", created_by="other-principal")
+        )
+
+        resp = client.request(
+            method,
+            path,
+            headers={SESSION_ID_HEADER: "session-1"},
+            json={} if method == "POST" else None,
+        )
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Session ID 'session-1' not found in workspace 'default'."
+        mock_entity_client.find_one.assert_awaited_once_with(
+            AgentSession,
+            workspace="default",
+            filter_obj={"id": "session-1", "created_by": OWNER_PRINCIPAL_ID},
+        )
 
     def test_closed_session_returns_409(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         mock_entity_client.find_one = AsyncMock(

--- a/plugins/nemo-agents/tests/unit/test_sessions_api.py
+++ b/plugins/nemo-agents/tests/unit/test_sessions_api.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 from nemo_agents_plugin.api.v2 import sessions as sessions_router_module
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.entities import AgentDeployment, AgentSession, SessionStatus
+from nemo_platform_plugin.dependencies import get_effective_principal_id
 from nemo_platform_plugin.entity_client import (
     NemoEntityConflictError,
     NemoEntityNotFoundError,
@@ -23,6 +24,7 @@ from nemo_platform_plugin.entity_client import (
 
 NOW = datetime.now(timezone.utc)
 BASE = "/apis/agents/v2/workspaces/default/sessions"
+OWNER_PRINCIPAL_ID = "session-owner"
 
 
 def _make_deployment(
@@ -43,6 +45,7 @@ def _make_session(
     workspace: str = "default",
     deployment_id: str = "deployment-id",
     status: SessionStatus = SessionStatus.ACTIVE,
+    created_by: str | None = OWNER_PRINCIPAL_ID,
 ) -> AgentSession:
     session = AgentSession(
         name=name,
@@ -52,6 +55,7 @@ def _make_session(
     )
     session._id = f"session-{name}-id"
     session._created_at = NOW
+    session._created_by = created_by
     return session
 
 
@@ -87,6 +91,7 @@ def client(mock_entity_client: AsyncMock) -> TestClient:
         prefix="/apis/agents/v2/workspaces/{workspace}",
     )
     app.dependency_overrides[get_entity_client] = lambda: mock_entity_client
+    app.dependency_overrides[get_effective_principal_id] = lambda: OWNER_PRINCIPAL_ID
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -195,6 +200,16 @@ class TestGetSession:
 
         assert response.status_code == 404
 
+    def test_get_returns_404_for_session_owned_by_another_principal(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        mock_entity_client.get.return_value = _make_session(created_by="other-principal")
+
+        response = client.get(f"{BASE}/session-one")
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Session 'session-one' not found in workspace 'default'."
+
 
 class TestCloseSession:
     def test_close_active_session(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
@@ -228,6 +243,16 @@ class TestCloseSession:
         response = client.post(f"{BASE}/missing/close")
 
         assert response.status_code == 404
+
+    def test_close_returns_404_for_session_owned_by_another_principal(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        mock_entity_client.get.return_value = _make_session(created_by="other-principal")
+
+        response = client.post(f"{BASE}/session-one/close")
+
+        assert response.status_code == 404
+        mock_entity_client.update.assert_not_awaited()
 
     def test_close_is_idempotent_after_concurrent_close(
         self, client: TestClient, mock_entity_client: AsyncMock
@@ -281,6 +306,16 @@ class TestDeleteSession:
         mock_entity_client.get.side_effect = NemoEntityNotFoundError("not found")
 
         response = client.delete(f"{BASE}/missing")
+
+        assert response.status_code == 404
+        mock_entity_client.delete.assert_not_awaited()
+
+    def test_delete_returns_404_for_session_owned_by_another_principal(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        mock_entity_client.get.return_value = _make_session(created_by="other-principal")
+
+        response = client.delete(f"{BASE}/session-one")
 
         assert response.status_code == 404
         mock_entity_client.delete.assert_not_awaited()

--- a/plugins/nemo-agents/tests/unit/test_sessions_api.py
+++ b/plugins/nemo-agents/tests/unit/test_sessions_api.py
@@ -32,10 +32,12 @@ def _make_deployment(
     name: str = "fabric-dep",
     workspace: str = "default",
     deployment_id: str = "deployment-id",
+    created_by: str | None = None,
 ) -> AgentDeployment:
     deployment = AgentDeployment(name=name, workspace=workspace, agent="fabric-agent", status="running")
     deployment._id = deployment_id
     deployment._created_at = NOW
+    deployment._created_by = created_by
     return deployment
 
 
@@ -60,8 +62,10 @@ def _make_session(
 
 
 async def _persist_session(session: AgentSession) -> AgentSession:
+    assert session.created_by is None
     session._id = "session-id"
     session._created_at = NOW
+    session._created_by = OWNER_PRINCIPAL_ID
     return session
 
 
@@ -107,6 +111,7 @@ class TestCreateSession:
         assert body["name"] == "session-one"
         assert body["deployment_id"] == "deployment-id"
         assert body["status"] == "active"
+        assert body["created_by"] == OWNER_PRINCIPAL_ID
         mock_entity_client.find_one.assert_awaited_once_with(
             AgentDeployment,
             workspace="default",
@@ -121,6 +126,17 @@ class TestCreateSession:
 
         assert response.status_code == 201
         assert response.json()["name"] == "fabric-dep-a1b2c3d4"
+
+    def test_create_for_deployment_owned_by_another_principal(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        mock_entity_client.find_one.return_value = _make_deployment(created_by="deployment-owner")
+        mock_entity_client.create.side_effect = _persist_session
+
+        response = client.post(BASE, json={"deployment_id": "deployment-id", "name": "session-one"})
+
+        assert response.status_code == 201
+        assert response.json()["created_by"] == OWNER_PRINCIPAL_ID
 
     def test_create_requires_deployment_id(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         response = client.post(BASE, json={"name": "session-one"})
@@ -166,7 +182,7 @@ class TestListSessions:
         body = response.json()
         assert body["data"][0]["name"] == "session-one"
         assert body["pagination"]["total_results"] == 1
-        assert mock_entity_client.list.await_args.kwargs["filter_obj"] is None
+        assert mock_entity_client.list.await_args.kwargs["filter_obj"] == {"created_by": OWNER_PRINCIPAL_ID}
 
     def test_list_filters_by_deployment_id(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         mock_entity_client.list.return_value = _list_response(_make_session())
@@ -174,7 +190,10 @@ class TestListSessions:
         response = client.get(f"{BASE}?filter[deployment_id]=deployment-id")
 
         assert response.status_code == 200
-        assert mock_entity_client.list.await_args.kwargs["filter_obj"] == {"deployment_id": "deployment-id"}
+        assert mock_entity_client.list.await_args.kwargs["filter_obj"] == {
+            "deployment_id": "deployment-id",
+            "created_by": OWNER_PRINCIPAL_ID,
+        }
 
     def test_list_rejects_unknown_filter(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         response = client.get(f"{BASE}?filter[unknown]=value")


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Makes persisted `AgentSession` resources private to the effective principal that created them while keeping `AgentDeployment` resources shared within a workspace. Session CRUD and gateway invocation now enforce ownership in addition to the existing path-rule authorization, and missing and foreign-owned sessions return the same non-disclosing `404` response.

## Related Issue

Closes [AIRCORE-948](https://linear.app/nvidia/issue/AIRCORE-948/define-production-session-ownership-and-auth-context-for-fabric-backed).

## Changes

- Add a public plugin-facing `get_effective_principal_id` FastAPI dependency and provide its runtime implementation from the authenticated request context. The dependency returns the principal's effective ID, including on-behalf-of identity resolution, without requiring plugins to import `nmp.common.auth`.
- Continue relying on existing `@path_rule` authorization for workspace and permission checks, then apply session ownership as a resource-level check in the Agents plugin.
- Use the Entity service's inherited `created_by` audit field as the session owner instead of introducing another ownership field or changing generic Entity-service authorization.
- Treat `created_by` as a top-level entity field when building Entity client filters so owner-scoped session queries target the persisted audit column rather than `data.created_by`.
- Add shared ownership-aware session access helpers for lookups by name and ID. The helpers validate workspace and owner and intentionally return identical `404` responses for missing and foreign-owned sessions.
- Restrict session lists to `created_by == effective_principal_id` while preserving optional deployment filtering.
- Require ownership when getting, closing, retrying a conflicted close, or deleting a session.
- Preserve session creation against any deployment visible in the same workspace. The Entity service stamps the new session with the creating effective principal, independently of the deployment's creator.
- Pass the effective principal through the agent-name and deployment-name gateway routes for both read and write methods.
- Resolve supplied invocation sessions using both session ID and owner, with defensive ID, workspace, and ownership validation before forwarding the request.
- Preserve existing session/deployment and session/agent binding validation and invocation behavior when no session ID is supplied.
- Add tests for effective-principal dependency injection, top-level `created_by` filtering, owner-scoped CRUD, shared-deployment session creation, non-disclosing cross-principal isolation, and invocation rejection across all gateway route variants.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest plugins/nemo-agents/tests/unit/test_gateway.py plugins/nemo-agents/tests/unit/test_sessions_api.py -q` — passed, 114 tests.
- Focused Ruff linting and formatting checks passed for the changed gateway, session-access, and gateway-test files.
- Focused `ty` checks passed for the changed gateway, session-access, and gateway-test files.
- `uv run pre-commit run no-nmp-common-in-plugins --all-files` — passed.
- `uv run --frozen pytest plugins/nemo-agents/tests/unit -q` — 1,332 tests passed.
- `git diff --check` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added effective identity handling for API requests.
  - Session listing, retrieval, closing, deletion, and gateway access now verify session ownership.
  - Sessions are created and filtered using the authenticated principal.
- **Bug Fixes**
  - Prevented access to sessions owned by another principal with standard not-found responses.
  - Improved handling of session lookup failures and ownership checks.
- **Tests**
  - Added coverage for delegated identities, ownership filtering, gateway access, and protected session operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->