### PR TITLE
fix(customizer): expose additional timeout knobs for RL sandboxing

### DIFF
--- a/services/rl/src/nmp/rl/app/jobs/compiler.py
+++ b/services/rl/src/nmp/rl/app/jobs/compiler.py
@@ -320,6 +320,7 @@ def _build_grpo_training_step_config(job_spec: RlJobOutput, *, trust_remote_code
             sandbox_resources=config.sandbox_resources,
             sandbox_ttl_s=config.sandbox_ttl_s,
             sandbox_rollout_chunk_size=config.sandbox_rollout_chunk_size,
+            sandbox_rollout_max_in_flight=config.sandbox_rollout_max_in_flight,
         ),
         training=TrainingStepConfig.TrainingConfig(
             training_type=TrainingType.GRPO,

--- a/services/rl/src/nmp/rl/app/jobs/training/schemas.py
+++ b/services/rl/src/nmp/rl/app/jobs/training/schemas.py
@@ -154,8 +154,10 @@ class TrainingStepConfig(BaseModel):
         # Operator-scoped, from platformConfig.rl.sandbox_resources / sandbox_ttl_s.
         sandbox_resources: dict[str, str] | None = None
         sandbox_ttl_s: int | None = None
-        # Rollouts per POST to the sandbox. None takes NeMo-RL's default.
+        # Rollouts per POST to the sandbox, and how many of those POSTs may run at once.
+        # None takes NeMo-RL's default. In-flight rollouts are the product of the two.
         sandbox_rollout_chunk_size: int | None = Field(default=None, gt=0)
+        sandbox_rollout_max_in_flight: int | None = Field(default=None, gt=0)
 
     class ScheduleConfig(BaseModel):
         epochs: int = 1

--- a/services/rl/src/nmp/rl/config.py
+++ b/services/rl/src/nmp/rl/config.py
@@ -106,7 +106,22 @@ class RlConfig(create_service_config_class("rl")):  # type: ignore[misc]  # ty: 
             "rollout with an HTTP 500 the job cannot recover from. The cap is fixed by the "
             "server build rather than exposed in its config, so the workable value is specific "
             "to this deployment and its models -- read the elapsed time on the failing POSTs "
-            "and divide down from 8. Operator-scoped: jobs cannot set it."
+            "and divide down from 8. Shrink this without raising sandbox_rollout_max_in_flight "
+            "and step throughput falls with it: in-flight rollouts are the product of the two. "
+            "Operator-scoped: jobs cannot set it."
+        ),
+    )
+
+    sandbox_rollout_max_in_flight: int | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Concurrent POSTs to the Gym sandbox, as "
+            "env.nemo_gym.sandbox.rollout_max_in_flight. Leave unset to take NeMo-RL's default "
+            "of 8. In-flight rollouts are rollout_chunk_size × this value, so a deployment that "
+            "lowers sandbox_rollout_chunk_size to stay under the proxy's per-request cap should "
+            "raise this in proportion if it wants the same step throughput. Operator-scoped: "
+            "jobs cannot set it."
         ),
     )
 

--- a/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/grpo_config.py
+++ b/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/grpo_config.py
@@ -231,41 +231,49 @@ def _build_nemo_gym_env_config(
             dataset_path=customizer_config.dataset.path,
         )
 
+        sandbox = SandboxConfig(
+            image=runtime_image,
+            env_mount_path=SANDBOX_ENVIRONMENT_PATH,
+            dataset_mount_path=SANDBOX_DATASET_PATH,
+            # Sandbox mount is /job/work; ephemeral host work prefers /scratch or /tmp.
+            work_mount_path=SANDBOX_WORK_PATH,
+            allow_internet=gym.allow_internet,
+            network_policy=SandboxNetworkPolicy(
+                # Defaults until the training master resolves live vLLM/broker endpoints.
+                egress_allow=assemble_master_egress_allow(),
+                public_dns_allow=tuple(gym.public_dns_allow),
+            ),
+            # Only emitted when the operator declared it, so an unset value leaves
+            # NeMo-RL's own default in place rather than this compiler asserting one.
+            host_provider_options=(
+                {"connection": {"protocol": gym.sandbox_server_protocol}} if gym.sandbox_server_protocol else {}
+            ),
+            # Same rule: unset leaves the OpenSandbox server's default in place.
+            resources=gym.sandbox_resources or None,
+            environment_pvc_claim=mounts.environment_pvc_claim,
+            environment_sub_path=mounts.environment_sub_path,
+            dataset_pvc_claim=mounts.dataset_pvc_claim,
+            dataset_sub_path=mounts.dataset_sub_path,
+            workspace_pvc_claim=mounts.workspace_pvc_claim,
+            workspace_sub_path=mounts.workspace_sub_path,
+        )
+
+        # Assigned after construction rather than passed in: these three carry non-null
+        # defaults mirroring NeMo-RL's, so handing them None would fail validation and
+        # asserting one here would override upstream on every job.
+        if gym.sandbox_ttl_s is not None:
+            sandbox.ttl_s = gym.sandbox_ttl_s
+        if gym.sandbox_rollout_chunk_size is not None:
+            sandbox.rollout_chunk_size = gym.sandbox_rollout_chunk_size
+        if gym.sandbox_rollout_max_in_flight is not None:
+            sandbox.rollout_max_in_flight = gym.sandbox_rollout_max_in_flight
+
         sandbox_cfg = NemoGymSandboxedConfig(
             sandboxed=True,
             host_provider="opensandbox",
             environment_path=gym.sandbox_environment_path or SANDBOX_ENVIRONMENT_PATH,
             job_id=job_ctx.job_id,
-            sandbox=SandboxConfig(
-                image=runtime_image,
-                env_mount_path=SANDBOX_ENVIRONMENT_PATH,
-                dataset_mount_path=SANDBOX_DATASET_PATH,
-                # Sandbox mount is /job/work; ephemeral host work prefers /scratch or /tmp.
-                work_mount_path=SANDBOX_WORK_PATH,
-                allow_internet=gym.allow_internet,
-                network_policy=SandboxNetworkPolicy(
-                    # Defaults until the training master resolves live vLLM/broker endpoints.
-                    egress_allow=assemble_master_egress_allow(),
-                    public_dns_allow=tuple(gym.public_dns_allow),
-                ),
-                # Only emitted when the operator declared it, so an unset value leaves
-                # NeMo-RL's own default in place rather than this compiler asserting one.
-                host_provider_options=(
-                    {"connection": {"protocol": gym.sandbox_server_protocol}} if gym.sandbox_server_protocol else {}
-                ),
-                # Same rule: unset leaves the OpenSandbox server's default in place.
-                resources=gym.sandbox_resources or None,
-                # ttl_s and rollout_chunk_size both have non-null defaults, so they are only
-                # overridden when declared.
-                **({"ttl_s": gym.sandbox_ttl_s} if gym.sandbox_ttl_s else {}),
-                **({"rollout_chunk_size": gym.sandbox_rollout_chunk_size} if gym.sandbox_rollout_chunk_size else {}),
-                environment_pvc_claim=mounts.environment_pvc_claim,
-                environment_sub_path=mounts.environment_sub_path,
-                dataset_pvc_claim=mounts.dataset_pvc_claim,
-                dataset_sub_path=mounts.dataset_sub_path,
-                workspace_pvc_claim=mounts.workspace_pvc_claim,
-                workspace_sub_path=mounts.workspace_sub_path,
-            ),
+            sandbox=sandbox,
         )
         # mode="json", not "python": this dict is written straight to YAML with yaml.dump
         # and read back by OmegaConf's SafeLoader. "python" mode keeps

--- a/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/sandbox_config.py
+++ b/services/rl/src/nmp/rl/tasks/training/backends/nemo_rl/sandbox_config.py
@@ -21,6 +21,9 @@ class GymHostEgressRule(BaseModel):
 
 #: NeMo-RL's ``DEFAULT_ROLLOUT_CHUNK_SIZE`` (``environments/sandbox/host/models.py``).
 DEFAULT_ROLLOUT_CHUNK_SIZE = 8
+#: NeMo-RL's ``DEFAULT_ROLLOUT_MAX_IN_FLIGHT``. Concurrent POSTs; effective in-flight
+#: rollouts are ``rollout_chunk_size * rollout_max_in_flight``.
+DEFAULT_ROLLOUT_MAX_IN_FLIGHT = 8
 
 
 class SandboxNetworkPolicy(BaseModel):
@@ -62,6 +65,9 @@ class SandboxConfig(BaseModel):
     # its rollouts ask for, and the OpenSandbox proxy caps how long one request may stay open,
     # so long generations can need a smaller chunk than NeMo-RL's default.
     rollout_chunk_size: int = Field(default=DEFAULT_ROLLOUT_CHUNK_SIZE, gt=0)
+    # Concurrent chunk POSTs. Lowering rollout_chunk_size without raising this throttles
+    # the step: in-flight rollouts are the product of the two.
+    rollout_max_in_flight: int = Field(default=DEFAULT_ROLLOUT_MAX_IN_FLIGHT, gt=0)
     network_policy: SandboxNetworkPolicy = Field(default_factory=SandboxNetworkPolicy)
     resources: dict[str, str] | None = None
     # Forwarded verbatim to NeMo-RL's host provider constructor (connection / create /

--- a/services/rl/tests/test_grpo_config.py
+++ b/services/rl/tests/test_grpo_config.py
@@ -20,7 +20,10 @@ from nmp.rl.app.jobs.training.schemas import (
 )
 from nmp.rl.entities.values import FinetuningType, TrainingType
 from nmp.rl.tasks.training.backends.nemo_rl.grpo_config import compile_grpo_config
-from nmp.rl.tasks.training.backends.nemo_rl.sandbox_config import DEFAULT_ROLLOUT_CHUNK_SIZE
+from nmp.rl.tasks.training.backends.nemo_rl.sandbox_config import (
+    DEFAULT_ROLLOUT_CHUNK_SIZE,
+    DEFAULT_ROLLOUT_MAX_IN_FLIGHT,
+)
 
 
 @pytest.fixture
@@ -1003,3 +1006,34 @@ def test_operator_can_pin_the_rollout_chunk_size(
     step.gym.sandbox_rollout_chunk_size = 2
     sandbox = compile_grpo_config(step, job_ctx)["env"]["nemo_gym"]["sandbox"]
     assert sandbox["rollout_chunk_size"] == 2
+
+
+def test_rollout_max_in_flight_defaults_to_the_upstream_value(
+    tmp_path: Path, job_ctx: NMPJobContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unset leaves NeMo-RL's default, so declaring the knob is never required."""
+    monkeypatch.setenv("NMP_JOB_STORAGE_PVC_CLAIM", "nmp-job-storage")
+    step, _ = _prepared_step(tmp_path)
+    assert step.gym is not None
+    assert step.gym.sandbox_rollout_max_in_flight is None
+
+    sandbox = compile_grpo_config(step, job_ctx)["env"]["nemo_gym"]["sandbox"]
+    assert sandbox["rollout_max_in_flight"] == DEFAULT_ROLLOUT_MAX_IN_FLIGHT
+
+
+def test_operator_can_pin_the_rollout_max_in_flight(
+    tmp_path: Path, job_ctx: NMPJobContext, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Lowering chunk_size without raising this throttles the step.
+
+    In-flight rollouts are chunk_size × max_in_flight, so a deployment that shrinks
+    chunks to stay under the proxy cap has to raise concurrency if it wants the same
+    throughput it had before chunking.
+    """
+    monkeypatch.setenv("NMP_JOB_STORAGE_PVC_CLAIM", "nmp-job-storage")
+    step, _ = _prepared_step(tmp_path)
+    assert step.gym is not None
+
+    step.gym.sandbox_rollout_max_in_flight = 64
+    sandbox = compile_grpo_config(step, job_ctx)["env"]["nemo_gym"]["sandbox"]
+    assert sandbox["rollout_max_in_flight"] == 64


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->
Expose additional timeout knobs for RL sandboxing

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->
AALGO-503

## Changes
<!-- List the concrete changes included in this pull request. -->
- Adds sandbox_rollout_max_in_flight for RL rollout request configuration
- Adds rollout_max_in_flight for RL rollout request configuration

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration to control the maximum number of concurrent sandbox rollout requests.
  * Supports operator-defined concurrency limits, with a default capacity of eight in-flight requests.
  * Documented how rollout chunk size and concurrency combine to determine effective capacity.

* **Bug Fixes**
  * Ensured sandbox settings are applied consistently when explicitly configured.

* **Tests**
  * Added coverage for default and customized rollout concurrency settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->