### PR TITLE
docs(manage-files): add client init block before Python SDK examples

### DIFF
--- a/docs/get-started/concepts/manage-files.mdx
+++ b/docs/get-started/concepts/manage-files.mdx
@@ -80,6 +80,20 @@ nemo files filesets list --workspace my-workspace
 ```
 
 </Tip>
+
+All Python SDK examples that follow assume this client initialization:
+
+```python
+import os
+
+from nemo_platform import NeMoPlatform
+
+client = NeMoPlatform(
+    base_url=os.environ.get("NMP_BASE_URL") or "http://localhost:8080",
+    workspace="default",
+)
+```
+
 ### Creating Filesets
 
 Creating a fileset involves specifying a name and workspace. You can optionally provide a description, purpose, and custom storage configuration.


### PR DESCRIPTION
## Summary
Most Python SDK snippets on `docs/get-started/concepts/manage-files.mdx` use `client.files....` without a prior `client = NeMoPlatform(...)`. Add the standard initialization block used on Manage Secrets, including the review tweak `os.environ.get("NMP_BASE_URL") or "http://localhost:8080"`.

This recreates fork PR #1478 as a same-repo branch so GitHub Actions can use org Docker Hub secrets.

## Changes
- Add a shared Python SDK client init block before the Manage Files examples
- Use `or` for the localhost fallback so an empty `NMP_BASE_URL` does not win

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: documentation example only
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Recreated on `origin/main` with DCO sign-off; unsigned GitHub suggestion commit was folded into this signed commit.
- Diff is the init block on `docs/get-started/concepts/manage-files.mdx`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a shared Python SDK client initialization example to the “Managing Filesets” guide.
  * Examples now use a configurable service URL with a localhost fallback and the default workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->