### PR TITLE
feat(studio): upload agent eval data and config

### DIFF
--- a/docs/fern/versions/latest.yml
+++ b/docs/fern/versions/latest.yml
@@ -150,6 +150,8 @@ navigation:
             path: ../../studio/agents.mdx
           - page: Data Designer
             path: ../../studio/data-designer-build.mdx
+          - page: Experiments
+            path: ../../studio/experiments.mdx
           - page: Monitor
             path: ../../studio/monitor.mdx
           - page: Plugin UIs

--- a/docs/studio/experiments.mdx
+++ b/docs/studio/experiments.mdx
@@ -51,7 +51,7 @@ prompt_template: |
 Example configuration. For more configuration options, review [NeMo evaluator documentation](https://docs.nvidia.com/nemo/evaluator/tutorials/walkthrough). 
 
 ```yaml
-prompt_template: {{item.question}}
+prompt_template: '{{ item.question }}'
 
 metrics:
   # 1. Did the report end with a Sources section at all? Deterministic and free:

--- a/docs/studio/experiments.mdx
+++ b/docs/studio/experiments.mdx
@@ -1,0 +1,163 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+title: "NeMo Studio Experiments"
+description: ""
+---
+
+{/* OUTLINE ONLY — headings and the sample config are in place; copy is not written yet.
+    Keep this page thin. It covers what the Studio UI does and nothing else; concepts,
+    the data model, and every CLI/SDK workflow belong to
+    /documentation/evaluate-models/experiments. Delete a heading rather than pad it. */}
+
+<Note>
+
+Experiments is still in early development. Many features are missing or should be expected to change.
+
+</Note>
+
+Use NeMo Studio Experiments is a comprehensive evaluation comparison solution that helps users compare the results of evaluations produced by NeMo Evaluator and other runners such as Harbor or Gym. 
+For concepts, the data model, and the CLI and SDK workflows, see [Experiments](/documentation/evaluate-models/experiments). This page covers only what you can do from the Agents evaluation tab. 
+
+---
+
+## Run an Evaluation from an Agent page
+
+Navigate to the Agent you wish evaluation and Select Run Evaluation in the top right. Choose to create a new experiment to group evaluations and an evaluation and supply a configuration and dataset, or select an existing evaluation and use it's configurate to re-run the test. 
+
+### Dataset and format
+
+Experiments expects a .jsonl format of multiple test cases. 
+
+```json
+{"subject": "Action Required: Review Updated Vendor Agreement", "sender": "procurement@lawvendor-support.com", "body": "Hi team,\n\nOur vendor, LawVendor Solutions, has updated the terms of our annual service agreement. Please review the attached document and confirm acceptance by Friday, May 10. If you have any questions, you can access the secure portal here: https://portal.lawvendor-support.com/login . Let me know once you've signed.\n\nThanks,\nJordan Lee\nProcurement Coordinator\nLawVendor Solutions", "label": "phishing"}
+{"subject": "Action Required: LabTech Solutions Contract Renewal \u2013 Review by Oct 15", "sender": "renewals@university-support.com", "body": "Hi Dr. Ellis,\n\nPlease review the updated contract for LabTech Solutions' spectroscopy equipment, set to renew on November 1. The revised terms are available in the attached PDF and can also be viewed via our secure portal: https://university-support.com/procurement/contract/LabTech. Log in with your university username and password to approve the renewal by October 15. If you have any questions, contact procurement@university-support.com.\n\nThank you,\nUniversity Procurement Team", "label": "phishing"}
+```
+
+The dataset's format should be paired with a prompt_template that references the keys in your test cases as so:
+
+```yaml
+prompt_template: |
+  From: {{ item.sender }}
+  Subject: {{ item.subject }}
+
+  {{ item.body }}
+```
+
+
+### Upload an Evaluation Config
+
+Example configuration. For more configuration options, review [NeMo evaluator documentation](https://docs.nvidia.com/nemo/evaluator/tutorials/walkthrough). 
+
+```yaml
+prompt_template: {{item.question}}
+
+metrics:
+  # 1. Did the report end with a Sources section at all? Deterministic and free:
+  #    a missing Sources section means the citation contract was dropped
+  #    entirely, which is worth separating from citations being merely sloppy.
+  - metric_type: string-check
+    outputs:
+      - name: string-check
+        value_json_schema:
+          title: ContinuousScore
+          description: Continuous numeric metric value.
+          type: number
+    payload:
+      kind: inline
+      metric:
+        type: string-check
+        operation: contains
+        left_template: "{{ (sample.output_text or '') | lower }}"
+        right_template: "### sources"
+
+  # 2. One judge, three independent scores. Three separate llm-judge metrics
+  #    would union their output names across rows and read NaN for each other,
+  #    so a multi-output metric is the right shape for several rubric criteria.
+  - metric_type: llm-judge
+    outputs:
+      - name: answers_question
+        value_json_schema:
+          title: ContinuousScore
+          description: Continuous numeric metric value.
+          type: number
+      - name: citation_integrity
+        value_json_schema:
+          title: ContinuousScore
+          description: Continuous numeric metric value.
+          type: number
+      - name: report_style
+        value_json_schema:
+          title: ContinuousScore
+          description: Continuous numeric metric value.
+          type: number
+    payload:
+      kind: inline
+      metric:
+        type: llm-judge
+        model: default/nvidia-nemotron-3-super-120b-a12b
+        prompt_template:
+          messages:
+            - role: user
+              content: |-
+                You are grading a deep research agent's report against three independent criteria. Judge only what is in the report; do not research the topic yourself, and do not reward length.
+
+                The research question was:
+                {{ item.question }}
+
+                A strong report was expected to cover:
+                {{ item.expectation }}
+
+                The agent's report:
+                {{ sample.output_text }}
+
+                Score each criterion independently — a report can be well cited but off topic, or on topic with broken citations.
+
+                1. answers_question: 1 if the report substantively covers the expectation above, 0 if it is off topic, hedges without committing, or leaves most of the expected ground uncovered. Different wording or extra material is fine; missing the substance is not.
+
+                2. citation_integrity: 1 if every inline [n] marker resolves to an entry in the Sources section, the Sources list is numbered sequentially from [1] with no gaps or duplicates, and each entry carries a URL. 0 if there are no inline markers, if any marker has no matching source, or if the numbering skips or repeats.
+
+                3. report_style: 1 if the report reads as a professional document — prose organised under `##` headings, no self-referential narration such as "I searched" or "I found", and no meta-commentary about the research process. 0 if it is mostly bullet fragments, narrates the agent's own process, or has no headings.
+
+                Return only a JSON object:
+                {"answers_question": <0 or 1>, "citation_integrity": <0 or 1>, "report_style": <0 or 1>}
+        scores:
+          # Judges narrate around the JSON, so each score is pulled out by name
+          # rather than by parsing the whole reply as a document.
+          - name: answers_question
+            minimum: 0.0
+            maximum: 1.0
+            parser:
+              type: regex
+              method: search
+              pattern: 'answers_question"?\s*:\s*([01])'
+          - name: citation_integrity
+            minimum: 0.0
+            maximum: 1.0
+            parser:
+              type: regex
+              method: search
+              pattern: 'citation_integrity"?\s*:\s*([01])'
+          - name: report_style
+            minimum: 0.0
+            maximum: 1.0
+            parser:
+              type: regex
+              method: search
+              pattern: 'report_style"?\s*:\s*([01])'
+        inference:
+          # Reports run long, so the judge needs more room than a verdict check.
+          max_tokens: 2048
+          extra_body:
+            nvext:
+              max_thinking_tokens: 512
+        reasoning:
+          end_token: "</think>"
+```
+
+## Related Topics
+
+- [Experiments](/documentation/evaluate-models/experiments)
+- [NeMo Studio Agents](/documentation/studio/agents)
+- [About NVIDIA NeMo Studio](/documentation/studio)

--- a/docs/studio/index.mdx
+++ b/docs/studio/index.mdx
@@ -36,7 +36,7 @@ The current sidebar groups related pages under expandable parents. Selecting a p
 | **Observability** | **Traces** | Inspect ingested traces, spans, and session details. |
 | **Components** | **Agents** | Opens the agent list. Select an agent to access Deployments, Logs, Chat, Evaluations, and Details. |
 | **Components** | **Models** | Opens the base-model list directly. Expand **Models** for **Fine-tune**, **Model Evaluations**, **Playground**, and **Virtual Models**, when those capabilities are enabled. |
-| **Evaluations** | **Experiments** | Review experiments, evaluations, sessions, and published results across the workspace. |
+| **Evaluations** | **Experiments** | Run evaluations against an agent, and review experiments, evaluations, sessions, and published results across the workspace. See [NeMo Studio Experiments](/documentation/studio/experiments). |
 | **Data** | **Datasets > Data Designer** | Build and monitor synthetic-data jobs. Other installed data plugins can appear below **Datasets**. |
 | **Governance** | **Guardrails** | Manage guardrail configurations. Disabled by default; see [Studio Guardrail Configs](/documentation/studio/guardrail-configs). |
 | **Governance** | **Iron Swarm** | Plugin-provided agent hardening UI. Appears only when the Iron Swarm plugin is installed; see [Studio Plugin UIs](/documentation/studio/plugins). |
@@ -117,9 +117,15 @@ Studio provides separate agent, model, and workspace evaluation views:
 | -------- | ------------- |
 | **Agents > select an agent > Evaluations** | Active evaluation jobs, completed evaluations, and experiments scoped to the selected agent. |
 | **Models > Model Evaluations** | Model evaluation results. |
-| **Evaluations > Experiments** | Experiments and their evaluations across the workspace. |
+| **Evaluations > Experiments** | Experiments and their evaluations across the workspace. See [NeMo Studio Experiments](/documentation/studio/experiments). |
 
 Use the agent's **Evaluations** tab when reviewing how a specific agent performed. Use **Experiments** for the broader workspace history.
+
+### Experiments
+
+Use **Evaluations > Experiments** to run an evaluation against an agent from the UI — selecting the agent and judge model, uploading a dataset and evaluation config — and to compare results across runs on the experiment leaderboard.
+
+For the full workflow, see [NeMo Studio Experiments](/documentation/studio/experiments). For concepts, the data model, and the CLI and SDK workflows, see [Experiments](/documentation/evaluate-models/experiments).
 
 ### Jobs
 

--- a/web/packages/studio/public/sample-agents/email-security-triage/eval-config.dataset-driven.yml
+++ b/web/packages/studio/public/sample-agents/email-security-triage/eval-config.dataset-driven.yml
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+dataset: <workspace>/<fileset>#dataset.jsonl
+prompt_template: |-
+  From: {{ item.sender }}
+  Subject: {{ item.subject }}
+
+  {{ item.body }}
+metrics:
+  - bundle_kind: metric-bundle
+    bundle_format_version: v1
+    metric_type: string-check
+    metadata:
+      description: Verdict key matches ground truth, without needing a judge model.
+      labels: {}
+    outputs:
+      - name: string-check
+        description: null
+        value_json_schema:
+          description: Continuous numeric metric value.
+          title: ContinuousScore
+          type: number
+    secrets: {}
+    payload:
+      kind: inline
+      metric:
+        type: string-check
+        operation: contains
+        left_template: "{{ (sample.output_text or '') | lower }}"
+        right_template: "is_likely_phishing: {% if item.label == 'phishing' %}true{% else %}false{% endif %}"
+  - bundle_kind: metric-bundle
+    bundle_format_version: v1
+    metric_type: llm-judge
+    metadata:
+      description: attack_type plausibility vs the ground-truth verdict.
+      labels: {}
+    outputs:
+      - name: attack_type_plausible
+        description: null
+        value_json_schema:
+          description: Continuous numeric metric value.
+          title: ContinuousScore
+          type: number
+    secrets: {}
+    payload:
+      kind: inline
+      metric:
+        type: llm-judge
+        model: default/nvidia-nemotron-3-super-120b-a12b
+        prompt_template:
+          messages:
+            - role: user
+              content: |-
+                You are scoring an email security triage agent.
+
+                The agent answers with a YAML block (often wrapped in a ``` fence). Its verdict is the `is_likely_phishing` key: `true` means phishing, `false` means benign. Read that key and nothing else — the `indicators` and `explanation` fields routinely mention the opposite verdict as things the agent considered, and must be ignored. Do not read the first line; it is usually the fence.
+
+                Agent response:
+                {{ sample.output_text }}
+
+                Ground-truth verdict: "{{ item.label }}".
+
+                Return a JSON object with one key:
+                  "attack_type_plausible": 1 if the `attack_type` value is a sensible label for this email (one of bec, credential, malware, spam, benign; `benign` iff the verdict is benign), else 0.
+        scores:
+          - name: attack_type_plausible
+            minimum: 0
+            maximum: 1
+            parser:
+              type: regex
+              method: search
+              pattern: attack_type_plausible"?\s*:\s*([01])
+        inference:
+          max_tokens: 1024
+          extra_body:
+            nvext:
+              max_thinking_tokens: 256
+        reasoning:
+          end_token: </think>

--- a/web/packages/studio/src/components/evaluation/JudgeModelSelect.tsx
+++ b/web/packages/studio/src/components/evaluation/JudgeModelSelect.tsx
@@ -20,6 +20,8 @@ export interface JudgeModelSelectProps<TFieldValues extends FieldValues = FieldV
   required?: boolean;
   placeholder?: string;
   slotLabel?: string;
+  /** Error to show instead of the field's own, for a problem derived outside the form state. */
+  slotError?: string;
   requiredMessage?: string;
   dropdownSide?: 'top' | 'bottom';
   formFieldName: Path<TFieldValues>;
@@ -36,6 +38,7 @@ export const JudgeModelSelect = <TFieldValues extends FieldValues = FieldValues>
   required = false,
   placeholder = 'Select a judge model',
   slotLabel = 'Judge Model',
+  slotError,
   requiredMessage = 'Judge model is required',
   dropdownSide,
   formFieldName,
@@ -78,8 +81,8 @@ export const JudgeModelSelect = <TFieldValues extends FieldValues = FieldValues>
   return (
     <FormField
       slotLabel={slotLabel}
-      status={fieldState.error ? 'error' : undefined}
-      slotError={fieldState.error?.message}
+      status={slotError || fieldState.error ? 'error' : undefined}
+      slotError={slotError ?? fieldState.error?.message}
       required={required}
     >
       <ModelSelectV2

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -5,9 +5,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
 import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
 import { FormModal, type FormModalProps } from '@nemo/common/src/components/FormModal';
+import { DEFAULT_DEBOUNCE_MS } from '@nemo/common/src/constants';
 import { getURNFromNamedEntityRef } from '@nemo/common/src/namedEntity';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
-import { getEntityNameError } from '@nemo/common/src/utils/entityName';
+import {
+  getEntityNameError,
+  sanitizeEntityName,
+  toValidEntityName,
+} from '@nemo/common/src/utils/entityName';
 import { useAgentsListAgents } from '@nemo/sdk/generated/agents/api';
 import { evaluatorCreateEvaluateJob } from '@nemo/sdk/generated/evaluator/api';
 import type {
@@ -66,6 +71,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { type FC, useEffect, useRef, useState } from 'react';
 import { FormProvider, type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
+import { useDebounce } from 'use-debounce';
 import { z } from 'zod';
 
 const EVAL_CONFIG_MODE_ITEMS = [
@@ -82,15 +88,87 @@ const LIST_PAGE_SIZE = 100;
 const NO_EVALUATIONS_MESSAGE =
   'No evaluations with a reusable eval config yet. Create one to run and re-use it.';
 
+/** An entity name as typed, sanitized on the way out. The field keeps the user's literal
+ *  keystrokes, so only unsalvageable input is an error — see the entity-naming contract. */
+const entityNameField = () => z.string().transform((value) => toValidEntityName(value, value));
+
+/** The message for a name with nothing salvageable in it, or undefined when there is. */
+const unsalvageableNameError = (value: string, label: string): string | undefined => {
+  if (sanitizeEntityName(value) !== undefined) return undefined;
+  return value ? `${label} must contain at least one letter or number.` : `${label} is required.`;
+};
+
+/** Where a name's uniqueness check stands. A debounced value that has fallen behind what is on
+ *  screen reads as still checking, never as a verdict for a name the user has moved on from. */
+type NameCheckStatus = 'checking' | 'conflict' | 'failed' | 'available' | undefined;
+
+const nameCheckStatus = (
+  preview: string,
+  debounced: string,
+  query: { data?: { data?: unknown[] }; isFetching: boolean; isError: boolean }
+): NameCheckStatus => {
+  if (!preview) return undefined;
+  if (debounced !== preview || query.isFetching) return 'checking';
+  if (query.isError) return 'failed';
+  return (query.data?.data?.length ?? 0) > 0 ? 'conflict' : 'available';
+};
+
+/** slotHelp/slotError for a name field, first match wins per the contract's precedence table. */
+const nameFieldSlots = ({
+  entity,
+  preview,
+  status,
+  schemaError,
+  describe,
+}: {
+  entity: string;
+  preview: string;
+  status: NameCheckStatus;
+  schemaError?: string;
+  describe: string;
+}): { slotHelp?: React.ReactNode; slotError?: string; status?: 'error' } => {
+  if (status === 'checking') return { slotHelp: 'Checking name...' };
+  if (status === 'conflict')
+    return { slotError: `An ${entity} named ${preview} already exists`, status: 'error' };
+  if (schemaError) return { slotError: schemaError, status: 'error' };
+  if (status === 'failed')
+    return { slotHelp: "Couldn't check name availability. You can still submit." };
+  if (!preview) return { slotHelp: describe };
+  return {
+    slotHelp: (
+      <>
+        Your {entity} will be created as <span className="text-primary">{preview}</span>
+      </>
+    ),
+  };
+};
+
+/** The server's own explanation for a failed submit, falling back to the transport error.
+ *  Without the `detail`, a 422 reads only as "Request failed with status code 422". */
+const submitErrorMessage = (error: unknown): string | undefined => {
+  if (!error) return undefined;
+  const detail = (error as { response?: { data?: { detail?: unknown } } } | undefined)?.response
+    ?.data?.detail;
+  if (typeof detail === 'string' && detail) return detail;
+  // Pydantic validation errors arrive as a list of {loc, msg} objects.
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map((item) => (item as { msg?: unknown })?.msg)
+      .filter((msg): msg is string => typeof msg === 'string' && msg.length > 0);
+    if (messages.length) return messages.join('; ');
+  }
+  return error instanceof Error ? error.message : 'An error occurred';
+};
+
 const submitEvaluationBaseSchema = z.object({
   agent: z.string().min(1, 'Agent is required'),
   judgeModel: z.string(),
   mode: z.enum([MODE_DEFAULT, MODE_EXPERIMENT]),
   /** Name of the experiment to create in "Create experiment" mode. The fileset holding this
    *  run's eval config and dataset is derived from it. */
-  newName: z.string(),
+  newName: entityNameField(),
   /** Name of the Intake Evaluation this run publishes under, in "Create experiment" mode. */
-  evaluationRecordName: z.string(),
+  evaluationRecordName: entityNameField(),
   /** Name of the existing evaluation whose eval config is reused in "Use existing evaluation" mode. */
   evaluationName: z.string(),
 });
@@ -102,17 +180,18 @@ const makeSubmitEvaluationSchema = (requiresJudgeModel: () => boolean) =>
     if (requiresJudgeModel() && !data.judgeModel) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Judge model is required',
+        message: 'Select a model to override the config',
         path: ['judgeModel'],
       });
     }
     if (data.mode === MODE_DEFAULT) {
-      // The derived fileset name is validated too — it is longer, so a name that is legal on
-      // its own can still overflow once "-data" is appended, and there is no fileset field to
-      // correct it in.
+      // Values here are already sanitized by the field transform, so the only naming failures
+      // left are "nothing salvageable" and the derived fileset name — which is longer, so a name
+      // that is legal on its own can still overflow once "-data" is appended, and there is no
+      // fileset field to correct it in.
       const nameError =
-        getEntityNameError(data.newName.trim(), 'Experiment name') ??
-        getEntityNameError(filesetNameForExperiment(data.newName.trim()), 'Derived fileset name');
+        unsalvageableNameError(data.newName, 'Experiment name') ??
+        getEntityNameError(filesetNameForExperiment(data.newName), 'Derived fileset name');
       if (nameError) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -120,10 +199,7 @@ const makeSubmitEvaluationSchema = (requiresJudgeModel: () => boolean) =>
           path: ['newName'],
         });
       }
-      const recordNameError = getEntityNameError(
-        data.evaluationRecordName.trim(),
-        'Evaluation name'
-      );
+      const recordNameError = unsalvageableNameError(data.evaluationRecordName, 'Evaluation name');
       if (recordNameError) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
@@ -281,7 +357,7 @@ const loadPersistedSpec = async (
   if (formData.mode === MODE_DEFAULT) {
     if (!uploads) throw new Error('Upload a dataset and an eval config before submitting');
     const signal = new AbortController().signal;
-    const name = filesetNameForExperiment(formData.newName.trim());
+    const name = filesetNameForExperiment(formData.newName);
     const judgeModel = formData.judgeModel || null;
     const spec: DatasetEvalSpec = {
       ...uploads.spec,
@@ -339,10 +415,11 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
 
-  // Ref keeps isLlmJudge current for the zod schema getter at validation time.
-  const isLlmJudgeRef = useRef(false);
-  const [schema] = useState(() => makeSubmitEvaluationSchema(() => isLlmJudgeRef.current));
+  // Ref keeps the override's required-ness current for the zod schema getter at validation time.
+  const judgeRequiredRef = useRef(false);
+  const [schema] = useState(() => makeSubmitEvaluationSchema(() => judgeRequiredRef.current));
 
+  const [submitAttempted, setSubmitAttempted] = useState(false);
   const [datasetPick, setDatasetPick] = useState<DatasetPick | null>(null);
   const [configPick, setConfigPick] = useState<ConfigPick | null>(null);
 
@@ -364,16 +441,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     mode: 'onSubmit',
     reValidateMode: 'onChange',
   });
-  const {
-    control,
-    reset: resetForm,
-    setValue,
-    getValues,
-    handleSubmit,
-    clearErrors,
-    formState,
-  } = methods;
-  const { errors } = formState;
+  const { control, reset: resetForm, setValue, handleSubmit, clearErrors, formState } = methods;
+  const { errors, touchedFields } = formState;
 
   const mode = useWatch({ control, name: 'mode' });
   const selectedAgent = useWatch({ control, name: 'agent' });
@@ -441,40 +510,108 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
         }
       : null;
 
-  const canSubmit =
-    mode === MODE_DEFAULT
-      ? !!uploads
-      : !isValidatingEvaluation && !!selectedEvaluation && !evaluationConfigIssue;
+  const rawExperimentName = useWatch({ control, name: 'newName' });
+  const rawRecordName = useWatch({ control, name: 'evaluationRecordName' });
+  const experimentPreview = toValidEntityName(rawExperimentName, '');
+  const recordPreview = toValidEntityName(rawRecordName, '');
 
-  // Mirrors injectJudgeModel's own guard, so the picker is shown exactly when a metric would
-  // have a model written into it — not just for the llm-judge type.
-  const judgeMetric = configPick?.spec?.metrics.find(
-    (metric) => metric.metric_type === 'llm-judge' || 'model' in metric.payload.metric
+  const [debouncedExperimentName] = useDebounce(experimentPreview, DEFAULT_DEBOUNCE_MS);
+  const [debouncedRecordName] = useDebounce(recordPreview, DEFAULT_DEBOUNCE_MS);
+  const isCreateMode = mode === MODE_DEFAULT;
+
+  const experimentConflictQuery = useListExperiments(
+    workspace,
+    { page_size: 1, filter: { name: debouncedExperimentName } },
+    { query: { enabled: open && isCreateMode && !!debouncedExperimentName } }
+  );
+  const recordConflictQuery = useListEvaluations(
+    workspace,
+    { page_size: 1, filter: { name: debouncedRecordName } },
+    { query: { enabled: open && isCreateMode && !!debouncedRecordName } }
   );
 
-  const isLlmJudge = mode === MODE_DEFAULT && !!judgeMetric;
-  isLlmJudgeRef.current = isLlmJudge;
+  const datasetError =
+    datasetPick?.error ?? (submitAttempted && !datasetPick ? 'Add a dataset' : undefined);
+  const configError =
+    configPick?.error ??
+    (submitAttempted && !configPick ? 'Select an evaluator config' : undefined);
 
-  const defaultModelRef =
-    isLlmJudge && typeof judgeMetric?.payload.metric.model === 'string'
-      ? judgeMetric.payload.metric.model
+  const experimentNameStatus = nameCheckStatus(
+    experimentPreview,
+    debouncedExperimentName,
+    experimentConflictQuery
+  );
+  const recordNameStatus = nameCheckStatus(recordPreview, debouncedRecordName, recordConflictQuery);
+
+  const experimentNameSlots = nameFieldSlots({
+    entity: 'experiment',
+    preview: experimentPreview,
+    status: experimentNameStatus,
+    schemaError: touchedFields.newName ? errors.newName?.message : undefined,
+    describe: 'Groups multiple evaluation runs together for comparison.',
+  });
+
+  const recordNameSlots = nameFieldSlots({
+    entity: 'evaluation',
+    preview: recordPreview,
+    status: recordNameStatus,
+    schemaError: touchedFields.evaluationRecordName
+      ? errors.evaluationRecordName?.message
+      : undefined,
+    describe: 'Names this run within the experiment. Results publish under it.',
+  });
+
+  // Only a conflict blocks here. The schema's own errors already stop handleSubmit; a conflict
+  // lives outside formState, so without this the request would fire and come back a 409.
+  const hasNameConflict =
+    isCreateMode && (experimentNameStatus === 'conflict' || recordNameStatus === 'conflict');
+
+  // Mirrors injectJudgeModel's own guard, so the picker is shown exactly when a metric would
+  // have a model written into it — not just for the llm-judge type. Every match is collected,
+  // not just the first: the override rewrites all of them, so all of them must be checked.
+  const judgeMetrics =
+    configPick?.spec?.metrics.filter(
+      (metric) => metric.metric_type === 'llm-judge' || 'model' in metric.payload.metric
+    ) ?? [];
+
+  const isLlmJudge = mode === MODE_DEFAULT && judgeMetrics.length > 0;
+
+  // A different query from the one behind the dropdown (lazy, paginated for search); this is the
+  // only complete workspace list, so it decides what counts as valid.
+  const { data: judgeModels, isLoading: isJudgeModelsLoading } = useJudgeModels({ enabled: open });
+
+  const workspaceModelUrns = new Set<string>(
+    judgeModels
+      ?.map((model) => getURNFromNamedEntityRef(model))
+      .filter((urn): urn is NonNullable<typeof urn> => urn !== undefined) ?? []
+  );
+
+  // Nothing to validate, but it still cannot run — so it requires the override just the same.
+  const hasModellessJudge =
+    isLlmJudge && judgeMetrics.some((metric) => typeof metric.payload.metric.model !== 'string');
+
+  // Full `workspace/name` ModelRefs: an unqualified bare name is unreachable to the evaluator's
+  // resolver. Empty while loading, or every model would read as unusable.
+  const invalidModelRefs =
+    isLlmJudge && !isJudgeModelsLoading
+      ? [
+          ...new Set(
+            judgeMetrics
+              .map((metric) => metric.payload.metric.model)
+              .filter((model): model is string => typeof model === 'string')
+              .filter((model) => !workspaceModelUrns.has(model))
+          ),
+        ]
+      : [];
+
+  const judgeModel = useWatch({ control, name: 'judgeModel' });
+  const invalidModelsError =
+    invalidModelRefs.length > 0 && !judgeModel
+      ? `The following llm judge models in the config are not valid in this workspace: [${invalidModelRefs.join(', ')}]`
       : undefined;
 
-  // Fetch judge models eagerly so they're ready when isLlmJudge resolves.
-  const { data: judgeModels } = useJudgeModels({ enabled: open });
-
-  // Pre-populate judge model from the config's ModelRef when modal opens or data arrives.
-  // Uses getValues (not a reactive watch) to avoid re-running on every model change.
-  useEffect(() => {
-    if (!open || !isLlmJudge || !defaultModelRef || !judgeModels?.length) return;
-    if (getValues('judgeModel')) return;
-    const target = bareName(defaultModelRef);
-    const match = judgeModels.find((m) => m.name === target);
-    if (match) {
-      const urn = getURNFromNamedEntityRef(match);
-      if (urn) setValue('judgeModel', urn);
-    }
-  }, [open, isLlmJudge, defaultModelRef, judgeModels, getValues, setValue]);
+  const judgeRequired = isLlmJudge && (invalidModelRefs.length > 0 || hasModellessJudge);
+  judgeRequiredRef.current = judgeRequired;
 
   const clearDatasetPick = () => {
     datasetToken.current += 1;
@@ -537,7 +674,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
 
       const isNew = formData.mode === MODE_DEFAULT;
       const filesetName = isNew
-        ? filesetNameForExperiment(formData.newName.trim())
+        ? filesetNameForExperiment(formData.newName)
         : (evaluationFileset ?? '');
 
       const seeded: SeededEntities = isNew ? { filesetName } : {};
@@ -549,7 +686,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
         let nameStem: string;
         let parentEvaluationId: string | undefined;
         if (isNew) {
-          const experiment = await createExperiment(workspace, { name: formData.newName.trim() });
+          const experiment = await createExperiment(workspace, { name: formData.newName });
           seeded.experimentName = experiment.name;
           experimentIds = [experiment.id];
           nameStem = experiment.name;
@@ -568,14 +705,14 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
 
         const evaluationId = await createRunEvaluation(workspace, {
           experimentIds,
-          name: isNew ? formData.evaluationRecordName.trim() : undefined,
+          name: isNew ? formData.evaluationRecordName : undefined,
           nameStem,
           filesetName,
           parentEvaluationId,
         }).catch((err: unknown) => {
           if (isConflictError(err)) {
             throw new Error(
-              `An evaluation named "${formData.evaluationRecordName.trim()}" already exists — choose a different evaluation name`
+              `An evaluation named "${formData.evaluationRecordName}" already exists — choose a different evaluation name`
             );
           }
           throw err;
@@ -620,6 +757,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     configToken.current += 1;
     setDatasetPick(null);
     setConfigPick(null);
+    setSubmitAttempted(false);
   }, [open, agentProp, resetForm]);
 
   // Seed the locked agent on open. A blanket reset here would clobber the judge-model
@@ -633,10 +771,18 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     resetForm(makeDefaultValues(agentProp));
     clearDatasetPick();
     clearConfigPick();
+    setSubmitAttempted(false);
     onClose();
   };
 
   const onSubmit: SubmitHandler<SubmitEvaluationFormData> = async (formData) => {
+    // The resolver has passed; these are the gates held outside form state.
+    if (mode === MODE_DEFAULT && (!uploads || hasNameConflict)) return;
+    if (
+      mode === MODE_EXPERIMENT &&
+      (isValidatingEvaluation || !selectedEvaluation || evaluationConfigIssue)
+    )
+      return;
     try {
       await submitEvaluation(formData);
     } catch {
@@ -644,12 +790,13 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     }
   };
 
-  const errorMessage =
-    submitError instanceof Error
-      ? submitError.message
-      : submitError
-        ? 'An error occurred'
-        : undefined;
+  // Submit stays enabled and reports what is missing on click; the pickers carry no asterisk.
+  const handleFormSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    setSubmitAttempted(true);
+    void handleSubmit(onSubmit)(event);
+  };
+
+  const errorMessage = submitErrorMessage(submitError);
 
   return (
     <FormModal
@@ -657,11 +804,9 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       onClose={resetAndClose}
       title="Run Agent Evaluation"
       submitButtonText="Submit"
-      onSubmit={handleSubmit(onSubmit)}
+      onSubmit={handleFormSubmit}
       disabled={isPending}
-      submitDisabled={!canSubmit}
       loading={isPending}
-      errorText={errorMessage}
       className="w-[690px]! max-w-[95vw]!"
     >
       <FormProvider {...methods}>
@@ -717,23 +862,19 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                 <>
                   <ControlledTextInput
                     useControllerProps={{ control, name: 'newName' }}
-                    placeholder="e.g. Model update tests"
+                    placeholder="e.g. model-update-tests"
                     formFieldProps={{
                       slotLabel: 'Experiment Name',
-                      required: true,
-                      slotHelp: 'Groups multiple evaluation runs together for comparison.',
-                      slotError: errors.newName?.message,
+                      ...experimentNameSlots,
                     }}
                   />
 
                   <ControlledTextInput
                     useControllerProps={{ control, name: 'evaluationRecordName' }}
-                    placeholder="e.g. Initial baseline"
+                    placeholder="e.g. initial-baseline"
                     formFieldProps={{
                       slotLabel: 'Evaluation Name',
-                      required: true,
-                      slotHelp: 'Names this run within the experiment. Results publish under it.',
-                      slotError: errors.evaluationRecordName?.message,
+                      ...recordNameSlots,
                     }}
                   />
 
@@ -758,15 +899,14 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                     accept=".jsonl,.json"
                     onValueChange={handleDatasetPicked}
                     onFileRemove={clearDatasetPick}
-                    status={datasetPick?.error ? 'error' : undefined}
+                    status={datasetError ? 'error' : undefined}
                     renderInput={(slotInput) => (
                       <FormField
                         name="dataset"
-                        required
                         slotLabel="Add dataset"
                         slotHelp="JSONL, or a JSON array of objects."
-                        slotError={datasetPick?.error}
-                        status={datasetPick?.error ? 'error' : undefined}
+                        slotError={datasetError}
+                        status={datasetError ? 'error' : undefined}
                       >
                         {datasetPick ? null : slotInput}
                       </FormField>
@@ -777,15 +917,14 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                     accept=".json,.yaml,.yml"
                     onValueChange={handleConfigPicked}
                     onFileRemove={clearConfigPick}
-                    status={configPick?.error ? 'error' : undefined}
+                    status={configError ? 'error' : undefined}
                     renderInput={(slotInput) => (
                       <FormField
                         name="evalConfig"
-                        required
                         slotLabel="Select evaluator config"
                         slotHelp="Select a JSON or YAML config."
-                        slotError={configPick?.error}
-                        status={configPick?.error ? 'error' : undefined}
+                        slotError={configError}
+                        status={configError ? 'error' : undefined}
                       >
                         {configPick ? null : slotInput}
                       </FormField>
@@ -795,7 +934,12 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                   {isLlmJudge && (
                     <JudgeModelSelect<SubmitEvaluationFormData>
                       formFieldName="judgeModel"
-                      slotLabel="Model for LLM evaluators"
+                      slotLabel={
+                        judgeRequired
+                          ? 'Override all LLM models'
+                          : 'Override all LLM models (optional)'
+                      }
+                      slotError={invalidModelsError}
                     />
                   )}
                 </>
@@ -824,6 +968,12 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
               )}
             </Stack>
           ) : null}
+
+          {errorMessage && (
+            <Text kind="body/regular/md" className="text-feedback-danger whitespace-normal">
+              {errorMessage}
+            </Text>
+          )}
         </Stack>
       </FormProvider>
     </FormModal>

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -8,6 +8,7 @@ import { FormModal, type FormModalProps } from '@nemo/common/src/components/Form
 import { getURNFromNamedEntityRef } from '@nemo/common/src/namedEntity';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { getEntityNameError } from '@nemo/common/src/utils/entityName';
+import { validateFileFormat } from '@nemo/common/src/utils/fileValidation';
 import { useAgentsListAgents } from '@nemo/sdk/generated/agents/api';
 import { evaluatorCreateEvaluateJob } from '@nemo/sdk/generated/evaluator/api';
 import type {
@@ -25,10 +26,16 @@ import {
   useListEvaluations,
   useListExperiments,
 } from '@nemo/sdk/generated/platform/api';
-import { Anchor, SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
-import { fetchSampleText } from '@studio/api/agents/fetchSampleText';
+import {
+  Anchor,
+  FormField,
+  SegmentedControl,
+  Stack,
+  Text,
+  Upload,
+} from '@nvidia/foundations-react-core';
 import { submitAgentEvalJob } from '@studio/api/evaluation/agent-evaluations';
-import { isConflictError, type EvalSeedFile } from '@studio/api/evaluation/eval-config-fileset';
+import { isConflictError } from '@studio/api/evaluation/eval-config-fileset';
 import {
   createRunEvaluation,
   EVAL_CONFIG_FILENAME,
@@ -40,22 +47,21 @@ import {
   bareName,
   buildAgentEvalRequestBody,
   buildDatasetEvalRequestBody,
-  buildPersistedSpec,
+  type DatasetEvalSpec,
   type EvalSpec,
   filesetNameForExperiment,
   injectJudgeModel,
-  type InlineMetricBundle,
   isDatasetEvalSpec,
   generateEvalConfigName,
   MODE_DEFAULT,
   MODE_EXPERIMENT,
   parseEvalConfig,
+  parseUploadedDatasetConfig,
 } from '@studio/components/evaluation/submitEvaluationJob';
-import { LINK_EVAL_DOCS } from '@studio/constants/links';
-import { DATASET_EVAL_CONFIG_KEY, getEvalConfigSample } from '@studio/constants/sampleAgents';
+import { LINK_EVAL_DOCS, LINK_EVAL_DOCS_APPROACHES } from '@studio/constants/links';
 import { useJudgeModels } from '@studio/hooks/evaluation/useJudgeModels';
 import { getAgentEvaluationsTabRoute } from '@studio/routes/utils';
-import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { type FC, useEffect, useRef, useState } from 'react';
 import { FormProvider, type SubmitHandler, useForm, useWatch } from 'react-hook-form';
 import { useNavigate } from 'react-router';
@@ -70,7 +76,6 @@ const DATASET_FILENAME = 'dataset.jsonl';
 
 /** Backend caps page_size at 100; the picker shows the most recent page. */
 const LIST_PAGE_SIZE = 100;
-const README_FILENAME = 'README.md';
 
 const NO_EVALUATIONS_MESSAGE =
   'No evaluations with a reusable eval config yet. Create one to run and re-use it.';
@@ -79,11 +84,9 @@ const submitEvaluationBaseSchema = z.object({
   agent: z.string().min(1, 'Agent is required'),
   judgeModel: z.string(),
   mode: z.enum([MODE_DEFAULT, MODE_EXPERIMENT]),
-  exampleKey: z.string(),
-  /** Name of the experiment to create in "Create experiment" mode. */
+  /** Name of the experiment to create in "Create experiment" mode. The fileset holding this
+   *  run's eval-config.json and dataset is derived from it. */
   newName: z.string(),
-  /** Fileset created alongside it, holding eval-config.json and any data artifacts. */
-  filesetName: z.string(),
   /** Name of the existing evaluation whose eval config is reused in "Use existing evaluation" mode. */
   evaluationName: z.string(),
 });
@@ -100,20 +103,17 @@ const makeSubmitEvaluationSchema = (requiresJudgeModel: () => boolean) =>
       });
     }
     if (data.mode === MODE_DEFAULT) {
-      const nameError = getEntityNameError(data.newName.trim());
+      // The derived fileset name is validated too — it is longer, so a name that is legal on
+      // its own can still overflow once "-data" is appended, and there is no fileset field to
+      // correct it in.
+      const nameError =
+        getEntityNameError(data.newName.trim()) ??
+        getEntityNameError(filesetNameForExperiment(data.newName.trim()), 'Derived fileset name');
       if (nameError) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: nameError,
           path: ['newName'],
-        });
-      }
-      const filesetError = getEntityNameError(data.filesetName.trim());
-      if (filesetError) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: filesetError,
-          path: ['filesetName'],
         });
       }
     }
@@ -126,17 +126,35 @@ const makeSubmitEvaluationSchema = (requiresJudgeModel: () => boolean) =>
     }
   });
 
-const makeDefaultValues = (agent?: string): SubmitEvaluationFormData => {
-  const newName = generateEvalConfigName();
-  return {
-    agent: agent ?? '',
-    judgeModel: '',
-    mode: MODE_DEFAULT,
-    exampleKey: DATASET_EVAL_CONFIG_KEY,
-    newName,
-    filesetName: filesetNameForExperiment(newName),
-    evaluationName: '',
-  };
+const makeDefaultValues = (agent?: string): SubmitEvaluationFormData => ({
+  agent: agent ?? '',
+  judgeModel: '',
+  mode: MODE_DEFAULT,
+  newName: generateEvalConfigName(),
+  evaluationName: '',
+});
+
+/** A file the user picked, plus why it was rejected when it was. */
+interface FilePick {
+  file: File;
+  error?: string;
+}
+
+/** The picked eval config, with its parsed spec once it validates. */
+interface ConfigPick extends FilePick {
+  spec?: DatasetEvalSpec;
+}
+
+/** Reject anything that is not one JSON value per line. ``validateFileFormat`` reports a
+ *  pretty-printed JSON document as valid ``json``, but the dataset is stored under a fixed
+ *  ``dataset.jsonl`` name and referenced as such, so accepting one would only fail at job time. */
+const datasetFileError = async (file: File): Promise<string | undefined> => {
+  const result = await validateFileFormat(file);
+  if (!result.isValid) return result.error ?? 'File is not valid JSON or JSONL';
+  if (result.format === 'json' && (await file.text()).trim().includes('\n')) {
+    return `${DATASET_FILENAME} must be JSON Lines: one JSON object per line.`;
+  }
+  return undefined;
 };
 
 interface SubmitEvaluationModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
@@ -188,78 +206,54 @@ const discardSeeded = async (
   );
 };
 
+/** The two files the user uploaded in "Create experiment" mode, already validated. */
+interface UploadedEvalInputs {
+  dataset: File;
+  spec: DatasetEvalSpec;
+}
+
 /** Resolves the persisted yardstick spec for this submission. In "Create experiment" mode
- *  it builds the spec from the sample template (fanning the metric onto every task with
- *  the picked judge baked in) and seeds it into a new fileset; in "Use existing evaluation"
- *  mode it reads the saved spec back verbatim (no re-fan, no judge re-pick). */
+ *  it takes the uploaded config, bakes in the picked judge and a ref to the dataset that is
+ *  about to be uploaded beside it, and seeds both into a new fileset; in "Use existing
+ *  evaluation" mode it reads the saved spec back verbatim (no re-bake, no judge re-pick). */
 const loadPersistedSpec = async (
   workspace: string,
   formData: SubmitEvaluationFormData,
-  configFileset: string | null
+  configFileset: string | null,
+  uploads: UploadedEvalInputs | null
 ): Promise<EvalSpec> => {
   if (formData.mode === MODE_DEFAULT) {
+    if (!uploads) throw new Error('Upload a dataset and an eval config before submitting');
     const signal = new AbortController().signal;
-    const name = formData.filesetName.trim();
-    const example = getEvalConfigSample(formData.exampleKey);
-    const template = parseEvalConfig(await fetchSampleText(example.configPath));
-    const files: EvalSeedFile[] = [];
-    let spec: EvalSpec;
-
-    if (isDatasetEvalSpec(template)) {
-      const judgeModel = formData.judgeModel || null;
-      const bakedMetrics = judgeModel
-        ? template.metrics.map((m) => injectJudgeModel(m, judgeModel))
-        : template.metrics;
-      if (example.datasetPath) {
-        const datasetFile = example.datasetPath.split('/').pop() ?? DATASET_FILENAME;
-        files.push({
-          path: datasetFile,
-          content: await fetchSampleText(example.datasetPath),
-          type: 'application/jsonl',
-        });
-        spec = {
-          ...template,
-          dataset: `${workspace}/${name}#${datasetFile}`,
-          metrics: bakedMetrics,
-        };
-      } else {
-        spec = { ...template, dataset: [], metrics: bakedMetrics };
-      }
-    } else {
-      spec = buildPersistedSpec(template, formData.judgeModel || null);
-    }
-
-    files.push({
-      path: EVAL_CONFIG_FILENAME,
-      content: JSON.stringify(spec, null, 2),
-      type: 'application/json',
-    });
-
-    if (example.readmePath) {
-      const readme = await fetchSampleText(example.readmePath).catch(() => null);
-      if (readme) {
-        files.push({ path: README_FILENAME, content: readme, type: 'text/markdown' });
-      }
-    }
+    const name = filesetNameForExperiment(formData.newName.trim());
+    const judgeModel = formData.judgeModel || null;
+    const spec: DatasetEvalSpec = {
+      ...uploads.spec,
+      dataset: `${workspace}/${name}#${DATASET_FILENAME}`,
+      metrics: judgeModel
+        ? uploads.spec.metrics.map((m) => injectJudgeModel(m, judgeModel))
+        : uploads.spec.metrics,
+    };
 
     try {
       await filesCreateFileset(workspace, { name, description: 'Agent Evaluation Config' }, signal);
     } catch (err) {
       if (isConflictError(err)) {
-        throw new Error(`A fileset named "${name}" already exists — choose a different name`);
+        throw new Error(
+          `A fileset named "${name}" already exists — choose a different experiment name`
+        );
       }
       throw err;
     }
     try {
-      for (const f of files) {
-        await filesUploadFile(
-          workspace,
-          name,
-          f.path,
-          new Blob([f.content], { type: f.type }),
-          signal
-        );
-      }
+      await filesUploadFile(workspace, name, DATASET_FILENAME, uploads.dataset, signal);
+      await filesUploadFile(
+        workspace,
+        name,
+        EVAL_CONFIG_FILENAME,
+        new Blob([JSON.stringify(spec, null, 2)], { type: 'application/json' }),
+        signal
+      );
     } catch (uploadErr) {
       throw await discardSeeded(workspace, { filesetName: name }, uploadErr);
     }
@@ -291,6 +285,9 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const isLlmJudgeRef = useRef(false);
   const [schema] = useState(() => makeSubmitEvaluationSchema(() => isLlmJudgeRef.current));
 
+  const [datasetPick, setDatasetPick] = useState<FilePick | null>(null);
+  const [configPick, setConfigPick] = useState<ConfigPick | null>(null);
+
   const { data: agentsResponse, isLoading: isAgentsLoading } = useAgentsListAgents(
     workspace,
     undefined,
@@ -306,7 +303,6 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   });
   const {
     control,
-    register,
     reset: resetForm,
     setValue,
     getValues,
@@ -320,7 +316,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const selectedAgent = useWatch({ control, name: 'agent' });
 
   const agentFieldError = errors.agent?.message;
-  const exampleKey = useWatch({ control, name: 'exampleKey' });
+  const newName = useWatch({ control, name: 'newName' });
   const evaluationName = useWatch({ control, name: 'evaluationName' });
 
   const { data: evaluationsResponse, isLoading: isEvaluationsLoading } = useListEvaluations(
@@ -373,33 +369,19 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const evaluationFileset = selectedEvaluation ? evaluationFilesetName(selectedEvaluation) : null;
   const evaluationFieldError = errors.evaluationName?.message ?? evaluationConfigIssue ?? undefined;
 
-  const canRunSelectedEvaluation =
-    mode !== MODE_EXPERIMENT ||
-    (!isValidatingEvaluation && !!selectedEvaluation && !evaluationConfigIssue);
+  const uploads: UploadedEvalInputs | null =
+    datasetPick?.file && !datasetPick.error && configPick?.spec && !configPick.error
+      ? { dataset: datasetPick.file, spec: configPick.spec }
+      : null;
 
-  // Fetch and parse the selected example config early to detect metric type and default model.
-  const { data: exampleConfig } = useQuery({
-    queryKey: ['eval-config-preview', exampleKey],
-    queryFn: async () => {
-      const example = getEvalConfigSample(exampleKey);
-      if (!example) return null;
-      const text = await fetchSampleText(example.configPath);
-      return parseEvalConfig(text);
-    },
-    enabled: open && mode === MODE_DEFAULT && !!exampleKey,
-    staleTime: Infinity,
-    // Retain the prior example's parsed config while the next one loads so the
-    // judge picker stays mounted (all examples are llm-judge) — no flicker.
-    placeholderData: keepPreviousData,
-  });
+  const canSubmit =
+    mode === MODE_DEFAULT
+      ? !!uploads
+      : !isValidatingEvaluation && !!selectedEvaluation && !evaluationConfigIssue;
 
-  const configMetrics: InlineMetricBundle[] = !exampleConfig
-    ? []
-    : isDatasetEvalSpec(exampleConfig)
-      ? exampleConfig.metrics
-      : exampleConfig.tasks.flatMap((task) => task.metrics);
-
-  const judgeMetric = configMetrics.find((metric) => metric.metric_type === 'llm-judge');
+  const judgeMetric = configPick?.spec?.metrics.find(
+    (metric) => metric.metric_type === 'llm-judge'
+  );
 
   const isLlmJudge = mode === MODE_DEFAULT && !!judgeMetric;
   isLlmJudgeRef.current = isLlmJudge;
@@ -425,6 +407,28 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     }
   }, [open, isLlmJudge, defaultModelRef, judgeModels, getValues, setValue]);
 
+  // Both handlers clear first: validation is async, and leaving the previous pick in place
+  // would keep the submit gate open against a file the user has already replaced.
+  const handleDatasetPicked = async (item: { file: File }) => {
+    setDatasetPick(null);
+    setDatasetPick({ file: item.file, error: await datasetFileError(item.file) });
+  };
+
+  // A fresh config also means a fresh judge: the preselect effect above bails once judgeModel
+  // is set, so leaving it would keep the previous file's judge.
+  const handleConfigPicked = async (item: { file: File }) => {
+    setValue('judgeModel', '');
+    setConfigPick(null);
+    try {
+      setConfigPick({ file: item.file, spec: parseUploadedDatasetConfig(await item.file.text()) });
+    } catch (err) {
+      setConfigPick({
+        file: item.file,
+        error: err instanceof Error ? err.message : 'Could not read the file',
+      });
+    }
+  };
+
   const {
     mutateAsync: submitEvaluation,
     error: submitError,
@@ -432,10 +436,12 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     reset: resetMutation,
   } = useMutation({
     mutationFn: async (formData: SubmitEvaluationFormData) => {
-      const spec = await loadPersistedSpec(workspace, formData, evaluationFileset);
+      const spec = await loadPersistedSpec(workspace, formData, evaluationFileset, uploads);
 
       const isNew = formData.mode === MODE_DEFAULT;
-      const filesetName = isNew ? formData.filesetName.trim() : (evaluationFileset ?? '');
+      const filesetName = isNew
+        ? filesetNameForExperiment(formData.newName.trim())
+        : (evaluationFileset ?? '');
 
       const seeded: SeededEntities = isNew ? { filesetName } : {};
 
@@ -503,7 +509,10 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   });
 
   useEffect(() => {
-    if (!open) resetForm(makeDefaultValues(agentProp));
+    if (open) return;
+    resetForm(makeDefaultValues(agentProp));
+    setDatasetPick(null);
+    setConfigPick(null);
   }, [open, agentProp, resetForm]);
 
   // Seed the locked agent on open. A blanket reset here would clobber the judge-model
@@ -515,6 +524,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const resetAndClose = () => {
     resetMutation();
     resetForm(makeDefaultValues(agentProp));
+    setDatasetPick(null);
+    setConfigPick(null);
     onClose();
   };
 
@@ -541,7 +552,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       submitButtonText="Submit"
       onSubmit={handleSubmit(onSubmit)}
       disabled={isPending}
-      submitDisabled={!canRunSelectedEvaluation}
+      submitDisabled={!canSubmit}
       loading={isPending}
       errorText={errorMessage}
       className="w-[690px]! max-w-[95vw]!"
@@ -597,32 +608,81 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
 
               {mode === MODE_DEFAULT ? (
                 <>
-                  <input type="hidden" {...register('exampleKey')} />
-                  {isLlmJudge && (
-                    <JudgeModelSelect<SubmitEvaluationFormData>
-                      formFieldName="judgeModel"
-                      slotLabel="Judge Model"
-                    />
-                  )}
                   <ControlledTextInput
                     useControllerProps={{ control, name: 'newName' }}
                     selectOnFocus
                     formFieldProps={{
-                      slotLabel: 'New Experiment Name',
-                      slotHelp:
-                        'Groups this run and future ones against the same config. Select it later to re-run.',
+                      slotLabel: 'Experiment Name',
+                      slotHelp: `Groups this run and future ones against the same config. Its ${EVAL_CONFIG_FILENAME} and dataset are stored in a fileset named "${filesetNameForExperiment(newName.trim() || '<name>')}".`,
                       slotError: errors.newName?.message,
                     }}
                   />
-                  <ControlledTextInput
-                    useControllerProps={{ control, name: 'filesetName' }}
-                    selectOnFocus
-                    formFieldProps={{
-                      slotLabel: 'Fileset Name',
-                      slotHelp: `Stores this experiment's ${EVAL_CONFIG_FILENAME} and any data files.`,
-                      slotError: errors.filesetName?.message,
-                    }}
-                  />
+
+                  <Text kind="label/bold/sm" color="secondary">
+                    Select evaluation set
+                  </Text>
+                  <Text kind="body/regular/md" color="secondary">
+                    Learn more about evaluation set requirements in the{' '}
+                    <Anchor
+                      kind="inline"
+                      textKind="body/regular/md"
+                      href={LINK_EVAL_DOCS_APPROACHES}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      evaluation documentation
+                    </Anchor>
+                    .
+                  </Text>
+
+                  <Upload
+                    accept=".jsonl"
+                    onValueChange={handleDatasetPicked}
+                    onFileRemove={() => setDatasetPick(null)}
+                    status={datasetPick?.error ? 'error' : undefined}
+                    renderInput={(slotInput) => (
+                      <FormField
+                        name="dataset"
+                        required
+                        slotLabel="Add dataset"
+                        slotHelp={`Uploaded as ${DATASET_FILENAME}. One JSON object per line.`}
+                        slotError={datasetPick?.error}
+                        status={datasetPick?.error ? 'error' : undefined}
+                      >
+                        {slotInput}
+                      </FormField>
+                    )}
+                  >
+                    JSON Lines (.jsonl)
+                  </Upload>
+
+                  <Upload
+                    accept=".json"
+                    onValueChange={handleConfigPicked}
+                    onFileRemove={() => setConfigPick(null)}
+                    status={configPick?.error ? 'error' : undefined}
+                    renderInput={(slotInput) => (
+                      <FormField
+                        name="evalConfig"
+                        required
+                        slotLabel="Select evaluator config"
+                        slotHelp={`Uploaded as ${EVAL_CONFIG_FILENAME}. The dataset reference and judge model below are overwritten for this run.`}
+                        slotError={configPick?.error}
+                        status={configPick?.error ? 'error' : undefined}
+                      >
+                        {slotInput}
+                      </FormField>
+                    )}
+                  >
+                    Dataset-driven eval config (.json)
+                  </Upload>
+
+                  {isLlmJudge && (
+                    <JudgeModelSelect<SubmitEvaluationFormData>
+                      formFieldName="judgeModel"
+                      slotLabel="Model for LLM evaluators"
+                    />
+                  )}
                 </>
               ) : (
                 <>

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -59,7 +59,7 @@ import {
   parseUploadedDatasetConfig,
   serializeEvalConfig,
 } from '@studio/components/evaluation/submitEvaluationJob';
-import { LINK_EVAL_DOCS, LINK_EVAL_DOCS_APPROACHES } from '@studio/constants/links';
+import { LINK_DOCS_STUDIO_EXPERIMENTS, LINK_EVAL_DOCS } from '@studio/constants/links';
 import { useJudgeModels } from '@studio/hooks/evaluation/useJudgeModels';
 import { getAgentEvaluationsTabRoute } from '@studio/routes/utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -745,7 +745,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                     <Anchor
                       kind="inline"
                       textKind="body/regular/md"
-                      href={LINK_EVAL_DOCS_APPROACHES}
+                      href={LINK_DOCS_STUDIO_EXPERIMENTS}
                       target="_blank"
                       rel="noreferrer"
                     >

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -8,7 +8,6 @@ import { FormModal, type FormModalProps } from '@nemo/common/src/components/Form
 import { getURNFromNamedEntityRef } from '@nemo/common/src/namedEntity';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { getEntityNameError } from '@nemo/common/src/utils/entityName';
-import { validateFileFormat } from '@nemo/common/src/utils/fileValidation';
 import { useAgentsListAgents } from '@nemo/sdk/generated/agents/api';
 import { evaluatorCreateEvaluateJob } from '@nemo/sdk/generated/evaluator/api';
 import type {
@@ -173,16 +172,42 @@ interface ConfigPick extends FilePick {
 const configFormatForFile = (name: string): EvalConfigFormat =>
   /\.ya?ml$/i.test(name) ? 'yaml' : 'json';
 
+const isRecord = (value: unknown): boolean =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
 /** Validate the dataset and settle the name it is stored under. The evaluator's loader takes
  *  ``.json`` and ``.jsonl`` interchangeably, sniffing a leading ``[`` to tell an array from
  *  line-delimited records — so the name follows the detected content, not the uploaded
- *  extension, and the dataset ref written into the config matches. */
+ *  extension, and the dataset ref written into the config matches.
+ *
+ *  Every record must be an object: the evaluator turns each one into a row keyed by its own
+ *  fields, and a file of scalars only fails once the job is running. Parsed here rather than
+ *  through ``validateFileFormat``, which does not check record shape and would mean reading a
+ *  large dataset into memory twice. */
 const inspectDatasetFile = async (file: File): Promise<Omit<DatasetPick, 'file'>> => {
-  const result = await validateFileFormat(file);
-  if (!result.isValid || (result.format !== 'json' && result.format !== 'jsonl')) {
-    return { error: result.error ?? 'File is not valid JSON or JSONL' };
+  const text = (await file.text()).trim();
+  if (!text) return { error: 'File is empty' };
+
+  let records: unknown[];
+  let format: 'json' | 'jsonl';
+  try {
+    const parsed: unknown = JSON.parse(text);
+    records = Array.isArray(parsed) ? parsed : [parsed];
+    format = 'json';
+  } catch {
+    try {
+      records = text.split('\n').flatMap((line) => (line.trim() ? [JSON.parse(line)] : []));
+      format = 'jsonl';
+    } catch {
+      return { error: 'File is not valid JSON or JSONL' };
+    }
   }
-  return { storedName: `${DATASET_BASENAME}.${result.format}` };
+
+  if (records.length === 0) return { error: 'File contains no data' };
+  if (!records.every(isRecord)) {
+    return { error: 'Every dataset record must be a JSON object.' };
+  }
+  return { storedName: `${DATASET_BASENAME}.${format}` };
 };
 
 interface SubmitEvaluationModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
@@ -321,6 +346,11 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const [datasetPick, setDatasetPick] = useState<DatasetPick | null>(null);
   const [configPick, setConfigPick] = useState<ConfigPick | null>(null);
 
+  // Bumped whenever a pick is replaced, removed, or reset, so an async validation that is
+  // still running when that happens knows to drop its result instead of committing it.
+  const datasetToken = useRef(0);
+  const configToken = useRef(0);
+
   const { data: agentsResponse, isLoading: isAgentsLoading } = useAgentsListAgents(
     workspace,
     undefined,
@@ -446,30 +476,54 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     }
   }, [open, isLlmJudge, defaultModelRef, judgeModels, getValues, setValue]);
 
-  // Both handlers clear first: validation is async, and leaving the previous pick in place
-  // would keep the submit gate open against a file the user has already replaced.
-  const handleDatasetPicked = async (item: { file: File }) => {
+  const clearDatasetPick = () => {
+    datasetToken.current += 1;
     setDatasetPick(null);
-    setDatasetPick({ file: item.file, ...(await inspectDatasetFile(item.file)) });
+  };
+
+  const clearConfigPick = () => {
+    configToken.current += 1;
+    setConfigPick(null);
+  };
+
+  // Both handlers clear first: validation is async, and leaving the previous pick in place
+  // would keep the submit gate open against a file the user has already replaced. Each also
+  // drops its own result if the pick it belongs to is no longer current — a slow read of a
+  // replaced file would otherwise land after a faster one and submit a file the card no
+  // longer shows. The tokens are per input: one shared counter would let a config pick
+  // cancel an in-flight dataset read, stranding the form with no pick and no error.
+  // Removing a file calls onValueChange with no item, so the argument is optional.
+  const handleDatasetPicked = async (item?: { file: File }) => {
+    clearDatasetPick();
+    if (!item?.file) return;
+    const token = datasetToken.current;
+    const inspected = await inspectDatasetFile(item.file);
+    if (token !== datasetToken.current) return;
+    setDatasetPick({ file: item.file, ...inspected });
   };
 
   // A fresh config also means a fresh judge: the preselect effect above bails once judgeModel
   // is set, so leaving it would keep the previous file's judge.
-  const handleConfigPicked = async (item: { file: File }) => {
+  const handleConfigPicked = async (item?: { file: File }) => {
     setValue('judgeModel', '');
-    setConfigPick(null);
+    clearConfigPick();
+    if (!item?.file) return;
+    const token = configToken.current;
+    let pick: ConfigPick;
     try {
-      setConfigPick({
+      pick = {
         file: item.file,
         spec: parseUploadedDatasetConfig(await item.file.text()),
         format: configFormatForFile(item.file.name),
-      });
+      };
     } catch (err) {
-      setConfigPick({
+      pick = {
         file: item.file,
         error: err instanceof Error ? err.message : 'Could not read the file',
-      });
+      };
     }
+    if (token !== configToken.current) return;
+    setConfigPick(pick);
   };
 
   const {
@@ -562,6 +616,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   useEffect(() => {
     if (open) return;
     resetForm(makeDefaultValues(agentProp));
+    datasetToken.current += 1;
+    configToken.current += 1;
     setDatasetPick(null);
     setConfigPick(null);
   }, [open, agentProp, resetForm]);
@@ -575,8 +631,8 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const resetAndClose = () => {
     resetMutation();
     resetForm(makeDefaultValues(agentProp));
-    setDatasetPick(null);
-    setConfigPick(null);
+    clearDatasetPick();
+    clearConfigPick();
     onClose();
   };
 
@@ -701,7 +757,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                   <Upload
                     accept=".jsonl,.json"
                     onValueChange={handleDatasetPicked}
-                    onFileRemove={() => setDatasetPick(null)}
+                    onFileRemove={clearDatasetPick}
                     status={datasetPick?.error ? 'error' : undefined}
                     renderInput={(slotInput) => (
                       <FormField
@@ -720,7 +776,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                   <Upload
                     accept=".json,.yaml,.yml"
                     onValueChange={handleConfigPicked}
-                    onFileRemove={() => setConfigPick(null)}
+                    onFileRemove={clearConfigPick}
                     status={configPick?.error ? 'error' : undefined}
                     renderInput={(slotInput) => (
                       <FormField

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -38,9 +38,10 @@ import { submitAgentEvalJob } from '@studio/api/evaluation/agent-evaluations';
 import { isConflictError } from '@studio/api/evaluation/eval-config-fileset';
 import {
   createRunEvaluation,
-  EVAL_CONFIG_FILENAME,
+  evalConfigFilename,
   evaluationConfigError,
   evaluationFilesetName,
+  findEvalConfigFile,
 } from '@studio/components/evaluation/experimentEvalConfig';
 import { JudgeModelSelect } from '@studio/components/evaluation/JudgeModelSelect';
 import {
@@ -48,15 +49,16 @@ import {
   buildAgentEvalRequestBody,
   buildDatasetEvalRequestBody,
   type DatasetEvalSpec,
+  type EvalConfigFormat,
   type EvalSpec,
   filesetNameForExperiment,
   injectJudgeModel,
   isDatasetEvalSpec,
-  generateEvalConfigName,
   MODE_DEFAULT,
   MODE_EXPERIMENT,
   parseEvalConfig,
   parseUploadedDatasetConfig,
+  serializeEvalConfig,
 } from '@studio/components/evaluation/submitEvaluationJob';
 import { LINK_EVAL_DOCS, LINK_EVAL_DOCS_APPROACHES } from '@studio/constants/links';
 import { useJudgeModels } from '@studio/hooks/evaluation/useJudgeModels';
@@ -72,7 +74,8 @@ const EVAL_CONFIG_MODE_ITEMS = [
   { value: MODE_EXPERIMENT, children: 'Use existing evaluation' },
 ];
 
-const DATASET_FILENAME = 'dataset.jsonl';
+/** Stem the dataset is stored under in the run's fileset; the extension follows its content. */
+const DATASET_BASENAME = 'dataset';
 
 /** Backend caps page_size at 100; the picker shows the most recent page. */
 const LIST_PAGE_SIZE = 100;
@@ -85,8 +88,10 @@ const submitEvaluationBaseSchema = z.object({
   judgeModel: z.string(),
   mode: z.enum([MODE_DEFAULT, MODE_EXPERIMENT]),
   /** Name of the experiment to create in "Create experiment" mode. The fileset holding this
-   *  run's eval-config.json and dataset is derived from it. */
+   *  run's eval config and dataset is derived from it. */
   newName: z.string(),
+  /** Name of the Intake Evaluation this run publishes under, in "Create experiment" mode. */
+  evaluationRecordName: z.string(),
   /** Name of the existing evaluation whose eval config is reused in "Use existing evaluation" mode. */
   evaluationName: z.string(),
 });
@@ -107,13 +112,24 @@ const makeSubmitEvaluationSchema = (requiresJudgeModel: () => boolean) =>
       // its own can still overflow once "-data" is appended, and there is no fileset field to
       // correct it in.
       const nameError =
-        getEntityNameError(data.newName.trim()) ??
+        getEntityNameError(data.newName.trim(), 'Experiment name') ??
         getEntityNameError(filesetNameForExperiment(data.newName.trim()), 'Derived fileset name');
       if (nameError) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: nameError,
           path: ['newName'],
+        });
+      }
+      const recordNameError = getEntityNameError(
+        data.evaluationRecordName.trim(),
+        'Evaluation name'
+      );
+      if (recordNameError) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: recordNameError,
+          path: ['evaluationRecordName'],
         });
       }
     }
@@ -130,7 +146,8 @@ const makeDefaultValues = (agent?: string): SubmitEvaluationFormData => ({
   agent: agent ?? '',
   judgeModel: '',
   mode: MODE_DEFAULT,
-  newName: generateEvalConfigName(),
+  newName: '',
+  evaluationRecordName: '',
   evaluationName: '',
 });
 
@@ -140,21 +157,32 @@ interface FilePick {
   error?: string;
 }
 
-/** The picked eval config, with its parsed spec once it validates. */
-interface ConfigPick extends FilePick {
-  spec?: DatasetEvalSpec;
+/** The picked dataset, with the name it will be stored under once it validates. */
+interface DatasetPick extends FilePick {
+  storedName?: string;
 }
 
-/** Reject anything that is not one JSON value per line. ``validateFileFormat`` reports a
- *  pretty-printed JSON document as valid ``json``, but the dataset is stored under a fixed
- *  ``dataset.jsonl`` name and referenced as such, so accepting one would only fail at job time. */
-const datasetFileError = async (file: File): Promise<string | undefined> => {
+/** The picked eval config, with its parsed spec once it validates. ``format`` follows the
+ *  uploaded extension, not the detected syntax: a file named .yaml is stored as YAML even if
+ *  its contents happen to be valid JSON, which is the mapping an author expects. */
+interface ConfigPick extends FilePick {
+  spec?: DatasetEvalSpec;
+  format?: EvalConfigFormat;
+}
+
+const configFormatForFile = (name: string): EvalConfigFormat =>
+  /\.ya?ml$/i.test(name) ? 'yaml' : 'json';
+
+/** Validate the dataset and settle the name it is stored under. The evaluator's loader takes
+ *  ``.json`` and ``.jsonl`` interchangeably, sniffing a leading ``[`` to tell an array from
+ *  line-delimited records — so the name follows the detected content, not the uploaded
+ *  extension, and the dataset ref written into the config matches. */
+const inspectDatasetFile = async (file: File): Promise<Omit<DatasetPick, 'file'>> => {
   const result = await validateFileFormat(file);
-  if (!result.isValid) return result.error ?? 'File is not valid JSON or JSONL';
-  if (result.format === 'json' && (await file.text()).trim().includes('\n')) {
-    return `${DATASET_FILENAME} must be JSON Lines: one JSON object per line.`;
+  if (!result.isValid || (result.format !== 'json' && result.format !== 'jsonl')) {
+    return { error: result.error ?? 'File is not valid JSON or JSONL' };
   }
-  return undefined;
+  return { storedName: `${DATASET_BASENAME}.${result.format}` };
 };
 
 interface SubmitEvaluationModalProps extends Pick<FormModalProps, 'open' | 'onClose'> {
@@ -209,7 +237,10 @@ const discardSeeded = async (
 /** The two files the user uploaded in "Create experiment" mode, already validated. */
 interface UploadedEvalInputs {
   dataset: File;
+  datasetName: string;
   spec: DatasetEvalSpec;
+  /** Serialization the config was uploaded in; the stored file keeps it. */
+  configFormat: EvalConfigFormat;
 }
 
 /** Resolves the persisted yardstick spec for this submission. In "Create experiment" mode
@@ -229,7 +260,7 @@ const loadPersistedSpec = async (
     const judgeModel = formData.judgeModel || null;
     const spec: DatasetEvalSpec = {
       ...uploads.spec,
-      dataset: `${workspace}/${name}#${DATASET_FILENAME}`,
+      dataset: `${workspace}/${name}#${uploads.datasetName}`,
       metrics: judgeModel
         ? uploads.spec.metrics.map((m) => injectJudgeModel(m, judgeModel))
         : uploads.spec.metrics,
@@ -246,12 +277,14 @@ const loadPersistedSpec = async (
       throw err;
     }
     try {
-      await filesUploadFile(workspace, name, DATASET_FILENAME, uploads.dataset, signal);
+      await filesUploadFile(workspace, name, uploads.datasetName, uploads.dataset, signal);
       await filesUploadFile(
         workspace,
         name,
-        EVAL_CONFIG_FILENAME,
-        new Blob([JSON.stringify(spec, null, 2)], { type: 'application/json' }),
+        evalConfigFilename(uploads.configFormat),
+        new Blob([serializeEvalConfig(spec, uploads.configFormat)], {
+          type: uploads.configFormat === 'yaml' ? 'application/yaml' : 'application/json',
+        }),
         signal
       );
     } catch (uploadErr) {
@@ -260,12 +293,12 @@ const loadPersistedSpec = async (
     return spec;
   }
   if (!configFileset) throw new Error('The selected evaluation has no eval config fileset');
-  const blob = await filesDownloadFile(
-    workspace,
-    configFileset,
-    EVAL_CONFIG_FILENAME,
-    new AbortController().signal
-  );
+  const signal = new AbortController().signal;
+  // The stored config keeps whichever serialization its author uploaded, so resolve the file
+  // by listing rather than assuming an extension. parseEvalConfig reads either.
+  const configFile = await findEvalConfigFile(workspace, configFileset, signal);
+  if (!configFile) throw new Error("Failed to read the selected evaluation's eval config");
+  const blob = await filesDownloadFile(workspace, configFileset, configFile, signal);
   if (!blob) throw new Error("Failed to read the selected evaluation's eval config");
   return parseEvalConfig(await blob.text());
 };
@@ -285,7 +318,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const isLlmJudgeRef = useRef(false);
   const [schema] = useState(() => makeSubmitEvaluationSchema(() => isLlmJudgeRef.current));
 
-  const [datasetPick, setDatasetPick] = useState<FilePick | null>(null);
+  const [datasetPick, setDatasetPick] = useState<DatasetPick | null>(null);
   const [configPick, setConfigPick] = useState<ConfigPick | null>(null);
 
   const { data: agentsResponse, isLoading: isAgentsLoading } = useAgentsListAgents(
@@ -316,7 +349,6 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const selectedAgent = useWatch({ control, name: 'agent' });
 
   const agentFieldError = errors.agent?.message;
-  const newName = useWatch({ control, name: 'newName' });
   const evaluationName = useWatch({ control, name: 'evaluationName' });
 
   const { data: evaluationsResponse, isLoading: isEvaluationsLoading } = useListEvaluations(
@@ -333,7 +365,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     { query: { enabled: open && mode === MODE_EXPERIMENT } }
   );
   const evaluations = evaluationsResponse?.data ?? [];
-  /* The eval-config.json is identified on each Evaluation by convention in Studio.
+  /* The eval config is identified on each Evaluation by convention in Studio.
    * It's not persisted by the CLI or API at all. Only Studio created jobs will
    * have this field written to the Evaluation's metadata (dict[str,str]).
    * Unfortunately there's no existing way for Evaluations to be matched to the
@@ -370,8 +402,13 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   const evaluationFieldError = errors.evaluationName?.message ?? evaluationConfigIssue ?? undefined;
 
   const uploads: UploadedEvalInputs | null =
-    datasetPick?.file && !datasetPick.error && configPick?.spec && !configPick.error
-      ? { dataset: datasetPick.file, spec: configPick.spec }
+    datasetPick?.storedName && !datasetPick.error && configPick?.spec && !configPick.error
+      ? {
+          dataset: datasetPick.file,
+          datasetName: datasetPick.storedName,
+          spec: configPick.spec,
+          configFormat: configPick.format ?? 'json',
+        }
       : null;
 
   const canSubmit =
@@ -379,8 +416,10 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
       ? !!uploads
       : !isValidatingEvaluation && !!selectedEvaluation && !evaluationConfigIssue;
 
+  // Mirrors injectJudgeModel's own guard, so the picker is shown exactly when a metric would
+  // have a model written into it — not just for the llm-judge type.
   const judgeMetric = configPick?.spec?.metrics.find(
-    (metric) => metric.metric_type === 'llm-judge'
+    (metric) => metric.metric_type === 'llm-judge' || 'model' in metric.payload.metric
   );
 
   const isLlmJudge = mode === MODE_DEFAULT && !!judgeMetric;
@@ -411,7 +450,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
   // would keep the submit gate open against a file the user has already replaced.
   const handleDatasetPicked = async (item: { file: File }) => {
     setDatasetPick(null);
-    setDatasetPick({ file: item.file, error: await datasetFileError(item.file) });
+    setDatasetPick({ file: item.file, ...(await inspectDatasetFile(item.file)) });
   };
 
   // A fresh config also means a fresh judge: the preselect effect above bails once judgeModel
@@ -420,7 +459,11 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     setValue('judgeModel', '');
     setConfigPick(null);
     try {
-      setConfigPick({ file: item.file, spec: parseUploadedDatasetConfig(await item.file.text()) });
+      setConfigPick({
+        file: item.file,
+        spec: parseUploadedDatasetConfig(await item.file.text()),
+        format: configFormatForFile(item.file.name),
+      });
     } catch (err) {
       setConfigPick({
         file: item.file,
@@ -471,9 +514,17 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
 
         const evaluationId = await createRunEvaluation(workspace, {
           experimentIds,
+          name: isNew ? formData.evaluationRecordName.trim() : undefined,
           nameStem,
           filesetName,
           parentEvaluationId,
+        }).catch((err: unknown) => {
+          if (isConflictError(err)) {
+            throw new Error(
+              `An evaluation named "${formData.evaluationRecordName.trim()}" already exists — choose a different evaluation name`
+            );
+          }
+          throw err;
         });
         seeded.evaluationName = evaluationId;
 
@@ -610,11 +661,23 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                 <>
                   <ControlledTextInput
                     useControllerProps={{ control, name: 'newName' }}
-                    selectOnFocus
+                    placeholder="e.g. Model update tests"
                     formFieldProps={{
                       slotLabel: 'Experiment Name',
-                      slotHelp: `Groups this run and future ones against the same config. Its ${EVAL_CONFIG_FILENAME} and dataset are stored in a fileset named "${filesetNameForExperiment(newName.trim() || '<name>')}".`,
+                      required: true,
+                      slotHelp: 'Groups multiple evaluation runs together for comparison.',
                       slotError: errors.newName?.message,
+                    }}
+                  />
+
+                  <ControlledTextInput
+                    useControllerProps={{ control, name: 'evaluationRecordName' }}
+                    placeholder="e.g. Initial baseline"
+                    formFieldProps={{
+                      slotLabel: 'Evaluation Name',
+                      required: true,
+                      slotHelp: 'Names this run within the experiment. Results publish under it.',
+                      slotError: errors.evaluationRecordName?.message,
                     }}
                   />
 
@@ -636,7 +699,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                   </Text>
 
                   <Upload
-                    accept=".jsonl"
+                    accept=".jsonl,.json"
                     onValueChange={handleDatasetPicked}
                     onFileRemove={() => setDatasetPick(null)}
                     status={datasetPick?.error ? 'error' : undefined}
@@ -645,19 +708,17 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                         name="dataset"
                         required
                         slotLabel="Add dataset"
-                        slotHelp={`Uploaded as ${DATASET_FILENAME}. One JSON object per line.`}
+                        slotHelp="JSONL, or a JSON array of objects."
                         slotError={datasetPick?.error}
                         status={datasetPick?.error ? 'error' : undefined}
                       >
-                        {slotInput}
+                        {datasetPick ? null : slotInput}
                       </FormField>
                     )}
-                  >
-                    JSON Lines (.jsonl)
-                  </Upload>
+                  />
 
                   <Upload
-                    accept=".json"
+                    accept=".json,.yaml,.yml"
                     onValueChange={handleConfigPicked}
                     onFileRemove={() => setConfigPick(null)}
                     status={configPick?.error ? 'error' : undefined}
@@ -666,16 +727,14 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                         name="evalConfig"
                         required
                         slotLabel="Select evaluator config"
-                        slotHelp={`Uploaded as ${EVAL_CONFIG_FILENAME}. The dataset reference and judge model below are overwritten for this run.`}
+                        slotHelp="Select a JSON or YAML config."
                         slotError={configPick?.error}
                         status={configPick?.error ? 'error' : undefined}
                       >
-                        {slotInput}
+                        {configPick ? null : slotInput}
                       </FormField>
                     )}
-                  >
-                    Dataset-driven eval config (.json)
-                  </Upload>
+                  />
 
                   {isLlmJudge && (
                     <JudgeModelSelect<SubmitEvaluationFormData>
@@ -699,7 +758,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
                       )}
                       formFieldProps={{
                         slotLabel: 'Evaluation',
-                        slotHelp: `Reuses the selected evaluation's ${EVAL_CONFIG_FILENAME}.`,
+                        slotHelp: "Reuses the selected evaluation's saved eval config.",
                         slotError: evaluationFieldError,
                         status: evaluationFieldError ? 'error' : undefined,
                       }}

--- a/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
+++ b/web/packages/studio/src/components/evaluation/SubmitEvaluationModal.tsx
@@ -442,7 +442,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     reValidateMode: 'onChange',
   });
   const { control, reset: resetForm, setValue, handleSubmit, clearErrors, formState } = methods;
-  const { errors, touchedFields } = formState;
+  const { errors } = formState;
 
   const mode = useWatch({ control, name: 'mode' });
   const selectedAgent = useWatch({ control, name: 'agent' });
@@ -547,7 +547,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     entity: 'experiment',
     preview: experimentPreview,
     status: experimentNameStatus,
-    schemaError: touchedFields.newName ? errors.newName?.message : undefined,
+    schemaError: errors.newName?.message,
     describe: 'Groups multiple evaluation runs together for comparison.',
   });
 
@@ -555,9 +555,7 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
     entity: 'evaluation',
     preview: recordPreview,
     status: recordNameStatus,
-    schemaError: touchedFields.evaluationRecordName
-      ? errors.evaluationRecordName?.message
-      : undefined,
+    schemaError: errors.evaluationRecordName?.message,
     describe: 'Names this run within the experiment. Results publish under it.',
   });
 
@@ -777,7 +775,13 @@ export const SubmitEvaluationModal: FC<SubmitEvaluationModalProps> = ({
 
   const onSubmit: SubmitHandler<SubmitEvaluationFormData> = async (formData) => {
     // The resolver has passed; these are the gates held outside form state.
-    if (mode === MODE_DEFAULT && (!uploads || hasNameConflict)) return;
+    // isJudgeModelsLoading blocks too: invalidModelRefs is empty while the list is in flight, so
+    // submitting inside that window would skip the check entirely.
+    if (
+      mode === MODE_DEFAULT &&
+      (!uploads || hasNameConflict || (isLlmJudge && isJudgeModelsLoading))
+    )
+      return;
     if (
       mode === MODE_EXPERIMENT &&
       (isValidatingEvaluation || !selectedEvaluation || evaluationConfigIssue)

--- a/web/packages/studio/src/components/evaluation/experimentEvalConfig.ts
+++ b/web/packages/studio/src/components/evaluation/experimentEvalConfig.ts
@@ -3,7 +3,10 @@
 
 import { createEvaluation, filesListFilesetFiles } from '@nemo/sdk/generated/platform/api';
 import type { EvaluationResponse } from '@nemo/sdk/generated/platform/schema';
-import { buildEvalJobName } from '@studio/components/evaluation/submitEvaluationJob';
+import {
+  buildEvalJobName,
+  type EvalConfigFormat,
+} from '@studio/components/evaluation/submitEvaluationJob';
 
 /** Evaluation metadata key holding the name of the fileset that stores its eval config.
  *  Lives on the Evaluation, not its ExperimentGroup: the config is a property of a single
@@ -12,8 +15,31 @@ import { buildEvalJobName } from '@studio/components/evaluation/submitEvaluation
 export const EVAL_CONFIG_FILESET_KEY = 'eval_config_fileset';
 
 /** Flat filename the reusable config is stored as inside its fileset. Every reusable
- *  evaluation's fileset carries one at the root — there is no per-run file picker. */
-export const EVAL_CONFIG_FILENAME = 'eval-config.json';
+ *  evaluation's fileset carries one at the root — there is no per-run file picker. The
+ *  extension records the serialization its author uploaded. */
+export const evalConfigFilename = (format: EvalConfigFormat): string => `eval-config.${format}`;
+
+/** Names a stored config may go by, newest convention first. ``.yml`` is read but never
+ *  written, so a fileset seeded by hand or by an older client still resolves. */
+export const EVAL_CONFIG_FILENAMES = [
+  evalConfigFilename('json'),
+  evalConfigFilename('yaml'),
+  'eval-config.yml',
+] as const;
+
+/** The config file a fileset actually carries at its root, or null when it carries none. */
+export const findEvalConfigFile = async (
+  workspace: string,
+  filesetName: string,
+  signal?: AbortSignal
+): Promise<string | null | undefined> => {
+  const files = await filesListFilesetFiles(workspace, filesetName, undefined, signal).catch(
+    () => null
+  );
+  if (!files) return undefined;
+  const paths = new Set((files.data ?? []).map((file) => file.path));
+  return EVAL_CONFIG_FILENAMES.find((name) => paths.has(name)) ?? null;
+};
 
 /** The fileset an Evaluation stores its eval config in, or null when it names none. A blank
  *  or whitespace-only metadata value counts as "none": it would otherwise pass the picker's
@@ -25,7 +51,7 @@ export const evaluationFilesetName = (evaluation: EvaluationResponse): string | 
 };
 
 /** Why an Evaluation cannot be reused, or null when it can. Two ways to be invalid:
- *  it names no fileset, or the fileset it names has no eval-config.json at the root. */
+ *  it names no fileset, or the fileset it names has no eval config at the root. */
 export const evaluationConfigError = async (
   workspace: string,
   evaluation: EvaluationResponse,
@@ -35,40 +61,41 @@ export const evaluationConfigError = async (
   if (!filesetName) {
     return `Evaluation "${evaluation.name}" has no eval config fileset. Pick another evaluation, or create one from a template.`;
   }
-  const files = await filesListFilesetFiles(workspace, filesetName, undefined, signal).catch(
-    () => null
-  );
-  if (!files) {
+  const configFile = await findEvalConfigFile(workspace, filesetName, signal);
+  if (configFile === undefined) {
     return `Could not read fileset "${filesetName}" for evaluation "${evaluation.name}". Pick another evaluation.`;
   }
-  const hasConfig = (files.data ?? []).some((file) => file.path === EVAL_CONFIG_FILENAME);
-  return hasConfig
+  return configFile
     ? null
-    : `Fileset "${filesetName}" has no ${EVAL_CONFIG_FILENAME} at its root, so evaluation "${evaluation.name}" cannot be reused. Pick another evaluation.`;
+    : `Fileset "${filesetName}" has no ${EVAL_CONFIG_FILENAMES.join(' or ')} at its root, so evaluation "${evaluation.name}" cannot be reused. Pick another evaluation.`;
 };
 
 /** Create the Intake Evaluation this run publishes under, returning its **name** —
  *  which is what ``publication.intake.evaluation_id`` takes (the entity id is not it).
  *  The eval-config fileset pointer is written to the Evaluation's own ``metadata`` (the
  *  documented "config snapshot" home) so a later run can reuse it; ``parentEvaluationId``
- *  records the evaluation this one was derived from, when reusing an existing one. */
+ *  records the evaluation this one was derived from, when reusing an existing one.
+ *  ``name`` is the user-supplied record name where there is one; without it the name is
+ *  generated from ``nameStem`` with a random suffix so repeat runs do not collide. */
 export const createRunEvaluation = async (
   workspace: string,
   {
     experimentIds,
+    name: explicitName,
     nameStem,
     filesetName,
     parentEvaluationId,
     signal,
   }: {
     experimentIds: string[];
+    name?: string;
     nameStem: string;
     filesetName: string;
     parentEvaluationId?: string;
     signal?: AbortSignal;
   }
 ): Promise<string> => {
-  const name = buildEvalJobName(nameStem);
+  const name = explicitName || buildEvalJobName(nameStem);
   await createEvaluation(
     workspace,
     {

--- a/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
+++ b/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
@@ -244,11 +244,38 @@ export const serializeEvalConfig = (spec: EvalSpec, format: EvalConfigFormat): s
 /** Reject metric entries that cannot be read as a metric bundle. Studio does not validate the
  *  metric body, but it does reach into ``payload.metric`` to decide whether a judge applies —
  *  so an entry without one would throw at render, past every error boundary this form has. */
+/** The evaluator recomputes an llm-judge's ``output_spec()`` from ``payload.metric.scores`` and
+ *  rejects the job if it disagrees with the declared ``outputs`` — but only after the run's
+ *  fileset already exists, so the mismatch is caught here instead. llm-judge only: other metric
+ *  types derive their outputs by different rules. */
+const assertJudgeOutputsMatchScores = (metric: InlineMetricBundle, where: string): void => {
+  if (metric.metric_type !== 'llm-judge') return;
+  const scores = metric.payload.metric.scores;
+  if (!Array.isArray(scores) || !Array.isArray(metric.outputs)) return;
+
+  const scoreNames = scores
+    .map((score) => (score as { name?: unknown })?.name)
+    .filter((name): name is string => typeof name === 'string');
+  const declared = new Set(
+    metric.outputs
+      .map((output) => (output as { name?: unknown })?.name)
+      .filter((name): name is string => typeof name === 'string')
+  );
+
+  const missing = scoreNames.filter((name) => !declared.has(name));
+  if (missing.length > 0) {
+    throw new Error(
+      `${where} has an llm-judge metric whose "outputs" do not list its score${missing.length > 1 ? 's' : ''} ${missing.map((name) => `"${name}"`).join(', ')}. Every entry in "scores" needs a matching entry in "outputs".`
+    );
+  }
+};
+
 const assertMetricBundles = (metrics: InlineMetricBundle[], where: string): void => {
   for (const metric of metrics) {
     if (!metric?.payload?.metric || typeof metric.payload.metric !== 'object') {
       throw new Error(`${where} has a metric without a "payload.metric" object`);
     }
+    assertJudgeOutputsMatchScores(metric, where);
   }
 };
 

--- a/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
+++ b/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
@@ -273,3 +273,22 @@ export const parseEvalConfig = (text: string): EvalSpec => {
   }
   return { tasks: parsed.tasks, max_concurrent_tasks: parsed.max_concurrent_tasks };
 };
+
+/** Parse a user-uploaded eval-config.json for the "create experiment" flow, which only runs
+ *  dataset-driven configs. The dataset arrives as a separate upload and its ref is written in
+ *  at submit, so a config that omits ``dataset`` entirely is accepted and filled in here —
+ *  otherwise an author would have to hand-write a placeholder that is immediately discarded. */
+export const parseUploadedDatasetConfig = (text: string): DatasetEvalSpec => {
+  const raw = JSON.parse(text) as Partial<PersistedEvalSpec & DatasetEvalSpec>;
+  const spec = parseEvalConfig(
+    JSON.stringify(
+      raw.tasks === undefined && raw.dataset === undefined ? { ...raw, dataset: '' } : raw
+    )
+  );
+  if (!isDatasetEvalSpec(spec)) {
+    throw new Error(
+      'This eval config is task-driven. Uploading a config requires the dataset-driven form: a "prompt_template" and a non-empty "metrics" array scored over the uploaded dataset.'
+    );
+  }
+  return spec;
+};

--- a/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
+++ b/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
@@ -4,6 +4,7 @@
 import { FILESET_NAME_MAX_LENGTH, toValidFilesetName } from '@nemo/common/src/utils/filesetName';
 import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
 
 /** Sentinel ``evalConfig`` value that switches the form into create mode. */
 export const CREATE_NEW = '__create_new__';
@@ -232,12 +233,18 @@ export const buildDatasetEvalRequestBody = (
   },
 });
 
-/** Parse an eval-config.json. Every task must carry its own ``metrics[]`` —
+/** The serialization an eval config is stored in. Both are accepted on upload and read back
+ *  on reuse; a run keeps whichever the author uploaded. */
+export type EvalConfigFormat = 'json' | 'yaml';
+
+/** Serialize a spec for storage in a fileset, in the format its author uploaded. */
+export const serializeEvalConfig = (spec: EvalSpec, format: EvalConfigFormat): string =>
+  format === 'yaml' ? stringifyYaml(spec) : JSON.stringify(spec, null, 2);
+
+/** Validate a parsed eval config. Every task must carry its own ``metrics[]`` —
  *  the config is submitted as authored, with only the judge model and the
  *  per-run agent target applied on top. */
-export const parseEvalConfig = (text: string): EvalSpec => {
-  const raw = JSON.parse(text) as Partial<PersistedEvalSpec & DatasetEvalSpec>;
-
+const validateEvalConfig = (raw: Partial<PersistedEvalSpec & DatasetEvalSpec>): EvalSpec => {
   if (raw.dataset !== undefined) {
     if (!Array.isArray(raw.metrics) || raw.metrics.length === 0) {
       throw new Error('a dataset-driven eval-config.json must contain a non-empty "metrics" array');
@@ -274,16 +281,38 @@ export const parseEvalConfig = (text: string): EvalSpec => {
   return { tasks: parsed.tasks, max_concurrent_tasks: parsed.max_concurrent_tasks };
 };
 
-/** Parse a user-uploaded eval-config.json for the "create experiment" flow, which only runs
+/** Parse a stored eval config, in either serialization. */
+export const parseEvalConfig = (text: string): EvalSpec =>
+  validateEvalConfig(parseConfigDocument(text));
+
+/** Read a config as JSON or YAML. JSON is tried first even though YAML 1.2 is a
+ *  superset of it: a JSON document indented with tabs is legal JSON but illegal YAML, and
+ *  a JSON file should fail with a JSON parser's message rather than a YAML one. */
+const parseConfigDocument = (text: string): Partial<PersistedEvalSpec & DatasetEvalSpec> => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (jsonErr) {
+    try {
+      parsed = parseYaml(text);
+    } catch {
+      throw jsonErr;
+    }
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('An eval config must be a JSON or YAML object.');
+  }
+  return parsed as Partial<PersistedEvalSpec & DatasetEvalSpec>;
+};
+
+/** Parse a user-uploaded eval config for the "create experiment" flow, which only runs
  *  dataset-driven configs. The dataset arrives as a separate upload and its ref is written in
  *  at submit, so a config that omits ``dataset`` entirely is accepted and filled in here —
  *  otherwise an author would have to hand-write a placeholder that is immediately discarded. */
 export const parseUploadedDatasetConfig = (text: string): DatasetEvalSpec => {
-  const raw = JSON.parse(text) as Partial<PersistedEvalSpec & DatasetEvalSpec>;
-  const spec = parseEvalConfig(
-    JSON.stringify(
-      raw.tasks === undefined && raw.dataset === undefined ? { ...raw, dataset: '' } : raw
-    )
+  const raw = parseConfigDocument(text);
+  const spec = validateEvalConfig(
+    raw.tasks === undefined && raw.dataset === undefined ? { ...raw, dataset: '' } : raw
   );
   if (!isDatasetEvalSpec(spec)) {
     throw new Error(

--- a/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
+++ b/web/packages/studio/src/components/evaluation/submitEvaluationJob.ts
@@ -241,6 +241,17 @@ export type EvalConfigFormat = 'json' | 'yaml';
 export const serializeEvalConfig = (spec: EvalSpec, format: EvalConfigFormat): string =>
   format === 'yaml' ? stringifyYaml(spec) : JSON.stringify(spec, null, 2);
 
+/** Reject metric entries that cannot be read as a metric bundle. Studio does not validate the
+ *  metric body, but it does reach into ``payload.metric`` to decide whether a judge applies —
+ *  so an entry without one would throw at render, past every error boundary this form has. */
+const assertMetricBundles = (metrics: InlineMetricBundle[], where: string): void => {
+  for (const metric of metrics) {
+    if (!metric?.payload?.metric || typeof metric.payload.metric !== 'object') {
+      throw new Error(`${where} has a metric without a "payload.metric" object`);
+    }
+  }
+};
+
 /** Validate a parsed eval config. Every task must carry its own ``metrics[]`` —
  *  the config is submitted as authored, with only the judge model and the
  *  per-run agent target applied on top. */
@@ -252,6 +263,7 @@ const validateEvalConfig = (raw: Partial<PersistedEvalSpec & DatasetEvalSpec>): 
     if (!raw.prompt_template) {
       throw new Error('a dataset-driven eval-config.json must contain a "prompt_template"');
     }
+    assertMetricBundles(raw.metrics, 'a dataset-driven eval-config.json');
     return {
       dataset: raw.dataset,
       metrics: raw.metrics,
@@ -270,13 +282,7 @@ const validateEvalConfig = (raw: Partial<PersistedEvalSpec & DatasetEvalSpec>): 
         `eval-config.json task "${task.id}" must contain a non-empty "metrics" array`
       );
     }
-    for (const metric of task.metrics) {
-      if (!metric?.payload?.metric || typeof metric.payload.metric !== 'object') {
-        throw new Error(
-          `eval-config.json task "${task.id}" has a metric without a "payload.metric" object`
-        );
-      }
-    }
+    assertMetricBundles(task.metrics, `eval-config.json task "${task.id}"`);
   }
   return { tasks: parsed.tasks, max_concurrent_tasks: parsed.max_concurrent_tasks };
 };

--- a/web/packages/studio/src/constants/links.ts
+++ b/web/packages/studio/src/constants/links.ts
@@ -8,6 +8,7 @@ const GITHUB_REPO_URL = 'https://github.com/NVIDIA-NeMo/nemo-platform';
 export const LINK_DOCS_STUDIO = `${DOCS_BASE_URL}studio`;
 export const LINK_DOCS_STUDIO_CUSTOMIZATION = `${DOCS_BASE_URL}customizer-reference`;
 export const LINK_DOCS_STUDIO_EVALUATION = `${DOCS_BASE_URL}evaluate-models`;
+export const LINK_DOCS_STUDIO_EXPERIMENTS = `${DOCS_BASE_URL}studio/experiments`;
 export const LINK_DOCS_PROJECT = `${DOCS_BASE_URL}get-started/core-concepts/projects`;
 export const LINK_DOCS_DATASETS = `${DOCS_BASE_URL}get-started/core-concepts/manage-files`;
 export const LINK_DOCS_MODELS = `${DOCS_BASE_URL}models-and-inference`;


### PR DESCRIPTION
## Validation showing

<img width="695" height="952" alt="Screenshot 2026-08-27 at 3 11 51 PM" src="https://github.com/user-attachments/assets/a1ad60b7-487b-497d-a9a0-3652735b6c0c" />

## Happy path

<img width="698" height="977" alt="Screenshot 2026-08-27 at 3 11 18 PM" src="https://github.com/user-attachments/assets/75a03929-805c-4183-a85a-10c62b362858" />



## What

Open up the Run Agent Evaluation modal: users now upload their own evaluator config and dataset instead of silently copying the canned sample.

## Form changes

- **Two required uploads** in "Create experiment" mode — dataset first, then evaluator config
- **Validated at pick time**, not submit. Malformed JSON/YAML/JSONL and task-driven configs are rejected the moment the file is chosen, with the error inline on the field. Submit stays disabled until both files are valid.
- **Experiment name** is blank with an `e.g. Model update tests` placeholder (no more auto-generated animal-adjective name), and required.
- **New required "Evaluation name" field** (`e.g. Initial baseline`) — the Intake Evaluation record is now user-named instead of auto-generated. A name collision reports "already exists — choose a different evaluation name" rather than a raw 409.
- **Fileset Name field removed** — derived as `<experiment>-data`.
- **Judge model picker auto-detects and self-gates.** Shown only when the uploaded config has a metric that would receive a model

## Formats

**Dataset** — `.jsonl` or `.json`. 

**Config** — `.json`, `.yaml`, or `.yml`.

The stored config keeps the format it arrived in — `eval-config.yaml` for YAML, `eval-config.json` for JSON

Reuse mode can now use either json//yaml

Nothing changed on the wire — the job POST always inlines the parsed spec, so the stored serialization never reaches the evaluator.

## Interpolation

Unchanged: the judge model is still baked into the metrics, and `dataset` is still overwritten with `<workspace>/<fileset>#<dataset file>` pointing at the fileset created for this run. Order of operations is unchanged (fileset + uploads → experiment → evaluation → POST).

## Also

Added `public/sample-agents/email-security-triage/eval-config.dataset-driven.yml` — a YAML twin of the existing JSON sample, for testing the upload path. Verified 1:1: it deep-equals the JSON through `YAML.parse`, and `parseUploadedDatasetConfig` returns `toStrictEqual` specs for both.

## Known limits

- We stay narrower than the backend on datasets. The evaluator also loads `.csv`, `.parquet`, `.feather`, `.arrow`, `.orc` (+ `.gz`), but pick-time validation can only inspect JSON/JSONL — a bad CSV or Parquet would upload unvalidated and fail inside the job, and unlike JSON it has no fallback loader to rescue it.
- A single-line `.jsonl` dataset is stored as `dataset.json`, since one JSON value on one line reads as `json`. Harmless (the evaluator reads either identically), but the filename won't always match what was dragged in.
- The name placeholders (`e.g. Model update tests`) are not legal entity names — typed verbatim they fail validation, though the error suggests a sanitized alternative.
- A config and dataset can disagree on field names; that surfaces at job time, not pick time. Inherent to letting users supply both.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Create experiments with uploaded JSON/JSONL datasets and JSON/YAML evaluation configurations.
- Preserve uploaded configuration formats when storing experiments.
- Support separate experiment and evaluation names with automatic fileset naming.
- Support dataset-driven evaluations, judge-model selection, and required model overrides.
- Added an email-security triage evaluation example.

## Bug Fixes
- Improved upload, naming, reset, and submission validation with clearer server error details.
- Prevented submissions with missing files, conflicting names, invalid fileset names, or incomplete metrics.
- Added evaluation-configuration discovery across JSON, YAML, and legacy formats.

## Documentation
- Added Studio Experiments documentation, workflow examples, and navigation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->