### PR TITLE
fix(studio): loader alignment and empty-state padding on eval surfaces (ASTD-477)

### DIFF
--- a/web/packages/common/src/components/form/TextInputSpinner/index.tsx
+++ b/web/packages/common/src/components/form/TextInputSpinner/index.tsx
@@ -8,5 +8,5 @@ import { Spinner } from '@nvidia/foundations-react-core';
  * Slotted in slotEnd
  */
 export const TextInputSpinner = () => {
-  return <Spinner aria-label="Loading" size="small" className="h-full" />;
+  return <Spinner aria-label="Loading" size="small" className="[&>div]:contents" />;
 };

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
@@ -160,6 +160,7 @@ export const EvaluationsTable: FC<EvaluationsTableProps> = ({ workspace, evaluat
           DataViewTableContent: {
             renderEmptyState: () => (
               <TableEmptyState
+                className="py-4"
                 icon={<FlaskConical className="size-16" />}
                 header="No published evaluations yet"
                 emptyMessage="Results appear here once a run finishes and its telemetry is ingested."

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
@@ -160,7 +160,7 @@ export const EvaluationsTable: FC<EvaluationsTableProps> = ({ workspace, evaluat
           DataViewTableContent: {
             renderEmptyState: () => (
               <TableEmptyState
-                className="py-4"
+                className="py-density-3xl"
                 icon={<FlaskConical className="size-16" />}
                 header="No published evaluations yet"
                 emptyMessage="Results appear here once a run finishes and its telemetry is ingested."

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/ExperimentsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/ExperimentsTable.tsx
@@ -124,6 +124,7 @@ export const ExperimentsTable: FC<ExperimentsTableProps> = ({ workspace, experim
           DataViewTableContent: {
             renderEmptyState: () => (
               <TableEmptyState
+                className="py-4"
                 icon={<FolderTree className="size-16" />}
                 header="No experiments yet"
                 emptyMessage="An experiment appears here once one of its evaluations publishes results for this agent."

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/ExperimentsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/ExperimentsTable.tsx
@@ -124,7 +124,7 @@ export const ExperimentsTable: FC<ExperimentsTableProps> = ({ workspace, experim
           DataViewTableContent: {
             renderEmptyState: () => (
               <TableEmptyState
-                className="py-4"
+                className="py-density-3xl"
                 icon={<FolderTree className="size-16" />}
                 header="No experiments yet"
                 emptyMessage="An experiment appears here once one of its evaluations publishes results for this agent."

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
@@ -137,6 +137,7 @@ export const JobsTable: FC<JobsTableProps> = ({ workspace, jobs, evaluations }) 
         DataViewTableContent: {
           renderEmptyState: () => (
             <TableEmptyState
+              className="py-4"
               icon={<ListChecks className="size-16" />}
               header="No evaluation jobs yet"
               emptyMessage="Runs appear here as soon as they are submitted, before any results are published."

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
@@ -137,7 +137,7 @@ export const JobsTable: FC<JobsTableProps> = ({ workspace, jobs, evaluations }) 
         DataViewTableContent: {
           renderEmptyState: () => (
             <TableEmptyState
-              className="py-4"
+              className="py-density-3xl"
               icon={<ListChecks className="size-16" />}
               header="No evaluation jobs yet"
               emptyMessage="Runs appear here as soon as they are submitted, before any results are published."


### PR DESCRIPTION

<img width="485" height="109" alt="Screenshot 2026-08-26 at 13 11 21" src="https://github.com/user-attachments/assets/3916a4c2-5407-416f-9396-dae66973baef" />

<img width="1780" height="1103" alt="Screenshot 2026-08-26 at 13 09 07" src="https://github.com/user-attachments/assets/afff4d98-c204-4661-a6ab-5cf94a1e85e2" />

# Summary

Two UI polish fixes on the agent entity page's Evaluations surface.

The loading spinner in Select/Combobox fields rendered flush to the top of the control. KUI's field-icon rule (`.nv-input-shell svg { width:16px; height:16px }`) clamps the spinner's svg to 16px, while KUI's own `.nv-spinner-root--size-small` wrapper stays 32px — leaving the 16px glyph top-anchored inside the taller box. Collapsing that wrapper with `[&>div]:contents` drops it from layout so the input shell's existing `align-items:center` centers the icon-sized spinner. The fix lives in the shared `TextInputSpinner`, so it corrects every consumer (Select, Combobox, searchable select, model selects), not just this modal.

Separately, the Completed Evaluations, Experiments, and Jobs table empty states passed no `className` to `TableEmptyState`, so they had no vertical padding and sat cramped against the table chrome. Added `className="py-4"` to match the padded default every other studio table already uses.

# Test plan

- [ ] Agent → **Evaluations** → **Run evaluation** → **Run Agent Evaluation** → **Use existing evaluation** tab → while options load, the **Evaluation** select's spinner is vertically centered and clear of the chevron (not flush to the top)
- [ ] Agent with no published evaluations → **Completed Evaluations** table shows "No published evaluations yet" with vertical padding around the illustration + text (not cramped)
- [ ] Same agent → **Experiments** table shows "No experiments yet" with matching padding
- [ ] Active eval jobs table empty state ("No evaluation jobs yet") is likewise padded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved loading spinner sizing within text inputs.
  - Increased vertical spacing in empty states for evaluations, experiments, and jobs tables.
  - Updated empty-state layouts for a more consistent and balanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->