### PR TITLE
feat(anonymizer): make run remote jobs

### DIFF
--- a/docs/anonymizer/cli.mdx
+++ b/docs/anonymizer/cli.mdx
@@ -11,14 +11,18 @@ This reference covers the `nemo anonymizer` commands exposed by the Anonymizer p
 
 ## Command Surface
 
-| Command                          | Source                          | Description                                                  |
-|----------------------------------|---------------------------------|--------------------------------------------------------------|
-| `nemo anonymizer validate`       | Manual Typer command            | Validate an `AnonymizerConfig` (and optional `model_configs`).|
-| `nemo anonymizer preview run`    | Generated from `NemoFunction`   | Local streaming preview.                                     |
-| `nemo anonymizer preview submit` | Generated from `NemoFunction`   | Remote streaming preview against the plugin service.         |
-| `nemo anonymizer run run`        | Generated from `NemoJob`        | Local job execution in the CLI process.                      |
-| `nemo anonymizer run submit`     | Generated from `NemoJob`        | Submit an `anonymizer.run` job to the NeMo Platform Jobs worker. |
-| `nemo anonymizer run explain`    | Generated from `NemoJob`        | Print the job key, submit endpoint, and JSON schemas.        |
+| Command                          | Description                                                  |
+|----------------------------------|--------------------------------------------------------------|
+| `nemo anonymizer preview`        | Stream a small preview through the Anonymizer plugin service. |
+| `nemo anonymizer validate`       | Validate an `AnonymizerConfig` (and optional `model_configs`). |
+| `nemo anonymizer run`            | Submit an `anonymizer.run` job to the NeMo Platform Jobs worker. |
+| `nemo anonymizer run --watch`    | Submit an `anonymizer.run` job and stream status/logs until terminal state. |
+| `nemo anonymizer run --dry-run`  | Print the job schema and resolved submit request without creating a job. |
+
+The example commands below use the checked-in spec under
+`plugins/nemo-anonymizer/examples/`. The spec points at the checked-in
+`plugins/nemo-anonymizer/examples/anonymizer-input.csv`; pass `--fileset anonymizer-inputs`
+and the CLI uploads that local CSV before calling the platform service.
 
 ## `nemo anonymizer validate`
 
@@ -26,8 +30,8 @@ Validate an `AnonymizerConfig` YAML file against the model selection. Useful for
 
 ```bash
 nemo anonymizer validate \
-  --config /tmp/anonymizer-config.yaml \
-  [--model-configs /tmp/anonymizer-model-configs.yaml]
+  --config ./anonymizer-config.yaml \
+  [--model-configs ./anonymizer-model-configs.yaml]
 ```
 
 | Flag              | Required | Description                                                                                       |
@@ -35,84 +39,117 @@ nemo anonymizer validate \
 | `--config`        | yes      | Path to the `AnonymizerConfig` YAML.                                                              |
 | `--model-configs` | no       | Optional path to a model-configs YAML to validate alongside the config (same shape the library expects). |
 
-The command does not accept `data.source`. Input-source validation happens during `preview` or `run`.
+The command does not accept `data.source`. Input-source validation happens during preview API calls or `run`.
 
 ## `nemo anonymizer preview`
 
-Both `preview run` and `preview submit` take a spec file matching `PreviewRequest`.
+Streams a small anonymized sample through the Anonymizer plugin service.
 
 ```bash
-nemo anonymizer preview run \
-  --spec-file /tmp/anonymizer-preview.yaml \
-  --workspace "${NMP_WORKSPACE:-default}"
-
-nemo anonymizer preview submit \
-  --spec-file /tmp/anonymizer-preview.yaml \
+nemo anonymizer preview \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --num-records 2 \
   --workspace "${NMP_WORKSPACE:-default}" \
-  --base-url "${NMP_BASE_URL:-http://localhost:8080}"
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}" \
+  --fileset anonymizer-inputs
+
+nemo anonymizer preview \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --num-records 2 \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}" \
+  --fileset anonymizer-inputs \
+  --output-file preview.ndjson \
+  --quiet
+
+nemo anonymizer preview \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --num-records 2 \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}" \
+  --fileset anonymizer-inputs \
+  --output-remote-path previews/redact.ndjson
 ```
 
-| Flag             | Description                                                                                       |
-|------------------|---------------------------------------------------------------------------------------------------|
-| `--spec-file`    | Path to the `PreviewRequest` YAML.                                                                |
-| `--workspace`    | NeMo Platform workspace. Used to resolve fileset references and Inference Gateway providers.   |
-| `--base-url`     | Override the platform base URL (typically auto-populated from the CLI config).                    |
+| Flag          | Description                                                                 |
+|---------------|-----------------------------------------------------------------------------|
+| `--spec-file` | Path to the `PreviewRequest` YAML or JSON file.                             |
+| `--spec`      | Inline `PreviewRequest` JSON string.                                        |
+| `--num-records` | Override the number of records to preview from the spec.                  |
+| `--workspace` | Workspace used for fileset resolution and Inference Gateway providers.      |
+| `--base-url`  | Override the platform base URL (typically auto-populated from the CLI config). |
+| `--cluster`   | Resolve the platform base URL from a configured cluster name.                |
+| `--request-id`| Set the `X-Request-ID` header.                                              |
+| `--fileset`   | Fileset used to upload local `data.source` files and store `--output-remote-path` output. |
+| `--input-remote-path` | Remote `.csv` or `.parquet` fileset path to use when uploading a local input file. Defaults to the input filename. |
+| `--quiet`     | Suppress preview log frames on stderr.                                      |
+| `--output-file` | Write non-log preview frames to an NDJSON file instead of stdout.         |
+| `--output-remote-path` | Write non-log preview frames to this path in `--fileset` after a successful stream. |
 
-### Preview source kinds
+Preview emits non-log NDJSON frames to stdout or `--output-file`. Log frames are
+printed to stderr unless `--quiet` is set. The stream may include
+`preview_dataset`, `trace_dataset`, `failed_records`, `heartbeat`, `done`, and
+`error` frames. The command exits with status 1 when the service emits an
+`error` frame. If the spec uses a local CSV or Parquet path, pass `--fileset`
+so the CLI can upload the file and rewrite `data.source` to a fileset reference
+before previewing.
 
-| Form                                  | `preview run` | `preview submit` |
-|---------------------------------------|---------------|------------------|
-| Local path (`/tmp/input.csv`)         | yes           | no               |
-| HTTP(S) URL (`https://.../input.csv`) | yes           | yes              |
-| Fileset reference (`fs#path`)         | yes           | yes              |
-
-### Preview output
-
-`preview` streams newline-delimited JSON frames to stdout. Filter with `jq`:
-
-```bash
-nemo anonymizer preview run --spec-file /tmp/anonymizer-preview.yaml > /tmp/preview.ndjson
-
-jq -R 'fromjson? | select(.kind == "preview_dataset") | .records' /tmp/preview.ndjson
-```
-
-Frame kinds: `log`, `preview_dataset`, `trace_dataset`, `failed_records`, `heartbeat`, `done`, `error`. See the [preview tutorial](/documentation/anonymize-data/tutorials/preview-a-config) for details.
+Use the Python SDK (`sdk.anonymizer.preview(...)`) when you want the stream
+collected into an `AnonymizerPreviewResult` with pandas DataFrames. See the
+[preview tutorial](/documentation/anonymize-data/tutorials/preview-a-config)
+for examples.
 
 ## `nemo anonymizer run`
 
 ```bash
-nemo anonymizer run run --spec-file /tmp/anonymizer-run.yaml
-
-nemo anonymizer run submit \
-  --spec-file /tmp/anonymizer-run.yaml \
+nemo anonymizer run \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
   --workspace "${NMP_WORKSPACE:-default}" \
-  --base-url "${NMP_BASE_URL:-http://localhost:8080}"
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}" \
+  --fileset anonymizer-inputs
 
-nemo anonymizer run explain
+nemo anonymizer run \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}" \
+  --fileset anonymizer-inputs \
+  --watch
+
+nemo anonymizer run \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}" \
+  --fileset anonymizer-inputs \
+  --watch \
+  --output-dir ./anonymizer-artifacts
 ```
 
 | Flag             | Description                                                                                       |
 |------------------|---------------------------------------------------------------------------------------------------|
 | `--spec-file`    | Path to the `AnonymizerRequest` YAML.                                                             |
 | `--workspace`    | Workspace used for fileset resolution, Inference Gateway providers, and job placement.            |
+| `--base-url`     | Override the platform base URL (typically auto-populated from the CLI config).                    |
+| `--fileset`      | Fileset used to upload local `data.source` files and store run artifacts.                         |
+| `--input-remote-path` | Remote `.csv` or `.parquet` fileset path to use when uploading a local input file. Defaults to the input filename. |
+| `--watch`        | Stream the submitted job status/logs until it reaches a terminal state.                           |
+| `--output-dir`   | Download run artifacts into this local directory after a successful `--watch`.                    |
+| `--timeout`      | Maximum watch time in seconds.                                                                    |
+| `--poll-interval`| Seconds between watch status checks.                                                              |
+| `--dry-run`      | Print the job schema and resolved submit request without creating the job. Cannot be combined with `--watch`. |
 
-### Run source kinds
+### Preview and run source kinds
 
-| Form                                  | `run run` | `run submit` |
-|---------------------------------------|-----------|--------------|
-| Local path (`/tmp/input.csv`)         | yes       | no           |
-| HTTP(S) URL (`https://.../input.csv`) | yes       | yes          |
-| Fileset reference (`fs#path`)         | yes       | yes          |
+| Form                                  | `preview` CLI | `run` CLI | SDK/API |
+|---------------------------------------|---------------|-----------|---------|
+| Local path (`./data/input.csv`)       | yes, with `--fileset` | yes, with `--fileset` | no |
+| HTTP(S) URL (`https://.../input.csv`) | yes           | yes       | yes     |
+| Fileset reference (`fs#path`)         | yes           | yes       | yes     |
 
 ### Run output
 
-`run run` prints `{"exit_code": 0}` on success. The local job results manager logs the artifact directory to stderr:
+`nemo anonymizer run` submits an `anonymizer.run` job to the Jobs service and prints the assigned job record. With `--watch`, it prints the submitted job record and then streams job status/logs until the job reaches a terminal state. If `--output-dir` is set, the CLI downloads the final `artifacts` result after a successful watch.
 
-```text
-Saved result 'artifacts' to file:///.../persistent/results/artifacts
-```
-
-The artifact directory contains:
+The job writes an `artifacts` result containing:
 
 | File                  | Description                                                  |
 |-----------------------|--------------------------------------------------------------|
@@ -121,13 +158,11 @@ The artifact directory contains:
 | `metadata.json`       | Run metadata (includes original text column).                |
 | `failed_records.json` | Per-record failures. Only written when records failed.       |
 
-`run submit` submits an `anonymizer.run` job to the Jobs service and prints the assigned job name and submit endpoint:
-
-```text
-  |-- job name: anonymizer-run-2026-05-12-abc123
-  |-- submit endpoint: /apis/anonymizer/v2/workspaces/default/jobs/run
-{"name": "anonymizer-run-2026-05-12-abc123", ...}
-```
+When `--fileset` is supplied, run artifacts are stored in that fileset under
+the job output path, for example
+`jobs/<job-name>/results/<attempt-id>/artifacts/...`. The CLI also uses the
+same fileset to upload a local `data.source` file before submission. Without
+`--fileset`, Jobs chooses the default output storage for the job.
 
 Track and pull artifacts using either the standard `nemo jobs ...` commands or the Python SDK:
 
@@ -145,31 +180,27 @@ dataset = results.load_dataset()
 
 See [SDK Resources](/documentation/anonymize-data/sdk-resources) for the full `AnonymizerJobResource` / `AnonymizerJobResults` surface.
 
-Compared to `run run`, `run submit` rejects local file paths in `data.source` (use a fileset reference or `http(s)` URL) and requires explicit `model_configs` because the job runs outside the CLI process.
+Full runs require explicit `model_configs` because the job runs outside the CLI process. The CLI can upload local input files when `--fileset` is supplied; SDK/API callers should use a fileset reference or `http(s)` URL in `data.source`.
 
 ## Spec File Reference
 
-Both preview and run specs use the shared `AnonymizerRequest` shape:
+Preview specs use the `PreviewRequest` shape. Run specs use the shared
+`AnonymizerRequest` shape, which is the same request without `num_records`:
 
 | Field             | Type                                            | Required | Notes                                                                  |
 |-------------------|-------------------------------------------------|----------|------------------------------------------------------------------------|
 | `config`          | `AnonymizerConfig`                              | yes      | Library config. See the [library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs). |
-| `data.source`     | string                                          | yes      | Local path, `http(s)` URL, or fileset reference.                       |
+| `data.source`     | string                                          | yes      | Local CSV/Parquet path for CLI with `--fileset`, `http(s)` URL, or fileset reference. SDK/API callers should use `http(s)` or fileset. |
 | `data.text_column`| string                                          | no       | Defaults to `text`.                                                    |
 | `data.id_column`  | string                                          | no       | Optional record identifier column.                                     |
 | `data.data_summary` | string                                        | no       | Optional short description of the data.                                |
-| `model_configs`   | list of Data Designer `ModelConfig`             | depends  | Required for `preview submit` and `run submit`; optional for `preview run` and `run run`. |
+| `model_configs`   | list of Data Designer `ModelConfig`             | yes      | Required so preview/run route model calls through the Inference Gateway. |
 | `selected_models` | object with `detection` / `replace` / `rewrite` | no       | Role overrides on top of bundled defaults. Requires `model_configs`.   |
-
-Preview-only:
-
-| Field         | Type    | Required | Notes                                                                  |
-|---------------|---------|----------|------------------------------------------------------------------------|
-| `num_records` | int ≥ 1 | no       | Defaults to 10. Capped by the service's `preview_num_records.max`.     |
+| `num_records`     | int                                             | preview only | Number of records to preview. Defaults to 10.                      |
 
 ## Fileset Reference Forms
 
-The `data.source` field accepts three fileset forms; the workspace and fileset must already exist:
+The `data.source` field accepts three fileset forms:
 
 ```text
 fileset://<workspace>/<fileset>#<path>

--- a/docs/anonymizer/index.mdx
+++ b/docs/anonymizer/index.mdx
@@ -11,7 +11,7 @@ The Anonymizer service detects personally identifiable information (PII) in text
 
 ## Overview
 
-The service wraps the open-source [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer) and exposes it through the NeMo Platform's Python SDK and CLI. The library still owns PII detection, replacement, rewrite, and config validation. The platform adds inference routing through the Inference Gateway, fileset-backed inputs, plugin-service execution for streaming preview, and a Jobs-worker path for full anonymization runs.
+The service wraps the open-source [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer) and exposes preview through the CLI, NeMo Platform Python SDK, and HTTP API, with CLI and SDK support for full anonymization jobs. The library still owns PII detection, replacement, rewrite, and config validation. The platform adds inference routing through the Inference Gateway, fileset-backed inputs, CLI upload/download conveniences, plugin-service execution for streaming preview, and a Jobs-worker path for full anonymization runs.
 
 ## How It Works: Library + Platform
 
@@ -62,14 +62,23 @@ preview_result.trace_dataset     # detection trace
 preview_result.display_record(0) # render a record with entity highlights
 ```
 
-For a full anonymization run, execute the job locally or submit it to the Jobs worker:
+The same preview request can be saved as YAML and streamed from the CLI:
 
 ```bash
-nemo anonymizer run run --spec-file /path/to/run-spec.yaml      # in-process
-nemo anonymizer run submit --spec-file /path/to/run-spec.yaml   # NeMo Services job
+nemo anonymizer preview --spec-file plugins/nemo-anonymizer/examples/redact.yaml --num-records 2 --fileset anonymizer-inputs
+nemo anonymizer preview --spec-file plugins/nemo-anonymizer/examples/redact.yaml --num-records 2 --fileset anonymizer-inputs --output-file preview.ndjson --quiet
 ```
 
-The SDK equivalent of `run submit` is `sdk.anonymizer.run(request)`, which returns an `AnonymizerJobResource` you can poll with `wait_until_done()` and pull artifacts from with `download_artifacts()`.
+For a full anonymization run, submit the job to the Jobs worker:
+
+```bash
+nemo anonymizer run --spec-file plugins/nemo-anonymizer/examples/redact.yaml --fileset anonymizer-inputs          # NeMo Platform job
+nemo anonymizer run --spec-file plugins/nemo-anonymizer/examples/redact.yaml --fileset anonymizer-inputs --watch  # submit and stream logs/status
+nemo anonymizer run --spec-file plugins/nemo-anonymizer/examples/redact.yaml --fileset anonymizer-inputs --watch --output-dir ./anonymizer-artifacts  # download artifacts after success
+nemo anonymizer run --spec-file plugins/nemo-anonymizer/examples/redact.yaml --fileset anonymizer-inputs --dry-run  # print schema/request without submitting
+```
+
+The SDK equivalent of `nemo anonymizer run` is `sdk.anonymizer.run(request)`, which returns an `AnonymizerJobResource` you can poll with `wait_until_done()` and pull artifacts from with `download_artifacts()`.
 
 **The platform handles:** Inference routing through the Inference Gateway, fileset-backed inputs, and authentication.
 
@@ -80,9 +89,9 @@ When using Anonymizer as a NeMo Platform service:
 | Feature           | Standalone Library                                  | NeMo Platform Service                                                                                       |
 |-------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | **Inference**     | Direct calls to NVIDIA Build defaults               | Routes through the Inference Gateway via `model_configs`                                                        |
-| **Execution**     | Local Python process                                | Streaming preview runs in the plugin service; full runs execute either in the local CLI (`run run`) or on the Jobs worker (`run submit`) |
-| **Input sources** | Local file, `http(s)` URL                           | Local file (`run run` only), `http(s)` URL, or NeMo Platform Fileset                                        |
-| **Artifacts**     | Local filesystem                                    | Local artifact directory (`persistent/results/artifacts`) for `run run`; NeMo Platform job artifact storage for `run submit` |
+| **Execution**     | Local Python process                                | Streaming preview runs in the plugin service; full runs execute on the Jobs worker |
+| **Input sources** | Local file, `http(s)` URL                           | CLI can upload local CSV/Parquet files to `--fileset`; SDK/API use `http(s)` URLs or NeMo Platform filesets |
+| **Artifacts**     | Local filesystem                                    | NeMo Platform job artifact storage for full `run`; CLI can download run artifacts with `--output-dir` |
 | **Authentication**| Direct API keys                                     | NeMo Platform Secrets service                                                                               |
 
 ## Replacement Strategies
@@ -103,11 +112,11 @@ See the [library documentation](https://github.com/NVIDIA-NeMo/Anonymizer/tree/m
 
 This package is a thin wrapper around the [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer). It does **not** re-document detection, replacement, or rewrite semantics. It adds:
 
-- A `nemo anonymizer` CLI with `validate`, `preview`, and `run` command groups.
+- A `nemo anonymizer` CLI with `preview`, `validate`, and `run` commands.
 - An `sdk.anonymizer` SDK accessor (`AnonymizerResource`, `AsyncAnonymizerResource`).
-- A streaming `anonymizer.preview` function that emits `preview_dataset`, `trace_dataset`, and `failed_records` frames from the plugin service.
-- An `anonymizer.run` job that writes `dataset.parquet`, `trace.parquet`, `metadata.json`, and optional `failed_records.json`. The job can execute in the local CLI process (`nemo anonymizer run run`) or on the NeMo Platform Jobs worker (`nemo anonymizer run submit` / `sdk.anonymizer.run`).
-- Fileset input handling (`fileset://<workspace>/<fileset>#<path>`).
+- A streaming preview API that emits `preview_dataset`, `trace_dataset`, and `failed_records` frames from the plugin service.
+- An `anonymizer.run` job that writes `dataset.parquet`, `trace.parquet`, `metadata.json`, and optional `failed_records.json`. The job executes on the NeMo Platform Jobs worker through `nemo anonymizer run` or `sdk.anonymizer.run`.
+- Fileset input handling (`fileset://<workspace>/<fileset>#<path>`) and CLI upload of local CSV/Parquet inputs when `--fileset` is supplied.
 - Inference Gateway routing for model providers referenced from `model_configs`.
 
 ## Next Steps
@@ -116,7 +125,7 @@ This package is a thin wrapper around the [NVIDIA NeMo Anonymizer library](https
 
 <Card title="Tutorials" href="/documentation/anonymize-data/tutorials">
 
-Walk through preview (`anonymizer.preview`) and job execution (`anonymizer.run`) end to end.
+Walk through preview (`nemo anonymizer preview` / `anonymizer.preview`) and job execution (`anonymizer.run`) end to end.
 
 </Card>
 <Card title="SDK Resources" href="/documentation/anonymize-data/sdk-resources">

--- a/docs/anonymizer/sdk-resources.mdx
+++ b/docs/anonymizer/sdk-resources.mdx
@@ -30,17 +30,28 @@ An `AsyncAnonymizerResource` with the same surface is available via `AsyncNeMoPl
 
 | Method                                                   | Description                                                                                                              |
 |----------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
-| `preview(request, *, workspace=None)`                    | Runs a streaming preview against the plugin service and returns an `AnonymizerPreviewResult` after the stream completes. |
+| `preview(request, *, workspace=None)`                    | Default preview method. Consumes `preview_stream` under the hood and returns an `AnonymizerPreviewResult` after the stream completes. |
+| `preview_stream(request, *, workspace=None)`             | Lower-level streaming method. Yields typed preview frames from the plugin service for callers that want logs, progress, or other frames as they arrive. |
 | `run(request, *, workspace=None, wait_until_done=False)` | Submits an `anonymizer.run` job to the NeMo Platform Jobs worker. Returns an `AnonymizerJobResource`. When `wait_until_done=True`, blocks until the job reaches a terminal state. |
 | `get_job_resource(job_name, workspace=None)`             | Returns an `AnonymizerJobResource` for an existing job (by job name).                                                    |
 
 `request` is a `PreviewRequest` or `AnonymizerRequest` instance from `nemo_anonymizer_plugin.app.task_config`. Both accept the same `config`, `data`, `model_configs`, and `selected_models` fields; `PreviewRequest` adds `num_records`.
 
-Both `preview` and `run` call the plugin service, so they require `model_configs` and reject local file paths in `data.source` — use a fileset reference or `http(s)` URL.
+SDK `preview`, `preview_stream`, and `run` call the plugin service directly, so they require `model_configs` and service-readable input in `data.source`: use a fileset reference or `http(s)` URL. The `nemo anonymizer` CLI can upload local CSV/Parquet files before making the same service calls when `--fileset` is supplied.
 
 ## AnonymizerPreviewResult
 
-`AnonymizerResource.preview` collects the frame stream and returns an `AnonymizerPreviewResult` once the stream completes.
+`AnonymizerResource.preview` collects frames from `preview_stream` and returns an `AnonymizerPreviewResult` once the stream completes. Use it for the normal SDK path: notebooks, scripts, and other callers that want the preview dataset and trace as pandas DataFrames.
+
+Use `preview_stream` when you need to process frames as they arrive, such as forwarding log frames to a UI, reporting progress, or implementing custom frame/NDJSON handling:
+
+```python
+for frame in sdk.anonymizer.preview_stream(request):
+    if frame.kind == "log":
+        print(frame.message)
+    elif frame.kind == "preview_dataset":
+        preview_records = frame.records
+```
 
 | Attribute / Method            | Description                                                                                          |
 |-------------------------------|------------------------------------------------------------------------------------------------------|
@@ -54,6 +65,7 @@ Both `preview` and `run` call the plugin service, so they require `model_configs
 `AnonymizerPreviewResult` holds everything in memory; nothing is persisted to disk by default. The `dataset` and `trace_dataset` fields are regular pandas DataFrames and can be saved with `to_csv` / `to_parquet`.
 
 </Accordion>
+
 ## AnonymizerJobResource
 
 `AnonymizerResource.run` returns an `AnonymizerJobResource`. You can also use `AnonymizerResource.get_job_resource` to get one for an existing job.
@@ -78,7 +90,7 @@ The async variant (`AsyncAnonymizerJobResource`) exposes the same surface with `
 
 ## AnonymizerJobResults
 
-`download_artifacts` returns an `AnonymizerJobResults` object that loads parquet / JSON artifacts into memory. The same class also works for the local `run run` flow — point it at the artifact directory the local job results manager logs:
+`download_artifacts` returns an `AnonymizerJobResults` object that loads parquet / JSON artifacts into memory. You can also construct the same class directly when you already have an extracted artifacts directory:
 
 ```python
 from pathlib import Path
@@ -141,7 +153,7 @@ The plugin-owned API-boundary input spec:
 
 | Field          | Type           | Description                                                                              |
 |----------------|----------------|------------------------------------------------------------------------------------------|
-| `source`       | `str`          | Local path, `http(s)` URL, or fileset reference for a CSV / Parquet file.                |
+| `source`       | `str`          | `http(s)` URL or fileset reference for SDK/API calls. The CLI also accepts a local CSV/Parquet path when `--fileset` is supplied. |
 | `text_column`  | `str` (default `"text"`) | Column containing text to anonymize.                                          |
 | `id_column`    | `str \\| None`  | Optional record identifier column.                                                       |
 | `data_summary` | `str \\| None`  | Optional short description of the data passed to Anonymizer library prompts.             |

--- a/docs/anonymizer/tutorials/index.mdx
+++ b/docs/anonymizer/tutorials/index.mdx
@@ -79,8 +79,8 @@ When using Anonymizer as a NeMo Platform service:
 | Feature        | Difference                                              | Details                                                                                |
 |----------------|---------------------------------------------------------|----------------------------------------------------------------------------------------|
 | **Inference**  | Routes through the Inference Gateway                    | Configure providers once and reference them by name from `model_configs`.              |
-| **Input data** | Filesets and HTTP(S) URLs (local paths only in local CLI execution) | Use `sdk.files.filesets.create` / `sdk.files.upload`, then reference with `#<path>`. |
-| **Artifacts**  | Local or platform-managed                               | `run run` writes to `persistent/results/artifacts` locally; `run submit` stores artifacts in NeMo Platform job storage. |
+| **Input data** | Filesets and HTTP(S) URLs for SDK/API; CLI can stage local files | Pass `--fileset` when a CLI spec points at a local CSV/Parquet file. |
+| **Artifacts**  | Platform-managed for full runs                          | `run` stores artifacts in NeMo Platform job storage; the CLI can download them with `--output-dir`. |
 
 ## Prerequisites
 
@@ -92,19 +92,24 @@ The root workspace includes the Anonymizer plugin, so `nemo services run` discov
 nemo anonymizer --help
 ```
 
-You should see `validate`, `preview`, and `run` command groups.
+You should see `preview`, `validate`, and `run` commands.
 
 These tutorials route inference through an [Inference Gateway](/documentation/models-and-inference) provider, so a NeMo Platform cluster must be running before you preview or run a job. The examples reference the default NVIDIA Build provider created during setup.
 
 <Markdown src="/snippets/_snippets/nvidia-build-model-provider.mdx" />
 
-### Upload an Input Fileset
+### Use the Example Input
 
-`sdk.anonymizer.preview`, `preview submit`, and `run submit` reject local file paths, so the tutorials read from a fileset. Create a small CSV containing PII and upload it to a fileset named `anonymizer-inputs`:
+The repo includes a small CSV containing PII at
+`plugins/nemo-anonymizer/examples/anonymizer-input.csv`. The checked-in CLI
+specs point at that local file; pass `--fileset anonymizer-inputs` and the CLI
+uploads it before previewing or submitting a run.
+
+For SDK or direct HTTP API examples, upload the same CSV to a fileset and use a
+fileset reference in `data.source`:
 
 ```python
 import os
-import tempfile
 from pathlib import Path
 
 from nemo_platform import NeMoPlatform
@@ -113,19 +118,12 @@ from nemo_platform._exceptions import ConflictError
 WORKSPACE = os.environ.get("NMP_WORKSPACE", "default")
 FILESET = "anonymizer-inputs"
 INPUT_FILENAME = "anonymizer-input.csv"
+INPUT_PATH = Path("plugins/nemo-anonymizer/examples/anonymizer-input.csv")
 
 sdk = NeMoPlatform(
     base_url=os.environ.get("NMP_BASE_URL", "http://localhost:8080"),
     workspace=WORKSPACE,
 )
-
-with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as f:
-    f.write(
-        "id,biography\n"
-        "1,Alice Johnson lives in Seattle and works at NVIDIA.\n"
-        "2,Bob Smith can be reached at bob.smith@example.com.\n"
-    )
-    input_path = Path(f.name)
 
 try:
     sdk.files.filesets.create(
@@ -137,14 +135,15 @@ except ConflictError:
     pass  # already exists
 
 sdk.files.upload(
-    local_path=str(input_path),
+    local_path=str(INPUT_PATH),
     fileset=FILESET,
     workspace=WORKSPACE,
     remote_path=INPUT_FILENAME,
 )
 ```
 
-The tutorials reference this file with `fileset://{WORKSPACE}/anonymizer-inputs#anonymizer-input.csv`.
+SDK/API requests can reference this file with
+`fileset://{WORKSPACE}/anonymizer-inputs#anonymizer-input.csv`.
 
 ## Tutorials
 
@@ -152,14 +151,14 @@ The tutorials reference this file with `fileset://{WORKSPACE}/anonymizer-inputs#
 
 <Card title="Preview a Config" href="/documentation/anonymize-data/tutorials/preview-a-config">
 
-Stream a small anonymized sample to iterate on `AnonymizerConfig` and `model_configs`. Covers `sdk.anonymizer.preview`, `nemo anonymizer preview run` / `preview submit`, and the NDJSON frame stream.
+Stream a small anonymized sample to iterate on `AnonymizerConfig` and `model_configs`. Covers `nemo anonymizer preview`, `sdk.anonymizer.preview`, the preview HTTP API, and the NDJSON frame stream.
 
 <small><span class="md-tag">beginner</span> <span class="md-tag">anonymizer</span></small>
 
 </Card>
 <Card title="Run an Anonymizer Job" href="/documentation/anonymize-data/tutorials/run-an-anonymizer-job">
 
-Run the full pipeline locally with `nemo anonymizer run run` or submit it to the Jobs worker with `nemo anonymizer run submit`. Load `dataset.parquet`, `trace.parquet`, and `failed_records.json` artifacts.
+Submit the full pipeline to the Jobs worker with `nemo anonymizer run`. Load `dataset.parquet`, `trace.parquet`, and `failed_records.json` artifacts.
 
 <small><span class="md-tag">intermediate</span> <span class="md-tag">anonymizer</span></small>
 

--- a/docs/anonymizer/tutorials/preview.mdx
+++ b/docs/anonymizer/tutorials/preview.mdx
@@ -15,15 +15,15 @@ For detection and replacement strategy details, see the [open-source library doc
 
 Complete the [tutorials prerequisites](/documentation/anonymize-data/tutorials#prerequisites), which cover:
 
-- A running NeMo Platform cluster with the `nemo anonymizer` CLI available (see [Setup](/documentation/get-started)).
+- A running NeMo Platform cluster with the Anonymizer plugin service mounted (see [Setup](/documentation/get-started)).
 - An inference provider configured (default examples use `nvidia-build`).
-- A fileset named `anonymizer-inputs` with `anonymizer-input.csv` uploaded.
+- The checked-in sample CSV at `plugins/nemo-anonymizer/examples/anonymizer-input.csv`. The CLI uploads it when you pass `--fileset anonymizer-inputs`.
 
 ## What `preview` Does
 
-`preview` runs the Anonymizer pipeline on a small number of records and streams results back from the plugin service. Both surfaces (Python SDK and CLI) produce the same data; the SDK collects it into a `pandas` DataFrame while the CLI prints newline-delimited JSON frames.
+`preview` runs the Anonymizer pipeline on a small number of records and streams results back from the plugin service. The CLI writes non-log NDJSON frames to stdout and log frames to stderr. The Python SDK collects the same stream into a `pandas` DataFrame. The direct HTTP API returns raw newline-delimited JSON frames.
 
-The plugin emits four frame kinds:
+The plugin emits these frame kinds:
 
 | Frame              | Purpose                                                                              |
 |--------------------|--------------------------------------------------------------------------------------|
@@ -37,13 +37,13 @@ Available preview surfaces:
 
 | Surface                          | Where it runs                       | Local paths | `model_configs` required |
 |----------------------------------|--------------------------------------|-------------|--------------------------|
-| `sdk.anonymizer.preview(...)`    | Anonymizer plugin service (remote)  | Rejected    | Required                 |
-| `nemo anonymizer preview run`    | Local CLI process                   | Allowed     | Optional                 |
-| `nemo anonymizer preview submit` | Anonymizer plugin service (remote)  | Rejected    | Required                 |
+| `nemo anonymizer preview`        | Anonymizer plugin service (remote)  | Uploaded with `--fileset` | Required |
+| `sdk.anonymizer.preview(...)`    | Anonymizer plugin service (remote)  | No          | Required                 |
+| `POST /apis/anonymizer/v2/workspaces/{workspace}/preview` | Anonymizer plugin service (remote) | No | Required |
 
 ## Step 1: Build a `PreviewRequest`
 
-A preview request bundles the `AnonymizerConfig`, the input spec, and optional `model_configs` / `selected_models`.
+A preview request bundles the `AnonymizerConfig`, the input spec, and `model_configs` / `selected_models`. `model_configs` is optional on the request model for compatibility, but required by plugin-service preview execution.
 
 ```python
 import os
@@ -83,15 +83,69 @@ Field reference:
 | Field             | Type                                  | Notes                                                                                                                  |
 |-------------------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------|
 | `config`          | [`AnonymizerConfig`](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) | The library config. The example uses `Redact`; the plugin also supports `substitute`, `annotate`, `hash`, and `rewrite`. |
-| `data.source`     | string                                | Local path, `http(s)` URL, or fileset reference. See [input source forms](#input-source-forms).                        |
+| `data.source`     | string                                | Local CSV/Parquet path for CLI with `--fileset`, `http(s)` URL, or fileset reference. SDK/API callers should use `http(s)` or fileset. See [input source forms](#input-source-forms). |
 | `data.text_column`| string                                | Column containing text to anonymize. Defaults to `text`.                                                               |
 | `data.id_column`  | string                                | Optional record identifier column.                                                                                     |
 | `data.data_summary`| string                               | Optional short description passed to Anonymizer library prompts.                                                       |
-| `model_configs`   | list                                  | Data Designer `ModelConfig` entries. `provider` must reference an Inference Gateway provider name (or `workspace/provider`). Omit to use Anonymizer library defaults (CLI local execution only). |
+| `model_configs`   | list                                  | Optional on the request model, but required for remote preview execution in the plugin service. Data Designer `ModelConfig` entries; each `provider` must reference an Inference Gateway provider name (or `workspace/provider`). |
 | `selected_models` | object                                | Optional `detection` / `replace` / `rewrite` overrides on top of the bundled defaults. Requires `model_configs`.       |
 | `num_records`     | int (≥ 1)                             | Number of records to preview. Defaults to 10.                                                                          |
 
-## Step 2: Run with the Python SDK
+For CLI usage, the repo includes a ready-to-run shared spec at
+`plugins/nemo-anonymizer/examples/redact.yaml`. It points at the checked-in CSV
+so the CLI can upload it. Use `--num-records` to choose the preview sample size:
+
+```yaml
+# plugins/nemo-anonymizer/examples/redact.yaml
+config:
+  replace:
+    kind: redact
+    format_template: "[REDACTED_{label}]"
+data:
+  source: "plugins/nemo-anonymizer/examples/anonymizer-input.csv"
+  text_column: biography
+  id_column: id
+model_configs:
+  - alias: gliner-pii-detector
+    provider: nvidia-build
+    model: nvidia/gliner-pii
+  - alias: gpt-oss-120b
+    provider: nvidia-build
+    model: openai/gpt-oss-120b
+  - alias: nemotron-30b-thinking
+    provider: nvidia-build
+    model: nvidia/nemotron-3-nano-30b-a3b
+```
+
+## Step 2: Run with the CLI
+
+```bash
+nemo anonymizer preview \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --num-records 2 \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}" \
+  --fileset anonymizer-inputs \
+  --output-file preview.ndjson
+```
+
+The command streams non-log frames to stdout by default. With `--output-file`,
+frames are written to that file instead. Log frames are printed to stderr; add
+`--quiet` to suppress them. Add `--output-remote-path previews/redact.ndjson`
+to save the same non-log stream in `--fileset` after the preview succeeds.
+
+Filter the preview dataset from the NDJSON stream:
+
+```bash
+jq -R 'fromjson? | select(.kind == "preview_dataset") | .records' \
+  preview.ndjson
+```
+
+## Step 3: Run with the Python SDK
+
+Use `preview()` for the normal SDK path. It consumes the service stream and
+returns an `AnonymizerPreviewResult` with pandas DataFrames after the preview
+completes:
 
 ```python
 import os
@@ -109,11 +163,24 @@ preview.failed_records     # list[dict] of per-record failures (usually empty)
 preview.display_record(0)  # render record 0 with entity highlights in a notebook
 ```
 
-`AnonymizerResource.preview` calls the plugin service, so the same constraints as `preview submit` apply: use a fileset or `http(s)` source, and include `model_configs`.
+Both SDK preview methods call the plugin service directly. Use a fileset or
+`http(s)` source, and include `model_configs`.
+
+Use `preview_stream()` when you need frame-by-frame handling, such as forwarding
+logs or progress to a UI, or writing custom NDJSON/frame handling:
+
+```python
+for frame in sdk.anonymizer.preview_stream(request):
+    if frame.kind == "log":
+        print(frame.message)
+    elif frame.kind == "preview_dataset":
+        preview_records = frame.records
+```
 
 <Accordion title="Async client">
 
-`AsyncAnonymizerResource.preview` has the same signature and return type:
+`AsyncAnonymizerResource.preview` has the same signature and return type. Use
+`preview_stream` with `async for` when you need frame-by-frame handling:
 
 ```python
 import os
@@ -124,10 +191,14 @@ async_sdk = AsyncNeMoPlatform(
     workspace=WORKSPACE,
 )
 preview = await async_sdk.anonymizer.preview(request)
+
+async for frame in async_sdk.anonymizer.preview_stream(request):
+    ...
 ```
 
 </Accordion>
-## Step 3: Persist Preview Records
+
+## Step 4: Persist Preview Records
 
 `AnonymizerPreviewResult.dataset` and `trace_dataset` are pandas DataFrames, so save them with standard pandas methods:
 
@@ -141,62 +212,56 @@ preview.dataset.to_parquet("anonymized-preview.parquet", index=False)
 `AnonymizerPreviewResult` stores everything in memory; nothing is persisted to disk by default. The `dataset` field is a regular pandas DataFrame and can be saved with `to_csv` or `to_parquet`.
 
 </Accordion>
-## Step 4: Run from the CLI (Alternative)
 
-The CLI accepts the same request shape as a YAML spec file. Use `preview run` for local execution (allows local paths, model configs optional) or `preview submit` for the plugin service path (same as `sdk.anonymizer.preview`).
+## Step 5: Call the HTTP API Directly
 
-Write the spec to YAML:
+The HTTP API accepts the same `PreviewRequest` shape as JSON and streams raw NDJSON frames.
+
+Write the request body to JSON:
 
 ```python
-import yaml
+import json
 from pathlib import Path
 
-spec_path = Path("/tmp/anonymizer-preview.yaml")
-spec_path.write_text(yaml.safe_dump(request.model_dump(mode="json", exclude_none=True)))
+request_path = Path("anonymizer-preview.json")
+request_path.write_text(json.dumps(request.model_dump(mode="json", exclude_none=True)))
 ```
 
-Run preview locally:
+Call the preview endpoint:
 
 ```bash
-nemo anonymizer preview run \
-  --spec-file /tmp/anonymizer-preview.yaml \
-  --workspace "${NMP_WORKSPACE:-default}"
+curl -N -X POST \
+  "${NMP_BASE_URL:-http://localhost:8080}/apis/anonymizer/v2/workspaces/${NMP_WORKSPACE:-default}/preview" \
+  -H "Content-Type: application/json" \
+  --data-binary @anonymizer-preview.json
 ```
 
-Or submit to the plugin service:
+Filter the response with `jq`:
 
 ```bash
-nemo anonymizer preview submit \
-  --spec-file /tmp/anonymizer-preview.yaml \
-  --workspace "${NMP_WORKSPACE:-default}" \
-  --base-url "${NMP_BASE_URL:-http://localhost:8080}"
-```
-
-Both commands stream NDJSON frames to stdout. Filter with `jq`:
-
-```bash
-nemo anonymizer preview run \
-  --spec-file /tmp/anonymizer-preview.yaml \
-  --workspace "${NMP_WORKSPACE:-default}" \
-  > /tmp/anonymizer-preview.ndjson
+curl -N -X POST \
+  "${NMP_BASE_URL:-http://localhost:8080}/apis/anonymizer/v2/workspaces/${NMP_WORKSPACE:-default}/preview" \
+  -H "Content-Type: application/json" \
+  --data-binary @anonymizer-preview.json \
+  > anonymizer-preview.ndjson
 
 jq -R 'fromjson? | select(.kind == "preview_dataset") | .records' \
-  /tmp/anonymizer-preview.ndjson
+  anonymizer-preview.ndjson
 ```
 
-If `preview submit` returns 404 against the gateway, the plugin service isn't mounted. Restart `nemo services run` so the plugin is discovered and remounts `/apis/anonymizer/...`; see [Setup](/documentation/get-started).
+If the preview endpoint returns 404 against the gateway, the plugin service isn't mounted. Restart `nemo services run` so the plugin is discovered and remounts `/apis/anonymizer/...`; see [Setup](/documentation/get-started).
 
 ## Input Source Forms
 
-The plugin accepts three forms for `data.source`:
+The plugin accepts these forms for `data.source`:
 
-| Form                                  | `sdk.anonymizer.preview` / `preview submit` | `preview run` |
-|---------------------------------------|-----------------------------------|---------------|
-| Local path (`/tmp/input.csv`)         | No                                | Yes           |
-| HTTP(S) URL (`https://.../input.csv`) | Yes                               | Yes           |
-| Fileset reference                     | Yes                               | Yes           |
+| Form                                  | CLI preview | SDK/API preview |
+|---------------------------------------|-------------|-----------------|
+| Local path (`./data/input.csv`)       | Yes, with `--fileset` | No |
+| HTTP(S) URL (`https://.../input.csv`) | Yes         | Yes             |
+| Fileset reference                     | Yes         | Yes             |
 
-Fileset references take any of these forms; the workspace and fileset must already exist:
+Fileset references take any of these forms:
 
 ```text
 fileset://<workspace>/<fileset>#<path>
@@ -214,13 +279,13 @@ If you want to validate just the `AnonymizerConfig` (and optionally a `model_con
 from pathlib import Path
 import yaml
 
-Path("/tmp/anonymizer-config.yaml").write_text(yaml.safe_dump({
+Path("./anonymizer-config.yaml").write_text(yaml.safe_dump({
     "replace": {"kind": "redact", "format_template": "[REDACTED_{label}]"},
 }))
 ```
 
 ```bash
-nemo anonymizer validate --config /tmp/anonymizer-config.yaml
+nemo anonymizer validate --config ./anonymizer-config.yaml
 ```
 
 `validate` checks the config against the model selection (for example, that a `Substitute` strategy has a `replacement_generator` model defined) and prints `Config is valid.` on success. It does not accept `data.source`, so input-source validation happens during `preview` or `run`.

--- a/docs/anonymizer/tutorials/run.mdx
+++ b/docs/anonymizer/tutorials/run.mdx
@@ -7,29 +7,30 @@ description: ""
 ---
 <a id="anonymizer-tutorials-run"></a>
 
-This tutorial walks through the `anonymizer.run` job: defining a run spec, executing it locally or on the NeMo Platform Jobs worker, and loading the parquet artifacts it produces.
-
-For detection, rewrite, and replacement strategy details, see the [open-source library documentation](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs).
-
 ## Prerequisites
 
 Complete the [tutorials prerequisites](/documentation/anonymize-data/tutorials#prerequisites), which cover:
 
 - A running NeMo Platform cluster with the `nemo anonymizer` CLI available (see [Setup](/documentation/get-started)).
 - An inference provider configured (default examples use `nvidia-build`).
-- A fileset named `anonymizer-inputs` with `anonymizer-input.csv` uploaded.
+- The checked-in sample CSV at `plugins/nemo-anonymizer/examples/anonymizer-input.csv`. The CLI uploads it when you pass `--fileset anonymizer-inputs`.
+
+This tutorial walks through the `anonymizer.run` job: defining a run spec, submitting it to the NeMo Platform Jobs worker, and loading the parquet artifacts it produces.
+
+For detection, rewrite, and replacement strategy details, see the [open-source library documentation](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs).
 
 ## What `run` Does
 
 `anonymizer.run` executes the full Anonymizer pipeline on every record of an input file and writes the output as job artifacts.
 
-There are three run commands:
+`nemo anonymizer run` submits the job to the NeMo Platform Jobs worker:
 
-| Command                       | Where it runs                                | Local paths | `model_configs` required | Artifacts                                              |
-|-------------------------------|----------------------------------------------|-------------|--------------------------|--------------------------------------------------------|
-| `nemo anonymizer run run`     | Local CLI process via generated `is_local` path | Allowed     | Optional                 | Written under `persistent/results/artifacts` locally   |
-| `nemo anonymizer run submit`  | NeMo Platform Jobs worker                | Rejected    | Required                 | Stored in NeMo Platform job artifact storage; pull with `download_artifacts()` |
-| `nemo anonymizer run explain` | Local schema introspection                   | n/a         | n/a                      | Prints job key, submit endpoint, and input/spec schemas |
+| Command                                | Behavior                                              |
+|----------------------------------------|-------------------------------------------------------|
+| `nemo anonymizer run`                  | Submit an `anonymizer.run` job.                       |
+| `nemo anonymizer run --watch`          | Submit the job and stream status/logs until terminal. |
+| `nemo anonymizer run --watch --output-dir ./out` | Submit, watch, and download artifacts after success. |
+| `nemo anonymizer run --dry-run`        | Print the job schema and resolved submit request without submitting. |
 
 Job artifacts (under the `artifacts/` directory):
 
@@ -76,56 +77,65 @@ request = AnonymizerRequest(
 )
 ```
 
-## Step 2: Write the Spec to YAML
+## Step 2: Use the Example Spec
 
-The CLI run commands read a YAML spec file. Serialize the `AnonymizerRequest` directly:
+The repo includes a ready-to-run CLI spec in the same request shape. It points
+at the checked-in CSV so the CLI can upload it:
+
+```text
+plugins/nemo-anonymizer/examples/redact.yaml
+```
+
+To generate a custom spec from Python, serialize the `AnonymizerRequest`
+directly:
 
 ```python
 import yaml
 from pathlib import Path
 
-spec_path = Path("/tmp/anonymizer-run.yaml")
+spec_path = Path("anonymizer-run.yaml")
 spec_path.write_text(yaml.safe_dump(request.model_dump(mode="json", exclude_none=True)))
 ```
 
 ## Step 3: Run the Job
 
-Choose one execution path. Option A runs in the local CLI process. Option B submits the same request to the NeMo Platform Jobs worker.
-
-### Option A: Run Locally
+Submit the spec to the NeMo Platform Jobs worker:
 
 ```bash
-nemo anonymizer run run --spec-file /tmp/anonymizer-run.yaml
-```
-
-The local job context runs the Anonymizer library `Anonymizer.run(...)` in-process, then writes artifacts through the generated local job results manager.
-
-Expected output:
-
-```json
-{"exit_code": 0}
-```
-
-`run run` does not echo the artifact path on stdout. The local job results manager logs the path to stderr in the form:
-
-```text
-Saved result 'artifacts' to file:///.../persistent/results/artifacts
-```
-
-Use that path in the next step.
-
-### Option B: Submit to the Jobs Worker
-
-To execute the same spec on the NeMo Platform Jobs worker instead of in the CLI process, use `run submit`:
-
-```bash
-nemo anonymizer run submit \
-  --spec-file /tmp/anonymizer-run.yaml \
+nemo anonymizer run \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
   --workspace "${NMP_WORKSPACE:-default}" \
-  --base-url "${NMP_BASE_URL:-http://localhost:8080}"
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}" \
+  --fileset anonymizer-inputs
 ```
 
-The command prints the assigned job name. You need that name to poll status and download artifacts in Step 4.
+Add `--watch` to stream status and logs until the job reaches a terminal state:
+
+```bash
+nemo anonymizer run \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --fileset anonymizer-inputs \
+  --watch
+```
+
+Add `--output-dir` with `--watch` to download the final artifacts locally after
+the job completes:
+
+```bash
+nemo anonymizer run \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --fileset anonymizer-inputs \
+  --watch \
+  --output-dir ./anonymizer-artifacts
+```
+
+The CLI uploads local CSV/Parquet inputs to `--fileset` before submission. It
+also uses that fileset for run artifacts, which land under the job output path,
+for example `jobs/<job-name>/results/<attempt-id>/artifacts/...`.
+
+The submit command prints the assigned job name. You need that name to poll status and download artifacts in Step 4 unless you used `--watch --output-dir`.
 
 The SDK equivalent is `sdk.anonymizer.run(request)`. It posts the request to the plugin's `/jobs/run` endpoint and returns an `AnonymizerJobResource`:
 
@@ -140,73 +150,32 @@ sdk = NeMoPlatform(
 job = sdk.anonymizer.run(request)
 ```
 
-Compared to `run run`, the submit path:
+Full runs:
 
-- Rejects local file paths in `data.source` — use a fileset reference (`<fileset>#<path>`) or `http(s)` URL.
-- Requires explicit `model_configs` referencing Inference Gateway providers, because the job runs outside the CLI process and cannot inherit Data Designer's locally-defined providers.
+- Support local CSV/Parquet paths through the CLI when `--fileset` is supplied. SDK/API callers should use a fileset reference (`<fileset>#<path>`) or `http(s)` URL.
+- Require explicit `model_configs` whose `provider` values reference Inference Gateway providers in the target workspace; the job resolves those provider endpoints before execution.
 
 ## Step 4: Get Results
 
-### Option A Results: Local Run
-
-For `run run`, the result already exists on the local filesystem. Use the artifact directory printed in stderr:
+Track the platform job first. The job is ready for artifact download when its status is `completed`:
 
 ```bash
-ARTIFACTS_DIR=/path/to/persistent/results/artifacts
-ls "$ARTIFACTS_DIR"
-```
-
-Then load the parquet artifacts from that directory:
-
-```python
-import json
-from pathlib import Path
-
-import pandas as pd
-
-artifacts_dir = Path("/path/to/persistent/results/artifacts")  # from the stderr log
-
-metadata = json.loads((artifacts_dir / "metadata.json").read_text())
-dataset = pd.read_parquet(artifacts_dir / "dataset.parquet", dtype_backend="pyarrow")
-trace = pd.read_parquet(artifacts_dir / "trace.parquet", dtype_backend="pyarrow")
-
-failed_path = artifacts_dir / "failed_records.json"
-failed_records = json.loads(failed_path.read_text()) if failed_path.exists() else []
-
-print(dataset.head())
-print(f"records={len(dataset)} failures={len(failed_records)}")
-```
-
-The trace dataset (and the dataset itself for `annotate` / `substitute` strategies) contains pyarrow-backed `struct<entities: list<...>>` columns. If you need plain Python `dict`/`list` values for JSON output, use `pyarrow.parquet`:
-
-```python
-import pyarrow.parquet as pq
-
-table = pq.read_table(artifacts_dir / "dataset.parquet")
-records = table.slice(0, 5).to_pylist()
-```
-
-### Option B Results: Remote Run
-
-For `run submit`, track the platform job first. The job is ready for artifact download when its status is `completed`:
-
-```bash
-# Replace with the job name printed by `run submit`.
+# Replace with the job name printed by `nemo anonymizer run`.
 nemo jobs get-status <job-name> --workspace "${NMP_WORKSPACE:-default}"
 nemo jobs get-logs <job-name> --workspace "${NMP_WORKSPACE:-default}"
 ```
 
-To download from the CLI, fetch the `artifacts` result and extract it:
+If you did not pass `--output-dir`, fetch the `artifacts` result and extract it:
 
 ```bash
 nemo jobs results download artifacts \
   --job <job-name> \
   --workspace "${NMP_WORKSPACE:-default}" \
-  --output-file /tmp/anonymizer-artifacts.tar.gz
+  --output-file ./anonymizer-artifacts.tar.gz
 
-mkdir -p /tmp/anonymizer-artifacts
-tar -xzf /tmp/anonymizer-artifacts.tar.gz -C /tmp/anonymizer-artifacts
-ls /tmp/anonymizer-artifacts/artifacts
+mkdir -p ./anonymizer-artifacts
+tar -xzf ./anonymizer-artifacts.tar.gz -C ./anonymizer-artifacts
+ls ./anonymizer-artifacts/artifacts
 ```
 
 Then point `AnonymizerJobResults` at the extracted `artifacts` directory:
@@ -216,7 +185,7 @@ from pathlib import Path
 
 from nemo_anonymizer_plugin.sdk.job_results import AnonymizerJobResults
 
-results = AnonymizerJobResults(Path("/tmp/anonymizer-artifacts/artifacts"))
+results = AnonymizerJobResults(Path("./anonymizer-artifacts/artifacts"))
 
 dataset = results.load_dataset()
 trace   = results.load_trace()
@@ -241,28 +210,18 @@ failed  = results.load_failed_records()
 
 `AnonymizerJobResults` exposes `load_dataset()`, `load_trace()`, `load_failed_records()`, and `display_record()` over the same underlying files. See [SDK Resources](/documentation/anonymize-data/sdk-resources#anonymizerjobresults).
 
-## Inspect the Schema Without Running
-
-`run explain` prints the job key, submit endpoint, and JSON schemas for `AnonymizerRequest` and the canonical `AnonymizerStepConfig`:
-
-```bash
-nemo anonymizer run explain
-```
-
-This is useful when authoring a spec programmatically or wiring the job into another tool.
-
 ## How the Job Compiles
 
 For each request, the plugin:
 
 1. Validates the Anonymizer library `AnonymizerConfig`.
-2. Validates the input source (rejects local paths on remote execution; checks fileset refs).
+2. Validates the input source and, for CLI calls with `--fileset`, uploads local CSV/Parquet inputs before remote execution.
 3. Validates that `selected_models` overrides also have `model_configs`.
-4. Resolves `model_configs` providers — locally-defined Data Designer providers first, then Inference Gateway providers. Remote execution (`run submit`) resolves only through the Inference Gateway.
+4. Resolves `model_configs` providers through the Inference Gateway.
 5. Renders a unified `model_configs` YAML body for the library.
-6. Stores the resolved providers and YAML in the internal `AnonymizerStepConfig` consumed by the worker (in-process for `run run`, or on the Jobs worker for `run submit`).
+6. Stores the resolved providers and YAML in the internal `AnonymizerStepConfig` consumed by the Jobs worker.
 
-For `run submit`, provider endpoints are re-resolved at runtime so the job uses the in-cluster Inference Gateway address rather than the address captured at submission time.
+Provider endpoints are re-resolved at runtime so the job uses the in-cluster Inference Gateway address rather than the address captured at submission time.
 
 ## Next Steps
 

--- a/packages/nemo_platform/pyproject.toml
+++ b/packages/nemo_platform/pyproject.toml
@@ -700,8 +700,8 @@ auditor = "nemo_auditor.docs:get_docs_path"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nemo.functions"]
-"anonymizer.preview" = "nemo_anonymizer_plugin.functions.preview:PreviewFunction"
 "data-designer.preview" = "nemo_data_designer_plugin.functions.preview:PreviewFunction"
+"anonymizer.preview" = "nemo_anonymizer_plugin.functions.preview:PreviewFunction"
 
 # Generated from [tool.bundle-package]; do not edit this table by hand.
 [project.entry-points."nemo.inference_middleware"]

--- a/plugins/nemo-anonymizer/README.md
+++ b/plugins/nemo-anonymizer/README.md
@@ -9,8 +9,8 @@ to detect and replace/rewrite PII in tabular text data.
 
 The plugin exposes an `anonymizer` service, CLI commands under
 `nemo anonymizer`, an SDK accessor on `NeMoPlatform.anonymizer`, a streaming
-`anonymizer.preview` function, and an `anonymizer.run` job that executes
-on the `nmp-cpu-tasks` container image.
+preview API, and an `anonymizer.run` job that executes on the
+`nmp-cpu-tasks` container image.
 
 ## What it does
 
@@ -26,10 +26,9 @@ The plugin provides functional parity with the
 [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer):
 
 - All four replacement strategies + `Rewrite` mode.
-- Input sources: local file path, `http(s)://` URL, or NeMo Platform fileset reference.
-  Local paths are only supported by local execution (`run` verbs).
-- Remote execution requires `model_configs` so requests route through NeMo Platform
-  Inference Gateway instead of the library's NVIDIA Build defaults.
+- Input sources for platform execution: local CSV/Parquet files through the CLI with `--fileset`, `http(s)://` URLs, or NeMo Platform fileset references.
+- Preview and run requests require `model_configs` so model calls route through
+  NeMo Platform Inference Gateway instead of the library's NVIDIA Build defaults.
 
 ## Installation (developer)
 
@@ -42,16 +41,23 @@ uv sync
 ## CLI quickstart
 
 ```bash
-nemo anonymizer preview run --spec-file ./preview_spec.yaml
-nemo anonymizer preview submit --spec-file ./preview_spec.yaml --workspace my-workspace
-
-nemo anonymizer run run --spec-file ./run_spec.yaml
-nemo anonymizer run submit --spec-file ./run_spec.yaml --workspace my-workspace
+nemo anonymizer preview --spec-file plugins/nemo-anonymizer/examples/redact.yaml --num-records 2 --workspace my-workspace --fileset anonymizer-inputs
+nemo anonymizer preview --spec-file plugins/nemo-anonymizer/examples/redact.yaml --num-records 2 --workspace my-workspace --fileset anonymizer-inputs --output-file preview.ndjson --quiet
+nemo anonymizer preview --spec-file plugins/nemo-anonymizer/examples/redact.yaml --num-records 2 --workspace my-workspace --fileset anonymizer-inputs --output-remote-path previews/redact.ndjson
+nemo anonymizer run --spec-file plugins/nemo-anonymizer/examples/redact.yaml --workspace my-workspace --fileset anonymizer-inputs
+nemo anonymizer run --spec-file plugins/nemo-anonymizer/examples/redact.yaml --workspace my-workspace --fileset anonymizer-inputs --watch
+nemo anonymizer run --spec-file plugins/nemo-anonymizer/examples/redact.yaml --workspace my-workspace --fileset anonymizer-inputs --watch --output-dir ./anonymizer-artifacts
+nemo anonymizer run --spec-file plugins/nemo-anonymizer/examples/redact.yaml --workspace my-workspace --fileset anonymizer-inputs --dry-run  # print schema/request without submitting
 ```
 
-Local execution can use local files, `http(s)` URLs, filesets, and locally
-defined Data Designer model providers. Remote execution supports `http(s)` URLs
-and filesets, and requires explicit `model_configs`.
+Preview runs through the Anonymizer plugin service and streams non-log NDJSON
+frames to stdout or `--output-file`; log frames go to stderr unless `--quiet`
+is set. The example spec points at `plugins/nemo-anonymizer/examples/anonymizer-input.csv`;
+pass `--fileset anonymizer-inputs` and the CLI uploads it before preview or run.
+Full anonymizer runs execute as NeMo Platform Jobs. When `--fileset` is set,
+run artifacts are stored in that fileset, and `--watch --output-dir` downloads
+them locally after success. SDK/API callers should use `http(s)` URLs or
+filesets directly and require explicit `model_configs`.
 
 Fileset input references point at one CSV or Parquet file:
 

--- a/plugins/nemo-anonymizer/examples/README.md
+++ b/plugins/nemo-anonymizer/examples/README.md
@@ -1,0 +1,24 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Anonymizer Examples
+
+This spec is usable from the repo root. It points at the checked-in
+`anonymizer-input.csv`; pass `--fileset` and the CLI uploads it before calling
+the Anonymizer service.
+
+```bash
+nemo anonymizer preview \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --num-records 2 \
+  --fileset anonymizer-inputs \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --output-file preview.ndjson
+
+nemo anonymizer run \
+  --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+  --fileset anonymizer-inputs \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --watch \
+  --output-dir ./anonymizer-artifacts
+```

--- a/plugins/nemo-anonymizer/examples/anonymizer-input.csv
+++ b/plugins/nemo-anonymizer/examples/anonymizer-input.csv
@@ -1,0 +1,3 @@
+id,biography
+1,Alice Johnson lives in Seattle and works at NVIDIA.
+2,Bob Smith can be reached at bob.smith@example.com.

--- a/plugins/nemo-anonymizer/examples/redact.yaml
+++ b/plugins/nemo-anonymizer/examples/redact.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Run from the repo root. The CLI uploads the local CSV to --fileset before
+# calling the preview service or submitting the run job.
+#
+#   nemo anonymizer preview \
+#     --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+#     --num-records 2 \
+#     --fileset anonymizer-inputs \
+#     --workspace default \
+#     --output-file preview.ndjson
+#
+#   nemo anonymizer run \
+#     --spec-file plugins/nemo-anonymizer/examples/redact.yaml \
+#     --fileset anonymizer-inputs \
+#     --workspace default \
+#     --watch \
+#     --output-dir ./anonymizer-artifacts
+
+config:
+  replace:
+    kind: redact
+    format_template: "[REDACTED_{label}]"
+data:
+  source: "plugins/nemo-anonymizer/examples/anonymizer-input.csv"
+  text_column: biography
+  id_column: id
+model_configs:
+  - alias: gliner-pii-detector
+    provider: nvidia-build
+    model: nvidia/gliner-pii
+  - alias: gpt-oss-120b
+    provider: nvidia-build
+    model: openai/gpt-oss-120b
+  - alias: nemotron-30b-thinking
+    provider: nvidia-build
+    model: nvidia/nemotron-3-nano-30b-a3b

--- a/plugins/nemo-anonymizer/openapi/openapi.yaml
+++ b/plugins/nemo-anonymizer/openapi/openapi.yaml
@@ -509,8 +509,8 @@ components:
         source:
           type: string
           title: Source
-          description: Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet
-            input file.
+          description: Local CSV/Parquet path for CLI calls with --fileset, or HTTP(S)
+            URL / fileset reference for SDK/API calls.
         text_column:
           type: string
           minLength: 1
@@ -563,11 +563,11 @@ components:
         \ text/id columns.\n  model_configs:    DD ``ModelConfig`` list. ``provider``\
         \ on each entry must\n                    reference a NeMo Platform inference\
         \ provider name (optionally\n                    ``workspace/provider``).\
-        \ When omitted, the upstream\n                    library defaults are used\
-        \ (which point at\n                    ``build.nvidia.com``); supplying this\
-        \ is the recommended\n                    path on NeMo Platform.\n  selected_models:\
-        \  Optional role->alias overrides. Omitted roles fall back\n             \
-        \       to the upstream library YAML defaults."
+        \ Optional on the request model for\n                    compatibility, but\
+        \ required by plugin preview/run execution\n                    so requests\
+        \ route through NeMo Platform Inference Gateway.\n  selected_models:  Optional\
+        \ role->alias overrides. Omitted roles fall back\n                    to the\
+        \ upstream library YAML defaults."
     AnonymizerStepConfig:
       properties:
         request:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/context.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/context.py
@@ -1,18 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Local/remote runtime context for the Anonymizer plugin."""
+"""Runtime context for the Anonymizer plugin."""
 
 from __future__ import annotations
 
-from typing import Protocol
-
 import data_designer.config as dd
 from data_designer.config.models import ModelProvider as DDModelProvider
-from data_designer_nemo.model_provider import (
-    make_local_first_model_provider_registry,
-    make_model_provider_registry,
-)
+from data_designer_nemo.model_provider import make_model_provider_registry
 from data_designer_nemo.sdk_translation import sync_to_async_sdk
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.input import (
@@ -24,73 +19,24 @@ from nemo_anonymizer_plugin.app.input import (
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 
 
-class AnonymizerContext(Protocol):
-    async def make_model_providers(
-        self,
-        model_configs: list[dd.ModelConfig] | None,
-        *,
-        require_model_configs: bool,
-    ) -> list[DDModelProvider] | None: ...
-
-    async def prepare_input(self, data: AnonymizerInputSpec) -> PreparedAnonymizerInput: ...
-
-    def validate_input_reference(self, data: AnonymizerInputSpec) -> None: ...
+def require_model_configs_for_execution(model_configs: list[dd.ModelConfig] | None) -> list[dd.ModelConfig]:
+    if not model_configs:
+        raise AnonymizerInvalidConfigError(
+            "model_configs are required for anonymizer execution so requests route through NeMo Platform "
+            "Inference Gateway instead of Anonymizer library defaults."
+        )
+    return model_configs
 
 
-class LocalAnonymizerContext:
+class AnonymizerContext:
     def __init__(self, sdk: AsyncNeMoPlatform | NeMoPlatform, workspace: str):
         self._sdk = sdk
         self._workspace = workspace
 
     async def make_model_providers(
         self,
-        model_configs: list[dd.ModelConfig] | None,
-        *,
-        require_model_configs: bool,
+        model_configs: list[dd.ModelConfig],
     ) -> list[DDModelProvider] | None:
-        if not model_configs:
-            if require_model_configs:
-                raise AnonymizerInvalidConfigError("model_configs are required for this anonymizer execution path.")
-            return None
-        registry = await make_local_first_model_provider_registry(
-            model_configs,
-            sdk=self._sdk,
-            default_workspace=self._workspace,
-        )
-        if registry is None:
-            return None
-        return registry.providers
-
-    async def prepare_input(self, data: AnonymizerInputSpec) -> PreparedAnonymizerInput:
-        return await prepare_anonymizer_input_async(
-            data,
-            sdk=self._sdk,
-            workspace=self._workspace,
-            allow_local_paths=True,
-        )
-
-    def validate_input_reference(self, data: AnonymizerInputSpec) -> None:
-        validate_anonymizer_input_source(data, workspace=self._workspace, allow_local_paths=True)
-
-
-class RemoteAnonymizerContext:
-    def __init__(self, sdk: AsyncNeMoPlatform | NeMoPlatform, workspace: str):
-        self._sdk = sdk
-        self._workspace = workspace
-
-    async def make_model_providers(
-        self,
-        model_configs: list[dd.ModelConfig] | None,
-        *,
-        require_model_configs: bool,
-    ) -> list[DDModelProvider] | None:
-        if not model_configs:
-            if require_model_configs:
-                raise AnonymizerInvalidConfigError(
-                    "model_configs are required for remote anonymizer execution so requests route through NeMo Platform "
-                    "Inference Gateway instead of Anonymizer library defaults."
-                )
-            return None
         async_sdk = sync_to_async_sdk(self._sdk) if isinstance(self._sdk, NeMoPlatform) else self._sdk
         registry = await make_model_provider_registry(
             model_configs,
@@ -114,10 +60,7 @@ class RemoteAnonymizerContext:
 
 
 def create_anonymizer_context(
-    is_local: bool,
     sdk: AsyncNeMoPlatform | NeMoPlatform,
     workspace: str,
 ) -> AnonymizerContext:
-    if is_local:
-        return LocalAnonymizerContext(sdk, workspace)
-    return RemoteAnonymizerContext(sdk, workspace)
+    return AnonymizerContext(sdk, workspace)

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/input.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/input.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-import anyio
 from anonymizer.config.anonymizer_config import AnonymizerInput
+from anyio.to_thread import run_sync as run_sync_in_worker_thread
 from filesets import FilesetPathError, build_fileset_ref, parse_fileset_ref
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
@@ -35,7 +35,11 @@ class AnonymizerInputSpec(BaseModel):
     is constructed.
     """
 
-    source: str = Field(description="Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet input file.")
+    source: str = Field(
+        description=(
+            "Local CSV/Parquet path for CLI calls with --fileset, or HTTP(S) URL / fileset reference for SDK/API calls."
+        )
+    )
     text_column: str = Field(default="text", min_length=1, description="Column containing text to anonymize.")
     id_column: str | None = Field(default=None, description="Optional column to use as record identifier.")
     data_summary: str | None = Field(default=None, description="Short description of the data.")
@@ -106,7 +110,7 @@ async def prepare_anonymizer_input_async(
         if sdk is None:
             raise AnonymizerInvalidConfigError("Fileset input requires a NeMo Platform SDK.")
         if isinstance(sdk, NeMoPlatform):
-            return await anyio.to_thread.run_sync(
+            return await run_sync_in_worker_thread(
                 partial(
                     prepare_anonymizer_input,
                     data,

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/model_configs.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/model_configs.py
@@ -4,8 +4,10 @@
 """Build and validate the ``model_configs`` YAML for the Anonymizer library.
 
 ``Anonymizer(model_configs=...)`` takes a unified YAML (string or file path)
-defining the model pool and optional ``selected_models`` overrides; ``None``
-uses bundled defaults. See ``anonymizer/config/default_model_configs/README.md``.
+defining the model aliases and optional ``selected_models`` overrides. The
+standalone library can use bundled defaults when this is omitted, but plugin
+preview/run execution requires explicit entries so providers resolve through
+NeMo Platform Inference Gateway.
 
 The plugin accepts overrides as a loose dict (``SelectedModelsOverrides``)
 because some roles take a scalar and others take a pool, then renders the
@@ -103,8 +105,8 @@ def validate_selected_models_have_model_configs(
 
     Upstream treats ``selected_models`` as a section in the same unified YAML
     document as ``model_configs``. If the plugin accepts overrides without a
-    model pool, the only choices are to silently ignore them or synthesize a
-    local default model pool that bypasses NeMo Platform provider resolution. Failing
+    model pool, the only choices are to silently ignore them or synthesize an
+    implicit default pool that bypasses NeMo Platform provider resolution. Failing
     fast keeps the user's intent explicit.
     """
     if has_selected_model_overrides(selected_models) and not model_configs:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/task_config.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/task_config.py
@@ -31,10 +31,9 @@ class AnonymizerRequest(BaseModel):
       data:             AnonymizerInputSpec — source URL/path/fileset + text/id columns.
       model_configs:    DD ``ModelConfig`` list. ``provider`` on each entry must
                         reference a NeMo Platform inference provider name (optionally
-                        ``workspace/provider``). When omitted, the upstream
-                        library defaults are used (which point at
-                        ``build.nvidia.com``); supplying this is the recommended
-                        path on NeMo Platform.
+                        ``workspace/provider``). Optional on the request model for
+                        compatibility, but required by plugin preview/run execution
+                        so requests route through NeMo Platform Inference Gateway.
       selected_models:  Optional role->alias overrides. Omitted roles fall back
                         to the upstream library YAML defaults.
     """
@@ -70,7 +69,7 @@ class AnonymizerStepConfig(BaseModel):
 
     request: AnonymizerRequest
     # YAML body to hand to ``Anonymizer(model_configs=...)`` after the service
-    # resolved providers and roles. Empty string means "use library defaults".
+    # resolved providers and roles.
     model_configs_yaml: str
     # Provider definitions resolved against NeMo Platform. Each entry already points at
     # the Inference Gateway URL with the right auth headers. The task will pass

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/cli.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/cli.py
@@ -5,16 +5,133 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import inspect
+import io
+import json
+import tarfile
+import tempfile
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Optional, cast
+from types import FunctionType
+from typing import Any, ClassVar, Literal, Optional, TextIO, cast
+from urllib.parse import quote
 
+import httpx
 import typer
 import yaml
 from anonymizer.config.anonymizer_config import AnonymizerConfig
+from nemo_anonymizer_plugin import cli_files
+from nemo_anonymizer_plugin.app.task_config import AnonymizerRequest, PreviewRequest
 from nemo_anonymizer_plugin.app.upstream_logging import preserve_root_logging
+from nemo_anonymizer_plugin.functions.preview import PreviewFunction
+from nemo_platform import NeMoPlatform
+from nemo_platform_ext.cli.core.job_watch_renderer import render_job_watch_events
+from nemo_platform_plugin._spec_flags import (
+    UNSET,
+    SpecLeafField,
+    build_overlay,
+    deep_merge,
+    kw,
+    walk_spec_leaves,
+)
 from nemo_platform_plugin.cli import NemoCLI
+from nemo_platform_plugin.cli_errors import print_http_request_error, print_http_status_error
+from nemo_platform_plugin.cli_renderer import CLIRenderer, RendererContext
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.commands import (
+    _load_spec,
+    _merge_options_inputs,
+    _output_format_is_json,
+    _resolve_submit_auth_headers,
+    _resolve_submit_base_url,
+)
+from nemo_platform_plugin.function import NemoFunction
 from nemo_platform_plugin.job import NemoJob
+from nemo_platform_plugin.jobs.archive import safe_extract_tar
+from nemo_platform_plugin.jobs.client import JobsClient
+from nemo_platform_plugin.scheduler import NemoJobScheduler
+from pydantic import BaseModel, ValidationError
+
+_ANONYMIZER_RUN_RESERVED_FLAGS = {
+    "spec",
+    "spec_file",
+    "fileset",
+    "input_remote_path",
+    "output_dir",
+    "options",
+    "options_file",
+    "profile",
+    "cluster",
+    "base_url",
+    "workspace",
+    "verbose",
+    "dry_run",
+    "watch",
+    "timeout",
+    "poll_interval",
+    "include_history",
+}
+
+_ANONYMIZER_RUN_WRAPPER_FLAGS = {
+    "config",
+    "config_file",
+    "fileset",
+    "input_remote_path",
+    "output_dir",
+    "verbose",
+    "dry_run",
+    "watch",
+    "timeout",
+    "poll_interval",
+    "include_history",
+}
+
+_ANONYMIZER_PREVIEW_RESERVED_FLAGS = {
+    "spec",
+    "spec_file",
+    "cluster",
+    "base_url",
+    "workspace",
+    "request_id",
+    "fileset",
+    "input_remote_path",
+    "output_remote_path",
+    "quiet",
+    "output_file",
+}
+
+
+@dataclass(frozen=True)
+class _RunCLIArgs:
+    spec: str
+    spec_file: Path | None
+    fileset: str | None
+    input_remote_path: str | None
+    output_dir: Path | None
+    options: list[str]
+    options_file: Path | None
+    profile: str | None
+    cluster: str | None
+    base_url: str | None
+    workspace: str
+    verbose: bool
+    dry_run: bool
+    watch: bool
+    timeout: int | None
+    poll_interval: int
+    include_history: bool
+
+
+@dataclass(frozen=True)
+class _RunSubmission:
+    spec: dict[str, Any]
+    options: dict[str, Any] | None
+    metadata: dict[str, str] | None
+    base_url: str
+    headers: dict[str, str]
+    platform_client: NeMoPlatform | None
 
 
 class AnonymizerCLI(NemoCLI):
@@ -22,39 +139,47 @@ class AnonymizerCLI(NemoCLI):
     description: ClassVar[str] = "Anonymizer: detect and replace/rewrite PII in text data"
 
     def get_cli(self) -> typer.Typer:
-        # ``preview`` and ``run`` are generated from the NemoFunction/NemoJob
-        # entry points. Keep only explicit commands that are not generated.
+        # ``preview`` and ``run`` are generated from NemoFunction/NemoJob
+        # entry points, then customized through the hooks below.
         app = typer.Typer(name=self.name, help=self.description, no_args_is_help=True)
 
         @app.callback()
         def _root() -> None:
-            # Keep Typer in command-group mode even while ``validate`` is the
-            # only manually registered command.
+            # Keep Typer in command-group mode for explicit manual commands.
             pass
 
         app.command("validate")(validate_command)
         return app
 
+    def update_function_cli(self, fn_cls: type[NemoFunction], group: typer.Typer) -> None:
+        if fn_cls is PreviewFunction:
+            _install_anonymizer_preview_verb(group)
+
     def update_job_cli(self, job_cls: type[NemoJob], group: typer.Typer) -> None:
-        if job_cls.name != "run":
+        if job_cls.name != "run" or job_cls.input_spec_schema is not AnonymizerRequest:
             return
 
-        run_command = next((command for command in group.registered_commands if command.name == "run"), None)
-        if run_command is None or run_command.callback is None:
-            return
+        _install_anonymizer_run_verb(group, service=self.name, job_cls=job_cls)
 
-        run_callback = cast(Callable[..., None], run_command.callback)
-        signature = getattr(run_callback, "__signature__", None)
-        if signature is None:
-            return
+    def get_function_renderer(
+        self,
+        fn_cls: type[NemoFunction],
+        *,
+        verb: Literal["run", "submit"],
+    ) -> type[CLIRenderer] | None:
+        if fn_cls is PreviewFunction and verb == "submit":
+            return AnonymizerPreviewRenderer
+        return None
 
-        def _collapsed_run(typer_ctx: typer.Context, **kwargs: object) -> None:
-            if typer_ctx.invoked_subcommand is not None:
-                return
-            run_callback(typer_ctx, **kwargs)
-
-        setattr(_collapsed_run, "__signature__", signature)
-        group.callback(invoke_without_command=True)(_collapsed_run)
+    def get_job_renderer(
+        self,
+        job_cls: type[NemoJob],
+        *,
+        verb: Literal["run", "submit"],
+    ) -> type[CLIRenderer] | None:
+        if job_cls.name == "run" and job_cls.input_spec_schema is AnonymizerRequest and verb == "submit":
+            return AnonymizerRunRenderer
+        return None
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:
@@ -92,3 +217,791 @@ def validate_command(
     anonymizer = _make_local_anonymizer(model_configs=str(model_configs) if model_configs else None)
     anonymizer.validate_config(anonymizer_config)
     typer.echo("Config is valid.")
+
+
+def _install_anonymizer_run_verb(
+    group: typer.Typer,
+    *,
+    service: str,
+    job_cls: type[NemoJob],
+) -> None:
+    original = _pluck_command_callback(group, "run")
+    scheduler = _pluck_command_scheduler(original)
+    resource_name = f"{service}.{job_cls.name}"
+    schema = job_cls.input_spec_schema or job_cls.spec_schema
+    leaves = walk_spec_leaves(schema, reserved=_ANONYMIZER_RUN_RESERVED_FLAGS)
+
+    def run(typer_ctx: typer.Context, **kwargs: object) -> None:
+        """Submit an anonymizer run job to NeMo Platform."""
+        _run_anonymizer_run_command(
+            scheduler=scheduler,
+            job_cls=job_cls,
+            resource_name=resource_name,
+            original=original,
+            typer_ctx=typer_ctx,
+            leaves=leaves,
+            kwargs=dict(kwargs),
+        )
+
+    setattr(run, "__signature__", _build_anonymizer_run_signature(original))
+    _replace_command(group, "run", run, rich_help_panel="Jobs")
+
+
+def _run_anonymizer_run_command(
+    *,
+    scheduler: NemoJobScheduler,
+    job_cls: type[NemoJob],
+    resource_name: str,
+    original: Callable[..., None],
+    typer_ctx: typer.Context,
+    leaves: list[SpecLeafField],
+    kwargs: dict[str, object],
+) -> None:
+    args = _parse_run_cli_args(kwargs)
+    _validate_run_cli_args(args)
+    if _output_format_is_json(typer_ctx) and args.watch:
+        typer.echo("Error: --watch cannot be combined with JSON output.", err=True)
+        raise typer.Exit(code=2)
+
+    try:
+        submission = _prepare_run_submission(typer_ctx=typer_ctx, args=args, leaves=leaves, kwargs=kwargs)
+        if args.verbose or args.dry_run:
+            for document in _build_remote_job_diagnostics(scheduler, job_cls, args=args, submission=submission):
+                typer.echo(json.dumps(document, indent=2))
+            if args.dry_run:
+                return
+
+        run_result: dict[str, object] = {}
+        _delegate_run_submission(
+            original,
+            scheduler=scheduler,
+            typer_ctx=typer_ctx,
+            args=args,
+            submission=submission,
+            kwargs=kwargs,
+            run_result=run_result,
+        )
+    except ValidationError as exc:
+        typer.echo(f"Error: invalid run spec: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    except OSError as exc:
+        typer.echo(f"Error: unable to write run output: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    except httpx.HTTPStatusError as exc:
+        print_http_status_error(exc, action=f"submit {resource_name}")
+        raise typer.Exit(code=2) from exc
+    except httpx.RequestError as exc:
+        print_http_request_error(exc, action=f"submit {resource_name}")
+        raise typer.Exit(code=2) from exc
+    except httpx.HTTPError as exc:
+        typer.echo(f"Error: submit {resource_name} failed: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    if args.watch:
+        result = cast(dict[str, object] | None, run_result.get("job"))
+        if result is None:
+            typer.echo(f"Error: Unable to determine submitted {resource_name} job name for --watch", err=True)
+            raise typer.Exit(code=1)
+        _watch_run_job(
+            resource_name=resource_name,
+            submission=submission,
+            args=args,
+            result=result,
+            platform_client=submission.platform_client,
+        )
+
+
+def _parse_run_cli_args(kwargs: dict[str, object]) -> _RunCLIArgs:
+    return _RunCLIArgs(
+        spec=cast(str, kwargs.pop("spec", "{}")),
+        spec_file=cast(Path | None, kwargs.pop("spec_file", None)),
+        fileset=cast(str | None, kwargs.pop("fileset", None)),
+        input_remote_path=cast(str | None, kwargs.pop("input_remote_path", None)),
+        output_dir=cast(Path | None, kwargs.pop("output_dir", None)),
+        options=cast(list[str], kwargs.pop("options", [])),
+        options_file=cast(Path | None, kwargs.pop("options_file", None)),
+        profile=cast(str | None, kwargs.pop("profile", None)),
+        cluster=cast(str | None, kwargs.pop("cluster", None)),
+        base_url=cast(str | None, kwargs.pop("base_url", None)),
+        workspace=cast(str, kwargs.pop("workspace", "default")),
+        verbose=cast(bool, kwargs.pop("verbose", False)),
+        dry_run=cast(bool, kwargs.pop("dry_run", False)),
+        watch=cast(bool, kwargs.pop("watch", False)),
+        timeout=cast(int | None, kwargs.pop("timeout", None)),
+        poll_interval=cast(int, kwargs.pop("poll_interval", 3)),
+        include_history=cast(bool, kwargs.pop("include_history", True)),
+    )
+
+
+def _validate_run_cli_args(args: _RunCLIArgs) -> None:
+    if args.dry_run and args.watch:
+        typer.echo("Error: --dry-run cannot be combined with --watch.", err=True)
+        raise typer.Exit(code=2)
+    if args.output_dir is not None and args.dry_run:
+        typer.echo("Error: --output-dir cannot be combined with --dry-run.", err=True)
+        raise typer.Exit(code=2)
+    if args.output_dir is not None and not args.watch:
+        typer.echo("Error: --output-dir requires --watch so artifacts are available before download.", err=True)
+        raise typer.Exit(code=2)
+
+
+def _prepare_run_submission(
+    *,
+    typer_ctx: typer.Context,
+    args: _RunCLIArgs,
+    leaves: list[SpecLeafField],
+    kwargs: dict[str, object],
+) -> _RunSubmission:
+    base = _load_spec(args.spec, args.spec_file)
+    overlay = build_overlay(leaves, kwargs, unset_sentinel=UNSET)
+    spec_data = deep_merge(base, overlay)
+    options = cast(dict[str, Any], _merge_options_inputs(args.options, args.options_file)) or None
+    base_url = _resolve_submit_base_url(typer_ctx, base_url=args.base_url, cluster=args.cluster)
+    headers = _resolve_submit_auth_headers(typer_ctx)
+    request = AnonymizerRequest.model_validate(spec_data)
+
+    platform_client: NeMoPlatform | None = None
+    if args.fileset is not None and not args.dry_run:
+        platform_client = cli_files.make_platform_client(
+            base_url=base_url,
+            workspace=args.workspace,
+            headers=headers,
+        )
+    staged_request = cli_files.stage_anonymizer_request_for_remote(
+        request,
+        platform_client=platform_client,
+        workspace=args.workspace,
+        fileset=args.fileset,
+        input_remote_path=args.input_remote_path,
+        upload=not args.dry_run,
+    )
+    request = staged_request.request
+    if args.fileset is not None and not args.dry_run and not staged_request.source_was_local:
+        if platform_client is None:
+            raise ValueError("--fileset requires a platform client.")
+        cli_files.ensure_fileset_exists(platform_client, workspace=args.workspace, fileset=args.fileset)
+
+    return _RunSubmission(
+        spec=request.model_dump(mode="json", exclude_none=True),
+        options=options,
+        metadata={"output_location": args.fileset} if args.fileset is not None else None,
+        base_url=base_url,
+        headers=headers,
+        platform_client=platform_client,
+    )
+
+
+def _delegate_run_submission(
+    original: Callable[..., None],
+    *,
+    scheduler: NemoJobScheduler,
+    typer_ctx: typer.Context,
+    args: _RunCLIArgs,
+    submission: _RunSubmission,
+    kwargs: dict[str, object],
+    run_result: dict[str, object],
+) -> None:
+    delegate_kwargs = dict(kwargs)
+    delegate_kwargs.pop("config", None)
+    delegate_kwargs.pop("config_file", None)
+    delegate_kwargs.update(
+        {
+            "spec": json.dumps(submission.spec),
+            "spec_file": None,
+            "options": args.options,
+            "options_file": args.options_file,
+            "profile": args.profile,
+            "cluster": None,
+            "base_url": submission.base_url,
+            "workspace": args.workspace,
+            "_run_result": run_result,
+        }
+    )
+    with _inject_submit_metadata(scheduler, submission.metadata):
+        original(typer_ctx, **delegate_kwargs)
+
+
+def _watch_run_job(
+    *,
+    resource_name: str,
+    submission: _RunSubmission,
+    args: _RunCLIArgs,
+    result: dict[str, object],
+    platform_client: NeMoPlatform | None,
+) -> None:
+    job_name = result.get("name")
+    if not job_name:
+        typer.echo(f"Error: Unable to determine submitted {resource_name} job name for --watch", err=True)
+        raise typer.Exit(code=1)
+
+    platform_client = platform_client or cli_files.make_platform_client(
+        base_url=submission.base_url,
+        workspace=args.workspace,
+        headers=submission.headers,
+    )
+    job_workspace = cast(str, result.get("workspace") or args.workspace)
+    jobs_client = client_from_platform(platform_client, JobsClient)
+    events = jobs_client.watch_job(
+        cast(str, job_name),
+        workspace=job_workspace,
+        timeout=args.timeout,
+        poll_interval=args.poll_interval,
+        include_history=args.include_history,
+    )
+    if not _watch_render_succeeded(render_job_watch_events(events, resource_label="job")):
+        raise typer.Exit(code=1)
+
+    if args.output_dir is not None:
+        _download_run_artifacts(
+            _build_run_artifacts_download_url(
+                submission.base_url,
+                workspace=job_workspace,
+                job_name=cast(str, job_name),
+            ),
+            headers=submission.headers,
+            output_dir=args.output_dir,
+        )
+        typer.echo(f"Downloaded run artifacts to {args.output_dir / 'artifacts'}", err=True)
+
+
+def _build_remote_job_diagnostics(
+    scheduler: NemoJobScheduler,
+    job_cls: type[NemoJob],
+    *,
+    args: _RunCLIArgs,
+    submission: _RunSubmission,
+) -> list[dict[str, Any]]:
+    return [
+        scheduler.explain(job_cls, profile=args.profile),
+        {
+            "method": "POST",
+            "url": scheduler._build_submit_url(
+                job_cls,
+                base_url=submission.base_url,
+                workspace=args.workspace,
+            ),
+            "body": scheduler._build_submit_body(
+                submission.spec,
+                profile=args.profile,
+                options=submission.options,
+                metadata=submission.metadata,
+            ),
+        },
+    ]
+
+
+def _build_anonymizer_run_signature(original: Callable[..., None]) -> inspect.Signature:
+    params = [
+        param
+        for param in inspect.signature(original).parameters.values()
+        if param.name not in _ANONYMIZER_RUN_WRAPPER_FLAGS
+    ]
+    params.extend(
+        [
+            kw(
+                "fileset",
+                Optional[str],
+                typer.Option(
+                    None,
+                    "--fileset",
+                    help="Fileset used for local input upload and run artifacts.",
+                    rich_help_panel="Files",
+                ),
+            ),
+            kw(
+                "input_remote_path",
+                Optional[str],
+                typer.Option(
+                    None,
+                    "--input-remote-path",
+                    help="Path inside --fileset for an uploaded local input file. Defaults to the local filename.",
+                    rich_help_panel="Files",
+                ),
+            ),
+            kw(
+                "output_dir",
+                Optional[Path],
+                typer.Option(
+                    None,
+                    "--output-dir",
+                    help="Download run artifacts to this local directory after --watch completes.",
+                    rich_help_panel="Output",
+                ),
+            ),
+            kw(
+                "verbose",
+                bool,
+                typer.Option(
+                    False,
+                    "--verbose",
+                    help="Print the job schema and resolved submit request before creating the job.",
+                    rich_help_panel="Submission",
+                ),
+            ),
+            kw(
+                "dry_run",
+                bool,
+                typer.Option(
+                    False,
+                    "--dry-run",
+                    help="Print the job schema and resolved submit request without creating a job.",
+                    rich_help_panel="Submission",
+                ),
+            ),
+            kw(
+                "watch",
+                bool,
+                typer.Option(
+                    False,
+                    "--watch",
+                    help="Watch the submitted job to a terminal state.",
+                    rich_help_panel="Watch",
+                ),
+            ),
+            kw(
+                "timeout",
+                Optional[int],
+                typer.Option(
+                    None,
+                    "--timeout",
+                    min=1,
+                    help="Maximum watch time in seconds.",
+                    rich_help_panel="Watch",
+                ),
+            ),
+            kw(
+                "poll_interval",
+                int,
+                typer.Option(
+                    3,
+                    "--poll-interval",
+                    min=1,
+                    help="Seconds between status checks.",
+                    rich_help_panel="Watch",
+                ),
+            ),
+            kw(
+                "include_history",
+                bool,
+                typer.Option(
+                    True,
+                    "--history/--no-history",
+                    help="Include logs already present before watching.",
+                    rich_help_panel="Watch",
+                ),
+            ),
+        ]
+    )
+    return inspect.Signature(parameters=params)
+
+
+def _install_anonymizer_preview_verb(group: typer.Typer) -> None:
+    original = _pluck_command_callback(group, "preview")
+
+    def preview(
+        typer_ctx: typer.Context,
+        **kwargs: object,
+    ) -> None:
+        """Run a streaming preview through the Anonymizer service."""
+        _run_preview_function_wrapper(
+            original,
+            typer_ctx=typer_ctx,
+            kwargs=dict(kwargs),
+        )
+
+    setattr(preview, "__signature__", _build_anonymizer_preview_signature(original))
+    _replace_command(group, "preview", preview, rich_help_panel="Functions")
+
+
+def _build_anonymizer_preview_signature(original: Callable[..., None]) -> inspect.Signature:
+    params = list(inspect.signature(original).parameters.values())
+    params.extend(
+        [
+            kw(
+                "fileset",
+                Optional[str],
+                typer.Option(
+                    None,
+                    "--fileset",
+                    help="Fileset used for local input upload and optional preview output upload.",
+                    rich_help_panel="Files",
+                ),
+            ),
+            kw(
+                "input_remote_path",
+                Optional[str],
+                typer.Option(
+                    None,
+                    "--input-remote-path",
+                    help="Path inside --fileset for an uploaded local input file. Defaults to the local filename.",
+                    rich_help_panel="Files",
+                ),
+            ),
+            kw(
+                "output_remote_path",
+                Optional[str],
+                typer.Option(
+                    None,
+                    "--output-remote-path",
+                    help="Path inside --fileset for saved preview NDJSON output.",
+                    rich_help_panel="Files",
+                ),
+            ),
+            kw(
+                "quiet",
+                bool,
+                typer.Option(
+                    False,
+                    "--quiet",
+                    help="Suppress preview log frames on stderr.",
+                    rich_help_panel="Output",
+                ),
+            ),
+            kw(
+                "output_file",
+                Optional[Path],
+                typer.Option(
+                    None,
+                    "--output-file",
+                    help="Write non-log preview frames to an NDJSON file instead of stdout.",
+                    rich_help_panel="Output",
+                ),
+            ),
+        ]
+    )
+    return inspect.Signature(parameters=params)
+
+
+def _pluck_command_callback(group: typer.Typer, command_name: str) -> Callable[..., None]:
+    for command in reversed(group.registered_commands):
+        if command.name == command_name and command.callback is not None:
+            return command.callback
+    raise RuntimeError(f"missing generated {command_name!r} command")
+
+
+def _pluck_command_scheduler(callback: Callable[..., None]) -> NemoJobScheduler:
+    if not isinstance(callback, FunctionType):
+        raise RuntimeError("missing generated run command scheduler")
+
+    closure = callback.__closure__
+    if closure is None:
+        raise RuntimeError("missing generated run command scheduler")
+
+    for name, cell in zip(callback.__code__.co_freevars, closure, strict=False):
+        if name != "scheduler":
+            continue
+        scheduler = cell.cell_contents
+        if isinstance(scheduler, NemoJobScheduler):
+            return scheduler
+
+    raise RuntimeError("missing generated run command scheduler")
+
+
+def _replace_command(
+    group: typer.Typer,
+    command_name: str,
+    callback: Callable[..., None],
+    *,
+    rich_help_panel: str,
+) -> None:
+    original_count = len(group.registered_commands)
+    group.registered_commands[:] = [command for command in group.registered_commands if command.name != command_name]
+    if len(group.registered_commands) == original_count:
+        raise RuntimeError(f"missing generated {command_name!r} command")
+    group.command(command_name, rich_help_panel=rich_help_panel)(callback)
+
+
+def _run_preview_function_wrapper(
+    original: Callable[..., None],
+    *,
+    typer_ctx: typer.Context,
+    kwargs: dict[str, object],
+) -> None:
+    spec = cast(str, kwargs.pop("spec", "{}"))
+    spec_file = cast(Path | None, kwargs.pop("spec_file", None))
+    cluster = cast(str | None, kwargs.pop("cluster", None))
+    base_url = cast(str | None, kwargs.pop("base_url", None))
+    workspace = cast(str, kwargs.pop("workspace", "default"))
+    request_id = cast(str | None, kwargs.pop("request_id", None))
+    fileset = cast(str | None, kwargs.pop("fileset", None))
+    input_remote_path = cast(str | None, kwargs.pop("input_remote_path", None))
+    output_remote_path = cast(str | None, kwargs.pop("output_remote_path", None))
+    quiet = cast(bool, kwargs.pop("quiet", False))
+    output_file = cast(Path | None, kwargs.pop("output_file", None))
+
+    if _output_format_is_json(typer_ctx) and (quiet or output_file is not None or output_remote_path is not None):
+        typer.echo(
+            "Error: --quiet, --output-file, and --output-remote-path cannot be combined with JSON output.", err=True
+        )
+        raise typer.Exit(code=2)
+
+    spec_data = _load_spec(spec, spec_file)
+    overlay = build_overlay(
+        walk_spec_leaves(PreviewRequest, reserved=_ANONYMIZER_PREVIEW_RESERVED_FLAGS),
+        kwargs,
+        unset_sentinel=UNSET,
+    )
+    spec_data = deep_merge(spec_data, overlay)
+    try:
+        request = PreviewRequest.model_validate(spec_data)
+    except ValidationError as exc:
+        typer.echo(f"Error: invalid preview spec: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    try:
+        resolved_base_url = _resolve_submit_base_url(typer_ctx, base_url=base_url, cluster=cluster)
+        headers = _resolve_submit_auth_headers(typer_ctx)
+        if request_id is not None:
+            headers["X-Request-ID"] = request_id
+        platform_client = cli_files.make_platform_client(
+            base_url=resolved_base_url,
+            workspace=workspace,
+            headers=headers,
+        )
+        staged_request = cli_files.stage_anonymizer_request_for_remote(
+            request,
+            platform_client=platform_client,
+            workspace=workspace,
+            fileset=fileset,
+            input_remote_path=input_remote_path,
+            upload=True,
+            quiet=quiet,
+        )
+        request = staged_request.request
+        if output_remote_path is not None and fileset is None:
+            raise ValueError("--output-remote-path requires --fileset.")
+        if output_remote_path is not None:
+            cli_files.validate_remote_file_path(output_remote_path, option_name="--output-remote-path")
+            cli_files.ensure_fileset_exists(platform_client, workspace=workspace, fileset=cast(str, fileset))
+
+        preview_status = {"succeeded": True}
+        with _preview_capture_path(output_file=output_file, output_remote_path=output_remote_path) as capture_file:
+            original(
+                typer_ctx,
+                spec=json.dumps(request.model_dump(mode="json", exclude_none=True)),
+                spec_file=None,
+                cluster=cluster,
+                base_url=base_url,
+                workspace=workspace,
+                request_id=request_id,
+                quiet=quiet,
+                output_file=output_file,
+                _capture_file=capture_file,
+                _preview_status=preview_status,
+            )
+            if not preview_status["succeeded"]:
+                raise typer.Exit(code=1)
+            if output_remote_path is not None:
+                cli_files.upload_file_to_fileset(
+                    platform_client,
+                    local_path=output_file or cast(Path, capture_file),
+                    remote_path=output_remote_path,
+                    fileset=cast(str, fileset),
+                    workspace=workspace,
+                    description="preview output",
+                    quiet=quiet,
+                )
+    except ValueError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    except OSError as exc:
+        typer.echo(f"Error: unable to write preview output: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+    except httpx.HTTPStatusError as exc:
+        print_http_status_error(exc, action="preview anonymizer")
+        raise typer.Exit(code=2) from exc
+    except httpx.RequestError as exc:
+        print_http_request_error(exc, action="preview anonymizer")
+        raise typer.Exit(code=2) from exc
+    except httpx.HTTPError as exc:
+        typer.echo(f"Error: preview anonymizer failed: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+
+class AnonymizerPreviewRenderer(CLIRenderer):
+    def __init__(self) -> None:
+        self._stack = ExitStack()
+        self._output: TextIO | None = None
+        self._capture: TextIO | None = None
+        self._quiet = False
+        self._error_seen = False
+
+    def on_start(self, *, ctx: RendererContext) -> None:
+        self._quiet = bool(ctx.cli_kwargs.get("quiet"))
+        output_file = _optional_path(ctx.cli_kwargs.get("output_file"))
+        capture_file = _optional_path(ctx.cli_kwargs.get("_capture_file"))
+        self._output = self._stack.enter_context(output_file.open("w")) if output_file is not None else None
+        self._capture = self._stack.enter_context(capture_file.open("w")) if capture_file is not None else None
+
+    def on_frame(self, frame: Any, *, ctx: RendererContext) -> None:
+        del ctx
+        line = frame.model_dump_json(exclude_none=True) if isinstance(frame, BaseModel) else json.dumps(frame)
+        self._error_seen = (
+            _emit_preview_line(
+                line,
+                quiet=self._quiet,
+                output=self._output,
+                capture=self._capture,
+            )
+            or self._error_seen
+        )
+
+    def on_complete(self, *, ctx: RendererContext) -> None:
+        self._set_status(ctx)
+        self._stack.close()
+
+    def on_error(self, error: BaseException, *, ctx: RendererContext) -> None:
+        del error
+        self._set_status(ctx)
+        self._stack.close()
+
+    def _set_status(self, ctx: RendererContext) -> None:
+        status = ctx.cli_kwargs.get("_preview_status")
+        if isinstance(status, dict):
+            status["succeeded"] = not self._error_seen
+
+
+class AnonymizerRunRenderer(CLIRenderer):
+    def on_frame(self, frame: Any, *, ctx: RendererContext) -> None:
+        result = ctx.cli_kwargs.get("_run_result")
+        if isinstance(result, dict) and isinstance(frame, dict):
+            result["job"] = frame
+        typer.echo(json.dumps(frame, indent=2))
+
+
+def _optional_path(value: object) -> Path | None:
+    return value if isinstance(value, Path) else None
+
+
+def _build_run_artifacts_download_url(base_url: str, *, workspace: str, job_name: str) -> str:
+    workspace_segment = quote(workspace, safe="")
+    job_segment = quote(job_name, safe="")
+    return (
+        f"{base_url.rstrip('/')}/apis/anonymizer/v2/workspaces/{workspace_segment}"
+        f"/jobs/run/{job_segment}/results/artifacts/download"
+    )
+
+
+@contextmanager
+def _preview_capture_path(
+    *,
+    output_file: Path | None,
+    output_remote_path: str | None,
+) -> Iterator[Path | None]:
+    if output_remote_path is None:
+        yield None
+        return
+    if output_file is not None:
+        yield None
+        return
+    with tempfile.TemporaryDirectory(prefix="nemo-anonymizer-preview-") as temp_dir:
+        yield Path(temp_dir) / "preview.ndjson"
+
+
+_SUBMIT_REMOTE_SENTINEL = object()
+
+
+@contextmanager
+def _inject_submit_metadata(
+    scheduler: NemoJobScheduler,
+    submit_metadata: dict[str, str] | None,
+) -> Iterator[None]:
+    previous = scheduler.__dict__.get("submit_remote", _SUBMIT_REMOTE_SENTINEL)
+    submit_remote = scheduler.submit_remote
+
+    def submit_remote_with_metadata(
+        job_cls: type[NemoJob],
+        spec: dict,
+        *,
+        base_url: str | None = None,
+        workspace: str = "default",
+        profile: str | None = None,
+        options: dict | None = None,
+        metadata: dict | None = None,
+        http_client: httpx.Client | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float = 30.0,
+    ) -> dict:
+        del metadata
+        submit_kwargs: dict[str, Any] = {
+            "base_url": base_url,
+            "workspace": workspace,
+            "profile": profile,
+            "options": options,
+            "metadata": submit_metadata,
+            "headers": headers,
+        }
+        if http_client is not None:
+            submit_kwargs["http_client"] = http_client
+        if timeout != 30.0:
+            submit_kwargs["timeout"] = timeout
+        return submit_remote(job_cls, spec, **submit_kwargs)
+
+    setattr(scheduler, "submit_remote", submit_remote_with_metadata)
+    try:
+        yield
+    finally:
+        if previous is _SUBMIT_REMOTE_SENTINEL:
+            delattr(scheduler, "submit_remote")
+        else:
+            setattr(scheduler, "submit_remote", previous)
+
+
+def _emit_preview_line(
+    line: str,
+    *,
+    quiet: bool,
+    output: TextIO | None = None,
+    capture: TextIO | None = None,
+) -> bool:
+    try:
+        frame = json.loads(line)
+    except json.JSONDecodeError:
+        _write_preview_output(line, output, capture=capture)
+        return False
+    if not isinstance(frame, dict):
+        _write_preview_output(json.dumps(frame), output, capture=capture)
+        return False
+
+    kind = frame.get("kind")
+    if kind == "log":
+        if not quiet:
+            message = frame.get("message")
+            typer.echo(str(message) if message is not None else json.dumps(frame), err=True)
+        return False
+
+    _write_preview_output(json.dumps(frame), output, capture=capture)
+    return kind == "error"
+
+
+def _write_preview_output(line: str, output: TextIO | None, *, capture: TextIO | None = None) -> None:
+    if output is None:
+        typer.echo(line)
+    else:
+        output.write(f"{line}\n")
+        output.flush()
+    if capture is not None:
+        capture.write(f"{line}\n")
+        capture.flush()
+
+
+def _download_run_artifacts(
+    url: str,
+    *,
+    headers: dict[str, str],
+    output_dir: Path,
+    timeout: float = 300.0,
+) -> None:
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(url, headers=headers)
+        if response.status_code >= 400:
+            response.raise_for_status()
+        with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:*") as tar:
+            safe_extract_tar(tar, output_dir)
+
+
+def _watch_render_succeeded(result: object) -> bool:
+    return result is True or result == "succeeded"

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/cli_files.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/cli_files.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fileset staging helpers shared by Anonymizer CLI verbs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Generic, TypeVar
+
+import typer
+from filesets import build_fileset_ref
+from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
+from nemo_anonymizer_plugin.app.input import classify_input_source
+from nemo_anonymizer_plugin.app.task_config import AnonymizerRequest
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.files.client import FilesClient
+from nemo_platform_plugin.files.types import CreateFilesetRequest
+
+AnonymizerRequestT = TypeVar("AnonymizerRequestT", bound=AnonymizerRequest)
+
+_SUPPORTED_INPUT_FILE_SUFFIXES = {".csv", ".parquet"}
+
+
+@dataclass(frozen=True)
+class StagedAnonymizerRequest(Generic[AnonymizerRequestT]):
+    request: AnonymizerRequestT
+    source_was_local: bool
+
+
+def make_platform_client(*, base_url: str, workspace: str, headers: dict[str, str]) -> NeMoPlatform:
+    return NeMoPlatform(base_url=base_url, workspace=workspace, default_headers=headers or None)
+
+
+def stage_anonymizer_request_for_remote(
+    request: AnonymizerRequestT,
+    *,
+    platform_client: NeMoPlatform | None,
+    workspace: str,
+    fileset: str | None,
+    input_remote_path: str | None,
+    upload: bool,
+    quiet: bool = False,
+) -> StagedAnonymizerRequest[AnonymizerRequestT]:
+    source_kind = classify_input_source_for_cli(request.data.source)
+    if source_kind != "local":
+        return StagedAnonymizerRequest(request=request, source_was_local=False)
+    if fileset is None:
+        raise ValueError("Local input sources require --fileset so the CLI can upload the file for remote execution.")
+
+    local_path = resolve_local_input_path(request.data.source)
+    remote_path = resolve_input_remote_path(input_remote_path, local_path)
+    if upload:
+        if platform_client is None:
+            raise ValueError("Local input upload requires a platform client.")
+        ensure_fileset_exists(platform_client, workspace=workspace, fileset=fileset)
+        upload_file_to_fileset(
+            platform_client,
+            local_path=local_path,
+            remote_path=remote_path,
+            fileset=fileset,
+            workspace=workspace,
+            description="local input",
+            quiet=quiet,
+        )
+
+    data = request.data.model_copy(
+        update={
+            "source": build_fileset_ref(remote_path, workspace=workspace, fileset=fileset),
+        }
+    )
+    return StagedAnonymizerRequest(
+        request=request.model_copy(update={"data": data}),
+        source_was_local=True,
+    )
+
+
+def classify_input_source_for_cli(source: str) -> str:
+    try:
+        return classify_input_source(source)
+    except AnonymizerInvalidConfigError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def resolve_local_input_path(source: str) -> Path:
+    path = Path(source).expanduser()
+    if not path.is_file():
+        raise ValueError(f"Local input source {source!r} must point to an existing file.")
+    validate_input_file_suffix(str(path), label=f"Local input source {source!r}")
+    return path
+
+
+def resolve_input_remote_path(input_remote_path: str | None, local_path: Path) -> str:
+    remote_path = input_remote_path or local_path.name
+    normalized = validate_remote_file_path(remote_path, option_name="--input-remote-path")
+    validate_input_file_suffix(normalized, label=f"--input-remote-path {normalized!r}")
+    return normalized
+
+
+def validate_input_file_suffix(path: str, *, label: str) -> None:
+    suffix = PurePosixPath(path).suffix.lower()
+    if suffix not in _SUPPORTED_INPUT_FILE_SUFFIXES:
+        expected = ", ".join(sorted(_SUPPORTED_INPUT_FILE_SUFFIXES))
+        raise ValueError(f"{label} must be one of: {expected}.")
+
+
+def validate_remote_file_path(remote_path: str, *, option_name: str) -> str:
+    normalized = remote_path.strip()
+    if not normalized:
+        raise ValueError(f"{option_name} must not be empty.")
+    if normalized.startswith("/"):
+        raise ValueError(f"{option_name} must be relative to the fileset root.")
+    if normalized.endswith("/"):
+        raise ValueError(f"{option_name} must include a file name.")
+    if ".." in PurePosixPath(normalized).parts:
+        raise ValueError(f"{option_name} must not include parent-directory segments.")
+    return normalized
+
+
+def ensure_fileset_exists(platform_client: NeMoPlatform, *, workspace: str, fileset: str) -> None:
+    files = client_from_platform(platform_client, FilesClient)
+    files.create_fileset(
+        workspace=workspace,
+        body=CreateFilesetRequest(name=fileset),
+        exist_ok=True,
+    )
+
+
+def upload_file_to_fileset(
+    platform_client: NeMoPlatform,
+    *,
+    local_path: Path,
+    remote_path: str,
+    fileset: str,
+    workspace: str,
+    description: str,
+    quiet: bool = False,
+) -> None:
+    if not quiet:
+        typer.echo(f"Uploading {description} to {fileset}#{remote_path}", err=True)
+    platform_client.files.upload(
+        local_path=str(local_path),
+        remote_path=remote_path,
+        fileset=fileset,
+        workspace=workspace,
+    )

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/_preview_worker.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/_preview_worker.py
@@ -66,9 +66,11 @@ def _make_anonymizer(
     model_configs_yaml: str,
     dd_providers: list[DDModelProvider] | None,
 ) -> Anonymizer:
+    if not model_configs_yaml:
+        raise RuntimeError("Anonymizer preview requires resolved model_configs.")
     with preserve_root_logging():
         return Anonymizer(
-            model_configs=model_configs_yaml or None,
+            model_configs=model_configs_yaml,
             model_providers=dd_providers,
         )
 
@@ -89,7 +91,10 @@ def _to_jsonable_records(df: pd.DataFrame) -> list[dict[str, Any]]:
             safe[col] = safe[col].apply(
                 lambda v: None if (v is None or (isinstance(v, float) and math.isnan(v))) else v
             )
-    return json.loads(safe.to_json(orient="records", date_format="iso", default_handler=str))
+    records_json = safe.to_json(orient="records", date_format="iso", default_handler=str)
+    if records_json is None:
+        return []
+    return json.loads(records_json)
 
 
 def _get_original_text_column(df: pd.DataFrame, *, fallback: str) -> str:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/preview.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/preview.py
@@ -14,7 +14,11 @@ import anyio.from_thread
 import anyio.to_thread
 from anyio.lowlevel import current_token
 from fastapi import HTTPException, status
-from nemo_anonymizer_plugin.app.context import AnonymizerContext, create_anonymizer_context
+from nemo_anonymizer_plugin.app.context import (
+    AnonymizerContext,
+    create_anonymizer_context,
+    require_model_configs_for_execution,
+)
 from nemo_anonymizer_plugin.app.errors import AnonymizerInternalError, AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec, PreparedAnonymizerInput
 from nemo_anonymizer_plugin.app.model_configs import (
@@ -78,6 +82,7 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
     description: ClassVar[str] = "Streaming preview of an Anonymizer config."
     spec_schema: ClassVar[type[BaseModel]] = PreviewSpec
     frame_schema: ClassVar[Any] = PreviewFrame
+    generate_legacy_verbs: ClassVar[bool] = False
 
     async def run(
         self,
@@ -85,26 +90,20 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
         *,
         ctx: FunctionContext,
         async_sdk: AsyncNeMoPlatform,
-        is_local: bool = False,
     ) -> AsyncIterator[BaseModel]:
         num_records = _validate_and_get_num_records(spec.num_records)
         validate_selected_models_have_model_configs(
             model_configs=spec.model_configs,
             selected_models=spec.selected_models,
         )
+        model_configs = require_model_configs_for_execution(spec.model_configs)
 
-        anon_ctx = create_anonymizer_context(is_local, async_sdk, ctx.workspace)
-        dd_providers = await anon_ctx.make_model_providers(
-            spec.model_configs,
-            require_model_configs=not is_local,
+        anon_ctx = create_anonymizer_context(async_sdk, ctx.workspace)
+        dd_providers = await anon_ctx.make_model_providers(model_configs)
+        model_configs_yaml = build_model_configs_yaml(
+            model_configs=model_configs,
+            selected_models=spec.selected_models,
         )
-        if spec.model_configs:
-            model_configs_yaml = build_model_configs_yaml(
-                model_configs=spec.model_configs,
-                selected_models=spec.selected_models,
-            )
-        else:
-            model_configs_yaml = ""
         async with _prepare_input(anon_ctx, spec.data) as prepared_input:
             send_stream, receive_stream = anyio.create_memory_object_stream[BaseModel]()
             token = current_token()

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/jobs/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/jobs/run.py
@@ -11,7 +11,7 @@ from anonymizer.config.anonymizer_config import AnonymizerConfig
 from anonymizer.interface.anonymizer import Anonymizer
 from anonymizer.interface.errors import InvalidConfigError
 from data_designer_nemo.errors import NDDInvalidConfigError
-from nemo_anonymizer_plugin.app.context import create_anonymizer_context
+from nemo_anonymizer_plugin.app.context import create_anonymizer_context, require_model_configs_for_execution
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.model_configs import (
     build_model_configs_yaml,
@@ -42,6 +42,7 @@ class RunJob(NemoJob):
     name: ClassVar[str] = "run"
     description: ClassVar[str] = "Anonymize a dataset of records"
     container: ClassVar[str] = "cpu-tasks"
+    generate_legacy_verbs: ClassVar[bool] = False
 
     input_spec_schema = AnonymizerRequest
     spec_schema = AnonymizerStepConfig
@@ -56,8 +57,9 @@ class RunJob(NemoJob):
         async_sdk: AsyncNeMoPlatform,
         is_local: bool,
     ) -> BaseModel:  # AnonymizerStepConfig
+        del entity_client, is_local
         input_spec = cast(AnonymizerRequest, input_spec)
-        anon_ctx = create_anonymizer_context(is_local, async_sdk, workspace)
+        anon_ctx = create_anonymizer_context(async_sdk, workspace)
 
         try:
             cls._validate_anonymizer_config(input_spec.config)
@@ -66,18 +68,13 @@ class RunJob(NemoJob):
                 model_configs=input_spec.model_configs,
                 selected_models=input_spec.selected_models,
             )
+            model_configs = require_model_configs_for_execution(input_spec.model_configs)
 
-            dd_providers = await anon_ctx.make_model_providers(
-                input_spec.model_configs,
-                require_model_configs=not is_local,
+            dd_providers = await anon_ctx.make_model_providers(model_configs)
+            yaml_body = build_model_configs_yaml(
+                model_configs=model_configs,
+                selected_models=input_spec.selected_models,
             )
-            if input_spec.model_configs:
-                yaml_body = build_model_configs_yaml(
-                    model_configs=input_spec.model_configs,
-                    selected_models=input_spec.selected_models,
-                )
-            else:
-                yaml_body = ""
         except (AnonymizerInvalidConfigError, NDDInvalidConfigError) as e:
             raise PlatformJobCompilationError(str(e)) from e
 
@@ -135,10 +132,9 @@ class RunJob(NemoJob):
         *,
         ctx: JobContext,
         sdk: NeMoPlatform,
-        is_local: bool = False,
     ) -> dict:
         step_config = AnonymizerStepConfig.model_validate(config)
-        return {"exit_code": run_step_config(step_config, ctx=ctx, sdk=sdk, is_local=is_local)}
+        return {"exit_code": run_step_config(step_config, ctx=ctx, sdk=sdk)}
 
 
 def _make_env_vars() -> list[EnvironmentVariable]:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/resources.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/resources.py
@@ -179,19 +179,21 @@ class AnonymizerResource(_BaseAnonymizerResource[NeMoPlatform]):
     ) -> AnonymizerPreviewResult:
         """Run a streaming preview against the Anonymizer service.
 
-        Returns an ``AnonymizerPreviewResult`` once the stream finishes.
+        This convenience method consumes ``preview_stream`` under the hood and
+        returns an ``AnonymizerPreviewResult`` once the stream finishes.
         """
         with _PreviewFrameCollector() as collector:
-            for frame in self._preview(request=request, workspace=workspace):
+            for frame in self.preview_stream(request, workspace=workspace):
                 collector.accept(frame)
             return _build_preview_result(collector)
 
-    def _preview(
+    def preview_stream(
         self,
-        *,
         request: PreviewRequest,
-        workspace: str | None,
+        *,
+        workspace: str | None = None,
     ) -> Iterator[PreviewFrame]:
+        """Stream typed preview frames from the Anonymizer service."""
         with self._client().stream(
             "POST",
             self._url("/preview", workspace),
@@ -255,17 +257,23 @@ class AsyncAnonymizerResource(_BaseAnonymizerResource[AsyncNeMoPlatform]):
         *,
         workspace: str | None = None,
     ) -> AnonymizerPreviewResult:
+        """Run a streaming preview against the Anonymizer service.
+
+        This convenience method consumes ``preview_stream`` under the hood and
+        returns an ``AnonymizerPreviewResult`` once the stream finishes.
+        """
         with _PreviewFrameCollector() as collector:
-            async for frame in self._preview(request=request, workspace=workspace):
+            async for frame in self.preview_stream(request, workspace=workspace):
                 collector.accept(frame)
             return _build_preview_result(collector)
 
-    async def _preview(
+    async def preview_stream(
         self,
-        *,
         request: PreviewRequest,
-        workspace: str | None,
+        *,
+        workspace: str | None = None,
     ) -> AsyncIterator[PreviewFrame]:
+        """Stream typed preview frames from the Anonymizer service."""
         async with self._client().stream(
             "POST",
             self._url("/preview", workspace),

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/SKILL.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/SKILL.md
@@ -21,9 +21,9 @@ $ARGUMENTS
 
 The plugin wraps the [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer) and exposes:
 
-- An `anonymizer.preview` streaming function (small samples, fast iteration). Use `nemo anonymizer preview run` for local execution and `nemo anonymizer preview submit` for platform execution.
-- An `anonymizer.run` job for full-dataset execution. Use `nemo anonymizer run run` for local execution and `nemo anonymizer run submit` for Jobs-worker execution.
-- A `nemo anonymizer validate` command (synchronous config validation).
+- An `anonymizer.preview` streaming API (small samples, fast iteration). Use `nemo anonymizer preview`, `sdk.anonymizer.preview(...)`, `sdk.anonymizer.preview_stream(...)`, or `POST /apis/anonymizer/v2/workspaces/{workspace}/preview`.
+- An `anonymizer.run` job for full-dataset execution. Use `nemo anonymizer run` for Jobs-worker execution.
+- A `nemo anonymizer` CLI with `preview`, `validate`, and `run` commands.
 
 # Workflow
 
@@ -36,21 +36,20 @@ Read **only** the workflow file that matches the selected mode, then follow it:
 
 # Rules
 
-- Prefer CLI surfaces. Generate YAML specs and run `nemo anonymizer ...` commands unless the user explicitly asks for Python.
-- Always iterate via `nemo anonymizer preview run` or `nemo anonymizer preview submit` before running the full job. Previews are cheap and stream a small sample (default 10 records) with full detection traces.
+- Prefer `nemo anonymizer preview` or the SDK for preview, and the CLI for validate/run. Use the direct HTTP API only when the user asks for it or the CLI is unavailable. Generate YAML preview/run specs and run `nemo anonymizer ...` commands unless the user explicitly asks for Python.
+- Always iterate via `nemo anonymizer preview`, `sdk.anonymizer.preview(...)`, or `sdk.anonymizer.preview_stream(...)` before running the full job. Previews are cheap and stream a small sample (default 10 records) with full detection traces.
 - When you include `config`, pick exactly one of `replace` (Annotate/Hash/Redact/Substitute) or `rewrite` on the `AnonymizerConfig`. Not both. Do not claim `config` is required for every flow; the Anonymizer library owns default config behavior and strategy semantics. See `references/replace-strategies.md` for plugin request formatting and the [library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) for semantics.
 - The input must be a single CSV or Parquet file. `text_column` defaults to `text`; set it explicitly when the free-text column has another name. If the dataset has a stable record id, also set `id_column`. See `references/inputs.md`.
-- `model_configs` is optional for local execution (`preview run` / `run run`); when omitted, the Anonymizer library defaults are used.
-- The current plugin-service / Jobs paths (`preview submit`, `run submit`) require `model_configs` so requests route through the NeMo Platform Inference Gateway. See `references/model-configs.md`.
+- Preview and run require `model_configs` so requests route through the NeMo Platform Inference Gateway. See `references/model-configs.md`.
 - `selected_models` overrides are only valid when `model_configs` is also supplied; aliases must resolve against that pool.
-- Local file paths only work for local execution. Plugin-service / Jobs execution requires an `http(s)` URL or a fileset reference (`<workspace>/<fileset>#<path>` or `fileset://...`).
+- SDK/API preview and run require an `http(s)` URL or a fileset reference (`<workspace>/<fileset>#<path>` or `fileset://...`) in `data.source`.
 - If a spec file matching the user's description already exists in the working directory, ask whether to edit it or create a new one.
 
 # Usage Tips and Common Pitfalls
 
 - **Replacement strategies need a discriminated payload.** Hand-written YAML specs must include `kind: redact` (or `annotate` / `hash` / `substitute`) inside the `replace` block.
 - **Substitute and rewrite need LLM-backed model aliases.** For plugin-service / Jobs execution they must be backed by providers declared in `model_configs`. For library-level details, refer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills.
-- **Spec files are YAML, not JSON.** `nemo anonymizer preview run --spec-file <path>` and `nemo anonymizer run run --spec-file <path>` both load YAML.
+- **CLI spec files can be YAML or JSON.** `nemo anonymizer preview --spec-file <path>` and `nemo anonymizer run --spec-file <path>` accept YAML or JSON. Prefer YAML for generated specs. Direct HTTP preview still uses a JSON request body.
 - **Run results are artifacts.** The job writes an artifacts directory containing `dataset.parquet`, `trace.parquet`, `metadata.json`, and optional `failed_records.json`.
 - **Fileset refs use `#` to point at a file.** `<workspace>/<fileset>#<path>`, `<fileset>#<path>` (uses request workspace), or `fileset://<workspace>/<fileset>#<path>`. The `#` fragment must point at a `.csv` or `.parquet` file.
 - **Detection labels.** Keep the Anonymizer library default label set unless the user asks to restrict detection. Refer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills for supported label/config details.
@@ -59,35 +58,36 @@ Read **only** the workflow file that matches the selected mode, then follow it:
 # Troubleshooting
 
 - **`nemo anonymizer` CLI not found:** The plugin isn't installed in this environment. From the repo root, run `uv sync`; the root workspace includes the Anonymizer plugin. Confirm with `nemo anonymizer --help`. Do not install anything without the user's permission.
-- **`nemo anonymizer preview submit` returns 404:** The plugin service isn't mounted on the gateway. `nemo setup` does not auto-mount it. Re-run `nemo services run` (no `--services` flag) and verify the routes show up under `/apis/anonymizer/` in the OpenAPI listing. See `docs/anonymizer/tutorials/index.mdx` Prerequisites.
-- **`model_configs are required for remote execution`:** `preview submit` and `run submit` go through plugin-service / Jobs paths. Add `model_configs` referencing an Inference Gateway provider; use the inference/model-provider docs or skill for provider discovery.
-- **`Input source ... is a local path`:** Plugin-service execution rejects local paths. Either upload the file to a fileset, use an `http(s)` URL, or switch to `preview run` / `run run` (local execution).
+- **Preview returns 404:** The plugin service isn't mounted on the gateway. Start or restart `nemo services run` (no `--services` flag) so the plugin is discovered, then verify the routes show up under `/apis/anonymizer/` in the OpenAPI listing. See `docs/anonymizer/tutorials/index.mdx` Prerequisites.
+- **`model_configs are required for remote execution`:** Preview and `run` go through plugin-service / Jobs paths. Add `model_configs` referencing an Inference Gateway provider; use the inference/model-provider docs or skill for provider discovery.
+- **`Input source ... is a local path`:** Add `--fileset <name>` when using the CLI so it can upload the local CSV/Parquet file, or use an `http(s)` URL / fileset reference for SDK/API calls.
 - **`Fileset input ... must resolve to a .csv or .parquet file`:** The `#<path>` fragment points at a directory or a non-CSV/Parquet file. Point it at a single file.
 - **Config validation failed (HTTP 422):** Run `nemo anonymizer validate --config <yaml> [--model-configs <yaml>]` to surface the exact error synchronously. Common causes: mixing `replace` and `rewrite`, picking `Substitute` without a `replacement_generator` alias in `model_configs`, fileset path missing the `#<file>` fragment.
 - **`selected_models requires model_configs ...`:** The user passed `selected_models` overrides without an explicit model pool. Either drop the overrides or define `model_configs` with the aliases the overrides reference.
-- **User asks to run remotely:** Use `nemo anonymizer run submit`. Ensure `data.source` is an HTTP(S) URL or fileset reference and `model_configs` is present.
-- **Empty preview dataset / "No preview dataset received":** Check the log frames printed by the preview stream. Most commonly the detection model alias is wrong, or the dataset has zero rows after column resolution.
+- **User asks to run remotely:** Use `nemo anonymizer run --watch` if they want logs streamed, otherwise `nemo anonymizer run`. If `data.source` is local, include `--fileset <name>` so the CLI uploads it and stores artifacts in that fileset. Ensure `model_configs` is present.
+- **User asks to inspect the remote request:** Use `nemo anonymizer run --verbose`. This prints the job schema plus POST method, resolved URL, and JSON body, then submits the job. Add `--watch` to print diagnostics, submit the job, and stream status/logs. It does not include authorization headers.
+- **User asks to inspect a run request without submitting:** Use `nemo anonymizer run --dry-run`. This prints the same job schema plus POST method, resolved URL, and JSON body as `--verbose`, then exits without creating a job. Do not combine `--dry-run` with `--watch`.
+- **Empty preview dataset / "No preview dataset received":** Check the log frames printed by the preview stream. `nemo anonymizer preview` sends log frames to stderr unless `--quiet` is set. Most commonly the detection model alias is wrong, or the dataset has zero rows after column resolution.
 
 # Output Template
 
-Generate a YAML spec file in the current directory describing the request. Name it descriptively (e.g., `redact_records_preview.yaml` or `redact_records_run.yaml`).
+Generate request files in the current directory describing the request. Prefer YAML for generated CLI preview/run specs; `--spec-file` also accepts JSON. Use JSON for direct HTTP preview request bodies. Name them descriptively (e.g., `redact_records_preview.yaml` or `redact_records_run.yaml`). The repo includes a checked-in example at `plugins/nemo-anonymizer/examples/redact.yaml`; use `nemo anonymizer preview --num-records <n>` to override the preview sample size.
 
-**Preview spec** — fast iteration over a small sample:
+**Preview spec** — fast iteration over a small sample with a remote-readable input:
 
 ```yaml
-# Local:  nemo anonymizer preview run    --spec-file ./<this_file>.yaml --workspace <ws>
-# Remote: nemo anonymizer preview submit --spec-file ./<this_file>.yaml --workspace <ws>
+# Preview: nemo anonymizer preview --spec-file ./<this_file>.yaml --workspace <ws>
+# Local CLI preview: set data.source to a local CSV/Parquet path and add --fileset <fileset>.
+# Save data frames only: nemo anonymizer preview --spec-file ./<this_file>.yaml --workspace <ws> --output-file preview.ndjson --quiet
 config:
   replace:
     kind: redact            # one of: redact, annotate, hash, substitute
     format_template: "[REDACTED_{label}]"
 data:
-  source: "anonymizer-inputs#anonymizer-input.csv"   # local path, http(s) URL, or fileset ref
+  source: "fileset://<ws>/<fileset>#input.csv"
   text_column: biography
   id_column: id
 num_records: 5
-# Required for plugin-service execution (`preview submit`),
-# optional for local `preview run`:
 model_configs:
   - alias: gliner-pii-detector
     provider: nvidia-build
@@ -98,28 +98,22 @@ model_configs:
   - alias: nemotron-30b-thinking
     provider: nvidia-build
     model: nvidia/nemotron-3-nano-30b-a3b
-# selected_models:
-#   detection:
-#     entity_detector: gliner-pii-detector
-#     entity_validator: gpt-oss-120b
-#   replace:
-#     replacement_generator: gpt-oss-120b
 ```
 
 **Run spec** — full-dataset job:
 
 ```yaml
-# Local:  nemo anonymizer run run    --spec-file ./<this_file>.yaml
-# Remote: nemo anonymizer run submit --spec-file ./<this_file>.yaml --workspace <ws>
+# Remote platform job: nemo anonymizer run --spec-file ./<this_file>.yaml --workspace <ws> --fileset <fileset> [--watch]
+# Download artifacts after success: nemo anonymizer run --spec-file ./<this_file>.yaml --workspace <ws> --fileset <fileset> --watch --output-dir ./anonymizer-artifacts
 config:
   replace:
     kind: redact
     format_template: "[REDACTED_{label}]"
 data:
-  source: "anonymizer-inputs#anonymizer-input.csv"
+  source: "./input.csv"
   text_column: biography
   id_column: id
-# Required for `run submit`, optional for `run run`:
+# Required for `run`:
 model_configs:
   - alias: gliner-pii-detector
     provider: nvidia-build
@@ -132,4 +126,4 @@ model_configs:
     model: nvidia/nemotron-3-nano-30b-a3b
 ```
 
-Include only the bits the task requires — e.g., omit `model_configs` for purely local previews, omit `selected_models` unless overrides are needed, and use `Substitute` / `rewrite` only when the user wants LLM-generated replacements or holistic rewriting.
+Include only the bits the task requires. Keep `model_configs` for preview/run, omit `selected_models` unless overrides are needed, and use `Substitute` / `rewrite` only when the user wants LLM-generated replacements or holistic rewriting.

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/inputs.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/inputs.md
@@ -17,11 +17,11 @@ data:
 
 | Kind     | Example                                          | Supported by                                                                              |
 |----------|--------------------------------------------------|-------------------------------------------------------------------------------------------|
-| Local    | `/tmp/input.csv` or `./data/input.parquet` | **Local execution only** (`preview run`, `run run`). |
-| HTTP(S)  | `https://example.com/input.csv`            | Local (`preview run`, `run run`) and plugin-service / Jobs execution (`preview submit`, `run submit`). |
-| Fileset  | `<workspace>/<fileset>#<path>`                   | Local (`preview run`, `run run`) and plugin-service / Jobs execution (`preview submit`, `run submit`). |
+| Local    | `./data/input.csv` or `./data/input.parquet`     | CLI preview/run with `--fileset <name>`; the CLI uploads the file before remote execution. |
+| HTTP(S)  | `https://example.com/input.csv`                  | Platform preview and Jobs execution (`run`).                                              |
+| Fileset  | `<workspace>/<fileset>#<path>`                   | Platform preview and Jobs execution (`run`).                                              |
 
-Plugin-service / Jobs execution runs outside the caller's filesystem — use HTTP(S) URLs or fileset refs for those surfaces.
+Platform preview and Jobs execution run outside the caller's filesystem. Use the CLI with `--fileset` to stage a local file, or use HTTP(S) URLs / fileset refs directly for SDK/API calls.
 
 ## Fileset references
 
@@ -33,7 +33,7 @@ my-workspace/input-files#data/input.csv
 input-files#data/input.csv          # uses the request's workspace
 ```
 
-For upload commands, use the platform files CLI docs or `nemo-files` skill. Then put the resulting fileset reference in `data.source`, for example `fileset://<workspace>/anonymizer-inputs#anonymizer-input.csv`.
+For SDK/API upload commands, use the platform files CLI docs or `nemo-files` skill. Then put the resulting fileset reference in `data.source`, for example `fileset://<workspace>/anonymizer-inputs#anonymizer-input.csv`. For CLI preview/run, put the local CSV/Parquet path in `data.source` and pass `--fileset <name>`.
 
 ## Choosing the text column
 
@@ -45,15 +45,7 @@ For upload commands, use the platform files CLI docs or `nemo-files` skill. Then
 
 Run jobs save a working artifacts directory; the anonymized dataset is one file inside that directory.
 
-### Where artifacts land for `run run`
-
-`nemo anonymizer run run` prints `{"exit_code": 0}` on success. The local job results manager logs the artifact directory to **stderr** in the form:
-
-```text
-Saved result 'artifacts' to file:///.../persistent/results/artifacts
-```
-
-Layout under that `artifacts/` directory:
+Full `run` jobs store an `artifacts` result in NeMo Platform job storage. Layout under that `artifacts/` directory:
 
 | File                  | Description                                                                |
 |-----------------------|----------------------------------------------------------------------------|
@@ -62,7 +54,7 @@ Layout under that `artifacts/` directory:
 | `metadata.json`       | Run metadata (includes the original text column name).                     |
 | `failed_records.json` | Per-record failures with reasons. Only written when at least one record failed. |
 
-### Loading the local artifacts
+### Loading downloaded artifacts
 
 Read the parquet files directly from the artifacts directory:
 
@@ -71,7 +63,7 @@ import json
 from pathlib import Path
 import pandas as pd
 
-artifacts_dir = Path("/path/to/persistent/results/artifacts")
+artifacts_dir = Path("/path/to/downloaded/artifacts")
 metadata = json.loads((artifacts_dir / "metadata.json").read_text())
 dataset = pd.read_parquet(artifacts_dir / "dataset.parquet", dtype_backend="pyarrow")
 trace   = pd.read_parquet(artifacts_dir / "trace.parquet",   dtype_backend="pyarrow")
@@ -83,7 +75,7 @@ The trace dataset (and `dataset.parquet` for `annotate` / `substitute` strategie
 
 ### Remote CLI retrieval
 
-For `run submit`, use the standard Jobs CLI after `nemo anonymizer run submit` prints the job name:
+For `run`, pass `--watch --output-dir <dir>` to download artifacts locally after a successful job. To retrieve artifacts later, use the standard Jobs CLI after `nemo anonymizer run` prints the job name:
 
 ```bash
 nemo jobs get-status <job-name> --workspace <ws>

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/model-configs.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/model-configs.md
@@ -9,10 +9,8 @@
 
 | Surface                            | Status                  | `model_configs` required?                                                                                  |
 |------------------------------------|-------------------------|------------------------------------------------------------------------------------------------------------|
-| `nemo anonymizer preview run`      | Available (local)       | No — Anonymizer library defaults are used.                                                                 |
-| `nemo anonymizer run run`          | Available (local)       | No — Anonymizer library defaults are used.                                                                 |
-| `nemo anonymizer preview submit`   | Available (plugin svc)  | **Yes** — needed so requests route through the NeMo Platform Inference Gateway instead of build.nvidia.com directly. |
-| `nemo anonymizer run submit`       | Available (Jobs worker) | **Yes** — the job routes through the NeMo Platform Inference Gateway.                                                |
+| `nemo anonymizer preview` / `sdk.anonymizer.preview(...)` / preview HTTP API | Available (plugin svc) | **Yes** — needed so requests route through the NeMo Platform Inference Gateway instead of build.nvidia.com directly. |
+| `nemo anonymizer run`              | Available (Jobs worker) | **Yes** — the job routes through the NeMo Platform Inference Gateway.                                      |
 | Strategy is `Substitute`           | n/a                     | Effectively yes for plugin-service / Jobs execution; provide a `replacement_generator`-capable alias.      |
 | Mode is `rewrite`                  | n/a                     | Effectively yes for plugin-service / Jobs execution; provide aliases for the Anonymizer library rewrite roles. |
 
@@ -33,7 +31,7 @@ The `provider` field is resolved at request time against NeMo Platform. The stri
 
 ## `selected_models` (role bindings)
 
-`selected_models` is a partial mapping that overrides the Anonymizer library's bundled defaults. Each section is optional; omitted sections fall back to defaults. Use Anonymizer library role names exactly.
+`selected_models` is a partial mapping that overrides the Anonymizer library's bundled role-selection defaults. Each section is optional; omitted sections fall back to the library's role aliases, which must be present in the explicit plugin `model_configs`. Use Anonymizer library role names exactly.
 
 ```yaml
 selected_models:
@@ -54,9 +52,7 @@ Only emit a section if you actually want to override its defaults — overrides 
 
 ## Common patterns
 
-**Local default-everything preview** — no `model_configs`, no `selected_models`. Lets the Anonymizer library use its bundled defaults. Works for `preview run` and `run run`.
-
-**Plugin-service default model pool** (`preview submit`, `run submit`) — provide the aliases used by the Anonymizer library defaults:
+**Default role alias pool** (`preview`, `run`) — provide explicit Inference Gateway-backed aliases used by the Anonymizer library defaults:
 
 ```yaml
 model_configs:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/preview-review.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/preview-review.md
@@ -5,11 +5,11 @@
 
 Use this when the user has run a preview and asked you to evaluate plugin results before committing to a full run.
 
-Reference docs: `docs/anonymizer/tutorials/preview.mdx` (frame schema, surfaces, CLI usage). For detection quality, strategy behavior, and rewrite tuning, defer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills.
+Reference docs: `docs/anonymizer/tutorials/preview.mdx` (frame schema and CLI/SDK/API usage). For detection quality, strategy behavior, and rewrite tuning, defer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills.
 
 ## What you get back
 
-`nemo anonymizer preview run` and `nemo anonymizer preview submit` stream newline-delimited JSON frames with the same logical data:
+`nemo anonymizer preview` streams non-log NDJSON frames to stdout or `--output-file`, and log frames to stderr. `sdk.anonymizer.preview(...)` collects the preview stream into an `AnonymizerPreviewResult`. The direct preview HTTP API streams raw newline-delimited JSON frames with the same logical data:
 
 - `preview_dataset` — public anonymized records.
 - `trace_dataset` — trace records with detection details.
@@ -19,11 +19,9 @@ Reference docs: `docs/anonymizer/tutorials/preview.mdx` (frame schema, surfaces,
 ## Plugin Review Checklist
 
 1. Surface any `failed_records` and the associated reasons.
-2. Confirm the preview used the intended execution surface:
-   - Local paths require `preview run`.
-   - `preview submit` requires HTTP(S) or fileset input and explicit `model_configs`.
+2. Confirm the preview used explicit `model_configs`. If the source was local, confirm the CLI uploaded it via `--fileset`; SDK/API previews should use HTTP(S) or fileset input.
 3. Confirm `model_configs` aliases line up with any `selected_models` overrides. For detection overrides, use Anonymizer library role names such as `entity_detector` and `entity_validator`.
-4. Ask the user to share CLI NDJSON frames for a specific record when you need to inspect exact spans and labels.
+4. Ask the user to share CLI NDJSON, SDK output, or HTTP NDJSON frames for a specific record when you need to inspect exact spans and labels.
 5. If quality needs tuning, refer to the Anonymizer library docs/skills for label selection, thresholds, replacement strategy parameters, and rewrite settings.
 
-When the preview is acceptable, derive the run spec by dropping `num_records`. Run writes artifacts. Use `nemo anonymizer run run` for local execution or `nemo anonymizer run submit` for platform execution.
+When the preview is acceptable, derive the run spec by dropping `num_records`. Full `run` writes artifacts through a NeMo Platform job; use `nemo anonymizer run --watch --output-dir ./anonymizer-artifacts` to submit, stream status/logs, and download artifacts after success.

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/replace-strategies.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/replace-strategies.md
@@ -9,7 +9,7 @@ Plugin notes:
 
 - When specifying `config`, choose either `config.replace` or `config.rewrite`, not both.
 - Hand-written YAML specs must include a `kind` discriminator inside `replace`.
-- Plugin-service / Jobs execution requires `model_configs`; local `preview run` / `run run` can omit it and use Anonymizer library defaults.
+- Preview and Jobs execution require `model_configs` so model calls route through the NeMo Platform Inference Gateway.
 
 Minimal YAML shape:
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/rewrite-mode.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/rewrite-mode.md
@@ -5,10 +5,10 @@
 
 Use this reference only for plugin execution concerns. The [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) and library skills own rewrite semantics, privacy-goal fields, risk tuning, and recommended prompt wording.
 
-For plugin-service / Jobs execution (`preview submit`, `run submit`):
+For plugin-service / Jobs execution (preview API, `run`):
 
 - Include `model_configs` so rewrite model calls route through NeMo Platform Inference Gateway providers.
-- Use HTTP(S) URLs or fileset references for `data.source`; local paths only work with `preview run` / `run run`.
+- Use HTTP(S) URLs or fileset references for SDK/API `data.source`. CLI preview/run can upload a local CSV/Parquet source when `--fileset <name>` is supplied.
 - Only include `selected_models.rewrite` when you need to override library defaults, and use Anonymizer library role names exactly.
 
 Example role override shape:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/autopilot.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/autopilot.md
@@ -7,35 +7,30 @@ The user has signaled they don't want to answer questions. Make defensible decis
 
 Source of truth for defaults: `docs/anonymizer/tutorials/index.mdx` and `docs/anonymizer/tutorials/{preview,run}.mdx`. If anything below conflicts with the docs, the docs win.
 
-1. **Resolve CLI command** — Run `command -v nemo 2>/dev/null || (test -x .venv/bin/nemo && realpath .venv/bin/nemo) || echo CLI_NOT_FOUND`.
-   - If the output is `CLI_NOT_FOUND`, STOP and follow the Troubleshooting section in SKILL.md.
+1. **Make sure `nemo` is on PATH** — Run `command -v nemo`. If it is missing but `.venv/bin/nemo` exists, run `export PATH="$(pwd)/.venv/bin:$PATH"` and verify with `command -v nemo`. If `nemo` still cannot be found, follow the Troubleshooting section in SKILL.md, use the SDK/API preview path only, and do not suggest CLI-only commands until `nemo` is available.
 2. **Decide defaults** without asking. Use these unless the user's prompt obviously requires otherwise:
    - **Strategy**: `Redact` with `format_template="[REDACTED_{label}]"`. Use `Substitute` only if the user explicitly says they want realistic synthetic replacements. Use `rewrite` only if the user explicitly mentions rewriting / a privacy goal / utility tradeoff.
    - **Detection config**: keep Anonymizer library defaults unless the user explicitly asks for detection tuning.
    - **`text_column`**: pick the column most plausibly holding free text — `text`, `biography`, `body`, `message`, `content`, `description`, in that order. If you genuinely can't tell, ask one short question.
    - **`id_column`**: include an obvious id column (`id`, `record_id`) if present; otherwise omit.
    - **`num_records`**: 5 for preview.
-   - **Preview surface**: `nemo anonymizer preview run` (local) if the input is a local file path. Otherwise (HTTP(S) URL or fileset ref), `nemo anonymizer preview submit`.
-   - **Run surface**: `nemo anonymizer run run` for local paths. Use `nemo anonymizer run submit` only when the user explicitly asks for platform/cluster execution or provides a non-local input and model configs.
-   - **Model configs**: only set when using a plugin-service surface (`preview submit` / `run submit`) or when the strategy is `Substitute` / `rewrite`. When required, default to `nvidia-build` as the provider (or the provider the user named) with these aliases:
+   - **Preview surface**: `nemo anonymizer preview` if the CLI is available, otherwise `sdk.anonymizer.preview(...)` or the preview HTTP API. If the input is a local file path and the CLI is available, pass `--fileset <name>` so the CLI uploads it; otherwise ask the user to upload it to a fileset or provide an HTTP(S) URL.
+   - **Run surface**: if the CLI is available, full runs use `nemo anonymizer run` on the Jobs worker. If the input is a local path, pass the same `--fileset <name>` so the CLI uploads it and stores artifacts there.
+   - **Model configs**: required for preview and `run`. Default to `nvidia-build` as the provider (or the provider the user named) with these aliases:
      - `gliner-pii-detector` → `nvidia/gliner-pii`
      - `gpt-oss-120b` → `openai/gpt-oss-120b`
      - `nemotron-30b-thinking` → `nvidia/nemotron-3-nano-30b-a3b`
-3. **(If using a plugin-service surface) Confirm the service is mounted.** Run `curl -s http://localhost:8080/openapi.json | jq -r '.paths | keys[]' | grep '^/apis/anonymizer/'`. If nothing prints, tell the user to run `nemo services run` (no `--services` flag) — `nemo setup` does not mount this plugin — then continue. Skip this step entirely for `preview run` / `run run`.
-4. **Build** — Write a YAML preview spec following the Output Template in SKILL.md. Default filename: `<text_column>_preview_spec.yaml` (e.g. `biography_preview_spec.yaml`).
-5. **Preview** — Run the surface chosen in step 2:
-   - Local: `nemo anonymizer preview run --spec-file <path> --workspace <ws>`
-   - Plugin service: `nemo anonymizer preview submit --spec-file <path> --workspace <ws>`
-
-   Briefly summarize the preview result — entities detected per label, any `failed_records`, and a one-record before/after example.
-6. **Generate run spec** — Without re-prompting, also produce a run YAML named `<text_column>_run_spec.yaml`. It mirrors the preview spec but drops `num_records`. Run writes artifacts, not a dataset entity. Keep `model_configs` only if it was needed for the preview or remote run.
-7. **Finalize** — Tell the user the preview ran, briefly summarize what happens to PII under the chosen strategy, and give them the launch command:
+3. **Confirm the plugin service is mounted before service-backed execution.** Run `curl -s http://localhost:8080/openapi.json | jq -r '.paths | keys[]' | grep '^/apis/anonymizer/'` before `nemo anonymizer preview`, SDK/API preview, or a full `nemo anonymizer run`. If nothing prints and `nemo` is available, tell the user to run `nemo services run` (no `--services` flag) and rerun the check before attempting preview or run. If `nemo` is unavailable, tell the user the plugin service must be mounted before SDK/API preview can run. `nemo anonymizer validate` does not need the plugin service.
+4. **Build** — Write a preview spec following the Output Template in SKILL.md. Default filename for CLI preview is `<text_column>_preview.yaml` (e.g. `biography_preview.yaml`).
+5. **Preview** — Use `nemo anonymizer preview --spec-file <preview_spec>.yaml --workspace <ws> --fileset <fileset> --output-file preview.ndjson` when the CLI is available and `data.source` is local; otherwise use the same command without `--fileset` for HTTP/fileset inputs, or `sdk.anonymizer.preview(...)` / `POST /apis/anonymizer/v2/workspaces/{workspace}/preview`. Briefly summarize the preview result — entities detected per label, any `failed_records`, and a one-record before/after example.
+6. **Generate run spec** — If `nemo` is available, produce a run YAML named `<text_column>_run_spec.yaml`. It mirrors the preview request but drops `num_records`. Run writes artifacts, not a dataset entity. If `nemo` is unavailable, skip this step.
+7. **Finalize** — Tell the user the preview ran and briefly summarize what happens to PII under the chosen strategy. If `nemo` is unavailable, tell the user to make `nemo` available on PATH before a full run and do not show CLI run or jobs commands. If `nemo` is available, give them the launch command:
 
    ```bash
-   nemo anonymizer run run --spec-file <run_spec>.yaml
+   nemo anonymizer run --spec-file <run_spec>.yaml --workspace <ws> --fileset <fileset> --watch --output-dir ./anonymizer-artifacts
    ```
 
-   If the user asked for cluster execution, give `nemo anonymizer run submit --spec-file <run_spec>.yaml --workspace <ws>` instead. Mention that local artifacts are printed to stderr (`Saved result 'artifacts' to file://...`) and remote artifacts can be fetched with:
+   Mention that the command creates a NeMo Platform job and artifacts can be fetched with:
 
    ```bash
    nemo jobs get-status <job-name> --workspace <ws>

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/interactive.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/interactive.md
@@ -7,45 +7,39 @@ This is an interactive, iterative anonymization design process. Do not disengage
 
 Source of truth for this workflow: `docs/anonymizer/tutorials/index.mdx`, `docs/anonymizer/tutorials/preview.mdx`, and `docs/anonymizer/tutorials/run.mdx`. Defer to them if the CLI flags or capabilities here look out of date.
 
-1. **Resolve CLI command** — Run `command -v nemo 2>/dev/null || (test -x .venv/bin/nemo && realpath .venv/bin/nemo) || echo CLI_NOT_FOUND`.
-   - If the output is a path, use `<path> anonymizer` as the command prefix for all `nemo anonymizer …` invocations in this workflow.
-   - If the output is `CLI_NOT_FOUND`, STOP and follow the Troubleshooting section in SKILL.md. Do not continue.
-2. **Confirm the plugin service is mounted (only if the user wants `preview submit` or `run submit`).** Run `curl -s http://localhost:8080/openapi.json | jq -r '.paths | keys[]' | grep '^/apis/anonymizer/'`. If nothing prints, the plugin service isn't loaded — `nemo setup` does not auto-mount it. Tell the user to run `nemo services run` (no `--services` flag) and rerun the check. Local previews (`preview run`) and local runs (`run run`) do **not** need the plugin service mounted.
-3. **Confirm input source** — Decide which kind of input you're working with: a local CSV/Parquet file, an `http(s)://` URL, or a NeMo Platform fileset reference. If the user named a file but it's not yet on the platform and they want to use `preview submit`, ask whether to upload it to a fileset first (see `references/inputs.md`).
+1. **Make sure `nemo` is on PATH** — Run `command -v nemo`. If it is missing but `.venv/bin/nemo` exists, run `export PATH="$(pwd)/.venv/bin:$PATH"` and verify with `command -v nemo`. If `nemo` still cannot be found, follow the Troubleshooting section in SKILL.md, use the SDK/API preview path only, and do not suggest CLI-only commands until `nemo` is available.
+2. **Confirm the plugin service is mounted before service-backed execution.** Run `curl -s http://localhost:8080/openapi.json | jq -r '.paths | keys[]' | grep '^/apis/anonymizer/'` before `nemo anonymizer preview`, SDK/API preview, or `nemo anonymizer run`. If nothing prints, the plugin service isn't loaded; if `nemo` is available, tell the user to run `nemo services run` (no `--services` flag) and rerun the check. If `nemo` is unavailable, tell the user the plugin service must be mounted before SDK/API preview can run. `nemo anonymizer validate` does not need the plugin service.
+3. **Confirm input source** — Decide whether you're working with a local CSV/Parquet file, an `http(s)://` URL, or a NeMo Platform fileset reference. If the user named a local file and the CLI is available, choose or ask for the `--fileset` name the CLI should use for upload and outputs (see `references/inputs.md`).
 4. **Clarify** — Ask the user clarifying questions to narrow down precisely what they want. Prefer a structured question tool if one is available, batch related questions together, keep the set short, and offer concrete options/defaults. Common things to make precise:
    - **Text column** to scan and (optional) **id column**.
    - **What to do with detected entities**: redact, annotate (tag inline), hash (deterministic token), substitute with realistic LLM-generated values, or fully rewrite the text under a privacy goal. See `references/replace-strategies.md` and `references/rewrite-mode.md`.
    - **Detection tuning** — keep Anonymizer library defaults unless the user explicitly asks for label/threshold changes; refer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills for those details.
-   - **Preview surface** — `preview run` (local, allows local paths) or `preview submit` (plugin service via CLI).
-   - **Run surface** — `nemo anonymizer run run` for local in-process execution or `nemo anonymizer run submit` for Jobs-worker execution. This is the Anonymizer equivalent of Data Designer's `create run` / `create submit` pattern.
-5. **Resolve model providers (only if needed)** — If the preview is going through the plugin service (`preview submit`), or the chosen replacement strategy is `Substitute` or `Rewrite`, ask which provider(s) and model aliases to use. For provider discovery or creation, refer to the platform inference/model-provider docs or the relevant inference/model skill. See `references/model-configs.md`.
-6. **Plan** — Summarize the planned config (replace vs rewrite strategy, detection tuning, model_configs, input source, num_records, preview surface) and ask the user to confirm before writing the spec.
-7. **Build** — Write a YAML spec file following the Output Template in SKILL.md. Use the **Preview** shape first.
-8. **Validate (optional)** — If you've also produced a stand-alone `AnonymizerConfig` YAML (e.g., the user wants `nemo anonymizer validate` to gate the run), invoke it now and address any errors before previewing.
-9. **Preview** — Pick the surface you agreed on in step 4:
-   - Local CLI: `nemo anonymizer preview run --spec-file <path> --workspace <ws>`
-   - Plugin service via CLI: `nemo anonymizer preview submit --spec-file <path> --workspace <ws>`
-
-   Inspect the resulting NDJSON frames: `log` lines, the `preview_dataset`, the `trace_dataset`, and any `failed_records`. Surface anything in `failed_records` to the user.
+   - **Preview surface** — `nemo anonymizer preview` if the CLI is available, otherwise `sdk.anonymizer.preview(...)` or the preview HTTP API.
+   - **Run surface** — if the CLI is available, full runs use `nemo anonymizer run` for Jobs-worker execution. If the input is local, pass `--fileset <name>` so the CLI uploads it and stores artifacts there.
+5. **Resolve model providers** — Ask which provider(s) and model aliases to use. Preview and run require `model_configs` so model calls route through the Inference Gateway. For provider discovery or creation, refer to the platform inference/model-provider docs or the relevant inference/model skill. See `references/model-configs.md`.
+6. **Plan** — Summarize the planned config (replace vs rewrite strategy, detection tuning, model_configs, input source, num_records, preview surface) and ask the user to confirm before writing the request.
+7. **Build** — Write a preview spec following the Output Template in SKILL.md. Use YAML for CLI preview, JSON for direct HTTP preview, or a `PreviewRequest` object for SDK preview.
+8. **Validate (optional, CLI only)** — If `nemo` is available and you've also produced a stand-alone `AnonymizerConfig` YAML (e.g., the user wants `nemo anonymizer validate` to gate the run), invoke it now and address any errors before previewing.
+9. **Preview** — Use `nemo anonymizer preview --spec-file <preview_spec>.yaml --workspace <ws> --fileset <fileset> --output-file preview.ndjson` when the CLI is available and `data.source` is local; otherwise use the same command without `--fileset` for HTTP/fileset inputs, or `sdk.anonymizer.preview(...)` / `POST /apis/anonymizer/v2/workspaces/{workspace}/preview`. Inspect the resulting `AnonymizerPreviewResult` or NDJSON frames: `log` lines, the `preview_dataset`, the `trace_dataset`, and any `failed_records`. Surface anything in `failed_records` to the user.
 10. **Iterate**
     - Ask the user for feedback on the preview output. Offer to review the records yourself and suggest plugin-surface fixes (input source, model configs, selected model aliases) or refer to Anonymizer library docs/skills for library-level tuning. See `references/preview-review.md`.
     - Apply changes, re-preview. Repeat until the user is satisfied.
-11. **Finalize** — Once the user is happy with the preview:
+11. **Finalize** — Once the user is happy with the preview, only continue to full-run guidance if `nemo` is available. If it is unavailable, tell the user to make `nemo` available on PATH before a full run and do not show CLI run or jobs commands. If it is available:
     - Generate a run spec by dropping `num_records` from the preview request. Run writes artifacts, not a dataset entity.
-    - Tell the user they can run the full job locally with:
+    - Tell the user they can submit the full job with:
 
       ```bash
-      nemo anonymizer run run --spec-file <run_spec>.yaml
+      nemo anonymizer run --spec-file <run_spec>.yaml --workspace <ws> --fileset <fileset> --watch --output-dir ./anonymizer-artifacts
       ```
 
-    - If they want platform execution, tell them to use:
+    - If they want to inspect the submit request first, tell them to use:
 
       ```bash
-      nemo anonymizer run submit --spec-file <run_spec>.yaml --workspace <ws>
+      nemo anonymizer run --spec-file <run_spec>.yaml --workspace <ws> --fileset <fileset> --verbose
       ```
 
-      The remote path requires `model_configs` and rejects local file paths.
-    - For remote jobs, show the CLI follow-up commands:
+      Use `--dry-run` instead of `--verbose` to print the schema and request without creating a job. Full runs require `model_configs`; local CLI input requires `--fileset`.
+    - For jobs, show the CLI follow-up commands:
 
       ```bash
       nemo jobs get-status <job-name> --workspace <ws>
@@ -53,6 +47,5 @@ Source of truth for this workflow: `docs/anonymizer/tutorials/index.mdx`, `docs/
       nemo jobs results list <job-name> --workspace <ws>
       nemo jobs results download artifacts --job <job-name> --workspace <ws> --output-file artifacts.tar.gz
       ```
-    - Note that local `run run` prints `{"exit_code": 0}` on success and logs the artifact directory to **stderr** in the form `Saved result 'artifacts' to file:///.../persistent/results/artifacts`. Walk through `references/inputs.md` if the user wants help loading those artifacts.
     - Caution that runtime depends on dataset size and the chosen strategy (LLM-backed strategies are slower).
     - Do not run the full job yourself — let the user decide when to launch it.

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
@@ -42,7 +42,7 @@ _TASK_LOG_HANDLER_MARKER = "_nemo_anonymizer_task_handler"
 def run(sdk: NeMoPlatform | None = None) -> int:
     try:
         service_sdk = sdk or get_platform_sdk(as_service="anonymizer")
-        return run_step_config(_load_step_config(), ctx=_get_ctx(service_sdk), sdk=service_sdk, is_local=False)
+        return run_step_config(_load_step_config(), ctx=_get_ctx(service_sdk), sdk=service_sdk)
     except Exception:
         logger.exception("Anonymizer task failed")
         return 1
@@ -53,10 +53,9 @@ def run_step_config(
     *,
     ctx: JobContext,
     sdk: NeMoPlatform | None = None,
-    is_local: bool = False,
 ) -> int:
     try:
-        return _run_with_step_config(sdk, step_config, ctx=ctx, is_local=is_local)
+        return _run_with_step_config(sdk, step_config, ctx=ctx)
     except Exception:
         logger.exception("Anonymizer task failed")
         return 1
@@ -67,28 +66,29 @@ def _run_with_step_config(
     step_config: AnonymizerStepConfig,
     *,
     ctx: JobContext,
-    is_local: bool,
 ) -> int:
     _configure_logging()
-    if service_sdk is None and not is_local:
+    if service_sdk is None:
         raise RuntimeError("Remote anonymizer task requires a NeMo Platform SDK.")
 
     storage_path = ctx.storage.persistent
     workspace = ctx.workspace
 
     request = step_config.request
-    dd_providers = _resolve_provider_endpoints(service_sdk, step_config, workspace, is_local=is_local)
+    if not step_config.model_configs_yaml:
+        raise RuntimeError("Remote anonymizer task requires resolved model_configs.")
+    dd_providers = _resolve_provider_endpoints(service_sdk, step_config, workspace)
     prepared_input = prepare_anonymizer_input(
         request.data,
         sdk=service_sdk,
         workspace=workspace,
-        allow_local_paths=is_local,
+        allow_local_paths=False,
     )
 
     try:
         with preserve_root_logging():
             anonymizer = Anonymizer(
-                model_configs=step_config.model_configs_yaml or None,
+                model_configs=step_config.model_configs_yaml,
                 model_providers=dd_providers,
                 artifact_path=storage_path / "anonymizer-artifacts",
             )
@@ -132,11 +132,9 @@ def _run_with_step_config(
 
 
 def _resolve_provider_endpoints(
-    sdk: NeMoPlatform | None,
+    sdk: NeMoPlatform,
     step_config: AnonymizerStepConfig,
     workspace: str,
-    *,
-    is_local: bool,
 ) -> list[DDModelProvider] | None:
     """Re-resolve provider endpoints in the task environment.
 
@@ -145,10 +143,6 @@ def _resolve_provider_endpoints(
     """
     if not step_config.dd_model_providers:
         return None
-    if is_local:
-        return [DDModelProvider.model_validate(raw) for raw in step_config.dd_model_providers]
-    if sdk is None:
-        raise RuntimeError("Remote anonymizer task requires a NeMo Platform SDK.")
     models = client_from_platform(sdk, ModelsClient)
     refreshed: list[DDModelProvider] = []
     for raw in step_config.dd_model_providers:

--- a/plugins/nemo-anonymizer/tests/unit/test_cli.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_cli.py
@@ -3,21 +3,35 @@
 
 from __future__ import annotations
 
+import io
 import json
+import tarfile
+from io import StringIO
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
+from unittest.mock import Mock
 
+import typer
 import yaml
 from nemo_anonymizer_plugin import cli as cli_module
+from nemo_anonymizer_plugin import cli_files as cli_files_module
+from nemo_anonymizer_plugin.app.task_config import AnonymizerRequest
 from nemo_anonymizer_plugin.cli import AnonymizerCLI
-from nemo_platform_plugin.commands import add_job_commands
+from nemo_anonymizer_plugin.functions.preview import PreviewDatasetFrame, PreviewFunction
+from nemo_platform_plugin.cli_renderer import CLIRenderer, RendererContext
+from nemo_platform_plugin.commands import add_function_commands, add_job_commands
+from nemo_platform_plugin.functions.frames import Done, Error, FrameModel
 from nemo_platform_plugin.job import NemoJob
+from rich.console import Console
 from typer.testing import CliRunner
 
 
-class _RunJob(NemoJob):
+class _AnonymizerRunJob(NemoJob):
     name: ClassVar[str] = "run"
-    description: ClassVar[str] = "Run test job."
+    description: ClassVar[str] = "Run anonymizer test job."
+    generate_legacy_verbs: ClassVar[bool] = False
+    input_spec_schema = AnonymizerRequest
+    spec_schema = AnonymizerRequest
 
     def run(self, config: dict) -> dict:
         return {"config": config}
@@ -36,32 +50,985 @@ def _write_config(path: Path) -> None:
     )
 
 
-def test_cli_only_registers_manual_validate_command() -> None:
+def _write_preview_request(path: Path) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "config": {
+                    "replace": {
+                        "kind": "redact",
+                        "format_template": "[REDACTED_{label}]",
+                    }
+                },
+                "data": {
+                    "source": "https://example.test/input.csv",
+                    "text_column": "text",
+                },
+                "num_records": 2,
+            }
+        )
+    )
+
+
+def _write_anonymizer_request(path: Path, *, source: str) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "config": {
+                    "replace": {
+                        "kind": "redact",
+                        "format_template": "[REDACTED_{label}]",
+                    }
+                },
+                "data": {
+                    "source": source,
+                    "text_column": "text",
+                },
+            }
+        )
+    )
+
+
+def _app_with_preview_function(monkeypatch) -> typer.Typer:
+    monkeypatch.setattr(
+        "nemo_platform_plugin.discovery.discover_functions",
+        lambda: {"anonymizer.preview": PreviewFunction},
+    )
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_function_commands(app, {"anonymizer.preview": PreviewFunction}, cli=cli)
+    return app
+
+
+def _patch_preview_submit(monkeypatch, frames: list[FrameModel]) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def fake_post(
+        url: str,
+        body: dict,
+        *,
+        headers: dict[str, str],
+        timeout: float = 30.0,
+        renderer_cls: type[CLIRenderer] | None = None,
+        cli_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        captured["url"] = url
+        captured["body"] = body
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        captured["cli_kwargs"] = cli_kwargs
+        assert renderer_cls is not None
+        renderer = renderer_cls()
+        ctx = RendererContext(
+            console=Console(file=StringIO()),
+            cli_kwargs=cli_kwargs or {},
+            verb="submit",
+            is_local=False,
+        )
+        renderer.on_start(ctx=ctx)
+        try:
+            for frame in frames:
+                renderer.on_frame(frame.model_dump(mode="json", exclude_none=True), ctx=ctx)
+            renderer.on_complete(ctx=ctx)
+        except BaseException as exc:
+            renderer.on_error(exc, ctx=ctx)
+            raise
+
+    monkeypatch.setattr("nemo_platform_plugin.commands._post_function_submit", fake_post)
+    return captured
+
+
+def test_cli_registers_validate_command() -> None:
     result = CliRunner().invoke(AnonymizerCLI().get_cli(), ["--help"])
 
     assert result.exit_code == 0, result.output
     assert "validate" in result.output
-    assert "preview-local" not in result.output
-    assert "run-local" not in result.output
 
 
-def test_run_job_collapses_local_run_alias() -> None:
+def test_preview_command_help_does_not_expose_watch(monkeypatch) -> None:
+    result = CliRunner().invoke(_app_with_preview_function(monkeypatch), ["preview", "--help"])
+
+    assert result.exit_code == 0, result.output
+    assert "--fileset" in result.output
+    assert "--input-remote-path" in result.output
+    assert "--output-remote-path" in result.output
+    assert "--quiet" in result.output
+    assert "--output-file" in result.output
+    assert "--watch" not in result.output
+
+
+def test_preview_command_does_not_accept_legacy_nested_verbs(monkeypatch) -> None:
+    runner = CliRunner()
+    app = _app_with_preview_function(monkeypatch)
+
+    run_result = runner.invoke(app, ["preview", "run", "--spec", "{}"])
+    submit_result = runner.invoke(app, ["preview", "submit", "--spec", "{}"])
+
+    assert run_result.exit_code == 2
+    assert "unexpected extra argument" in run_result.output
+    assert submit_result.exit_code == 2
+    assert "unexpected extra argument" in submit_result.output
+
+
+def _load_json_documents(output: str) -> list[object]:
+    decoder = json.JSONDecoder()
+    remaining = output.strip()
+    documents: list[object] = []
+    while remaining:
+        document, index = decoder.raw_decode(remaining)
+        documents.append(document)
+        remaining = remaining[index:].strip()
+    return documents
+
+
+def test_anonymizer_run_help_exposes_files_options_without_output_location() -> None:
     cli = AnonymizerCLI()
     app = cli.get_cli()
-    add_job_commands(app, {"anonymizer.run": _RunJob}, cli=cli)
-    runner = CliRunner()
+    add_job_commands(app, {"anonymizer.run": _AnonymizerRunJob}, cli=cli)
 
-    alias_result = runner.invoke(app, ["run", "--config", '{"name": "Alias"}'])
-    nested_result = runner.invoke(app, ["run", "run", "--config", '{"name": "Nested"}'])
-    help_result = runner.invoke(app, ["run", "--help"])
+    result = CliRunner().invoke(app, ["run", "--help"])
 
-    assert alias_result.exit_code == 0, alias_result.output
-    assert json.loads(alias_result.output) == {"config": {"name": "Alias"}}
-    assert nested_result.exit_code == 0, nested_result.output
-    assert json.loads(nested_result.output) == {"config": {"name": "Nested"}}
-    assert help_result.exit_code == 0, help_result.output
-    assert "Run locally, in-process." in help_result.output
-    assert "Run run locally" not in help_result.output
+    assert result.exit_code == 0, result.output
+    assert "[COMMAND]" not in result.output
+    assert "--fileset" in result.output
+    assert "--input-remote-path" in result.output
+    assert "--output-dir" in result.output
+    assert "--verbose" in result.output
+    assert "--print-request" not in result.output
+    assert "--output-location" not in result.output
+
+
+def test_anonymizer_run_command_does_not_accept_legacy_nested_verbs() -> None:
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_job_commands(app, {"anonymizer.run": _AnonymizerRunJob}, cli=cli)
+
+    run_result = CliRunner().invoke(app, ["run", "run", "--spec", "{}"])
+    submit_result = CliRunner().invoke(app, ["run", "submit", "--spec", "{}"])
+
+    assert run_result.exit_code == 2
+    assert "unexpected extra argument" in run_result.output
+    assert submit_result.exit_code == 2
+    assert "unexpected extra argument" in submit_result.output
+
+
+def test_anonymizer_run_delegates_to_generated_job_submit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    spec_file = tmp_path / "run.yaml"
+    _write_anonymizer_request(spec_file, source="https://example.test/input.csv")
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_job_commands(app, {"anonymizer.run": _AnonymizerRunJob}, cli=cli)
+    captured: dict[str, object] = {}
+
+    def fake_submit_remote(self, job_cls, spec, **kwargs):
+        captured["job_cls"] = job_cls
+        captured["spec"] = spec
+        captured["kwargs"] = kwargs
+        return {"name": "anon-job-1", "workspace": "team-a"}
+
+    monkeypatch.setattr("nemo_platform_plugin.scheduler.NemoJobScheduler.submit_remote", fake_submit_remote)
+
+    class _State:
+        def get_base_url(self, default: str | None = None) -> str | None:
+            return default
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "--spec-file",
+            str(spec_file),
+            "--workspace",
+            "team-a",
+            "--base-url",
+            "http://platform.example",
+        ],
+        obj=_State(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"name": "anon-job-1", "workspace": "team-a"}
+    assert captured["job_cls"] is _AnonymizerRunJob
+    spec = cast(dict[str, Any], captured["spec"])
+    assert spec["data"]["source"] == "https://example.test/input.csv"
+    assert captured["kwargs"] == {
+        "base_url": "http://platform.example",
+        "workspace": "team-a",
+        "profile": None,
+        "options": None,
+        "metadata": None,
+        "headers": None,
+    }
+
+
+def test_anonymizer_run_uploads_local_input_and_maps_fileset_to_output_location(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    local_input = tmp_path / "input.csv"
+    local_input.write_text("text\nAlice met Bob\n")
+    spec_file = tmp_path / "run.yaml"
+    _write_anonymizer_request(spec_file, source=str(local_input))
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_job_commands(app, {"anonymizer.run": _AnonymizerRunJob}, cli=cli)
+    captured: dict[str, object] = {"ensured": [], "uploads": []}
+    platform_client = object()
+
+    def fake_make_platform_client(**kwargs: object) -> object:
+        captured["platform_kwargs"] = kwargs
+        return platform_client
+
+    def fake_ensure(platform: object, *, workspace: str, fileset: str) -> None:
+        assert platform is platform_client
+        cast(list[tuple[str, str]], captured["ensured"]).append((workspace, fileset))
+
+    def fake_upload(
+        platform: object,
+        *,
+        local_path: Path,
+        remote_path: str,
+        fileset: str,
+        workspace: str,
+        description: str,
+        quiet: bool = False,
+    ) -> None:
+        assert platform is platform_client
+        cast(list[dict[str, object]], captured["uploads"]).append(
+            {
+                "local_path": local_path,
+                "remote_path": remote_path,
+                "fileset": fileset,
+                "workspace": workspace,
+                "description": description,
+                "quiet": quiet,
+            }
+        )
+
+    def fake_submit_remote(self, job_cls, spec, **kwargs):
+        captured["job_cls"] = job_cls
+        captured["spec"] = spec
+        captured["kwargs"] = kwargs
+        return {"name": "anon-job-1", "workspace": "team-a"}
+
+    monkeypatch.setattr(cli_files_module, "make_platform_client", fake_make_platform_client)
+    monkeypatch.setattr(cli_files_module, "ensure_fileset_exists", fake_ensure)
+    monkeypatch.setattr(cli_files_module, "upload_file_to_fileset", fake_upload)
+    monkeypatch.setattr(
+        "nemo_platform_plugin.scheduler.NemoJobScheduler.submit_remote",
+        fake_submit_remote,
+    )
+
+    class _State:
+        def get_base_url(self, default: str | None = None) -> str | None:
+            return default
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "--spec-file",
+            str(spec_file),
+            "--fileset",
+            "anonymizer-inputs",
+            "--input-remote-path",
+            "inputs/input.csv",
+            "--workspace",
+            "team-a",
+            "--base-url",
+            "http://platform.example",
+        ],
+        obj=_State(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["platform_kwargs"] == {
+        "base_url": "http://platform.example",
+        "workspace": "team-a",
+        "headers": {},
+    }
+    assert captured["ensured"] == [("team-a", "anonymizer-inputs")]
+    assert captured["uploads"] == [
+        {
+            "local_path": local_input,
+            "remote_path": "inputs/input.csv",
+            "fileset": "anonymizer-inputs",
+            "workspace": "team-a",
+            "description": "local input",
+            "quiet": False,
+        }
+    ]
+    assert captured["job_cls"] is _AnonymizerRunJob
+    spec = cast(dict[str, Any], captured["spec"])
+    assert spec["data"]["source"] == "team-a/anonymizer-inputs#inputs/input.csv"
+    assert captured["kwargs"] == {
+        "base_url": "http://platform.example",
+        "workspace": "team-a",
+        "profile": None,
+        "options": None,
+        "metadata": {"output_location": "anonymizer-inputs"},
+        "headers": None,
+    }
+
+
+def test_anonymizer_run_verbose_outputs_submit_payload_then_submits(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    spec_file = tmp_path / "run.yaml"
+    _write_anonymizer_request(spec_file, source="https://example.test/input.csv")
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_job_commands(app, {"anonymizer.run": _AnonymizerRunJob}, cli=cli)
+    captured: dict[str, object] = {}
+
+    def fake_build_submit_url(self, job_cls, *, base_url, workspace):
+        assert job_cls is _AnonymizerRunJob
+        return f"{base_url.rstrip('/')}/submit/{workspace}"
+
+    def fake_build_submit_body(self, spec, *, profile, options, metadata):
+        assert metadata is None
+        return {"spec": spec, "profile": profile, "options": options}
+
+    def fake_submit_remote(self, job_cls, spec, **kwargs):
+        captured["job_cls"] = job_cls
+        captured["spec"] = spec
+        captured["kwargs"] = kwargs
+        return {"name": "anon-job-1", "workspace": "team-a"}
+
+    monkeypatch.setattr(
+        "nemo_platform_plugin.scheduler.NemoJobScheduler._build_submit_url",
+        fake_build_submit_url,
+    )
+    monkeypatch.setattr(
+        "nemo_platform_plugin.scheduler.NemoJobScheduler._build_submit_body",
+        fake_build_submit_body,
+    )
+    monkeypatch.setattr(
+        "nemo_platform_plugin.scheduler.NemoJobScheduler.submit_remote",
+        fake_submit_remote,
+    )
+
+    class _State:
+        def get_base_url(self, default: str | None = None) -> str | None:
+            return default
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "--spec-file",
+            str(spec_file),
+            "--workspace",
+            "team-a",
+            "--base-url",
+            "http://platform.example",
+            "--profile",
+            "gpu",
+            "--verbose",
+        ],
+        obj=_State(),
+    )
+
+    assert result.exit_code == 0, result.output
+    documents = _load_json_documents(result.output)
+    schema_document = cast(dict[str, Any], documents[0])
+    request_document = cast(dict[str, Any], documents[1])
+    job_document = documents[2]
+    assert schema_document["profile"] == "gpu"
+    assert schema_document["input_spec_schema"]["title"] == "AnonymizerRequest"
+    assert request_document["method"] == "POST"
+    assert request_document["url"] == "http://platform.example/submit/team-a"
+    assert request_document["body"]["profile"] == "gpu"
+    assert request_document["body"]["options"] is None
+    assert request_document["body"]["spec"]["data"] == {
+        "source": "https://example.test/input.csv",
+        "text_column": "text",
+    }
+    assert request_document["body"]["spec"]["config"]["replace"] == {
+        "kind": "redact",
+        "format_template": "[REDACTED_{label}]",
+        "normalize_label": True,
+    }
+    assert job_document == {"name": "anon-job-1", "workspace": "team-a"}
+    assert captured["job_cls"] is _AnonymizerRunJob
+    assert captured["kwargs"] == {
+        "base_url": "http://platform.example",
+        "workspace": "team-a",
+        "profile": "gpu",
+        "options": None,
+        "metadata": None,
+        "headers": None,
+    }
+
+
+def test_anonymizer_run_dry_run_rewrites_local_input_without_uploading(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    local_input = tmp_path / "input.csv"
+    local_input.write_text("text\nAlice met Bob\n")
+    spec_file = tmp_path / "run.yaml"
+    _write_anonymizer_request(spec_file, source=str(local_input))
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_job_commands(app, {"anonymizer.run": _AnonymizerRunJob}, cli=cli)
+    monkeypatch.setattr(cli_files_module, "make_platform_client", Mock(side_effect=AssertionError("no client")))
+    monkeypatch.setattr(cli_files_module, "ensure_fileset_exists", Mock(side_effect=AssertionError("no create")))
+    monkeypatch.setattr(cli_files_module, "upload_file_to_fileset", Mock(side_effect=AssertionError("no upload")))
+
+    def fake_build_submit_url(self, job_cls, *, base_url, workspace):
+        assert job_cls is _AnonymizerRunJob
+        return f"{base_url.rstrip('/')}/submit/{workspace}"
+
+    monkeypatch.setattr(
+        "nemo_platform_plugin.scheduler.NemoJobScheduler._build_submit_url",
+        fake_build_submit_url,
+    )
+
+    class _State:
+        def get_base_url(self, default: str | None = None) -> str | None:
+            return default
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "--spec-file",
+            str(spec_file),
+            "--fileset",
+            "anonymizer-inputs",
+            "--workspace",
+            "team-a",
+            "--base-url",
+            "http://platform.example",
+            "--dry-run",
+        ],
+        obj=_State(),
+    )
+
+    assert result.exit_code == 0, result.output
+    documents = _load_json_documents(result.output)
+    schema_document = cast(dict[str, Any], documents[0])
+    request_document = cast(dict[str, Any], documents[1])
+    assert schema_document["input_spec_schema"]["title"] == "AnonymizerRequest"
+    body = request_document["body"]
+    assert body["spec"]["data"]["source"] == "team-a/anonymizer-inputs#input.csv"
+    assert body["output_location"] == "anonymizer-inputs"
+
+
+def test_anonymizer_run_output_dir_requires_watch(tmp_path: Path) -> None:
+    spec_file = tmp_path / "run.yaml"
+    _write_anonymizer_request(spec_file, source="https://example.test/input.csv")
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_job_commands(app, {"anonymizer.run": _AnonymizerRunJob}, cli=cli)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "--spec-file",
+            str(spec_file),
+            "--base-url",
+            "http://platform.example",
+            "--output-dir",
+            str(tmp_path / "out"),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "--output-dir requires --watch" in result.output
+
+
+def test_anonymizer_run_downloads_artifacts_after_successful_watch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    spec_file = tmp_path / "run.yaml"
+    _write_anonymizer_request(spec_file, source="https://example.test/input.csv")
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    add_job_commands(app, {"anonymizer.run": _AnonymizerRunJob}, cli=cli)
+    platform_client = object()
+    jobs_client = Mock()
+    events = object()
+    jobs_client.watch_job.return_value = events
+    captured: dict[str, object] = {}
+
+    def fake_client_from_platform(platform: object, client_type: object) -> object:
+        assert platform is platform_client
+        assert client_type is cli_module.JobsClient
+        return jobs_client
+
+    def fake_download(url: str, *, headers: dict[str, str], output_dir: Path) -> None:
+        captured["download"] = {
+            "url": url,
+            "headers": headers,
+            "output_dir": output_dir,
+        }
+
+    def fake_submit_remote(self, job_cls, spec, **kwargs):
+        captured["job_cls"] = job_cls
+        captured["spec"] = spec
+        captured["kwargs"] = kwargs
+        return {"name": "anon-job-1", "workspace": "team-a"}
+
+    monkeypatch.setattr(cli_files_module, "make_platform_client", Mock(return_value=platform_client))
+    monkeypatch.setattr(cli_module, "client_from_platform", fake_client_from_platform)
+    monkeypatch.setattr("nemo_platform_plugin.scheduler.NemoJobScheduler.submit_remote", fake_submit_remote)
+    monkeypatch.setattr(cli_module, "render_job_watch_events", Mock(return_value=True))
+    monkeypatch.setattr(cli_module, "_download_run_artifacts", fake_download)
+
+    class _State:
+        def get_base_url(self, default: str | None = None) -> str | None:
+            return default
+
+    output_dir = tmp_path / "out"
+    result = CliRunner().invoke(
+        app,
+        [
+            "run",
+            "--spec-file",
+            str(spec_file),
+            "--base-url",
+            "http://platform.example",
+            "--workspace",
+            "team-a",
+            "--watch",
+            "--output-dir",
+            str(output_dir),
+        ],
+        obj=_State(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["job_cls"] is _AnonymizerRunJob
+    assert captured["kwargs"] == {
+        "base_url": "http://platform.example",
+        "workspace": "team-a",
+        "profile": None,
+        "options": None,
+        "metadata": None,
+        "headers": None,
+    }
+    jobs_client.watch_job.assert_called_once_with(
+        "anon-job-1",
+        workspace="team-a",
+        timeout=None,
+        poll_interval=3,
+        include_history=True,
+    )
+    assert captured["download"] == {
+        "url": "http://platform.example/apis/anonymizer/v2/workspaces/team-a/jobs/run/anon-job-1/results/artifacts/download",
+        "headers": {},
+        "output_dir": output_dir,
+    }
+
+
+def test_preview_command_delegates_to_function_submit(tmp_path: Path, monkeypatch) -> None:
+    spec_file = tmp_path / "preview.yaml"
+    _write_preview_request(spec_file)
+    captured: dict[str, object] = {}
+    platform_client = object()
+    output_file = tmp_path / "preview.ndjson"
+    submit_capture = _patch_preview_submit(monkeypatch, [PreviewDatasetFrame(records=[]), Done()])
+
+    def fake_make_platform_client(**kwargs: object) -> object:
+        captured["platform_kwargs"] = kwargs
+        return platform_client
+
+    monkeypatch.setattr(cli_files_module, "make_platform_client", fake_make_platform_client)
+
+    class _State:
+        def get_base_url(self, default: str | None = None) -> str | None:
+            return default
+
+    result = CliRunner().invoke(
+        _app_with_preview_function(monkeypatch),
+        [
+            "preview",
+            "--spec-file",
+            str(spec_file),
+            "--base-url",
+            "http://platform.example/",
+            "--workspace",
+            "team/a",
+            "--request-id",
+            "req-1",
+            "--quiet",
+            "--output-file",
+            str(output_file),
+        ],
+        obj=_State(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["platform_kwargs"] == {
+        "base_url": "http://platform.example/",
+        "workspace": "team/a",
+        "headers": {"X-Request-ID": "req-1"},
+    }
+    assert str(submit_capture["url"]).endswith("/apis/anonymizer/v2/workspaces/team/a/preview")
+    assert submit_capture["headers"] == {"X-Request-ID": "req-1"}
+    body = cast(dict[str, object], submit_capture["body"])
+    config = cast(dict[str, object], body["config"])
+    replace = cast(dict[str, object], config["replace"])
+    assert replace["kind"] == "redact"
+    assert replace["format_template"] == "[REDACTED_{label}]"
+    assert body["data"] == {
+        "source": "https://example.test/input.csv",
+        "text_column": "text",
+    }
+    assert body["num_records"] == 2
+    assert [json.loads(line) for line in output_file.read_text().splitlines()] == [
+        {
+            "kind": "preview_dataset",
+            "records": [],
+        },
+        {"kind": "done"},
+    ]
+
+
+def test_preview_command_num_records_overrides_spec(tmp_path: Path, monkeypatch) -> None:
+    spec_file = tmp_path / "preview.yaml"
+    _write_preview_request(spec_file)
+    submit_capture = _patch_preview_submit(monkeypatch, [PreviewDatasetFrame(records=[]), Done()])
+
+    result = CliRunner().invoke(
+        _app_with_preview_function(monkeypatch),
+        [
+            "preview",
+            "--spec-file",
+            str(spec_file),
+            "--base-url",
+            "http://platform.example/",
+            "--num-records",
+            "4",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert cast(dict[str, object], submit_capture["body"])["num_records"] == 4
+
+
+def test_preview_command_uploads_local_input_before_streaming(tmp_path: Path, monkeypatch) -> None:
+    local_input = tmp_path / "input.csv"
+    local_input.write_text("text\nAlice met Bob\n")
+    spec_file = tmp_path / "preview.yaml"
+    _write_anonymizer_request(spec_file, source=str(local_input))
+    captured: dict[str, object] = {"ensured": [], "uploads": []}
+    platform_client = object()
+    submit_capture = _patch_preview_submit(monkeypatch, [PreviewDatasetFrame(records=[]), Done()])
+
+    def fake_make_platform_client(**kwargs: object) -> object:
+        captured["platform_kwargs"] = kwargs
+        return platform_client
+
+    def fake_ensure(platform: object, *, workspace: str, fileset: str) -> None:
+        assert platform is platform_client
+        cast(list[tuple[str, str]], captured["ensured"]).append((workspace, fileset))
+
+    def fake_upload(
+        platform: object,
+        *,
+        local_path: Path,
+        remote_path: str,
+        fileset: str,
+        workspace: str,
+        description: str,
+        quiet: bool = False,
+    ) -> None:
+        assert platform is platform_client
+        cast(list[dict[str, object]], captured["uploads"]).append(
+            {
+                "local_path": local_path,
+                "remote_path": remote_path,
+                "fileset": fileset,
+                "workspace": workspace,
+                "description": description,
+                "quiet": quiet,
+            }
+        )
+
+    monkeypatch.setattr(cli_files_module, "make_platform_client", fake_make_platform_client)
+    monkeypatch.setattr(cli_files_module, "ensure_fileset_exists", fake_ensure)
+    monkeypatch.setattr(cli_files_module, "upload_file_to_fileset", fake_upload)
+
+    class _State:
+        def get_base_url(self, default: str | None = None) -> str | None:
+            return default
+
+    result = CliRunner().invoke(
+        _app_with_preview_function(monkeypatch),
+        [
+            "preview",
+            "--spec-file",
+            str(spec_file),
+            "--fileset",
+            "anonymizer-inputs",
+            "--input-remote-path",
+            "inputs/input.csv",
+            "--workspace",
+            "team-a",
+            "--base-url",
+            "http://platform.example",
+        ],
+        obj=_State(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["platform_kwargs"] == {
+        "base_url": "http://platform.example",
+        "workspace": "team-a",
+        "headers": {},
+    }
+    assert captured["ensured"] == [("team-a", "anonymizer-inputs")]
+    assert captured["uploads"] == [
+        {
+            "local_path": local_input,
+            "remote_path": "inputs/input.csv",
+            "fileset": "anonymizer-inputs",
+            "workspace": "team-a",
+            "description": "local input",
+            "quiet": False,
+        }
+    ]
+    assert cast(dict[str, object], cast(dict[str, object], submit_capture["body"])["data"])["source"] == (
+        "team-a/anonymizer-inputs#inputs/input.csv"
+    )
+
+
+def test_preview_command_local_input_requires_fileset(tmp_path: Path, monkeypatch) -> None:
+    local_input = tmp_path / "input.csv"
+    local_input.write_text("text\nAlice met Bob\n")
+    spec_file = tmp_path / "preview.yaml"
+    _write_anonymizer_request(spec_file, source=str(local_input))
+
+    result = CliRunner().invoke(
+        _app_with_preview_function(monkeypatch),
+        [
+            "preview",
+            "--spec-file",
+            str(spec_file),
+            "--base-url",
+            "http://platform.example",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "Local input sources require --fileset" in result.output
+
+
+def test_preview_command_uploads_output_remote_path(tmp_path: Path, monkeypatch) -> None:
+    spec_file = tmp_path / "preview.yaml"
+    _write_preview_request(spec_file)
+    captured: dict[str, object] = {"ensured": [], "uploads": []}
+    platform_client = object()
+    _patch_preview_submit(monkeypatch, [PreviewDatasetFrame(records=[]), Done()])
+
+    def fake_ensure(platform: object, *, workspace: str, fileset: str) -> None:
+        assert platform is platform_client
+        cast(list[tuple[str, str]], captured["ensured"]).append((workspace, fileset))
+
+    def fake_upload(
+        platform: object,
+        *,
+        local_path: Path,
+        remote_path: str,
+        fileset: str,
+        workspace: str,
+        description: str,
+        quiet: bool = False,
+    ) -> None:
+        assert platform is platform_client
+        captured["uploaded_content"] = local_path.read_text()
+        cast(list[dict[str, object]], captured["uploads"]).append(
+            {
+                "local_path": local_path,
+                "remote_path": remote_path,
+                "fileset": fileset,
+                "workspace": workspace,
+                "description": description,
+                "quiet": quiet,
+            }
+        )
+
+    monkeypatch.setattr(cli_files_module, "make_platform_client", Mock(return_value=platform_client))
+    monkeypatch.setattr(cli_files_module, "ensure_fileset_exists", fake_ensure)
+    monkeypatch.setattr(cli_files_module, "upload_file_to_fileset", fake_upload)
+
+    class _State:
+        def get_base_url(self, default: str | None = None) -> str | None:
+            return default
+
+    result = CliRunner().invoke(
+        _app_with_preview_function(monkeypatch),
+        [
+            "preview",
+            "--spec-file",
+            str(spec_file),
+            "--base-url",
+            "http://platform.example",
+            "--fileset",
+            "anonymizer-inputs",
+            "--output-remote-path",
+            "previews/latest.ndjson",
+            "--quiet",
+        ],
+        obj=_State(),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["ensured"] == [("default", "anonymizer-inputs")]
+    uploads = cast(list[dict[str, object]], captured["uploads"])
+    assert len(uploads) == 1
+    upload = uploads[0]
+    assert isinstance(upload["local_path"], Path)
+    assert {key: value for key, value in upload.items() if key != "local_path"} == {
+        "remote_path": "previews/latest.ndjson",
+        "fileset": "anonymizer-inputs",
+        "workspace": "default",
+        "description": "preview output",
+        "quiet": True,
+    }
+    assert [json.loads(line) for line in cast(str, captured["uploaded_content"]).splitlines()] == [
+        {
+            "kind": "preview_dataset",
+            "records": [],
+        },
+        {"kind": "done"},
+    ]
+
+
+def test_preview_command_exits_one_when_stream_reports_error(tmp_path: Path, monkeypatch) -> None:
+    spec_file = tmp_path / "preview.yaml"
+    _write_preview_request(spec_file)
+    _patch_preview_submit(monkeypatch, [Error(message="bad config")])
+
+    result = CliRunner().invoke(
+        _app_with_preview_function(monkeypatch),
+        [
+            "preview",
+            "--spec-file",
+            str(spec_file),
+            "--base-url",
+            "http://platform.example",
+        ],
+    )
+
+    assert result.exit_code == 1
+
+
+def test_preview_stream_routes_log_frames_to_stderr(capsys) -> None:
+    assert (
+        cli_module._emit_preview_line(
+            '{"kind":"log","level":"info","message":"loading models"}',
+            quiet=False,
+        )
+        is False
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == "loading models\n"
+
+
+def test_preview_stream_quiet_suppresses_log_frames(capsys) -> None:
+    assert (
+        cli_module._emit_preview_line(
+            '{"kind":"log","level":"info","message":"loading models"}',
+            quiet=True,
+        )
+        is False
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_preview_stream_writes_non_log_frames_to_stdout(capsys) -> None:
+    line = '{"kind":"preview_dataset","records":[{"text":"[REDACTED_PERSON]"}]}'
+
+    assert cli_module._emit_preview_line(line, quiet=False) is False
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "kind": "preview_dataset",
+        "records": [{"text": "[REDACTED_PERSON]"}],
+    }
+    assert captured.err == ""
+
+
+def test_preview_stream_writes_non_log_frames_to_output_file(capsys) -> None:
+    line = '{"kind":"preview_dataset","records":[{"text":"[REDACTED_PERSON]"}]}'
+    output = StringIO()
+
+    assert cli_module._emit_preview_line(line, quiet=False, output=output) is False
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+    assert json.loads(output.getvalue()) == {
+        "kind": "preview_dataset",
+        "records": [{"text": "[REDACTED_PERSON]"}],
+    }
+
+
+def test_download_run_artifacts_extracts_tar(tmp_path: Path, monkeypatch) -> None:
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        content = b"ok"
+        info = tarfile.TarInfo("artifacts/dataset.txt")
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+
+    class _Response:
+        status_code = 200
+        content = buffer.getvalue()
+
+    class _Client:
+        def __init__(self, *, timeout: float) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> "_Client":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def get(self, url: str, *, headers: dict[str, str]) -> _Response:
+            assert url == "http://platform.example/artifacts"
+            assert headers == {"Authorization": "Bearer token"}
+            return _Response()
+
+    monkeypatch.setattr(cli_module.httpx, "Client", _Client)
+
+    cli_module._download_run_artifacts(
+        "http://platform.example/artifacts",
+        headers={"Authorization": "Bearer token"},
+        output_dir=tmp_path / "out",
+    )
+
+    assert (tmp_path / "out" / "artifacts" / "dataset.txt").read_text() == "ok"
+
+
+def test_preview_stream_error_frame_exits_unsuccessfully(capsys) -> None:
+    line = '{"kind":"error","message":"bad config","details":{"type":"ValueError"}}'
+
+    assert cli_module._emit_preview_line(line, quiet=False) is True
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "kind": "error",
+        "message": "bad config",
+        "details": {"type": "ValueError"},
+    }
+    assert captured.err == ""
 
 
 def test_validate_command_runs_library_validation(tmp_path: Path, monkeypatch) -> None:

--- a/plugins/nemo-anonymizer/tests/unit/test_cli_files.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_cli_files.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from anonymizer.config.anonymizer_config import AnonymizerConfig
+from anonymizer.config.replace_strategies import Redact
+from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
+from nemo_anonymizer_plugin.app.task_config import AnonymizerRequest
+from nemo_anonymizer_plugin.cli_files import (
+    resolve_input_remote_path,
+    resolve_local_input_path,
+    stage_anonymizer_request_for_remote,
+    validate_remote_file_path,
+)
+
+
+def test_resolve_local_input_path_rejects_missing_file(tmp_path: Path) -> None:
+    missing_file = tmp_path / "missing.csv"
+
+    with pytest.raises(ValueError, match="must point to an existing file"):
+        resolve_local_input_path(str(missing_file))
+
+
+def test_resolve_local_input_path_rejects_unsupported_suffix(tmp_path: Path) -> None:
+    unsupported_file = tmp_path / "input.jsonl"
+    unsupported_file.write_text('{"text":"Alice"}\n')
+
+    with pytest.raises(ValueError, match=r"must be one of: \.csv, \.parquet"):
+        resolve_local_input_path(str(unsupported_file))
+
+
+def test_resolve_input_remote_path_rejects_unsupported_suffix(tmp_path: Path) -> None:
+    local_input = tmp_path / "input.csv"
+    local_input.write_text("text\nAlice\n")
+
+    with pytest.raises(ValueError, match=r"--input-remote-path 'inputs/input.txt' must be one of: \.csv, \.parquet"):
+        resolve_input_remote_path("inputs/input.txt", local_input)
+
+
+def test_resolve_input_remote_path_accepts_supported_suffix(tmp_path: Path) -> None:
+    local_input = tmp_path / "input.csv"
+    local_input.write_text("text\nAlice\n")
+
+    assert resolve_input_remote_path("inputs/input.parquet", local_input) == "inputs/input.parquet"
+
+
+@pytest.mark.parametrize("remote_path", ["../input.csv", "inputs/../input.csv", "inputs/.."])
+def test_validate_remote_file_path_rejects_parent_directory_segments(remote_path: str) -> None:
+    with pytest.raises(ValueError, match="must not include parent-directory segments"):
+        validate_remote_file_path(remote_path, option_name="--input-remote-path")
+
+
+def test_stage_anonymizer_request_rewrites_valid_local_input(tmp_path: Path) -> None:
+    local_input = tmp_path / "input.csv"
+    local_input.write_text("text\nAlice\n")
+    request = AnonymizerRequest(
+        config=AnonymizerConfig(replace=Redact()),
+        data=AnonymizerInputSpec(source=str(local_input)),
+    )
+
+    staged = stage_anonymizer_request_for_remote(
+        request,
+        platform_client=None,
+        workspace="team-a",
+        fileset="anonymizer-inputs",
+        input_remote_path=None,
+        upload=False,
+    )
+
+    assert staged.source_was_local is True
+    assert staged.request.data.source == "team-a/anonymizer-inputs#input.csv"

--- a/plugins/nemo-anonymizer/tests/unit/test_example_specs.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_example_specs.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from nemo_anonymizer_plugin.app.task_config import AnonymizerRequest, PreviewRequest
+from nemo_anonymizer_plugin.config import DEFAULT_MAX_PREVIEW_NUM_RECORDS
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+_EXAMPLES = _PLUGIN_ROOT / "examples"
+
+
+def _load_example(name: str) -> dict:
+    loaded = yaml.safe_load((_EXAMPLES / name).read_text())
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_redact_example_validates_for_preview_and_run() -> None:
+    payload = _load_example("redact.yaml")
+    request = AnonymizerRequest.model_validate(payload)
+    preview_request = PreviewRequest.model_validate(payload)
+
+    assert request.data.source == "plugins/nemo-anonymizer/examples/anonymizer-input.csv"
+    assert request.data.text_column == "biography"
+    assert preview_request.num_records == DEFAULT_MAX_PREVIEW_NUM_RECORDS

--- a/plugins/nemo-anonymizer/tests/unit/test_preview_function.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_preview_function.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from pathlib import Path
 from unittest.mock import AsyncMock
 
+import data_designer.config as dd
 import pandas as pd
 import pytest
-from anonymizer.config.anonymizer_config import AnonymizerConfig
+from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput
 from anonymizer.config.replace_strategies import Redact
+from nemo_anonymizer_plugin.app import context as context_module
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
 from nemo_anonymizer_plugin.app.model_configs import SelectedModelsOverrides
@@ -22,18 +23,16 @@ from nemo_platform_plugin.function_context import FunctionContext
 from pydantic import BaseModel
 
 
-def _preview_spec(tmp_path: Path) -> PreviewSpec:
-    csv = tmp_path / "input.csv"
-    csv.write_text("biography\nhello\n")
+def _preview_spec() -> PreviewSpec:
     return PreviewSpec(
         config=AnonymizerConfig(replace=Redact()),
-        data=AnonymizerInputSpec(source=str(csv), text_column="biography"),
+        data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="biography"),
+        model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
         num_records=1,
     )
 
 
 def test_preview_worker_sends_original_text_column_metadata(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     frames: list[BaseModel] = []
@@ -55,9 +54,9 @@ def test_preview_worker_sends_original_text_column_metadata(
 
     worker_module._make_preview(
         frames.append,
-        _preview_spec(tmp_path),
-        data=object(),  # type: ignore[arg-type]
-        model_configs_yaml="",
+        _preview_spec(),
+        data=AnonymizerInput(source="https://example.com/input.csv", text_column="biography"),
+        model_configs_yaml="model_configs:\n- alias: detector\n  model: test/model\n  provider: provider\n",
         dd_providers=None,
         num_records=1,
     )
@@ -66,10 +65,14 @@ def test_preview_worker_sends_original_text_column_metadata(
     assert trace_frame.original_text_column == "biography"
 
 
+def test_preview_worker_requires_model_configs() -> None:
+    with pytest.raises(RuntimeError, match="requires resolved model_configs"):
+        worker_module._make_anonymizer(model_configs_yaml="", dd_providers=None)
+
+
 @pytest.mark.asyncio
 async def test_preview_function_resets_request_log_callback(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
     def fake_worker(
         send_frame: Callable[[BaseModel], None],
@@ -77,26 +80,34 @@ async def test_preview_function_resets_request_log_callback(
     ) -> None:
         send_frame(LogFrame(level="info", message="generated"))
 
+    igw_lookup = AsyncMock(return_value=None)
+    monkeypatch.setattr(context_module, "make_model_provider_registry", igw_lookup)
     monkeypatch.setattr(worker_module, "_make_preview", fake_worker)
+    async_sdk = AsyncMock(spec=AsyncNeMoPlatform)
 
     frames = [
         frame
         async for frame in PreviewFunction().run(
-            _preview_spec(tmp_path),
+            _preview_spec(),
             ctx=FunctionContext(workspace="team-a"),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=True,
+            async_sdk=async_sdk,
         )
     ]
 
+    igw_lookup.assert_awaited_once()
+    assert igw_lookup.await_args is not None
+    assert igw_lookup.await_args.kwargs["sdk"] is async_sdk
     assert [frame.model_dump()["kind"] for frame in frames] == ["log", "done"]
     assert request_callback_cvar.get() is None
 
 
 @pytest.mark.asyncio
-async def test_preview_function_rejects_selected_models_without_model_configs(tmp_path: Path) -> None:
-    spec = _preview_spec(tmp_path).model_copy(
-        update={"selected_models": SelectedModelsOverrides(detection={"entity_detector": "local"})}
+async def test_preview_function_rejects_selected_models_without_model_configs() -> None:
+    spec = _preview_spec().model_copy(
+        update={
+            "model_configs": None,
+            "selected_models": SelectedModelsOverrides(detection={"entity_detector": "detector"}),
+        }
     )
 
     with pytest.raises(AnonymizerInvalidConfigError, match="selected_models requires model_configs"):
@@ -106,22 +117,18 @@ async def test_preview_function_rejects_selected_models_without_model_configs(tm
                 spec,
                 ctx=FunctionContext(workspace="team-a"),
                 async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-                is_local=True,
             )
         ]
 
 
 @pytest.mark.asyncio
-async def test_preview_submit_requires_model_configs(tmp_path: Path) -> None:
+async def test_preview_submit_requires_model_configs() -> None:
     with pytest.raises(AnonymizerInvalidConfigError, match="model_configs are required"):
         [
             frame
             async for frame in PreviewFunction().run(
-                _preview_spec(tmp_path).model_copy(
-                    update={"data": AnonymizerInputSpec(source="https://example.com/input.csv")}
-                ),
+                _preview_spec().model_copy(update={"model_configs": None}),
                 ctx=FunctionContext(workspace="team-a"),
                 async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-                is_local=False,
             )
         ]

--- a/plugins/nemo-anonymizer/tests/unit/test_run_job.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_run_job.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import data_designer.config as dd
@@ -55,6 +56,24 @@ def _restore_task_loggers(snapshot: dict[str, tuple[list[logging.Handler], int, 
         logger.propagate = propagate
 
 
+async def _to_run_spec(
+    request: AnonymizerRequest,
+    *,
+    async_sdk: AsyncNeMoPlatform | None = None,
+) -> AnonymizerStepConfig:
+    resolved_async_sdk = (
+        async_sdk if async_sdk is not None else cast(AsyncNeMoPlatform, AsyncMock(spec=AsyncNeMoPlatform))
+    )
+    spec = await RunJob.to_spec(
+        request,
+        workspace="team-a",
+        entity_client=object(),
+        async_sdk=resolved_async_sdk,
+        is_local=False,
+    )
+    return cast(AnonymizerStepConfig, spec)
+
+
 @pytest.mark.asyncio
 async def test_run_job_rejects_selected_models_without_model_configs(
     monkeypatch: pytest.MonkeyPatch,
@@ -62,18 +81,12 @@ async def test_run_job_rejects_selected_models_without_model_configs(
     request = AnonymizerRequest(
         config=AnonymizerConfig(replace=Redact()),
         data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
-        selected_models=SelectedModelsOverrides(detection={"entity_detector": "local"}),
+        selected_models=SelectedModelsOverrides(detection={"entity_detector": "detector"}),
     )
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
 
     with pytest.raises(PlatformJobCompilationError, match="selected_models requires model_configs"):
-        await RunJob.to_spec(
-            request,
-            workspace="team-a",
-            entity_client=object(),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=False,
-        )
+        await _to_run_spec(request)
 
 
 @pytest.mark.asyncio
@@ -93,13 +106,7 @@ async def test_run_job_wraps_shared_provider_config_errors(
     )
 
     with pytest.raises(PlatformJobCompilationError, match="bad provider"):
-        await RunJob.to_spec(
-            request,
-            workspace="team-a",
-            entity_client=object(),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=False,
-        )
+        await _to_run_spec(request)
 
 
 @pytest.mark.asyncio
@@ -113,116 +120,64 @@ async def test_run_submit_requires_model_configs(
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
 
     with pytest.raises(PlatformJobCompilationError, match="model_configs are required"):
-        await RunJob.to_spec(
-            request,
-            workspace="team-a",
-            entity_client=object(),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=False,
-        )
+        await _to_run_spec(request)
 
 
 @pytest.mark.asyncio
-async def test_run_local_allows_missing_model_configs(
-    tmp_path: Path,
+async def test_run_job_uses_igw_provider_registry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
+    igw_registry = ModelProviderRegistry(
+        providers=[NDDModelProvider(name="provider", endpoint="http://platform.example/apis/models/provider")],
+    )
+    igw_lookup = AsyncMock(return_value=igw_registry)
     request = AnonymizerRequest(
         config=AnonymizerConfig(replace=Redact()),
-        data=AnonymizerInputSpec(source=str(csv), text_column="text"),
+        data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
+        model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
     )
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
-
-    step_config = await RunJob.to_spec(
-        request,
-        workspace="team-a",
-        entity_client=object(),
-        async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-        is_local=True,
-    )
-
-    assert isinstance(step_config, AnonymizerStepConfig)
-    assert step_config.model_configs_yaml == ""
-    assert step_config.dd_model_providers == []
-    round_tripped = AnonymizerStepConfig.model_validate(step_config.model_dump())
-    assert isinstance(round_tripped.request.config.replace, Redact)
-
-
-@pytest.mark.asyncio
-async def test_run_local_model_configs_uses_injected_async_sdk(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
-    local_first_registry = ModelProviderRegistry(
-        providers=[NDDModelProvider(name="local-provider", endpoint="http://localhost:8000")],
-    )
-    local_first_lookup = AsyncMock(return_value=local_first_registry)
-    request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
-        data=AnonymizerInputSpec(source=str(csv), text_column="text"),
-        model_configs=[dd.ModelConfig(alias="detector", model="local/model", provider="local-provider")],
-    )
-    monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
-    monkeypatch.setattr(context_module, "make_local_first_model_provider_registry", local_first_lookup)
+    monkeypatch.setattr(context_module, "make_model_provider_registry", igw_lookup)
     async_sdk = AsyncMock(spec=AsyncNeMoPlatform)
 
-    step_config = await RunJob.to_spec(
-        request,
-        workspace="team-a",
-        entity_client=object(),
-        async_sdk=async_sdk,
-        is_local=True,
-    )
+    step_config = await _to_run_spec(request, async_sdk=async_sdk)
 
-    local_first_lookup.assert_awaited_once()
-    assert local_first_lookup.await_args is not None
-    assert local_first_lookup.await_args.kwargs["sdk"] is async_sdk
+    igw_lookup.assert_awaited_once()
+    assert igw_lookup.await_args is not None
+    assert igw_lookup.await_args.kwargs["sdk"] is async_sdk
     assert isinstance(step_config, AnonymizerStepConfig)
     assert len(step_config.dd_model_providers) == 1
-    assert step_config.dd_model_providers[0]["name"] == "local-provider"
+    assert step_config.dd_model_providers[0]["name"] == "provider"
 
 
 @pytest.mark.asyncio
-async def test_run_local_serialized_step_config_can_be_revalidated(
+async def test_run_serialized_step_config_can_be_revalidated(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
     request = AnonymizerRequest(
         config=AnonymizerConfig(replace=Redact()),
-        data=AnonymizerInputSpec(source=str(csv), text_column="text"),
+        data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
+        model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
     )
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
+    monkeypatch.setattr(context_module, "make_model_provider_registry", AsyncMock(return_value=None))
     monkeypatch.setattr(run_module, "run_step_config", lambda *args, **kwargs: 0)
 
-    step_config = await RunJob.to_spec(
-        request,
-        workspace="team-a",
-        entity_client=object(),
-        async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-        is_local=True,
-    )
+    step_config = await _to_run_spec(request)
 
     ctx = _make_job_context(tmp_path)
     assert RunJob().run(
         step_config.model_dump(),
         ctx=ctx,
         sdk=Mock(spec=NeMoPlatform),
-        is_local=True,
     ) == {"exit_code": 0}
 
 
-def test_run_step_config_local_uses_ctx_results(
+def test_run_step_config_uses_ctx_results(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
     captured: dict[str, object] = {}
 
     class FakeFrame:
@@ -262,9 +217,9 @@ def test_run_step_config_local_uses_ctx_results(
     step_config = AnonymizerStepConfig(
         request=AnonymizerRequest(
             config=AnonymizerConfig(replace=Redact()),
-            data=AnonymizerInputSpec(source=str(csv), text_column="text"),
+            data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         ),
-        model_configs_yaml="",
+        model_configs_yaml="model_configs:\n- alias: detector\n  model: test/model\n  provider: provider\n",
         dd_model_providers=[],
     )
 
@@ -277,12 +232,13 @@ def test_run_step_config_local_uses_ctx_results(
             task_run_module.run_step_config(
                 step_config,
                 ctx=ctx,
-                is_local=True,
+                sdk=Mock(spec=NeMoPlatform),
             )
             == 0
         )
     finally:
         _restore_task_loggers(logging_snapshot)
+    assert captured["model_configs"] == "model_configs:\n- alias: detector\n  model: test/model\n  provider: provider\n"
     assert captured["artifact_path"] == ctx.storage.persistent / "anonymizer-artifacts"
     artifacts_dir = ctx.storage.persistent / "artifacts"
     assert (artifacts_dir / "dataset.parquet").read_text() == "dataset"
@@ -295,12 +251,10 @@ def test_run_step_config_local_uses_ctx_results(
 
 
 def test_run_step_config_remote_requires_sdk(tmp_path: Path) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
     step_config = AnonymizerStepConfig(
         request=AnonymizerRequest(
             config=AnonymizerConfig(replace=Redact()),
-            data=AnonymizerInputSpec(source=str(csv), text_column="text"),
+            data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         ),
         model_configs_yaml="",
         dd_model_providers=[],
@@ -309,9 +263,33 @@ def test_run_step_config_remote_requires_sdk(tmp_path: Path) -> None:
     logging_snapshot = _snapshot_task_loggers()
 
     try:
-        assert task_run_module.run_step_config(step_config, ctx=ctx, is_local=False) == 1
+        assert task_run_module.run_step_config(step_config, ctx=ctx) == 1
     finally:
         _restore_task_loggers(logging_snapshot)
+
+
+def test_run_step_config_requires_resolved_model_configs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    step_config = AnonymizerStepConfig(
+        request=AnonymizerRequest(
+            config=AnonymizerConfig(replace=Redact()),
+            data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
+        ),
+        model_configs_yaml="",
+        dd_model_providers=[],
+    )
+    anonymizer = Mock(side_effect=AssertionError("Anonymizer should not be constructed"))
+    monkeypatch.setattr(task_run_module, "Anonymizer", anonymizer)
+    ctx = _make_job_context(tmp_path)
+    logging_snapshot = _snapshot_task_loggers()
+
+    try:
+        assert task_run_module.run_step_config(step_config, ctx=ctx, sdk=Mock(spec=NeMoPlatform)) == 1
+    finally:
+        _restore_task_loggers(logging_snapshot)
+    anonymizer.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -329,10 +307,4 @@ async def test_run_submit_rejects_local_file(
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
 
     with pytest.raises(PlatformJobCompilationError, match="local path"):
-        await RunJob.to_spec(
-            request,
-            workspace="team-a",
-            entity_client=object(),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=False,
-        )
+        await _to_run_spec(request)

--- a/plugins/nemo-anonymizer/tests/unit/test_sdk_resources.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_sdk_resources.py
@@ -4,13 +4,25 @@
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
+from typing import Any, cast
 
 import httpx
 import pandas as pd
-from nemo_anonymizer_plugin.functions.preview import TraceDatasetFrame
+from anonymizer.config.anonymizer_config import AnonymizerConfig
+from anonymizer.config.replace_strategies import Redact
+from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
+from nemo_anonymizer_plugin.app.task_config import PreviewRequest
+from nemo_anonymizer_plugin.functions.preview import LogFrame, PreviewDatasetFrame, TraceDatasetFrame
 from nemo_anonymizer_plugin.sdk import display as display_module
 from nemo_anonymizer_plugin.sdk.errors import AnonymizerClientError, AnonymizerConfigValidationError
-from nemo_anonymizer_plugin.sdk.resources import AnonymizerPreviewResult, _get_error, _PreviewFrameCollector
+from nemo_anonymizer_plugin.sdk.resources import (
+    AnonymizerPreviewResult,
+    AnonymizerResource,
+    _get_error,
+    _PreviewFrameCollector,
+)
+from nemo_platform_plugin.functions.frames import Done
 
 
 def _status_error(status_code: int, content: bytes) -> httpx.HTTPStatusError:
@@ -85,3 +97,89 @@ def test_preview_result_display_record_matches_upstream_display_cycle(
     assert captured["record_index"] == 0
     assert captured["resolved_text_column"] == "body"
     assert result._display_cycle_index == 1
+
+
+def test_preview_stream_decodes_typed_frames() -> None:
+    calls: list[tuple[str, str, dict[str, object]]] = []
+
+    class Response:
+        def __enter__(self) -> "Response":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def iter_lines(self) -> list[str]:
+            return [
+                '{"kind":"log","level":"info","message":"loading models"}',
+                '{"kind":"preview_dataset","records":[{"text":"[REDACTED_PERSON]"}]}',
+                '{"kind":"done"}',
+            ]
+
+    class Client:
+        def stream(self, method: str, url: str, **kwargs: object) -> Response:
+            calls.append((method, url, kwargs))
+            return Response()
+
+    platform = SimpleNamespace(
+        base_url="https://platform.test",
+        workspace="default",
+        default_headers={"Authorization": "Bearer token"},
+        _client=Client(),
+    )
+    resource = AnonymizerResource(cast(Any, platform))
+    request = PreviewRequest(
+        config=AnonymizerConfig(replace=Redact()),
+        data=AnonymizerInputSpec(source="inputs#records.csv"),
+        num_records=1,
+    )
+
+    frames = list(resource.preview_stream(request, workspace="team/a"))
+
+    assert isinstance(frames[0], LogFrame)
+    assert isinstance(frames[1], PreviewDatasetFrame)
+    assert isinstance(frames[2], Done)
+    assert len(calls) == 1
+    method, url, kwargs = calls[0]
+    assert method == "POST"
+    assert url == "https://platform.test/apis/anonymizer/v2/workspaces/team%2Fa/preview"
+    assert kwargs["headers"] == {"Authorization": "Bearer token"}
+    body = cast(dict[str, Any], kwargs["json"])
+    assert body["config"]["replace"]["kind"] == "redact"
+    assert body["config"]["replace"]["format_template"] == "[REDACTED_{label}]"
+    assert body["data"]["source"] == "inputs#records.csv"
+    assert body["num_records"] == 1
+
+
+def test_preview_collects_frames_from_preview_stream(monkeypatch) -> None:
+    platform = SimpleNamespace(
+        base_url="https://platform.test",
+        workspace="default",
+        default_headers={},
+        _client=object(),
+    )
+    resource = AnonymizerResource(cast(Any, platform))
+    request = PreviewRequest(
+        config=AnonymizerConfig(replace=Redact()),
+        data=AnonymizerInputSpec(source="inputs#records.csv"),
+        num_records=1,
+    )
+    captured: dict[str, object] = {}
+
+    def fake_preview_stream(request: PreviewRequest, *, workspace: str | None = None):
+        captured["request"] = request
+        captured["workspace"] = workspace
+        yield PreviewDatasetFrame(records=[{"text": "[REDACTED_PERSON]"}])
+        yield TraceDatasetFrame(records=[{"text": "Alice"}], original_text_column="text")
+        yield Done()
+
+    monkeypatch.setattr(resource, "preview_stream", fake_preview_stream)
+
+    result = resource.preview(request, workspace="team-a")
+
+    assert captured == {"request": request, "workspace": "team-a"}
+    assert result.dataset.to_dict(orient="records") == [{"text": "[REDACTED_PERSON]"}]
+    assert result.trace_dataset.attrs["original_text_column"] == "text"

--- a/plugins/nemo-anonymizer/tests/unit/test_upstream_logging.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_upstream_logging.py
@@ -66,7 +66,10 @@ def test_make_anonymizer_preserves_root_logging_when_upstream_clobbers_it(monkey
         root.setLevel(logging.INFO)
         monkeypatch.setattr(worker_module, "Anonymizer", ClobberingAnonymizer)
 
-        anonymizer = worker_module._make_anonymizer(model_configs_yaml="", dd_providers=None)
+        anonymizer = worker_module._make_anonymizer(
+            model_configs_yaml="model_configs:\n- alias: detector\n  model: test/model\n  provider: provider\n",
+            dd_providers=None,
+        )
 
         assert isinstance(anonymizer, ClobberingAnonymizer)
         assert root.handlers == [sentinel_handler]


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified `nemo anonymizer preview` and `run` commands.
  * Added streaming previews through the CLI, Python SDK, and HTTP API.
  * Added local CSV/Parquet uploads through filesets for remote execution.
  * Added request inspection, dry runs, job monitoring, and artifact downloads.
  * Added example preview and run specifications.

* **Changes**
  * Full anonymization runs now execute through NeMo Platform Jobs.
  * Preview and run requests require model configurations for platform execution.

* **Documentation**
  * Updated tutorials, SDK references, workflows, and input/artifact guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->