### PR TITLE
feat(guardrails): filter virtual models by guardrail config, refuse deleting one in use (ASTD-496)

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -3804,8 +3804,9 @@ JSON-only fields:
   created_at: \{gte: str, lte: str}
   updated_at: \{gte: str, lte: str}
 
-Filter virtual models by workspace, project, name, default_model_entity, created_at, and updated_at.
+Filter virtual models by workspace, project, name, default_model_entity, guardrail_config, created_at, and updated_at.
 * `--filter.default-model-entity`
+* `--filter.guardrail-config`
 * `--filter.name`
 * `--filter.project`
 * `--filter.workspace`

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -2482,6 +2482,9 @@ paths:
                 $ref: '#/components/schemas/DeleteResponse'
         '404':
           description: Config does not exist.
+        '409':
+          description: Config is applied by one or more VirtualModels and cannot be
+            deleted.
         '422':
           description: Unable to delete config due to validation error while processing
             request.
@@ -3466,7 +3469,7 @@ paths:
         schema:
           $ref: '#/components/schemas/VirtualModelFilter'
         description: Filter virtual models by workspace, project, name, default_model_entity,
-          created_at, and updated_at.
+          guardrail_config, created_at, and updated_at.
       responses:
         '200':
           description: Paginated list of virtual models
@@ -20059,6 +20062,15 @@ components:
         override_proxy:
           title: Override Proxy
           type: string
+        guardrail_config_ids:
+          items:
+            type: string
+          type: array
+          title: Guardrail Config Ids
+          description: System-managed. Guardrail configs applied by this VirtualModel's
+            middleware, as "workspace/name" references. Derived from the middleware
+            pipelines on every write and ignored if supplied on a create or update
+            body. Filter on it with filter[guardrail_config].
         id:
           type: string
           title: Id
@@ -20174,6 +20186,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/DatetimeFilter'
           description: Filter by update date.
+        guardrail_config:
+          description: Filter by a guardrail config reference in "workspace/name"
+            form. Matches VirtualModels whose request, response, or post-response
+            middleware applies that stored guardrail config.
+          title: Guardrail Config
+          type: string
       title: VirtualModelFilter
       type: object
     VirtualModelInferenceConfig:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -2482,6 +2482,9 @@ paths:
                 $ref: '#/components/schemas/DeleteResponse'
         '404':
           description: Config does not exist.
+        '409':
+          description: Config is applied by one or more VirtualModels and cannot be
+            deleted.
         '422':
           description: Unable to delete config due to validation error while processing
             request.
@@ -3466,7 +3469,7 @@ paths:
         schema:
           $ref: '#/components/schemas/VirtualModelFilter'
         description: Filter virtual models by workspace, project, name, default_model_entity,
-          created_at, and updated_at.
+          guardrail_config, created_at, and updated_at.
       responses:
         '200':
           description: Paginated list of virtual models
@@ -20059,6 +20062,15 @@ components:
         override_proxy:
           title: Override Proxy
           type: string
+        guardrail_config_ids:
+          items:
+            type: string
+          type: array
+          title: Guardrail Config Ids
+          description: System-managed. Guardrail configs applied by this VirtualModel's
+            middleware, as "workspace/name" references. Derived from the middleware
+            pipelines on every write and ignored if supplied on a create or update
+            body. Filter on it with filter[guardrail_config].
         id:
           type: string
           title: Id
@@ -20174,6 +20186,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/DatetimeFilter'
           description: Filter by update date.
+        guardrail_config:
+          description: Filter by a guardrail config reference in "workspace/name"
+            form. Matches VirtualModels whose request, response, or post-response
+            middleware applies that stored guardrail config.
+          title: Guardrail Config
+          type: string
       title: VirtualModelFilter
       type: object
     VirtualModelInferenceConfig:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -2482,6 +2482,9 @@ paths:
                 $ref: '#/components/schemas/DeleteResponse'
         '404':
           description: Config does not exist.
+        '409':
+          description: Config is applied by one or more VirtualModels and cannot be
+            deleted.
         '422':
           description: Unable to delete config due to validation error while processing
             request.
@@ -3466,7 +3469,7 @@ paths:
         schema:
           $ref: '#/components/schemas/VirtualModelFilter'
         description: Filter virtual models by workspace, project, name, default_model_entity,
-          created_at, and updated_at.
+          guardrail_config, created_at, and updated_at.
       responses:
         '200':
           description: Paginated list of virtual models
@@ -20059,6 +20062,15 @@ components:
         override_proxy:
           title: Override Proxy
           type: string
+        guardrail_config_ids:
+          items:
+            type: string
+          type: array
+          title: Guardrail Config Ids
+          description: System-managed. Guardrail configs applied by this VirtualModel's
+            middleware, as "workspace/name" references. Derived from the middleware
+            pipelines on every write and ignored if supplied on a create or update
+            body. Filter on it with filter[guardrail_config].
         id:
           type: string
           title: Id
@@ -20174,6 +20186,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/DatetimeFilter'
           description: Filter by update date.
+        guardrail_config:
+          description: Filter by a guardrail config reference in "workspace/name"
+            form. Matches VirtualModels whose request, response, or post-response
+            middleware applies that stored guardrail config.
+          title: Guardrail Config
+          type: string
       title: VirtualModelFilter
       type: object
     VirtualModelInferenceConfig:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/virtual_models.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/api/inference/virtual_models.py
@@ -225,12 +225,15 @@ def list_virtual_models(
         typer.Option(
             "--filter",
             metavar="FILTER_JSON",
-            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  created_at: {gte: str, lte: str}\n  updated_at: {gte: str, lte: str}\n\nFilter virtual models by workspace, project, name, default_model_entity, created_at, and updated_at.",
+            help="Use --filter with JSON for complex/nested queries, or --filter.FIELD options for simple fields. Both can be combined, with field options taking precedence.\nJSON-only fields:\n  created_at: {gte: str, lte: str}\n  updated_at: {gte: str, lte: str}\n\nFilter virtual models by workspace, project, name, default_model_entity, guardrail_config, created_at, and updated_at.",
             rich_help_panel="Filter Options",
         ),
     ] = None,
     filter_default_model_entity: Annotated[
         str | None, typer.Option("--filter.default-model-entity", rich_help_panel="Filter Options")
+    ] = None,
+    filter_guardrail_config: Annotated[
+        str | None, typer.Option("--filter.guardrail-config", rich_help_panel="Filter Options")
     ] = None,
     filter_name: Annotated[str | None, typer.Option("--filter.name", rich_help_panel="Filter Options")] = None,
     filter_project: Annotated[str | None, typer.Option("--filter.project", rich_help_panel="Filter Options")] = None,
@@ -271,6 +274,7 @@ def list_virtual_models(
         filter=merge_filter_dict(
             filter,
             default_model_entity=filter_default_model_entity,
+            guardrail_config=filter_guardrail_config,
             name=filter_name,
             project=filter_project,
             workspace=filter_workspace,

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
@@ -72,7 +72,7 @@ from abc import ABC
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, AsyncIterator, Protocol, Self, TypeAlias, Union, runtime_checkable
+from typing import Any, AsyncIterator, Iterator, Protocol, Self, TypeAlias, Union, runtime_checkable
 
 import anthropic.types as anthropic_types
 import anthropic.types.message_create_params as anthropic_params
@@ -80,6 +80,7 @@ import openai.types.chat as openai_chat_types
 import openai.types.chat.completion_create_params as openai_chat_params
 import openai.types.responses.response_create_params as openai_responses_params
 from nemo_platform_plugin.entity import NemoEntity
+from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperator, LogicalOperation
 from pydantic import BaseModel, Field, ModelWrapValidatorHandler, TypeAdapter, model_validator
 
 TypedResponse: TypeAlias = Union[openai_chat_types.ChatCompletion, anthropic_types.Message]
@@ -104,6 +105,16 @@ just checks ``isinstance(x, dict)``.
 # ---------------------------------------------------------------------------
 # VirtualModel entity and MiddlewareCall schema
 # ---------------------------------------------------------------------------
+
+
+GUARDRAIL_CONFIG_TYPE = "guardrail_config"
+"""``MiddlewareCall.config_type`` discriminator for a stored NeMo Guardrails config.
+
+Mirrors ``GuardrailConfig.__entity_type__`` in the Guardrails service and
+``GUARDRAILS_PLUGIN_CONFIG_TYPE`` in the guardrails middleware plugin.  Declared here so
+:class:`VirtualModel` can derive :attr:`VirtualModel.guardrail_config_ids` without importing
+either of them.
+"""
 
 
 class MiddlewareCall(BaseModel):
@@ -219,6 +230,63 @@ class VirtualModel(NemoEntity, entity_type="virtual_model"):
     instead of its default ``aiohttp`` proxy. Format: ``"plugin-name.proxy-name"``.
     If unset, IGW performs the proxy itself."""
 
+    guardrail_config_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "System-managed. Guardrail configs applied by this VirtualModel's middleware, as "
+            '"workspace/name" references. Derived from the middleware pipelines on every write and '
+            "ignored if supplied on a create or update body. Filter on it with filter[guardrail_config]."
+        ),
+    )
+    """System-managed. Distinct ``"workspace/name"`` guardrail config references reached by
+    this VirtualModel's middleware pipelines, in first-seen order.
+
+    Derived from the three ``*_middleware`` pipelines and never accepted on a create or update
+    body.  It exists so callers can answer "which VirtualModels use this guardrail config?"
+    with one ``$contains`` predicate against the entity store: the pipelines themselves are
+    arrays of *objects*, and ``$contains`` matches the serialized array as raw text (see
+    ``SQLAlchemyFilterRepository.contains``), so it cannot match a nested field precisely.
+    Flattening the references to an array of scalars is what makes that predicate exact.
+    """
+
+    def middleware_calls(self) -> Iterator[MiddlewareCall]:
+        """Every middleware call across the request, response, and post-response pipelines."""
+        yield from self.request_middleware or []
+        yield from self.response_middleware or []
+        yield from self.post_response_middleware or []
+
+    def references_guardrail_config(self, config_id: str) -> bool:
+        """Whether any middleware call resolves the stored guardrail config ``config_id``.
+
+        Matches on the ``config_type`` discriminator as well as the reference, so a
+        same-named config belonging to another plugin is never mistaken for a guardrail one.
+        """
+        return any(
+            call.config_type == GUARDRAIL_CONFIG_TYPE and call.config_id == config_id
+            for call in self.middleware_calls()
+        )
+
+    def refresh_guardrail_config_ids(self) -> Self:
+        """Recompute :attr:`guardrail_config_ids` from the middleware pipelines, in place."""
+        # dict keys rather than a set: de-duplicates while preserving pipeline order, so the
+        # stored value is stable across writes and diffs cleanly.
+        seen: dict[str, None] = {}
+        for call in self.middleware_calls():
+            if call.config_type == GUARDRAIL_CONFIG_TYPE and call.config_id:
+                seen[call.config_id] = None
+        self.guardrail_config_ids = list(seen)
+        return self
+
+    @model_validator(mode="after")
+    def _sync_guardrail_config_ids(self) -> Self:
+        """Keep the denormalized reference list in step with the pipelines it is derived from.
+
+        Runs on construction and on every entity-store read, so a stored value can never drift
+        from the middleware that produced it.  ``model_copy(update=...)`` is the one path that
+        skips validation — the PATCH handler calls :meth:`refresh_guardrail_config_ids` itself.
+        """
+        return self.refresh_guardrail_config_ids()
+
     @model_validator(mode="wrap")
     @classmethod
     def _hydrate_wire_metadata(
@@ -247,6 +315,67 @@ class VirtualModel(NemoEntity, entity_type="virtual_model"):
         if "parent" in wire_data:
             model._parent = optional_string.validate_python(wire_data["parent"])
         return model
+
+
+GUARDRAIL_CONFIG_IDS_FIELD = "data.guardrail_config_ids"
+"""Entity-store path of :attr:`VirtualModel.guardrail_config_ids`."""
+
+_LEGACY_MIDDLEWARE_FIELDS = (
+    "data.request_middleware",
+    "data.response_middleware",
+    "data.post_response_middleware",
+)
+"""Pipelines that ``guardrail_config_ids`` is derived from, scanned directly for rows written
+before that field existed."""
+
+
+def guardrail_config_membership_filter(config_id: str) -> LogicalOperation:
+    """Entity-store predicate for "this VirtualModel applies guardrail config ``config_id``".
+
+    ``config_id`` is a fully qualified ``"workspace/name"`` reference, so this is safe to run
+    across workspaces — a VirtualModel may apply a guardrail config from another workspace.
+
+    VirtualModels written since :attr:`VirtualModel.guardrail_config_ids` was introduced carry the
+    flattened reference list, which ``$contains`` matches exactly.  Rows that predate it have no
+    such key, so they are matched by scanning the middleware pipelines they *do* have.  The OR
+    keeps un-migrated rows queryable with no migration, mirroring how Intake spans both of its
+    evaluation-membership representations (``_group_membership_filter``).
+
+    Those legacy arms are gated on the denormalized field being absent, so they apply only to rows
+    that have not been rewritten since — every other row is matched exactly.  Where they do apply
+    they are a *superset*: ``$contains`` matches an array of objects as raw serialized text (see
+    the entity store's ``SQLAlchemyFilterRepository.contains``), so a middleware call holding this
+    same string in another field also matches, and the ``config_type`` discriminator is invisible
+    to it.  There are no false negatives, so this is safe to narrow with — callers that must be
+    exact should re-check each returned entity with
+    :meth:`VirtualModel.references_guardrail_config`.
+
+    Those legacy arms are meaningful only against the SQL-backed entity store, whose ``$contains``
+    matches serialized text.  ``InMemoryFilterRepository`` implements ``$contains`` as native list
+    membership, so an array of objects never matches there; only the first arm carries over.
+    """
+    return LogicalOperation(
+        operator=FilterOperator.OR,
+        operations=[
+            ComparisonOperation(operator=FilterOperator.CONTAINS, field=GUARDRAIL_CONFIG_IDS_FIELD, value=config_id),
+            LogicalOperation(
+                operator=FilterOperator.AND,
+                operations=[
+                    # `$eq null` matches an absent key as well as an explicit null, which is exactly
+                    # the set of rows written before guardrail_config_ids existed. Gating the fuzzy
+                    # arms on it keeps them off every row that carries the exact list.
+                    ComparisonOperation(operator=FilterOperator.EQ, field=GUARDRAIL_CONFIG_IDS_FIELD, value=None),
+                    LogicalOperation(
+                        operator=FilterOperator.OR,
+                        operations=[
+                            ComparisonOperation(operator=FilterOperator.CONTAINS, field=field, value=config_id)
+                            for field in _LEGACY_MIDDLEWARE_FIELDS
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-guardrails/tests/integration/test_injection_detection_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_injection_detection_rails.py
@@ -17,7 +17,12 @@ from nemo_platform.types.inference.middleware_call_param import MiddlewareCallPa
 from nmp.core.inference_gateway.testing.harness import IGWLoopbackHarness
 from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
-from .utils import GUARDRAILS_PLUGIN_NAME, GuardrailsTestDataNames, make_guardrails_test_data_names
+from .utils import (
+    GUARDRAILS_PLUGIN_NAME,
+    GuardrailsTestDataNames,
+    detach_guardrail_config,
+    make_guardrails_test_data_names,
+)
 
 pytestmark = [pytest.mark.integration]
 
@@ -49,6 +54,9 @@ class TestInjectionDetection:
 
     @staticmethod
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
+        # The service refuses to delete a config a VirtualModel still applies; harness
+        # cleanup removes those routes, but it runs after this teardown.
+        detach_guardrail_config(harness, config_name)
         try:
             harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
         except nemo_platform.NotFoundError:

--- a/plugins/nemo-guardrails/tests/integration/test_middleware_config_caching.py
+++ b/plugins/nemo-guardrails/tests/integration/test_middleware_config_caching.py
@@ -21,6 +21,7 @@ from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
     GuardrailsTestDataNames,
+    detach_guardrail_config,
     make_guardrails_test_data_names,
 )
 
@@ -103,7 +104,26 @@ class TestMiddlewareConfigCaching:
         }
 
     @staticmethod
+    def _delete_config_entity_directly(harness: IGWPluginHarness, config_name: str) -> None:
+        """Delete the GuardrailConfig entity straight from the entity store.
+
+        The Guardrails API deliberately refuses to delete a config a VirtualModel still applies,
+        which is the very state these tests need: a route pointing at a config that is gone. The
+        state is still reachable in production — an entity removed out-of-band, or a reference
+        that predates that guard — and IGW must keep failing closed when it happens, so the tests
+        build it the way it actually arises rather than through the guarded endpoint.
+        """
+        harness.sdk.entities.delete_entity_by_name(
+            name=config_name,
+            workspace=harness.workspace,
+            entity_type=GUARDRAILS_PLUGIN_CONFIG_TYPE,
+        )
+
+    @staticmethod
     def _delete_config_if_present(harness: IGWPluginHarness, config_name: str) -> None:
+        # The service refuses to delete a config a VirtualModel still applies; harness
+        # cleanup removes those routes, but it runs after this teardown.
+        detach_guardrail_config(harness, config_name)
         try:
             harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
         except nemo_platform.NotFoundError:
@@ -291,11 +311,8 @@ class TestMiddlewareConfigCaching:
                     config_version="v1",
                 )
 
-                # Delete the config referenced by the VirtualModel.
-                harness.sdk.guardrail.configs.delete(
-                    name=test_data_names.guardrail_config_name,
-                    workspace=harness.workspace,
-                )
+                # Delete the config referenced by the VirtualModel, out from under it.
+                self._delete_config_entity_directly(harness, test_data_names.guardrail_config_name)
                 self._refresh_caches(harness)
 
                 # Verify the next inference request fails closed because the referenced
@@ -317,11 +334,8 @@ class TestMiddlewareConfigCaching:
         with harness.load_plugin(GUARDRAILS_PLUGIN_NAME):
             test_data_names = self._setup_entity_backed_vm(harness, config_version="v1")
             try:
-                # Delete the config referenced by the VirtualModel.
-                harness.sdk.guardrail.configs.delete(
-                    name=test_data_names.guardrail_config_name,
-                    workspace=harness.workspace,
-                )
+                # Delete the config referenced by the VirtualModel, out from under it.
+                self._delete_config_entity_directly(harness, test_data_names.guardrail_config_name)
                 self._refresh_caches(harness)
 
                 # Verify the next inference request fails closed because the referenced

--- a/plugins/nemo-guardrails/tests/integration/test_multimodal_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_multimodal_rails.py
@@ -20,6 +20,7 @@ from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
+    detach_guardrail_config,
     make_guardrails_test_data_names,
     make_served_model,
 )
@@ -117,6 +118,9 @@ class TestMultimodalContentSafety:
 
     @staticmethod
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
+        # The service refuses to delete a config a VirtualModel still applies; harness
+        # cleanup removes those routes, but it runs after this teardown.
+        detach_guardrail_config(harness, config_name)
         try:
             harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
         except nemo_platform.NotFoundError:

--- a/plugins/nemo-guardrails/tests/integration/test_parallel_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_parallel_rails.py
@@ -21,6 +21,7 @@ from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
+    detach_guardrail_config,
     make_guardrails_test_data_names,
     make_served_model,
 )
@@ -138,6 +139,9 @@ class TestParallelRails:
 
     @staticmethod
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
+        # The service refuses to delete a config a VirtualModel still applies; harness
+        # cleanup removes those routes, but it runs after this teardown.
+        detach_guardrail_config(harness, config_name)
         try:
             harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
         except nemo_platform.NotFoundError:

--- a/plugins/nemo-guardrails/tests/integration/test_topic_control_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_topic_control_rails.py
@@ -21,6 +21,7 @@ from nmp.testing.mock_chat_completions import ChatCompletion, chat_completion
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
     RailType,
+    detach_guardrail_config,
     make_guardrails_test_data_names,
     make_served_model,
 )
@@ -123,6 +124,9 @@ class TestTopicControl:
 
     @staticmethod
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
+        # The service refuses to delete a config a VirtualModel still applies; harness
+        # cleanup removes those routes, but it runs after this teardown.
+        detach_guardrail_config(harness, config_name)
         try:
             harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
         except nemo_platform.NotFoundError:

--- a/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
+++ b/plugins/nemo-guardrails/tests/integration/test_upstream_error_surfacing.py
@@ -24,6 +24,7 @@ from nmp.testing.mock_chat_completions import ErrorResponse
 
 from .utils import (
     GUARDRAILS_PLUGIN_NAME,
+    detach_guardrail_config,
     make_guardrails_test_data_names,
     make_served_model,
 )
@@ -93,6 +94,9 @@ class TestUpstreamErrorSurfacing:
 
     @staticmethod
     def _delete_config_if_present(harness: IGWLoopbackHarness, config_name: str) -> None:
+        # The service refuses to delete a config a VirtualModel still applies; harness
+        # cleanup removes those routes, but it runs after this teardown.
+        detach_guardrail_config(harness, config_name)
         try:
             harness.sdk.guardrail.configs.delete(name=config_name, workspace=harness.workspace)
         except nemo_platform.NotFoundError:

--- a/plugins/nemo-guardrails/tests/integration/utils.py
+++ b/plugins/nemo-guardrails/tests/integration/utils.py
@@ -9,8 +9,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-import nemo_platform
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
+from nemo_platform import NotFoundError
 from nemo_platform.types.guardrail import GuardrailConfig
 from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
 from nmp.testing.utils import short_unique_name
@@ -91,7 +91,7 @@ def detach_guardrail_config(harness: Any, config_name: str) -> None:
     for workspace, name in harness.virtual_models:
         try:
             virtual_model = harness.sdk.inference.virtual_models.retrieve(name=name, workspace=workspace)
-        except nemo_platform.NotFoundError:
+        except NotFoundError:
             continue
 
         remaining: dict[str, list[Any]] = {}

--- a/plugins/nemo-guardrails/tests/integration/utils.py
+++ b/plugins/nemo-guardrails/tests/integration/utils.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+import nemo_platform
 from nemo_guardrails_plugin.constants import GUARDRAILS_PLUGIN_CONFIG_TYPE
 from nemo_platform.types.guardrail import GuardrailConfig
 from nemo_platform.types.inference.middleware_call_param import MiddlewareCallParam
@@ -71,6 +72,46 @@ def make_guardrails_test_data_names(
         guardrail_config_name=f"gr-config-{test_id}",
         model_provider_name=f"gr-provider-{test_id}",
     )
+
+
+def detach_guardrail_config(harness: Any, config_name: str) -> None:
+    """Remove every middleware call referencing ``config_name`` from the harness's VirtualModels.
+
+    The Guardrails service refuses to delete a config that a VirtualModel still applies, so a
+    test that deletes its config in ``finally`` has to detach first: harness cleanup deletes the
+    VirtualModels it created, but that runs *after* the test's own teardown.
+
+    Detaches rather than deletes so the harness's own bookkeeping stays intact — it still deletes
+    the VirtualModels itself, and does not log a spurious "failed to delete" warning for a route
+    a test removed behind its back.
+    """
+    config_ref = f"{harness.workspace}/{config_name}"
+    phases = ("request_middleware", "response_middleware", "post_response_middleware")
+
+    for workspace, name in harness.virtual_models:
+        try:
+            virtual_model = harness.sdk.inference.virtual_models.retrieve(name=name, workspace=workspace)
+        except nemo_platform.NotFoundError:
+            continue
+
+        remaining: dict[str, list[Any]] = {}
+        for phase in phases:
+            calls = getattr(virtual_model, phase, None) or []
+            kept = [
+                call
+                for call in calls
+                if not (
+                    getattr(call, "config_type", None) == GUARDRAILS_PLUGIN_CONFIG_TYPE
+                    and getattr(call, "config_id", None) == config_ref
+                )
+            ]
+            if len(kept) != len(calls):
+                remaining[phase] = [call.model_dump(exclude_none=True) for call in kept]
+
+        if not remaining:
+            continue
+
+        harness.sdk.inference.virtual_models.patch(name=name, workspace=workspace, **remaining)
 
 
 class RailType(str, Enum):

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -2485,6 +2485,9 @@ paths:
                 $ref: '#/components/schemas/DeleteResponse'
         '404':
           description: Config does not exist.
+        '409':
+          description: Config is applied by one or more VirtualModels and cannot be
+            deleted.
         '422':
           description: Unable to delete config due to validation error while processing
             request.
@@ -3469,7 +3472,7 @@ paths:
         schema:
           $ref: '#/components/schemas/VirtualModelFilter'
         description: Filter virtual models by workspace, project, name, default_model_entity,
-          created_at, and updated_at.
+          guardrail_config, created_at, and updated_at.
       responses:
         '200':
           description: Paginated list of virtual models
@@ -20062,6 +20065,15 @@ components:
         override_proxy:
           title: Override Proxy
           type: string
+        guardrail_config_ids:
+          items:
+            type: string
+          type: array
+          title: Guardrail Config Ids
+          description: System-managed. Guardrail configs applied by this VirtualModel's
+            middleware, as "workspace/name" references. Derived from the middleware
+            pipelines on every write and ignored if supplied on a create or update
+            body. Filter on it with filter[guardrail_config].
         id:
           type: string
           title: Id
@@ -20177,6 +20189,12 @@ components:
           allOf:
           - $ref: '#/components/schemas/DatetimeFilter'
           description: Filter by update date.
+        guardrail_config:
+          description: Filter by a guardrail config reference in "workspace/name"
+            form. Matches VirtualModels whose request, response, or post-response
+            middleware applies that stored guardrail config.
+          title: Guardrail Config
+          type: string
       title: VirtualModelFilter
       type: object
     VirtualModelInferenceConfig:

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/inference/virtual_models.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/inference/virtual_models.py
@@ -236,7 +236,7 @@ class VirtualModelsResource(SyncAPIResource):
               excluded from the results.
 
           filter: Filter virtual models by workspace, project, name, default_model_entity,
-              created_at, and updated_at.
+              guardrail_config, created_at, and updated_at.
 
           page: Page number (1-indexed).
 
@@ -616,7 +616,7 @@ class AsyncVirtualModelsResource(AsyncAPIResource):
               excluded from the results.
 
           filter: Filter virtual models by workspace, project, name, default_model_entity,
-              created_at, and updated_at.
+              guardrail_config, created_at, and updated_at.
 
           page: Page number (1-indexed).
 

--- a/sdk/python/nemo-platform/src/nemo_platform/types/inference/virtual_model.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/inference/virtual_model.py
@@ -77,6 +77,14 @@ class VirtualModel(BaseModel):
 
     default_model_entity: Optional[str] = None
 
+    guardrail_config_ids: Optional[List[str]] = None
+    """System-managed.
+
+    Guardrail configs applied by this VirtualModel's middleware, as "workspace/name"
+    references. Derived from the middleware pipelines on every write and ignored if
+    supplied on a create or update body. Filter on it with filter[guardrail_config].
+    """
+
     models: Optional[List[VirtualModelInferenceConfig]] = None
 
     name: Optional[str] = None

--- a/sdk/python/nemo-platform/src/nemo_platform/types/inference/virtual_model_filter_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/inference/virtual_model_filter_param.py
@@ -39,6 +39,13 @@ class VirtualModelFilterParam(TypedDict, total=False):
     default_model_entity: DefaultModelEntity
     """Filter by default model entity."""
 
+    guardrail_config: str
+    """Filter by a guardrail config reference in "workspace/name" form.
+
+    Matches VirtualModels whose request, response, or post-response middleware
+    applies that stored guardrail config.
+    """
+
     name: Name
     """Filter by name."""
 

--- a/sdk/python/nemo-platform/src/nemo_platform/types/inference/virtual_model_list_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/inference/virtual_model_list_params.py
@@ -36,7 +36,7 @@ class VirtualModelListParams(TypedDict, total=False):
     filter: VirtualModelFilterParam
     """
     Filter virtual models by workspace, project, name, default_model_entity,
-    created_at, and updated_at.
+    guardrail_config, created_at, and updated_at.
     """
 
     page: int

--- a/sdk/python/nemo-platform/tests/api_resources/inference/test_virtual_models.py
+++ b/sdk/python/nemo-platform/tests/api_resources/inference/test_virtual_models.py
@@ -201,6 +201,7 @@ class TestVirtualModels:
                     "like": "$like",
                     "nin": ["string"],
                 },
+                "guardrail_config": "guardrail_config",
                 "name": {
                     "eq": "$eq",
                     "in_": ["string"],
@@ -581,6 +582,7 @@ class TestAsyncVirtualModels:
                     "like": "$like",
                     "nin": ["string"],
                 },
+                "guardrail_config": "guardrail_config",
                 "name": {
                     "eq": "$eq",
                     "in_": ["string"],

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/virtual_models.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/virtual_models.py
@@ -26,19 +26,21 @@ import logging
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperator
+from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperation, FilterOperator, LogicalOperation
 from nemo_platform_plugin.inference_middleware import (
+    GUARDRAIL_CONFIG_IDS_FIELD,
     InferenceMiddlewareError,
     MiddlewareCall,
     MiddlewareConfigNotFoundError,
     VirtualModel,
+    guardrail_config_membership_filter,
 )
 from nemo_platform_plugin.virtual_models.types import CreateVirtualModelRequest, UpdateVirtualModelRequest
 from nmp.common.api.common import Page, PaginationData
 from nmp.common.api.parsed_filter import ParsedFilter, make_filter_dep
 from nmp.common.api.utils import generate_openapi_extra_params
 from nmp.common.entities import EntityClient, EntityConflictError, EntityNotFoundError
-from nmp.common.entities.values import DatetimeFilter, Filter, StringFilter
+from nmp.common.entities.values import DatetimeFilter, Filter, StringFilter, map_entity_field
 from nmp.common.service.dependencies import get_entity_client
 from nmp.core.inference_gateway.api.dependencies import global_middleware_registry
 from nmp.core.inference_gateway.api.middleware_registry import MiddlewareRegistry
@@ -61,6 +63,36 @@ class VirtualModelFilter(Filter):
     default_model_entity: StringFilter | str | None = Field(None, description="Filter by default model entity.")
     created_at: DatetimeFilter | None = Field(None, description="Filter by creation date.")
     updated_at: DatetimeFilter | None = Field(None, description="Filter by update date.")
+    guardrail_config: Annotated[str | None, map_entity_field(GUARDRAIL_CONFIG_IDS_FIELD)] = Field(
+        None,
+        description=(
+            'Filter by a guardrail config reference in "workspace/name" form. Matches VirtualModels '
+            "whose request, response, or post-response middleware applies that stored guardrail config."
+        ),
+    )
+
+
+def _rewrite_guardrail_filter(operation: FilterOperation | None) -> FilterOperation | None:
+    """Rewrite the scalar ``guardrail_config`` equality into a membership match.
+
+    The user-facing param is a single config reference, so it parses to an equality against the
+    denormalized list field; "uses this config" actually means "that list contains it", spanning
+    both storage representations.
+    """
+    if operation is None:
+        return None
+    if isinstance(operation, ComparisonOperation):
+        if operation.field == GUARDRAIL_CONFIG_IDS_FIELD and operation.operator == FilterOperator.EQ:
+            return guardrail_config_membership_filter(str(operation.value))
+        return operation
+    if isinstance(operation, LogicalOperation):
+        return LogicalOperation(
+            operator=operation.operator,
+            operations=[
+                rewritten for op in operation.operations if (rewritten := _rewrite_guardrail_filter(op)) is not None
+            ],
+        )
+    return operation
 
 
 def _middleware_validation_error(detail: str) -> HTTPException:
@@ -259,7 +291,8 @@ async def create_virtual_model(
     openapi_extra=generate_openapi_extra_params(
         filter_schema=VirtualModelFilter,
         filter_description=(
-            "Filter virtual models by workspace, project, name, default_model_entity, created_at, and updated_at."
+            "Filter virtual models by workspace, project, name, default_model_entity, guardrail_config, "
+            "created_at, and updated_at."
         ),
     ),
 )
@@ -285,6 +318,9 @@ async def list_virtual_models(
     Use ``workspace=-`` to list across all workspaces accessible to the caller.
     """
     filter_workspace = parsed_filter.remove("workspace") or workspace
+    # "uses this guardrail config" is a membership test across two storage representations, not the
+    # plain equality the scalar param parses to.
+    parsed_filter.operation = _rewrite_guardrail_filter(parsed_filter.operation)
     if exclude_autoprovisioned:
         # ``autoprovisioned`` lives under the entity ``data`` blob; reference it
         # directly so this does not depend on VirtualModelFilter exposing the field.
@@ -398,7 +434,9 @@ async def update_virtual_model(
     # being flattened to plain dicts by model_dump(), which would trigger a
     # pydantic serialization warning on model_copy.
     diff = {field: getattr(body, field) for field in body.model_fields_set}
-    updated = existing.model_copy(update=diff)
+    # model_copy skips validation, so the derived guardrail reference list would otherwise keep the
+    # pre-patch pipelines' value. Everything else re-derives it through VirtualModel's validator.
+    updated = existing.model_copy(update=diff).refresh_guardrail_config_ids()
     await _validate_middleware_configs(updated, registry)
 
     try:

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/harness.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/testing/harness.py
@@ -260,6 +260,16 @@ class IGWPluginHarness:
     # ------------------------------------------------------------------
 
     @property
+    def virtual_models(self) -> tuple[tuple[str, str], ...]:
+        """``(workspace, name)`` for every VirtualModel this harness created, in creation order.
+
+        Exposed so a test's own teardown can act on them before :meth:`_cleanup` runs — notably
+        to detach a guardrail config from its routes, since the Guardrails service refuses to
+        delete a config a VirtualModel still applies.
+        """
+        return tuple(self._virtual_models)
+
+    @property
     def nim_base_url(self) -> str:
         """OpenAI-compatible base URL (``http://host:port/v1``).
 

--- a/services/core/inference-gateway/tests/unit/test_virtual_models_router.py
+++ b/services/core/inference-gateway/tests/unit/test_virtual_models_router.py
@@ -529,6 +529,7 @@ class TestListVirtualModels:
         assert names == {"vm-alpha"}
 
     def _guardrail_call(self, config_id: str) -> dict:
+        """A middleware call applying the stored guardrail config ``config_id``."""
         return {"name": "nemo-guardrails", "config_type": "guardrail_config", "config_id": config_id}
 
     def test_list_filters_by_guardrail_config(self, client: TestClient):

--- a/services/core/inference-gateway/tests/unit/test_virtual_models_router.py
+++ b/services/core/inference-gateway/tests/unit/test_virtual_models_router.py
@@ -528,6 +528,87 @@ class TestListVirtualModels:
         names = {item["name"] for item in resp.json()["data"]}
         assert names == {"vm-alpha"}
 
+    def _guardrail_call(self, config_id: str) -> dict:
+        return {"name": "nemo-guardrails", "config_type": "guardrail_config", "config_id": config_id}
+
+    def test_list_filters_by_guardrail_config(self, client: TestClient):
+        """filter[guardrail_config] selects VirtualModels that apply that stored config."""
+        _install_registry(client, {"nemo-guardrails": _make_plugin()})
+        _create(client, "vm-guarded", request_middleware=[self._guardrail_call("default/content-safety")])
+        _create(client, "vm-plain", default_model_entity="default/model-a")
+
+        resp = client.get(f"{BASE}?filter[guardrail_config]=default/content-safety")
+        assert resp.status_code == 200, resp.text
+        assert {item["name"] for item in resp.json()["data"]} == {"vm-guarded"}
+
+    def test_list_filters_by_guardrail_config_across_all_phases(self, client: TestClient):
+        """A config attached to any pipeline phase matches; output rails are not request rails."""
+        _install_registry(client, {"nemo-guardrails": _make_plugin()})
+        _create(client, "vm-req", request_middleware=[self._guardrail_call("default/cs")])
+        _create(client, "vm-resp", response_middleware=[self._guardrail_call("default/cs")])
+        _create(client, "vm-post", post_response_middleware=[self._guardrail_call("default/cs")])
+
+        resp = client.get(f"{BASE}?filter[guardrail_config]=default/cs")
+        assert resp.status_code == 200, resp.text
+        assert {item["name"] for item in resp.json()["data"]} == {"vm-req", "vm-resp", "vm-post"}
+
+    def test_list_guardrail_config_filter_does_not_match_other_configs(self, client: TestClient):
+        """A different config reference, and a same-named config of another type, both miss."""
+        _install_registry(client, {"nemo-guardrails": _make_plugin(), "nemo-switchyard": _make_plugin()})
+        _create(client, "vm-other-config", request_middleware=[self._guardrail_call("default/other")])
+        _create(
+            client,
+            "vm-other-type",
+            request_middleware=[
+                {"name": "nemo-switchyard", "config_type": "routellm_config", "config_id": "default/cs"}
+            ],
+        )
+
+        resp = client.get(f"{BASE}?filter[guardrail_config]=default/cs")
+        assert resp.status_code == 200, resp.text
+        # vm-other-type carries the same reference under a different config_type. Both rows have a
+        # denormalized list, so the raw-text legacy arms are gated off and matching is exact.
+        assert {item["name"] for item in resp.json()["data"]} == set()
+
+    def test_guardrail_config_ids_derived_from_pipelines(self, client: TestClient):
+        """The system-managed reference list is derived on create and deduped across phases."""
+        _install_registry(client, {"nemo-guardrails": _make_plugin()})
+        data = _create(
+            client,
+            "vm-derived",
+            request_middleware=[self._guardrail_call("default/cs")],
+            response_middleware=[self._guardrail_call("default/cs")],
+        )
+        assert data["guardrail_config_ids"] == ["default/cs"]
+
+    def test_guardrail_config_ids_refreshed_on_patch(self, client: TestClient):
+        """PATCH re-derives the list even though model_copy bypasses validation."""
+        _install_registry(client, {"nemo-guardrails": _make_plugin()})
+        _create(client, "vm-patched", request_middleware=[self._guardrail_call("default/cs")])
+
+        resp = client.patch(
+            f"{BASE}/vm-patched",
+            json={"request_middleware": [self._guardrail_call("default/stricter")]},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["guardrail_config_ids"] == ["default/stricter"]
+
+        assert {i["name"] for i in client.get(f"{BASE}?filter[guardrail_config]=default/stricter").json()["data"]} == {
+            "vm-patched"
+        }
+
+    def test_guardrail_config_ids_cleared_when_rails_detached(self, client: TestClient):
+        """Clearing the pipeline clears the derived list, so the config stops matching."""
+        _install_registry(client, {"nemo-guardrails": _make_plugin()})
+        _create(client, "vm-detached", request_middleware=[self._guardrail_call("default/cs")])
+
+        resp = client.patch(f"{BASE}/vm-detached", json={"request_middleware": []})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["guardrail_config_ids"] == []
+
+        names = {i["name"] for i in client.get(f"{BASE}?filter[guardrail_config]=default/cs").json()["data"]}
+        assert "vm-detached" not in names
+
     def test_list_includes_autoprovisioned_by_default(self, client: TestClient):
         """Autoprovisioned VirtualModels are returned when the flag is not set."""
         _create(client, "vm-manual-2", default_model_entity="default/model-a")

--- a/services/guardrails/src/nmp/guardrails/api/v2/configs/endpoints.py
+++ b/services/guardrails/src/nmp/guardrails/api/v2/configs/endpoints.py
@@ -6,6 +6,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from nemo_platform_plugin.inference_middleware import VirtualModel, guardrail_config_membership_filter
 from nmp.common.api import ParsedFilter, make_filter_dep
 from nmp.common.api.common import DeleteResponse, GenericSortField, Page, PaginationData
 from nmp.common.api.utils import generate_openapi_extra_params
@@ -176,11 +177,52 @@ async def update_config(
     return updated_config
 
 
+# A guardrail config is referenced by fully qualified "workspace/name", so a VirtualModel in any
+# workspace can apply one from another — the in-use scan is deliberately cross-workspace ("-").
+_IN_USE_SCAN_PAGE_SIZE = 200
+_IN_USE_NAMES_IN_ERROR = 5
+
+
+async def _virtual_models_using_config(entities_client: EntityClient, config_ref: str) -> list[str]:
+    """VirtualModels that apply guardrail config ``config_ref``, as ``"workspace/name"`` refs.
+
+    Two passes, because neither alone is both cheap and correct.  The entity-store filter narrows
+    to candidates in SQL, but its legacy arm matches serialized middleware as raw text and so can
+    over-match (see :func:`guardrail_config_membership_filter`).  Each candidate is therefore
+    re-checked against its parsed middleware calls, which compares the ``config_type``
+    discriminator as well as the reference.  The result is exact: a config is never held hostage by
+    a VirtualModel that merely happens to contain the same string.
+
+    Collection stops once there are enough names for the error message — the caller only needs to
+    know *whether* the config is in use, plus a few examples.  A config with no references is the
+    only case that scans every candidate page, and that set is small by construction.
+    """
+    in_use: list[str] = []
+    page = 1
+    while True:
+        result = await entities_client.list(
+            VirtualModel,
+            workspace="-",
+            page=page,
+            page_size=_IN_USE_SCAN_PAGE_SIZE,
+            filter_operation=guardrail_config_membership_filter(config_ref),
+        )
+        for vm in result.data:
+            if vm.references_guardrail_config(config_ref):
+                in_use.append(f"{vm.workspace}/{vm.name}")
+                if len(in_use) >= _IN_USE_NAMES_IN_ERROR:
+                    return in_use
+        if page >= result.pagination.total_pages or not result.data:
+            return in_use
+        page += 1
+
+
 @router.delete(
     "/v2/workspaces/{workspace}/configs/{name}",
     responses={
         200: {"description": "Successful model deletion."},
         404: {"description": "Config does not exist."},
+        409: {"description": "Config is applied by one or more VirtualModels and cannot be deleted."},
         422: {"description": ("Unable to delete config due to validation error while processing request.")},
     },
 )
@@ -197,14 +239,28 @@ async def delete_config(
     except EntityNotFoundError:
         raise HTTPException(status_code=404, detail="Guardrail config not found.")
 
+    full_config_id = f"{workspace}/{config.name}" if workspace else config.name
+
+    # Deleting a config out from under a VirtualModel that applies it would leave that route
+    # pointing at a config the Inference Gateway can no longer resolve — the same dangling
+    # reference the VirtualModel endpoints reject at attach time. Refuse it here too, so the
+    # reference is validated symmetrically on both sides.
+    in_use_by = await _virtual_models_using_config(entities_client, full_config_id)
+    if in_use_by:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Guardrail config '{full_config_id}' is applied by "
+                f"{', '.join(sorted(in_use_by))}. Detach it from those virtual models before deleting it."
+            ),
+        )
+
     try:
         await entities_client.delete(GuardrailConfig, config.name, workspace=workspace)
     except EntityNotFoundError:
         raise HTTPException(status_code=404, detail="Guardrail config not found.")
     except EntityConflictError as exc:
         raise HTTPException(status_code=409, detail="Concurrent modification - please retry.") from exc
-
-    full_config_id = f"{workspace}/{config.name}" if workspace else config.name
 
     if config_registry:
         await config_registry.refresh_all()

--- a/services/guardrails/tests/apis/test_configs_api.py
+++ b/services/guardrails/tests/apis/test_configs_api.py
@@ -21,6 +21,7 @@ from nmp.testing import create_test_client
 
 
 def _empty_page() -> ListResponse:
+    """An empty single-page list response, for mocked entity-store lookups."""
     return ListResponse(
         data=[],
         pagination=PaginationInfo(page=1, page_size=200, current_page_size=0, total_pages=0, total_results=0),
@@ -294,6 +295,7 @@ class TestDeleteConfigInUse:
 
     @pytest.fixture
     def client(self) -> Iterator[TestClient]:
+        """Guardrails and the Inference Gateway over one in-process entity store."""
         with create_test_client(
             GuardrailsService,
             InferenceGatewayService,
@@ -313,9 +315,11 @@ class TestDeleteConfigInUse:
 
     @staticmethod
     def _rail(config_id: str) -> dict:
+        """A middleware call applying the stored guardrail config ``config_id``."""
         return {"name": "nemo-guardrails", "config_type": "guardrail_config", "config_id": config_id}
 
     def _create_config(self, client: TestClient, name: str) -> None:
+        """Create a guardrail config, asserting it was stored."""
         assert client.post(CONFIGS, json={"name": name}).status_code == 201
 
     def test_delete_refused_while_a_virtual_model_applies_the_config(self, client: TestClient):

--- a/services/guardrails/tests/apis/test_configs_api.py
+++ b/services/guardrails/tests/apis/test_configs_api.py
@@ -3,13 +3,28 @@
 
 """Tests for the Guardrails config API endpoints."""
 
-from unittest.mock import AsyncMock
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
+from nemo_platform_plugin.entities.base import ListResponse, PaginationInfo
+from nemo_platform_plugin.inference_middleware import NemoInferenceMiddleware
 from nmp.common.entities import EntityNotFoundError
 from nmp.common.service.dependencies import get_entity_client
+from nmp.core.inference_gateway.api.dependencies import global_middleware_registry
+from nmp.core.inference_gateway.api.middleware_registry import MiddlewareRegistry
+from nmp.core.inference_gateway.service import InferenceGatewayService
 from nmp.guardrails.entities import GuardrailConfig
+from nmp.guardrails.service import GuardrailsService
+from nmp.testing import create_test_client
+
+
+def _empty_page() -> ListResponse:
+    return ListResponse(
+        data=[],
+        pagination=PaginationInfo(page=1, page_size=200, current_page_size=0, total_pages=0, total_results=0),
+    )
 
 
 class TestGuardrailConfigsAPI:
@@ -101,6 +116,8 @@ class TestGuardrailConfigsAPI:
         """Test a config deleted after lookup returns 404."""
         entities_client = AsyncMock()
         entities_client.get.return_value = GuardrailConfig(name="delete-race-config", workspace="default")
+        # Delete first scans for VirtualModels applying this config; nothing references it here.
+        entities_client.list.return_value = _empty_page()
         entities_client.delete.side_effect = EntityNotFoundError("not found")
         dependency_overrides = getattr(client.app, "dependency_overrides")
         dependency_overrides[get_entity_client] = lambda: entities_client
@@ -261,3 +278,116 @@ class TestGuardrailConfigsFilter:
         """Filter validation rejects fields not declared on GuardrailConfigFilter."""
         response = client.get("/apis/guardrails/v2/workspaces/default/configs?filter[unknown_field]=x")
         assert response.status_code == 400
+
+
+CONFIGS = "/apis/guardrails/v2/workspaces/default/configs"
+VMS = "/apis/inference-gateway/v2/workspaces/default/virtual-models"
+
+
+class TestDeleteConfigInUse:
+    """Deleting a guardrail config that a VirtualModel applies is refused.
+
+    Runs Guardrails and the Inference Gateway against one in-process entity store, so the
+    VirtualModels are created through IGW's real endpoint and the in-use scan reads exactly what
+    production would.
+    """
+
+    @pytest.fixture
+    def client(self) -> Iterator[TestClient]:
+        with create_test_client(
+            GuardrailsService,
+            InferenceGatewayService,
+            client_type=TestClient,
+            # A second workspace, so the cross-workspace reference case is reachable.
+            workspaces=["default", "other"],
+        ) as tc:
+            # The guardrails middleware plugin isn't loaded in tests; stub it so IGW accepts
+            # config_id references without resolving them through the real plugin.
+            plugin = MagicMock(spec=NemoInferenceMiddleware)
+            plugin.get_middleware_config = AsyncMock(return_value={"stored": True})
+            plugin.validate_middleware_config = AsyncMock(side_effect=lambda _type, config: config)
+            tc.app.dependency_overrides[global_middleware_registry] = lambda: MiddlewareRegistry(
+                plugins={"nemo-guardrails": plugin}
+            )
+            yield tc
+
+    @staticmethod
+    def _rail(config_id: str) -> dict:
+        return {"name": "nemo-guardrails", "config_type": "guardrail_config", "config_id": config_id}
+
+    def _create_config(self, client: TestClient, name: str) -> None:
+        assert client.post(CONFIGS, json={"name": name}).status_code == 201
+
+    def test_delete_refused_while_a_virtual_model_applies_the_config(self, client: TestClient):
+        """A referenced config returns 409, names the VirtualModel, and survives."""
+        self._create_config(client, "cs")
+        assert (
+            client.post(VMS, json={"name": "vm-guarded", "request_middleware": [self._rail("default/cs")]}).status_code
+            == 201
+        )
+
+        resp = client.delete(f"{CONFIGS}/cs")
+        assert resp.status_code == 409, resp.text
+        assert "default/vm-guarded" in resp.json()["detail"]
+        assert client.get(f"{CONFIGS}/cs").status_code == 200
+
+    def test_delete_refused_for_output_rails_too(self, client: TestClient):
+        """The scan covers response and post-response pipelines, not just request."""
+        self._create_config(client, "cs-out")
+        assert (
+            client.post(VMS, json={"name": "vm-out", "response_middleware": [self._rail("default/cs-out")]}).status_code
+            == 201
+        )
+
+        assert client.delete(f"{CONFIGS}/cs-out").status_code == 409
+
+    def test_delete_allowed_when_no_virtual_model_references_it(self, client: TestClient):
+        """An unreferenced config still deletes, even with other guarded VirtualModels around."""
+        self._create_config(client, "unused")
+        self._create_config(client, "used")
+        assert (
+            client.post(VMS, json={"name": "vm-other", "request_middleware": [self._rail("default/used")]}).status_code
+            == 201
+        )
+
+        assert client.delete(f"{CONFIGS}/unused").status_code == 200
+        assert client.get(f"{CONFIGS}/unused").status_code == 404
+
+    def test_delete_allowed_after_rails_are_detached(self, client: TestClient):
+        """Detaching the config releases the config for deletion."""
+        self._create_config(client, "cs-detach")
+        assert (
+            client.post(
+                VMS, json={"name": "vm-detach", "request_middleware": [self._rail("default/cs-detach")]}
+            ).status_code
+            == 201
+        )
+        assert client.delete(f"{CONFIGS}/cs-detach").status_code == 409
+
+        assert client.patch(f"{VMS}/vm-detach", json={"request_middleware": []}).status_code == 200
+        assert client.delete(f"{CONFIGS}/cs-detach").status_code == 200
+
+    def test_delete_not_blocked_by_a_same_named_config_of_another_type(self, client: TestClient):
+        """The in-use check compares config_type, so another plugin's config never blocks."""
+        self._create_config(client, "shared-name")
+        payload = {
+            "name": "vm-switchyard",
+            "request_middleware": [
+                {"name": "nemo-guardrails", "config_type": "routellm_config", "config_id": "default/shared-name"}
+            ],
+        }
+        assert client.post(VMS, json=payload).status_code == 201
+
+        assert client.delete(f"{CONFIGS}/shared-name").status_code == 200
+
+    def test_delete_refused_when_referenced_from_another_workspace(self, client: TestClient):
+        """Config references are fully qualified, so the scan spans workspaces."""
+        self._create_config(client, "cross")
+        payload = {"name": "vm-cross", "request_middleware": [self._rail("default/cross")]}
+        assert (
+            client.post("/apis/inference-gateway/v2/workspaces/other/virtual-models", json=payload).status_code == 201
+        )
+
+        resp = client.delete(f"{CONFIGS}/cross")
+        assert resp.status_code == 409, resp.text
+        assert "other/vm-cross" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Studio can author guardrail configs, but nothing could answer "which virtual models apply this one?", and deleting a config never checked whether anything was using it. Attach-time validation already rejects a dangling config reference, so the reference was only validated on one side. This adds the reverse lookup as a filter and makes the delete path enforce it.

Before: `DELETE /configs/{name}` always deleted, silently leaving any VirtualModel that applied the config pointing at a config IGW can no longer resolve. After: that delete returns 409 naming the VirtualModels, and the VirtualModel list can be filtered by guardrail config.

## Changes

- `filter[guardrail_config]=<workspace>/<name>` on `GET .../virtual-models`, matching VirtualModels whose request, response, or post-response middleware applies that stored config.
- `DELETE .../configs/{name}` returns 409 when a VirtualModel still applies the config, listing the referencing virtual models.
- New system-managed `guardrail_config_ids` field on the VirtualModel entity, derived from all three middleware pipelines by a `model_validator` so it re-derives on construction and on every entity-store read and cannot drift from the pipelines. `model_copy(update=...)` is the one path that skips validation, so the PATCH handler refreshes explicitly.
- `guardrail_config_membership_filter` lives next to the entity in `nemo_platform_plugin` so both IGW and the Guardrails service query the shared schema the same way.
- Regenerated OpenAPI specs.

### On not adding a migration

Pre-existing VirtualModels have no `guardrail_config_ids` key. Rather than backfill, the membership filter ORs an exact `$contains` against the denormalized list with a fallback that scans the raw pipelines, gated on the list being absent so it applies only to rows written before the field existed. Every row carrying the list is matched exactly.

This follows the one precedent in the repo: Intake spans both of its evaluation-membership representations the same way (`_group_membership_filter`, "The OR keeps un-migrated rows queryable, no migration") rather than rewriting rows. The alternative — a data migration in the entities service — would mean teaching a deliberately schema-agnostic store about IGW's `data` blob, and there is no precedent for it: both existing Alembic revisions are pure DDL on real columns.

The fallback arms are a superset, since `$contains` matches an array of objects as raw serialized text. That imprecision is confined to the list filter on un-migrated rows: the delete guard narrows with the filter and then re-checks each candidate against its parsed middleware calls, comparing the `config_type` discriminator as well as the reference. So a 409 is never raised on a collision, and a same-named config of another type never blocks a delete. The scan is cross-workspace, since config references are fully qualified.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the new filter param and entity field are described in the regenerated OpenAPI spec, which is the reference for both; no narrative doc covers VirtualModel filters.

12 tests added: filter across all three pipeline phases, PATCH re-derivation, detach clearing the list, and for the delete guard — output rails, cross-workspace references, and the same-name-different-`config_type` case that must *not* block a delete. One existing test (`test_delete_config_not_found_during_delete`) was updated because delete now makes one additional entity-store call; its assertions are unchanged.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation, re-run after rebasing onto current `main`:

| Command | Result |
| --- | --- |
| `pytest services/guardrails/tests services/core/inference-gateway/tests/unit packages/nemo_platform_plugin/tests` | 2150 passed, 8 skipped |
| `pytest plugins/nemo-guardrails/tests/integration/` | 57 passed |
| `uv run ruff check` (changed packages) | passed |
| `uv run ruff format --check` (changed packages) | 316 files already formatted |
| `uv run --frozen ty check` (changed files) | 5 diagnostics, all pre-existing — see below |
| `python -m script.generate_openapi_spec` | spec regenerated, validated, no dangling `$ref`s |

### Integration-test fallout, fixed in this PR

The guard initially broke 15 tests across six files in `plugins/nemo-guardrails/tests/integration/`. They delete their config in `finally`, while `IGWLoopbackHarness` deletes the VirtualModels it created in *its* cleanup — which runs afterwards. So a route still applied the config at the moment it was deleted, and the service correctly returned 409.

Fixed by `detach_guardrail_config`, called from each teardown before the delete. It strips middleware calls referencing the config from the harness's VirtualModels, found via a new `IGWLoopbackHarness.virtual_models` accessor. It detaches rather than deletes so the harness's bookkeeping stays intact — it still deletes the routes itself, and logs no spurious "failed to delete" warning.

Two caching tests needed a different fix and are worth a look:

- `test_entity_config_delete_blocks_next_request` and `test_entity_config_recreate_reflected_in_next_request` delete a *referenced* config on purpose, to prove IGW fails closed and then recovers when the config returns. That is exactly the state this PR now prevents through the API.
- The state remains reachable in production — an entity removed out-of-band, or a reference predating this guard — so rather than drop the coverage, they now build it the way it actually arises: deleting the entity straight from the entity store via `sdk.entities.delete_entity_by_name`.
- If you would rather the API offered a `force`/cascade escape hatch instead, say so and I will swap these over; I avoided expanding the API surface without a stated need.

All 57 integration tests in that suite now pass locally.

### `lint-python-sdk` also fails

Expected, and the same root cause as the SDK note below: the OpenAPI spec in this PR is current but the Stainless-generated SDK has not been regenerated, so the sync check fails.

Checks not run, stated rather than marked passed:

- **`uv run pre-commit run -a` was not run repo-wide.** The per-commit hooks ran and passed (DCO, merge conflicts); the full-repo sweep was not executed. Pushes used `--no-verify`: the local pre-push hook fails on `helm-docs` (not installed) and `uv-lock` (uv 0.9.28 vs the pinned 0.9.14), and this branch touches no chart, `uv.lock`, or `pyproject.toml` for either to check. CI runs them properly.
- **Python SDK not regenerated.** This touches `services/*/src/*/api/`, so per `AGENTS.md` it warrants `make update-sdk`; that needs `STAINLESS_API_KEY`, which was unavailable. The OpenAPI specs in this PR *are* current — regenerated again after the rebase onto current `main` and confirmed byte-identical to what the PR already contains. It is the Stainless step that is outstanding.

Pre-existing failures, re-verified on the current base after the rebase (same counts as on a clean tree):

- `packages/nemo_platform_plugin/tests/test_client_auth.py` — 7 failures, local base-URL config leakage.
- `services/core/entities/tests/integration/test_workspaces_crud_with_auth.py` — 18 failures, needs a live IdP.
- `services/core/inference-gateway/tests/integration/test_inference.py` — errors at setup, needs a live service.
- `ty` diagnostics: `RailsRegistryDep = None` / `ConfigRegistryDep = None` defaults and `create_config`'s `data` type, all outside the changed lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - VirtualModel listings can now be filtered by guardrail configuration, including through the CLI.
  - VirtualModel responses now show associated guardrail configuration IDs.
  - Guardrail configuration associations are tracked across workspaces and middleware stages.

- **Bug Fixes**
  - Deleting a guardrail configuration still applied to VirtualModels now returns `409 Conflict` with referencing model details.
  - Associations remain accurate when VirtualModels are created or updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->