### PR TITLE
feat(studio): upload an eval config, with dataset/prompt/model overrides [ASTD-442]

### DIFF
--- a/web/packages/common/src/components/FormModal/index.tsx
+++ b/web/packages/common/src/components/FormModal/index.tsx
@@ -49,6 +49,17 @@ export interface FormModalProps {
    * Use this to prevent the user from submitting until the form is valid and dirty.
    * */
   submitDisabled?: boolean;
+  /**
+   * Whether clicking the backdrop or pressing Escape dismisses the modal.
+   *
+   * Set `false` on a form holding work a stray click would discard — uploaded files and
+   * typed-in overrides cannot be recovered once the modal unmounts. The close button and
+   * Cancel still work, so the form is never a trap, and `disabled` still blocks every
+   * route out while a request is in flight.
+   *
+   * Defaults to `true`, which is the dialog convention and what every other caller gets.
+   */
+  dismissible?: boolean;
   onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   onClose: () => void;
   styles?: React.CSSProperties;
@@ -72,6 +83,7 @@ export const FormModal: FC<PropsWithChildren<FormModalProps>> = ({
   disabled = false,
   loading = false,
   submitDisabled = false,
+  dismissible = true,
   onSubmit,
   onClose,
   children,
@@ -97,7 +109,10 @@ export const FormModal: FC<PropsWithChildren<FormModalProps>> = ({
 
   return (
     <ModalRoot id={modalId} open={open} onOpenChange={handleUserClose}>
-      <ModalDialog>
+      <ModalDialog
+        closeOnClickOutside={dismissible}
+        onEscapeKeyDown={dismissible ? undefined : (event) => event.preventDefault()}
+      >
         <ModalContent className={`max-h-[90vh] ${className || ''}`}>
           <form className="contents" onSubmit={handleSubmit} noValidate {...attributes?.Form}>
             <ModalHeading>{title}</ModalHeading>

--- a/web/packages/studio/public/sample-agents/email-security-triage/eval-config.dataset-driven.README.md
+++ b/web/packages/studio/public/sample-agents/email-security-triage/eval-config.dataset-driven.README.md
@@ -52,3 +52,24 @@ every row.
   needs no judge model and scores even when the judge is unreachable.
 - `llm-judge` — grades the verdict and whether `attack_type` is a sensible label, as two `scores`
   on one metric.
+
+## Which file to upload
+
+Three copies of this suite sit beside this note, in the order you probably want them:
+
+| File | Use it for |
+| --- | --- |
+| `eval-config.minimal.yaml` | The smallest config that runs — one `string-check`, no judge model. Start here when writing your own. |
+| `eval-config.dataset-driven.yaml` | The full suite, commented. Same two metrics as the JSON, in the format the Run Evaluation form expects. |
+| `eval-config.dataset-driven.json` | The original. Kept as the machine-readable reference; the YAML is easier to read and edit. |
+
+Upload one of them as the **Evaluator config** with `dataset.jsonl` as the dataset.
+
+The YAML files omit `dataset`, `target` and `publication` on purpose — Studio supplies all three
+per run, and the dataset ref in particular names a fileset that does not exist until you submit.
+Setting them anyway is allowed; Studio replaces them rather than complaining.
+
+They also drop `bundle_kind`, `bundle_format_version`, `metadata` and `secrets`, which have schema
+defaults. `outputs` cannot be dropped: the backend rehydrates `payload.metric`, recomputes the
+output spec, and rejects the job if the two disagree — so if you change a metric's `scores`, change
+`outputs` to match.

--- a/web/packages/studio/public/sample-agents/email-security-triage/eval-config.dataset-driven.yaml
+++ b/web/packages/studio/public/sample-agents/email-security-triage/eval-config.dataset-driven.yaml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Dataset-driven eval config for the Email Security Triage sample agent.
+#
+# Upload this in Run Agent Evaluation -> Create new evaluation -> Evaluator config,
+# with dataset.jsonl (beside this file) as the dataset. It is a NeMo Evaluator
+# `EvaluateInputSpec`, so the same file also runs from the CLI:
+#
+#   nemo evaluator evaluate submit --spec-file eval-config.dataset-driven.yaml
+#
+# Three keys Studio fills in for you, which is why they are absent here:
+#   dataset     - needs the fileset name, which does not exist until you submit
+#   target      - the agent you picked in the form
+#   publication - where this run's results are recorded
+# Setting them anyway is allowed; Studio replaces them rather than complaining.
+
+# How each dataset row becomes the request sent to the agent. Jinja, rendered against
+# the row: `item.<column>` for this file's four columns. There is no default — a custom
+# dataset's column names are arbitrary, so nothing can guess the framing for you.
+prompt_template: |-
+  From: {{ item.sender }}
+  Subject: {{ item.subject }}
+
+  {{ item.body }}
+
+# Every metric listed here scores every row. Each entry is a metric bundle: `payload.metric`
+# is the metric itself, `outputs` declares what it returns, and `metric_type` names its kind.
+# `bundle_kind`, `bundle_format_version`, `metadata` and `secrets` are omitted on purpose —
+# they have schema defaults, and `outputs` must keep agreeing with `payload.metric.scores`
+# or the job is rejected, so there is less to keep in sync this way.
+metrics:
+  # 1. Deterministic verdict check. No judge model, so it costs nothing and never
+  #    disagrees with itself. The agent answers with a YAML block; this asserts the
+  #    `is_likely_phishing` key matches the row's ground-truth label.
+  - metric_type: string-check
+    outputs:
+      - name: string-check
+        value_json_schema:
+          title: ContinuousScore
+          description: Continuous numeric metric value.
+          type: number
+    payload:
+      kind: inline
+      metric:
+        type: string-check
+        operation: contains
+        left_template: "{{ (sample.output_text or '') | lower }}"
+        right_template: "is_likely_phishing: {% if item.label == 'phishing' %}true{% else %}false{% endif %}"
+
+  # 2. Judged check on a field a string match cannot grade: whether the `attack_type`
+  #    the agent chose is a sensible label for this email. `model` is what the form's
+  #    "Model for LLM evaluators" picker pre-selects, and overrides when you change it.
+  - metric_type: llm-judge
+    outputs:
+      - name: attack_type_plausible
+        value_json_schema:
+          title: ContinuousScore
+          description: Continuous numeric metric value.
+          type: number
+    payload:
+      kind: inline
+      metric:
+        type: llm-judge
+        model: default/nvidia-nemotron-3-super-120b-a12b
+        prompt_template:
+          messages:
+            - role: user
+              content: |-
+                You are scoring an email security triage agent.
+
+                The agent answers with a YAML block (often wrapped in a ``` fence). Its verdict is the `is_likely_phishing` key: `true` means phishing, `false` means benign. Read that key and nothing else — the `indicators` and `explanation` fields routinely mention the opposite verdict as things the agent considered, and must be ignored. Do not read the first line; it is usually the fence.
+
+                Agent response:
+                {{ sample.output_text }}
+
+                Ground-truth verdict: "{{ item.label }}".
+
+                Return a JSON object with one key:
+                  "attack_type_plausible": 1 if the `attack_type` value is a sensible label for this email (one of bec, credential, malware, spam, benign; `benign` iff the verdict is benign), else 0.
+        scores:
+          - name: attack_type_plausible
+            minimum: 0.0
+            maximum: 1.0
+            # Judges narrate. Pull the digit out rather than parsing the whole reply.
+            parser:
+              type: regex
+              method: search
+              pattern: 'attack_type_plausible"?\s*:\s*([01])'
+        inference:
+          max_tokens: 1024
+          extra_body:
+            nvext:
+              max_thinking_tokens: 256
+        # Reasoning models emit their scratchpad first; everything up to this token
+        # is dropped before the parser runs.
+        reasoning:
+          end_token: "</think>"

--- a/web/packages/studio/public/sample-agents/email-security-triage/eval-config.minimal.yaml
+++ b/web/packages/studio/public/sample-agents/email-security-triage/eval-config.minimal.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# The smallest eval config that runs against the Email Security Triage sample agent.
+# Start here when writing your own; see eval-config.dataset-driven.yaml for a judged
+# metric, score parsing, and inference options.
+#
+# Upload it as the Evaluator config with dataset.jsonl as the dataset. One metric, no
+# judge model, so the run costs nothing beyond the agent's own generations.
+#
+# `dataset`, `target` and `publication` are absent because Studio supplies them per run.
+
+# Jinja, rendered against each dataset row: `item.<column>`.
+prompt_template: |-
+  From: {{ item.sender }}
+  Subject: {{ item.subject }}
+
+  {{ item.body }}
+
+metrics:
+  - metric_type: string-check
+    # `outputs` must keep matching what the metric actually returns — the backend
+    # rehydrates `payload.metric`, recomputes this block, and rejects the job if the
+    # two disagree. Copy it as-is unless you change the metric below.
+    outputs:
+      - name: string-check
+        value_json_schema:
+          title: ContinuousScore
+          description: Continuous numeric metric value.
+          type: number
+    payload:
+      kind: inline
+      metric:
+        type: string-check
+        operation: contains
+        # The agent answers with a YAML block; assert its verdict key matches the
+        # row's ground-truth `label` column.
+        left_template: "{{ (sample.output_text or '') | lower }}"
+        right_template: "is_likely_phishing: {% if item.label == 'phishing' %}true{% else %}false{% endif %}"

--- a/web/packages/studio/src/components/evaluation/EvalFilePickerField.tsx
+++ b/web/packages/studio/src/components/evaluation/EvalFilePickerField.tsx
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { UseControllerComponentProps } from '@nemo/common/src/types';
+import { Button, Flex, FormField, TextInput } from '@nvidia/foundations-react-core';
+import { type ReactNode, useRef } from 'react';
+import { useController } from 'react-hook-form';
+
+interface Props extends UseControllerComponentProps {
+  /** Comma-joined extension list for the native picker, e.g. ``.yaml,.yml,.json``. */
+  accept: string;
+  label: string;
+  placeholder?: string;
+  required?: boolean;
+  disabled?: boolean;
+  slotHelp?: ReactNode;
+}
+
+/** A file field shaped like the rest of this form: the chosen filename sits in a read-only
+ *  text input with an Upload button beside it, rather than a dropzone. Form state holds the
+ *  `File` itself — the caller reads its text at submit, so nothing is uploaded on pick. */
+export const EvalFilePickerField = ({
+  useControllerProps,
+  accept,
+  label,
+  placeholder,
+  required,
+  disabled,
+  slotHelp,
+  formFieldProps,
+}: Props) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const {
+    field: { onChange, value },
+    fieldState: { error },
+  } = useController(useControllerProps);
+  const file = value as File | undefined;
+
+  return (
+    <FormField
+      name={useControllerProps.name}
+      slotLabel={label}
+      slotHelp={slotHelp}
+      slotError={error?.message?.toString()}
+      status={error ? 'error' : undefined}
+      required={required}
+      {...formFieldProps}
+    >
+      <Flex gap="density-md" align="center" className="w-full">
+        <TextInput
+          value={file?.name ?? ''}
+          placeholder={placeholder}
+          readOnly
+          disabled={disabled}
+          status={error ? 'error' : undefined}
+          aria-label={label}
+          onChange={() => undefined}
+        />
+        <Button
+          color="neutral"
+          kind="secondary"
+          disabled={disabled}
+          onClick={(event) => {
+            // The picker lives inside a form; without this the click submits it.
+            event.preventDefault();
+            inputRef.current?.click();
+          }}
+        >
+          Upload
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          className="hidden"
+          onChange={(event) => {
+            onChange(event.currentTarget.files?.[0]);
+            // Clear the native value so re-picking the same file after a parse error still fires.
+            event.currentTarget.value = '';
+          }}
+        />
+      </Flex>
+    </FormField>
+  );
+};

--- a/web/packages/studio/src/components/evaluation/EvalFilePickerField.tsx
+++ b/web/packages/studio/src/components/evaluation/EvalFilePickerField.tsx
@@ -2,84 +2,89 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { UseControllerComponentProps } from '@nemo/common/src/types';
-import { Button, Flex, FormField, TextInput } from '@nvidia/foundations-react-core';
-import { type ReactNode, useRef } from 'react';
+import {
+  FormField,
+  UploadContent,
+  UploadDescription,
+  UploadInputElement,
+  UploadRoot,
+  UploadTrigger,
+} from '@nvidia/foundations-react-core';
+import { type ReactNode } from 'react';
 import { useController } from 'react-hook-form';
 
 interface Props extends UseControllerComponentProps {
-  /** Comma-joined extension list for the native picker, e.g. ``.yaml,.yml,.json``. */
+  /** Comma-joined extension list for the picker, e.g. ``.yaml,.yml,.json``. */
   accept: string;
   label: string;
-  placeholder?: string;
+  /** Helper text rendered inside the dropzone, naming what it takes. */
+  hint: ReactNode;
   required?: boolean;
   disabled?: boolean;
   slotHelp?: ReactNode;
+  /**
+   * Error owned by the caller — a parse failure or an unsupported config shape, neither of
+   * which is knowable until the file has been read. Takes precedence over the field's own
+   * validation message so one field only ever shows one error.
+   */
+  slotError?: string;
 }
 
-/** A file field shaped like the rest of this form: the chosen filename sits in a read-only
- *  text input with an Upload button beside it, rather than a dropzone. Form state holds the
- *  `File` itself — the caller reads its text at submit, so nothing is uploaded on pick. */
+/** A single-file drag-and-drop field bound to react-hook-form.
+ *
+ *  Form state holds the `File` itself rather than an upload record: nothing is sent when a file
+ *  is picked, and the caller reads its text at submit.
+ *
+ *  The composed `Upload` parts are used rather than the `Upload` convenience component because
+ *  it renders the file list *after* the trigger, which would leave a picked file sitting below
+ *  its own error message. Composing puts exactly one of the two inside the `FormField` — the
+ *  dropzone, or the file that replaced it — so the error always reads as belonging to the file
+ *  above it, and a second file cannot be added without removing the first. */
 export const EvalFilePickerField = ({
   useControllerProps,
   accept,
   label,
-  placeholder,
+  hint,
   required,
   disabled,
   slotHelp,
+  slotError,
   formFieldProps,
 }: Props) => {
-  const inputRef = useRef<HTMLInputElement>(null);
   const {
     field: { onChange, value },
     fieldState: { error },
   } = useController(useControllerProps);
+
   const file = value as File | undefined;
+  const errorText = slotError ?? error?.message?.toString();
 
   return (
-    <FormField
-      name={useControllerProps.name}
-      slotLabel={label}
-      slotHelp={slotHelp}
-      slotError={error?.message?.toString()}
-      status={error ? 'error' : undefined}
-      required={required}
-      {...formFieldProps}
+    <UploadRoot
+      multiple={false}
+      disabled={disabled}
+      value={file ? { id: file.name, file, status: 'success' } : undefined}
+      onValueChange={(item) => onChange(item?.file)}
+      onFileRemove={() => onChange(undefined)}
     >
-      <Flex gap="density-md" align="center" className="w-full">
-        <TextInput
-          value={file?.name ?? ''}
-          placeholder={placeholder}
-          readOnly
-          disabled={disabled}
-          status={error ? 'error' : undefined}
-          aria-label={label}
-          onChange={() => undefined}
-        />
-        <Button
-          color="neutral"
-          kind="secondary"
-          disabled={disabled}
-          onClick={(event) => {
-            // The picker lives inside a form; without this the click submits it.
-            event.preventDefault();
-            inputRef.current?.click();
-          }}
-        >
-          Upload
-        </Button>
-        <input
-          ref={inputRef}
-          type="file"
-          accept={accept}
-          className="hidden"
-          onChange={(event) => {
-            onChange(event.currentTarget.files?.[0]);
-            // Clear the native value so re-picking the same file after a parse error still fires.
-            event.currentTarget.value = '';
-          }}
-        />
-      </Flex>
-    </FormField>
+      <FormField
+        name={useControllerProps.name}
+        required={required}
+        slotLabel={label}
+        slotHelp={slotHelp}
+        slotError={errorText}
+        status={errorText ? 'error' : undefined}
+        {...formFieldProps}
+      >
+        {file ? (
+          <UploadContent />
+        ) : (
+          <UploadTrigger status={errorText ? 'error' : undefined}>
+            <UploadInputElement accept={accept} aria-label={label} />
+            <UploadDescription>{hint}</UploadDescription>
+          </UploadTrigger>
+        )}
+      </FormField>
+    </UploadRoot>
   );
 };

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.test.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.test.tsx
@@ -11,7 +11,7 @@ import { http, HttpResponse } from 'msw';
 const emptyPage = { data: [], pagination: { total: 0, page: 1, page_size: 100 } };
 
 describe('SubmitEvaluationModal', () => {
-  it('scopes the "Use existing evaluation" list to the current agent', async () => {
+  it('scopes the "Create from existing evaluation" list to the current agent', async () => {
     const evaluationsUrls: URL[] = [];
     server.use(
       http.get('*/apis/intake/v2/workspaces/:workspace/evaluations', ({ request }) => {
@@ -39,7 +39,7 @@ describe('SubmitEvaluationModal', () => {
     });
 
     // The list query only fires in experiment mode; switch to it.
-    await user.click(await screen.findByRole('radio', { name: 'Use existing evaluation' }));
+    await user.click(await screen.findByRole('radio', { name: 'Create from existing evaluation' }));
 
     await waitFor(() => {
       const filtered = evaluationsUrls.find((u) => u.searchParams.has('filter[agent_name]'));

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.test.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.test.tsx
@@ -47,4 +47,33 @@ describe('SubmitEvaluationModal', () => {
       expect(filtered!.searchParams.get('filter[agent_name]')).toBe('my-agent');
     });
   });
+
+  // Backdrop and Escape dismissal are deliberately NOT asserted here: jsdom implements
+  // neither native `<dialog>` light-dismiss nor Escape-to-cancel, so such a test passes
+  // whatever `dismissible` is set to. Cancel is a real button, so it is testable — it
+  // guards the half of the contract that would turn the modal into a trap.
+  it('still closes on Cancel while backdrop dismissal is disabled', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    renderRoute(undefined, {
+      history: `/workspaces/${DEFAULT_WORKSPACE}`,
+      routes: [
+        {
+          path: '/workspaces/:workspace',
+          element: (
+            <SubmitEvaluationModal
+              open
+              onClose={onClose}
+              workspace={DEFAULT_WORKSPACE}
+              agent="my-agent"
+            />
+          ),
+        },
+      ],
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
 });

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -578,6 +578,9 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       onSubmit={handleSubmit(onSubmit)}
       disabled={isPending}
       submitDisabled={!canSubmit}
+      // An uploaded config and dataset live only in form state; a stray backdrop click
+      // would discard both with nothing to restore them from. Close and Cancel remain.
+      dismissible={false}
       loading={isPending}
       errorText={errorMessage}
       className="w-[690px]! max-w-[95vw]!"

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -8,6 +8,7 @@ import { FormModal, type FormModalProps } from '@nemo/common/src/components/Form
 import { getURNFromNamedEntityRef } from '@nemo/common/src/namedEntity';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { getEntityNameError } from '@nemo/common/src/utils/entityName';
+import { validateFileFormat } from '@nemo/common/src/utils/fileValidation';
 import { useAgentsListAgents } from '@nemo/sdk/generated/agents/api';
 import { evaluatorCreateEvaluateJob } from '@nemo/sdk/generated/evaluator/api';
 import type {
@@ -201,6 +202,19 @@ const discardSeeded = async (
  *  this only labels the blob so the fileset preview renders it as the right kind of file. */
 const datasetMimeType = (filename: string): string =>
   filename.toLowerCase().endsWith('.csv') ? 'text/csv' : 'application/jsonl';
+
+/** Why an uploaded dataset would fail at job time, or nothing when it reads cleanly.
+ *
+ *  `validateFileFormat` only understands JSON and JSONL, so a `.csv` is taken on trust — the
+ *  evaluator reads it, and reimplementing CSV parsing here to prove it would duplicate that.
+ *  Unlike a flow that renames the upload to a fixed `dataset.jsonl`, this one keeps the file's
+ *  own name in the ref, so a pretty-printed `.json` array is a legitimate dataset and is not
+ *  rejected for failing to be JSON Lines. */
+const datasetFileError = async (file: File): Promise<string | undefined> => {
+  if (file.name.toLowerCase().endsWith('.csv')) return undefined;
+  const result = await validateFileFormat(file);
+  return result.isValid ? undefined : (result.error ?? 'File is not valid JSON or JSONL');
+};
 
 /** Resolve the spec this submission runs, and persist it for later reuse.
  *
@@ -404,6 +418,22 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     staleTime: Infinity,
   });
 
+  // Same idea for the dataset: read it at pick time so an unparseable file is caught here
+  // rather than by the job, minutes later.
+  const { data: datasetPickError, isFetching: isCheckingDataset } = useQuery({
+    queryKey: [
+      'uploaded-eval-dataset',
+      datasetFile?.name,
+      datasetFile?.size,
+      datasetFile?.lastModified,
+    ],
+    queryFn: async () => (await datasetFileError(datasetFile!)) ?? null,
+    enabled: open && mode === MODE_DEFAULT && !!datasetFile,
+    retry: false,
+    staleTime: Infinity,
+  });
+  const datasetFieldError = errors.datasetFile?.message ?? datasetPickError ?? undefined;
+
   const datasetConfig: DatasetEvalSpec | null =
     uploadedConfig && isDatasetEvalSpec(uploadedConfig) ? uploadedConfig : null;
 
@@ -428,7 +458,10 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const canSubmit =
     mode === MODE_EXPERIMENT
       ? !isValidatingEvaluation && !!selectedEvaluation && !evaluationConfigIssue
-      : !isParsingConfig && (!configFile || (!!datasetConfig && !configFieldError));
+      : !isParsingConfig &&
+        !isCheckingDataset &&
+        !datasetFieldError &&
+        (!configFile || (!!datasetConfig && !configFieldError));
 
   const judgeMetric = datasetConfig?.metrics.find((metric) => metric.metric_type === 'llm-judge');
 
@@ -676,12 +709,9 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                     useControllerProps={{ control, name: 'configFile' }}
                     accept={CONFIG_FILE_ACCEPT}
                     label="Evaluator config"
-                    placeholder="Select a JSON or YAML config"
+                    hint="NeMo Evaluator config (.yaml, .yml or .json)"
                     required
-                    formFieldProps={{
-                      slotError: configFieldError,
-                      status: configFieldError ? 'error' : undefined,
-                    }}
+                    slotError={configFieldError}
                   />
 
                   <Stack gap="density-lg">
@@ -692,8 +722,9 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                       useControllerProps={{ control, name: 'datasetFile' }}
                       accept={DATASET_FILE_ACCEPT}
                       label="Add dataset"
-                      placeholder="Select a .jsonl, .json or .csv file"
+                      hint="Rows to score (.jsonl, .json or .csv)"
                       slotHelp="Replaces the config's own dataset reference."
+                      slotError={datasetFieldError}
                     />
                     <ControlledTextInput
                       useControllerProps={{ control, name: 'promptTemplate' }}

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -26,9 +26,9 @@ import {
   useListExperiments,
 } from '@nemo/sdk/generated/platform/api';
 import { Anchor, SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
-import { fetchSampleText } from '@studio/api/agents/fetchSampleText';
 import { submitAgentEvalJob } from '@studio/api/evaluation/agent-evaluations';
 import { isConflictError, type EvalSeedFile } from '@studio/api/evaluation/eval-config-fileset';
+import { EvalFilePickerField } from '@studio/components/evaluation/EvalFilePickerField';
 import {
   createRunEvaluation,
   EVAL_CONFIG_FILENAME,
@@ -37,14 +37,14 @@ import {
 } from '@studio/components/evaluation/experimentEvalConfig';
 import { JudgeModelSelect } from '@studio/components/evaluation/JudgeModelSelect';
 import {
+  applyDatasetEvalOverrides,
   bareName,
   buildAgentEvalRequestBody,
   buildDatasetEvalRequestBody,
-  buildPersistedSpec,
+  buildEvalJobName,
+  type DatasetEvalSpec,
+  datasetEvalConfigError,
   type EvalSpec,
-  filesetNameForExperiment,
-  injectJudgeModel,
-  type InlineMetricBundle,
   isDatasetEvalSpec,
   generateEvalConfigName,
   MODE_DEFAULT,
@@ -52,92 +52,101 @@ import {
   parseEvalConfig,
 } from '@studio/components/evaluation/submitEvaluationJob';
 import { LINK_EVAL_DOCS } from '@studio/constants/links';
-import { DATASET_EVAL_CONFIG_KEY, getEvalConfigSample } from '@studio/constants/sampleAgents';
 import { useJudgeModels } from '@studio/hooks/evaluation/useJudgeModels';
 import { getAgentEvaluationsTabRoute } from '@studio/routes/utils';
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { type FC, useEffect, useRef, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { type FC, useEffect } from 'react';
 import { FormProvider, type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 import { z } from 'zod';
 
 const EVAL_CONFIG_MODE_ITEMS = [
-  { value: MODE_DEFAULT, children: 'Create experiment' },
-  { value: MODE_EXPERIMENT, children: 'Use existing evaluation' },
+  { value: MODE_DEFAULT, children: 'Create new evaluation' },
+  { value: MODE_EXPERIMENT, children: 'Create from existing evaluation' },
 ];
 
-const DATASET_FILENAME = 'dataset.jsonl';
+/** What the two pickers accept. The config mirrors the platform CLI's ``--spec-file``
+ *  (JSON or YAML); the dataset mirrors the row formats the evaluator reads. */
+const CONFIG_FILE_ACCEPT = '.yaml,.yml,.json';
+const DATASET_FILE_ACCEPT = '.jsonl,.json,.csv';
+
+/** Stand-in dataset ref for the pre-submit readiness check. The real ref needs the fileset
+ *  that submit creates, and the check only asks whether a dataset will be present at all. */
+const PENDING_DATASET_REF = 'pending://uploaded-dataset';
+
+const TASK_CONFIG_UNSUPPORTED =
+  'This is a task-driven config. Upload a dataset-driven config (one with "dataset" and "metrics") to run it here.';
 
 /** Backend caps page_size at 100; the picker shows the most recent page. */
 const LIST_PAGE_SIZE = 100;
-const README_FILENAME = 'README.md';
 
 const NO_EVALUATIONS_MESSAGE =
   'No evaluations with a reusable eval config yet. Create one to run and re-use it.';
 
 const submitEvaluationBaseSchema = z.object({
   agent: z.string().min(1, 'Agent is required'),
+  /** Optional override for the model every llm-judge metric in the config scores with. */
   judgeModel: z.string(),
   mode: z.enum([MODE_DEFAULT, MODE_EXPERIMENT]),
-  exampleKey: z.string(),
-  /** Name of the experiment to create in "Create experiment" mode. */
-  newName: z.string(),
-  /** Fileset created alongside it, holding eval-config.json and any data artifacts. */
-  filesetName: z.string(),
-  /** Name of the existing evaluation whose eval config is reused in "Use existing evaluation" mode. */
+  /** Experiment created in "Create new evaluation" mode; groups runs for comparison. */
+  experimentName: z.string(),
+  /** Names this run, and stems the fileset holding its eval-config.json and data files. */
+  runName: z.string(),
+  /** The uploaded NeMo Evaluator config. Required in "Create new evaluation" mode. */
+  configFile: z.instanceof(File).optional(),
+  /** Optional dataset uploaded alongside it, overriding the config's own `dataset`. */
+  datasetFile: z.instanceof(File).optional(),
+  /** Optional override for the config's `prompt_template`. */
+  promptTemplate: z.string(),
+  /** Name of the existing evaluation whose eval config is reused in reuse mode. */
   evaluationName: z.string(),
 });
 
 type SubmitEvaluationFormData = z.infer<typeof submitEvaluationBaseSchema>;
 
-const makeSubmitEvaluationSchema = (requiresJudgeModel: () => boolean) =>
-  submitEvaluationBaseSchema.superRefine((data, ctx) => {
-    if (requiresJudgeModel() && !data.judgeModel) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'Judge model is required',
-        path: ['judgeModel'],
-      });
-    }
-    if (data.mode === MODE_DEFAULT) {
-      const nameError = getEntityNameError(data.newName.trim());
+/** Judge model is deliberately not required: an uploaded config may already name one, and
+ *  the picker only overrides it. Whether the run has everything it needs is decided against
+ *  the parsed config by `datasetEvalConfigError`, not here. */
+const submitEvaluationSchema = submitEvaluationBaseSchema.superRefine((data, ctx) => {
+  if (data.mode === MODE_DEFAULT) {
+    const names = [
+      ['experimentName', data.experimentName],
+      ['runName', data.runName],
+    ] as const;
+    for (const [path, value] of names) {
+      const nameError = getEntityNameError(value.trim());
       if (nameError) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: nameError,
-          path: ['newName'],
-        });
-      }
-      const filesetError = getEntityNameError(data.filesetName.trim());
-      if (filesetError) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: filesetError,
-          path: ['filesetName'],
-        });
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: nameError, path: [path] });
       }
     }
-    if (data.mode === MODE_EXPERIMENT && !data.evaluationName) {
+    if (!data.configFile) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Pick an evaluation to reuse',
-        path: ['evaluationName'],
+        message: 'Upload an evaluator config to run',
+        path: ['configFile'],
       });
     }
-  });
+  }
+  if (data.mode === MODE_EXPERIMENT && !data.evaluationName) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Pick an evaluation to reuse',
+      path: ['evaluationName'],
+    });
+  }
+});
 
-const makeDefaultValues = (agent?: string): SubmitEvaluationFormData => {
-  const newName = generateEvalConfigName();
-  return {
-    agent: agent ?? '',
-    judgeModel: '',
-    mode: MODE_DEFAULT,
-    exampleKey: DATASET_EVAL_CONFIG_KEY,
-    newName,
-    filesetName: filesetNameForExperiment(newName),
-    evaluationName: '',
-  };
-};
+const makeDefaultValues = (agent?: string): SubmitEvaluationFormData => ({
+  agent: agent ?? '',
+  judgeModel: '',
+  mode: MODE_DEFAULT,
+  experimentName: generateEvalConfigName(),
+  runName: generateEvalConfigName(),
+  configFile: undefined,
+  datasetFile: undefined,
+  promptTemplate: '',
+  evaluationName: '',
+});
 
 interface SubmitEvaluationModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
   workspace: string;
@@ -188,92 +197,96 @@ const discardSeeded = async (
   );
 };
 
-/** Resolves the persisted yardstick spec for this submission. In "Create experiment" mode
- *  it builds the spec from the sample template (fanning the metric onto every task with
- *  the picked judge baked in) and seeds it into a new fileset; in "Use existing evaluation"
- *  mode it reads the saved spec back verbatim (no re-fan, no judge re-pick). */
+/** Content type for an uploaded dataset, by extension. The evaluator reads the rows itself;
+ *  this only labels the blob so the fileset preview renders it as the right kind of file. */
+const datasetMimeType = (filename: string): string =>
+  filename.toLowerCase().endsWith('.csv') ? 'text/csv' : 'application/jsonl';
+
+/** Resolve the spec this submission runs, and persist it for later reuse.
+ *
+ *  In "Create new evaluation" mode the uploaded config is parsed (JSON or YAML), the form's
+ *  overrides are layered on, and the result is written to a fresh fileset alongside any
+ *  uploaded dataset. What lands in `eval-config.json` is the *resolved* spec — real dataset
+ *  ref, chosen judge model, overridden prompt — so reusing this evaluation later replays what
+ *  actually ran. In reuse mode the saved spec is read back verbatim. */
 const loadPersistedSpec = async (
   workspace: string,
   formData: SubmitEvaluationFormData,
-  configFileset: string | null
+  configFileset: string | null,
+  filesetName: string
 ): Promise<EvalSpec> => {
-  if (formData.mode === MODE_DEFAULT) {
-    const signal = new AbortController().signal;
-    const name = formData.filesetName.trim();
-    const example = getEvalConfigSample(formData.exampleKey);
-    const template = parseEvalConfig(await fetchSampleText(example.configPath));
-    const files: EvalSeedFile[] = [];
-    let spec: EvalSpec;
-
-    if (isDatasetEvalSpec(template)) {
-      const judgeModel = formData.judgeModel || null;
-      const bakedMetrics = judgeModel
-        ? template.metrics.map((m) => injectJudgeModel(m, judgeModel))
-        : template.metrics;
-      if (example.datasetPath) {
-        const datasetFile = example.datasetPath.split('/').pop() ?? DATASET_FILENAME;
-        files.push({
-          path: datasetFile,
-          content: await fetchSampleText(example.datasetPath),
-          type: 'application/jsonl',
-        });
-        spec = {
-          ...template,
-          dataset: `${workspace}/${name}#${datasetFile}`,
-          metrics: bakedMetrics,
-        };
-      } else {
-        spec = { ...template, dataset: [], metrics: bakedMetrics };
-      }
-    } else {
-      spec = buildPersistedSpec(template, formData.judgeModel || null);
-    }
-
-    files.push({
-      path: EVAL_CONFIG_FILENAME,
-      content: JSON.stringify(spec, null, 2),
-      type: 'application/json',
-    });
-
-    if (example.readmePath) {
-      const readme = await fetchSampleText(example.readmePath).catch(() => null);
-      if (readme) {
-        files.push({ path: README_FILENAME, content: readme, type: 'text/markdown' });
-      }
-    }
-
-    try {
-      await filesCreateFileset(workspace, { name, description: 'Agent Evaluation Config' }, signal);
-    } catch (err) {
-      if (isConflictError(err)) {
-        throw new Error(`A fileset named "${name}" already exists — choose a different name`);
-      }
-      throw err;
-    }
-    try {
-      for (const f of files) {
-        await filesUploadFile(
-          workspace,
-          name,
-          f.path,
-          new Blob([f.content], { type: f.type }),
-          signal
-        );
-      }
-    } catch (uploadErr) {
-      throw await discardSeeded(workspace, { filesetName: name }, uploadErr);
-    }
-    return spec;
+  if (formData.mode !== MODE_DEFAULT) {
+    if (!configFileset) throw new Error('The selected evaluation has no eval config fileset');
+    const blob = await filesDownloadFile(
+      workspace,
+      configFileset,
+      EVAL_CONFIG_FILENAME,
+      new AbortController().signal
+    );
+    if (!blob) throw new Error("Failed to read the selected evaluation's eval config");
+    return parseEvalConfig(await blob.text(), EVAL_CONFIG_FILENAME);
   }
-  if (!configFileset) throw new Error('The selected evaluation has no eval config fileset');
-  const blob = await filesDownloadFile(
-    workspace,
-    configFileset,
-    EVAL_CONFIG_FILENAME,
-    new AbortController().signal
-  );
-  if (!blob) throw new Error("Failed to read the selected evaluation's eval config");
-  return parseEvalConfig(await blob.text());
+
+  const signal = new AbortController().signal;
+  const { configFile, datasetFile } = formData;
+  if (!configFile) throw new Error('Upload an evaluator config to run');
+
+  const authored = parseEvalConfig(await configFile.text(), configFile.name);
+  if (!isDatasetEvalSpec(authored)) throw new Error(TASK_CONFIG_UNSUPPORTED);
+
+  const files: EvalSeedFile[] = [];
+  let datasetRef: string | undefined;
+  if (datasetFile) {
+    files.push({
+      path: datasetFile.name,
+      content: await datasetFile.text(),
+      type: datasetMimeType(datasetFile.name),
+    });
+    datasetRef = `${workspace}/${filesetName}#${datasetFile.name}`;
+  }
+
+  const spec = applyDatasetEvalOverrides(authored, {
+    dataset: datasetRef,
+    promptTemplate: formData.promptTemplate,
+    judgeModel: formData.judgeModel || null,
+  });
+  const configError = datasetEvalConfigError(spec);
+  if (configError) throw new Error(configError);
+
+  files.push({
+    path: EVAL_CONFIG_FILENAME,
+    content: JSON.stringify(spec, null, 2),
+    type: 'application/json',
+  });
+
+  try {
+    await filesCreateFileset(
+      workspace,
+      { name: filesetName, description: 'Agent Evaluation Config' },
+      signal
+    );
+  } catch (err) {
+    if (isConflictError(err)) {
+      throw new Error(
+        `A fileset named "${filesetName}" already exists — choose a different evaluation name`
+      );
+    }
+    throw err;
+  }
+  try {
+    for (const f of files) {
+      await filesUploadFile(
+        workspace,
+        filesetName,
+        f.path,
+        new Blob([f.content], { type: f.type }),
+        signal
+      );
+    }
+  } catch (uploadErr) {
+    throw await discardSeeded(workspace, { filesetName }, uploadErr);
+  }
+  return spec;
 };
 
 export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
@@ -287,10 +300,6 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
-  // Ref keeps isLlmJudge current for the zod schema getter at validation time.
-  const isLlmJudgeRef = useRef(false);
-  const [schema] = useState(() => makeSubmitEvaluationSchema(() => isLlmJudgeRef.current));
-
   const { data: agentsResponse, isLoading: isAgentsLoading } = useAgentsListAgents(
     workspace,
     undefined,
@@ -299,14 +308,13 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const agents = agentsResponse?.data ?? [];
 
   const methods = useForm<SubmitEvaluationFormData>({
-    resolver: zodResolver(schema),
+    resolver: zodResolver(submitEvaluationSchema),
     defaultValues: makeDefaultValues(agentProp),
     mode: 'onSubmit',
     reValidateMode: 'onChange',
   });
   const {
     control,
-    register,
     reset: resetForm,
     setValue,
     getValues,
@@ -320,8 +328,11 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const selectedAgent = useWatch({ control, name: 'agent' });
 
   const agentFieldError = errors.agent?.message;
-  const exampleKey = useWatch({ control, name: 'exampleKey' });
   const evaluationName = useWatch({ control, name: 'evaluationName' });
+  const configFile = useWatch({ control, name: 'configFile' });
+  const datasetFile = useWatch({ control, name: 'datasetFile' });
+  const promptTemplate = useWatch({ control, name: 'promptTemplate' });
+  const judgeModel = useWatch({ control, name: 'judgeModel' });
 
   const { data: evaluationsResponse, isLoading: isEvaluationsLoading } = useListEvaluations(
     workspace,
@@ -373,49 +384,67 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const evaluationFileset = selectedEvaluation ? evaluationFilesetName(selectedEvaluation) : null;
   const evaluationFieldError = errors.evaluationName?.message ?? evaluationConfigIssue ?? undefined;
 
-  const canRunSelectedEvaluation =
-    mode !== MODE_EXPERIMENT ||
-    (!isValidatingEvaluation && !!selectedEvaluation && !evaluationConfigIssue);
-
-  // Fetch and parse the selected example config early to detect metric type and default model.
-  const { data: exampleConfig } = useQuery({
-    queryKey: ['eval-config-preview', exampleKey],
-    queryFn: async () => {
-      const example = getEvalConfigSample(exampleKey);
-      if (!example) return null;
-      const text = await fetchSampleText(example.configPath);
-      return parseEvalConfig(text);
-    },
-    enabled: open && mode === MODE_DEFAULT && !!exampleKey,
+  // Parse the uploaded config as soon as it's picked, so a bad file, an unsupported shape, or
+  // a missing dataset/prompt is reported on the field rather than after a submit round-trip.
+  // Keyed on the file's identity, not its contents — re-picking a file re-reads it.
+  const {
+    data: uploadedConfig,
+    error: configParseError,
+    isFetching: isParsingConfig,
+  } = useQuery({
+    queryKey: [
+      'uploaded-eval-config',
+      configFile?.name,
+      configFile?.size,
+      configFile?.lastModified,
+    ],
+    queryFn: async () => parseEvalConfig(await configFile!.text(), configFile!.name),
+    enabled: open && mode === MODE_DEFAULT && !!configFile,
+    retry: false,
     staleTime: Infinity,
-    // Retain the prior example's parsed config while the next one loads so the
-    // judge picker stays mounted (all examples are llm-judge) — no flicker.
-    placeholderData: keepPreviousData,
   });
 
-  const configMetrics: InlineMetricBundle[] = !exampleConfig
-    ? []
-    : isDatasetEvalSpec(exampleConfig)
-      ? exampleConfig.metrics
-      : exampleConfig.tasks.flatMap((task) => task.metrics);
+  const datasetConfig: DatasetEvalSpec | null =
+    uploadedConfig && isDatasetEvalSpec(uploadedConfig) ? uploadedConfig : null;
 
-  const judgeMetric = configMetrics.find((metric) => metric.metric_type === 'llm-judge');
+  // What the run would submit, given the overrides entered so far. The dataset ref is a
+  // stand-in because the real one needs the fileset submit creates.
+  const resolvedConfig = datasetConfig
+    ? applyDatasetEvalOverrides(datasetConfig, {
+        dataset: datasetFile ? PENDING_DATASET_REF : undefined,
+        promptTemplate,
+        judgeModel: judgeModel || null,
+      })
+    : null;
 
-  const isLlmJudge = mode === MODE_DEFAULT && !!judgeMetric;
-  isLlmJudgeRef.current = isLlmJudge;
+  const configFieldError =
+    errors.configFile?.message ??
+    (configParseError instanceof Error ? configParseError.message : undefined) ??
+    (uploadedConfig && !datasetConfig ? TASK_CONFIG_UNSUPPORTED : undefined) ??
+    (resolvedConfig ? (datasetEvalConfigError(resolvedConfig) ?? undefined) : undefined);
+
+  // With no config picked yet, submit stays enabled so the click surfaces the required-field
+  // error on the picker; once one is picked it must actually be runnable.
+  const canSubmit =
+    mode === MODE_EXPERIMENT
+      ? !isValidatingEvaluation && !!selectedEvaluation && !evaluationConfigIssue
+      : !isParsingConfig && (!configFile || (!!datasetConfig && !configFieldError));
+
+  const judgeMetric = datasetConfig?.metrics.find((metric) => metric.metric_type === 'llm-judge');
 
   const defaultModelRef =
-    isLlmJudge && typeof judgeMetric?.payload.metric.model === 'string'
+    typeof judgeMetric?.payload.metric.model === 'string'
       ? judgeMetric.payload.metric.model
       : undefined;
 
-  // Fetch judge models eagerly so they're ready when isLlmJudge resolves.
+  // Fetch judge models eagerly so they're ready when a config naming one is picked.
   const { data: judgeModels } = useJudgeModels({ enabled: open });
 
-  // Pre-populate judge model from the config's ModelRef when modal opens or data arrives.
-  // Uses getValues (not a reactive watch) to avoid re-running on every model change.
+  // Pre-select the model the uploaded config already names, so the picker shows what will run
+  // rather than looking unset. Uses getValues (not a reactive watch) to avoid re-running on
+  // every model change — a pick the user made themselves is never overwritten.
   useEffect(() => {
-    if (!open || !isLlmJudge || !defaultModelRef || !judgeModels?.length) return;
+    if (!open || !defaultModelRef || !judgeModels?.length) return;
     if (getValues('judgeModel')) return;
     const target = bareName(defaultModelRef);
     const match = judgeModels.find((m) => m.name === target);
@@ -423,7 +452,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       const urn = getURNFromNamedEntityRef(match);
       if (urn) setValue('judgeModel', urn);
     }
-  }, [open, isLlmJudge, defaultModelRef, judgeModels, getValues, setValue]);
+  }, [open, defaultModelRef, judgeModels, getValues, setValue]);
 
   const {
     mutateAsync: submitEvaluation,
@@ -432,24 +461,31 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     reset: resetMutation,
   } = useMutation({
     mutationFn: async (formData: SubmitEvaluationFormData) => {
-      const spec = await loadPersistedSpec(workspace, formData, evaluationFileset);
-
       const isNew = formData.mode === MODE_DEFAULT;
-      const filesetName = isNew ? formData.filesetName.trim() : (evaluationFileset ?? '');
+      // The fileset carries its own random suffix rather than being named by the user: it is
+      // an artifact of this run, and deriving it from the evaluation name alone would 409 the
+      // second time that name is reused.
+      const filesetName = isNew
+        ? buildEvalJobName(formData.runName.trim())
+        : (evaluationFileset ?? '');
+
+      const spec = await loadPersistedSpec(workspace, formData, evaluationFileset, filesetName);
 
       const seeded: SeededEntities = isNew ? { filesetName } : {};
 
       try {
-        // "Create experiment" creates a fresh ExperimentGroup to hold this run; "Use existing
-        // evaluation" reuses the picked evaluation's group(s) and records the lineage.
+        // "Create new evaluation" creates a fresh ExperimentGroup to hold this run; "Create
+        // from existing evaluation" reuses the picked evaluation's group(s) and records lineage.
         let experimentIds: string[];
         let nameStem: string;
         let parentEvaluationId: string | undefined;
         if (isNew) {
-          const experiment = await createExperiment(workspace, { name: formData.newName.trim() });
+          const experiment = await createExperiment(workspace, {
+            name: formData.experimentName.trim(),
+          });
           seeded.experimentName = experiment.name;
           experimentIds = [experiment.id];
-          nameStem = experiment.name;
+          nameStem = formData.runName.trim();
         } else {
           if (!selectedEvaluation) throw new Error('No evaluation to reuse');
           experimentIds = selectedEvaluation.experiment_ids;
@@ -541,7 +577,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       submitButtonText="Submit"
       onSubmit={handleSubmit(onSubmit)}
       disabled={isPending}
-      submitDisabled={!canRunSelectedEvaluation}
+      submitDisabled={!canSubmit}
       loading={isPending}
       errorText={errorMessage}
       className="w-[690px]! max-w-[95vw]!"
@@ -580,9 +616,6 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
 
           {selectedAgent ? (
             <Stack gap="density-xl">
-              <Text kind="label/bold/sm" color="secondary">
-                Eval Config
-              </Text>
               <SegmentedControl
                 className="w-full [&_button]:flex-1"
                 value={mode}
@@ -597,32 +630,84 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
 
               {mode === MODE_DEFAULT ? (
                 <>
-                  <input type="hidden" {...register('exampleKey')} />
-                  {isLlmJudge && (
+                  <ControlledTextInput
+                    useControllerProps={{ control, name: 'experimentName' }}
+                    selectOnFocus
+                    required
+                    formFieldProps={{
+                      slotLabel: 'Experiment name',
+                      slotHelp: 'Groups multiple evaluation runs together for comparison.',
+                      slotError: errors.experimentName?.message,
+                    }}
+                  />
+                  <ControlledTextInput
+                    useControllerProps={{ control, name: 'runName' }}
+                    selectOnFocus
+                    required
+                    formFieldProps={{
+                      slotLabel: 'Evaluation name',
+                      slotHelp:
+                        'The name of the evaluation you are testing, e.g. "Baseline evaluation run".',
+                      slotError: errors.runName?.message,
+                    }}
+                  />
+
+                  <Stack gap="density-sm">
+                    <Text kind="label/bold/lg">Dataset and metrics</Text>
+                    <Text kind="label/regular/md" color="secondary">
+                      Upload a NeMo Evaluator configuration.{' '}
+                      <Anchor
+                        kind="inline"
+                        textKind="label/regular/md"
+                        href={LINK_EVAL_DOCS}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Learn more
+                      </Anchor>
+                      .
+                    </Text>
+                  </Stack>
+
+                  <EvalFilePickerField
+                    useControllerProps={{ control, name: 'configFile' }}
+                    accept={CONFIG_FILE_ACCEPT}
+                    label="Evaluator config"
+                    placeholder="Select a JSON or YAML config"
+                    required
+                    formFieldProps={{
+                      slotError: configFieldError,
+                      status: configFieldError ? 'error' : undefined,
+                    }}
+                  />
+
+                  <Stack gap="density-lg">
+                    <Text kind="label/regular/md" color="secondary">
+                      Optional configuration overrides
+                    </Text>
+                    <EvalFilePickerField
+                      useControllerProps={{ control, name: 'datasetFile' }}
+                      accept={DATASET_FILE_ACCEPT}
+                      label="Add dataset"
+                      placeholder="Select a .jsonl, .json or .csv file"
+                      slotHelp="Replaces the config's own dataset reference."
+                    />
+                    <ControlledTextInput
+                      useControllerProps={{ control, name: 'promptTemplate' }}
+                      placeholder="{{ item.question }}"
+                      formFieldProps={{
+                        slotLabel: 'Prompt template',
+                        slotHelp:
+                          "Jinja rendered against each dataset row. Replaces the config's own prompt_template.",
+                        slotError: errors.promptTemplate?.message,
+                      }}
+                    />
                     <JudgeModelSelect<SubmitEvaluationFormData>
                       formFieldName="judgeModel"
-                      slotLabel="Judge Model"
+                      slotLabel="Model for LLM evaluators"
+                      placeholder="Select a model to get started"
                     />
-                  )}
-                  <ControlledTextInput
-                    useControllerProps={{ control, name: 'newName' }}
-                    selectOnFocus
-                    formFieldProps={{
-                      slotLabel: 'New Experiment Name',
-                      slotHelp:
-                        'Groups this run and future ones against the same config. Select it later to re-run.',
-                      slotError: errors.newName?.message,
-                    }}
-                  />
-                  <ControlledTextInput
-                    useControllerProps={{ control, name: 'filesetName' }}
-                    selectOnFocus
-                    formFieldProps={{
-                      slotLabel: 'Fileset Name',
-                      slotHelp: `Stores this experiment's ${EVAL_CONFIG_FILENAME} and any data files.`,
-                      slotError: errors.filesetName?.message,
-                    }}
-                  />
+                  </Stack>
                 </>
               ) : (
                 <>

--- a/web/packages/studio/src/components/evaluation/submitEvaluationJob.test.ts
+++ b/web/packages/studio/src/components/evaluation/submitEvaluationJob.test.ts
@@ -2,16 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  applyDatasetEvalOverrides,
   bareName,
   buildAgentEvalRequestBody,
   buildAgentTarget,
   buildDatasetAgentTarget,
   buildDatasetEvalRequestBody,
   type DatasetEvalSpec,
+  datasetEvalConfigError,
   buildEvalJobName,
   buildPersistedSpec,
   injectJudgeModel,
   type InlineMetricBundle,
+  isDatasetEvalSpec,
   parseEvalConfig,
   type PersistedEvalSpec,
 } from '@studio/components/evaluation/submitEvaluationJob';
@@ -202,6 +205,38 @@ describe('buildDatasetEvalRequestBody', () => {
     );
     expect(without.spec.publication).toBeUndefined();
   });
+
+  it('forwards authored keys Studio has no opinion about', () => {
+    const body = buildDatasetEvalRequestBody(
+      { ...datasetConfig, field_mapping: { input: 'question', reference: 'gold' } },
+      { workspace: 'ws-a', agent: 'a' },
+      null
+    );
+    expect(body.spec.field_mapping).toEqual({ input: 'question', reference: 'gold' });
+    expect(body.spec.dataset).toEqual([{ prompt: '2+2?' }]);
+    expect(body.spec.prompt_template).toBe('{{item.prompt}}');
+  });
+
+  it('overrides target and params the config authored, rather than forwarding them', () => {
+    const body = buildDatasetEvalRequestBody(
+      {
+        ...datasetConfig,
+        target: { kind: 'model', model: 'someone-elses-model' },
+        params: { parallelism: 99 },
+        publication: { intake: { evaluation_id: 'stale' } },
+      },
+      { workspace: 'ws-a', agent: 'support-bot', evaluationId: 'eval-1' },
+      null
+    );
+    expect(body.spec.target).toEqual(buildDatasetAgentTarget('ws-a', 'support-bot'));
+    expect(body.spec.params).toEqual({
+      parallelism: 1,
+      request_timeout: 300,
+      max_retries: 3,
+      ignore_request_failure: true,
+    });
+    expect(body.spec.publication).toEqual({ intake: { evaluation_id: 'eval-1' } });
+  });
 });
 
 describe('buildEvalJobName', () => {
@@ -252,5 +287,127 @@ describe('parseEvalConfig', () => {
         })
       )
     ).toThrow(/payload\.metric/);
+  });
+
+  const datasetYaml = `
+dataset: ws-a/data#rows.jsonl
+prompt_template: |-
+  Is this legit?
+  {{ item.body }}
+metrics:
+  - bundle_kind: metric-bundle
+    bundle_format_version: v1
+    metric_type: llm-judge
+    payload:
+      kind: inline
+      metric:
+        type: llm-judge
+        scores:
+          - name: accuracy
+`;
+
+  it('parses a dataset-driven config authored as YAML', () => {
+    const parsed = parseEvalConfig(datasetYaml, 'eval.yaml') as DatasetEvalSpec;
+    expect(isDatasetEvalSpec(parsed)).toBe(true);
+    expect(parsed.dataset).toBe('ws-a/data#rows.jsonl');
+    expect(parsed.prompt_template).toBe('Is this legit?\n{{ item.body }}');
+    expect(parsed.metrics[0].metric_type).toBe('llm-judge');
+  });
+
+  it('parses YAML with no filename to sniff from', () => {
+    expect((parseEvalConfig(datasetYaml) as DatasetEvalSpec).dataset).toBe('ws-a/data#rows.jsonl');
+  });
+
+  it('keeps top-level keys it does not recognize instead of dropping them', () => {
+    const parsed = parseEvalConfig(
+      JSON.stringify({ ...(parseEvalConfig(datasetYaml) as object), field_mapping: { input: 'q' } })
+    ) as DatasetEvalSpec;
+    expect(parsed.field_mapping).toEqual({ input: 'q' });
+  });
+
+  it('accepts a dataset-driven config with no dataset or prompt_template', () => {
+    const parsed = parseEvalConfig(JSON.stringify({ metrics: [metric] })) as DatasetEvalSpec;
+    expect(isDatasetEvalSpec(parsed)).toBe(true);
+    expect(parsed.dataset).toBeUndefined();
+    expect(parsed.prompt_template).toBeUndefined();
+  });
+
+  it('rejects a dataset-driven config with no metrics', () => {
+    expect(() => parseEvalConfig(JSON.stringify({ dataset: 'a/b#c.jsonl' }))).toThrow(/metrics/);
+  });
+
+  it('reports the filename when the text parses as neither JSON nor YAML', () => {
+    expect(() => parseEvalConfig('{ nope: [', 'broken.yaml')).toThrow(/"broken\.yaml"/);
+  });
+
+  it('rejects a non-object document', () => {
+    expect(() => parseEvalConfig('- a\n- b', 'list.yaml')).toThrow(/top-level object/);
+  });
+});
+
+describe('applyDatasetEvalOverrides', () => {
+  const authored: DatasetEvalSpec = {
+    dataset: 'ws-a/authored#rows.jsonl',
+    prompt_template: '{{ item.authored }}',
+    metrics: [metric],
+  };
+
+  it('leaves a complete config untouched when every override is blank', () => {
+    const out = applyDatasetEvalOverrides(authored, {
+      dataset: undefined,
+      promptTemplate: '',
+      judgeModel: null,
+    });
+    expect(out.dataset).toBe('ws-a/authored#rows.jsonl');
+    expect(out.prompt_template).toBe('{{ item.authored }}');
+    expect(out.metrics[0].payload.metric.model).toBeUndefined();
+  });
+
+  it('replaces dataset, prompt template and judge model when supplied', () => {
+    const out = applyDatasetEvalOverrides(authored, {
+      dataset: 'ws-a/uploaded#new.jsonl',
+      promptTemplate: '{{ item.override }}',
+      judgeModel: 'ws-a/judge',
+    });
+    expect(out.dataset).toBe('ws-a/uploaded#new.jsonl');
+    expect(out.prompt_template).toBe('{{ item.override }}');
+    expect(out.metrics[0].payload.metric.model).toBe('ws-a/judge');
+  });
+
+  it('fills in a config that authored neither dataset nor prompt template', () => {
+    const out = applyDatasetEvalOverrides(
+      { metrics: [metric] },
+      { dataset: 'ws-a/up#d.jsonl', promptTemplate: '{{ item.q }}' }
+    );
+    expect(datasetEvalConfigError(out)).toBeNull();
+  });
+
+  it('treats a whitespace-only prompt template as unset', () => {
+    expect(applyDatasetEvalOverrides(authored, { promptTemplate: '   ' }).prompt_template).toBe(
+      '{{ item.authored }}'
+    );
+  });
+});
+
+describe('datasetEvalConfigError', () => {
+  it('names the missing dataset', () => {
+    expect(datasetEvalConfigError({ metrics: [metric], prompt_template: 'x' })).toMatch(/dataset/);
+  });
+
+  it('treats an empty inline dataset and a blank ref as missing', () => {
+    expect(datasetEvalConfigError({ metrics: [metric], dataset: [] })).toMatch(/dataset/);
+    expect(datasetEvalConfigError({ metrics: [metric], dataset: '  ' })).toMatch(/dataset/);
+  });
+
+  it('names the missing prompt template once a dataset is present', () => {
+    expect(datasetEvalConfigError({ metrics: [metric], dataset: 'a/b#c.jsonl' })).toMatch(
+      /prompt template/
+    );
+  });
+
+  it('passes a complete config', () => {
+    expect(
+      datasetEvalConfigError({ metrics: [metric], dataset: 'a/b#c.jsonl', prompt_template: 'x' })
+    ).toBeNull();
   });
 });

--- a/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
+++ b/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
@@ -4,6 +4,7 @@
 import { FILESET_NAME_MAX_LENGTH, toValidFilesetName } from '@nemo/common/src/utils/filesetName';
 import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import YAML from 'yaml';
 
 /** Sentinel ``evalConfig`` value that switches the form into create mode. */
 export const CREATE_NEW = '__create_new__';
@@ -78,10 +79,16 @@ export interface PersistedEvalSpec {
   max_concurrent_tasks?: number;
 }
 
-/** A dataset-driven config: an `EvaluateInputSpec` minus `target`. One metric set
- *  scores every row of a dataset, instead of each task carrying its own. */
-export interface DatasetEvalSpec {
-  dataset: string | Record<string, unknown>[];
+/** A dataset-driven config: an `EvaluateInputSpec` minus the keys Studio owns per run.
+ *  One metric set scores every row of a dataset, instead of each task carrying its own.
+ *
+ *  `dataset` and `prompt_template` are optional *as authored*: an uploaded config may
+ *  leave either out and have it supplied from the form instead. Both are required by the
+ *  time we submit — see {@link datasetEvalConfigError}. Any other key the author wrote is
+ *  carried through untouched, so a valid `EvaluateInputSpec` field Studio has no opinion
+ *  about (e.g. `field_mapping`) reaches the backend rather than being silently dropped. */
+export interface DatasetEvalSpec extends Record<string, unknown> {
+  dataset?: string | Record<string, unknown>[];
   metrics: InlineMetricBundle[];
   prompt_template?: string | Record<string, unknown>;
   field_mapping?: Record<string, unknown> | null;
@@ -89,11 +96,14 @@ export interface DatasetEvalSpec {
 
 export type EvalSpec = PersistedEvalSpec | DatasetEvalSpec;
 
-/** Which evaluator endpoint a config targets, decided by its shape alone: a
- *  `dataset` + `metrics` pair means row-based `evaluate/jobs`, `tasks[]` means
- *  task-based `agent-evaluate/jobs`. No extra registry metadata to keep in sync. */
-export const isDatasetEvalSpec = (spec: EvalSpec): spec is DatasetEvalSpec =>
-  'dataset' in spec && Array.isArray((spec as DatasetEvalSpec).metrics);
+/** Which evaluator endpoint a config targets, decided by its shape alone: `tasks[]` means
+ *  task-based `agent-evaluate/jobs`, anything else is row-based `evaluate/jobs`. Keyed on
+ *  `tasks` rather than `dataset` because an uploaded dataset-driven config is allowed to
+ *  omit `dataset` and take it from the form. */
+export const isTaskEvalSpec = (spec: EvalSpec): spec is PersistedEvalSpec =>
+  Array.isArray((spec as PersistedEvalSpec).tasks);
+
+export const isDatasetEvalSpec = (spec: EvalSpec): spec is DatasetEvalSpec => !isTaskEvalSpec(spec);
 
 // ---------------------------------------------------------------------------
 // Submit-time selections + request assembly
@@ -213,63 +223,140 @@ export const buildDatasetAgentTarget = (workspace: string, agent: string) =>
 /** Build the ``evaluate/jobs`` POST body from a dataset-driven config. ``params``
  *  must be exactly RunConfigOnline for an agent target, and ``prompt_template``
  *  is required — the job 500s without both. */
+/** Keys Studio sets itself on every submit, so an authored value for any of them is replaced
+ *  rather than rejected: `target` names the agent picked in the form, `params` is the
+ *  failure-tolerant profile above, and `publication` routes results to this run's Evaluation.
+ *  Everything else the author wrote survives — `EvaluateInputSpec` is `extra="forbid"`, so an
+ *  unknown key surfaces as a 422 naming the field instead of vanishing on the way out. */
+const STUDIO_OWNED_SPEC_KEYS = ['target', 'params', 'publication'] as const;
+
+const withoutStudioOwnedKeys = (spec: DatasetEvalSpec): DatasetEvalSpec => {
+  const authored = { ...spec };
+  for (const key of STUDIO_OWNED_SPEC_KEYS) delete authored[key];
+  return authored;
+};
+
 export const buildDatasetEvalRequestBody = (
   spec: DatasetEvalSpec,
   selections: SubmitSelections,
   judgeModel: string | null
-) => ({
-  ...jobName(selections),
-  spec: {
-    dataset: spec.dataset,
-    metrics: judgeModel
-      ? spec.metrics.map((metric) => injectJudgeModel(metric, judgeModel))
-      : spec.metrics,
-    target: buildDatasetAgentTarget(selections.workspace, selections.agent),
-    prompt_template: spec.prompt_template,
-    ...(spec.field_mapping ? { field_mapping: spec.field_mapping } : {}),
-    params: AGENT_RUN_PARAMS,
-    ...publicationSpec(selections.evaluationId),
-  },
-});
+) => {
+  const authored = withoutStudioOwnedKeys(spec);
+  return {
+    ...jobName(selections),
+    spec: {
+      ...authored,
+      metrics: judgeModel
+        ? spec.metrics.map((metric) => injectJudgeModel(metric, judgeModel))
+        : spec.metrics,
+      target: buildDatasetAgentTarget(selections.workspace, selections.agent),
+      params: AGENT_RUN_PARAMS,
+      ...publicationSpec(selections.evaluationId),
+    },
+  };
+};
 
-/** Parse an eval-config.json. Every task must carry its own ``metrics[]`` —
- *  the config is submitted as authored, with only the judge model and the
- *  per-run agent target applied on top. */
-export const parseEvalConfig = (text: string): EvalSpec => {
-  const raw = JSON.parse(text) as Partial<PersistedEvalSpec & DatasetEvalSpec>;
-
-  if (raw.dataset !== undefined) {
-    if (!Array.isArray(raw.metrics) || raw.metrics.length === 0) {
-      throw new Error('a dataset-driven eval-config.json must contain a non-empty "metrics" array');
-    }
-    if (!raw.prompt_template) {
-      throw new Error('a dataset-driven eval-config.json must contain a "prompt_template"');
-    }
-    return {
-      dataset: raw.dataset,
-      metrics: raw.metrics,
-      prompt_template: raw.prompt_template,
-      field_mapping: raw.field_mapping ?? null,
-    };
+/** Decode config text as JSON or YAML, chosen by extension and sniffed when there is none.
+ *  Mirrors the platform CLI's ``--spec-file`` loader, so a file that runs through
+ *  ``nemo evaluator evaluate submit`` is accepted here unchanged. YAML is a superset of
+ *  JSON, so the order only decides which parser's message a malformed file reports. */
+const decodeConfigText = (text: string, filename?: string): unknown => {
+  const extension = /\.[^.]+$/.exec(filename?.toLowerCase() ?? '')?.[0];
+  if (extension === '.json') return JSON.parse(text);
+  if (extension === '.yaml' || extension === '.yml') return YAML.parse(text);
+  try {
+    return JSON.parse(text);
+  } catch {
+    return YAML.parse(text);
   }
+};
 
-  const parsed = raw;
-  if (!Array.isArray(parsed.tasks) || parsed.tasks.length === 0) {
-    throw new Error('eval-config.json must contain "tasks" or a "dataset"');
+/** Parse an eval config authored as JSON or YAML.
+ *
+ *  Both shapes are submitted close to as-authored: unrecognized top-level keys are kept
+ *  rather than dropped, so a key the backend rejects fails loudly at submit instead of
+ *  disappearing here. A dataset-driven config may omit `dataset` and `prompt_template`,
+ *  which the form then supplies — {@link datasetEvalConfigError} is the gate before submit. */
+export const parseEvalConfig = (text: string, filename?: string): EvalSpec => {
+  const label = filename ? `"${filename}"` : 'the eval config';
+  let raw: unknown;
+  try {
+    raw = decodeConfigText(text, filename);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`Could not parse ${label} as JSON or YAML: ${detail}`);
   }
-  for (const task of parsed.tasks) {
-    if (!Array.isArray(task.metrics) || task.metrics.length === 0) {
-      throw new Error(
-        `eval-config.json task "${task.id}" must contain a non-empty "metrics" array`
-      );
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(`${label} must contain a top-level object`);
+  }
+  const parsed = raw as Partial<PersistedEvalSpec & DatasetEvalSpec> & Record<string, unknown>;
+
+  if (parsed.tasks !== undefined) {
+    if (!Array.isArray(parsed.tasks) || parsed.tasks.length === 0) {
+      throw new Error(`${label} must contain a non-empty "tasks" array`);
     }
-    for (const metric of task.metrics) {
-      if (!metric?.payload?.metric || typeof metric.payload.metric !== 'object') {
-        throw new Error(
-          `eval-config.json task "${task.id}" has a metric without a "payload.metric" object`
-        );
+    for (const task of parsed.tasks) {
+      if (!Array.isArray(task.metrics) || task.metrics.length === 0) {
+        throw new Error(`${label} task "${task.id}" must contain a non-empty "metrics" array`);
+      }
+      for (const metric of task.metrics) {
+        if (!metric?.payload?.metric || typeof metric.payload.metric !== 'object') {
+          throw new Error(
+            `${label} task "${task.id}" has a metric without a "payload.metric" object`
+          );
+        }
       }
     }
+    return { ...parsed, tasks: parsed.tasks } as PersistedEvalSpec;
   }
-  return { tasks: parsed.tasks, max_concurrent_tasks: parsed.max_concurrent_tasks };
+
+  if (!Array.isArray(parsed.metrics) || parsed.metrics.length === 0) {
+    throw new Error(`${label} must contain a non-empty "metrics" array, or a "tasks" array`);
+  }
+  for (const metric of parsed.metrics) {
+    if (!metric?.payload?.metric || typeof metric.payload.metric !== 'object') {
+      throw new Error(`${label} has a metric without a "payload.metric" object`);
+    }
+  }
+  return { ...parsed, metrics: parsed.metrics } as DatasetEvalSpec;
+};
+
+/** Form-supplied values layered over an authored config. */
+export interface DatasetEvalOverrides {
+  /** ``<workspace>/<fileset>#<file>`` for a dataset uploaded alongside the config. */
+  dataset?: string;
+  promptTemplate?: string;
+  judgeModel?: string | null;
+}
+
+/** Layer the form's overrides onto an authored config. Only values the user actually
+ *  supplied win, so a complete uploaded config runs unchanged with every override blank,
+ *  and a config missing a field is completed rather than replaced. */
+export const applyDatasetEvalOverrides = (
+  spec: DatasetEvalSpec,
+  { dataset, promptTemplate, judgeModel }: DatasetEvalOverrides
+): DatasetEvalSpec => ({
+  ...spec,
+  ...(dataset ? { dataset } : {}),
+  ...(promptTemplate?.trim() ? { prompt_template: promptTemplate } : {}),
+  metrics: judgeModel
+    ? spec.metrics.map((metric) => injectJudgeModel(metric, judgeModel))
+    : spec.metrics,
+});
+
+/** Why a dataset-driven config cannot be submitted yet, or null when it can. The backend
+ *  requires both against an online target: `prompt_template` has no default here because a
+ *  custom dataset's columns are arbitrary, so nothing can infer how a row becomes a request. */
+export const datasetEvalConfigError = (spec: DatasetEvalSpec): string | null => {
+  const hasDataset =
+    typeof spec.dataset === 'string'
+      ? spec.dataset.trim().length > 0
+      : Array.isArray(spec.dataset) && spec.dataset.length > 0;
+  if (!hasDataset) {
+    return 'This config names no dataset. Upload a dataset file, or add a "dataset" reference to the config.';
+  }
+  if (!spec.prompt_template) {
+    return 'This config has no prompt template. Add one under Optional configuration overrides, or add "prompt_template" to the config.';
+  }
+  return null;
 };


### PR DESCRIPTION


https://github.com/user-attachments/assets/beee9d30-dc49-43d1-b532-5c8077eefae2

Run Agent Evaluation now accepts an uploaded NeMo Evaluator configuration in place of a built-in sample. The picker takes JSON or YAML — the same rule the platform CLI's `--spec-file` loader uses, so a file that runs through `nemo evaluator evaluate submit` is accepted here unchanged. The config is parsed the moment it's selected rather than at submit, so a malformed file, a task-driven config, or a missing required field is reported inline on the field, and Submit stays disabled until the run would actually succeed.

The uploaded file can be complete or partial, and three optional override fields sit below it: a dataset upload, a prompt template, and a model for LLM evaluators. Overrides only take effect when you actually fill them in, so a complete config runs exactly as authored with every override left blank, while a config that omits `dataset` or `prompt_template` is completed from the form instead of rejected. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create evaluations by uploading JSON or YAML evaluator configurations.
  * Optionally upload JSONL, JSON, or CSV datasets.
  * Configure prompt and judge-model overrides before submission.
  * Reuse existing evaluations with saved configurations.
  * Upload files using a drag-and-drop picker with validation feedback.
  * Evaluation submission validates configurations and datasets before proceeding.
  * Forms with uploaded data remain open until explicitly canceled or submitted.
* **Documentation**
  * Added guidance for evaluator files, uploads, supported fields, and dataset requirements.
* **Examples**
  * Added minimal and dataset-driven Email Security Triage configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->