### PR TITLE
docs(plugins-and-skills): drop version literal from opening sentence

### DIFF
--- a/docs/agents/plugins.mdx
+++ b/docs/agents/plugins.mdx
@@ -7,7 +7,7 @@ description: ""
 ---
 <a id="agents-plugins"></a>
 
-NeMo Platform 0.3.0 is extended through Python plugins and
+NeMo Platform is extended through Python plugins and
 coding-agent skills. Plugins add runtime capabilities to the local platform.
 Skills teach your coding agent how to operate those capabilities on your behalf.
 


### PR DESCRIPTION
## Summary
`docs/agents/plugins.mdx` opened with "NeMo Platform 0.3.0 is extended through Python plugins and coding-agent skills." The version literal has drifted against later releases. Drop it so the sentence stays release-agnostic.

This recreates fork PR #1477 as a same-repo branch so GitHub Actions can use org Docker Hub secrets (fork `pull_request` CI failed at Docker Hub login with `Secret source: None`).

## Changes
- Remove the `0.3.0` version literal from the opening sentence of `docs/agents/plugins.mdx`

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: one-word docs edit
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Replay of `2dc068219` onto current `origin/main`.
- DCO audit passed.
- Diff is the single opening-sentence change on `docs/agents/plugins.mdx`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugins documentation to remove a version-specific reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->