### PR TITLE
docs(home): link Harbor first-use to harborframework.com

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -16,7 +16,7 @@ NeMo Platform exposes the same local services through the CLI, Python SDK, Studi
 ## What You Can Do
 
 - **Secure agents.** Guardrails (content safety, jailbreak detection, PII redaction), Auditor (red-teaming via garak), Anonymizer (PII handling for training data).
-- **Evaluate agents.** LLM-as-judge, deterministic, agentic, and RAG benchmarks. Harbor-backed eval suites for regression testing.
+- **Evaluate agents.** LLM-as-judge, deterministic, agentic, and RAG benchmarks. [Harbor](https://www.harborframework.com/)-backed eval suites for regression testing.
 - **Tune agents.** Skill optimization, prompt and hyperparameter tuning, Switchyard model routing.
 - **Build agents.** Create platform-managed agents with agent.yaml, with legacy support for NAT-based LangGraph agents. Shared infrastructure: Inference Gateway, Secrets, Files, Entity Store, Jobs.
 - **Generate synthetic data.** Generate synthetic data for training or evaluation purposes using Data Designer.


### PR DESCRIPTION
## Summary
The landing page (`docs/index.mdx`) introduces "Harbor-backed eval suites" without defining Harbor or linking to a concept page. Link the first use to https://www.harborframework.com/.

This recreates fork PR #1476 as a same-repo branch so GitHub Actions can use org Docker Hub secrets.

## Changes
- First-use "Harbor" on `docs/index.mdx` now links to https://www.harborframework.com/

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: one-line docs markdown link
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Cherry-picked onto current `origin/main` with DCO sign-off.
- Diff is the single Harbor link on `docs/index.mdx`.
- Full local `uv run pre-commit run -a` was not rerun; same-repo CI is the gate.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a hyperlink to the Harbor website in the agent evaluation capability description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->