### PR TITLE
fix(customizer): include filesets in customizer images

### DIFF
--- a/docker/Dockerfile.nmp-customizer-tasks
+++ b/docker/Dockerfile.nmp-customizer-tasks
@@ -70,6 +70,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --python ${VIRTUAL_ENV}/bin/python --no-cache \
     --overrides /app/docker/customizer/no_override_requirements.txt \
     -e /app/sdk/python/nemo-platform \
+    -e /app/packages/filesets \
     -e /app/packages/nemo_platform_plugin \
     -e /app/packages/nmp_common \
     -e /app/packages/nmp_customization_common \

--- a/docker/Dockerfile.nmp-unsloth-training
+++ b/docker/Dockerfile.nmp-unsloth-training
@@ -171,6 +171,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --reinstall-package wandb \
     --overrides /opt/docker/no_override_requirements.txt \
     -e /app/sdk/python/nemo-platform \
+    -e /app/packages/filesets \
     -e /app/packages/nemo_platform_plugin \
     -e /app/packages/nmp_common \
     -e /app/packages/nmp_customization_common \

--- a/docker/customizer/Dockerfile.platform-workspace
+++ b/docker/customizer/Dockerfile.platform-workspace
@@ -14,6 +14,7 @@ COPY docker/customizer/no_override_requirements.txt docker/customizer/no_overrid
 COPY docs docs
 COPY openapi openapi
 COPY packages/nmp_build_tools packages/nmp_build_tools
+COPY packages/filesets packages/filesets
 COPY packages/models packages/models
 COPY packages/nmp_common packages/nmp_common
 COPY packages/nmp_customization_common packages/nmp_customization_common

--- a/docker/customizer/pyproject.workspace.toml
+++ b/docker/customizer/pyproject.workspace.toml
@@ -16,6 +16,7 @@ constraint-dependencies = ["greenlet>=3.0.0,<3.5"]
 [tool.uv.workspace]
 members = [
   "packages/nmp_build_tools",
+  "packages/filesets",
   "packages/models",
   "sdk/python/nemo-platform",
   "packages/nemo_platform_plugin",
@@ -27,6 +28,7 @@ members = [
 
 [tool.uv.sources]
 nmp-build-tools = { workspace = true }
+filesets = { workspace = true }
 models = { workspace = true }
 nemo-platform-sdk = { workspace = true }
 nemo-platform-plugin = { workspace = true }

--- a/docker/rl/Dockerfile.nmp-rl-training
+++ b/docker/rl/Dockerfile.nmp-rl-training
@@ -63,6 +63,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv-glue pip install --python /opt/nemo_rl_venv/bin/python --no-cache \
         --overrides /tmp/base-overrides.txt \
         -e /app/sdk/python/nemo-platform \
+        -e /app/packages/filesets \
         -e /app/packages/nemo_platform_plugin \
         -e /app/packages/nmp_common \
         -e /app/packages/nmp_customization_common \

--- a/docker/rl/Dockerfile.platform-workspace
+++ b/docker/rl/Dockerfile.platform-workspace
@@ -14,6 +14,7 @@ COPY docker/rl/pyproject.workspace.toml pyproject.toml
 COPY docs docs
 COPY openapi openapi
 COPY packages/nmp_build_tools packages/nmp_build_tools
+COPY packages/filesets packages/filesets
 COPY packages/nmp_common packages/nmp_common
 COPY packages/nmp_customization_common packages/nmp_customization_common
 COPY packages/nemo_platform_plugin packages/nemo_platform_plugin

--- a/docker/rl/pyproject.workspace.toml
+++ b/docker/rl/pyproject.workspace.toml
@@ -16,6 +16,7 @@ required-version = ">=0.9.14,<0.10.0"
 [tool.uv.workspace]
 members = [
   "packages/nmp_build_tools",
+  "packages/filesets",
   "sdk/python/nemo-platform",
   "packages/nemo_platform_plugin",
   "packages/nmp_common",
@@ -25,6 +26,7 @@ members = [
 
 [tool.uv.sources]
 nmp-build-tools = { workspace = true }
+filesets = { workspace = true }
 nemo-platform-sdk = { workspace = true }
 nemo-platform-plugin = { workspace = true }
 nmp-common = { workspace = true }

--- a/docker/unsloth/Dockerfile.platform-workspace
+++ b/docker/unsloth/Dockerfile.platform-workspace
@@ -16,6 +16,7 @@ COPY docker/unsloth/pyproject.workspace.toml pyproject.toml
 COPY docs docs
 COPY openapi openapi
 COPY packages/nmp_build_tools packages/nmp_build_tools
+COPY packages/filesets packages/filesets
 COPY packages/nmp_common packages/nmp_common
 COPY packages/nmp_customization_common packages/nmp_customization_common
 COPY packages/nemo_platform_plugin packages/nemo_platform_plugin

--- a/docker/unsloth/pyproject.workspace.toml
+++ b/docker/unsloth/pyproject.workspace.toml
@@ -15,6 +15,7 @@ required-version = ">=0.9.14,<0.10.0"
 [tool.uv.workspace]
 members = [
   "packages/nmp_build_tools",
+  "packages/filesets",
   "sdk/python/nemo-platform",
   "packages/nemo_platform_plugin",
   "packages/nmp_common",
@@ -24,6 +25,7 @@ members = [
 
 [tool.uv.sources]
 nmp-build-tools = { workspace = true }
+filesets = { workspace = true }
 nemo-platform-sdk = { workspace = true }
 nemo-platform-plugin = { workspace = true }
 nmp-common = { workspace = true }

--- a/tests/unit/test_docker_workspace_slices.py
+++ b/tests/unit/test_docker_workspace_slices.py
@@ -10,7 +10,13 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).parent.parent.parent
-WORKSPACE_SLICES = ("automodel", "rl", "unsloth")
+WORKSPACE_SLICES = ("automodel", "customizer", "rl", "unsloth")
+SDK_EDITABLE_DOCKERFILES = (
+    Path("docker/Dockerfile.nmp-customizer-tasks"),
+    Path("docker/Dockerfile.nmp-unsloth-training"),
+    Path("docker/automodel/Dockerfile.nmp-automodel-training"),
+    Path("docker/rl/Dockerfile.nmp-rl-training"),
+)
 WANDB_PACKAGE_SPEC_RE = re.compile(r"(?<![\w./-])wandb(?:\[[^\]]+\])?(?:==|~=|!=|<=|>=|<|>)[^\\\s\"']+")
 DOCKER_IMAGE_WANDB_CONFIG_PATHS = (
     Path("docker/Dockerfile.nmp-customizer-tasks"),
@@ -87,6 +93,32 @@ def test_docker_workspace_slice_contains_all_workspace_sources(slice_name):
             f"{slice_name} workspace is missing {sorted(missing_sources)} referenced by "
             f"{project_path.relative_to(ROOT)}"
         )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [pytest.param(ROOT / path, id=str(path)) for path in SDK_EDITABLE_DOCKERFILES],
+)
+def test_sdk_editable_image_installs_filesets(path: Path) -> None:
+    """Editable SDK installs need the filesets source package available separately."""
+    text = path.read_text(encoding="utf-8")
+
+    assert "-e /app/sdk/python/nemo-platform" in text
+    assert "-e /app/packages/filesets" in text
+
+
+@pytest.mark.parametrize("slice_name", WORKSPACE_SLICES)
+def test_sdk_editable_workspace_slice_includes_filesets(slice_name: str) -> None:
+    """The SDK imports ``filesets`` lazily when ``sdk.files`` is accessed."""
+    workspace_path = ROOT / "docker" / slice_name / "pyproject.workspace.toml"
+    workspace = _load_pyproject(workspace_path)
+    member_paths = set(workspace["tool"]["uv"]["workspace"]["members"])
+    source_names = _workspace_sources(workspace)
+    dockerfile_text = (ROOT / "docker" / slice_name / "Dockerfile.platform-workspace").read_text(encoding="utf-8")
+
+    assert "packages/filesets" in member_paths
+    assert "filesets" in source_names
+    assert "COPY packages/filesets packages/filesets" in dockerfile_text
 
 
 def test_deployments_plugin_is_optional_for_models_service():


### PR DESCRIPTION
## Summary
Adds the `filesets` source package to the remaining Customizer-related reduced Docker workspaces so editable `nemo-platform-sdk` installs can resolve `nemo_platform.filesets` at runtime. This fixes the `ModuleNotFoundError: No module named 'filesets'` path when file I/O tasks access `sdk.files`.

## Changes
- Include `packages/filesets` in the Customizer, Unsloth, and RL platform workspace slices.
- Install `packages/filesets` editably in the Customizer tasks, Unsloth training, and RL training images alongside the editable SDK.
- Extend Docker workspace-slice regression tests to cover the Customizer slice and require `filesets` for SDK-editable images.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Docker image packaging fix with no user-facing documentation change.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox -q activate -- uv run pre-commit run -a` — passed
- `uv run --frozen pytest tests/unit/test_docker_workspace_slices.py -v` — passed, 19 tests
- `uv run ruff check tests/unit/test_docker_workspace_slices.py` — passed
- `make docker-print TARGET=nmp-customizer` — passed
- `git diff --check` — passed
- DCO audit for `origin/main..HEAD` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `filesets` package to platform workspace builds.
  - Enabled editable installation of `filesets` in customizer, RL training, and unsloth images.

- **Bug Fixes**
  - Improved workspace packaging consistency across supported build configurations.

- **Tests**
  - Added coverage verifying `filesets` is included and installed correctly in Docker workspace slices.
  - Expanded validation to include the customizer workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->