### PR TITLE
feat(eval-author): add audit-spec schema skill

### DIFF
--- a/plugins/nemo-eval-author/README.md
+++ b/plugins/nemo-eval-author/README.md
@@ -12,7 +12,7 @@ gets installed.
 | --- | --- |
 | [`eval-author`](skills/eval-author/SKILL.md) | Core. Owns the standard every sub-flow follows and routes to one. |
 | [`eval-author-discover`](skills/eval-author-discover/SKILL.md) | Sub-flow. Records whether a repository's Harbor evals are ready to run. |
-| [`eval-author-audit`](skills/eval-author-audit/SKILL.md) | Sub-flow. Defines and validates the finite coverage denominator derived from Ethos. |
+| [`eval-author-audit`](skills/eval-author-audit/SKILL.md) | Sub-flow. Validates an existing finite `audit.md` coverage denominator. |
 
 ## Where findings go
 

--- a/plugins/nemo-eval-author/README.md
+++ b/plugins/nemo-eval-author/README.md
@@ -8,6 +8,19 @@ repository. There is no CLI, no service, and no importable code, so this directo
 builds no package at all. A customer points their agent at `skills/` and nothing
 gets installed.
 
+## Prerequisites
+
+Discovery imports nothing beyond the standard library and Harbor itself, so it
+runs on whatever Python the customer already has. Audit validation needs PyYAML
+to read the marked YAML block and jsonschema to enforce
+`schemas/audit.schema.json`.
+
+`tests/test_skill_contract.py` holds to the same boundary and imports nothing
+from the platform, so `pytest`, `pyyaml`, and `jsonschema` are enough to run it.
+The five tests that make Harbor judge a fixture suite skip when Harbor is absent,
+which is why this directory declares no dependencies and appears in no dependency
+group.
+
 | Skill | Role |
 | --- | --- |
 | [`eval-author`](skills/eval-author/SKILL.md) | Core. Owns the standard every sub-flow follows and routes to one. |
@@ -35,18 +48,16 @@ The Eval Author agent that Experimentalist insight mode still uses lives in
 
 ## Dependencies
 
-The scripts under `skills/*/scripts/` keep dependencies narrow. Discovery imports
-nothing beyond the standard library and Harbor itself, so it runs on whatever
-Python the customer already has. Audit validation needs PyYAML to read the marked
-YAML block and jsonschema to enforce `schemas/audit.schema.json`.
-
-`tests/test_skill_contract.py` holds to the same boundary and imports nothing from
-the platform, so `pytest`, `pyyaml`, and `jsonschema` are enough to run it. The
-five tests that make Harbor judge a fixture suite skip when Harbor is absent,
-which is why this directory declares no dependencies and appears in no dependency
-group.
-
 Adding a runtime dependency to a bundled script is a breaking change for anyone who
 copied the skill, so the contract test walks each script's imports and fails on
 anything outside the standard library, a sibling module, or the explicitly allowed
 third-party validators.
+
+## Next Steps
+
+- Start with [`eval-author`](skills/eval-author/SKILL.md) to select the right
+  sub-flow and apply the shared evaluation standard.
+- Use [`eval-author-discover`](skills/eval-author-discover/SKILL.md) to check
+  whether a Harbor suite can run.
+- Use [`eval-author-audit`](skills/eval-author-audit/SKILL.md) to validate an
+  existing finite `audit.md` coverage denominator.

--- a/plugins/nemo-eval-author/README.md
+++ b/plugins/nemo-eval-author/README.md
@@ -4,9 +4,13 @@
 # NeMo Eval Author
 
 Three skills that an agent reads to work on the evaluation suites in a user's own
-repository. There is no CLI, no service, and no importable code, so this directory
-builds no package at all. A customer points their agent at `skills/` and nothing
-gets installed.
+repository. This directory provides no installed public package or service, so a
+customer points their agent at `skills/` and nothing gets installed.
+
+The audit sub-flow also ships a bundled validator CLI at
+[`skills/eval-author-audit/scripts/audit_spec/validate.py`](skills/eval-author-audit/scripts/audit_spec/validate.py)
+and private helper modules under `scripts/audit_spec/`. They are invoked from the
+copied skill tree, not published as a package API.
 
 ## Prerequisites
 

--- a/plugins/nemo-eval-author/README.md
+++ b/plugins/nemo-eval-author/README.md
@@ -3,7 +3,7 @@
 
 # NeMo Eval Author
 
-Two skills that an agent reads to work on the evaluation suites in a user's own
+Three skills that an agent reads to work on the evaluation suites in a user's own
 repository. There is no CLI, no service, and no importable code, so this directory
 builds no package at all. A customer points their agent at `skills/` and nothing
 gets installed.
@@ -12,6 +12,7 @@ gets installed.
 | --- | --- |
 | [`eval-author`](skills/eval-author/SKILL.md) | Core. Owns the standard every sub-flow follows and routes to one. |
 | [`eval-author-discover`](skills/eval-author-discover/SKILL.md) | Sub-flow. Records whether a repository's Harbor evals are ready to run. |
+| [`eval-author-audit`](skills/eval-author-audit/SKILL.md) | Sub-flow. Defines and validates the finite coverage denominator derived from Ethos. |
 
 ## Where findings go
 
@@ -34,17 +35,18 @@ The Eval Author agent that Experimentalist insight mode still uses lives in
 
 ## Dependencies
 
-The scripts under `skills/*/scripts/` import nothing beyond the standard library and
-Harbor itself, so they run on whatever Python the customer already has. Where a real
-answer needs a provider, the skill defers to the provider's own validators rather
-than guessing from file layout, which is why `eval-author-discover` probes for an
-installed Harbor and asks Harbor to judge each config.
+The scripts under `skills/*/scripts/` keep dependencies narrow. Discovery imports
+nothing beyond the standard library and Harbor itself, so it runs on whatever
+Python the customer already has. Audit validation needs PyYAML to read the marked
+YAML block and jsonschema to enforce `schemas/audit.schema.json`.
 
 `tests/test_skill_contract.py` holds to the same boundary and imports nothing from
-the platform, so `pytest` and `pyyaml` are enough to run it. The five tests that
-make Harbor judge a fixture suite skip when Harbor is absent, which is why this
-directory declares no dependencies and appears in no dependency group.
+the platform, so `pytest`, `pyyaml`, and `jsonschema` are enough to run it. The
+five tests that make Harbor judge a fixture suite skip when Harbor is absent,
+which is why this directory declares no dependencies and appears in no dependency
+group.
 
 Adding a runtime dependency to a bundled script is a breaking change for anyone who
 copied the skill, so the contract test walks each script's imports and fails on
-anything outside the standard library, a sibling module, or Harbor.
+anything outside the standard library, a sibling module, or the explicitly allowed
+third-party validators.

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -66,9 +66,11 @@ Shared helpers are private modules in the same tree:
 ## Input
 
 Expect `.eval-author/audit.md` to exist before this skill runs. If it is missing,
-stop and say audit generation is future work for a separate sub-flow. `ETHOS.md`
-is the expected first source for generated audit specs when present, but the
-audit schema does not require Ethos.
+stop and say audit generation is future work for a separate sub-flow. A
+hand-author can copy `templates/audit.md` as a starting format, but this
+validation skill should not populate missing items. `ETHOS.md` is the expected
+first source for generated audit specs when present, but the audit schema does
+not require Ethos.
 
 Use `templates/audit.md` and `schemas/audit.schema.json` only as format
 references when explaining validation failures. The marked YAML block is the
@@ -83,6 +85,9 @@ shasum -a 256 ETHOS.md | awk '{print "sha256:" $1}'
 `schemas/audit.schema.json` is the canonical structural schema. The Python
 validator applies that schema first, then checks any source digests that are
 provided and cross-item references such as `required_tools` and `applies_to`.
+`source_refs` are advisory provenance notes in v1; the validator preserves them
+but does not resolve them against `sources` until a future generator or grammar
+defines that reference format.
 
 Capabilities that do not need tools, such as policy refusals or out-of-scope
 handling, should use `required_tools: []`. Failure cases attach to capability

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -20,9 +20,9 @@ not-for:
   - eval-author-discover (use to prove whether a Harbor suite is runnable)
   - nemo-experimentalist (use to optimize an agent from Insights or explicit datasets)
 compatibility: >-
-  Python 3.11 or later. PyYAML must be importable by the interpreter that runs
-  the bundled scripts. Validation reads local audit files only; it does not
-  start Harbor jobs or call platform services.
+  Python 3.11 or later. PyYAML and jsonschema must be importable by the
+  interpreter that runs the bundled scripts. Validation reads local audit files
+  only; it does not start Harbor jobs or call platform services.
 maturity: alpha
 license: Apache-2.0
 user-invocable: true
@@ -66,7 +66,9 @@ variants, or ordinary happy-path permutations.
 
 Use `templates/audit.md` as the starting format for `.eval-author/audit.md`.
 The marked YAML block is the machine-readable part; prose outside the markers is
-for reviewers and may be edited freely.
+for reviewers and may be edited freely. `schemas/audit.schema.json` is the
+canonical structural schema. The Python validator applies that schema first,
+then checks cross-item references such as `required_tools` and `applies_to`.
 
 ## Step 2: Validate
 

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -1,0 +1,81 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: eval-author-audit
+description: >-
+  Define and validate an audit-spec coverage denominator for Eval Author. Use
+  when the user wants a hand-editable audit.md format derived from Ethos, needs
+  schema enforcement for declared tools, capabilities, and failure cases, or
+  wants to review the finite set of things future evals should cover.
+  Changes none of the user's source, and saves audit artifacts under
+  `.eval-author/`.
+triggers:
+  - define audit.md from ETHOS.md
+  - validate audit.md coverage schema
+  - what should my evals cover from the agent ethos
+  - review the audit coverage denominator
+not-for:
+  - eval-author (use for the standard, the boundaries, and to pick a sub-flow)
+  - eval-author-discover (use to prove whether a Harbor suite is runnable)
+  - nemo-experimentalist (use to optimize an agent from Insights or explicit datasets)
+compatibility: >-
+  Python 3.11 or later. PyYAML must be importable by the interpreter that runs
+  the bundled scripts. Validation reads local audit files only; it does not
+  start Harbor jobs or call platform services.
+maturity: alpha
+license: Apache-2.0
+user-invocable: true
+allowed-tools: [Bash, Read, Write, Grep, Glob]
+---
+
+# Eval Author: audit
+
+Read `eval-author` for the shared standard, vocabulary, and boundaries. This
+sub-flow defines and validates a finite coverage denominator from `ETHOS.md`.
+It does not generate tasks or measure traces yet.
+
+The audit-spec approach has three item kinds in v1:
+
+| Kind | Meaning |
+|---|---|
+| `tool` | A canonical tool name the agent may call |
+| `capability` | A high-level behavior the agent should exercise |
+| `failure_case` | Expected safe behavior when a capability cannot proceed normally |
+
+Write audit artifacts under `.eval-author/`. Do not edit the customer's source,
+existing evals, or `ETHOS.md`.
+
+## Scripts
+
+Audit-spec mechanics live under `scripts/audit_spec/`:
+
+| Script | Use it to |
+|---|---|
+| `scripts/audit_spec/validate.py` | Validate the marked audit-spec block in `audit.md` |
+
+Shared helpers are private modules in the same tree:
+`scripts/audit_spec/_schema.py` and `scripts/audit_spec/_markdown.py`.
+
+## Step 1: Draft Or Update The Audit Spec
+
+Read `ETHOS.md` and draft audit items at the level between Ethos and runnable
+tasks: canonical tools, high-level capabilities, and material failure cases. Keep
+the list finite. Do not create separate items for prompt paraphrases, fixture
+variants, or ordinary happy-path permutations.
+
+Use `templates/audit.md` as the starting format for `.eval-author/audit.md`.
+The marked YAML block is the machine-readable part; prose outside the markers is
+for reviewers and may be edited freely.
+
+## Step 2: Validate
+
+Run validation after every hand-edited audit file:
+
+```bash
+python <skill_dir>/scripts/audit_spec/validate.py --audit .eval-author/audit.md
+```
+
+Validation proves only structure and references, not that the denominator is
+complete or correct. Treat generator, measurement, and coverage-report scripts
+as future work until those scripts exist in this skill.

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -24,7 +24,7 @@ compatibility: >-
 maturity: alpha
 license: Apache-2.0
 user-invocable: true
-allowed-tools: [Bash, Read, Write, Grep, Glob]
+allowed-tools: [Bash, Read, Grep, Glob]
 ---
 
 # Eval Author: audit

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -43,6 +43,13 @@ The audit-spec approach has three item kinds in v1:
 | `capability` | A high-level behavior the agent should exercise |
 | `failure_case` | Expected safe behavior when a capability cannot proceed normally |
 
+Every item uses `name` as its stable coverage key. Names must be unique across
+the whole file; do not add sequential numeric IDs. Tool references in
+`required_tools`, `expected_tools`, and `evidence_required[].tool` must match the
+`name` of a declared `tool` item. `prohibited_tools` may name any syntactically
+valid tool name, including tools the agent must never call and therefore should
+not declare as allowed tools.
+
 Write audit artifacts under `.eval-author/`. Do not edit the customer's source,
 existing evals, or `ETHOS.md`.
 
@@ -66,9 +73,21 @@ variants, or ordinary happy-path permutations.
 
 Use `templates/audit.md` as the starting format for `.eval-author/audit.md`.
 The marked YAML block is the machine-readable part; prose outside the markers is
-for reviewers and may be edited freely. `schemas/audit.schema.json` is the
-canonical structural schema. The Python validator applies that schema first,
-then checks cross-item references such as `required_tools` and `applies_to`.
+for reviewers and may be edited freely. For `.eval-author/audit.md`, set
+`source_ethos: ../ETHOS.md` and replace the digest placeholder with:
+
+```bash
+shasum -a 256 ETHOS.md | awk '{print "sha256:" $1}'
+```
+
+`schemas/audit.schema.json` is the canonical structural schema. The Python
+validator applies that schema first, then checks source Ethos drift and cross-item
+references such as `required_tools` and `applies_to`.
+
+Capabilities that do not need tools, such as policy refusals or out-of-scope
+handling, should use `required_tools: []`. Failure cases attach to capability
+names through `applies_to`; tool-level failure expectations stay on the tool item
+as `expected_failure_behavior`.
 
 ## Step 2: Validate
 

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -4,18 +4,15 @@
 
 name: eval-author-audit
 description: >-
-  Define and validate an audit-spec coverage denominator for Eval Author. Use
-  when the user wants a hand-editable audit.md format, needs
-  schema enforcement for declared tools, capabilities, and failure cases, or
-  wants to review the finite set of things future evals should cover. Ethos is
-  the preferred first source when present, but is not required by the format.
-  Changes none of the user's source, and saves audit artifacts under
-  `.eval-author/`.
+  Validate an existing audit-spec coverage denominator for Eval Author. Use when
+  the user already has an audit.md file and needs schema enforcement for declared
+  tools, capabilities, failure cases, evidence, and references. Does not generate
+  or draft audit.md.
 triggers:
-  - define audit.md from ETHOS.md
   - validate audit.md coverage schema
-  - what should my evals cover from the agent ethos
-  - review the audit coverage denominator
+  - check audit.md coverage denominator
+  - audit.md schema validation
+  - is this audit spec valid
 not-for:
   - eval-author (use for the standard, the boundaries, and to pick a sub-flow)
   - eval-author-discover (use to prove whether a Harbor suite is runnable)
@@ -33,10 +30,9 @@ allowed-tools: [Bash, Read, Write, Grep, Glob]
 # Eval Author: audit
 
 Read `eval-author` for the shared standard, vocabulary, and boundaries. This
-sub-flow defines and validates a finite coverage denominator. It is expected and
-strongly encouraged to start from `ETHOS.md` when one exists, but `audit.md` is a
-standalone contract and can also be authored from other source-of-truth
-documents. It does not generate tasks or measure traces yet.
+sub-flow validates an existing finite coverage denominator. It assumes
+`.eval-author/audit.md` already exists. It does not draft or update audit specs,
+generate tasks, or measure traces yet.
 
 The audit-spec approach has three item kinds in v1:
 
@@ -53,8 +49,8 @@ the whole file; do not add sequential numeric IDs. Tool references in
 valid tool name, including tools the agent must never call and therefore should
 not declare as allowed tools.
 
-Write audit artifacts under `.eval-author/`. Do not edit the customer's source,
-existing evals, or source-of-truth documents such as `ETHOS.md`.
+Do not edit the customer's source, existing evals, source-of-truth documents, or
+`.eval-author/audit.md` while validating.
 
 ## Scripts
 
@@ -67,19 +63,18 @@ Audit-spec mechanics live under `scripts/audit_spec/`:
 Shared helpers are private modules in the same tree:
 `scripts/audit_spec/_schema.py` and `scripts/audit_spec/_markdown.py`.
 
-## Step 1: Draft Or Update The Audit Spec
+## Input
 
-Prefer `ETHOS.md` as the first source when it exists, then draft audit items at
-the level between source-of-truth material and runnable tasks: canonical tools,
-high-level capabilities, and material failure cases. If there is no Ethos file,
-use the available product, agent, policy, or requirements document instead. Keep
-the list finite. Do not create separate items for prompt paraphrases, fixture
-variants, or ordinary happy-path permutations.
+Expect `.eval-author/audit.md` to exist before this skill runs. If it is missing,
+stop and say audit generation is future work for a separate sub-flow. `ETHOS.md`
+is the expected first source for generated audit specs when present, but the
+audit schema does not require Ethos.
 
-Use `templates/audit.md` as the starting format for `.eval-author/audit.md`.
-The marked YAML block is the machine-readable part; prose outside the markers is
-for reviewers and may be edited freely. When generating from `ETHOS.md`, include
-the optional `sources` entry for Ethos and replace the digest placeholder with:
+Use `templates/audit.md` and `schemas/audit.schema.json` only as format
+references when explaining validation failures. The marked YAML block is the
+machine-readable part; prose outside the markers is for reviewers and may be
+edited freely. When an audit spec was generated from `ETHOS.md`, it should
+include the optional `sources` entry for Ethos with a digest computed as:
 
 ```bash
 shasum -a 256 ETHOS.md | awk '{print "sha256:" $1}'
@@ -94,9 +89,9 @@ handling, should use `required_tools: []`. Failure cases attach to capability
 names through `applies_to`; tool-level failure expectations stay on the tool item
 as `expected_failure_behavior`.
 
-## Step 2: Validate
+## Validate
 
-Run validation after every hand-edited audit file:
+Run validation on the existing audit file:
 
 ```bash
 python <skill_dir>/scripts/audit_spec/validate.py --audit .eval-author/audit.md

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -5,9 +5,10 @@
 name: eval-author-audit
 description: >-
   Define and validate an audit-spec coverage denominator for Eval Author. Use
-  when the user wants a hand-editable audit.md format derived from Ethos, needs
+  when the user wants a hand-editable audit.md format, needs
   schema enforcement for declared tools, capabilities, and failure cases, or
-  wants to review the finite set of things future evals should cover.
+  wants to review the finite set of things future evals should cover. Ethos is
+  the preferred first source when present, but is not required by the format.
   Changes none of the user's source, and saves audit artifacts under
   `.eval-author/`.
 triggers:
@@ -32,8 +33,10 @@ allowed-tools: [Bash, Read, Write, Grep, Glob]
 # Eval Author: audit
 
 Read `eval-author` for the shared standard, vocabulary, and boundaries. This
-sub-flow defines and validates a finite coverage denominator from `ETHOS.md`.
-It does not generate tasks or measure traces yet.
+sub-flow defines and validates a finite coverage denominator. It is expected and
+strongly encouraged to start from `ETHOS.md` when one exists, but `audit.md` is a
+standalone contract and can also be authored from other source-of-truth
+documents. It does not generate tasks or measure traces yet.
 
 The audit-spec approach has three item kinds in v1:
 
@@ -51,7 +54,7 @@ valid tool name, including tools the agent must never call and therefore should
 not declare as allowed tools.
 
 Write audit artifacts under `.eval-author/`. Do not edit the customer's source,
-existing evals, or `ETHOS.md`.
+existing evals, or source-of-truth documents such as `ETHOS.md`.
 
 ## Scripts
 
@@ -66,23 +69,25 @@ Shared helpers are private modules in the same tree:
 
 ## Step 1: Draft Or Update The Audit Spec
 
-Read `ETHOS.md` and draft audit items at the level between Ethos and runnable
-tasks: canonical tools, high-level capabilities, and material failure cases. Keep
+Prefer `ETHOS.md` as the first source when it exists, then draft audit items at
+the level between source-of-truth material and runnable tasks: canonical tools,
+high-level capabilities, and material failure cases. If there is no Ethos file,
+use the available product, agent, policy, or requirements document instead. Keep
 the list finite. Do not create separate items for prompt paraphrases, fixture
 variants, or ordinary happy-path permutations.
 
 Use `templates/audit.md` as the starting format for `.eval-author/audit.md`.
 The marked YAML block is the machine-readable part; prose outside the markers is
-for reviewers and may be edited freely. For `.eval-author/audit.md`, set
-`source_ethos: ../ETHOS.md` and replace the digest placeholder with:
+for reviewers and may be edited freely. When generating from `ETHOS.md`, include
+the optional `sources` entry for Ethos and replace the digest placeholder with:
 
 ```bash
 shasum -a 256 ETHOS.md | awk '{print "sha256:" $1}'
 ```
 
 `schemas/audit.schema.json` is the canonical structural schema. The Python
-validator applies that schema first, then checks source Ethos drift and cross-item
-references such as `required_tools` and `applies_to`.
+validator applies that schema first, then checks any source digests that are
+provided and cross-item references such as `required_tools` and `applies_to`.
 
 Capabilities that do not need tools, such as policy refusals or out-of-scope
 handling, should use `required_tools: []`. Failure cases attach to capability

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
@@ -23,7 +23,6 @@
     "sources": {
       "description": "Optional provenance records for source-of-truth material used to author this audit spec, such as ETHOS.md, policy docs, product requirements, or generated agent specs.",
       "type": "array",
-      "minItems": 1,
       "items": {
         "$ref": "#/$defs/source"
       }
@@ -79,7 +78,7 @@
       },
       "properties": {
         "name": {
-          "description": "Stable source key used by source_refs, for example ethos or product_requirements.",
+          "description": "Stable source key for this provenance record, for example ethos or product_requirements.",
           "$ref": "#/$defs/itemName"
         },
         "path": {
@@ -127,7 +126,7 @@
       }
     },
     "sourceRefs": {
-      "description": "Optional item-level provenance pointers into sources, for example ethos:Tools or policy.md#refunds.",
+      "description": "Optional free-form provenance notes for item authors and reviewers, for example ethos:Tools or policy.md#refunds. The v1 validator preserves these strings but does not resolve them against sources.",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -223,7 +222,7 @@
           "$ref": "#/$defs/itemName"
         },
         "source_refs": {
-          "description": "Optional provenance pointers showing where this tool expectation came from.",
+          "description": "Optional provenance notes showing where this tool expectation came from.",
           "$ref": "#/$defs/sourceRefs"
         },
         "description": {
@@ -266,7 +265,7 @@
           "$ref": "#/$defs/itemName"
         },
         "source_refs": {
-          "description": "Optional provenance pointers showing where this capability expectation came from.",
+          "description": "Optional provenance notes showing where this capability expectation came from.",
           "$ref": "#/$defs/sourceRefs"
         },
         "description": {
@@ -314,7 +313,7 @@
           "$ref": "#/$defs/capabilityRefList"
         },
         "source_refs": {
-          "description": "Optional provenance pointers showing where this failure expectation came from.",
+          "description": "Optional provenance notes showing where this failure expectation came from.",
           "$ref": "#/$defs/sourceRefs"
         },
         "description": {

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
@@ -2,14 +2,12 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://developer.nvidia.com/nemo/eval-author/audit.schema.json",
   "title": "NeMo Eval Author audit spec",
-  "description": "A finite coverage denominator derived from ETHOS.md for Eval Author audit measurement.",
+  "description": "A finite coverage denominator for Eval Author audit measurement.",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "schema",
     "agent",
-    "source_ethos",
-    "source_ethos_sha256",
     "status",
     "items"
   ],
@@ -20,12 +18,12 @@
     "agent": {
       "$ref": "#/$defs/nonEmptyString"
     },
-    "source_ethos": {
-      "$ref": "#/$defs/nonEmptyString"
-    },
-    "source_ethos_sha256": {
-      "type": "string",
-      "pattern": "^sha256:[0-9a-f]{64}$"
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/source"
+      }
     },
     "status": {
       "enum": [
@@ -60,6 +58,33 @@
       "type": "string",
       "pattern": "^[A-Za-z][A-Za-z0-9_.:/-]*$"
     },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "dependentRequired": {
+        "sha256": [
+          "path"
+        ]
+      },
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/itemName"
+        },
+        "path": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
     "toolList": {
       "type": "array",
       "items": {
@@ -85,29 +110,11 @@
         "$ref": "#/$defs/itemName"
       }
     },
-    "ethosSection": {
-      "$comment": "Keep this enum aligned with the Ethos section titles used by nemo_agents_plugin.ethos.",
-      "enum": [
-        "Behavior",
-        "Change Scope",
-        "Evaluation Setup",
-        "Framework",
-        "Harness",
-        "Model",
-        "Open Questions",
-        "Purpose",
-        "Role",
-        "Scope",
-        "Signals",
-        "Success Criteria",
-        "Tools"
-      ]
-    },
-    "ethosRefs": {
+    "sourceRefs": {
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "#/$defs/ethosSection"
+        "$ref": "#/$defs/nonEmptyString"
       }
     },
     "evidenceRequired": {
@@ -175,7 +182,6 @@
       "required": [
         "kind",
         "name",
-        "ethos_refs",
         "description",
         "expected_use",
         "expected_failure_behavior",
@@ -188,8 +194,8 @@
         "name": {
           "$ref": "#/$defs/itemName"
         },
-        "ethos_refs": {
-          "$ref": "#/$defs/ethosRefs"
+        "source_refs": {
+          "$ref": "#/$defs/sourceRefs"
         },
         "description": {
           "$ref": "#/$defs/nonEmptyString"
@@ -211,7 +217,6 @@
       "required": [
         "kind",
         "name",
-        "ethos_refs",
         "description",
         "required_tools",
         "expected_behavior",
@@ -224,8 +229,8 @@
         "name": {
           "$ref": "#/$defs/itemName"
         },
-        "ethos_refs": {
-          "$ref": "#/$defs/ethosRefs"
+        "source_refs": {
+          "$ref": "#/$defs/sourceRefs"
         },
         "description": {
           "$ref": "#/$defs/nonEmptyString"
@@ -248,7 +253,6 @@
         "kind",
         "name",
         "applies_to",
-        "ethos_refs",
         "description",
         "trigger",
         "expected_behavior",
@@ -264,8 +268,8 @@
         "applies_to": {
           "$ref": "#/$defs/capabilityRefList"
         },
-        "ethos_refs": {
-          "$ref": "#/$defs/ethosRefs"
+        "source_refs": {
+          "$ref": "#/$defs/sourceRefs"
         },
         "description": {
           "$ref": "#/$defs/nonEmptyString"

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
@@ -1,0 +1,295 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://developer.nvidia.com/nemo/eval-author/audit.schema.json",
+  "title": "NeMo Eval Author audit spec",
+  "description": "A finite coverage denominator derived from ETHOS.md for Eval Author audit measurement.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "agent",
+    "source_ethos",
+    "source_ethos_sha256",
+    "status",
+    "items"
+  ],
+  "properties": {
+    "schema": {
+      "const": "nemo.eval_author.audit.v1"
+    },
+    "agent": {
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "source_ethos": {
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "source_ethos_sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
+    "status": {
+      "enum": [
+        "draft",
+        "approved"
+      ]
+    },
+    "items": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/toolItem"
+          },
+          {
+            "$ref": "#/$defs/capabilityItem"
+          },
+          {
+            "$ref": "#/$defs/failureCaseItem"
+          }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "itemName": {
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_.:/-]*$"
+    },
+    "toolId": {
+      "type": "string",
+      "pattern": "^TOOL-[0-9]{3,}$"
+    },
+    "capabilityId": {
+      "type": "string",
+      "pattern": "^CAP-[0-9]{3,}$"
+    },
+    "failureCaseId": {
+      "type": "string",
+      "pattern": "^FAIL-[0-9]{3,}$"
+    },
+    "toolList": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/itemName"
+      }
+    },
+    "optionalToolList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/itemName"
+      }
+    },
+    "optionalStringList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "capabilityRefList": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/capabilityId"
+      }
+    },
+    "ethosSection": {
+      "enum": [
+        "Behavior",
+        "Change Scope",
+        "Evaluation Setup",
+        "Framework",
+        "Harness",
+        "Model",
+        "Open Questions",
+        "Purpose",
+        "Role",
+        "Scope",
+        "Signals",
+        "Success Criteria",
+        "Tools"
+      ]
+    },
+    "ethosRefs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/ethosSection"
+      }
+    },
+    "evidenceKind": {
+      "enum": [
+        "environment_state",
+        "outcome",
+        "output",
+        "policy_boundary",
+        "state_change",
+        "tool_call",
+        "trace_span",
+        "user_intent",
+        "verifier"
+      ]
+    },
+    "evidenceRequired": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "kind",
+          "description"
+        ],
+        "properties": {
+          "kind": {
+            "$ref": "#/$defs/evidenceKind"
+          },
+          "description": {
+            "$ref": "#/$defs/nonEmptyString"
+          },
+          "tool": {
+            "$ref": "#/$defs/itemName"
+          }
+        }
+      }
+    },
+    "toolItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "name",
+        "ethos_refs",
+        "description",
+        "expected_use",
+        "expected_failure_behavior",
+        "evidence_required"
+      ],
+      "properties": {
+        "kind": {
+          "const": "tool"
+        },
+        "id": {
+          "$ref": "#/$defs/toolId"
+        },
+        "name": {
+          "$ref": "#/$defs/itemName"
+        },
+        "ethos_refs": {
+          "$ref": "#/$defs/ethosRefs"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "expected_use": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "expected_failure_behavior": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "evidence_required": {
+          "$ref": "#/$defs/evidenceRequired"
+        }
+      }
+    },
+    "capabilityItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "name",
+        "ethos_refs",
+        "description",
+        "required_tools",
+        "expected_behavior",
+        "evidence_required"
+      ],
+      "properties": {
+        "kind": {
+          "const": "capability"
+        },
+        "id": {
+          "$ref": "#/$defs/capabilityId"
+        },
+        "name": {
+          "$ref": "#/$defs/itemName"
+        },
+        "ethos_refs": {
+          "$ref": "#/$defs/ethosRefs"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "required_tools": {
+          "$ref": "#/$defs/toolList"
+        },
+        "expected_behavior": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "evidence_required": {
+          "$ref": "#/$defs/evidenceRequired"
+        }
+      }
+    },
+    "failureCaseItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "id",
+        "name",
+        "applies_to",
+        "ethos_refs",
+        "description",
+        "trigger",
+        "expected_behavior",
+        "evidence_required"
+      ],
+      "properties": {
+        "kind": {
+          "const": "failure_case"
+        },
+        "id": {
+          "$ref": "#/$defs/failureCaseId"
+        },
+        "name": {
+          "$ref": "#/$defs/itemName"
+        },
+        "applies_to": {
+          "$ref": "#/$defs/capabilityRefList"
+        },
+        "ethos_refs": {
+          "$ref": "#/$defs/ethosRefs"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "trigger": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "expected_behavior": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "expected_tools": {
+          "$ref": "#/$defs/optionalToolList"
+        },
+        "prohibited_tools": {
+          "$ref": "#/$defs/optionalToolList"
+        },
+        "prohibited_outputs": {
+          "$ref": "#/$defs/optionalStringList"
+        },
+        "evidence_required": {
+          "$ref": "#/$defs/evidenceRequired"
+        }
+      }
+    }
+  }
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
@@ -60,21 +60,8 @@
       "type": "string",
       "pattern": "^[A-Za-z][A-Za-z0-9_.:/-]*$"
     },
-    "toolId": {
-      "type": "string",
-      "pattern": "^TOOL-[0-9]{3,}$"
-    },
-    "capabilityId": {
-      "type": "string",
-      "pattern": "^CAP-[0-9]{3,}$"
-    },
-    "failureCaseId": {
-      "type": "string",
-      "pattern": "^FAIL-[0-9]{3,}$"
-    },
     "toolList": {
       "type": "array",
-      "minItems": 1,
       "items": {
         "$ref": "#/$defs/itemName"
       }
@@ -95,10 +82,11 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "$ref": "#/$defs/capabilityId"
+        "$ref": "#/$defs/itemName"
       }
     },
     "ethosSection": {
+      "$comment": "Keep this enum aligned with the Ethos section titles used by nemo_agents_plugin.ethos.",
       "enum": [
         "Behavior",
         "Change Scope",
@@ -122,39 +110,62 @@
         "$ref": "#/$defs/ethosSection"
       }
     },
-    "evidenceKind": {
-      "enum": [
-        "environment_state",
-        "outcome",
-        "output",
-        "policy_boundary",
-        "state_change",
-        "tool_call",
-        "trace_span",
-        "user_intent",
-        "verifier"
-      ]
-    },
     "evidenceRequired": {
       "type": "array",
       "minItems": 1,
       "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "kind",
-          "description"
-        ],
-        "properties": {
-          "kind": {
-            "$ref": "#/$defs/evidenceKind"
+        "oneOf": [
+          {
+            "$ref": "#/$defs/toolCallEvidence"
           },
-          "description": {
-            "$ref": "#/$defs/nonEmptyString"
-          },
-          "tool": {
-            "$ref": "#/$defs/itemName"
+          {
+            "$ref": "#/$defs/nonToolEvidence"
           }
+        ]
+      }
+    },
+    "toolCallEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "description",
+        "tool"
+      ],
+      "properties": {
+        "kind": {
+          "const": "tool_call"
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "tool": {
+          "$ref": "#/$defs/itemName"
+        }
+      }
+    },
+    "nonToolEvidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "description"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "environment_state",
+            "outcome",
+            "output",
+            "policy_boundary",
+            "state_change",
+            "trace_span",
+            "user_intent",
+            "verifier"
+          ]
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
         }
       }
     },
@@ -163,7 +174,6 @@
       "additionalProperties": false,
       "required": [
         "kind",
-        "id",
         "name",
         "ethos_refs",
         "description",
@@ -174,9 +184,6 @@
       "properties": {
         "kind": {
           "const": "tool"
-        },
-        "id": {
-          "$ref": "#/$defs/toolId"
         },
         "name": {
           "$ref": "#/$defs/itemName"
@@ -203,7 +210,6 @@
       "additionalProperties": false,
       "required": [
         "kind",
-        "id",
         "name",
         "ethos_refs",
         "description",
@@ -214,9 +220,6 @@
       "properties": {
         "kind": {
           "const": "capability"
-        },
-        "id": {
-          "$ref": "#/$defs/capabilityId"
         },
         "name": {
           "$ref": "#/$defs/itemName"
@@ -243,7 +246,6 @@
       "additionalProperties": false,
       "required": [
         "kind",
-        "id",
         "name",
         "applies_to",
         "ethos_refs",
@@ -255,9 +257,6 @@
       "properties": {
         "kind": {
           "const": "failure_case"
-        },
-        "id": {
-          "$ref": "#/$defs/failureCaseId"
         },
         "name": {
           "$ref": "#/$defs/itemName"

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json
@@ -13,12 +13,15 @@
   ],
   "properties": {
     "schema": {
+      "description": "Version marker for the audit spec format. This must match the validator's supported schema.",
       "const": "nemo.eval_author.audit.v1"
     },
     "agent": {
+      "description": "Human-readable name of the agent, workflow, or system this audit denominator covers.",
       "$ref": "#/$defs/nonEmptyString"
     },
     "sources": {
+      "description": "Optional provenance records for source-of-truth material used to author this audit spec, such as ETHOS.md, policy docs, product requirements, or generated agent specs.",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -26,12 +29,14 @@
       }
     },
     "status": {
+      "description": "Review state for this audit spec. Draft specs can still change; approved specs are intended to act as the coverage denominator.",
       "enum": [
         "draft",
         "approved"
       ]
     },
     "items": {
+      "description": "Finite set of discrete coverage items that future eval traces can be measured against.",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -51,14 +56,17 @@
   },
   "$defs": {
     "nonEmptyString": {
+      "description": "String value that must contain at least one non-whitespace character.",
       "type": "string",
       "pattern": "\\S"
     },
     "itemName": {
+      "description": "Stable machine-readable name used for source, tool, capability, and failure-case references.",
       "type": "string",
       "pattern": "^[A-Za-z][A-Za-z0-9_.:/-]*$"
     },
     "source": {
+      "description": "Optional source-of-truth record. If sha256 is provided, validation compares it to the file at path.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -71,39 +79,47 @@
       },
       "properties": {
         "name": {
+          "description": "Stable source key used by source_refs, for example ethos or product_requirements.",
           "$ref": "#/$defs/itemName"
         },
         "path": {
+          "description": "Optional local path to the source document, resolved relative to audit.md when validation runs.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "sha256": {
+          "description": "Optional sha256 digest for the source document at path, formatted as sha256:<64 lowercase hex characters>.",
           "type": "string",
           "pattern": "^sha256:[0-9a-f]{64}$"
         },
         "description": {
+          "description": "Optional human-readable note describing the source and why it matters to this audit spec.",
           "$ref": "#/$defs/nonEmptyString"
         }
       }
     },
     "toolList": {
+      "description": "List of tool item names. Validation requires every value to match a declared tool item.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/itemName"
       }
     },
     "optionalToolList": {
+      "description": "Optional list of tool-like names. Some fields require declared tool item names; prohibited_tools intentionally does not.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/itemName"
       }
     },
     "optionalStringList": {
+      "description": "Optional list of non-empty human-readable string values.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/nonEmptyString"
       }
     },
     "capabilityRefList": {
+      "description": "List of capability item names this failure case applies to.",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -111,6 +127,7 @@
       }
     },
     "sourceRefs": {
+      "description": "Optional item-level provenance pointers into sources, for example ethos:Tools or policy.md#refunds.",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -118,6 +135,7 @@
       }
     },
     "evidenceRequired": {
+      "description": "Evidence predicates that a measurement method must satisfy before marking an item covered.",
       "type": "array",
       "minItems": 1,
       "items": {
@@ -132,6 +150,7 @@
       }
     },
     "toolCallEvidence": {
+      "description": "Machine-checkable evidence that a specific declared tool was called in the trace.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -141,17 +160,21 @@
       ],
       "properties": {
         "kind": {
+          "description": "Evidence discriminator. tool_call evidence requires a tool field.",
           "const": "tool_call"
         },
         "description": {
+          "description": "Human-readable explanation of the tool-call evidence expected in the trace.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "tool": {
+          "description": "Declared tool item name expected to appear as a call in the trace.",
           "$ref": "#/$defs/itemName"
         }
       }
     },
     "nonToolEvidence": {
+      "description": "Typed non-tool evidence that may require trace inspection, output inspection, verifier results, or later LLM/manual judgment.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -160,6 +183,7 @@
       ],
       "properties": {
         "kind": {
+          "description": "Evidence discriminator for non-tool evidence.",
           "enum": [
             "environment_state",
             "outcome",
@@ -172,11 +196,13 @@
           ]
         },
         "description": {
+          "description": "Human-readable explanation of the evidence expected for this predicate.",
           "$ref": "#/$defs/nonEmptyString"
         }
       }
     },
     "toolItem": {
+      "description": "Coverage item for a canonical tool the agent may call.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -189,29 +215,37 @@
       ],
       "properties": {
         "kind": {
+          "description": "Item discriminator for tool coverage items.",
           "const": "tool"
         },
         "name": {
+          "description": "Stable tool name used by tool references and coverage reports.",
           "$ref": "#/$defs/itemName"
         },
         "source_refs": {
+          "description": "Optional provenance pointers showing where this tool expectation came from.",
           "$ref": "#/$defs/sourceRefs"
         },
         "description": {
+          "description": "What this tool provides from the agent's point of view.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "expected_use": {
+          "description": "When the agent is expected to use this tool.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "expected_failure_behavior": {
+          "description": "What the agent should do when the tool is unavailable, fails, returns no useful result, or should not be called.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "evidence_required": {
+          "description": "Evidence needed to mark this tool item covered.",
           "$ref": "#/$defs/evidenceRequired"
         }
       }
     },
     "capabilityItem": {
+      "description": "Coverage item for a high-level behavior or capability the agent should exercise.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -224,29 +258,37 @@
       ],
       "properties": {
         "kind": {
+          "description": "Item discriminator for capability coverage items.",
           "const": "capability"
         },
         "name": {
+          "description": "Stable capability name used by failure cases, generated tasks, and coverage reports.",
           "$ref": "#/$defs/itemName"
         },
         "source_refs": {
+          "description": "Optional provenance pointers showing where this capability expectation came from.",
           "$ref": "#/$defs/sourceRefs"
         },
         "description": {
+          "description": "What user-facing or system-facing behavior this capability covers.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "required_tools": {
+          "description": "Declared tool item names needed for this capability. Use an empty list when no tools are required.",
           "$ref": "#/$defs/toolList"
         },
         "expected_behavior": {
+          "description": "What successful execution of this capability should look like at a high level.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "evidence_required": {
+          "description": "Evidence needed to mark this capability item covered.",
           "$ref": "#/$defs/evidenceRequired"
         }
       }
     },
     "failureCaseItem": {
+      "description": "Coverage item for expected safe behavior when a capability cannot proceed normally.",
       "type": "object",
       "additionalProperties": false,
       "required": [
@@ -260,36 +302,47 @@
       ],
       "properties": {
         "kind": {
+          "description": "Item discriminator for failure-case coverage items.",
           "const": "failure_case"
         },
         "name": {
+          "description": "Stable failure-case name used by generated tasks and coverage reports.",
           "$ref": "#/$defs/itemName"
         },
         "applies_to": {
+          "description": "Capability item names this failure case exercises.",
           "$ref": "#/$defs/capabilityRefList"
         },
         "source_refs": {
+          "description": "Optional provenance pointers showing where this failure expectation came from.",
           "$ref": "#/$defs/sourceRefs"
         },
         "description": {
+          "description": "What failure condition or boundary this item covers.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "trigger": {
+          "description": "Condition in a user request, environment, dependency, or policy boundary that should activate this failure case.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "expected_behavior": {
+          "description": "Safe behavior expected when this failure case is triggered.",
           "$ref": "#/$defs/nonEmptyString"
         },
         "expected_tools": {
+          "description": "Declared tool item names that may be appropriate to call while handling this failure case.",
           "$ref": "#/$defs/optionalToolList"
         },
         "prohibited_tools": {
+          "description": "Tool names that must not be called in this failure case. These do not need to be declared tool items.",
           "$ref": "#/$defs/optionalToolList"
         },
         "prohibited_outputs": {
+          "description": "Output content or data classes that must not appear when handling this failure case.",
           "$ref": "#/$defs/optionalStringList"
         },
         "evidence_required": {
+          "description": "Evidence needed to mark this failure-case item covered.",
           "$ref": "#/$defs/evidenceRequired"
         }
       }

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_markdown.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_markdown.py
@@ -37,7 +37,7 @@ def extract_schema_block(path: Path) -> str:
     if start >= end:
         raise AuditMarkdownError(f"{path} has audit markers in the wrong order")
 
-    match = _YAML_BLOCK_RE.search(text[start:end])
-    if match is None:
+    matches = list(_YAML_BLOCK_RE.finditer(text[start:end]))
+    if len(matches) != 1:
         raise AuditMarkdownError("audit marker block must contain one fenced yaml block")
-    return match.group("body")
+    return matches[0].group("body")

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_markdown.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_markdown.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Markdown extraction helpers for audit-spec documents."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+BEGIN_MARKER = "<!-- BEGIN:nemo-eval-author-audit:v1 -->"
+END_MARKER = "<!-- END:nemo-eval-author-audit:v1 -->"
+
+_YAML_BLOCK_RE = re.compile(r"```(?:yaml|yml)\s*\n(?P<body>.*?)\n```", re.DOTALL)
+
+
+class AuditMarkdownError(ValueError):
+    """Raised when the audit-spec block cannot be extracted from Markdown."""
+
+
+def extract_schema_block(path: Path) -> str:
+    """Return the YAML block between the audit markers in *path*."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise AuditMarkdownError(f"could not read {path}: {exc}") from exc
+
+    starts = [match.start() for match in re.finditer(re.escape(BEGIN_MARKER), text)]
+    ends = [match.start() for match in re.finditer(re.escape(END_MARKER), text)]
+    if len(starts) != 1 or len(ends) != 1:
+        raise AuditMarkdownError(f"{path} must contain exactly one {BEGIN_MARKER!r} and one {END_MARKER!r}")
+    start = starts[0] + len(BEGIN_MARKER)
+    end = ends[0]
+    if start >= end:
+        raise AuditMarkdownError(f"{path} has audit markers in the wrong order")
+
+    match = _YAML_BLOCK_RE.search(text[start:end])
+    if match is None:
+        raise AuditMarkdownError("audit marker block must contain one fenced yaml block")
+    return match.group("body")

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_markdown.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_markdown.py
@@ -12,6 +12,8 @@ from pathlib import Path
 BEGIN_MARKER = "<!-- BEGIN:nemo-eval-author-audit:v1 -->"
 END_MARKER = "<!-- END:nemo-eval-author-audit:v1 -->"
 
+_BEGIN_MARKER_RE = re.compile(rf"(?m)^[ \t]*{re.escape(BEGIN_MARKER)}[ \t]*$")
+_END_MARKER_RE = re.compile(rf"(?m)^[ \t]*{re.escape(END_MARKER)}[ \t]*$")
 _YAML_BLOCK_RE = re.compile(r"```(?:yaml|yml)\s*\n(?P<body>.*?)\n```", re.DOTALL)
 
 
@@ -26,11 +28,11 @@ def extract_schema_block(path: Path) -> str:
     except (OSError, UnicodeError) as exc:
         raise AuditMarkdownError(f"could not read {path}: {exc}") from exc
 
-    starts = [match.start() for match in re.finditer(re.escape(BEGIN_MARKER), text)]
-    ends = [match.start() for match in re.finditer(re.escape(END_MARKER), text)]
+    starts = [match.end() for match in _BEGIN_MARKER_RE.finditer(text)]
+    ends = [match.start() for match in _END_MARKER_RE.finditer(text)]
     if len(starts) != 1 or len(ends) != 1:
         raise AuditMarkdownError(f"{path} must contain exactly one {BEGIN_MARKER!r} and one {END_MARKER!r}")
-    start = starts[0] + len(BEGIN_MARKER)
+    start = starts[0]
     end = ends[0]
     if start >= end:
         raise AuditMarkdownError(f"{path} has audit markers in the wrong order")

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_markdown.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_markdown.py
@@ -14,7 +14,10 @@ END_MARKER = "<!-- END:nemo-eval-author-audit:v1 -->"
 
 _BEGIN_MARKER_RE = re.compile(rf"(?m)^[ \t]*{re.escape(BEGIN_MARKER)}[ \t]*$")
 _END_MARKER_RE = re.compile(rf"(?m)^[ \t]*{re.escape(END_MARKER)}[ \t]*$")
-_YAML_BLOCK_RE = re.compile(r"```(?:yaml|yml)\s*\n(?P<body>.*?)\n```", re.DOTALL)
+_YAML_BLOCK_RE = re.compile(
+    r"^[ \t]*```(?:yaml|yml)[ \t]*\n(?P<body>.*?)\n[ \t]*```[ \t]*$",
+    re.DOTALL | re.MULTILINE,
+)
 
 
 class AuditMarkdownError(ValueError):

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
@@ -6,8 +6,10 @@
 
 from __future__ import annotations
 
+import json
 import re
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -15,62 +17,8 @@ import yaml
 from _markdown import extract_schema_block
 
 AUDIT_SCHEMA = "nemo.eval_author.audit.v1"
-
-ETHOS_SECTION_TITLES = frozenset(
-    {
-        "Role",
-        "Purpose",
-        "Scope",
-        "Tools",
-        "Model",
-        "Framework",
-        "Harness",
-        "Behavior",
-        "Success Criteria",
-        "Evaluation Setup",
-        "Change Scope",
-        "Signals",
-        "Open Questions",
-    }
-)
-
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "audit.schema.json"
 ITEM_KINDS = frozenset({"tool", "capability", "failure_case"})
-STATUS_VALUES = frozenset({"draft", "approved"})
-EVIDENCE_KINDS = frozenset(
-    {
-        "environment_state",
-        "outcome",
-        "output",
-        "policy_boundary",
-        "state_change",
-        "tool_call",
-        "trace_span",
-        "user_intent",
-        "verifier",
-    }
-)
-
-_TOP_LEVEL_FIELDS = frozenset({"schema", "agent", "source_ethos", "source_ethos_sha256", "status", "items"})
-_COMMON_ITEM_FIELDS = frozenset({"kind", "id", "name", "ethos_refs", "description", "evidence_required"})
-_TOOL_FIELDS = _COMMON_ITEM_FIELDS | frozenset({"expected_use", "expected_failure_behavior"})
-_CAPABILITY_FIELDS = _COMMON_ITEM_FIELDS | frozenset({"required_tools", "expected_behavior"})
-_FAILURE_CASE_FIELDS = _COMMON_ITEM_FIELDS | frozenset(
-    {"applies_to", "trigger", "expected_behavior", "expected_tools", "prohibited_tools", "prohibited_outputs"}
-)
-_ITEM_FIELDS_BY_KIND = {
-    "tool": _TOOL_FIELDS,
-    "capability": _CAPABILITY_FIELDS,
-    "failure_case": _FAILURE_CASE_FIELDS,
-}
-_REQUIRED_BY_KIND = {
-    "tool": _COMMON_ITEM_FIELDS | frozenset({"expected_use", "expected_failure_behavior"}),
-    "capability": _COMMON_ITEM_FIELDS | frozenset({"required_tools", "expected_behavior"}),
-    "failure_case": _COMMON_ITEM_FIELDS | frozenset({"applies_to", "trigger", "expected_behavior"}),
-}
-_ID_PREFIX_BY_KIND = {"tool": "TOOL-", "capability": "CAP-", "failure_case": "FAIL-"}
-_EVIDENCE_FIELDS = frozenset({"kind", "description", "tool"})
-_ID_RE = re.compile(r"^[A-Z]+-[0-9]{3,}$")
-_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:/-]*$")
 
 
 class AuditSpecError(ValueError):
@@ -101,23 +49,40 @@ def load_items_file(path: Path) -> list[dict[str, Any]]:
 
 
 def validate_audit_spec(payload: Any) -> dict[str, Any]:
-    """Return *payload* when it satisfies the audit-spec schema."""
-    errors: list[str] = []
+    """Return *payload* when it satisfies the audit spec."""
+    _validate_json_schema(payload)
     if not isinstance(payload, dict):
         raise AuditSpecError("audit spec must be a mapping")
+    return _validate_semantics(payload)
 
-    _check_fields("audit", payload, required=_TOP_LEVEL_FIELDS, allowed=_TOP_LEVEL_FIELDS, errors=errors)
-    _check_literal("audit.schema", payload.get("schema"), AUDIT_SCHEMA, errors)
-    _check_nonempty_string("audit.agent", payload.get("agent"), errors)
-    _check_nonempty_string("audit.source_ethos", payload.get("source_ethos"), errors)
-    _check_hash("audit.source_ethos_sha256", payload.get("source_ethos_sha256"), errors)
-    _check_enum("audit.status", payload.get("status"), STATUS_VALUES, errors)
 
-    items = payload.get("items")
-    if not isinstance(items, list) or not items:
-        errors.append("audit.items must be a non-empty list")
-        raise AuditSpecError("\n".join(errors))
+def item_counts(spec: dict[str, Any]) -> dict[str, int]:
+    """Return item counts by kind."""
+    counts = Counter(item["kind"] for item in spec["items"])
+    return {kind: counts.get(kind, 0) for kind in sorted(ITEM_KINDS)}
 
+
+def _validate_json_schema(payload: Any) -> None:
+    try:
+        from jsonschema import Draft202012Validator
+    except ImportError as exc:
+        raise AuditSpecError("jsonschema is required to validate audit specs") from exc
+
+    try:
+        schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise AuditSpecError(f"could not load audit JSON Schema from {SCHEMA_PATH}: {exc}") from exc
+
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    errors = sorted(validator.iter_errors(payload), key=lambda error: (list(error.absolute_path), error.message))
+    if errors:
+        raise AuditSpecError("\n".join(_format_schema_error(error) for error in errors))
+
+
+def _validate_semantics(payload: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    items = payload["items"]
     item_ids: set[str] = set()
     tool_names: set[str] = set()
     capability_ids: set[str] = set()
@@ -125,27 +90,14 @@ def validate_audit_spec(payload: Any) -> dict[str, Any]:
 
     for index, item in enumerate(items):
         path = f"audit.items[{index}]"
-        if not isinstance(item, dict):
-            errors.append(f"{path} must be a mapping")
-            continue
         kind = item.get("kind")
-        _check_enum(f"{path}.kind", kind, ITEM_KINDS, errors)
-        if kind not in ITEM_KINDS:
-            continue
-        _check_fields(
-            path,
-            item,
-            required=_REQUIRED_BY_KIND[kind],
-            allowed=_ITEM_FIELDS_BY_KIND[kind],
-            errors=errors,
-        )
-        item_id = _check_id(f"{path}.id", item.get("id"), _ID_PREFIX_BY_KIND[kind], errors)
-        if item_id is not None:
-            if item_id in item_ids:
-                errors.append(f"{path}.id {item_id!r} is duplicated")
-            item_ids.add(item_id)
-            if kind == "capability":
-                capability_ids.add(item_id)
+        item_id = item["id"]
+        if item_id in item_ids:
+            errors.append(f"{path}.id {item_id!r} is duplicated")
+        item_ids.add(item_id)
+        if kind == "capability":
+            capability_ids.add(item_id)
+
         name = _check_name(f"{path}.name", item.get("name"), errors)
         if name is not None:
             if name in names_by_kind[kind]:
@@ -153,22 +105,6 @@ def validate_audit_spec(payload: Any) -> dict[str, Any]:
             names_by_kind[kind].add(name)
             if kind == "tool":
                 tool_names.add(name)
-        _check_string_list(f"{path}.ethos_refs", item.get("ethos_refs"), errors, allowed=ETHOS_SECTION_TITLES)
-        _check_nonempty_string(f"{path}.description", item.get("description"), errors)
-        _check_evidence(f"{path}.evidence_required", item.get("evidence_required"), errors)
-        if kind == "tool":
-            _check_nonempty_string(f"{path}.expected_use", item.get("expected_use"), errors)
-            _check_nonempty_string(f"{path}.expected_failure_behavior", item.get("expected_failure_behavior"), errors)
-        elif kind == "capability":
-            _check_string_list(f"{path}.required_tools", item.get("required_tools"), errors)
-            _check_nonempty_string(f"{path}.expected_behavior", item.get("expected_behavior"), errors)
-        elif kind == "failure_case":
-            _check_string_list(f"{path}.applies_to", item.get("applies_to"), errors)
-            _check_nonempty_string(f"{path}.trigger", item.get("trigger"), errors)
-            _check_nonempty_string(f"{path}.expected_behavior", item.get("expected_behavior"), errors)
-            _check_optional_string_list(f"{path}.expected_tools", item.get("expected_tools"), errors)
-            _check_optional_string_list(f"{path}.prohibited_tools", item.get("prohibited_tools"), errors)
-            _check_optional_string_list(f"{path}.prohibited_outputs", item.get("prohibited_outputs"), errors)
 
     if errors:
         raise AuditSpecError("\n".join(errors))
@@ -178,9 +114,10 @@ def validate_audit_spec(payload: Any) -> dict[str, Any]:
         for field in ("required_tools", "expected_tools", "prohibited_tools"):
             _check_known_tools(f"{path}.{field}", item.get(field), tool_names, errors)
         for evidence_index, evidence in enumerate(item["evidence_required"]):
-            _check_known_tools(
-                f"{path}.evidence_required[{evidence_index}].tool", [evidence.get("tool")], tool_names, errors
-            )
+            if "tool" in evidence:
+                _check_known_tools(
+                    f"{path}.evidence_required[{evidence_index}].tool", [evidence["tool"]], tool_names, errors
+                )
         if item["kind"] == "failure_case":
             for ref in item["applies_to"]:
                 if ref not in capability_ids:
@@ -191,132 +128,48 @@ def validate_audit_spec(payload: Any) -> dict[str, Any]:
     return payload
 
 
-def item_counts(spec: dict[str, Any]) -> dict[str, int]:
-    """Return item counts by kind."""
-    counts = Counter(item["kind"] for item in spec["items"])
-    return {kind: counts.get(kind, 0) for kind in sorted(ITEM_KINDS)}
-
-
-def _check_fields(
-    path: str,
-    payload: dict[str, Any],
-    *,
-    required: frozenset[str],
-    allowed: frozenset[str],
-    errors: list[str],
-) -> None:
-    missing = sorted(required - payload.keys())
-    extra = sorted(payload.keys() - allowed)
-    if missing:
-        errors.append(f"{path} missing required fields: {', '.join(missing)}")
-    if extra:
-        errors.append(f"{path} has unknown fields: {', '.join(extra)}")
-
-
-def _check_literal(path: str, value: Any, expected: str, errors: list[str]) -> None:
-    if value != expected:
-        errors.append(f"{path} must be {expected!r}")
-
-
-def _check_enum(path: str, value: Any, allowed: frozenset[str], errors: list[str]) -> None:
-    if not isinstance(value, str) or value not in allowed:
-        errors.append(f"{path} must be one of {sorted(allowed)}")
-
-
-def _check_nonempty_string(path: str, value: Any, errors: list[str]) -> str | None:
-    if not isinstance(value, str) or not value.strip():
-        errors.append(f"{path} must be a non-empty string")
-        return None
-    return value
-
-
-def _check_hash(path: str, value: Any, errors: list[str]) -> None:
-    if not isinstance(value, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", value):
-        errors.append(f"{path} must be a sha256:<64 hex chars> digest")
-
-
-def _check_id(path: str, value: Any, prefix: str, errors: list[str]) -> str | None:
-    if not isinstance(value, str) or not _ID_RE.fullmatch(value):
-        errors.append(f"{path} must match {_ID_RE.pattern}")
-        return None
-    if not value.startswith(prefix):
-        errors.append(f"{path} must start with {prefix!r}")
-    return value
-
-
 def _check_name(path: str, value: Any, errors: list[str]) -> str | None:
-    if not isinstance(value, str) or not _NAME_RE.fullmatch(value):
-        errors.append(f"{path} must be a non-empty identifier matching {_NAME_RE.pattern}")
+    if not isinstance(value, str) or not re.fullmatch(r"^[A-Za-z][A-Za-z0-9_.:/-]*$", value):
+        errors.append(f"{path} must be a non-empty identifier matching ^[A-Za-z][A-Za-z0-9_.:/-]*$")
         return None
     return value
-
-
-def _check_string_list(
-    path: str,
-    value: Any,
-    errors: list[str],
-    *,
-    allowed: frozenset[str] | None = None,
-) -> list[str]:
-    if not isinstance(value, list) or not value:
-        errors.append(f"{path} must be a non-empty list of strings")
-        return []
-    result: list[str] = []
-    for index, item in enumerate(value):
-        if not isinstance(item, str) or not item.strip():
-            errors.append(f"{path}[{index}] must be a non-empty string")
-            continue
-        if allowed is not None and item not in allowed:
-            errors.append(f"{path}[{index}] must be one of {sorted(allowed)}")
-        result.append(item)
-    return result
-
-
-def _check_optional_string_list(path: str, value: Any, errors: list[str]) -> list[str]:
-    if value is None:
-        return []
-    if not isinstance(value, list):
-        errors.append(f"{path} must be a list of strings")
-        return []
-    result: list[str] = []
-    for index, item in enumerate(value):
-        if not isinstance(item, str) or not item.strip():
-            errors.append(f"{path}[{index}] must be a non-empty string")
-            continue
-        result.append(item)
-    return result
-
-
-def _check_evidence(path: str, value: Any, errors: list[str]) -> None:
-    if not isinstance(value, list) or not value:
-        errors.append(f"{path} must be a non-empty list")
-        return
-    for index, item in enumerate(value):
-        item_path = f"{path}[{index}]"
-        if not isinstance(item, dict):
-            errors.append(f"{item_path} must be a mapping")
-            continue
-        _check_fields(
-            item_path,
-            item,
-            required=frozenset({"kind", "description"}),
-            allowed=_EVIDENCE_FIELDS,
-            errors=errors,
-        )
-        _check_enum(f"{item_path}.kind", item.get("kind"), EVIDENCE_KINDS, errors)
-        _check_nonempty_string(f"{item_path}.description", item.get("description"), errors)
-        if "tool" in item:
-            _check_name(f"{item_path}.tool", item.get("tool"), errors)
 
 
 def _check_known_tools(path: str, values: Any, tool_names: set[str], errors: list[str]) -> None:
     if values is None:
         return
-    if not isinstance(values, list):
-        errors.append(f"{path} must be a list of tool names")
-        return
     for value in values:
-        if value is None:
-            continue
         if value not in tool_names:
             errors.append(f"{path} references unknown tool name {value!r}")
+
+
+def _format_schema_error(error: Any) -> str:
+    if error.validator == "oneOf":
+        matching_kind_errors = list(_matching_kind_context_errors(error))
+        if matching_kind_errors:
+            return "\n".join(_format_schema_error(context) for context in matching_kind_errors)
+    return f"{_json_path(error.absolute_path)}: {error.message}"
+
+
+def _matching_kind_context_errors(error: Any) -> Iterable[Any]:
+    instance = error.instance
+    if not isinstance(instance, dict):
+        return ()
+    kind = instance.get("kind")
+    if not isinstance(kind, str):
+        return ()
+    return (
+        context
+        for context in error.context
+        if context.schema.get("properties", {}).get("kind", {}).get("const") == kind
+    )
+
+
+def _json_path(parts: Iterable[Any]) -> str:
+    path = "audit"
+    for part in parts:
+        if isinstance(part, int):
+            path += f"[{part}]"
+        else:
+            path += f".{part}"
+    return path

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
@@ -20,7 +20,7 @@ from _markdown import extract_schema_block
 AUDIT_SCHEMA = "nemo.eval_author.audit.v1"
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "audit.schema.json"
 ITEM_KINDS = frozenset({"tool", "capability", "failure_case"})
-_ZERO_SOURCE_ETHOS_DIGEST = "sha256:" + ("0" * 64)
+_ZERO_SOURCE_DIGEST = "sha256:" + ("0" * 64)
 
 
 class AuditSpecError(ValueError):
@@ -42,7 +42,7 @@ def validate_audit_spec(payload: Any, *, audit_path: Path | None = None) -> dict
     _validate_json_schema(payload)
     if not isinstance(payload, dict):
         raise AuditSpecError("audit spec must be a mapping")
-    _validate_source_ethos(payload, audit_path=audit_path)
+    _validate_sources(payload, audit_path=audit_path)
     return _validate_semantics(payload)
 
 
@@ -73,9 +73,17 @@ def _validate_json_schema(payload: Any) -> None:
 def _validate_semantics(payload: dict[str, Any]) -> dict[str, Any]:
     errors: list[str] = []
     items = payload["items"]
+    source_names: set[str] = set()
     item_names: set[str] = set()
     tool_names: set[str] = set()
     capability_names: set[str] = set()
+
+    for index, source in enumerate(payload.get("sources", [])):
+        name = _check_name(f"audit.sources[{index}].name", source.get("name"), errors)
+        if name is not None:
+            if name in source_names:
+                errors.append(f"audit.sources[{index}].name {name!r} is duplicated")
+            source_names.add(name)
 
     for index, item in enumerate(items):
         path = f"audit.items[{index}]"
@@ -112,25 +120,33 @@ def _validate_semantics(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def _validate_source_ethos(payload: dict[str, Any], *, audit_path: Path | None) -> None:
-    digest = payload["source_ethos_sha256"]
-    if digest == _ZERO_SOURCE_ETHOS_DIGEST:
-        raise AuditSpecError("audit.source_ethos_sha256 must not be the all-zero placeholder digest")
-    if audit_path is None:
-        return
+def _validate_sources(payload: dict[str, Any], *, audit_path: Path | None) -> None:
+    errors: list[str] = []
+    for index, source in enumerate(payload.get("sources", [])):
+        digest = source.get("sha256")
+        if digest is None:
+            continue
+        path = f"audit.sources[{index}].sha256"
+        if digest == _ZERO_SOURCE_DIGEST:
+            errors.append(f"{path} must not be the all-zero placeholder digest")
+            continue
+        if audit_path is None:
+            continue
 
-    source_ethos = Path(payload["source_ethos"])
-    if not source_ethos.is_absolute():
-        source_ethos = audit_path.parent / source_ethos
-    try:
-        with source_ethos.open("rb") as stream:
-            actual = f"sha256:{hashlib.file_digest(stream, 'sha256').hexdigest()}"
-    except OSError as exc:
-        raise AuditSpecError(f"audit.source_ethos could not be read at {source_ethos}: {exc}") from exc
-    if actual != digest:
-        raise AuditSpecError(
-            f"audit.source_ethos_sha256 does not match {source_ethos}: expected {digest}, got {actual}"
-        )
+        source_path = Path(source["path"])
+        if not source_path.is_absolute():
+            source_path = audit_path.parent / source_path
+        try:
+            with source_path.open("rb") as stream:
+                actual = f"sha256:{hashlib.file_digest(stream, 'sha256').hexdigest()}"
+        except OSError as exc:
+            errors.append(f"audit.sources[{index}].path could not be read at {source_path}: {exc}")
+            continue
+        if actual != digest:
+            errors.append(f"{path} does not match {source_path}: expected {digest}, got {actual}")
+
+    if errors:
+        raise AuditSpecError("\n".join(errors))
 
 
 def _check_name(path: str, value: Any, errors: list[str]) -> str | None:

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Schema validation for the audit-spec coverage denominator."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+from _markdown import extract_schema_block
+
+AUDIT_SCHEMA = "nemo.eval_author.audit.v1"
+
+ETHOS_SECTION_TITLES = frozenset(
+    {
+        "Role",
+        "Purpose",
+        "Scope",
+        "Tools",
+        "Model",
+        "Framework",
+        "Harness",
+        "Behavior",
+        "Success Criteria",
+        "Evaluation Setup",
+        "Change Scope",
+        "Signals",
+        "Open Questions",
+    }
+)
+
+ITEM_KINDS = frozenset({"tool", "capability", "failure_case"})
+STATUS_VALUES = frozenset({"draft", "approved"})
+EVIDENCE_KINDS = frozenset(
+    {
+        "environment_state",
+        "outcome",
+        "output",
+        "policy_boundary",
+        "state_change",
+        "tool_call",
+        "trace_span",
+        "user_intent",
+        "verifier",
+    }
+)
+
+_TOP_LEVEL_FIELDS = frozenset({"schema", "agent", "source_ethos", "source_ethos_sha256", "status", "items"})
+_COMMON_ITEM_FIELDS = frozenset({"kind", "id", "name", "ethos_refs", "description", "evidence_required"})
+_TOOL_FIELDS = _COMMON_ITEM_FIELDS | frozenset({"expected_use", "expected_failure_behavior"})
+_CAPABILITY_FIELDS = _COMMON_ITEM_FIELDS | frozenset({"required_tools", "expected_behavior"})
+_FAILURE_CASE_FIELDS = _COMMON_ITEM_FIELDS | frozenset(
+    {"applies_to", "trigger", "expected_behavior", "expected_tools", "prohibited_tools", "prohibited_outputs"}
+)
+_ITEM_FIELDS_BY_KIND = {
+    "tool": _TOOL_FIELDS,
+    "capability": _CAPABILITY_FIELDS,
+    "failure_case": _FAILURE_CASE_FIELDS,
+}
+_REQUIRED_BY_KIND = {
+    "tool": _COMMON_ITEM_FIELDS | frozenset({"expected_use", "expected_failure_behavior"}),
+    "capability": _COMMON_ITEM_FIELDS | frozenset({"required_tools", "expected_behavior"}),
+    "failure_case": _COMMON_ITEM_FIELDS | frozenset({"applies_to", "trigger", "expected_behavior"}),
+}
+_ID_PREFIX_BY_KIND = {"tool": "TOOL-", "capability": "CAP-", "failure_case": "FAIL-"}
+_EVIDENCE_FIELDS = frozenset({"kind", "description", "tool"})
+_ID_RE = re.compile(r"^[A-Z]+-[0-9]{3,}$")
+_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:/-]*$")
+
+
+class AuditSpecError(ValueError):
+    """Raised when an audit spec fails schema validation."""
+
+
+def load_audit_spec(path: Path) -> dict[str, Any]:
+    """Load and validate an ``audit.md`` file."""
+    block = extract_schema_block(path)
+    try:
+        payload = yaml.safe_load(block)
+    except yaml.YAMLError as exc:
+        raise AuditSpecError(f"audit YAML does not parse: {exc}") from exc
+    return validate_audit_spec(payload)
+
+
+def load_items_file(path: Path) -> list[dict[str, Any]]:
+    """Load a YAML items file accepted by ``generate.py``."""
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise AuditSpecError(f"could not load items from {path}: {exc}") from exc
+    if isinstance(payload, dict):
+        payload = payload.get("items")
+    if not isinstance(payload, list):
+        raise AuditSpecError(f"{path} must contain an item list or a mapping with an 'items' list")
+    return payload
+
+
+def validate_audit_spec(payload: Any) -> dict[str, Any]:
+    """Return *payload* when it satisfies the audit-spec schema."""
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        raise AuditSpecError("audit spec must be a mapping")
+
+    _check_fields("audit", payload, required=_TOP_LEVEL_FIELDS, allowed=_TOP_LEVEL_FIELDS, errors=errors)
+    _check_literal("audit.schema", payload.get("schema"), AUDIT_SCHEMA, errors)
+    _check_nonempty_string("audit.agent", payload.get("agent"), errors)
+    _check_nonempty_string("audit.source_ethos", payload.get("source_ethos"), errors)
+    _check_hash("audit.source_ethos_sha256", payload.get("source_ethos_sha256"), errors)
+    _check_enum("audit.status", payload.get("status"), STATUS_VALUES, errors)
+
+    items = payload.get("items")
+    if not isinstance(items, list) or not items:
+        errors.append("audit.items must be a non-empty list")
+        raise AuditSpecError("\n".join(errors))
+
+    item_ids: set[str] = set()
+    tool_names: set[str] = set()
+    capability_ids: set[str] = set()
+    names_by_kind: dict[str, set[str]] = {kind: set() for kind in ITEM_KINDS}
+
+    for index, item in enumerate(items):
+        path = f"audit.items[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{path} must be a mapping")
+            continue
+        kind = item.get("kind")
+        _check_enum(f"{path}.kind", kind, ITEM_KINDS, errors)
+        if kind not in ITEM_KINDS:
+            continue
+        _check_fields(
+            path,
+            item,
+            required=_REQUIRED_BY_KIND[kind],
+            allowed=_ITEM_FIELDS_BY_KIND[kind],
+            errors=errors,
+        )
+        item_id = _check_id(f"{path}.id", item.get("id"), _ID_PREFIX_BY_KIND[kind], errors)
+        if item_id is not None:
+            if item_id in item_ids:
+                errors.append(f"{path}.id {item_id!r} is duplicated")
+            item_ids.add(item_id)
+            if kind == "capability":
+                capability_ids.add(item_id)
+        name = _check_name(f"{path}.name", item.get("name"), errors)
+        if name is not None:
+            if name in names_by_kind[kind]:
+                errors.append(f"{path}.name {name!r} is duplicated for kind {kind!r}")
+            names_by_kind[kind].add(name)
+            if kind == "tool":
+                tool_names.add(name)
+        _check_string_list(f"{path}.ethos_refs", item.get("ethos_refs"), errors, allowed=ETHOS_SECTION_TITLES)
+        _check_nonempty_string(f"{path}.description", item.get("description"), errors)
+        _check_evidence(f"{path}.evidence_required", item.get("evidence_required"), errors)
+        if kind == "tool":
+            _check_nonempty_string(f"{path}.expected_use", item.get("expected_use"), errors)
+            _check_nonempty_string(f"{path}.expected_failure_behavior", item.get("expected_failure_behavior"), errors)
+        elif kind == "capability":
+            _check_string_list(f"{path}.required_tools", item.get("required_tools"), errors)
+            _check_nonempty_string(f"{path}.expected_behavior", item.get("expected_behavior"), errors)
+        elif kind == "failure_case":
+            _check_string_list(f"{path}.applies_to", item.get("applies_to"), errors)
+            _check_nonempty_string(f"{path}.trigger", item.get("trigger"), errors)
+            _check_nonempty_string(f"{path}.expected_behavior", item.get("expected_behavior"), errors)
+            _check_optional_string_list(f"{path}.expected_tools", item.get("expected_tools"), errors)
+            _check_optional_string_list(f"{path}.prohibited_tools", item.get("prohibited_tools"), errors)
+            _check_optional_string_list(f"{path}.prohibited_outputs", item.get("prohibited_outputs"), errors)
+
+    if errors:
+        raise AuditSpecError("\n".join(errors))
+
+    for index, item in enumerate(items):
+        path = f"audit.items[{index}]"
+        for field in ("required_tools", "expected_tools", "prohibited_tools"):
+            _check_known_tools(f"{path}.{field}", item.get(field), tool_names, errors)
+        for evidence_index, evidence in enumerate(item["evidence_required"]):
+            _check_known_tools(
+                f"{path}.evidence_required[{evidence_index}].tool", [evidence.get("tool")], tool_names, errors
+            )
+        if item["kind"] == "failure_case":
+            for ref in item["applies_to"]:
+                if ref not in capability_ids:
+                    errors.append(f"{path}.applies_to references unknown capability id {ref!r}")
+
+    if errors:
+        raise AuditSpecError("\n".join(errors))
+    return payload
+
+
+def item_counts(spec: dict[str, Any]) -> dict[str, int]:
+    """Return item counts by kind."""
+    counts = Counter(item["kind"] for item in spec["items"])
+    return {kind: counts.get(kind, 0) for kind in sorted(ITEM_KINDS)}
+
+
+def _check_fields(
+    path: str,
+    payload: dict[str, Any],
+    *,
+    required: frozenset[str],
+    allowed: frozenset[str],
+    errors: list[str],
+) -> None:
+    missing = sorted(required - payload.keys())
+    extra = sorted(payload.keys() - allowed)
+    if missing:
+        errors.append(f"{path} missing required fields: {', '.join(missing)}")
+    if extra:
+        errors.append(f"{path} has unknown fields: {', '.join(extra)}")
+
+
+def _check_literal(path: str, value: Any, expected: str, errors: list[str]) -> None:
+    if value != expected:
+        errors.append(f"{path} must be {expected!r}")
+
+
+def _check_enum(path: str, value: Any, allowed: frozenset[str], errors: list[str]) -> None:
+    if not isinstance(value, str) or value not in allowed:
+        errors.append(f"{path} must be one of {sorted(allowed)}")
+
+
+def _check_nonempty_string(path: str, value: Any, errors: list[str]) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{path} must be a non-empty string")
+        return None
+    return value
+
+
+def _check_hash(path: str, value: Any, errors: list[str]) -> None:
+    if not isinstance(value, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", value):
+        errors.append(f"{path} must be a sha256:<64 hex chars> digest")
+
+
+def _check_id(path: str, value: Any, prefix: str, errors: list[str]) -> str | None:
+    if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+        errors.append(f"{path} must match {_ID_RE.pattern}")
+        return None
+    if not value.startswith(prefix):
+        errors.append(f"{path} must start with {prefix!r}")
+    return value
+
+
+def _check_name(path: str, value: Any, errors: list[str]) -> str | None:
+    if not isinstance(value, str) or not _NAME_RE.fullmatch(value):
+        errors.append(f"{path} must be a non-empty identifier matching {_NAME_RE.pattern}")
+        return None
+    return value
+
+
+def _check_string_list(
+    path: str,
+    value: Any,
+    errors: list[str],
+    *,
+    allowed: frozenset[str] | None = None,
+) -> list[str]:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{path} must be a non-empty list of strings")
+        return []
+    result: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"{path}[{index}] must be a non-empty string")
+            continue
+        if allowed is not None and item not in allowed:
+            errors.append(f"{path}[{index}] must be one of {sorted(allowed)}")
+        result.append(item)
+    return result
+
+
+def _check_optional_string_list(path: str, value: Any, errors: list[str]) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        errors.append(f"{path} must be a list of strings")
+        return []
+    result: list[str] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            errors.append(f"{path}[{index}] must be a non-empty string")
+            continue
+        result.append(item)
+    return result
+
+
+def _check_evidence(path: str, value: Any, errors: list[str]) -> None:
+    if not isinstance(value, list) or not value:
+        errors.append(f"{path} must be a non-empty list")
+        return
+    for index, item in enumerate(value):
+        item_path = f"{path}[{index}]"
+        if not isinstance(item, dict):
+            errors.append(f"{item_path} must be a mapping")
+            continue
+        _check_fields(
+            item_path,
+            item,
+            required=frozenset({"kind", "description"}),
+            allowed=_EVIDENCE_FIELDS,
+            errors=errors,
+        )
+        _check_enum(f"{item_path}.kind", item.get("kind"), EVIDENCE_KINDS, errors)
+        _check_nonempty_string(f"{item_path}.description", item.get("description"), errors)
+        if "tool" in item:
+            _check_name(f"{item_path}.tool", item.get("tool"), errors)
+
+
+def _check_known_tools(path: str, values: Any, tool_names: set[str], errors: list[str]) -> None:
+    if values is None:
+        return
+    if not isinstance(values, list):
+        errors.append(f"{path} must be a list of tool names")
+        return
+    for value in values:
+        if value is None:
+            continue
+        if value not in tool_names:
+            errors.append(f"{path} references unknown tool name {value!r}")

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
@@ -8,13 +8,11 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 from collections import Counter
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
-import yaml
 from _markdown import extract_schema_block
 
 AUDIT_SCHEMA = "nemo.eval_author.audit.v1"
@@ -27,9 +25,18 @@ class AuditSpecError(ValueError):
     """Raised when an audit spec fails schema validation."""
 
 
+class AuditEnvironmentError(RuntimeError):
+    """Raised when the validator cannot load required local dependencies."""
+
+
 def load_audit_spec(path: Path) -> dict[str, Any]:
     """Load and validate an ``audit.md`` file."""
     block = extract_schema_block(path)
+    try:
+        import yaml
+    except ImportError as exc:
+        raise AuditEnvironmentError("PyYAML is required to parse audit specs") from exc
+
     try:
         payload = yaml.safe_load(block)
     except yaml.YAMLError as exc:
@@ -55,15 +62,19 @@ def item_counts(spec: dict[str, Any]) -> dict[str, int]:
 def _validate_json_schema(payload: Any) -> None:
     try:
         from jsonschema import Draft202012Validator
+        from jsonschema.exceptions import SchemaError
     except ImportError as exc:
-        raise AuditSpecError("jsonschema is required to validate audit specs") from exc
+        raise AuditEnvironmentError("jsonschema is required to validate audit specs") from exc
 
     try:
         schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise AuditSpecError(f"could not load audit JSON Schema from {SCHEMA_PATH}: {exc}") from exc
+        raise AuditEnvironmentError(f"could not load audit JSON Schema from {SCHEMA_PATH}: {exc}") from exc
 
-    Draft202012Validator.check_schema(schema)
+    try:
+        Draft202012Validator.check_schema(schema)
+    except SchemaError as exc:
+        raise AuditEnvironmentError(f"bundled audit JSON Schema is invalid: {exc.message}") from exc
     validator = Draft202012Validator(schema)
     errors = sorted(validator.iter_errors(payload), key=lambda error: (list(error.absolute_path), error.message))
     if errors:
@@ -156,8 +167,8 @@ def _validate_sources(payload: dict[str, Any], *, audit_path: Path | None) -> No
 
 
 def _check_name(path: str, value: Any, errors: list[str]) -> str | None:
-    if not isinstance(value, str) or not re.fullmatch(r"^[A-Za-z][A-Za-z0-9_.:/-]*$", value):
-        errors.append(f"{path} must be a non-empty identifier matching ^[A-Za-z][A-Za-z0-9_.:/-]*$")
+    if not isinstance(value, str):
+        errors.append(f"{path} must be a string")
         return None
     return value
 

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from collections import Counter
@@ -19,6 +20,7 @@ from _markdown import extract_schema_block
 AUDIT_SCHEMA = "nemo.eval_author.audit.v1"
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schemas" / "audit.schema.json"
 ITEM_KINDS = frozenset({"tool", "capability", "failure_case"})
+_ZERO_SOURCE_ETHOS_DIGEST = "sha256:" + ("0" * 64)
 
 
 class AuditSpecError(ValueError):
@@ -32,27 +34,15 @@ def load_audit_spec(path: Path) -> dict[str, Any]:
         payload = yaml.safe_load(block)
     except yaml.YAMLError as exc:
         raise AuditSpecError(f"audit YAML does not parse: {exc}") from exc
-    return validate_audit_spec(payload)
+    return validate_audit_spec(payload, audit_path=path)
 
 
-def load_items_file(path: Path) -> list[dict[str, Any]]:
-    """Load a YAML items file accepted by ``generate.py``."""
-    try:
-        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, yaml.YAMLError) as exc:
-        raise AuditSpecError(f"could not load items from {path}: {exc}") from exc
-    if isinstance(payload, dict):
-        payload = payload.get("items")
-    if not isinstance(payload, list):
-        raise AuditSpecError(f"{path} must contain an item list or a mapping with an 'items' list")
-    return payload
-
-
-def validate_audit_spec(payload: Any) -> dict[str, Any]:
+def validate_audit_spec(payload: Any, *, audit_path: Path | None = None) -> dict[str, Any]:
     """Return *payload* when it satisfies the audit spec."""
     _validate_json_schema(payload)
     if not isinstance(payload, dict):
         raise AuditSpecError("audit spec must be a mapping")
+    _validate_source_ethos(payload, audit_path=audit_path)
     return _validate_semantics(payload)
 
 
@@ -83,35 +73,29 @@ def _validate_json_schema(payload: Any) -> None:
 def _validate_semantics(payload: dict[str, Any]) -> dict[str, Any]:
     errors: list[str] = []
     items = payload["items"]
-    item_ids: set[str] = set()
+    item_names: set[str] = set()
     tool_names: set[str] = set()
-    capability_ids: set[str] = set()
-    names_by_kind: dict[str, set[str]] = {kind: set() for kind in ITEM_KINDS}
+    capability_names: set[str] = set()
 
     for index, item in enumerate(items):
         path = f"audit.items[{index}]"
         kind = item.get("kind")
-        item_id = item["id"]
-        if item_id in item_ids:
-            errors.append(f"{path}.id {item_id!r} is duplicated")
-        item_ids.add(item_id)
-        if kind == "capability":
-            capability_ids.add(item_id)
-
         name = _check_name(f"{path}.name", item.get("name"), errors)
         if name is not None:
-            if name in names_by_kind[kind]:
-                errors.append(f"{path}.name {name!r} is duplicated for kind {kind!r}")
-            names_by_kind[kind].add(name)
+            if name in item_names:
+                errors.append(f"{path}.name {name!r} is duplicated")
+            item_names.add(name)
             if kind == "tool":
                 tool_names.add(name)
+            elif kind == "capability":
+                capability_names.add(name)
 
     if errors:
         raise AuditSpecError("\n".join(errors))
 
     for index, item in enumerate(items):
         path = f"audit.items[{index}]"
-        for field in ("required_tools", "expected_tools", "prohibited_tools"):
+        for field in ("required_tools", "expected_tools"):
             _check_known_tools(f"{path}.{field}", item.get(field), tool_names, errors)
         for evidence_index, evidence in enumerate(item["evidence_required"]):
             if "tool" in evidence:
@@ -120,12 +104,33 @@ def _validate_semantics(payload: dict[str, Any]) -> dict[str, Any]:
                 )
         if item["kind"] == "failure_case":
             for ref in item["applies_to"]:
-                if ref not in capability_ids:
-                    errors.append(f"{path}.applies_to references unknown capability id {ref!r}")
+                if ref not in capability_names:
+                    errors.append(f"{path}.applies_to references unknown capability name {ref!r}")
 
     if errors:
         raise AuditSpecError("\n".join(errors))
     return payload
+
+
+def _validate_source_ethos(payload: dict[str, Any], *, audit_path: Path | None) -> None:
+    digest = payload["source_ethos_sha256"]
+    if digest == _ZERO_SOURCE_ETHOS_DIGEST:
+        raise AuditSpecError("audit.source_ethos_sha256 must not be the all-zero placeholder digest")
+    if audit_path is None:
+        return
+
+    source_ethos = Path(payload["source_ethos"])
+    if not source_ethos.is_absolute():
+        source_ethos = audit_path.parent / source_ethos
+    try:
+        with source_ethos.open("rb") as stream:
+            actual = f"sha256:{hashlib.file_digest(stream, 'sha256').hexdigest()}"
+    except OSError as exc:
+        raise AuditSpecError(f"audit.source_ethos could not be read at {source_ethos}: {exc}") from exc
+    if actual != digest:
+        raise AuditSpecError(
+            f"audit.source_ethos_sha256 does not match {source_ethos}: expected {digest}, got {actual}"
+        )
 
 
 def _check_name(path: str, value: Any, errors: list[str]) -> str | None:
@@ -161,8 +166,12 @@ def _matching_kind_context_errors(error: Any) -> Iterable[Any]:
     return (
         context
         for context in error.context
-        if context.schema.get("properties", {}).get("kind", {}).get("const") == kind
+        if _schema_kind_matches(context.schema.get("properties", {}).get("kind", {}), kind)
     )
+
+
+def _schema_kind_matches(kind_schema: dict[str, Any], kind: str) -> bool:
+    return kind_schema.get("const") == kind or kind in kind_schema.get("enum", [])
 
 
 def _json_path(parts: Iterable[Any]) -> str:

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/_schema.py
@@ -78,6 +78,7 @@ def _validate_semantics(payload: dict[str, Any]) -> dict[str, Any]:
     tool_names: set[str] = set()
     capability_names: set[str] = set()
 
+    # Source records must have unique names so provenance references are unambiguous.
     for index, source in enumerate(payload.get("sources", [])):
         name = _check_name(f"audit.sources[{index}].name", source.get("name"), errors)
         if name is not None:
@@ -85,6 +86,7 @@ def _validate_semantics(payload: dict[str, Any]) -> dict[str, Any]:
                 errors.append(f"audit.sources[{index}].name {name!r} is duplicated")
             source_names.add(name)
 
+    # Item names must be globally unique because name is the stable coverage key.
     for index, item in enumerate(items):
         path = f"audit.items[{index}]"
         kind = item.get("kind")
@@ -101,16 +103,20 @@ def _validate_semantics(payload: dict[str, Any]) -> dict[str, Any]:
     if errors:
         raise AuditSpecError("\n".join(errors))
 
+    # Cross-item references must resolve after tool and capability namespaces are known.
     for index, item in enumerate(items):
         path = f"audit.items[{index}]"
+        # Required and expected tools must reference declared tool items.
         for field in ("required_tools", "expected_tools"):
             _check_known_tools(f"{path}.{field}", item.get(field), tool_names, errors)
+        # Evidence tool references must reference declared tool items.
         for evidence_index, evidence in enumerate(item["evidence_required"]):
             if "tool" in evidence:
                 _check_known_tools(
                     f"{path}.evidence_required[{evidence_index}].tool", [evidence["tool"]], tool_names, errors
                 )
         if item["kind"] == "failure_case":
+            # Failure cases must apply only to declared capability items.
             for ref in item["applies_to"]:
                 if ref not in capability_names:
                     errors.append(f"{path}.applies_to references unknown capability name {ref!r}")

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/validate.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/validate.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate an audit-spec ``audit.md`` file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _markdown import AuditMarkdownError  # noqa: E402
+from _schema import AuditSpecError, item_counts, load_audit_spec  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--audit", type=Path, required=True, help="audit.md file to validate")
+    parser.add_argument("--compact", action="store_true", help="emit compact JSON")
+    args = parser.parse_args(argv)
+
+    try:
+        spec = load_audit_spec(args.audit)
+    except (AuditMarkdownError, AuditSpecError) as exc:
+        _print({"valid": False, "error": str(exc)}, compact=args.compact)
+        return 1
+
+    _print(
+        {
+            "valid": True,
+            "schema": spec["schema"],
+            "agent": spec["agent"],
+            "status": spec["status"],
+            "item_count": len(spec["items"]),
+            "item_counts": item_counts(spec),
+        },
+        compact=args.compact,
+    )
+    return 0
+
+
+def _print(payload: dict, *, compact: bool) -> None:
+    kwargs = {"separators": (",", ":")} if compact else {"indent": 2}
+    print(json.dumps(payload, sort_keys=True, **kwargs))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/validate.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/validate.py
@@ -14,7 +14,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _markdown import AuditMarkdownError  # noqa: E402
-from _schema import AuditSpecError, item_counts, load_audit_spec  # noqa: E402
+from _schema import AuditEnvironmentError, AuditSpecError, item_counts, load_audit_spec  # noqa: E402
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -25,8 +25,11 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         spec = load_audit_spec(args.audit)
+    except AuditEnvironmentError as exc:
+        _print({"valid": None, "error_type": "environment", "error": str(exc)}, compact=args.compact)
+        return 2
     except (AuditMarkdownError, AuditSpecError) as exc:
-        _print({"valid": False, "error": str(exc)}, compact=args.compact)
+        _print({"valid": False, "error_type": "audit_spec", "error": str(exc)}, compact=args.compact)
         return 1
 
     _print(

--- a/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
@@ -1,23 +1,26 @@
 # Audit: example-agent
 
-This file defines the finite coverage denominator derived from `ETHOS.md`.
-Generated and hand-edited content is allowed outside the marked block; scripts
-validate only the block between the markers.
+This file defines a finite coverage denominator for audit measurement. This
+example records `ETHOS.md` as an optional source; generated and hand-edited
+content is allowed outside the marked block, and scripts validate only the block
+between the markers.
 
 <!-- BEGIN:nemo-eval-author-audit:v1 -->
 ```yaml
 schema: nemo.eval_author.audit.v1
 agent: example-agent
-source_ethos: ../ETHOS.md
-source_ethos_sha256: "sha256:<replace-with-64-hex-digest>"
+sources:
+  - name: ethos
+    path: ../ETHOS.md
+    sha256: "sha256:<replace-with-64-hex-digest>"
 status: draft
 
 items:
   - kind: tool
     name: customer.lookup
-    ethos_refs:
-      - Tools
-      - Behavior
+    source_refs:
+      - ethos:Tools
+      - ethos:Behavior
     description: >
       Looks up customer profile, plan, account status, and contact details.
     expected_use: >
@@ -32,12 +35,12 @@ items:
 
   - kind: capability
     name: account_recovery
-    ethos_refs:
-      - Purpose
-      - Scope
-      - Tools
-      - Behavior
-      - Success Criteria
+    source_refs:
+      - ethos:Purpose
+      - ethos:Scope
+      - ethos:Tools
+      - ethos:Behavior
+      - ethos:Success Criteria
     description: >
       Help users recover account access while preserving identity and credential
       boundaries.
@@ -57,10 +60,10 @@ items:
     name: account_recovery_unverified_identity
     applies_to:
       - account_recovery
-    ethos_refs:
-      - Scope
-      - Behavior
-      - Success Criteria
+    source_refs:
+      - ethos:Scope
+      - ethos:Behavior
+      - ethos:Success Criteria
     description: >
       Safe failure when account recovery cannot continue because identity is not
       verified.

--- a/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
@@ -1,3 +1,6 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
 # Audit: example-agent
 
 This file defines a finite coverage denominator for audit measurement. This

--- a/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
@@ -8,13 +8,12 @@ validate only the block between the markers.
 ```yaml
 schema: nemo.eval_author.audit.v1
 agent: example-agent
-source_ethos: ETHOS.md
-source_ethos_sha256: sha256:0000000000000000000000000000000000000000000000000000000000000000
+source_ethos: ../ETHOS.md
+source_ethos_sha256: "sha256:<replace-with-64-hex-digest>"
 status: draft
 
 items:
   - kind: tool
-    id: TOOL-001
     name: customer.lookup
     ethos_refs:
       - Tools
@@ -32,7 +31,6 @@ items:
         description: Trace shows a customer.lookup call for a relevant request.
 
   - kind: capability
-    id: CAP-001
     name: account_recovery
     ethos_refs:
       - Purpose
@@ -56,10 +54,9 @@ items:
         description: Agent grounds the request in customer profile data.
 
   - kind: failure_case
-    id: FAIL-001
     name: account_recovery_unverified_identity
     applies_to:
-      - CAP-001
+      - account_recovery
     ethos_refs:
       - Scope
       - Behavior

--- a/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md
@@ -1,0 +1,84 @@
+# Audit: example-agent
+
+This file defines the finite coverage denominator derived from `ETHOS.md`.
+Generated and hand-edited content is allowed outside the marked block; scripts
+validate only the block between the markers.
+
+<!-- BEGIN:nemo-eval-author-audit:v1 -->
+```yaml
+schema: nemo.eval_author.audit.v1
+agent: example-agent
+source_ethos: ETHOS.md
+source_ethos_sha256: sha256:0000000000000000000000000000000000000000000000000000000000000000
+status: draft
+
+items:
+  - kind: tool
+    id: TOOL-001
+    name: customer.lookup
+    ethos_refs:
+      - Tools
+      - Behavior
+    description: >
+      Looks up customer profile, plan, account status, and contact details.
+    expected_use: >
+      Used when account-specific information is required.
+    expected_failure_behavior: >
+      If no matching customer is found, the agent asks for clarification or
+      explains that it cannot proceed.
+    evidence_required:
+      - kind: tool_call
+        tool: customer.lookup
+        description: Trace shows a customer.lookup call for a relevant request.
+
+  - kind: capability
+    id: CAP-001
+    name: account_recovery
+    ethos_refs:
+      - Purpose
+      - Scope
+      - Tools
+      - Behavior
+      - Success Criteria
+    description: >
+      Help users recover account access while preserving identity and credential
+      boundaries.
+    required_tools:
+      - customer.lookup
+    expected_behavior: >
+      The agent grounds recovery in customer identity and routes to an approved
+      recovery path.
+    evidence_required:
+      - kind: user_intent
+        description: User is trying to recover account access.
+      - kind: tool_call
+        tool: customer.lookup
+        description: Agent grounds the request in customer profile data.
+
+  - kind: failure_case
+    id: FAIL-001
+    name: account_recovery_unverified_identity
+    applies_to:
+      - CAP-001
+    ethos_refs:
+      - Scope
+      - Behavior
+      - Success Criteria
+    description: >
+      Safe failure when account recovery cannot continue because identity is not
+      verified.
+    trigger: >
+      User requests account recovery but cannot satisfy identity verification.
+    expected_behavior: >
+      The agent does not reset access directly or disclose private account data.
+    expected_tools:
+      - customer.lookup
+    prohibited_tools: []
+    prohibited_outputs:
+      - passwords
+      - reset_tokens
+    evidence_required:
+      - kind: output
+        description: Agent refuses direct recovery and explains the allowed path.
+```
+<!-- END:nemo-eval-author-audit:v1 -->

--- a/plugins/nemo-eval-author/skills/eval-author/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author/SKILL.md
@@ -21,7 +21,7 @@ triggers:
   - which eval author step do I need
 not-for:
   - eval-author-discover (use to run the discovery pass and get a runnable verdict)
-  - eval-author-audit (use to define and validate audit.md coverage denominators)
+  - eval-author-audit (use to validate existing audit.md coverage denominators)
   - nemo-experimentalist (use to run insight-driven optimization end to end, which drives the Eval Author agent itself)
   - nemo-evaluator (use to run an existing benchmark rather than work on a repository's own suite)
 compatibility: Reading only. Each sub-flow states its own runtime needs.
@@ -81,13 +81,14 @@ and the boundaries; the sub-flow carries the steps.
 | Sub-flow | Use it to |
 |---|---|
 | `eval-author-discover` | Establish whether a repository's evaluations run, name the rung that fails, and get the exact command to run them |
-| `eval-author-audit` | Define and validate a finite `audit.md` coverage denominator from `ETHOS.md` |
+| `eval-author-audit` | Validate an existing finite `audit.md` coverage denominator |
 
-Authoring new runnable tasks and verifier metrics is not built yet. `eval-author-audit`
-works one level above tasks: it defines the coverage denominator that future task
-authoring and measurement can target. When a user asks for new runnable tasks, say so
-plainly rather than improvising a task layout by hand. A task written against a
-guessed convention scores nothing and costs a full evaluation run to discover.
+Authoring or generating audit specs, runnable tasks, and verifier metrics is not
+built yet. `eval-author-audit` works one level above tasks: it validates the
+coverage denominator that future generation, task authoring, and measurement can
+target. When a user asks for new runnable tasks, say so plainly rather than
+improvising a task layout by hand. A task written against a guessed convention
+scores nothing and costs a full evaluation run to discover.
 
 ## Boundaries
 

--- a/plugins/nemo-eval-author/skills/eval-author/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author/SKILL.md
@@ -21,6 +21,7 @@ triggers:
   - which eval author step do I need
 not-for:
   - eval-author-discover (use to run the discovery pass and get a runnable verdict)
+  - eval-author-audit (use to define and validate audit.md coverage denominators)
   - nemo-experimentalist (use to run insight-driven optimization end to end, which drives the Eval Author agent itself)
   - nemo-evaluator (use to run an existing benchmark rather than work on a repository's own suite)
 compatibility: Reading only. Each sub-flow states its own runtime needs.
@@ -80,11 +81,13 @@ and the boundaries; the sub-flow carries the steps.
 | Sub-flow | Use it to |
 |---|---|
 | `eval-author-discover` | Establish whether a repository's evaluations run, name the rung that fails, and get the exact command to run them |
+| `eval-author-audit` | Define and validate a finite `audit.md` coverage denominator from `ETHOS.md` |
 
-Authoring new tasks and verifier metrics is not built yet. When a user asks for
-that, say so plainly rather than improvising a task layout by hand. A task written
-against a guessed convention scores nothing and costs a full evaluation run to
-discover.
+Authoring new runnable tasks and verifier metrics is not built yet. `eval-author-audit`
+works one level above tasks: it defines the coverage denominator that future task
+authoring and measurement can target. When a user asks for new runnable tasks, say so
+plainly rather than improvising a task layout by hand. A task written against a
+guessed convention scores nothing and costs a full evaluation run to discover.
 
 ## Boundaries
 

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -33,7 +33,7 @@ so a Harbor change that tightens a rule flows through without a test change here
 Nothing here imports the platform, for the same reason the bundled scripts do not:
 these skills are copied into someone else's repository and have to stand alone. The
 tests that make Harbor judge a fixture suite skip when Harbor is absent, so the whole
-file runs against nothing but pytest and PyYAML.
+file runs against nothing but pytest, PyYAML, and jsonschema.
 """
 
 import ast
@@ -61,6 +61,7 @@ _DISCOVER = _DISCOVER_SCRIPTS_DIR / "discover.py"
 _LADDER = _DISCOVER_SCRIPTS_DIR / "providers" / "harbor" / "_ladder.py"
 _AUDIT_VALIDATE = _AUDIT_SPEC_DIR / "validate.py"
 _AUDIT_TEMPLATE = _AUDIT_DIR / "templates" / "audit.md"
+_AUDIT_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit.schema.json"
 
 _REQUIRED_FRONTMATTER = (
     "name",
@@ -92,9 +93,9 @@ _needs_unreadable_files = pytest.mark.skipif(
     reason="this user can read a file whatever its mode, so unreadability cannot be staged",
 )
 
-# Harbor brings these in, so a bundled script may name them. Nothing else outside
-# the standard library may appear.
-_PERMITTED_THIRD_PARTY = frozenset({"harbor", "pydantic", "yaml"})
+# Bundled scripts may name only these third-party roots. Anything else would
+# become a hidden dependency for repositories that copy the skill.
+_PERMITTED_THIRD_PARTY = frozenset({"harbor", "jsonschema", "pydantic", "yaml"})
 
 
 def _not_for_names(frontmatter: dict) -> set[str]:
@@ -294,10 +295,17 @@ def test_every_audit_spec_path_the_skill_names_exists() -> None:
         "scripts/audit_spec/validate.py",
         "scripts/audit_spec/_schema.py",
         "scripts/audit_spec/_markdown.py",
+        "schemas/audit.schema.json",
         "templates/audit.md",
     ):
         assert relative in body, f"SKILL.md no longer documents {relative}"
         assert (_AUDIT_DIR / relative).exists(), f"SKILL.md names {relative}, which is missing on disk"
+
+
+def test_audit_json_schema_is_valid() -> None:
+    from jsonschema import Draft202012Validator
+
+    Draft202012Validator.check_schema(json.loads(_AUDIT_JSON_SCHEMA.read_text(encoding="utf-8")))
 
 
 def test_audit_template_validates() -> None:
@@ -323,6 +331,23 @@ def test_audit_validation_rejects_unknown_tool_reference(tmp_path: Path) -> None
     assert code == 1
     assert report["valid"] is False
     assert "unknown tool name 'ticket.create'" in report["error"]
+
+
+def test_audit_validation_rejects_unknown_schema_field(tmp_path: Path) -> None:
+    audit = tmp_path / "audit.md"
+    audit.write_text(
+        _AUDIT_TEMPLATE.read_text(encoding="utf-8").replace(
+            "status: draft\n",
+            "status: draft\nunexpected: true\n",
+        ),
+        encoding="utf-8",
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "unexpected" in report["error"]
 
 
 def test_bundled_scripts_never_import_the_platform() -> None:

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -37,11 +37,13 @@ file runs against nothing but pytest, PyYAML, and jsonschema.
 """
 
 import ast
+import hashlib
 import json
 import os
 import re
 import subprocess
 import sys
+from collections.abc import Callable
 from importlib.util import find_spec
 from pathlib import Path
 
@@ -156,6 +158,28 @@ def _run_json_script(script: Path, *args: str) -> tuple[int, dict, str]:
     result = subprocess.run([sys.executable, str(script), *args], capture_output=True, text=True, check=False)
     assert result.stdout, f"{script.name} printed nothing; stderr:\n{result.stderr}"
     return result.returncode, json.loads(result.stdout), result.stderr
+
+
+def _digest(path: Path) -> str:
+    with path.open("rb") as stream:
+        return f"sha256:{hashlib.file_digest(stream, 'sha256').hexdigest()}"
+
+
+def _write_audit(tmp_path: Path, transform: Callable[[str], str] | None = None) -> Path:
+    ethos = tmp_path / "ETHOS.md"
+    ethos.write_text("# Ethos\n\n## Tools\n\n- customer.lookup\n", encoding="utf-8")
+
+    audit_dir = tmp_path / ".eval-author"
+    audit_dir.mkdir()
+    audit = audit_dir / "audit.md"
+    text = _AUDIT_TEMPLATE.read_text(encoding="utf-8").replace(
+        'source_ethos_sha256: "sha256:<replace-with-64-hex-digest>"',
+        f"source_ethos_sha256: {_digest(ethos)}",
+    )
+    if transform is not None:
+        text = transform(text)
+    audit.write_text(text, encoding="utf-8")
+    return audit
 
 
 def _write_task(task_dir: Path, *, name: str = "smoke/generated") -> None:
@@ -308,22 +332,33 @@ def test_audit_json_schema_is_valid() -> None:
     Draft202012Validator.check_schema(json.loads(_AUDIT_JSON_SCHEMA.read_text(encoding="utf-8")))
 
 
-def test_audit_template_validates() -> None:
-    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(_AUDIT_TEMPLATE))
+def test_audit_file_with_matching_ethos_digest_validates(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+
+    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
 
     assert code == 0, stderr or report
     assert report["valid"] is True
     assert report["item_counts"] == {"capability": 1, "failure_case": 1, "tool": 1}
 
 
+def test_audit_validation_compact_output(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+
+    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit), "--compact")
+
+    assert code == 0, stderr or report
+    assert report["valid"] is True
+    assert report["item_count"] == 3
+
+
 def test_audit_validation_rejects_unknown_tool_reference(tmp_path: Path) -> None:
-    audit = tmp_path / "audit.md"
-    audit.write_text(
-        _AUDIT_TEMPLATE.read_text(encoding="utf-8").replace(
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
             "    required_tools:\n      - customer.lookup\n",
             "    required_tools:\n      - ticket.create\n",
         ),
-        encoding="utf-8",
     )
 
     code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
@@ -334,13 +369,12 @@ def test_audit_validation_rejects_unknown_tool_reference(tmp_path: Path) -> None
 
 
 def test_audit_validation_rejects_unknown_schema_field(tmp_path: Path) -> None:
-    audit = tmp_path / "audit.md"
-    audit.write_text(
-        _AUDIT_TEMPLATE.read_text(encoding="utf-8").replace(
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
             "status: draft\n",
             "status: draft\nunexpected: true\n",
         ),
-        encoding="utf-8",
     )
 
     code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
@@ -348,6 +382,163 @@ def test_audit_validation_rejects_unknown_schema_field(tmp_path: Path) -> None:
     assert code == 1
     assert report["valid"] is False
     assert "unexpected" in report["error"]
+
+
+def test_audit_validation_rejects_all_zero_source_digest(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: re.sub(
+            r"source_ethos_sha256: sha256:[0-9a-f]{64}",
+            "source_ethos_sha256: sha256:" + ("0" * 64),
+            text,
+        ),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "all-zero placeholder" in report["error"]
+
+
+def test_audit_validation_rejects_stale_source_digest(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: re.sub(
+            r"source_ethos_sha256: sha256:[0-9a-f]{64}",
+            "source_ethos_sha256: sha256:" + ("1" * 64),
+            text,
+        ),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "does not match" in report["error"]
+
+
+def test_audit_validation_allows_unknown_prohibited_tool(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
+            "    prohibited_tools: []\n",
+            "    prohibited_tools:\n      - admin.reset_password\n",
+        ),
+    )
+
+    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 0, stderr or report
+    assert report["valid"] is True
+
+
+def test_audit_validation_requires_tool_for_tool_call_evidence(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
+            "      - kind: tool_call\n        tool: customer.lookup\n        description:",
+            "      - kind: tool_call\n        description:",
+            1,
+        ),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "tool" in report["error"]
+
+
+def test_audit_validation_rejects_tool_on_non_tool_evidence(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
+            "      - kind: user_intent\n        description:",
+            "      - kind: user_intent\n        tool: customer.lookup\n        description:",
+            1,
+        ),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "tool" in report["error"]
+
+
+def test_audit_validation_rejects_duplicate_names(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
+            "    name: account_recovery_unverified_identity\n",
+            "    name: account_recovery\n",
+        ),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "duplicated" in report["error"]
+
+
+def test_audit_validation_rejects_unknown_capability_reference(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
+            "      - account_recovery\n",
+            "      - account_closure\n",
+            1,
+        ),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "unknown capability name 'account_closure'" in report["error"]
+
+
+def test_audit_validation_allows_toolless_capability(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
+            "    required_tools:\n      - customer.lookup\n",
+            "    required_tools: []\n",
+        ),
+    )
+
+    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 0, stderr or report
+    assert report["valid"] is True
+
+
+def test_audit_validation_allows_marker_mentions_in_prose(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: (
+            "The literal <!-- BEGIN:nemo-eval-author-audit:v1 --> marker can be discussed in prose.\n\n"
+            + text
+            + "\nThe literal <!-- END:nemo-eval-author-audit:v1 --> marker can be discussed too.\n"
+        ),
+    )
+
+    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 0, stderr or report
+    assert report["valid"] is True
+
+
+def test_audit_validation_rejects_missing_marker(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path, lambda text: text.replace("<!-- END:nemo-eval-author-audit:v1 -->", ""))
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "must contain exactly one" in report["error"]
 
 
 def test_bundled_scripts_never_import_the_platform() -> None:

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -671,6 +671,16 @@ def test_audit_validation_rejects_multiple_yaml_blocks(tmp_path: Path) -> None:
     assert "must contain one fenced yaml block" in report["error"]
 
 
+def test_audit_validation_rejects_prefixed_yaml_fence(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path, lambda text: text.replace("```yaml\n", "prefix ```yaml\n", 1))
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "must contain one fenced yaml block" in report["error"]
+
+
 def test_bundled_scripts_never_import_the_platform() -> None:
     """The boundary that makes the skill copyable: Harbor is fine, NeMo is not."""
     offenders: dict[str, set[str]] = {}

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -275,10 +275,15 @@ def test_no_skill_can_edit_what_it_did_not_write(skill_dir: Path) -> None:
 def test_the_core_routes_and_the_sub_flow_executes() -> None:
     """The core only picks a sub-flow, so it neither runs nor saves anything."""
     core_tools = set(_frontmatter_and_body(_CORE_DIR)[0]["allowed-tools"])
+    discover_tools = set(_frontmatter_and_body(_DISCOVER_DIR)[0]["allowed-tools"])
+    audit_tools = set(_frontmatter_and_body(_AUDIT_DIR)[0]["allowed-tools"])
+
     assert not {"Bash", "Write"} & core_tools, f"the core routes and explains; {sorted(core_tools)} is too broad"
-    for skill_dir in _SUB_FLOW_DIRS:
-        tools = set(_frontmatter_and_body(skill_dir)[0]["allowed-tools"])
-        assert {"Bash", "Write"} <= tools, f"{skill_dir.name} runs a script and saves a report; it has {sorted(tools)}"
+    assert {"Bash", "Write"} <= discover_tools, (
+        f"{_DISCOVER_DIR.name} runs a script and saves a report; it has {sorted(discover_tools)}"
+    )
+    assert "Bash" in audit_tools, f"{_AUDIT_DIR.name} runs a validation script; it has {sorted(audit_tools)}"
+    assert "Write" not in audit_tools, f"{_AUDIT_DIR.name} validates only; {sorted(audit_tools)} is too broad"
 
 
 def test_the_core_names_every_sub_flow() -> None:
@@ -648,6 +653,22 @@ def test_audit_validation_rejects_missing_marker(tmp_path: Path) -> None:
     assert code == 1
     assert report["valid"] is False
     assert "must contain exactly one" in report["error"]
+
+
+def test_audit_validation_rejects_multiple_yaml_blocks(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace(
+            "```\n<!-- END:nemo-eval-author-audit:v1 -->",
+            "```\n\n```yaml\nschema: conflicting.audit.v1\n```\n<!-- END:nemo-eval-author-audit:v1 -->",
+        ),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "must contain one fenced yaml block" in report["error"]
 
 
 def test_bundled_scripts_never_import_the_platform() -> None:

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -153,9 +153,20 @@ def _run_discover(repo: Path, *args: str, with_harbor: bool = True) -> tuple[int
     return result.returncode, json.loads(result.stdout)
 
 
-def _run_json_script(script: Path, *args: str) -> tuple[int, dict, str]:
+def _run_json_script(
+    script: Path,
+    *args: str,
+    python_args: tuple[str, ...] = (),
+    env: dict[str, str] | None = None,
+) -> tuple[int, dict, str]:
     """Run an audit script that emits JSON on stdout."""
-    result = subprocess.run([sys.executable, str(script), *args], capture_output=True, text=True, check=False)
+    result = subprocess.run(
+        [sys.executable, *python_args, str(script), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
     assert result.stdout, f"{script.name} printed nothing; stderr:\n{result.stderr}"
     return result.returncode, json.loads(result.stdout), result.stderr
 
@@ -342,12 +353,28 @@ def test_audit_file_with_matching_source_digest_validates(tmp_path: Path) -> Non
     assert report["item_counts"] == {"capability": 1, "failure_case": 1, "tool": 1}
 
 
-def test_audit_file_without_sources_validates(tmp_path: Path) -> None:
+def test_audit_file_without_sources_allows_source_refs_as_notes(tmp_path: Path) -> None:
     audit = _write_audit(
         tmp_path,
         lambda text: re.sub(
             r"sources:\n  - name: ethos\n    path: ../ETHOS.md\n    sha256: sha256:[0-9a-f]{64}\n",
             "",
+            text,
+        ),
+    )
+
+    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 0, stderr or report
+    assert report["valid"] is True
+
+
+def test_audit_file_with_empty_sources_validates(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: re.sub(
+            r"sources:\n  - name: ethos\n    path: ../ETHOS.md\n    sha256: sha256:[0-9a-f]{64}\n",
+            "sources: []\n",
             text,
         ),
     )
@@ -366,6 +393,41 @@ def test_audit_validation_compact_output(tmp_path: Path) -> None:
     assert code == 0, stderr or report
     assert report["valid"] is True
     assert report["item_count"] == 3
+
+
+def test_audit_validation_marks_missing_pyyaml_as_environment_error(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit), python_args=("-S",))
+
+    assert code == 2
+    assert report["valid"] is None
+    assert report["error_type"] == "environment"
+    assert "PyYAML is required" in report["error"]
+
+
+def test_audit_validation_marks_missing_jsonschema_as_environment_error(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    (tmp_path / "jsonschema.py").write_text('raise ImportError("simulated missing jsonschema")\n', encoding="utf-8")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path) if not env.get("PYTHONPATH") else f"{tmp_path}{os.pathsep}{env['PYTHONPATH']}"
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit), "--compact", env=env)
+
+    assert code == 2
+    assert report["valid"] is None
+    assert report["error_type"] == "environment"
+    assert "jsonschema is required" in report["error"]
+
+
+def test_audit_schema_load_failure_is_environment_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.syspath_prepend(str(_AUDIT_SPEC_DIR))
+    import _schema
+
+    monkeypatch.setattr(_schema, "SCHEMA_PATH", tmp_path / "missing.schema.json")
+
+    with pytest.raises(_schema.AuditEnvironmentError, match="could not load audit JSON Schema"):
+        _schema.validate_audit_spec({})
 
 
 def test_audit_validation_rejects_unknown_tool_reference(tmp_path: Path) -> None:

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -38,6 +38,7 @@ file runs against nothing but pytest, PyYAML, and jsonschema.
 
 import ast
 import hashlib
+import importlib
 import json
 import os
 import re
@@ -422,12 +423,12 @@ def test_audit_validation_marks_missing_jsonschema_as_environment_error(tmp_path
 
 def test_audit_schema_load_failure_is_environment_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.syspath_prepend(str(_AUDIT_SPEC_DIR))
-    import _schema
+    schema_module = importlib.import_module("_schema")
 
-    monkeypatch.setattr(_schema, "SCHEMA_PATH", tmp_path / "missing.schema.json")
+    monkeypatch.setattr(schema_module, "SCHEMA_PATH", tmp_path / "missing.schema.json")
 
-    with pytest.raises(_schema.AuditEnvironmentError, match="could not load audit JSON Schema"):
-        _schema.validate_audit_spec({})
+    with pytest.raises(schema_module.AuditEnvironmentError, match="could not load audit JSON Schema"):
+        schema_module.validate_audit_spec({})
 
 
 def test_audit_validation_rejects_unknown_tool_reference(tmp_path: Path) -> None:

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -173,8 +173,8 @@ def _write_audit(tmp_path: Path, transform: Callable[[str], str] | None = None) 
     audit_dir.mkdir()
     audit = audit_dir / "audit.md"
     text = _AUDIT_TEMPLATE.read_text(encoding="utf-8").replace(
-        'source_ethos_sha256: "sha256:<replace-with-64-hex-digest>"',
-        f"source_ethos_sha256: {_digest(ethos)}",
+        'sha256: "sha256:<replace-with-64-hex-digest>"',
+        f"sha256: {_digest(ethos)}",
     )
     if transform is not None:
         text = transform(text)
@@ -332,7 +332,7 @@ def test_audit_json_schema_is_valid() -> None:
     Draft202012Validator.check_schema(json.loads(_AUDIT_JSON_SCHEMA.read_text(encoding="utf-8")))
 
 
-def test_audit_file_with_matching_ethos_digest_validates(tmp_path: Path) -> None:
+def test_audit_file_with_matching_source_digest_validates(tmp_path: Path) -> None:
     audit = _write_audit(tmp_path)
 
     code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
@@ -340,6 +340,22 @@ def test_audit_file_with_matching_ethos_digest_validates(tmp_path: Path) -> None
     assert code == 0, stderr or report
     assert report["valid"] is True
     assert report["item_counts"] == {"capability": 1, "failure_case": 1, "tool": 1}
+
+
+def test_audit_file_without_sources_validates(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: re.sub(
+            r"sources:\n  - name: ethos\n    path: ../ETHOS.md\n    sha256: sha256:[0-9a-f]{64}\n",
+            "",
+            text,
+        ),
+    )
+
+    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 0, stderr or report
+    assert report["valid"] is True
 
 
 def test_audit_validation_compact_output(tmp_path: Path) -> None:
@@ -388,8 +404,8 @@ def test_audit_validation_rejects_all_zero_source_digest(tmp_path: Path) -> None
     audit = _write_audit(
         tmp_path,
         lambda text: re.sub(
-            r"source_ethos_sha256: sha256:[0-9a-f]{64}",
-            "source_ethos_sha256: sha256:" + ("0" * 64),
+            r"sha256: sha256:[0-9a-f]{64}",
+            "sha256: sha256:" + ("0" * 64),
             text,
         ),
     )
@@ -405,8 +421,8 @@ def test_audit_validation_rejects_stale_source_digest(tmp_path: Path) -> None:
     audit = _write_audit(
         tmp_path,
         lambda text: re.sub(
-            r"source_ethos_sha256: sha256:[0-9a-f]{64}",
-            "source_ethos_sha256: sha256:" + ("1" * 64),
+            r"sha256: sha256:[0-9a-f]{64}",
+            "sha256: sha256:" + ("1" * 64),
             text,
         ),
     )
@@ -416,6 +432,36 @@ def test_audit_validation_rejects_stale_source_digest(tmp_path: Path) -> None:
     assert code == 1
     assert report["valid"] is False
     assert "does not match" in report["error"]
+
+
+def test_audit_validation_rejects_source_digest_without_path(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: text.replace("    path: ../ETHOS.md\n", ""),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "path" in report["error"]
+
+
+def test_audit_validation_rejects_duplicate_source_names(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: re.sub(
+            r"(sources:\n  - name: ethos\n    path: ../ETHOS.md\n    sha256: sha256:[0-9a-f]{64}\n)",
+            "\\1  - name: ethos\n    description: duplicate\n",
+            text,
+        ),
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "audit.sources[1].name 'ethos' is duplicated" in report["error"]
 
 
 def test_audit_validation_allows_unknown_prohibited_tool(tmp_path: Path) -> None:

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -50,12 +50,17 @@ import yaml
 
 _SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
 _CORE_DIR = _SKILLS_DIR / "eval-author"
-_FLOW_DIR = _SKILLS_DIR / "eval-author-discover"
-_SKILL_DIRS = (_CORE_DIR, _FLOW_DIR)
-_SUB_FLOW_DIRS = (_FLOW_DIR,)
-_SCRIPTS_DIR = _FLOW_DIR / "scripts"
-_DISCOVER = _SCRIPTS_DIR / "discover.py"
-_LADDER = _SCRIPTS_DIR / "providers" / "harbor" / "_ladder.py"
+_DISCOVER_DIR = _SKILLS_DIR / "eval-author-discover"
+_AUDIT_DIR = _SKILLS_DIR / "eval-author-audit"
+_SKILL_DIRS = (_CORE_DIR, _DISCOVER_DIR, _AUDIT_DIR)
+_SUB_FLOW_DIRS = (_DISCOVER_DIR, _AUDIT_DIR)
+_DISCOVER_SCRIPTS_DIR = _DISCOVER_DIR / "scripts"
+_AUDIT_SPEC_DIR = _AUDIT_DIR / "scripts" / "audit_spec"
+_SCRIPT_DIRS = (_DISCOVER_SCRIPTS_DIR, _AUDIT_SPEC_DIR)
+_DISCOVER = _DISCOVER_SCRIPTS_DIR / "discover.py"
+_LADDER = _DISCOVER_SCRIPTS_DIR / "providers" / "harbor" / "_ladder.py"
+_AUDIT_VALIDATE = _AUDIT_SPEC_DIR / "validate.py"
+_AUDIT_TEMPLATE = _AUDIT_DIR / "templates" / "audit.md"
 
 _REQUIRED_FRONTMATTER = (
     "name",
@@ -104,15 +109,16 @@ def _frontmatter_and_body(skill_dir: Path) -> tuple[dict, str]:
     return yaml.safe_load(frontmatter), body
 
 
-def _bundled_scripts() -> list[Path]:
+def _bundled_scripts(scripts_dir: Path | None = None) -> list[Path]:
     """Return every bundled module, including the ones under providers/."""
-    return sorted(path for path in _SCRIPTS_DIR.rglob("*.py") if "__pycache__" not in path.parts)
+    roots = _SCRIPT_DIRS if scripts_dir is None else (scripts_dir,)
+    return sorted(path for root in roots for path in root.rglob("*.py") if "__pycache__" not in path.parts)
 
 
-def _local_roots() -> set[str]:
+def _local_roots(scripts_dir: Path) -> set[str]:
     """Return the top-level names a bundled module can import from scripts/."""
-    return {path.stem if path.is_file() else path.name for path in _SCRIPTS_DIR.iterdir()} | {
-        path.stem for path in _bundled_scripts()
+    return {path.stem if path.is_file() else path.name for path in scripts_dir.iterdir()} | {
+        path.stem for path in _bundled_scripts(scripts_dir)
     }
 
 
@@ -142,6 +148,13 @@ def _run_discover(repo: Path, *args: str, with_harbor: bool = True) -> tuple[int
     result = subprocess.run(command, capture_output=True, text=True, check=False)
     assert result.stdout, f"discover.py printed nothing; stderr:\n{result.stderr}"
     return result.returncode, json.loads(result.stdout)
+
+
+def _run_json_script(script: Path, *args: str) -> tuple[int, dict, str]:
+    """Run an audit script that emits JSON on stdout."""
+    result = subprocess.run([sys.executable, str(script), *args], capture_output=True, text=True, check=False)
+    assert result.stdout, f"{script.name} printed nothing; stderr:\n{result.stderr}"
+    return result.returncode, json.loads(result.stdout), result.stderr
 
 
 def _write_task(task_dir: Path, *, name: str = "smoke/generated") -> None:
@@ -263,7 +276,7 @@ def test_skill_body_stays_within_the_line_budget(skill_dir: Path) -> None:
 
 
 def test_every_bundled_path_the_skill_names_exists() -> None:
-    _, body = _frontmatter_and_body(_FLOW_DIR)
+    _, body = _frontmatter_and_body(_DISCOVER_DIR)
     for relative in (
         "scripts/discover.py",
         "scripts/_checks.py",
@@ -272,17 +285,55 @@ def test_every_bundled_path_the_skill_names_exists() -> None:
         "scripts/providers/harbor/_ladder.py",
     ):
         assert relative in body, f"SKILL.md no longer documents {relative}"
-        assert (_FLOW_DIR / relative).exists(), f"SKILL.md names {relative}, which is missing on disk"
+        assert (_DISCOVER_DIR / relative).exists(), f"SKILL.md names {relative}, which is missing on disk"
+
+
+def test_every_audit_spec_path_the_skill_names_exists() -> None:
+    _, body = _frontmatter_and_body(_AUDIT_DIR)
+    for relative in (
+        "scripts/audit_spec/validate.py",
+        "scripts/audit_spec/_schema.py",
+        "scripts/audit_spec/_markdown.py",
+        "templates/audit.md",
+    ):
+        assert relative in body, f"SKILL.md no longer documents {relative}"
+        assert (_AUDIT_DIR / relative).exists(), f"SKILL.md names {relative}, which is missing on disk"
+
+
+def test_audit_template_validates() -> None:
+    code, report, stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(_AUDIT_TEMPLATE))
+
+    assert code == 0, stderr or report
+    assert report["valid"] is True
+    assert report["item_counts"] == {"capability": 1, "failure_case": 1, "tool": 1}
+
+
+def test_audit_validation_rejects_unknown_tool_reference(tmp_path: Path) -> None:
+    audit = tmp_path / "audit.md"
+    audit.write_text(
+        _AUDIT_TEMPLATE.read_text(encoding="utf-8").replace(
+            "    required_tools:\n      - customer.lookup\n",
+            "    required_tools:\n      - ticket.create\n",
+        ),
+        encoding="utf-8",
+    )
+
+    code, report, _ = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+
+    assert code == 1
+    assert report["valid"] is False
+    assert "unknown tool name 'ticket.create'" in report["error"]
 
 
 def test_bundled_scripts_never_import_the_platform() -> None:
     """The boundary that makes the skill copyable: Harbor is fine, NeMo is not."""
-    permitted = _local_roots() | sys.stdlib_module_names | _PERMITTED_THIRD_PARTY
     offenders: dict[str, set[str]] = {}
-    for path in _bundled_scripts():
-        found = {root for root in _imported_roots(path) if root not in permitted}
-        if found:
-            offenders[path.name] = found
+    for scripts_dir in _SCRIPT_DIRS:
+        permitted = _local_roots(scripts_dir) | sys.stdlib_module_names | _PERMITTED_THIRD_PARTY
+        for path in _bundled_scripts(scripts_dir):
+            found = {root for root in _imported_roots(path) if root not in permitted}
+            if found:
+                offenders[path.relative_to(scripts_dir).as_posix()] = found
     assert not offenders, (
         "Bundled scripts may import the standard library, a sibling, or "
         f"{sorted(_PERMITTED_THIRD_PARTY)}, found: "
@@ -298,21 +349,22 @@ def test_no_bundled_directory_is_named_after_a_provider_package() -> None:
     succeed, so the probe reports an install that is not there and the ladder then
     fails on import. Provider code sits one level down for exactly this reason.
     """
-    collisions = _local_roots() & _PERMITTED_THIRD_PARTY
-    assert not collisions, (
-        f"{sorted(collisions)} shadows a package the skill imports; "
-        "keep it under scripts/providers/ rather than directly in scripts/"
-    )
+    for scripts_dir in _SCRIPT_DIRS:
+        collisions = _local_roots(scripts_dir) & _PERMITTED_THIRD_PARTY
+        assert not collisions, (
+            f"{sorted(collisions)} shadows a package the skill imports; "
+            "keep it under scripts/providers/ rather than directly in scripts/"
+        )
 
 
 def test_only_the_ladder_imports_harbor() -> None:
     """Every other module must keep working when Harbor is absent."""
     assert "harbor" in _imported_roots(_LADDER), "the ladder is the Harbor boundary and must import Harbor"
-    for path in _bundled_scripts():
+    for path in _bundled_scripts(_DISCOVER_SCRIPTS_DIR):
         if path == _LADDER:
             continue
         assert "harbor" not in _imported_roots(path), (
-            f"{path.relative_to(_SCRIPTS_DIR)} imports Harbor; move that call behind the probe"
+            f"{path.relative_to(_DISCOVER_SCRIPTS_DIR)} imports Harbor; move that call behind the probe"
         )
 
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Adds an Eval Author audit validation sub-flow for an existing finite `audit.md` coverage denominator. The format is standalone and hand-editable; Ethos is the preferred first source when present, but the schema does not require `ETHOS.md` and can carry optional generic source provenance for future sources of truth.

## Related Issue

None.

## Changes

- Add `eval-author-audit` as a routable Eval Author sub-flow that validates an existing audit denominator; it does not draft, update, or generate `audit.md`.
- Add `templates/audit.md` as a reviewer-friendly format reference with a marked YAML block and optional Ethos provenance for hand-authored files.
- Add `schemas/audit.schema.json` as the canonical structural schema for `tool`, `capability`, and `failure_case` items, with field-level `description` text for schema-aware editors and reviewers.
- Model provenance with optional generic `sources` and optional per-item `source_refs`, instead of making Ethos fields required; `source_refs` are advisory v1 notes and are not resolved until a generator/reference grammar is defined.
- Update the validator to compare provided source `sha256` values against referenced local paths, reject placeholder digests, enforce globally unique source names and item `name` keys, and validate cross-item references.
- Reject audit specs whose marked block contains zero or multiple fenced YAML blocks, and require YAML fence delimiters to occupy complete Markdown lines.
- Report missing PyYAML, missing `jsonschema`, and bundled schema load failures as validator environment errors with exit 2 and `valid: null`, not invalid audit specs.
- Clarify the semantic validation loops with single-line comments naming the constraint each loop enforces.
- Treat item `name` as the stable coverage key everywhere; remove sequential numeric item IDs.
- Require `evidence_required[].tool` for `tool_call` evidence, reject `tool` on non-tool evidence, and require those evidence tools to reference declared tool items.
- Allow `prohibited_tools` to name syntactically valid undeclared tools, since prohibited tools are often outside the allowed tool set.
- Document toolless capabilities with `required_tools: []` and capability-name-only `failure_case.applies_to` references.
- Keep the audit validation skill read-only by removing `Write` from its allowed tool set.
- Reorganize the Eval Author README to list prerequisites before skill usage, describe the bundled validator/private helpers without implying an installed public package, and add related-skill next steps.
- Extend the skill contract tests for optional sources, empty sources, unresolved `source_refs`, source digest drift, duplicate source names, marker extraction, duplicate item names, schema-field rejection, evidence validation, compact output, environment errors, tool references, capability references, toolless capabilities, multiple YAML blocks, prefixed YAML fences, and audit skill permissions.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --no-project --with pytest --with pyyaml --with jsonschema pytest plugins/nemo-eval-author/tests/test_skill_contract.py -q` — passed, `51 passed, 5 skipped`.
- `uv run --no-project --with ruff ruff check plugins/nemo-eval-author` — passed.
- `uv run --no-project --with ruff ruff format --check plugins/nemo-eval-author` — passed, `14 files already formatted`.
- `python3 tools/lint/copyright_fixer.py --check --include plugins/nemo-eval-author/skills/eval-author-audit/templates/audit.md` — passed.
- `python3 -m json.tool plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit.schema.json` — passed.
- `git diff --check && git diff --check origin/main...HEAD` — passed.
- DCO audit over `origin/main..HEAD` — passed for all 11 commits.
- Secret-token pattern scan over the PR diff — passed.
- `uv run pre-commit run -a` — blocked before hooks start because local `rustc 1.93.1` cannot build `litellm==1.95.0`; AWS Rust crates require `rustc 1.94.1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `eval-author-audit` skill for validating existing `audit.md` coverage specifications.
  * Added schema-based checks for metadata, sources, tools, capabilities, failure cases, evidence rules, references, naming, and source integrity.
  * Added a ready-to-use audit specification template.
  * Added a command-line validator with structured JSON output and distinct success and error statuses.

* **Documentation**
  * Documented the audit workflow, validation boundaries, prerequisites, supported tools, and contract-testing requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

