### PR TITLE
fix: keep SDK importable without platform_ext, related automodel image fixes

### DIFF
--- a/docker/automodel/Dockerfile.nmp-automodel-training
+++ b/docker/automodel/Dockerfile.nmp-automodel-training
@@ -35,6 +35,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --python ${VIRTUAL_ENV}/bin/python --no-cache \
     --overrides /app/docker/automodel/no_override_requirements.txt \
     -e /app/sdk/python/nemo-platform \
+    -e /app/packages/filesets \
     -e /app/packages/nemo_platform_plugin \
     -e /app/packages/nmp_common \
     -e /app/packages/nmp_customization_common \

--- a/docker/automodel/Dockerfile.platform-workspace
+++ b/docker/automodel/Dockerfile.platform-workspace
@@ -18,6 +18,7 @@ COPY docker/automodel/no_override_requirements.txt docker/automodel/no_override_
 COPY docs docs
 COPY openapi openapi
 COPY packages/nmp_build_tools packages/nmp_build_tools
+COPY packages/filesets packages/filesets
 COPY packages/models packages/models
 COPY packages/nmp_common packages/nmp_common
 COPY packages/nmp_customization_common packages/nmp_customization_common

--- a/docker/automodel/pyproject.workspace.toml
+++ b/docker/automodel/pyproject.workspace.toml
@@ -17,6 +17,7 @@ constraint-dependencies = ["greenlet>=3.0.0,<3.5"]
 [tool.uv.workspace]
 members = [
   "packages/nmp_build_tools",
+  "packages/filesets",
   "packages/models",
   "sdk/python/nemo-platform",
   "packages/nemo_platform_plugin",
@@ -29,6 +30,7 @@ members = [
 
 [tool.uv.sources]
 nmp-build-tools = { workspace = true }
+filesets = { workspace = true }
 models = { workspace = true }
 nemo-platform-sdk = { workspace = true }
 nemo-platform-plugin = { workspace = true }

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/client/enhanced.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/client/enhanced.py
@@ -22,8 +22,7 @@ from nemo_platform import (
 )
 from nemo_platform._base_client import AsyncAPIClient, SyncAPIClient
 from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
-
-from nemo_platform_ext.client.tls import client_verify_from_env
+from nemo_platform_plugin.client.tls import client_verify_from_env
 
 
 def _should_bootstrap_config(

--- a/sdk/python/nemo-platform/src/nemo_platform/_client.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/_client.py
@@ -49,8 +49,8 @@ from ._base_client import (
     AsyncAPIClient,
 )
 from nemo_platform._base_client import DefaultAsyncHttpxClient, DefaultHttpxClient
-from nemo_platform_ext.client.tls import client_verify_from_env
 from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
+from nemo_platform_plugin.client.tls import client_verify_from_env
 from pathlib import Path
 
 if TYPE_CHECKING:

--- a/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/vendor/vendor_package.py
+++ b/tools/nemo-platform-sdk-tools/src/nemo_platform_sdk_tools/sdk/vendor/vendor_package.py
@@ -82,12 +82,13 @@ _CLIENT_METHOD_NAMES = ("__init__", "__getattr__", "copy")
 _CLIENT_HELPER_FUNCTION_NAMES = ("_should_bootstrap_config", "_copy_requires_bootstrap")
 _CLIENT_INIT_REQUIRED_IMPORTS: dict[str, tuple[str, ...]] = {
     "nemo_platform._base_client": ("DefaultAsyncHttpxClient", "DefaultHttpxClient"),
-    "nemo_platform_ext.client.tls": ("client_verify_from_env",),
     "nemo_platform_plugin.client.constants": ("WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR",),
+    "nemo_platform_plugin.client.tls": ("client_verify_from_env",),
     "pathlib": ("Path",),
 }
 _STALE_CLIENT_INIT_IMPORTS: dict[str, tuple[str, ...]] = {
     "nemo_platform.client.tls": ("client_verify_from_env",),
+    "nemo_platform_ext.client.tls": ("client_verify_from_env",),
 }
 
 

--- a/tools/nemo-platform-sdk-tools/tests/sdk/vendor/test_vendor_package.py
+++ b/tools/nemo-platform-sdk-tools/tests/sdk/vendor/test_vendor_package.py
@@ -1028,12 +1028,36 @@ name = "example"
     assert "entry-points" not in wrapper_updated["project"]
 
 
-def test_replace_client_methods_updates_init_and_getattr(tmp_path: Path) -> None:
+def test_replace_client_methods_updates_init_and_getattr(tmp_path: Path, monkeypatch) -> None:
     sdk_path = tmp_path / "sdk/python/nemo-platform"
     client_path = sdk_path / "src/nemo_platform/_client.py"
     source_path = tmp_path / "packages/nemo_platform_ext/src/nemo_platform_ext/client/enhanced.py"
     client_path.parent.mkdir(parents=True, exist_ok=True)
     source_path.parent.mkdir(parents=True, exist_ok=True)
+    plugin_client_path = tmp_path / "nemo_platform_plugin/client"
+    plugin_client_path.mkdir(parents=True)
+    (client_path.parent / "__init__.py").write_text("", encoding="utf-8")
+    (client_path.parent / "_base_client.py").write_text(
+        """
+class DefaultAsyncHttpxClient:
+    pass
+
+
+class DefaultHttpxClient:
+    pass
+""".lstrip(),
+        encoding="utf-8",
+    )
+    (tmp_path / "nemo_platform_plugin/__init__.py").write_text("", encoding="utf-8")
+    (plugin_client_path / "__init__.py").write_text("", encoding="utf-8")
+    (plugin_client_path / "constants.py").write_text(
+        'WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR = "NMP_WORKLOAD_IDENTITY_TOKEN_FILE"\n',
+        encoding="utf-8",
+    )
+    (plugin_client_path / "tls.py").write_text(
+        "def client_verify_from_env() -> bool:\n    return True\n",
+        encoding="utf-8",
+    )
 
     client_path.write_text(
         """
@@ -1108,3 +1132,41 @@ class AsyncNeMoPlatform:
     assert updated.count("def __getattr__(self, name: str) -> Any:") == 2
     assert "self.value = 1" not in updated
     assert "self.value = 2" not in updated
+
+    class BlockNemoPlatformExt:
+        def find_spec(
+            self,
+            fullname: str,
+            path: object | None = None,
+            target: object | None = None,
+        ) -> None:
+            del path, target
+            if fullname == "nemo_platform_ext" or fullname.startswith("nemo_platform_ext."):
+                raise ModuleNotFoundError("nemo_platform_ext must not be imported")
+            return None
+
+    blocked_finder = BlockNemoPlatformExt()
+    module_names = (
+        "nemo_platform",
+        "nemo_platform._base_client",
+        "nemo_platform._client",
+        "nemo_platform_plugin",
+        "nemo_platform_plugin.client",
+        "nemo_platform_plugin.client.constants",
+        "nemo_platform_plugin.client.tls",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.syspath_prepend(str(sdk_path / "src"))
+    sys.meta_path.insert(0, blocked_finder)
+    try:
+        for module_name in module_names:
+            sys.modules.pop(module_name, None)
+
+        generated_client = import_module("nemo_platform._client")
+
+        assert generated_client.NeMoPlatform(config_path=Path("config.yaml")).should_bootstrap is True
+    finally:
+        if blocked_finder in sys.meta_path:
+            sys.meta_path.remove(blocked_finder)
+        for module_name in module_names:
+            sys.modules.pop(module_name, None)

--- a/tools/nemo-platform-sdk-tools/tests/sdk/vendor/test_vendor_package.py
+++ b/tools/nemo-platform-sdk-tools/tests/sdk/vendor/test_vendor_package.py
@@ -1038,6 +1038,7 @@ def test_replace_client_methods_updates_init_and_getattr(tmp_path: Path) -> None
     client_path.write_text(
         """
 from typing import Any
+from nemo_platform_ext.client.tls import client_verify_from_env
 
 
 def _should_bootstrap_config(config_path: object | None = None) -> bool:
@@ -1096,8 +1097,9 @@ class AsyncNeMoPlatform:
 
     assert "from pathlib import Path" in updated
     assert "from nemo_platform._base_client import DefaultAsyncHttpxClient, DefaultHttpxClient" in updated
-    assert "from nemo_platform_ext.client.tls import client_verify_from_env" in updated
     assert "from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR" in updated
+    assert "from nemo_platform_plugin.client.tls import client_verify_from_env" in updated
+    assert "from nemo_platform_ext.client.tls import client_verify_from_env" not in updated
     assert "def _should_bootstrap_config(config_path: Path | None = None) -> bool:" in updated
     assert "return config_path is not None" in updated
     assert "return False" not in updated


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TLS verification handling to use the current plugin-provided implementation.
  * Removed outdated TLS import references from generated SDK clients.
  * Improved client generation validation to ensure correct TLS imports are produced.

* **Chores**
  * Added the filesets package to platform workspace and automated model training builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->