### PR TITLE
feat(auth): add PlatformAdmin-provisioned service-bound access keys

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -278,7 +278,7 @@ nemo auth access-keys [OPTIONS] COMMAND [ARGS]...
 
 **Commands:**
 
-* `create`: Create a Scoped Access Key for the currently...
+* `create`: Create a user-bound or service-bound Scoped Access Key.
 * `list`: List Scoped Access Keys owned by the currently...
 * `revoke`: Revoke a Scoped Access Key owned by the currently...
 * `suspend`: Temporarily suspend a Scoped Access Key owned by the...
@@ -286,7 +286,7 @@ nemo auth access-keys [OPTIONS] COMMAND [ARGS]...
 
 ##### nemo auth access-keys create
 
-Create a Scoped Access Key for the currently authenticated user.
+Create a user-bound or service-bound Scoped Access Key.
 
 **Usage:**
 
@@ -299,6 +299,7 @@ nemo auth access-keys create [OPTIONS]
 * `--name, -n`: Optional human-readable label for the Scoped Access Key.
 * `--description, -d`: Optional description for the Scoped Access Key.
 * `--expires-in`: Scoped Access Key lifetime in seconds. Use 'none' to request no expiration.
+* `--service-account`: Bind the key to a non-human service account (PlatformAdmin only).
 
 **Help:**
 
@@ -307,6 +308,9 @@ nemo auth access-keys create [OPTIONS]
 ##### nemo auth access-keys list
 
 List Scoped Access Keys owned by the currently authenticated user.
+
+PlatformAdmins also see every service-bound Scoped Access Key, not just the
+ones they personally created.
 
 **Usage:**
 

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -191,6 +191,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '403':
+          description: Service-bound Scoped Access Keys require PlatformAdmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
         '404':
           description: Scoped Access Keys are not enabled
           content:
@@ -8213,6 +8219,15 @@ components:
           nullable: true
           type: integer
           minimum: 1.0
+        service_account_id:
+          title: Service Account Id
+          description: Optional non-human service account to bind the key to. Service-bound
+            keys can only be created by a PlatformAdmin and authenticate as service-account:<id>.
+          nullable: true
+          type: string
+          maxLength: 240
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9._+/-]*$
       type: object
       title: AccessKeyCreateRequest
       description: Request body for creating a Scoped Access Key.
@@ -8236,6 +8251,14 @@ components:
           type: string
           title: Principal
           description: Principal ID stamped into the token.
+        entity_type:
+          type: string
+          enum:
+          - USER
+          - SERVICE_ACCOUNT
+          title: Entity Type
+          description: Whether the key is bound to a user or a non-human service account.
+          default: USER
         status:
           type: string
           enum:
@@ -8337,6 +8360,14 @@ components:
           type: string
           title: Principal
           description: Principal ID stamped into the token.
+        entity_type:
+          type: string
+          enum:
+          - USER
+          - SERVICE_ACCOUNT
+          title: Entity Type
+          description: Whether the key is bound to a user or a non-human service account.
+          default: USER
         status:
           type: string
           enum:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -191,6 +191,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '403':
+          description: Service-bound Scoped Access Keys require PlatformAdmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
         '404':
           description: Scoped Access Keys are not enabled
           content:
@@ -8213,6 +8219,15 @@ components:
           nullable: true
           type: integer
           minimum: 1.0
+        service_account_id:
+          title: Service Account Id
+          description: Optional non-human service account to bind the key to. Service-bound
+            keys can only be created by a PlatformAdmin and authenticate as service-account:<id>.
+          nullable: true
+          type: string
+          maxLength: 240
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9._+/-]*$
       type: object
       title: AccessKeyCreateRequest
       description: Request body for creating a Scoped Access Key.
@@ -8236,6 +8251,14 @@ components:
           type: string
           title: Principal
           description: Principal ID stamped into the token.
+        entity_type:
+          type: string
+          enum:
+          - USER
+          - SERVICE_ACCOUNT
+          title: Entity Type
+          description: Whether the key is bound to a user or a non-human service account.
+          default: USER
         status:
           type: string
           enum:
@@ -8337,6 +8360,14 @@ components:
           type: string
           title: Principal
           description: Principal ID stamped into the token.
+        entity_type:
+          type: string
+          enum:
+          - USER
+          - SERVICE_ACCOUNT
+          title: Entity Type
+          description: Whether the key is bound to a user or a non-human service account.
+          default: USER
         status:
           type: string
           enum:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -191,6 +191,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '403':
+          description: Service-bound Scoped Access Keys require PlatformAdmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
         '404':
           description: Scoped Access Keys are not enabled
           content:
@@ -8213,6 +8219,15 @@ components:
           nullable: true
           type: integer
           minimum: 1.0
+        service_account_id:
+          title: Service Account Id
+          description: Optional non-human service account to bind the key to. Service-bound
+            keys can only be created by a PlatformAdmin and authenticate as service-account:<id>.
+          nullable: true
+          type: string
+          maxLength: 240
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9._+/-]*$
       type: object
       title: AccessKeyCreateRequest
       description: Request body for creating a Scoped Access Key.
@@ -8236,6 +8251,14 @@ components:
           type: string
           title: Principal
           description: Principal ID stamped into the token.
+        entity_type:
+          type: string
+          enum:
+          - USER
+          - SERVICE_ACCOUNT
+          title: Entity Type
+          description: Whether the key is bound to a user or a non-human service account.
+          default: USER
         status:
           type: string
           enum:
@@ -8337,6 +8360,14 @@ components:
           type: string
           title: Principal
           description: Principal ID stamped into the token.
+        entity_type:
+          type: string
+          enum:
+          - USER
+          - SERVICE_ACCOUNT
+          title: Entity Type
+          description: Whether the key is bound to a user or a non-human service account.
+          default: USER
         status:
           type: string
           enum:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/auth.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/auth.py
@@ -850,12 +850,20 @@ def create_access_key(
             help="Scoped Access Key lifetime in seconds. Use 'none' to request no expiration.",
         ),
     ] = None,
+    service_account: Annotated[
+        str | None,
+        typer.Option(
+            "--service-account",
+            help="Bind the key to a non-human service account (PlatformAdmin only).",
+        ),
+    ] = None,
 ) -> None:
-    """Create a Scoped Access Key for the currently authenticated user."""
+    """Create a user-bound or service-bound Scoped Access Key."""
     expires_in_was_set, parsed_expires_in = _parse_access_key_expires_in(expires_in)
     request = AccessKeyCreateRequest(
         name=name,
         description=description,
+        service_account_id=service_account,
         **({"expires_in_seconds": parsed_expires_in} if expires_in_was_set else {}),
     )
     try:
@@ -877,7 +885,11 @@ def list_access_keys(
         typer.Option("--page-size", min=1, max=100, help="Number of keys to retrieve per page."),
     ] = 100,
 ) -> None:
-    """List Scoped Access Keys owned by the currently authenticated user."""
+    """List Scoped Access Keys owned by the currently authenticated user.
+
+    PlatformAdmins also see every service-bound Scoped Access Key, not just the
+    ones they personally created.
+    """
     try:
         listed = _access_key_issuer(ctx).list(page=page, page_size=page_size)
     except AccessKeyFeatureDisabledError as exc:
@@ -894,6 +906,8 @@ def list_access_keys(
             Column("jti", None),
             Column("name", None),
             Column("description", None),
+            Column("entity_type", None),
+            Column("principal", None),
             Column("status", None),
             Column("issuer", None),
             Column("audiences", None),

--- a/packages/nemo_platform_ext/tests/cli/commands/test_auth.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_auth.py
@@ -430,6 +430,27 @@ def test_auth_access_keys_create_sends_optional_metadata_and_expiration(monkeypa
     )
 
 
+def test_auth_access_keys_create_sends_service_account(monkeypatch: pytest.MonkeyPatch):
+    fake_platform_client = MagicMock()
+    fake_access_keys_client = MagicMock()
+    fake_access_keys_client.create_access_key.return_value.data.return_value = _created_access_key("otel")
+    monkeypatch.setattr("nemo_platform_ext.cli.core.context.CLIContext.get_client", lambda self: fake_platform_client)
+    monkeypatch.setattr(
+        "nemo_platform_ext.cli.commands.auth.client_from_platform",
+        lambda platform, client_cls: fake_access_keys_client,
+    )
+
+    result = runner.invoke(
+        app,
+        ["auth", "access-keys", "create", "--name", "otel", "--service-account", "otel-collector"],
+    )
+
+    assert_exit_code(result, 0)
+    fake_access_keys_client.create_access_key.assert_called_once_with(
+        body=AccessKeyCreateRequest(name="otel", service_account_id="otel-collector")
+    )
+
+
 def test_auth_access_keys_create_sends_explicit_null_expiration(monkeypatch: pytest.MonkeyPatch):
     fake_platform_client = MagicMock()
     fake_access_keys_client = MagicMock()

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/types.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 AccessKeyStatus = Literal["ACTIVE", "EXPIRED", "REVOKED", "SUSPENDED"]
 AccessKeyReversibleStatus = Literal["ACTIVE", "EXPIRED", "SUSPENDED"]
+AccessKeyEntityType = Literal["USER", "SERVICE_ACCOUNT"]
 
 
 class AccessKeyListQueryParams(TypedDict, total=False):
@@ -46,6 +47,17 @@ class AccessKeyCreateRequest(BaseModel):
             "to be disabled."
         ),
     )
+    service_account_id: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=240,
+        pattern=r"^[a-zA-Z0-9][a-zA-Z0-9._+/-]*$",
+        json_schema_extra={"nullable": True},
+        description=(
+            "Optional non-human service account to bind the key to. Service-bound keys can only be "
+            "created by a PlatformAdmin and authenticate as service-account:<id>."
+        ),
+    )
 
 
 class AccessKeyMetadataResponse(BaseModel):
@@ -63,6 +75,10 @@ class AccessKeyMetadataResponse(BaseModel):
         description="Human-readable description of the Scoped Access Key.",
     )
     principal: str = Field(description="Principal ID stamped into the token.")
+    entity_type: AccessKeyEntityType = Field(
+        default="USER",
+        description="Whether the key is bound to a user or a non-human service account.",
+    )
     status: AccessKeyStatus
     issuer: str = Field(description="Issuer stamped into the Scoped Access Key JWT.")
     audiences: list[str] = Field(

--- a/packages/nmp_common/src/nmp/common/auth/access_keys.py
+++ b/packages/nmp_common/src/nmp/common/auth/access_keys.py
@@ -22,6 +22,7 @@ from nemo_platform_plugin.auth.access_keys.issuer import (
 from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyCreateRequest,
     AccessKeyCreateResponse,
+    AccessKeyEntityType,
     AccessKeyListResponse,
     AccessKeyRevokeResponse,
     AccessKeyStatus,
@@ -41,6 +42,7 @@ LEGACY_ACCESS_KEY_METADATA_VERSION = 1
 ACCESS_KEY_JTI_PATTERN = r"^ak_[0-9a-f]{32}$"
 _ACCESS_KEY_JTI_RE = re.compile(ACCESS_KEY_JTI_PATTERN)
 _NEWLY_CREATED_STATUS: AccessKeyStatus = "ACTIVE"
+SERVICE_ACCOUNT_PRINCIPAL_PREFIX = "service-account:"
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +81,7 @@ class _AccessKeyTokenPayload:
     name: str | None
     description: str | None
     principal: str
+    entity_type: AccessKeyEntityType
     issuer: str
     audiences: list[str]
     created_at: datetime
@@ -206,29 +209,54 @@ class AccessKeyIssuerService(AccessKeyIssuer):
         if not self._config.access_keys.enabled:
             raise AccessKeyFeatureDisabledError("Scoped Access Keys are not enabled")
 
-    def create(self, request: AccessKeyCreateRequest) -> AccessKeyCreateResponse:
+    def create(
+        self, request: AccessKeyCreateRequest, *, allow_service_account: bool = False
+    ) -> AccessKeyCreateResponse:
         self._ensure_enabled()
         expires_in_seconds = _resolve_expires_in_seconds(self._config, request)
+        principal, entity_type = self._target_principal(request, allow_service_account=allow_service_account)
         return _create_access_key_token(
             self._config,
-            principal=self._principal,
+            principal=principal,
+            entity_type=entity_type,
             name=request.name,
             description=request.description,
             expires_in_seconds=expires_in_seconds,
             now=self._now(),
         )
 
-    async def create_async(self, request: AccessKeyCreateRequest) -> AccessKeyCreateResponse:
+    async def create_async(
+        self, request: AccessKeyCreateRequest, *, allow_service_account: bool = False
+    ) -> AccessKeyCreateResponse:
         self._ensure_enabled()
         expires_in_seconds = _resolve_expires_in_seconds(self._config, request)
+        principal, entity_type = self._target_principal(request, allow_service_account=allow_service_account)
         return await _create_access_key_token_async(
             self._config,
-            principal=self._principal,
+            principal=principal,
+            entity_type=entity_type,
             name=request.name,
             description=request.description,
             expires_in_seconds=expires_in_seconds,
             now=self._now(),
         )
+
+    def _target_principal(
+        self, request: AccessKeyCreateRequest, *, allow_service_account: bool
+    ) -> tuple[Principal, AccessKeyEntityType]:
+        # A service-account caller can never mint Scoped Access Keys, for itself or for any
+        # other service account: that would let a compromised or over-delegated service
+        # credential renew its own (or another service's) access indefinitely. Only human
+        # PlatformAdmins may create service-bound keys.
+        if self._principal.is_service_identity():
+            if self._principal.is_privileged:
+                raise AccessKeyValidationError("Scoped Access Keys cannot be created for service principals")
+            raise AccessKeyValidationError("Scoped Access Keys cannot be created by service-account principals")
+        if request.service_account_id is None:
+            return self._principal, "USER"
+        if not allow_service_account:
+            raise AccessKeyValidationError("Service-bound Scoped Access Keys require PlatformAdmin")
+        return Principal(id=f"{SERVICE_ACCOUNT_PRINCIPAL_PREFIX}{request.service_account_id}"), "SERVICE_ACCOUNT"
 
     def list(self, *, page: int = 1, page_size: int = 100) -> AccessKeyListResponse:  # noqa: ARG002
         self._ensure_enabled()
@@ -251,6 +279,7 @@ def _create_access_key_token(
     config: AuthConfig,
     *,
     principal: Principal,
+    entity_type: AccessKeyEntityType = "USER",
     name: str | None = None,
     description: str | None = None,
     expires_in_seconds: int | None = None,
@@ -259,6 +288,7 @@ def _create_access_key_token(
     payload = _build_access_key_token_payload(
         config,
         principal=principal,
+        entity_type=entity_type,
         name=name,
         description=description,
         expires_in_seconds=expires_in_seconds,
@@ -271,6 +301,7 @@ async def _create_access_key_token_async(
     config: AuthConfig,
     *,
     principal: Principal,
+    entity_type: AccessKeyEntityType = "USER",
     name: str | None = None,
     description: str | None = None,
     expires_in_seconds: int | None = None,
@@ -279,6 +310,7 @@ async def _create_access_key_token_async(
     payload = _build_access_key_token_payload(
         config,
         principal=principal,
+        entity_type=entity_type,
         name=name,
         description=description,
         expires_in_seconds=expires_in_seconds,
@@ -292,6 +324,7 @@ def _build_access_key_token_payload(
     config: AuthConfig,
     *,
     principal: Principal,
+    entity_type: AccessKeyEntityType = "USER",
     name: str | None,
     description: str | None,
     expires_in_seconds: int | None,
@@ -305,6 +338,8 @@ def _build_access_key_token_payload(
     issued_at = now
     jti = f"ak_{uuid.uuid4().hex}"
     access_key_metadata: dict[str, Any] = {"version": ACCESS_KEY_METADATA_VERSION}
+    if entity_type == "SERVICE_ACCOUNT":
+        access_key_metadata["entity_type"] = entity_type
     if name is not None:
         access_key_metadata["name"] = name
     issuer = access_key_issuer(config)
@@ -337,6 +372,7 @@ def _build_access_key_token_payload(
         name=name,
         description=description,
         principal=principal.id,
+        entity_type=entity_type,
         issuer=issuer,
         audiences=audiences,
         created_at=datetime.fromtimestamp(issued_at, tz=UTC),
@@ -361,6 +397,7 @@ def _access_key_response_from_payload(
         token=token,
         token_type="Bearer",
         principal=payload.principal,
+        entity_type=payload.entity_type,
         status=_NEWLY_CREATED_STATUS,
         issuer=payload.issuer,
         audiences=payload.audiences,
@@ -413,7 +450,18 @@ async def validate_access_key_token(
         claims = jwt.decode(token, signing_key, **decode_kwargs)
 
         subject = claims.get("sub")
+        metadata = claims.get("nmp_access_key")
         if not isinstance(subject, str) or not subject or subject.startswith("service:"):
+            return None
+        if not isinstance(metadata, dict):
+            return None
+        entity_type = metadata.get("entity_type", "USER")
+        is_service_account = subject.startswith(SERVICE_ACCOUNT_PRINCIPAL_PREFIX)
+        if is_service_account and subject == SERVICE_ACCOUNT_PRINCIPAL_PREFIX:
+            return None
+        if (entity_type == "SERVICE_ACCOUNT") != is_service_account:
+            return None
+        if entity_type not in {"USER", "SERVICE_ACCOUNT"}:
             return None
 
         groups = groups_from_claim(claims.get("groups", []))

--- a/packages/nmp_common/src/nmp/common/auth/client.py
+++ b/packages/nmp_common/src/nmp/common/auth/client.py
@@ -178,6 +178,43 @@ class AuthClient(BaseModel):
 
         return AuthorizationResult(allowed=allowed, reason=reason)
 
+    async def _pdp_check(self, pdp_endpoint: str, auth_input: dict, result_key: str, check_name: str) -> bool:
+        """Send a single-shot PDP check and extract a boolean result.
+
+        Shared by has_permissions/has_role: both open/close the PDP http client the
+        same way and map httpx errors to the same HTTPException pair, differing only
+        in the endpoint, request payload, and which result field holds the answer.
+
+        ``check_name`` is a lowercase phrase (e.g. "permission check", "role check")
+        used to build both the log message and the HTTPException detail, matching the
+        wording each caller used before this helper was factored out.
+        """
+        from fastapi import HTTPException
+
+        client = self.http_client
+        should_close = False
+        if client is None:
+            client = self._new_pdp_http_client()
+            should_close = True
+
+        try:
+            response = await client.post(
+                self.config.get_pdp_url(pdp_endpoint),
+                json={"input": auth_input},
+                headers=self._pdp_request_headers,
+            )
+            response.raise_for_status()
+            return bool(response.json().get("result", {}).get(result_key, False))
+        except httpx.HTTPError as exc:
+            logger.error("Failed to contact auth endpoint for %s: %s", check_name, str(exc))
+            raise HTTPException(status_code=503, detail=f"{check_name.capitalize()} service unavailable") from exc
+        except Exception as exc:
+            logger.error("Unexpected error during %s: %s", check_name, str(exc))
+            raise HTTPException(status_code=500, detail=f"Internal {check_name} error") from exc
+        finally:
+            if should_close:
+                await client.aclose()
+
     async def has_permissions(self, workspace_id: str, permissions: List[str]) -> bool:
         """Check if the current principal has specific permissions in a workspace.
 
@@ -208,8 +245,6 @@ class AuthClient(BaseModel):
                     pass
             ```
         """
-        from fastapi import HTTPException
-
         validate_permission_strings(permissions, context="AuthClient.has_permissions")
 
         # If auth is disabled, allow all permissions
@@ -220,59 +255,51 @@ class AuthClient(BaseModel):
         if not self.policy_decision_point_base_url:
             raise RuntimeError("Policy Decision Point URL not configured for permission checks")
 
-        # Use injected http_client (from middleware) or create a new one
-        # See architecture/docs/http-client-injection.md for injection patterns.
-        client = self.http_client
-        should_close = False
-        if client is None:
-            client = self._new_pdp_http_client()
-            should_close = True
+        # Prepare input with all principal identifiers (acting user when delegating)
+        auth_input = {
+            "principal_id": self.principal.id,
+            "workspace": workspace_id,
+            "permissions": permissions,
+        }
+        if self.principal.effective_email:
+            auth_input["principal_email"] = self.principal.effective_email
+        if self.principal.effective_groups:
+            auth_input["principal_groups"] = self.principal.effective_groups
+        if self.principal.on_behalf_of:
+            auth_input["on_behalf_of_principal_id"] = self.principal.on_behalf_of
 
-        try:
-            auth_url = self.config.get_pdp_url("has_permissions")
+        allowed = await self._pdp_check("has_permissions", auth_input, "allowed", "permission check")
 
-            # Prepare input with all principal identifiers (acting user when delegating)
-            auth_input = {
-                "principal_id": self.principal.id,
-                "workspace": workspace_id,
-                "permissions": permissions,
-            }
-            if self.principal.effective_email:
-                auth_input["principal_email"] = self.principal.effective_email
-            if self.principal.effective_groups:
-                auth_input["principal_groups"] = self.principal.effective_groups
-            if self.principal.on_behalf_of:
-                auth_input["on_behalf_of_principal_id"] = self.principal.on_behalf_of
+        logger.info(
+            "Permission check for principal=%s workspace=%s permissions=%s: %s",
+            self.principal.id,
+            workspace_id,
+            permissions,
+            "ALLOWED" if allowed else "DENIED",
+        )
 
-            response = await client.post(
-                auth_url,
-                json={"input": auth_input},
-                headers=self._pdp_request_headers,
-            )
-            response.raise_for_status()
+        return allowed
 
-            result = response.json()
-            allowed = result.get("result", {}).get("allowed", False)
+    async def has_role(self, workspace_id: str, role: str) -> bool:
+        """Check whether the current effective principal has a role in a workspace."""
+        if not self.auth_enabled:
+            return True
+        if not self.policy_decision_point_base_url:
+            raise RuntimeError("Policy Decision Point URL not configured for role checks")
 
-            logger.info(
-                "Permission check for principal=%s workspace=%s permissions=%s: %s",
-                self.principal.id,
-                workspace_id,
-                permissions,
-                "ALLOWED" if allowed else "DENIED",
-            )
+        auth_input = {
+            "principal_id": self.principal.effective_id,
+            "workspace": workspace_id,
+            "role": role,
+        }
+        if self.principal.effective_email:
+            auth_input["principal_email"] = self.principal.effective_email
+        if self.principal.effective_groups:
+            auth_input["principal_groups"] = self.principal.effective_groups
+        if self.principal.on_behalf_of:
+            auth_input["on_behalf_of_principal_id"] = self.principal.on_behalf_of
 
-            return allowed
-
-        except httpx.HTTPError as e:
-            logger.error("Failed to contact auth endpoint for permission check: %s", str(e))
-            raise HTTPException(status_code=503, detail="Permission check service unavailable")
-        except Exception as e:
-            logger.error("Unexpected error during permission check: %s", str(e))
-            raise HTTPException(status_code=500, detail="Internal permission check error")
-        finally:
-            if should_close:
-                await client.aclose()
+        return await self._pdp_check("has_role", auth_input, "has_role", "role check")
 
     async def on_behalf_of_has_permissions(self, workspace_id: str, permissions: List[str]) -> bool:
         """Check if the on-behalf-of principal has specific permissions in a workspace.

--- a/packages/nmp_common/src/nmp/common/auth/models.py
+++ b/packages/nmp_common/src/nmp/common/auth/models.py
@@ -132,6 +132,10 @@ class Principal(BaseModel):
         """Whether the principal is privileged."""
         return self.id.startswith("service:")
 
+    def is_service_identity(self) -> bool:
+        """Whether the principal is an internal service or service account."""
+        return self.is_privileged or self.id.startswith("service-account:")
+
     @classmethod
     def from_headers(cls, headers: Dict[str, str]) -> Optional[Principal]:
         """Create a Principal from request headers.

--- a/packages/nmp_common/tests/auth/test_access_keys.py
+++ b/packages/nmp_common/tests/auth/test_access_keys.py
@@ -649,6 +649,131 @@ async def test_validate_access_key_token_rejects_service_principal_subject(tmp_p
         await issuer.create_async(AccessKeyCreateRequest(name="bad-service-key", expires_in_seconds=600))
 
 
+async def test_service_account_cannot_create_an_access_key_for_itself(tmp_path):
+    config = _access_key_config(tmp_path)
+    issuer = AccessKeyIssuerService(
+        config=config,
+        principal=Principal(id="service-account:otel-collector"),
+        now=lambda: 1785280000,
+    )
+
+    with pytest.raises(AccessKeyValidationError, match="service-account principals"):
+        await issuer.create_async(AccessKeyCreateRequest(name="self-renewal", expires_in_seconds=600))
+
+
+async def test_service_account_cannot_create_a_service_bound_access_key_even_with_allow_flag(tmp_path):
+    config = _access_key_config(tmp_path)
+    issuer = AccessKeyIssuerService(
+        config=config,
+        principal=Principal(id="service-account:otel-collector"),
+        now=lambda: 1785280000,
+    )
+    request = AccessKeyCreateRequest(service_account_id="otel-collector", expires_in_seconds=600)
+
+    # allow_service_account=True models a (mis)configuration where a service-account principal
+    # was somehow granted PlatformAdmin; the identity check must still block self/peer renewal.
+    with pytest.raises(AccessKeyValidationError, match="service-account principals"):
+        await issuer.create_async(request, allow_service_account=True)
+
+
+async def test_privileged_service_principal_cannot_create_a_service_bound_access_key_even_with_allow_flag(tmp_path):
+    config = _access_key_config(tmp_path)
+    issuer = AccessKeyIssuerService(
+        config=config,
+        principal=Principal(id="service:auth"),
+        now=lambda: 1785280000,
+    )
+    request = AccessKeyCreateRequest(service_account_id="otel-collector", expires_in_seconds=600)
+
+    with pytest.raises(AccessKeyValidationError, match="service principals"):
+        await issuer.create_async(request, allow_service_account=True)
+
+
+async def test_service_account_access_key_requires_explicit_admin_authorization(tmp_path):
+    config = _access_key_config(tmp_path)
+    issuer = AccessKeyIssuerService(
+        config=config,
+        principal=Principal(id="admin@example.com", groups=["platform-admins"]),
+        now=lambda: 1785280000,
+    )
+    request = AccessKeyCreateRequest(service_account_id="otel-collector", expires_in_seconds=600)
+
+    with pytest.raises(AccessKeyValidationError, match="PlatformAdmin"):
+        await issuer.create_async(request)
+
+
+async def test_service_account_access_key_uses_non_privileged_machine_identity(tmp_path):
+    config = _access_key_config(tmp_path, max_expires_in_seconds=None)
+    issuer = AccessKeyIssuerService(
+        config=config,
+        principal=Principal(id="admin@example.com", email="admin@example.com", groups=["platform-admins"]),
+        now=lambda: 1785280000,
+    )
+    created = await issuer.create_async(
+        AccessKeyCreateRequest(service_account_id="otel-collector", expires_in_seconds=None),
+        allow_service_account=True,
+    )
+    claims = jwt.decode(created.token, options={"verify_signature": False})
+    jwks = {"keys": [await public_jwk_from_private_key_pem_async(config)]}
+    validated = await validate_access_key_token(config, created.token, jwks_override=jwks)
+
+    assert created.principal == "service-account:otel-collector"
+    assert created.entity_type == "SERVICE_ACCOUNT"
+    assert claims["sub"] == "service-account:otel-collector"
+    assert claims["nmp_access_key"]["entity_type"] == "SERVICE_ACCOUNT"
+    assert "email" not in claims
+    assert "groups" not in claims
+    assert validated is not None
+    assert validated.subject == "service-account:otel-collector"
+
+
+async def test_validate_access_key_token_rejects_service_entity_type_for_user_subject(tmp_path):
+    config = _access_key_config(tmp_path)
+    issuer = AccessKeyIssuerService(
+        config=config,
+        principal=Principal(id="alice@example.com"),
+        now=lambda: 1785280000,
+    )
+    created = await issuer.create_async(AccessKeyCreateRequest(expires_in_seconds=600))
+    claims = jwt.decode(created.token, options={"verify_signature": False})
+    claims["nmp_access_key"]["entity_type"] = "SERVICE_ACCOUNT"
+    signing_key = await access_keys_mod._access_key_signing_key_async(config)
+    token = jwt.encode(
+        claims,
+        signing_key.private_key,
+        algorithm="RS256",
+        headers={"kid": config.token_signing.key_id},
+    )
+    jwks = {"keys": [await public_jwk_from_private_key_pem_async(config)]}
+
+    assert await validate_access_key_token(config, token, jwks_override=jwks) is None
+
+
+async def test_validate_access_key_token_rejects_service_subject_without_service_entity_type(tmp_path):
+    config = _access_key_config(tmp_path)
+    issuer = AccessKeyIssuerService(
+        config=config,
+        principal=Principal(id="admin@example.com"),
+        now=lambda: 1785280000,
+    )
+    created = await issuer.create_async(
+        AccessKeyCreateRequest(service_account_id="otel-collector", expires_in_seconds=600),
+        allow_service_account=True,
+    )
+    claims = jwt.decode(created.token, options={"verify_signature": False})
+    claims["nmp_access_key"].pop("entity_type")
+    signing_key = await access_keys_mod._access_key_signing_key_async(config)
+    token = jwt.encode(
+        claims,
+        signing_key.private_key,
+        algorithm="RS256",
+        headers={"kid": config.token_signing.key_id},
+    )
+    jwks = {"keys": [await public_jwk_from_private_key_pem_async(config)]}
+
+    assert await validate_access_key_token(config, token, jwks_override=jwks) is None
+
+
 async def test_validate_access_key_token_rejects_expired_key(tmp_path):
     config = _access_key_config(tmp_path)
     issuer = AccessKeyIssuerService(

--- a/packages/nmp_common/tests/auth/test_client.py
+++ b/packages/nmp_common/tests/auth/test_client.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from fastapi import HTTPException
 from nemo_platform import NeMoPlatform
 from nmp.common.auth.client import AuthClient
 from nmp.common.auth.exceptions import InvalidPermissionFormatError, InvalidScopeFormatError
@@ -140,7 +141,6 @@ class TestHasPermissionsPdpPayloadWithDelegation:
                 http_client=mock_http_client,
             )
             assert await auth_client.has_permissions("ws", ["models.read"]) is True
-
         body = mock_post.call_args[1]["json"]["input"]
         assert body["principal_id"] == "service:evaluator"
         assert body["on_behalf_of_principal_id"] == "user@example.com"
@@ -203,6 +203,67 @@ class TestHasPermissionsPdpPayloadWithDelegation:
             mock_post.side_effect = decide_post
             auth_client = AuthClient(principal=principal, config=auth_config, http_client=mock_http_client)
             assert await auth_client.has_permissions("ws", ["models.read"]) is True
+
+
+class TestHasRole:
+    @pytest.mark.asyncio
+    async def test_has_role_sends_effective_delegate_claims(self, auth_config, principal_service_delegating):
+        mock_http_client = httpx.AsyncClient()
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"result": {"has_role": True}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(mock_http_client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = mock_response
+            auth_client = AuthClient(
+                principal=principal_service_delegating,
+                config=auth_config,
+                http_client=mock_http_client,
+            )
+            assert await auth_client.has_role("system", "PlatformAdmin") is True
+
+        body = mock_post.call_args.kwargs["json"]["input"]
+        assert body == {
+            "principal_id": "user@example.com",
+            "principal_email": "user@example.com",
+            "principal_groups": ["workspace-editors"],
+            "on_behalf_of_principal_id": "user@example.com",
+            "workspace": "system",
+            "role": "PlatformAdmin",
+        }
+
+    @pytest.mark.asyncio
+    async def test_has_role_maps_pdp_transport_failure_to_service_unavailable(self, auth_config, principal):
+        mock_http_client = httpx.AsyncClient()
+        request = httpx.Request("POST", "http://localhost:8181/v1/data/authz/has_role")
+
+        with patch.object(
+            mock_http_client,
+            "post",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("PDP unavailable", request=request),
+        ):
+            auth_client = AuthClient(principal=principal, config=auth_config, http_client=mock_http_client)
+            with pytest.raises(HTTPException) as exc_info:
+                await auth_client.has_role("system", "PlatformAdmin")
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Role check service unavailable"
+
+    @pytest.mark.asyncio
+    async def test_has_role_maps_invalid_pdp_response_to_internal_error(self, auth_config, principal):
+        mock_http_client = httpx.AsyncClient()
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.side_effect = ValueError("invalid JSON")
+
+        with patch.object(mock_http_client, "post", new_callable=AsyncMock, return_value=mock_response):
+            auth_client = AuthClient(principal=principal, config=auth_config, http_client=mock_http_client)
+            with pytest.raises(HTTPException) as exc_info:
+                await auth_client.has_role("system", "PlatformAdmin")
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "Internal role check error"
 
 
 class TestAuthorizeRequestPdpPayloadWithDelegation:

--- a/packages/nmp_common/tests/auth/test_models.py
+++ b/packages/nmp_common/tests/auth/test_models.py
@@ -203,6 +203,17 @@ class TestPrincipalEffectiveIdentity:
         assert eff.groups == ["human-group"]
         assert eff.on_behalf_of is None
 
+    @pytest.mark.parametrize(
+        ("principal_id", "expected"),
+        [
+            ("user@example.com", False),
+            ("service:auth", True),
+            ("service-account:otel-collector", True),
+        ],
+    )
+    def test_is_service_identity(self, principal_id: str, expected: bool):
+        assert Principal(id=principal_id).is_service_identity() is expected
+
 
 class TestPrincipalEffectiveId:
     """Tests for Principal.effective_id property."""

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -194,6 +194,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '403':
+          description: Service-bound Scoped Access Keys require PlatformAdmin
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
         '404':
           description: Scoped Access Keys are not enabled
           content:
@@ -8216,6 +8222,15 @@ components:
           nullable: true
           type: integer
           minimum: 1.0
+        service_account_id:
+          title: Service Account Id
+          description: Optional non-human service account to bind the key to. Service-bound
+            keys can only be created by a PlatformAdmin and authenticate as service-account:<id>.
+          nullable: true
+          type: string
+          maxLength: 240
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9._+/-]*$
       type: object
       title: AccessKeyCreateRequest
       description: Request body for creating a Scoped Access Key.
@@ -8239,6 +8254,14 @@ components:
           type: string
           title: Principal
           description: Principal ID stamped into the token.
+        entity_type:
+          type: string
+          enum:
+          - USER
+          - SERVICE_ACCOUNT
+          title: Entity Type
+          description: Whether the key is bound to a user or a non-human service account.
+          default: USER
         status:
           type: string
           enum:
@@ -8340,6 +8363,14 @@ components:
           type: string
           title: Principal
           description: Principal ID stamped into the token.
+        entity_type:
+          type: string
+          enum:
+          - USER
+          - SERVICE_ACCOUNT
+          title: Entity Type
+          description: Whether the key is bound to a user or a non-human service account.
+          default: USER
         status:
           type: string
           enum:

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/access_keys/access_keys.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/access_keys/access_keys.py
@@ -67,6 +67,7 @@ class AccessKeysResource(SyncAPIResource):
         description: Optional[str] | Omit = omit,
         expires_in_seconds: Optional[int] | Omit = omit,
         name: Optional[str] | Omit = omit,
+        service_account_id: Optional[str] | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -88,6 +89,9 @@ class AccessKeysResource(SyncAPIResource):
           name: Optional human-readable Scoped Access Key label. The token jti remains the
               stable identifier.
 
+          service_account_id: Optional non-human service account to bind the key to. Service-bound keys can
+              only be created by a PlatformAdmin and authenticate as service-account:<id>.
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -103,6 +107,7 @@ class AccessKeysResource(SyncAPIResource):
                     "description": description,
                     "expires_in_seconds": expires_in_seconds,
                     "name": name,
+                    "service_account_id": service_account_id,
                 },
                 access_key_create_params.AccessKeyCreateParams,
             ),
@@ -290,6 +295,7 @@ class AsyncAccessKeysResource(AsyncAPIResource):
         description: Optional[str] | Omit = omit,
         expires_in_seconds: Optional[int] | Omit = omit,
         name: Optional[str] | Omit = omit,
+        service_account_id: Optional[str] | Omit = omit,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -311,6 +317,9 @@ class AsyncAccessKeysResource(AsyncAPIResource):
           name: Optional human-readable Scoped Access Key label. The token jti remains the
               stable identifier.
 
+          service_account_id: Optional non-human service account to bind the key to. Service-bound keys can
+              only be created by a PlatformAdmin and authenticate as service-account:<id>.
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -326,6 +335,7 @@ class AsyncAccessKeysResource(AsyncAPIResource):
                     "description": description,
                     "expires_in_seconds": expires_in_seconds,
                     "name": name,
+                    "service_account_id": service_account_id,
                 },
                 access_key_create_params.AccessKeyCreateParams,
             ),

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_create_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_create_params.py
@@ -40,3 +40,10 @@ class AccessKeyCreateParams(TypedDict, total=False):
 
     The token jti remains the stable identifier.
     """
+
+    service_account_id: Optional[str]
+    """Optional non-human service account to bind the key to.
+
+    Service-bound keys can only be created by a PlatformAdmin and authenticate as
+    service-account:<id>.
+    """

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_create_response.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_create_response.py
@@ -50,6 +50,9 @@ class AccessKeyCreateResponse(BaseModel):
     description: Optional[str] = None
     """Human-readable description of the Scoped Access Key."""
 
+    entity_type: Optional[Literal["USER", "SERVICE_ACCOUNT"]] = None
+    """Whether the key is bound to a user or a non-human service account."""
+
     expires_at: Optional[datetime] = None
 
     name: Optional[str] = None

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_metadata_response.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_metadata_response.py
@@ -46,6 +46,9 @@ class AccessKeyMetadataResponse(BaseModel):
     description: Optional[str] = None
     """Human-readable description of the Scoped Access Key."""
 
+    entity_type: Optional[Literal["USER", "SERVICE_ACCOUNT"]] = None
+    """Whether the key is bound to a user or a non-human service account."""
+
     expires_at: Optional[datetime] = None
 
     name: Optional[str] = None

--- a/sdk/python/nemo-platform/tests/api_resources/test_access_keys.py
+++ b/sdk/python/nemo-platform/tests/api_resources/test_access_keys.py
@@ -50,6 +50,7 @@ class TestAccessKeys:
             description="description",
             expires_in_seconds=1,
             name="x",
+            service_account_id="service_account_id",
         )
         assert_matches_type(AccessKeyCreateResponse, access_key, path=["response"])
 
@@ -257,6 +258,7 @@ class TestAsyncAccessKeys:
             description="description",
             expires_in_seconds=1,
             name="x",
+            service_account_id="service_account_id",
         )
         assert_matches_type(AccessKeyCreateResponse, access_key, path=["response"])
 

--- a/services/core/auth/src/nmp/core/auth/api/v2/access_keys/endpoints.py
+++ b/services/core/auth/src/nmp/core/auth/api/v2/access_keys/endpoints.py
@@ -14,7 +14,10 @@ from nemo_platform_plugin.auth.access_keys.issuer import (
 )
 from nemo_platform_plugin.auth.access_keys.types import AccessKeyReversibleStatus
 from nmp.common.auth import AuthClient, get_auth_client
-from nmp.common.auth.access_keys import ACCESS_KEY_JTI_PATTERN, AccessKeyValidationError
+from nmp.common.auth.access_keys import (
+    ACCESS_KEY_JTI_PATTERN,
+    AccessKeyValidationError,
+)
 from nmp.common.config import get_auth_config
 from nmp.common.entities import EntityConflictError
 from nmp.core.auth.app.access_keys import (
@@ -64,6 +67,10 @@ _ACCESS_KEY_CREATE_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
         "description": "Scoped Access Key creation error",
         "model": schemas.AccessKeyErrorResponse,
     },
+    403: {
+        "description": "Service-bound Scoped Access Keys require PlatformAdmin",
+        "model": schemas.AccessKeyErrorResponse,
+    },
     404: _ACCESS_KEY_DISABLED_ERROR_RESPONSE,
     409: _ACCESS_KEY_CONFLICT_ERROR_RESPONSE,
     501: _ACCESS_KEY_NOT_IMPLEMENTED_ERROR_RESPONSE,
@@ -84,11 +91,30 @@ _ACCESS_KEY_SUSPENSION_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
 }
 
 
+async def _is_platform_admin(auth_client: AuthClient) -> bool:
+    # Only human PlatformAdmins may create or manage service-bound Scoped Access Keys — the
+    # same invariant AccessKeyIssuerService._target_principal enforces for creation. A
+    # service-account principal must never qualify here, even if it were ever (mis)granted
+    # the PlatformAdmin role, since that would let a service credential manage other
+    # service-bound credentials, including its own.
+    if auth_client.principal.effective_principal.is_service_identity():
+        return False
+    # Deny (rather than has_role's own default-allow) when auth is globally disabled: there is
+    # no real identity to check "is PlatformAdmin" against, so we don't silently grant this
+    # highly privileged, service-account-impersonating capability.
+    return auth_client.auth_enabled and await auth_client.has_role("system", "PlatformAdmin")
+
+
 def get_access_key_issuer(
     auth_client: AuthClient = Depends(get_auth_client),
     registry: AccessKeyRegistry = Depends(get_access_key_registry),
 ) -> PersistentAccessKeyIssuer:
-    return PersistentAccessKeyIssuer(get_auth_config(), auth_client.principal, registry)
+    return PersistentAccessKeyIssuer(
+        get_auth_config(),
+        auth_client.principal.effective_principal,
+        registry,
+        admin_override=lambda: _is_platform_admin(auth_client),
+    )
 
 
 def _not_implemented(exc: AccessKeyOperationNotImplementedError) -> HTTPException:
@@ -131,6 +157,18 @@ async def create_access_key(
     issuer: PersistentAccessKeyIssuer = Depends(get_access_key_issuer),
 ) -> schemas.AccessKeyCreateResponse | JSONResponse:
     try:
+        if request.service_account_id is not None:
+            if not get_auth_config().access_keys.enabled:
+                raise AccessKeyFeatureDisabledError("Scoped Access Keys are not enabled")
+            # Delegates to the issuer's own memoized admin check (rather than calling
+            # _is_platform_admin(auth_client) directly here) so this pre-check and
+            # create_async's defense-in-depth re-check share one PDP has_role round trip.
+            if not await issuer.is_platform_admin():
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Only PlatformAdmin can create service-bound Scoped Access Keys",
+                )
+            return await issuer.create_async(request, allow_service_account=True)
         return await issuer.create_async(request)
     except AccessKeyFeatureDisabledError:
         return _disabled_response()

--- a/services/core/auth/src/nmp/core/auth/app/access_keys.py
+++ b/services/core/auth/src/nmp/core/auth/app/access_keys.py
@@ -6,10 +6,11 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
 from typing import Literal
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from nemo_platform_plugin.auth.access_keys.issuer import AccessKeyFeatureDisabledError
 from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyCreateRequest,
@@ -19,7 +20,12 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyReversibleStatus,
     AccessKeyStatus,
 )
-from nmp.common.auth.access_keys import LEGACY_ACCESS_KEY_METADATA_VERSION, AccessKeyIssuerService
+from nmp.common.api.filter import ComparisonOperation, FilterOperator, LogicalOperation
+from nmp.common.auth.access_keys import (
+    LEGACY_ACCESS_KEY_METADATA_VERSION,
+    AccessKeyIssuerService,
+    AccessKeyValidationError,
+)
 from nmp.common.auth.jwt import TokenClaims
 from nmp.common.auth.models import Principal
 from nmp.common.config import AuthConfig
@@ -29,6 +35,32 @@ from nmp.core.auth.entities import AccessKeyEntity
 
 ACCESS_KEY_WORKSPACE = "system"
 logger = logging.getLogger(__name__)
+
+# Service-bound keys are machine-to-machine credentials owned by the platform, not
+# by the creating individual (AIRCORE-986). Every lifecycle operation therefore
+# uses this callback to require a current PlatformAdmin, including when the caller
+# originally created the key.
+AdminOverride = Callable[[], Awaitable[bool]]
+
+
+def _memoize_admin_override(admin_override: AdminOverride | None) -> AdminOverride | None:
+    """Cache a single admin_override result for the lifetime of one lifecycle call.
+
+    _get_owned() may be invoked twice within one revoke()/suspend()/unsuspend() call
+    (initial read, then a re-read after a losing optimistic-lock race). Without this,
+    each read would trigger its own PDP has_role round trip for service-bound keys.
+    """
+    if admin_override is None:
+        return None
+    result: bool | None = None
+
+    async def cached() -> bool:
+        nonlocal result
+        if result is None:
+            result = await admin_override()
+        return result
+
+    return cached
 
 
 class AccessKeyNotFoundError(Exception):
@@ -45,14 +77,17 @@ class AccessKeyRegistry:
     def __init__(self, entity_client: EntityClient) -> None:
         self._entity_client = entity_client
 
-    async def add(self, key: AccessKeyCreateResponse) -> None:
+    async def add(self, key: AccessKeyCreateResponse, *, owner_principal: str | None = None) -> None:
+        owner = owner_principal or key.principal
         await self._entity_client.create(
             AccessKeyEntity(
                 name=key.jti,
                 workspace=ACCESS_KEY_WORKSPACE,
                 key_name=key.name,
                 description=key.description,
-                principal=key.principal,
+                principal=owner,
+                subject_principal=key.principal if key.principal != owner else None,
+                entity_type=key.entity_type,
                 issuer=key.issuer,
                 audiences=key.audiences,
                 issued_at=key.created_at,
@@ -60,25 +95,51 @@ class AccessKeyRegistry:
             )
         )
 
-    async def list_for_principal(self, principal: str, *, page: int, page_size: int) -> AccessKeyListResponse:
+    async def list_for_principal(
+        self, principal: str, *, page: int, page_size: int, include_service_accounts: bool = False
+    ) -> AccessKeyListResponse:
+        # Service-bound keys are platform-owned, not creator-owned (AIRCORE-986): a
+        # PlatformAdmin other than the creator can already revoke/suspend one via
+        # _get_owned's admin_override, so listing must surface every service-bound key
+        # to any current admin rather than only the one who happened to create it.
+        # EntityBase fields (all fields on AccessKeyEntity besides the base name/workspace/etc.)
+        # live in the data JSON column, so filter_operation needs the same `data.` prefix
+        # that _convert_filter_obj_to_filter_str applies for the filter_obj shorthand.
+        own_principal = ComparisonOperation(operator=FilterOperator.EQ, field="data.principal", value=principal)
+        filter_operation = (
+            LogicalOperation(
+                operator=FilterOperator.OR,
+                operations=[
+                    own_principal,
+                    ComparisonOperation(operator=FilterOperator.EQ, field="data.entity_type", value="SERVICE_ACCOUNT"),
+                ],
+            )
+            if include_service_accounts
+            else own_principal
+        )
         result = await self._entity_client.list(
             AccessKeyEntity,
             workspace=ACCESS_KEY_WORKSPACE,
-            filter_obj={"principal": principal},
+            filter_operation=filter_operation,
             sort="-issued_at",
             page=page,
             page_size=page_size,
         )
+        records = result.data
+        if not include_service_accounts:
+            records = [record for record in records if record.entity_type != "SERVICE_ACCOUNT"]
+        # Short non-admin pages after Python filtering are intentional: favor never hiding valid keys over exact pagination; no fix needed.
         return AccessKeyListResponse(
-            data=[self._metadata(record) for record in result.data],
+            data=[self._metadata(record) for record in records],
             has_more=page < result.pagination.total_pages,
         )
 
-    async def revoke(self, jti: str, principal: str) -> bool:
+    async def revoke(self, jti: str, principal: str, *, admin_override: AdminOverride | None = None) -> bool:
         # Note: unlike is_active, revoke has no backfill path for legacy v1 keys that have
         # never authenticated after migration. Without the original JWT claims we cannot
         # construct a valid entity, so callers receive 404 until the key authenticates once.
-        record = await self._get_owned(jti, principal)
+        admin_override = _memoize_admin_override(admin_override)
+        record = await self._get_owned(jti, principal, admin_override=admin_override)
         if record.status == "REVOKED":
             return False
         updated = record.model_copy(update={"status": "REVOKED"})
@@ -88,7 +149,7 @@ class AccessKeyRegistry:
             # EntityClient.update uses db_version optimistic locking. Re-read to
             # determine whether a concurrent revoke won the race.
             try:
-                current = await self._get_owned(jti, principal)
+                current = await self._get_owned(jti, principal, admin_override=admin_override)
             except AccessKeyNotFoundError:
                 # The key was concurrently hard-deleted between our update and this
                 # read. Treat as already-revoked (idempotent outcome).
@@ -98,18 +159,28 @@ class AccessKeyRegistry:
             raise
         return True
 
-    async def suspend(self, jti: str, principal: str) -> tuple[bool, AccessKeyReversibleStatus]:
-        return await self._set_suspension(jti, principal, suspended=True)
+    async def suspend(
+        self, jti: str, principal: str, *, admin_override: AdminOverride | None = None
+    ) -> tuple[bool, AccessKeyReversibleStatus]:
+        return await self._set_suspension(jti, principal, suspended=True, admin_override=admin_override)
 
-    async def unsuspend(self, jti: str, principal: str) -> tuple[bool, AccessKeyReversibleStatus]:
-        return await self._set_suspension(jti, principal, suspended=False)
+    async def unsuspend(
+        self, jti: str, principal: str, *, admin_override: AdminOverride | None = None
+    ) -> tuple[bool, AccessKeyReversibleStatus]:
+        return await self._set_suspension(jti, principal, suspended=False, admin_override=admin_override)
 
     async def _set_suspension(
-        self, jti: str, principal: str, *, suspended: bool
+        self,
+        jti: str,
+        principal: str,
+        *,
+        suspended: bool,
+        admin_override: AdminOverride | None = None,
     ) -> tuple[bool, AccessKeyReversibleStatus]:
         target_status: Literal["ACTIVE", "SUSPENDED"] = "SUSPENDED" if suspended else "ACTIVE"
         completed_action = "suspended" if suspended else "unsuspended"
-        record = await self._get_owned(jti, principal)
+        admin_override = _memoize_admin_override(admin_override)
+        record = await self._get_owned(jti, principal, admin_override=admin_override)
         if record.status == "REVOKED":
             raise AccessKeyStateConflictError(f"Revoked Scoped Access Key {jti} cannot be {completed_action}")
         effective_status = self._reversible_status(record)
@@ -123,7 +194,7 @@ class AccessKeyRegistry:
         except EntityConflictError:
             # EntityClient.update uses db_version optimistic locking. Re-read to
             # determine whether a concurrent update won the race.
-            current = await self._get_owned(jti, principal)
+            current = await self._get_owned(jti, principal, admin_override=admin_override)
             if current.status == "REVOKED":
                 raise AccessKeyStateConflictError(f"Revoked Scoped Access Key {jti} cannot be {completed_action}")
             current_status = self._reversible_status(current)
@@ -134,7 +205,7 @@ class AccessKeyRegistry:
 
     async def is_active(self, jti: str, principal: str, *, claims: TokenClaims | None = None) -> bool:
         try:
-            record = await self._get_owned(jti, principal)
+            record = await self._get_for_subject(jti, principal)
         except AccessKeyNotFoundError:
             if claims is None:
                 return False
@@ -143,18 +214,35 @@ class AccessKeyRegistry:
                 return False
         return self._status(record, leeway_seconds=30) == "ACTIVE"
 
-    async def _get_owned(self, jti: str, principal: str) -> AccessKeyEntity:
+    async def _get_for_subject(self, jti: str, principal: str) -> AccessKeyEntity:
+        record = await self._get(jti)
+        if (record.subject_principal or record.principal) != principal:
+            raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
+        return record
+
+    async def _get_owned(
+        self, jti: str, principal: str, *, admin_override: AdminOverride | None = None
+    ) -> AccessKeyEntity:
+        record = await self._get(jti)
+        if record.is_service_account:
+            # Service-bound keys belong to the platform, not to the administrator who
+            # created them. Require the caller to be a *current* PlatformAdmin for every
+            # lifecycle operation, including when that caller is the recorded creator.
+            if admin_override is not None and await admin_override():
+                return record
+        elif record.principal == principal:
+            return record
+        raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
+
+    async def _get(self, jti: str) -> AccessKeyEntity:
         try:
-            record = await self._entity_client.get(
+            return await self._entity_client.get(
                 AccessKeyEntity,
                 name=jti,
                 workspace=ACCESS_KEY_WORKSPACE,
             )
         except EntityNotFoundError as exc:
             raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found") from exc
-        if record.principal != principal:
-            raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
-        return record
 
     @staticmethod
     def _metadata(record: AccessKeyEntity) -> AccessKeyMetadataResponse:
@@ -162,7 +250,8 @@ class AccessKeyRegistry:
             jti=record.name,
             name=record.key_name,
             description=record.description,
-            principal=record.principal,
+            principal=record.subject_principal or record.principal,
+            entity_type=record.entity_type,
             # Report lifecycle status against the published expiration instant.
             # Clock-skew leeway applies only while authenticating the JWT.
             status=AccessKeyRegistry._status(record),
@@ -204,7 +293,7 @@ class AccessKeyRegistry:
             await self._entity_client.create(record)
         except EntityConflictError:
             try:
-                return await self._get_owned(jti, principal)
+                return await self._get_for_subject(jti, principal)
             except AccessKeyNotFoundError:
                 return None
         logger.info(
@@ -290,17 +379,47 @@ def get_access_key_registry(entity_client: EntityClient = Depends(get_entity_cli
 class PersistentAccessKeyIssuer:
     """Signs access keys and records their lifecycle before returning them."""
 
-    def __init__(self, config: AuthConfig, principal: Principal, registry: AccessKeyRegistry) -> None:
+    def __init__(
+        self,
+        config: AuthConfig,
+        principal: Principal,
+        registry: AccessKeyRegistry,
+        *,
+        admin_override: AdminOverride | None = None,
+    ) -> None:
         self._issuer = AccessKeyIssuerService(config=config, principal=principal)
         self._config = config
         self._registry = registry
         self.principal = principal.id
+        # Lets any current PlatformAdmin revoke or suspend a service-bound key;
+        # see AdminOverride and AIRCORE-986. Memoized for the lifetime of this issuer
+        # instance (one per request, see get_access_key_issuer) so that an endpoint-level
+        # pre-check (is_platform_admin) and create_async's own defense-in-depth re-check
+        # share a single PDP has_role round trip instead of each paying for one.
+        self._admin_override = _memoize_admin_override(admin_override)
 
-    async def create_async(self, request: AccessKeyCreateRequest) -> AccessKeyCreateResponse:
+    async def is_platform_admin(self) -> bool:
+        """Whether the caller is a current PlatformAdmin.
+
+        Backed by the same memoized admin_override create_async consults, so callers that
+        need to gate on PlatformAdmin status before invoking create_async (to return 403
+        instead of create_async's 400) do not trigger a second PDP round trip.
+        """
+        return self._admin_override is not None and await self._admin_override()
+
+    async def create_async(
+        self, request: AccessKeyCreateRequest, *, allow_service_account: bool = False
+    ) -> AccessKeyCreateResponse:
         self._ensure_enabled()
-        key = await self._issuer.create_async(request)
+        if allow_service_account:
+            # Defense-in-depth, mirroring the admin_override re-check that revoke/suspend/
+            # unsuspend apply for service-bound keys: don't rely solely on the caller having
+            # verified PlatformAdmin status before setting this flag (see AdminOverride).
+            if not await self.is_platform_admin():
+                raise AccessKeyValidationError("Service-bound Scoped Access Keys require PlatformAdmin")
+        key = await self._issuer.create_async(request, allow_service_account=allow_service_account)
         try:
-            await self._registry.add(key)
+            await self._registry.add(key, owner_principal=self.principal)
         except Exception:
             logger.warning(
                 "Failed to persist Scoped Access Key lifecycle record; the signed JWT will not be returned to the caller",
@@ -320,11 +439,28 @@ class PersistentAccessKeyIssuer:
 
     async def list_async(self, *, page: int = 1, page_size: int = 100) -> AccessKeyListResponse:
         self._ensure_enabled()
-        return await self._registry.list_for_principal(self.principal, page=page, page_size=page_size)
+        # A current PlatformAdmin sees every service-bound key, not just the ones they
+        # personally created, mirroring the admin_override check lifecycle operations
+        # already apply (see AccessKeyRegistry.list_for_principal). If the PDP role check
+        # itself fails (e.g. unreachable), degrade to the caller's own keys rather than
+        # failing listing outright for every user.
+        try:
+            include_service_accounts = await self.is_platform_admin()
+        except HTTPException:
+            logger.warning(
+                "PlatformAdmin check failed while listing Scoped Access Keys; "
+                "falling back to listing only the caller's own keys",
+                extra={"actor_principal": self.principal},
+                exc_info=True,
+            )
+            include_service_accounts = False
+        return await self._registry.list_for_principal(
+            self.principal, page=page, page_size=page_size, include_service_accounts=include_service_accounts
+        )
 
     async def revoke_async(self, jti: str) -> bool:
         self._ensure_enabled()
-        revoked = await self._registry.revoke(jti, self.principal)
+        revoked = await self._registry.revoke(jti, self.principal, admin_override=self._admin_override)
         audit_event = "access_key.revoked" if revoked else "access_key.revoke_noop"
         logger.info(
             "Scoped Access Key revoked" if revoked else "Scoped Access Key revoke requested for already-revoked key",
@@ -339,13 +475,17 @@ class PersistentAccessKeyIssuer:
 
     async def suspend_async(self, jti: str) -> tuple[bool, AccessKeyReversibleStatus]:
         self._ensure_enabled()
-        suspended, effective_status = await self._registry.suspend(jti, self.principal)
+        suspended, effective_status = await self._registry.suspend(
+            jti, self.principal, admin_override=self._admin_override
+        )
         self._log_suspension(jti, changed=suspended, action="suspend")
         return suspended, effective_status
 
     async def unsuspend_async(self, jti: str) -> tuple[bool, AccessKeyReversibleStatus]:
         self._ensure_enabled()
-        unsuspended, effective_status = await self._registry.unsuspend(jti, self.principal)
+        unsuspended, effective_status = await self._registry.unsuspend(
+            jti, self.principal, admin_override=self._admin_override
+        )
         self._log_suspension(jti, changed=unsuspended, action="unsuspend")
         return unsuspended, effective_status
 

--- a/services/core/auth/src/nmp/core/auth/entities/entities.py
+++ b/services/core/auth/src/nmp/core/auth/entities/entities.py
@@ -4,8 +4,11 @@
 """Auth service entities."""
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
+from nemo_platform_plugin.auth.access_keys.types import AccessKeyEntityType
+from nmp.common.auth.access_keys import SERVICE_ACCOUNT_PRINCIPAL_PREFIX
+from nmp.common.auth.models import Principal
 from nmp.common.entities import EntityBase
 from pydantic import model_validator
 
@@ -44,7 +47,11 @@ class AccessKeyEntity(EntityBase):
 
     key_name: str | None = None
     description: str | None = None
+    # ``principal`` is the lifecycle owner. It remains the token subject for
+    # user-bound keys and is the creating administrator for service-bound keys.
     principal: str
+    subject_principal: str | None = None
+    entity_type: AccessKeyEntityType = "USER"
     issuer: str
     audiences: list[str]
     issued_at: datetime
@@ -54,7 +61,29 @@ class AccessKeyEntity(EntityBase):
     @model_validator(mode="before")
     @classmethod
     def _migrate_revoked_at(cls, data: Any) -> Any:
+        if isinstance(data, dict) and data.get("entity_type") == cls.__entity_type__:
+            data = dict(data)
+            data.pop("entity_type")
         if isinstance(data, dict) and data.get("revoked_at") is not None:
             data = dict(data)
             data["status"] = "REVOKED"
         return data
+
+    @property
+    def is_service_account(self) -> bool:
+        return self.entity_type == "SERVICE_ACCOUNT"
+
+    @model_validator(mode="after")
+    def _validate_identity_binding(self) -> Self:
+        if self.is_service_account:
+            if (
+                self.subject_principal is None
+                or self.subject_principal == SERVICE_ACCOUNT_PRINCIPAL_PREFIX
+                or not self.subject_principal.startswith(SERVICE_ACCOUNT_PRINCIPAL_PREFIX)
+            ):
+                raise ValueError("service-account access keys require a service-account subject principal")
+            if Principal(id=self.principal).is_service_identity():
+                raise ValueError("service-account access keys require a human creator principal")
+        elif self.subject_principal is not None:
+            raise ValueError("user access keys cannot have a separate subject principal")
+        return self

--- a/services/core/auth/tests/integration/test_scoped_access_keys.py
+++ b/services/core/auth/tests/integration/test_scoped_access_keys.py
@@ -36,17 +36,21 @@ def _wait_for_authorization_response(
     *,
     expected_status_code: int,
 ) -> Response:
+    return _wait_for_condition(request, lambda response: response.status_code == expected_status_code)
+
+
+def _wait_for_condition(
+    request: Callable[[], Response],
+    condition: Callable[[Response], bool],
+) -> Response:
     deadline = monotonic() + AUTHZ_PROPAGATION_TIMEOUT_SECONDS
     response = request()
-    while response.status_code != expected_status_code and monotonic() < deadline:
+    while not condition(response) and monotonic() < deadline:
         sleep(AUTHZ_PROPAGATION_POLL_INTERVAL_SECONDS)
         response = request()
 
-    if response.status_code != expected_status_code:
-        raise AssertionError(
-            f"Timed out waiting for authorization response {expected_status_code}; "
-            f"last response {response.status_code}: {response.text}"
-        )
+    if not condition(response):
+        raise AssertionError(f"Timed out waiting for expected authorization response: {response.text}")
     return response
 
 
@@ -91,6 +95,48 @@ def _auth_configs(private_key_file: str) -> tuple[AuthConfig, AuthServiceConfig]
         admin_email="admin@example.com",
     )
     return shared_config, service_config
+
+
+def test_legacy_access_key_without_identity_fields_is_listed_as_user(tmp_path: Path) -> None:
+    private_key_file = tmp_path / "legacy-access-key-private.pem"
+    _write_private_key(private_key_file)
+    shared_config, service_config = _auth_configs(str(private_key_file))
+    principal = f"legacy-access-key-{uuid.uuid4().hex[:8]}@example.com"
+    jti = f"ak_legacy_{uuid.uuid4().hex}"
+    user_headers = {
+        "X-NMP-Principal-Id": principal,
+        "X-NMP-Principal-Email": principal,
+    }
+
+    with create_test_client(
+        client_type=TestClient,
+        auth_enabled=True,
+        service_configs={AuthConfig: shared_config, AuthServiceConfig: service_config},
+    ) as client:
+        legacy_data = {
+            "key_name": "legacy-key",
+            "description": "Pre-migration access key",
+            "principal": principal,
+            "issuer": "http://testserver/apis/auth",
+            "audiences": ["nemo-platform-access-key"],
+            "issued_at": "2026-08-25T00:00:00Z",
+            "expires_at": "2030-01-01T00:00:00Z",
+            "status": "ACTIVE",
+        }
+        assert "entity_type" not in legacy_data
+        assert "subject_principal" not in legacy_data
+        created = client.post(
+            "/apis/entities/v2/workspaces/system/entities/access_key",
+            json={"name": jti, "data": legacy_data},
+            headers=SERVICE_HEADERS,
+        )
+        assert created.status_code == 201, created.text
+
+        listed = client.get(ACCESS_KEYS_PATH, headers=user_headers)
+
+        assert listed.status_code == 200, listed.text
+        legacy_key = next(key for key in listed.json()["data"] if key["jti"] == jti)
+        assert legacy_key["entity_type"] == "USER"
 
 
 def test_scoped_access_key_created_by_auth_service_authenticates_platform_requests(tmp_path: Path) -> None:
@@ -223,3 +269,106 @@ def test_scoped_access_key_created_by_auth_service_authenticates_platform_reques
             assert revoked_workspace_response.status_code == 401, revoked_workspace_response.text
         finally:
             client.delete(f"{WORKSPACES_PATH}/{workspace}", headers=SERVICE_HEADERS)
+
+
+def test_platform_admin_creates_service_bound_key_with_independent_identity(tmp_path: Path) -> None:
+    private_key_file = tmp_path / "service-access-key-private.pem"
+    _write_private_key(private_key_file)
+    shared_config, service_config = _auth_configs(str(private_key_file))
+    admin_headers = {
+        "X-NMP-Principal-Id": "admin@example.com",
+        "X-NMP-Principal-Email": "admin@example.com",
+    }
+    user_headers = {
+        "X-NMP-Principal-Id": "user@example.com",
+        "X-NMP-Principal-Email": "user@example.com",
+    }
+
+    with create_test_client(
+        client_type=TestClient,
+        auth_enabled=True,
+        service_configs={AuthConfig: shared_config, AuthServiceConfig: service_config},
+    ) as client:
+        denied = client.post(
+            ACCESS_KEYS_PATH,
+            json={"service_account_id": "otel-collector"},
+            headers=user_headers,
+        )
+        assert denied.status_code == 403, denied.text
+
+        created = client.post(
+            ACCESS_KEYS_PATH,
+            json={"name": "otel", "service_account_id": "otel-collector"},
+            headers=admin_headers,
+        )
+        assert created.status_code == 200, created.text
+        body = created.json()
+        assert body["principal"] == "service-account:otel-collector"
+        assert body["entity_type"] == "SERVICE_ACCOUNT"
+
+        jwks = {"keys": [public_jwk_from_private_key_pem(shared_config)]}
+
+        async def validate_with_local_jwks(config: AuthConfig, token: str) -> TokenClaims | None:
+            return await validate_access_key_token(config, token, jwks_override=jwks)
+
+        with patch("nmp.common.auth.access_keys.validate_access_key_token", validate_with_local_jwks):
+            authenticated = client.get(
+                "/apis/auth/authenticate",
+                headers={"Authorization": f"Bearer {body['token']}"},
+            )
+        assert authenticated.status_code == 200, authenticated.text
+        assert authenticated.json()["principal"] == "service-account:otel-collector"
+
+        workspace = f"service-key-scope-{uuid.uuid4().hex[:8]}"
+        create_workspace = client.post(
+            WORKSPACES_PATH,
+            json={"name": workspace, "description": "Service-bound key scope check"},
+            headers=SERVICE_HEADERS,
+        )
+        assert create_workspace.status_code in {200, 201}, create_workspace.text
+
+        def get_workspace_with_service_key() -> Response:
+            with patch("nmp.common.auth.access_keys.validate_access_key_token", validate_with_local_jwks):
+                return client.get(
+                    f"{WORKSPACES_PATH}/{workspace}",
+                    headers={"Authorization": f"Bearer {body['token']}"},
+                )
+
+        assert get_workspace_with_service_key().status_code == 403
+        role_binding = client.post(
+            IAM_ROLE_BINDINGS_PATH,
+            json={"principal": body["principal"], "role": "Viewer", "workspace": workspace},
+            headers=SERVICE_HEADERS,
+        )
+        assert role_binding.status_code in {200, 201}, role_binding.text
+        _wait_for_authorization_response(get_workspace_with_service_key, expected_status_code=200)
+
+        listed = client.get(ACCESS_KEYS_PATH, headers=admin_headers)
+        assert listed.status_code == 200, listed.text
+        assert listed.json()["data"][0]["principal"] == "service-account:otel-collector"
+
+        # Service-bound keys are platform-owned, not creator-owned (AIRCORE-986): a second
+        # PlatformAdmin who did not create this key must still see it in their own listing,
+        # not just be able to look it up by jti.
+        other_admin_headers = {
+            "X-NMP-Principal-Id": "admin2@example.com",
+            "X-NMP-Principal-Email": "admin2@example.com",
+        }
+        other_admin_role_binding = client.post(
+            IAM_ROLE_BINDINGS_PATH,
+            json={"principal": "admin2@example.com", "role": "PlatformAdmin", "workspace": "system"},
+            headers=SERVICE_HEADERS,
+        )
+        assert other_admin_role_binding.status_code in {200, 201}, other_admin_role_binding.text
+        other_admin_listed = _wait_for_condition(
+            lambda: client.get(ACCESS_KEYS_PATH, headers=other_admin_headers),
+            lambda response: (
+                response.status_code == 200
+                and any(key["principal"] == "service-account:otel-collector" for key in response.json()["data"])
+            ),
+        )
+        assert other_admin_listed.status_code == 200, other_admin_listed.text
+
+        revoked = client.delete(f"{ACCESS_KEYS_PATH}/{body['jti']}", headers=admin_headers)
+        assert revoked.status_code == 200, revoked.text
+        client.delete(f"{WORKSPACES_PATH}/{workspace}", headers=SERVICE_HEADERS)

--- a/services/core/auth/tests/test_access_key_registry.py
+++ b/services/core/auth/tests/test_access_key_registry.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from nemo_platform_plugin.auth.access_keys.types import AccessKeyCreateResponse
+from nemo_platform_plugin.auth.access_keys.types import AccessKeyCreateResponse, AccessKeyEntityType
 from nmp.common.auth.jwt import TokenClaims
 from nmp.common.entities import EntityConflictError, EntityNotFoundError
 from nmp.core.auth.app.access_keys import AccessKeyNotFoundError, AccessKeyRegistry, AccessKeyStateConflictError
@@ -15,13 +15,21 @@ from nmp.core.auth.entities import AccessKeyEntity
 NOW = datetime(2026, 8, 4, 18, 0, tzinfo=UTC)
 
 
-def _record(*, jti: str = "ak_example", principal: str = "alice@example.com", revoked: bool = False):
+def _record(
+    *,
+    jti: str = "ak_example",
+    principal: str = "alice@example.com",
+    revoked: bool = False,
+    service_account: bool = False,
+):
     return AccessKeyEntity(
         name=jti,
         workspace="system",
         key_name="ci-build",
         description="CI build automation",
         principal=principal,
+        subject_principal="service-account:otel-collector" if service_account else None,
+        entity_type="SERVICE_ACCOUNT" if service_account else "USER",
         issued_at=NOW,
         expires_at=datetime(2030, 1, 1, tzinfo=UTC),
         status="REVOKED" if revoked else "ACTIVE",
@@ -72,6 +80,33 @@ def test_access_key_entity_defaults_unrevoked_legacy_record_to_active() -> None:
     assert record.status == "ACTIVE"
 
 
+@pytest.mark.parametrize(
+    ("entity_type", "principal", "subject_principal"),
+    [
+        ("SERVICE_ACCOUNT", "admin@example.com", None),
+        ("SERVICE_ACCOUNT", "admin@example.com", "service-account:"),
+        ("SERVICE_ACCOUNT", "admin@example.com", "alice@example.com"),
+        ("SERVICE_ACCOUNT", "service:auth", "service-account:otel-collector"),
+        ("SERVICE_ACCOUNT", "service-account:creator", "service-account:otel-collector"),
+        ("USER", "alice@example.com", "service-account:otel-collector"),
+    ],
+)
+def test_access_key_entity_rejects_inconsistent_identity_binding(
+    entity_type: AccessKeyEntityType, principal: str, subject_principal: str | None
+) -> None:
+    with pytest.raises(ValueError):
+        AccessKeyEntity(
+            name="ak_invalid",
+            workspace="system",
+            principal=principal,
+            subject_principal=subject_principal,
+            entity_type=entity_type,
+            issued_at=NOW,
+            issuer="https://platform.example.com/apis/auth",
+            audiences=["nemo-platform-access-key"],
+        )
+
+
 @pytest.mark.asyncio
 async def test_registry_persists_created_key_metadata() -> None:
     entity_client = AsyncMock()
@@ -101,11 +136,43 @@ async def test_registry_persists_created_key_metadata() -> None:
 
 
 @pytest.mark.asyncio
+async def test_registry_separates_service_key_owner_from_token_subject() -> None:
+    entity_client = AsyncMock()
+    registry = AccessKeyRegistry(entity_client)
+    key = AccessKeyCreateResponse(
+        jti="ak_service",
+        name="otel",
+        principal="service-account:otel-collector",
+        entity_type="SERVICE_ACCOUNT",
+        created_at=NOW,
+        expires_at=NOW + timedelta(hours=1),
+        description=None,
+        status="ACTIVE",
+        issuer="https://platform.example.com/apis/auth",
+        audiences=["nemo-platform-access-key"],
+        token="secret-token",
+        token_type="Bearer",
+    )
+
+    await registry.add(key, owner_principal="admin@example.com")
+
+    saved = entity_client.create.await_args.args[0]
+    assert saved.principal == "admin@example.com"
+    assert saved.subject_principal == "service-account:otel-collector"
+    assert saved.entity_type == "SERVICE_ACCOUNT"
+
+
+@pytest.mark.asyncio
 async def test_registry_lists_principals_keys_with_status_across_pages() -> None:
     entity_client = AsyncMock()
     active_record = _record().model_copy(update={"audiences": ["nemo-platform-access-key", "nemo-platform-access-key"]})
     entity_client.list.return_value = SimpleNamespace(
-        data=[active_record, _record(jti="ak_revoked", revoked=True)], pagination=SimpleNamespace(total_pages=2)
+        data=[
+            active_record,
+            _record(jti="ak_service", principal="alice@example.com", service_account=True),
+            _record(jti="ak_revoked", revoked=True),
+        ],
+        pagination=SimpleNamespace(total_pages=2),
     )
     registry = AccessKeyRegistry(entity_client)
 
@@ -118,7 +185,26 @@ async def test_registry_lists_principals_keys_with_status_across_pages() -> None
     entity_client.list.assert_awaited_once()
     assert entity_client.list.await_args.kwargs["page"] == 1
     assert entity_client.list.await_args.kwargs["page_size"] == 2
-    assert entity_client.list.await_args.kwargs["filter_obj"] == {"principal": "alice@example.com"}
+    assert entity_client.list.await_args.kwargs["filter_operation"].to_dict() == {
+        "data.principal": {"$eq": "alice@example.com"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_registry_lists_all_service_accounts_when_include_service_accounts() -> None:
+    entity_client = AsyncMock()
+    entity_client.list.return_value = SimpleNamespace(data=[], pagination=SimpleNamespace(total_pages=1))
+    registry = AccessKeyRegistry(entity_client)
+
+    await registry.list_for_principal("admin@example.com", page=1, page_size=100, include_service_accounts=True)
+
+    filter_operation = entity_client.list.await_args.kwargs["filter_operation"]
+    assert filter_operation.to_dict() == {
+        "$or": [
+            {"data.principal": {"$eq": "admin@example.com"}},
+            {"data.entity_type": {"$eq": "SERVICE_ACCOUNT"}},
+        ]
+    }
 
 
 @pytest.mark.asyncio
@@ -252,6 +338,104 @@ async def test_registry_hides_missing_and_other_principals_keys() -> None:
 
     entity_client.get.side_effect = EntityNotFoundError("missing")
     assert not await registry.is_active("ak_missing", "alice@example.com")
+
+
+@pytest.mark.asyncio
+async def test_registry_admin_override_lets_a_different_admin_revoke_a_service_bound_key() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record(principal="admin-a@example.com", service_account=True)
+    registry = AccessKeyRegistry(entity_client)
+
+    assert await registry.revoke("ak_example", "admin-b@example.com", admin_override=AsyncMock(return_value=True))
+
+    updated = entity_client.update.await_args.args[0]
+    assert updated.status == "REVOKED"
+
+
+@pytest.mark.asyncio
+async def test_registry_admin_override_is_not_consulted_for_a_personal_key() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record(principal="alice@example.com")
+    registry = AccessKeyRegistry(entity_client)
+    admin_override = AsyncMock(return_value=True)
+
+    with pytest.raises(AccessKeyNotFoundError):
+        await registry.revoke("ak_example", "bob@example.com", admin_override=admin_override)
+
+    admin_override.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_registry_admin_override_denied_still_hides_a_service_bound_key() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record(principal="admin-a@example.com", service_account=True)
+    registry = AccessKeyRegistry(entity_client)
+
+    with pytest.raises(AccessKeyNotFoundError):
+        await registry.revoke("ak_example", "admin-b@example.com", admin_override=AsyncMock(return_value=False))
+
+
+@pytest.mark.asyncio
+async def test_registry_service_key_creator_must_still_pass_admin_override() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record(principal="admin-a@example.com", service_account=True)
+    registry = AccessKeyRegistry(entity_client)
+    admin_override = AsyncMock(return_value=False)
+
+    with pytest.raises(AccessKeyNotFoundError):
+        await registry.revoke("ak_example", "admin-a@example.com", admin_override=admin_override)
+
+    admin_override.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_registry_admin_override_is_not_consulted_when_the_caller_already_owns_the_key() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record(principal="alice@example.com")
+    registry = AccessKeyRegistry(entity_client)
+    admin_override = AsyncMock(return_value=True)
+
+    assert await registry.revoke("ak_example", "alice@example.com", admin_override=admin_override)
+
+    admin_override.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_registry_admin_override_lets_a_different_admin_suspend_and_unsuspend_a_service_bound_key() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [
+        _record(principal="admin-a@example.com", service_account=True),
+        _record(principal="admin-a@example.com", service_account=True).model_copy(update={"status": "SUSPENDED"}),
+    ]
+    registry = AccessKeyRegistry(entity_client)
+    admin_override = AsyncMock(return_value=True)
+
+    suspend_changed, suspend_status = await registry.suspend(
+        "ak_example", "admin-b@example.com", admin_override=admin_override
+    )
+    assert suspend_changed
+    assert suspend_status == "SUSPENDED"
+
+    unsuspend_changed, unsuspend_status = await registry.unsuspend(
+        "ak_example", "admin-b@example.com", admin_override=admin_override
+    )
+    assert unsuspend_changed
+    assert unsuspend_status == "ACTIVE"
+
+
+@pytest.mark.asyncio
+async def test_registry_is_active_for_service_bound_key_checks_subject_not_owner() -> None:
+    entity_client = AsyncMock()
+    record = _record(principal="admin-a@example.com", service_account=True).model_copy(
+        update={"subject_principal": "service-account:otel-collector"}
+    )
+    entity_client.get.return_value = record
+    registry = AccessKeyRegistry(entity_client)
+
+    # Authenticating as the service-account subject succeeds...
+    assert await registry.is_active("ak_example", "service-account:otel-collector")
+    # ...but the owning admin's principal is not itself a valid authentication subject.
+    assert not await registry.is_active("ak_example", "admin-a@example.com")
 
 
 @pytest.mark.asyncio

--- a/services/core/auth/tests/test_access_keys.py
+++ b/services/core/auth/tests/test_access_keys.py
@@ -3,7 +3,7 @@
 
 import logging
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -22,11 +22,13 @@ from nmp.core.auth.app.access_keys import AccessKeyNotFoundError, AccessKeyState
 class InMemoryAccessKeyRegistry:
     def __init__(self):
         self.keys = {}
+        self.owners = {}
         self.revoked = set()
         self.suspended = set()
 
-    async def add(self, key):
+    async def add(self, key, *, owner_principal=None):
         self.keys[key.jti] = key
+        self.owners[key.jti] = owner_principal or key.principal
 
     def _status(self, jti, key):
         if jti in self.revoked:
@@ -37,12 +39,29 @@ class InMemoryAccessKeyRegistry:
             return "SUSPENDED"
         return key.status
 
-    async def list_for_principal(self, principal, *, page, page_size):
+    async def _may_manage(self, jti, principal, *, admin_override=None):
+        key = self.keys.get(jti)
+        if key is None:
+            return None
+        if key.entity_type == "SERVICE_ACCOUNT":
+            if admin_override is not None and await admin_override():
+                return key
+        elif self.owners[jti] == principal:
+            return key
+        return None
+
+    async def list_for_principal(self, principal, *, page, page_size, include_service_accounts=False):
         from nemo_platform_plugin.auth.access_keys.types import AccessKeyListResponse, AccessKeyMetadataResponse
 
         # Sort newest-first then by jti to match the real registry's `sort="-issued_at"`.
         owned = sorted(
-            [(jti, key) for jti, key in self.keys.items() if key.principal == principal],
+            [
+                (jti, key)
+                for jti, key in self.keys.items()
+                if self.owners[jti] == principal
+                and key.entity_type != "SERVICE_ACCOUNT"
+                or (include_service_accounts and key.entity_type == "SERVICE_ACCOUNT")
+            ],
             key=lambda item: (-item[1].created_at.timestamp(), item[0]),
         )
         start = (page - 1) * page_size
@@ -57,18 +76,18 @@ class InMemoryAccessKeyRegistry:
             has_more=start + page_size < len(owned),
         )
 
-    async def revoke(self, jti, principal):
-        key = self.keys.get(jti)
-        if key is None or key.principal != principal:
+    async def revoke(self, jti, principal, *, admin_override=None):
+        key = await self._may_manage(jti, principal, admin_override=admin_override)
+        if key is None:
             raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
         revoked = jti not in self.revoked
         self.revoked.add(jti)
         self.suspended.discard(jti)
         return revoked
 
-    async def suspend(self, jti, principal):
-        key = self.keys.get(jti)
-        if key is None or key.principal != principal:
+    async def suspend(self, jti, principal, *, admin_override=None):
+        key = await self._may_manage(jti, principal, admin_override=admin_override)
+        if key is None:
             raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
         if jti in self.revoked:
             raise AccessKeyStateConflictError(f"Revoked Scoped Access Key {jti} cannot be suspended")
@@ -78,9 +97,9 @@ class InMemoryAccessKeyRegistry:
         self.suspended.add(jti)
         return changed, self._status(jti, key)
 
-    async def unsuspend(self, jti, principal):
-        key = self.keys.get(jti)
-        if key is None or key.principal != principal:
+    async def unsuspend(self, jti, principal, *, admin_override=None):
+        key = await self._may_manage(jti, principal, admin_override=admin_override)
+        if key is None:
             raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
         if jti in self.revoked:
             raise AccessKeyStateConflictError(f"Revoked Scoped Access Key {jti} cannot be unsuspended")
@@ -174,6 +193,181 @@ def test_create_access_key_returns_token_for_current_principal(client):
     assert body["principal"] == "alice@example.com"
     assert body["expires_at"] is not None
     assert body["token"].count(".") == 2
+
+
+def test_access_key_issuer_uses_effective_principal_for_delegated_requests():
+    auth_client = AuthClient(
+        principal=Principal(
+            id="service:evaluator",
+            on_behalf_of="admin@example.com",
+            on_behalf_of_email="admin@example.com",
+        ),
+        config=AuthConfig(enabled=True),
+    )
+
+    issuer = get_access_key_issuer(auth_client=auth_client, registry=InMemoryAccessKeyRegistry())
+
+    assert issuer.principal == "admin@example.com"
+
+
+def test_create_service_access_key_requires_platform_admin(client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=False) as has_role:
+        response = client.post(
+            "/v2/access-keys",
+            json={"name": "otel", "service_account_id": "otel-collector"},
+        )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Only PlatformAdmin can create service-bound Scoped Access Keys"
+    has_role.assert_awaited_once_with("system", "PlatformAdmin")
+
+
+def test_service_account_principal_cannot_create_or_manage_service_bound_keys_even_with_platform_admin_role(client):
+    service_account_token = auth_client_context.set(
+        AuthClient(
+            principal=Principal(id="service-account:ci-bot"),
+            config=AuthConfig(enabled=True, access_keys=AccessKeyConfig(enabled=True)),
+        )
+    )
+    try:
+        with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True) as has_role:
+            response = client.post(
+                "/v2/access-keys",
+                json={"name": "otel", "service_account_id": "otel-collector"},
+            )
+    finally:
+        auth_client_context.reset(service_account_token)
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Only PlatformAdmin can create service-bound Scoped Access Keys"
+    # The service-account identity check short-circuits before any PDP role lookup.
+    has_role.assert_not_awaited()
+
+
+def test_privileged_service_principal_cannot_create_service_bound_keys_even_with_platform_admin_role(client):
+    service_token = auth_client_context.set(
+        AuthClient(
+            principal=Principal(id="service:auth"),
+            config=AuthConfig(enabled=True, access_keys=AccessKeyConfig(enabled=True)),
+        )
+    )
+    try:
+        with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True) as has_role:
+            response = client.post(
+                "/v2/access-keys",
+                json={"name": "otel", "service_account_id": "otel-collector"},
+            )
+    finally:
+        auth_client_context.reset(service_token)
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Only PlatformAdmin can create service-bound Scoped Access Keys"
+    has_role.assert_not_awaited()
+
+
+def test_create_service_access_key_is_denied_when_auth_is_disabled(client):
+    with (
+        patch.object(AuthClient, "auth_enabled", new_callable=PropertyMock, return_value=False),
+        patch.object(AuthClient, "has_role", new_callable=AsyncMock) as has_role,
+    ):
+        response = client.post(
+            "/v2/access-keys",
+            json={"service_account_id": "otel-collector"},
+        )
+
+    assert response.status_code == 403
+    has_role.assert_not_awaited()
+
+
+def test_platform_admin_creates_and_manages_service_access_key(client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True):
+        response = client.post(
+            "/v2/access-keys",
+            json={"name": "otel", "service_account_id": "otel-collector"},
+        )
+
+        assert response.status_code == 200
+        created = response.json()
+        assert created["principal"] == "service-account:otel-collector"
+        assert created["entity_type"] == "SERVICE_ACCOUNT"
+
+        listed = client.get("/v2/access-keys")
+        assert listed.status_code == 200
+        assert listed.json()["data"][0]["principal"] == "service-account:otel-collector"
+        assert client.delete(f"/v2/access-keys/{created['jti']}").status_code == 200
+
+
+def test_demoted_platform_admin_lists_personal_key_but_not_service_key(client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True):
+        personal = client.post("/v2/access-keys", json={"name": "personal"}).json()
+        service = client.post(
+            "/v2/access-keys",
+            json={"name": "otel", "service_account_id": "otel-collector"},
+        ).json()
+
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=False):
+        response = client.get("/v2/access-keys")
+
+    assert response.status_code == 200
+    listed_jtis = {key["jti"] for key in response.json()["data"]}
+    assert personal["jti"] in listed_jtis
+    assert service["jti"] not in listed_jtis
+
+
+def test_service_key_creator_cannot_revoke_after_losing_platform_admin(client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True):
+        created = client.post(
+            "/v2/access-keys",
+            json={"name": "otel", "service_account_id": "otel-collector"},
+        ).json()
+
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=False):
+        revoked = client.delete(f"/v2/access-keys/{created['jti']}")
+
+    assert revoked.status_code == 404
+
+
+def test_platform_admin_can_revoke_service_key_created_by_a_different_admin(client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True):
+        created = client.post(
+            "/v2/access-keys",
+            json={"name": "otel", "service_account_id": "otel-collector"},
+        ).json()
+
+        # A second PlatformAdmin, distinct from the creator, manages the same registry.
+        other_admin_token = auth_client_context.set(
+            AuthClient(
+                principal=Principal(id="bob@example.com", email="bob@example.com"),
+                config=AuthConfig(enabled=True, access_keys=AccessKeyConfig(enabled=True)),
+            )
+        )
+        try:
+            # Listing stays scoped to the caller's own keys (see PersistentAccessKeyIssuer.list_async);
+            # a PlatformAdmin manages another admin's service-bound key by its jti directly.
+            revoked = client.delete(f"/v2/access-keys/{created['jti']}")
+        finally:
+            auth_client_context.reset(other_admin_token)
+
+    assert revoked.status_code == 200
+    assert revoked.json()["revoked"] is True
+
+
+def test_platform_admin_cannot_revoke_another_admins_personal_access_key(client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True):
+        created = client.post("/v2/access-keys", json={"name": "personal"}).json()
+
+        other_admin_token = auth_client_context.set(
+            AuthClient(
+                principal=Principal(id="bob@example.com", email="bob@example.com"),
+                config=AuthConfig(enabled=True, access_keys=AccessKeyConfig(enabled=True)),
+            )
+        )
+        try:
+            revoked = client.delete(f"/v2/access-keys/{created['jti']}")
+        finally:
+            auth_client_context.reset(other_admin_token)
+
+    assert revoked.status_code == 404
 
 
 def test_create_and_revoke_emit_actor_aware_audit_logs(client, caplog):
@@ -298,6 +492,21 @@ def test_create_access_key_is_disabled_by_default(disabled_client):
     assert body["code"] == "access_keys_disabled"
 
 
+def test_create_service_access_key_is_disabled_before_role_check(disabled_client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock) as has_role:
+        response = disabled_client.post(
+            "/v2/access-keys",
+            json={"service_account_id": "otel-collector"},
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "detail": "Scoped Access Keys are not enabled",
+        "code": "access_keys_disabled",
+    }
+    has_role.assert_not_awaited()
+
+
 def test_create_access_key_is_explicitly_not_implemented(client):
     class NotImplementedIssuer:
         async def create_async(self, request):
@@ -375,6 +584,10 @@ def test_access_key_lifecycle_openapi_documents_error_responses(client):
     }
     assert create_responses["400"]["description"] == "Scoped Access Key creation error"
     assert create_responses["400"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/AccessKeyErrorResponse"
+    }
+    assert create_responses["403"]["description"] == "Service-bound Scoped Access Keys require PlatformAdmin"
+    assert create_responses["403"]["content"]["application/json"]["schema"] == {
         "$ref": "#/components/schemas/AccessKeyErrorResponse"
     }
     assert create_responses["404"]["description"] == "Scoped Access Keys are not enabled"
@@ -499,6 +712,7 @@ def test_list_access_keys_returns_current_principals_persisted_keys(client):
             "jti": created["jti"],
             "name": "ci-intake",
             "principal": "alice@example.com",
+            "entity_type": "USER",
             "created_at": created["created_at"],
             "expires_at": created["expires_at"],
             "description": "CI intake automation",


### PR DESCRIPTION
## Summary
Adds PlatformAdmin-provisioned, service-bound Scoped Access Keys for machine-to-machine authentication: a key can now be minted for a non-human `service-account:<id>` identity instead of the caller's own user identity, distinct from the existing user-bound (self-serve) key path.

## Related Issue
AIRCORE-986: https://linear.app/nvidia/issue/AIRCORE-986/implement-service-scoped-access-keys

## Changes
- `AccessKeyCreateRequest` gains an optional `service_account_id` field; when set, the issuer mints a token for `service-account:<id>` instead of the caller, tagged with a new `entity_type: USER | SERVICE_ACCOUNT`.
- Creating a service-bound key requires the caller to be a current PlatformAdmin (`AuthClient.has_role`, new method), enforced both at the API layer (403 pre-check) and defense-in-depth inside `AccessKeyIssuerService`/`PersistentAccessKeyIssuer` (400 re-check). Service-account and `service:` principals are explicitly blocked from creating or self-renewing service-bound keys, even if misconfigured with the PlatformAdmin role.
- `AccessKeyEntity` now tracks `principal` (lifecycle owner/creator) separately from `subject_principal` (token subject) for service-bound keys, with a model validator enforcing the identity-binding invariants.
- Lifecycle operations (revoke/suspend/unsuspend/list) on service-bound keys now check current PlatformAdmin status via a memoized `admin_override` callback, rather than trusting only the original creator — so any current admin can manage any service-bound key, and a demoted admin loses access to keys they created.
- Listing surfaces every service-bound key to a current PlatformAdmin (not just ones they personally created); non-admins/demoted admins see only their own non-service keys.
- `AuthClient` gains `has_role`, refactored alongside `has_permissions` to share a `_pdp_check` helper.
- CLI (`nemo auth access-keys create`) gains a `--service-account` flag; `list` output gains `entity_type`/`principal` columns.
- OpenAPI spec and generated CLI docs regenerated to reflect the new field/flag/403 response.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer — not re-verified this session.
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below — not run this session; run before committing.
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest packages/nmp_common/tests/auth/test_access_keys.py packages/nmp_common/tests/auth/test_client.py services/core/auth/tests/test_access_key_registry.py services/core/auth/tests/test_access_keys.py packages/nemo_platform_ext/tests/cli/commands/test_auth.py -q` → 215 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create Scoped Access Keys for users or service accounts.
  - View key type and principal metadata (`USER` or `SERVICE_ACCOUNT`).
  - PlatformAdmins can view, suspend, unsuspend, and revoke service-bound keys, including those created by other administrators.
  - Specify a service account when creating keys through the CLI or API.
  - Added role-membership authorization checks.

- **Documentation**
  - Updated CLI and API references with service-account options, validation rules, permissions, and error responses.

- **Bug Fixes**
  - Improved validation of service-account identity and authorization details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->