### PR TITLE
fix(sdk): add [project.urls] to nemo-platform wrapper distribution

### DIFF
--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -45,6 +45,11 @@ dependencies = [
   "nmp-common",
 ]
 
+[project.urls]
+Homepage = "https://github.com/NVIDIA-NeMo/nemo-platform"
+Documentation = "https://docs.nvidia.com/nemo-platform"
+Source = "https://github.com/NVIDIA-NeMo/nemo-platform"
+
 [project.optional-dependencies]
 all = ["nemo-platform[services]"]
 


### PR DESCRIPTION
## Summary
Published PyPI wheel currently has `info.project_urls == null` and no `home_page`, so the [pypi.org/project/nemo-platform/](https://pypi.org/project/nemo-platform/) sidebar shows no **Project links** section. Users landing on PyPI cannot navigate to the docs site or the GitHub repo.

Sister distribution [`nemo-platform-plugin`](https://pypi.org/project/nemo-platform-plugin/) already sets these; this mirrors that pattern on the main wrapper. `Documentation` points at the public docs site. `Bug Tracker` is omitted per review on the original fork PR.

This recreates fork PR #1475 as a same-repo branch so GitHub Actions can use org Docker Hub secrets.

## Changes
- Add `[project.urls]` (`Homepage`, `Documentation`, `Source`) to `packages/nemo_platform/pyproject.toml`

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: packaging metadata only; no runtime behavior change
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: PyPI sidebar metadata, not product docs

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Recreated on `origin/main` (`b2ba47187`) so CI runs in the canonical repo.
- DCO audit: `Signed-off-by: Jinxiang Guo <jinxiang@nvidia.com>` matches commit author.
- Diff limited to the four `[project.urls]` lines (no unrelated `pyproject.toml` churn).
- Full `uv run pre-commit run -a` was not rerun for this metadata-only replay; GitHub CI on the same-repo branch is the gate.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added project homepage, documentation, and source repository links to the package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->