### PR TITLE
fix(agents): add `agent.yaml` translation support for new Fabric 0.2.0 fields

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/agent_config.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/agent_config.py
@@ -98,6 +98,8 @@ class McpServerConfig(BaseModel):
     args: list[str] = Field(default_factory=list)
     env: dict[str, str] = Field(default_factory=dict)
     exposure: Literal["harness_native", "fabric_managed"] = "harness_native"
+    allowed_tools: list[str] | None = None
+    blocked_tools: list[str] = Field(default_factory=list)
 
 
 class McpConfig(BaseModel):

--- a/plugins/nemo-agents/src/nemo_agents_plugin/agent_config.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/agent_config.py
@@ -69,6 +69,7 @@ class TelemetryConfig(BaseModel):
     project: str | None = None
     atif: dict[str, Any] | None = None
     atof: dict[str, Any] | None = None
+    opentelemetry: dict[str, Any] | None = None
 
 
 class InstructionConfig(BaseModel):

--- a/plugins/nemo-agents/src/nemo_agents_plugin/agent_config.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/agent_config.py
@@ -98,6 +98,7 @@ class McpServerConfig(BaseModel):
     url: str
     args: list[str] = Field(default_factory=list)
     env: dict[str, str] = Field(default_factory=dict)
+    custom_headers: dict[str, str] = Field(default_factory=dict)
     exposure: Literal["harness_native", "fabric_managed"] = "harness_native"
     allowed_tools: list[str] | None = None
     blocked_tools: list[str] = Field(default_factory=list)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/translator.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/translator.py
@@ -207,7 +207,29 @@ def _relay_observability_config(config: AgentConfig, model: ModelConfig) -> dict
     if telemetry.atof is not None:
         observability["atof"] = _relay_atof_config(telemetry.atof, output_dir=telemetry.output_dir)
 
+    if telemetry.opentelemetry is not None:
+        observability["opentelemetry"] = _relay_opentelemetry_config(
+            telemetry.opentelemetry,
+            agent_name=config.name,
+        )
+
     return observability
+
+
+def _relay_opentelemetry_config(opentelemetry_config: dict[str, Any], agent_name: str) -> dict[str, Any]:
+    opentelemetry = dict(opentelemetry_config)
+    endpoints = opentelemetry.get("endpoints")
+    if not isinstance(endpoints, list):
+        return opentelemetry
+
+    enriched_endpoints: list[Any] = []
+    for endpoint_config in endpoints:
+        if isinstance(endpoint_config, dict):
+            endpoint_config = dict(endpoint_config)
+            endpoint_config.setdefault("service_name", agent_name)
+        enriched_endpoints.append(endpoint_config)
+    opentelemetry["endpoints"] = enriched_endpoints
+    return opentelemetry
 
 
 def _relay_atof_config(atof_config: dict[str, Any], output_dir: str | None) -> dict[str, Any]:

--- a/plugins/nemo-agents/tests/unit/test_agent_config.py
+++ b/plugins/nemo-agents/tests/unit/test_agent_config.py
@@ -137,6 +137,8 @@ class TestAgentConfig:
                 "repo": {
                     "transport": "stdio",
                     "url": "repo-mcp --root .",
+                    "allowed_tools": ["read_file", "search_files"],
+                    "blocked_tools": ["write_file"],
                 }
             }
         }
@@ -149,8 +151,28 @@ class TestAgentConfig:
         assert config.mcp is not None
         assert config.mcp.servers["repo"].transport == "stdio"
         assert config.mcp.servers["repo"].exposure == "harness_native"
+        assert config.mcp.servers["repo"].allowed_tools == ["read_file", "search_files"]
+        assert config.mcp.servers["repo"].blocked_tools == ["write_file"]
         assert config.tools is not None
         assert config.tools.blocked == ["shell", "browser"]
+
+    def test_mcp_server_preserves_explicit_empty_tool_allowlist(self) -> None:
+        payload = _example_yaml_config()
+        payload["mcp"] = {
+            "servers": {
+                "repo": {
+                    "transport": "stdio",
+                    "url": "repo-mcp --root .",
+                    "allowed_tools": [],
+                }
+            }
+        }
+
+        config = AgentConfig.model_validate(payload)
+
+        assert config.mcp is not None
+        assert config.mcp.servers["repo"].allowed_tools == []
+        assert config.mcp.servers["repo"].blocked_tools == []
 
     def test_default_harness_must_reference_configured_harness(self) -> None:
         with pytest.raises(ValidationError, match="default_harness must reference one of harnesses: codex"):

--- a/plugins/nemo-agents/tests/unit/test_agent_config.py
+++ b/plugins/nemo-agents/tests/unit/test_agent_config.py
@@ -174,6 +174,23 @@ class TestAgentConfig:
         assert config.mcp.servers["repo"].allowed_tools == []
         assert config.mcp.servers["repo"].blocked_tools == []
 
+    def test_opentelemetry_export_config_validates(self) -> None:
+        payload = _example_yaml_config()
+        payload["telemetry"]["opentelemetry"] = {
+            "enabled": True,
+            "endpoints": [
+                {
+                    "type": "full",
+                    "endpoint": "http://otel-collector:4317",
+                    "transport": "grpc",
+                }
+            ],
+        }
+
+        config = AgentConfig.model_validate(payload)
+
+        assert config.telemetry.opentelemetry == payload["telemetry"]["opentelemetry"]
+
     def test_default_harness_must_reference_configured_harness(self) -> None:
         with pytest.raises(ValidationError, match="default_harness must reference one of harnesses: codex"):
             AgentConfig.model_validate(

--- a/plugins/nemo-agents/tests/unit/test_agent_config.py
+++ b/plugins/nemo-agents/tests/unit/test_agent_config.py
@@ -139,7 +139,12 @@ class TestAgentConfig:
                     "url": "repo-mcp --root .",
                     "allowed_tools": ["read_file", "search_files"],
                     "blocked_tools": ["write_file"],
-                }
+                },
+                "private-api": {
+                    "transport": "streamable-http",
+                    "url": "https://mcp.example.com",
+                    "custom_headers": {"Authorization": "Bearer ${MCP_ACCESS_TOKEN}"},
+                },
             }
         }
         payload["tools"] = {"blocked": ["shell", "browser"]}
@@ -153,6 +158,7 @@ class TestAgentConfig:
         assert config.mcp.servers["repo"].exposure == "harness_native"
         assert config.mcp.servers["repo"].allowed_tools == ["read_file", "search_files"]
         assert config.mcp.servers["repo"].blocked_tools == ["write_file"]
+        assert config.mcp.servers["private-api"].custom_headers == {"Authorization": "Bearer ${MCP_ACCESS_TOKEN}"}
         assert config.tools is not None
         assert config.tools.blocked == ["shell", "browser"]
 

--- a/plugins/nemo-agents/tests/unit/test_environment_resolution.py
+++ b/plugins/nemo-agents/tests/unit/test_environment_resolution.py
@@ -210,7 +210,17 @@ def test_merge_top_level_secrets_collected_not_in_config() -> None:
 
 
 def test_merge_mcp_fulfills_declared_server_env_wins_and_secrets_collected() -> None:
-    config = _agent_config(mcp={"servers": {"search": {"transport": "streamable-http", "url": "http://agent-url"}}})
+    config = _agent_config(
+        mcp={
+            "servers": {
+                "search": {
+                    "transport": "streamable-http",
+                    "url": "http://agent-url",
+                    "custom_headers": {"Authorization": "Bearer ${SEARCH_TOKEN}"},
+                }
+            }
+        }
+    )
     spec = EnvironmentSpecInline(
         mcp={
             "search": McpFulfillment(
@@ -227,6 +237,7 @@ def test_merge_mcp_fulfills_declared_server_env_wins_and_secrets_collected() -> 
     # Fulfillment url overrides the Agent's; non-secret env merges in.
     assert servers["search"]["url"] == "http://env-url"
     assert servers["search"]["env"] == {"E": "1"}
+    assert servers["search"]["custom_headers"] == {"Authorization": "Bearer ${SEARCH_TOKEN}"}
     # The secret ref is collected for process-env injection, NOT written into the
     # server config as a literal reference string (env-var-name indirection).
     assert "SEARCH_TOKEN" not in servers["search"]["env"]

--- a/plugins/nemo-agents/tests/unit/test_fabric_translator.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_translator.py
@@ -394,3 +394,44 @@ class TestTranslateAgentConfig:
                 "field_name_policy": "preserve",
             },
         ]
+
+    def test_relay_opentelemetry_export_translates_to_fabric(self) -> None:
+        payload = copy.deepcopy(_example_yaml_config())
+        payload["telemetry"]["enabled"] = True
+        payload["telemetry"]["opentelemetry"] = {
+            "enabled": True,
+            "endpoints": [
+                {
+                    "type": "full",
+                    "endpoint": "http://otel-collector:4317",
+                    "transport": "grpc",
+                    "header_env": {"Authorization": "OTEL_AUTH_HEADER"},
+                    "resource_attributes": {"deployment.environment": "test"},
+                },
+                {
+                    "type": "gen_ai",
+                    "endpoint": "http://shared-collector:4318/v1/traces",
+                    "service_name": "shared-agent-service",
+                },
+            ],
+        }
+        config = AgentConfig.model_validate(payload)
+
+        fabric_config = translate_agent_config(config)
+
+        relay = fabric_config.relay
+        assert relay is not None
+        observability = relay.observability
+        assert observability is not None
+        opentelemetry = observability.opentelemetry
+        assert opentelemetry is not None
+        assert opentelemetry.enabled is True
+        assert len(opentelemetry.endpoints) == 2
+        endpoint = opentelemetry.endpoints[0]
+        assert endpoint.type == "full"
+        assert endpoint.endpoint == "http://otel-collector:4317"
+        assert endpoint.transport == "grpc"
+        assert endpoint.header_env == {"Authorization": "OTEL_AUTH_HEADER"}
+        assert endpoint.resource_attributes == {"deployment.environment": "test"}
+        assert endpoint.service_name == "example-agent"
+        assert opentelemetry.endpoints[1].service_name == "shared-agent-service"

--- a/plugins/nemo-agents/tests/unit/test_fabric_translator.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_translator.py
@@ -196,7 +196,14 @@ class TestTranslateAgentConfig:
                     "transport": "stdio",
                     "url": "repo-mcp --root .",
                     "exposure": "fabric_managed",
-                }
+                    "allowed_tools": ["read_file", "search_files"],
+                    "blocked_tools": ["write_file"],
+                },
+                "disabled": {
+                    "transport": "streamable-http",
+                    "url": "https://mcp.example.com",
+                    "allowed_tools": [],
+                },
             }
         }
         payload["tools"] = {"blocked": ["shell", "browser"]}
@@ -214,6 +221,9 @@ class TestTranslateAgentConfig:
         assert mcp.servers["repo"].transport == "stdio"
         assert mcp.servers["repo"].url == "repo-mcp --root ."
         assert mcp.servers["repo"].exposure == "fabric_managed"
+        assert mcp.servers["repo"].allowed_tools == ["read_file", "search_files"]
+        assert mcp.servers["repo"].blocked_tools == ["write_file"]
+        assert mcp.servers["disabled"].allowed_tools == []
         assert tools.blocked == ["shell", "browser"]
 
     def test_top_level_prompts_rejected_until_shared_prompt_contract_exists(self) -> None:

--- a/plugins/nemo-agents/tests/unit/test_fabric_translator.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_translator.py
@@ -203,6 +203,7 @@ class TestTranslateAgentConfig:
                     "transport": "streamable-http",
                     "url": "https://mcp.example.com",
                     "allowed_tools": [],
+                    "custom_headers": {"Authorization": "Bearer ${MCP_ACCESS_TOKEN}"},
                 },
             }
         }
@@ -224,6 +225,7 @@ class TestTranslateAgentConfig:
         assert mcp.servers["repo"].allowed_tools == ["read_file", "search_files"]
         assert mcp.servers["repo"].blocked_tools == ["write_file"]
         assert mcp.servers["disabled"].allowed_tools == []
+        assert mcp.servers["disabled"].custom_headers == {"Authorization": "Bearer ${MCP_ACCESS_TOKEN}"}
         assert tools.blocked == ["shell", "browser"]
 
     def test_top_level_prompts_rejected_until_shared_prompt_contract_exists(self) -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Extends the Platform-owned `nemo-agents-spec-v1` `agent.yaml` schema and Fabric translator to cover the three Fabric configuration paths requested for MCP policy, OpenTelemetry export, and deployment-scoped MCP bearer authentication.

After this change, an `agent.yaml` can carry per-server `allowed_tools` and `blocked_tools`, HTTP `custom_headers` containing secret-safe environment-variable references, and Relay OpenTelemetry configuration into the generated `FabricConfig`.

## Related Issue

None.

## Changes

- Add `allowed_tools` and `blocked_tools` to each Platform `McpServerConfig` and pass both fields through to Fabric's normalized MCP server configuration. An explicit empty allowlist is preserved rather than treated as an omitted value.
- Preserve Fabric's capability gate for MCP tool filtering. Fabric 0.2 includes the normalized fields, but none of its bundled Claude, Codex, Deep Agents, or Hermes adapters declares `mcp.tool_filters`; those adapters therefore reject filtered configurations during planning instead of silently ignoring the policy. The translated fields are usable by custom and future adapters that declare and enforce the capability.
- Add per-server `custom_headers` so HTTP MCP clients can use deployment-scoped bearer authentication such as `Authorization: Bearer ${MCP_ACCESS_TOKEN}`.
- Keep bearer token values out of `agent.yaml` and the staged MCP configuration. Existing environment resolution collects the referenced secret for process-environment injection while preserving the `${MCP_ACCESS_TOKEN}` reference in `custom_headers`. This does not add per-user token propagation.
- Add `telemetry.opentelemetry` and translate it to Relay's OpenTelemetry export configuration alongside ATIF and ATOF.
- Default a missing OpenTelemetry endpoint `service_name` to the agent name while preserving explicitly configured service names and all other endpoint options.
- Add schema, translation, and environment-resolution tests for MCP filters, explicit empty allowlists, bearer header references, OpenTelemetry endpoints, transport and header settings, resource attributes, and service-name behavior.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: this PR adds schema and translation parity; product documentation can be updated when a bundled adapter supports MCP tool filtering.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `.venv/bin/pytest plugins/nemo-agents/tests/unit/test_agent_config.py plugins/nemo-agents/tests/unit/test_fabric_translator.py plugins/nemo-agents/tests/unit/test_environment_resolution.py -q` — passed, 56 tests.
- Focused Ruff linting and formatting checks passed for all five changed Python files.
- Focused `ty` checks passed for the production schema and its configuration-model tests. Broader touched test modules retain unrelated pre-existing type diagnostics.
- Manual Fabric 0.2 planning accepted the translated OpenTelemetry and bearer-header configurations.
- Manual Fabric 0.2 planning rejected MCP tool-filter configurations for each bundled adapter with the expected missing-capability error, confirming the policies are not silently ignored.
- `git diff --check` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry configuration support, including endpoint metadata, authentication mappings, resource attributes, and automatic service naming.
  * Added custom headers for MCP servers.
  * Added optional MCP tool allowlists and blocklists for more precise tool exposure control.
  * Preserved explicitly empty allowlists and existing server headers during configuration merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->