### PR TITLE
feat(agents): define deployment session lifecycle

### DIFF
--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -4259,11 +4259,12 @@ components:
         status:
           allOf:
           - $ref: '#/components/schemas/SessionStatus'
-          description: 'Lifecycle status: active | closed.'
+          description: 'Lifecycle status: active | expired | lost | closed.'
           default: active
         last_active_at:
           title: Last Active At
-          description: UTC timestamp of the last activity in the session.
+          description: UTC timestamp of the last activity in the session; null until
+            a runtime has successfully attached.
           nullable: true
           type: string
           format: date-time
@@ -6826,6 +6827,8 @@ components:
       type: string
       enum:
       - active
+      - expired
+      - lost
       - closed
       title: SessionStatus
       description: Lifecycle status of an agent session.

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -4263,14 +4263,14 @@ components:
           default: active
         last_active_at:
           title: Last Active At
-          description: UTC timestamp of the last activity in the session; null until
-            a runtime has successfully attached.
+          description: UTC timestamp of the latest accepted or completed invocation;
+            null until the first invocation is accepted.
           nullable: true
           type: string
           format: date-time
         expires_at:
           title: Expires At
-          description: UTC timestamp when the session expires, if expiration is configured.
+          description: UTC rolling idle deadline derived from the latest session activity.
           nullable: true
           type: string
           format: date-time

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -4261,6 +4261,13 @@ components:
           - $ref: '#/components/schemas/SessionStatus'
           description: 'Lifecycle status: active | expired | lost | closed.'
           default: active
+        first_active_at:
+          title: First Active At
+          description: UTC timestamp of the first accepted invocation; immutable once
+            set.
+          nullable: true
+          type: string
+          format: date-time
         last_active_at:
           title: Last Active At
           description: UTC timestamp of the latest accepted or completed invocation;

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -344,14 +344,16 @@ async def _proxy_deployment(
         if activity_session is not None:
             await _best_effort_session_activity_update(entity_client, activity_session)
 
+    tracks_session_activity = session is not None and request.method.upper() in _PROXY_WRITE_METHODS
+
     return await _proxy(
         request,
         endpoint,
         trailing_uri,
         model_name=model_name,
         session_id=session.id if session is not None else None,
-        on_start=persist_start_activity if session is not None else None,
-        on_complete=persist_finish_activity if session is not None else None,
+        on_start=persist_start_activity if tracks_session_activity else None,
+        on_complete=persist_finish_activity if tracks_session_activity else None,
     )
 
 
@@ -465,10 +467,7 @@ async def _resolve_request_session(
     if session.status is not SessionStatus.ACTIVE:
         raise _session_inactive(session)
     if session.expires_at is not None and session_expiration_is_due(session, at=_utc_now()):
-        raise HTTPException(
-            status_code=409,
-            detail=f"Session ID '{session.id}' has status 'expired' and cannot be invoked.",
-        )
+        raise _session_expired(session)
     return session
 
 
@@ -521,6 +520,13 @@ def _session_inactive(session: AgentSession) -> HTTPException:
     )
 
 
+def _session_expired(session: AgentSession) -> HTTPException:
+    return HTTPException(
+        status_code=409,
+        detail=f"Session ID '{session.id}' has status 'expired' and cannot be invoked.",
+    )
+
+
 def _utc_now() -> datetime:
     return datetime.now(UTC)
 
@@ -538,6 +544,8 @@ async def _persist_session_activity(
     for attempt in range(2):
         if session_to_update.status is not SessionStatus.ACTIVE:
             raise _session_inactive(session_to_update)
+        if session_expiration_is_due(session_to_update, at=timestamp):
+            raise _session_expired(session_to_update)
 
         last_active_at = session_to_update.last_active_at
         if last_active_at is not None:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -51,6 +51,7 @@ from nemo_agents_plugin.authz import scope
 from nemo_agents_plugin.deployment_routing import get_deployment_endpoint, is_deployment_routable
 from nemo_agents_plugin.entities import Agent, AgentDeployment, AgentSession, SessionStatus
 from nemo_agents_plugin.fabric.session_manager import DEFAULT_IDLE_SESSION_TIMEOUT_SECONDS
+from nemo_agents_plugin.session_lifecycle import session_expiration_is_due
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 from nemo_platform_plugin.authz import CallerKind, path_rule
 from nemo_platform_plugin.dependencies import get_effective_principal_id
@@ -463,6 +464,11 @@ async def _resolve_request_session(
     )
     if session.status is not SessionStatus.ACTIVE:
         raise _session_inactive(session)
+    if session.expires_at is not None and session_expiration_is_due(session, at=_utc_now()):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Session ID '{session.id}' has status 'expired' and cannot be invoked.",
+        )
     return session
 
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -31,7 +31,8 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import UTC, datetime, timedelta
 from urllib.parse import urljoin, urlparse, urlunparse
 
 import httpx
@@ -49,14 +50,23 @@ from nemo_agents_plugin.api.v2.session_access import get_owned_session_by_id
 from nemo_agents_plugin.authz import scope
 from nemo_agents_plugin.deployment_routing import get_deployment_endpoint, is_deployment_routable
 from nemo_agents_plugin.entities import Agent, AgentDeployment, AgentSession, SessionStatus
+from nemo_agents_plugin.fabric.session_manager import DEFAULT_IDLE_SESSION_TIMEOUT_SECONDS
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 from nemo_platform_plugin.authz import CallerKind, path_rule
 from nemo_platform_plugin.dependencies import get_effective_principal_id
-from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
+from nemo_platform_plugin.entity_client import (
+    NemoEntitiesClient,
+    NemoEntityConflictError,
+    NemoEntityNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Platform-created Fabric deployments currently use the serving default. If the
+# timeout becomes deployment-configurable, this value must come from the deployment.
+_SESSION_IDLE_TIMEOUT = timedelta(seconds=DEFAULT_IDLE_SESSION_TIMEOUT_SECONDS)
 
 # HTTP methods forwarded through the proxy, split by authorization scope. Read-like methods
 # require only agents:read; mutating methods require agents:write. This mirrors the Inference
@@ -167,7 +177,8 @@ async def _resolve_and_proxy_agent(
         deployment,
         trailing_uri,
         model_name=name,
-        session_id=session.id if session is not None else None,
+        entity_client=entity_client,
+        session=session,
     )
 
 
@@ -289,7 +300,8 @@ async def _resolve_and_proxy_deployment(
         dep,
         trailing_uri,
         model_name=name,
-        session_id=session.id if session is not None else None,
+        entity_client=entity_client,
+        session=session,
     )
 
 
@@ -299,7 +311,8 @@ async def _proxy_deployment(
     trailing_uri: str,
     *,
     model_name: str,
-    session_id: str | None = None,
+    entity_client: NemoEntitiesClient,
+    session: AgentSession | None = None,
 ) -> StreamingResponse:
     """Validate and proxy to an already-resolved deployment entity."""
     if not is_deployment_routable(deployment):
@@ -319,12 +332,25 @@ async def _proxy_deployment(
             detail=f"Deployment '{deployment.name}' has no routable endpoint (status='{deployment.status}').",
         )
 
+    activity_session = session
+
+    async def persist_start_activity() -> None:
+        nonlocal activity_session
+        if activity_session is not None:
+            activity_session = await _require_session_activity_update(entity_client, activity_session)
+
+    async def persist_finish_activity() -> None:
+        if activity_session is not None:
+            await _best_effort_session_activity_update(entity_client, activity_session)
+
     return await _proxy(
         request,
         endpoint,
         trailing_uri,
         model_name=model_name,
-        session_id=session_id,
+        session_id=session.id if session is not None else None,
+        on_start=persist_start_activity if session is not None else None,
+        on_complete=persist_finish_activity if session is not None else None,
     )
 
 
@@ -436,10 +462,7 @@ async def _resolve_request_session(
         effective_principal_id=effective_principal_id,
     )
     if session.status is not SessionStatus.ACTIVE:
-        raise HTTPException(
-            status_code=409,
-            detail=(f"Session ID '{session_id}' has status '{session.status.value}' and cannot be invoked."),
-        )
+        raise _session_inactive(session)
     return session
 
 
@@ -485,6 +508,99 @@ def _session_deployment_mismatch(session: AgentSession, *, detail: str) -> HTTPE
     )
 
 
+def _session_inactive(session: AgentSession) -> HTTPException:
+    return HTTPException(
+        status_code=409,
+        detail=(f"Session ID '{session.id}' has status '{session.status.value}' and cannot be invoked."),
+    )
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+async def _persist_session_activity(
+    entity_client: NemoEntitiesClient,
+    session: AgentSession,
+    *,
+    activity_at: datetime | None = None,
+) -> AgentSession:
+    """Advance persisted activity timestamps, retrying one optimistic conflict."""
+    timestamp = (activity_at or _utc_now()).astimezone(UTC)
+    session_to_update = session
+
+    for attempt in range(2):
+        if session_to_update.status is not SessionStatus.ACTIVE:
+            raise _session_inactive(session_to_update)
+
+        last_active_at = session_to_update.last_active_at
+        if last_active_at is not None:
+            if last_active_at.tzinfo is None or last_active_at.utcoffset() is None:
+                last_active_at = last_active_at.replace(tzinfo=UTC)
+            if last_active_at >= timestamp:
+                return session_to_update
+
+        session_to_update.last_active_at = timestamp
+        session_to_update.expires_at = timestamp + _SESSION_IDLE_TIMEOUT
+        try:
+            return await entity_client.update(session_to_update)
+        except NemoEntityConflictError:
+            if attempt == 1:
+                raise
+            session_to_update = await entity_client.get_by_id(AgentSession, session.id)
+
+    raise RuntimeError("Session activity update retry loop exited unexpectedly.")  # pragma: no cover
+
+
+async def _require_session_activity_update(
+    entity_client: NemoEntitiesClient,
+    session: AgentSession,
+) -> AgentSession:
+    """Persist required invocation-start activity or reject the invocation."""
+    try:
+        return await _persist_session_activity(entity_client, session)
+    except HTTPException:
+        raise
+    except NemoEntityNotFoundError as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Session ID '{session.id}' was deleted before invocation.",
+        ) from exc
+    except NemoEntityConflictError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Session ID '{session.id}' is being modified concurrently.",
+        ) from exc
+    except Exception as exc:
+        logger.exception("Failed to persist invocation-start activity for session ID '%s'.", session.id)
+        raise HTTPException(
+            status_code=503,
+            detail=f"Could not persist activity for session ID '{session.id}'.",
+        ) from exc
+
+
+async def _best_effort_session_activity_update(
+    entity_client: NemoEntitiesClient,
+    session: AgentSession,
+) -> None:
+    """Persist invocation-finish activity without changing an emitted response."""
+    try:
+        await _persist_session_activity(entity_client, session)
+    except HTTPException:
+        logger.debug(
+            "Session ID '%s' became non-active before finish activity was persisted.",
+            session.id,
+        )
+    except NemoEntityNotFoundError:
+        logger.debug("Session ID '%s' was deleted before finish activity was persisted.", session.id)
+    except Exception:
+        logger.warning(
+            "Failed to persist invocation-finish activity for session ID '%s'.",
+            session.id,
+            exc_info=True,
+        )
+
+
 async def _proxy(
     request: Request,
     endpoint: str,
@@ -492,6 +608,8 @@ async def _proxy(
     *,
     model_name: str | None = None,
     session_id: str | None = None,
+    on_start: Callable[[], Awaitable[None]] | None = None,
+    on_complete: Callable[[], Awaitable[None]] | None = None,
 ) -> StreamingResponse:
     """Forward *request* to ``{endpoint}/{trailing_uri}`` and stream the response.
 
@@ -531,6 +649,19 @@ async def _proxy(
         headers[SESSION_ID_HEADER] = session_id
 
     body = await request.body()
+
+    activity_started = False
+    activity_completed = False
+    if on_start is not None:
+        await on_start()
+        activity_started = True
+
+    async def _complete_activity_once() -> None:
+        nonlocal activity_completed
+        if not activity_started or activity_completed or on_complete is None:
+            return
+        activity_completed = True
+        await on_complete()
 
     # We need the upstream response headers before we can construct StreamingResponse
     # (to forward content-type, etc.).  Use a two-phase approach:
@@ -579,10 +710,13 @@ async def _proxy(
     chunks: list[bytes] = []
 
     async def _buffered() -> AsyncIterator[bytes]:
-        for c in chunks:
-            yield c
-        async for c in stream_gen:
-            yield c
+        try:
+            for c in chunks:
+                yield c
+            async for c in stream_gen:
+                yield c
+        finally:
+            await _complete_activity_once()
 
     # Prime: triggers the HTTP request, populates response_headers / status_code_holder,
     # and catches the most common failure modes before we commit to a StreamingResponse.
@@ -592,9 +726,14 @@ async def _proxy(
     except StopAsyncIteration:
         pass  # empty body — still valid (e.g. 204)
     except HTTPException:
+        await _complete_activity_once()
         raise  # 5xx → 502 translation raised inside the generator; propagate as-is
     except httpx.RequestError as exc:
+        await _complete_activity_once()
         raise HTTPException(status_code=502, detail=f"Could not connect to agent: {exc}") from exc
+    except BaseException:
+        await _complete_activity_once()
+        raise
 
     content_type = response_headers.get("content-type", "application/json")
 
@@ -607,8 +746,12 @@ async def _proxy(
     # NemoAgentWrapperFunction.convert_to_chat_response where the LLM's
     # response_metadata carries the real model name.
     if model_name and not content_type.startswith("text/event-stream"):
-        async for remaining in stream_gen:
-            chunks.append(remaining)
+        try:
+            async for remaining in stream_gen:
+                chunks.append(remaining)
+        except BaseException:
+            await _complete_activity_once()
+            raise
         raw = b"".join(chunks)
         try:
             data = json.loads(raw)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -548,6 +548,8 @@ async def _persist_session_activity(
             raise _session_expired(session_to_update)
 
         last_active_at = session_to_update.last_active_at
+        if session_to_update.first_active_at is None and last_active_at is None:
+            session_to_update.first_active_at = timestamp
         if last_active_at is not None:
             if last_active_at.tzinfo is None or last_active_at.utcoffset() is None:
                 last_active_at = last_active_at.replace(tzinfo=UTC)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -523,7 +523,7 @@ def _session_inactive(session: AgentSession) -> HTTPException:
 def _session_expired(session: AgentSession) -> HTTPException:
     return HTTPException(
         status_code=409,
-        detail=f"Session ID '{session.id}' has status 'expired' and cannot be invoked.",
+        detail=f"Session ID '{session.id}' has expired and cannot be invoked.",
     )
 
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/gateway.py
@@ -438,7 +438,7 @@ async def _resolve_request_session(
     if session.status is not SessionStatus.ACTIVE:
         raise HTTPException(
             status_code=409,
-            detail=f"Session ID '{session_id}' is closed and cannot be invoked.",
+            detail=(f"Session ID '{session_id}' has status '{session.status.value}' and cannot be invoked."),
         )
     return session
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
@@ -16,7 +16,7 @@ import secrets
 from collections.abc import Awaitable
 from typing import cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from nemo_agents_plugin.api.v2._perms import SessionPerms
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.api.v2.session_access import get_owned_session, session_not_found
@@ -159,6 +159,7 @@ async def get_session(
 async def close_session(
     workspace: str,
     name: str,
+    background_tasks: BackgroundTasks,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
     effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> AgentSession:
@@ -170,46 +171,47 @@ async def close_session(
         effective_principal_id=effective_principal_id,
     )
 
-    if session.status is SessionStatus.CLOSED:
-        await _cleanup_fabric_runtime(entity_client, session)
-        return session
+    session_to_update = session
+    for attempt in range(2):
+        if session_to_update.status is SessionStatus.CLOSED:
+            background_tasks.add_task(_cleanup_fabric_runtime, entity_client, session_to_update)
+            return session_to_update
 
-    if not session.status.can_transition_to(SessionStatus.CLOSED):
-        raise HTTPException(
-            status_code=409,
-            detail=f"Session '{name}' cannot transition from '{session.status}' to 'closed'.",
-        )
+        if not session_to_update.status.can_transition_to(SessionStatus.CLOSED):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Session '{name}' cannot transition from '{session_to_update.status}' to 'closed'.",
+            )
 
-    session.status = SessionStatus.CLOSED
-    try:
-        updated_session = await entity_client.update(session)
-    except NemoEntityNotFoundError as exc:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Session '{name}' not found in workspace '{workspace}'.",
-        ) from exc
-    except NemoEntityConflictError as exc:
-        latest_session = await get_owned_session(
-            entity_client,
-            workspace=workspace,
-            name=name,
-            effective_principal_id=effective_principal_id,
-        )
+        session_to_update.status = SessionStatus.CLOSED
+        try:
+            updated_session = await entity_client.update(session_to_update)
+        except NemoEntityNotFoundError as exc:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Session '{name}' not found in workspace '{workspace}'.",
+            ) from exc
+        except NemoEntityConflictError as exc:
+            if attempt == 1:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Session '{name}' is being modified concurrently.",
+                ) from exc
+            session_to_update = await get_owned_session(
+                entity_client,
+                workspace=workspace,
+                name=name,
+                effective_principal_id=effective_principal_id,
+            )
+            continue
+        except Exception as exc:
+            logger.exception("Failed to close session '%s'", name)
+            raise HTTPException(status_code=500, detail="Failed to close session.") from exc
 
-        if latest_session.status is SessionStatus.CLOSED:
-            await _cleanup_fabric_runtime(entity_client, latest_session)
-            return latest_session
+        background_tasks.add_task(_cleanup_fabric_runtime, entity_client, updated_session)
+        return updated_session
 
-        raise HTTPException(
-            status_code=409,
-            detail=f"Session '{name}' is being modified concurrently.",
-        ) from exc
-    except Exception as exc:
-        logger.exception("Failed to close session '%s'", name)
-        raise HTTPException(status_code=500, detail="Failed to close session.") from exc
-
-    await _cleanup_fabric_runtime(entity_client, updated_session)
-    return updated_session
+    raise RuntimeError("Session close retry loop exited unexpectedly.")  # pragma: no cover
 
 
 @router.delete("/sessions/{name}", status_code=204, tags=["Agent Sessions"])
@@ -221,6 +223,7 @@ async def close_session(
 async def delete_session(
     workspace: str,
     name: str,
+    background_tasks: BackgroundTasks,
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
     effective_principal_id: str = Depends(get_effective_principal_id),
 ) -> None:
@@ -250,7 +253,7 @@ async def delete_session(
         logger.exception("Failed to delete session '%s'", name)
         raise HTTPException(status_code=500, detail="Failed to delete session.") from exc
 
-    await _cleanup_fabric_runtime(entity_client, session)
+    background_tasks.add_task(_cleanup_fabric_runtime, entity_client, session)
 
 
 async def _get_deployment_for_session(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
@@ -15,17 +15,15 @@ import logging
 import secrets
 from collections.abc import Awaitable
 from typing import cast
-from urllib.parse import quote
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
 from nemo_agents_plugin.api.v2._perms import SessionPerms
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.api.v2.session_access import get_owned_session, session_not_found
 from nemo_agents_plugin.authz import scope
-from nemo_agents_plugin.deployment_routing import get_deployment_endpoint
 from nemo_agents_plugin.entities import AgentDeployment, AgentSession, SessionStatus
 from nemo_agents_plugin.schema import CreateSessionRequest, SessionFilter, SessionPage
+from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime as _cleanup_fabric_runtime
 from nemo_platform_plugin.api.filters import make_filter_obj_dep
 from nemo_platform_plugin.authz import CallerKind, path_rule
 from nemo_platform_plugin.dependencies import get_effective_principal_id
@@ -38,8 +36,6 @@ from starlette.requests import Request
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
-
-_FABRIC_CLEANUP_TIMEOUT_SECONDS = 5.0
 
 _raw_session_filter_dep = make_filter_obj_dep(SessionFilter)
 
@@ -285,66 +281,4 @@ def _deployment_not_found(workspace: str, deployment_id: str) -> HTTPException:
     return HTTPException(
         status_code=404,
         detail=f"Deployment ID '{deployment_id}' not found in workspace '{workspace}'.",
-    )
-
-
-async def _cleanup_fabric_runtime(
-    entity_client: NemoEntitiesClient,
-    session: AgentSession,
-) -> None:
-    """Best-effort removal of a session's process-local Fabric runtime."""
-    try:
-        deployment = await entity_client.find_one(
-            AgentDeployment,
-            workspace=session.workspace,
-            filter_obj={"id": session.deployment_id},
-        )
-    except Exception:
-        logger.warning(
-            "Could not resolve deployment ID '%s' while cleaning up session ID '%s'.",
-            session.deployment_id,
-            session.id,
-            exc_info=True,
-        )
-        return
-
-    if deployment.id != session.deployment_id or deployment.workspace != session.workspace:
-        logger.warning(
-            "Resolved deployment did not match session ID '%s'; skipping Fabric runtime cleanup.",
-            session.id,
-        )
-        return
-
-    endpoint = get_deployment_endpoint(deployment)
-    if endpoint is None:
-        logger.warning(
-            "Deployment ID '%s' has no endpoint; skipping cleanup for session ID '%s'.",
-            deployment.id,
-            session.id,
-        )
-        return
-
-    cleanup_url = f"{endpoint.rstrip('/')}/v1/sessions/{quote(session.id, safe='')}"
-    try:
-        async with httpx.AsyncClient(
-            timeout=_FABRIC_CLEANUP_TIMEOUT_SECONDS,
-            follow_redirects=False,
-        ) as client:
-            response = await client.delete(cleanup_url)
-    except Exception:
-        logger.warning(
-            "Fabric runtime cleanup request failed for session ID '%s'.",
-            session.id,
-            exc_info=True,
-        )
-        return
-
-    # A missing runtime is already clean: the session may never have been invoked or may
-    # have expired from the deployment's process-local registry.
-    if response.status_code == 404 or 200 <= response.status_code < 300:
-        return
-    logger.warning(
-        "Fabric runtime cleanup returned HTTP %s for session ID '%s'.",
-        response.status_code,
-        session.id,
     )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
@@ -178,6 +178,12 @@ async def close_session(
         await _cleanup_fabric_runtime(entity_client, session)
         return session
 
+    if not session.status.can_transition_to(SessionStatus.CLOSED):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Session '{name}' cannot transition from '{session.status}' to 'closed'.",
+        )
+
     session.status = SessionStatus.CLOSED
     try:
         updated_session = await entity_client.update(session)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
@@ -473,6 +473,11 @@ class AgentSession(NemoEntity, entity_type="agent_session"):
         default=SessionStatus.ACTIVE,
         description="Lifecycle status: active | expired | lost | closed.",
     )
+    first_active_at: datetime | None = Field(
+        default=None,
+        description="UTC timestamp of the first accepted invocation; immutable once set.",
+        json_schema_extra={"nullable": True},
+    )
     last_active_at: datetime | None = Field(
         default=None,
         description=(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
@@ -26,7 +26,26 @@ class SessionStatus(StrEnum):
     """Lifecycle status of an agent session."""
 
     ACTIVE = "active"
+    EXPIRED = "expired"
+    LOST = "lost"
     CLOSED = "closed"
+
+    def can_transition_to(self, new_status: SessionStatus) -> bool:
+        """Return whether transitioning to *new_status* is allowed."""
+        if self == new_status:
+            return True
+
+        valid_transitions = {
+            SessionStatus.ACTIVE: {
+                SessionStatus.EXPIRED,
+                SessionStatus.LOST,
+                SessionStatus.CLOSED,
+            },
+            SessionStatus.EXPIRED: {SessionStatus.CLOSED},
+            SessionStatus.LOST: {SessionStatus.CLOSED},
+            SessionStatus.CLOSED: set(),
+        }
+        return new_status in valid_transitions[self]
 
 
 # Runtime backend for an AgentDeployment. ``subprocess`` (the default) runs the
@@ -452,11 +471,13 @@ class AgentSession(NemoEntity, entity_type="agent_session"):
     )
     status: SessionStatus = Field(
         default=SessionStatus.ACTIVE,
-        description="Lifecycle status: active | closed.",
+        description="Lifecycle status: active | expired | lost | closed.",
     )
     last_active_at: datetime | None = Field(
         default=None,
-        description="UTC timestamp of the last activity in the session.",
+        description=(
+            "UTC timestamp of the last activity in the session; null until a runtime has successfully attached."
+        ),
         json_schema_extra={"nullable": True},
     )
     expires_at: datetime | None = Field(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
@@ -476,12 +476,12 @@ class AgentSession(NemoEntity, entity_type="agent_session"):
     last_active_at: datetime | None = Field(
         default=None,
         description=(
-            "UTC timestamp of the last activity in the session; null until a runtime has successfully attached."
+            "UTC timestamp of the latest accepted or completed invocation; null until the first invocation is accepted."
         ),
         json_schema_extra={"nullable": True},
     )
     expires_at: datetime | None = Field(
         default=None,
-        description="UTC timestamp when the session expires, if expiration is configured.",
+        description="UTC rolling idle deadline derived from the latest session activity.",
         json_schema_extra={"nullable": True},
     )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -278,10 +278,11 @@ def create_fabric_serving_app(
                 await session_manager.close_all_sessions()
 
     app = FastAPI(title="NeMo Agents Fabric Server", lifespan=lifespan)
+    runtime_instance_id = str(uuid.uuid4())
 
     @app.get("/health")
     async def health() -> dict[str, str]:
-        return {"status": "ok"}
+        return {"status": "ok", "runtime_instance_id": runtime_instance_id}
 
     @app.post("/v1/chat/completions", response_model=None, response_model_exclude_none=True)
     async def chat_completions(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -390,6 +390,8 @@ def main(argv: list[str] | None = None) -> int:
         default=DEFAULT_MAX_CONCURRENT_INVOCATIONS,
         help="Maximum concurrent Fabric invocations; use 0 for unlimited.",
     )
+    # Overrides must stay aligned with the gateway timeout used to compute
+    # persisted ``expires_at``; ideally both come from the deployment config.
     parser.add_argument(
         "--idle-session-timeout-seconds",
         type=float,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -256,7 +256,6 @@ def create_fabric_serving_app(
             base_dir=config_path.parent,
             session_registry=session_registry,
             max_concurrent_invocations=settings.max_concurrent_invocations,
-            idle_session_timeout_seconds=settings.idle_session_timeout_seconds,
         )
         app.state.session_manager = session_manager
         cleanup_shutdown = asyncio.Event()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -256,6 +256,7 @@ def create_fabric_serving_app(
             base_dir=config_path.parent,
             session_registry=session_registry,
             max_concurrent_invocations=settings.max_concurrent_invocations,
+            idle_session_timeout_seconds=settings.idle_session_timeout_seconds,
         )
         app.state.session_manager = session_manager
         cleanup_shutdown = asyncio.Event()

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -13,6 +13,7 @@ import uuid
 from collections.abc import AsyncGenerator, AsyncIterator, Mapping
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -279,10 +280,15 @@ def create_fabric_serving_app(
 
     app = FastAPI(title="NeMo Agents Fabric Server", lifespan=lifespan)
     runtime_instance_id = str(uuid.uuid4())
+    runtime_started_at = datetime.now(UTC)
 
     @app.get("/health")
     async def health() -> dict[str, str]:
-        return {"status": "ok", "runtime_instance_id": runtime_instance_id}
+        return {
+            "status": "ok",
+            "runtime_instance_id": runtime_instance_id,
+            "runtime_started_at": runtime_started_at.isoformat(),
+        }
 
     @app.post("/v1/chat/completions", response_model=None, response_model_exclude_none=True)
     async def chat_completions(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/session_manager.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/session_manager.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from nemo_agents_plugin.agent_config import AgentConfig
@@ -44,6 +45,18 @@ class FabricSessionStopError(RuntimeError):
     """Raised when a Fabric runtime cannot be stopped for a Platform session."""
 
 
+@dataclass(frozen=True, slots=True)
+class FabricSessionActivity:
+    """One persisted activity timestamp update for a Platform session."""
+
+    session_id: str
+    last_active_at: datetime
+    expires_at: datetime
+
+
+SessionActivityCallback = Callable[[FabricSessionActivity], Awaitable[None]]
+
+
 @dataclass(slots=True)
 class _SessionCreationGate:
     """Per-session runtime-start lock and its current holder/waiter count."""
@@ -63,14 +76,22 @@ class FabricSessionManager:
         session_registry: FabricSessionRegistry,
         fabric: Fabric | None = None,
         max_concurrent_invocations: int = DEFAULT_MAX_CONCURRENT_INVOCATIONS,
+        idle_session_timeout_seconds: float = DEFAULT_IDLE_SESSION_TIMEOUT_SECONDS,
+        activity_callback: SessionActivityCallback | None = None,
+        clock: Callable[[], datetime] | None = None,
     ) -> None:
         if max_concurrent_invocations < 0:
             raise ValueError("max_concurrent_invocations must be greater than or equal to zero.")
+        if idle_session_timeout_seconds <= 0:
+            raise ValueError("idle_session_timeout_seconds must be greater than zero.")
 
         self._agent_config = agent_config
         self._base_dir = base_dir
         self._session_registry = session_registry
         self._fabric = fabric
+        self._idle_session_timeout = timedelta(seconds=idle_session_timeout_seconds)
+        self._activity_callback = activity_callback
+        self._clock = clock or (lambda: datetime.now(UTC))
         self._session_creation_gates: dict[str, _SessionCreationGate] = {}
         self._closed_session_ids: set[str] = set()
         self._invocation_semaphore = (
@@ -95,10 +116,15 @@ class FabricSessionManager:
         except FabricError as error:
             raise FabricSessionStartError(f"Fabric runtime startup failed: {error}") from error
 
+        registered_session: FabricRuntimeSession | None = None
         try:
-            return await self._session_registry.register(runtime, session_id=session_id)
+            registered_session = await self._session_registry.register(runtime, session_id=session_id)
+            await self._report_activity(registered_session)
+            return registered_session
         except BaseException:
             # A started runtime must not leak if registration fails or is cancelled.
+            if registered_session is not None:
+                await self._session_registry.remove(registered_session.session_id)
             try:
                 await runtime.stop()
             except FabricError:
@@ -141,13 +167,20 @@ class FabricSessionManager:
         async with session.invocation_lock:
             if session.closing:
                 raise FabricSessionNotFoundError(f"Fabric session '{session.session_id}' was not found.")
+            invocation_started = False
             try:
                 if self._invocation_semaphore is None:
+                    await self._report_activity(session)
+                    invocation_started = True
                     return await invoke_fabric_runtime(session.runtime, request)
                 async with self._invocation_semaphore:
+                    await self._report_activity(session)
+                    invocation_started = True
                     return await invoke_fabric_runtime(session.runtime, request)
             finally:
                 await self._session_registry.refresh_activity(session)
+                if invocation_started:
+                    await self._report_activity(session)
 
     @asynccontextmanager
     async def stream_session(
@@ -159,14 +192,21 @@ class FabricSessionManager:
         async with session.invocation_lock:
             if session.closing:
                 raise FabricSessionNotFoundError(f"Fabric session '{session.session_id}' was not found.")
+            invocation_started = False
             try:
                 if self._invocation_semaphore is None:
+                    await self._report_activity(session)
+                    invocation_started = True
                     yield stream_fabric_runtime(session.runtime, request)
                 else:
                     async with self._invocation_semaphore:
+                        await self._report_activity(session)
+                        invocation_started = True
                         yield stream_fabric_runtime(session.runtime, request)
             finally:
                 await self._session_registry.refresh_activity(session)
+                if invocation_started:
+                    await self._report_activity(session)
 
     async def close_session(self, session_id: str) -> None:
         """Remove a session and stop its runtime after any active turn finishes."""
@@ -239,6 +279,23 @@ class FabricSessionManager:
                 await session.runtime.stop()
             except FabricError as error:
                 raise FabricSessionStopError(f"Fabric runtime shutdown failed: {error}") from error
+
+    async def _report_activity(self, session: FabricRuntimeSession) -> None:
+        """Report one timezone-aware UTC activity update when reporting is configured."""
+        if self._activity_callback is None:
+            return
+
+        last_active_at = self._clock()
+        if last_active_at.tzinfo is None or last_active_at.utcoffset() is None:
+            raise ValueError("The Fabric session activity clock must return a timezone-aware datetime.")
+        last_active_at = last_active_at.astimezone(UTC)
+        await self._activity_callback(
+            FabricSessionActivity(
+                session_id=session.session_id,
+                last_active_at=last_active_at,
+                expires_at=last_active_at + self._idle_session_timeout,
+            )
+        )
 
 
 def _prepare_serving_fabric_config(fabric_config: FabricConfig) -> FabricConfig:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/session_manager.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/session_manager.py
@@ -32,6 +32,9 @@ from nemo_fabric import Fabric, FabricConfig, FabricError
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_CONCURRENT_INVOCATIONS = 8
+# The gateway derives persisted ``AgentSession.expires_at`` from this same
+# value. If the timeout becomes configurable, single-source it from the
+# deployment so persisted expiry and process-local runtime eviction stay aligned.
 DEFAULT_IDLE_SESSION_TIMEOUT_SECONDS = 30 * 60
 DEFAULT_SESSION_CLEANUP_INTERVAL_SECONDS = 5 * 60
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/session_manager.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/session_manager.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 from nemo_agents_plugin.agent_config import AgentConfig
@@ -45,18 +44,6 @@ class FabricSessionStopError(RuntimeError):
     """Raised when a Fabric runtime cannot be stopped for a Platform session."""
 
 
-@dataclass(frozen=True, slots=True)
-class FabricSessionActivity:
-    """One persisted activity timestamp update for a Platform session."""
-
-    session_id: str
-    last_active_at: datetime
-    expires_at: datetime
-
-
-SessionActivityCallback = Callable[[FabricSessionActivity], Awaitable[None]]
-
-
 @dataclass(slots=True)
 class _SessionCreationGate:
     """Per-session runtime-start lock and its current holder/waiter count."""
@@ -76,22 +63,14 @@ class FabricSessionManager:
         session_registry: FabricSessionRegistry,
         fabric: Fabric | None = None,
         max_concurrent_invocations: int = DEFAULT_MAX_CONCURRENT_INVOCATIONS,
-        idle_session_timeout_seconds: float = DEFAULT_IDLE_SESSION_TIMEOUT_SECONDS,
-        activity_callback: SessionActivityCallback | None = None,
-        clock: Callable[[], datetime] | None = None,
     ) -> None:
         if max_concurrent_invocations < 0:
             raise ValueError("max_concurrent_invocations must be greater than or equal to zero.")
-        if idle_session_timeout_seconds <= 0:
-            raise ValueError("idle_session_timeout_seconds must be greater than zero.")
 
         self._agent_config = agent_config
         self._base_dir = base_dir
         self._session_registry = session_registry
         self._fabric = fabric
-        self._idle_session_timeout = timedelta(seconds=idle_session_timeout_seconds)
-        self._activity_callback = activity_callback
-        self._clock = clock or (lambda: datetime.now(UTC))
         self._session_creation_gates: dict[str, _SessionCreationGate] = {}
         self._closed_session_ids: set[str] = set()
         self._invocation_semaphore = (
@@ -116,15 +95,10 @@ class FabricSessionManager:
         except FabricError as error:
             raise FabricSessionStartError(f"Fabric runtime startup failed: {error}") from error
 
-        registered_session: FabricRuntimeSession | None = None
         try:
-            registered_session = await self._session_registry.register(runtime, session_id=session_id)
-            await self._report_activity(registered_session)
-            return registered_session
+            return await self._session_registry.register(runtime, session_id=session_id)
         except BaseException:
             # A started runtime must not leak if registration fails or is cancelled.
-            if registered_session is not None:
-                await self._session_registry.remove(registered_session.session_id)
             try:
                 await runtime.stop()
             except FabricError:
@@ -167,20 +141,13 @@ class FabricSessionManager:
         async with session.invocation_lock:
             if session.closing:
                 raise FabricSessionNotFoundError(f"Fabric session '{session.session_id}' was not found.")
-            invocation_started = False
             try:
                 if self._invocation_semaphore is None:
-                    await self._report_activity(session)
-                    invocation_started = True
                     return await invoke_fabric_runtime(session.runtime, request)
                 async with self._invocation_semaphore:
-                    await self._report_activity(session)
-                    invocation_started = True
                     return await invoke_fabric_runtime(session.runtime, request)
             finally:
                 await self._session_registry.refresh_activity(session)
-                if invocation_started:
-                    await self._report_activity(session)
 
     @asynccontextmanager
     async def stream_session(
@@ -192,21 +159,14 @@ class FabricSessionManager:
         async with session.invocation_lock:
             if session.closing:
                 raise FabricSessionNotFoundError(f"Fabric session '{session.session_id}' was not found.")
-            invocation_started = False
             try:
                 if self._invocation_semaphore is None:
-                    await self._report_activity(session)
-                    invocation_started = True
                     yield stream_fabric_runtime(session.runtime, request)
                 else:
                     async with self._invocation_semaphore:
-                        await self._report_activity(session)
-                        invocation_started = True
                         yield stream_fabric_runtime(session.runtime, request)
             finally:
                 await self._session_registry.refresh_activity(session)
-                if invocation_started:
-                    await self._report_activity(session)
 
     async def close_session(self, session_id: str) -> None:
         """Remove a session and stop its runtime after any active turn finishes."""
@@ -279,23 +239,6 @@ class FabricSessionManager:
                 await session.runtime.stop()
             except FabricError as error:
                 raise FabricSessionStopError(f"Fabric runtime shutdown failed: {error}") from error
-
-    async def _report_activity(self, session: FabricRuntimeSession) -> None:
-        """Report one timezone-aware UTC activity update when reporting is configured."""
-        if self._activity_callback is None:
-            return
-
-        last_active_at = self._clock()
-        if last_active_at.tzinfo is None or last_active_at.utcoffset() is None:
-            raise ValueError("The Fabric session activity clock must return a timezone-aware datetime.")
-        last_active_at = last_active_at.astimezone(UTC)
-        await self._activity_callback(
-            FabricSessionActivity(
-                session_id=session.session_id,
-                last_active_at=last_active_at,
-                expires_at=last_active_at + self._idle_session_timeout,
-            )
-        )
 
 
 def _prepare_serving_fabric_config(fabric_config: FabricConfig) -> FabricConfig:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -81,8 +81,7 @@ class AgentDeploymentController(NemoController):
         self._controller_config: ControllerConfig | None = None
         self._starting_since: dict[tuple[str, str], float] = {}
         self._runtime_instance_ids: dict[tuple[str, str], str] = {}
-        self._pending_restart_deployment_ids: set[str] = set()
-        self._pending_restart_reconciliation_times: dict[str, datetime] = {}
+        self._pending_restart_reconciliations: dict[str, datetime] = {}
         self._runtime_cleanup_tasks: set[asyncio.Task[None]] = set()
         self._runtime_health_client: httpx.AsyncClient | None = None
         self._startup_sessions_reconciled = False
@@ -395,7 +394,7 @@ class AgentDeploymentController(NemoController):
         if dep.id is None:
             logger.warning("Cannot reconcile sessions for deployment '%s' without an entity ID.", dep.name)
             return False
-        reconciliation_time = self._pending_restart_reconciliation_times.get(dep.id)
+        reconciliation_time = self._pending_restart_reconciliations.get(dep.id)
         if reconciliation_time is None:
             reconciliation_time = (at or datetime.now(UTC)).astimezone(UTC)
         reconciled = await self._reconcile_sessions_after_restart(
@@ -403,25 +402,21 @@ class AgentDeploymentController(NemoController):
             at=reconciliation_time,
         )
         if reconciled:
-            self._pending_restart_deployment_ids.discard(dep.id)
-            self._pending_restart_reconciliation_times.pop(dep.id, None)
+            self._pending_restart_reconciliations.pop(dep.id, None)
         else:
-            self._pending_restart_deployment_ids.add(dep.id)
-            self._pending_restart_reconciliation_times.setdefault(dep.id, reconciliation_time)
+            self._pending_restart_reconciliations.setdefault(dep.id, reconciliation_time)
         return reconciled
 
     async def _retry_pending_restart_reconciliations(self) -> None:
         """Retry deployment-scoped restart passes whose prior attempt was incomplete."""
-        for deployment_id in list(self._pending_restart_deployment_ids):
+        for deployment_id, reconciliation_time in list(self._pending_restart_reconciliations.items()):
             if self.stop_requested():
                 return
-            reconciliation_time = self._pending_restart_reconciliation_times[deployment_id]
             if await self._reconcile_sessions_after_restart(
                 deployment_id=deployment_id,
                 at=reconciliation_time,
             ):
-                self._pending_restart_deployment_ids.discard(deployment_id)
-                self._pending_restart_reconciliation_times.pop(deployment_id, None)
+                self._pending_restart_reconciliations.pop(deployment_id, None)
 
     async def _observe_runtime_instance(self, dep: AgentDeployment) -> None:
         """Detect a Fabric server process replacement from its health identity."""
@@ -525,21 +520,7 @@ class AgentDeploymentController(NemoController):
             name=f"cleanup-agent-session-{session.id}",
         )
         self._runtime_cleanup_tasks.add(task)
-        task.add_done_callback(self._runtime_cleanup_finished)
-
-    def _runtime_cleanup_finished(self, task: asyncio.Task[None]) -> None:
-        """Release a completed cleanup task and consume any unexpected exception."""
-        self._runtime_cleanup_tasks.discard(task)
-        if task.cancelled():
-            return
-        try:
-            task.result()
-        except Exception as exc:  # pragma: no cover - cleanup helper contains its own failures
-            logger.error(
-                "Unexpected failure in runtime cleanup task '%s'.",
-                task.get_name(),
-                exc_info=(type(exc), exc, exc.__traceback__),
-            )
+        task.add_done_callback(self._runtime_cleanup_tasks.discard)
 
     async def _start_deployment(self, dep: AgentDeployment) -> None:
         """pending -> starting: allocate port (subprocess) and spawn via the mode backend."""
@@ -747,7 +728,7 @@ class AgentDeploymentController(NemoController):
         self._starting_since.pop((dep.workspace, dep.name), None)
         self._runtime_instance_ids.pop((dep.workspace, dep.name), None)
         if dep.id is not None:
-            self._pending_restart_deployment_ids.discard(dep.id)
+            self._pending_restart_reconciliations.pop(dep.id, None)
         try:
             await self.entities.delete(
                 AgentDeployment,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -28,8 +28,16 @@ import time
 from datetime import UTC, datetime
 from typing import ClassVar, cast
 
+import httpx
 from nemo_agents_plugin.config import ControllerConfig
-from nemo_agents_plugin.entities import AgentDeployment, AgentSession, SessionStatus, is_container_deployment_mode
+from nemo_agents_plugin.deployment_routing import get_deployment_endpoint
+from nemo_agents_plugin.entities import (
+    NEMO_AGENTS_SPEC_CONFIG_FORMAT,
+    AgentDeployment,
+    AgentSession,
+    SessionStatus,
+    is_container_deployment_mode,
+)
 from nemo_agents_plugin.runner.backend import RunnerBackend
 from nemo_agents_plugin.runner.registry import RunnerBackendRegistry
 from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime, session_expiration_is_due
@@ -43,6 +51,11 @@ from nemo_platform_plugin.entity_client import (
 logger = logging.getLogger(__name__)
 
 _SESSION_LIST_PAGE_SIZE = 100
+_RUNTIME_HEALTH_TIMEOUT_SECONDS = 5.0
+
+
+def _is_fabric_deployment(dep: AgentDeployment) -> bool:
+    return dep.config.get("config_format") == NEMO_AGENTS_SPEC_CONFIG_FORMAT
 
 
 class AgentDeploymentController(NemoController):
@@ -66,6 +79,10 @@ class AgentDeploymentController(NemoController):
         self._entities: NemoEntitiesClient | None = None
         self._controller_config: ControllerConfig | None = None
         self._starting_since: dict[tuple[str, str], float] = {}
+        self._runtime_instance_ids: dict[tuple[str, str], str] = {}
+        self._pending_restart_deployment_ids: set[str] = set()
+        self._runtime_health_client: httpx.AsyncClient | None = None
+        self._startup_sessions_reconciled = False
         self._interval_seconds: float = 5.0  # default; overwritten in on_startup
 
     # ------------------------------------------------------------------
@@ -139,10 +156,14 @@ class AgentDeploymentController(NemoController):
         self._registry = registry
         set_runner_registry(registry)
 
+        await self._reconcile_sessions_after_controller_start()
         logger.info("AgentDeploymentController started.")
 
     async def on_shutdown(self) -> None:
         """Shut down the runner backends."""
+        if self._runtime_health_client is not None:
+            await self._runtime_health_client.aclose()
+            self._runtime_health_client = None
         if self._registry is not None:
             await self._registry.shutdown()
         logger.info("AgentDeploymentController shut down.")
@@ -158,7 +179,13 @@ class AgentDeploymentController(NemoController):
 
     async def reconcile(self) -> None:
         """Reconcile deployments, then independently expire due sessions."""
+        if not self._startup_sessions_reconciled:
+            await self._reconcile_sessions_after_controller_start()
+            if not self._startup_sessions_reconciled or self.stop_requested():
+                return
         await self._reconcile_deployments()
+        if not self.stop_requested():
+            await self._retry_pending_restart_reconciliations()
         if not self.stop_requested():
             await self._reconcile_expired_sessions()
 
@@ -201,7 +228,11 @@ class AgentDeploymentController(NemoController):
 
     async def _reconcile_expired_sessions(self) -> None:
         """Persist expiration and clean up runtimes for sessions past their deadline."""
-        sessions = await self._list_active_sessions()
+        try:
+            sessions = await self._list_active_sessions()
+        except Exception:
+            logger.exception("Failed to list active sessions across all workspaces")
+            return
         reconciliation_time = datetime.now(UTC)
         for session in sessions:
             if self.stop_requested():
@@ -227,26 +258,178 @@ class AgentDeploymentController(NemoController):
                     session.workspace,
                 )
 
-    async def _list_active_sessions(self) -> list[AgentSession]:
+    async def _list_active_sessions(self, *, deployment_id: str | None = None) -> list[AgentSession]:
         """List every active session across workspaces, following pagination."""
         sessions: list[AgentSession] = []
         page = 1
+        filter_obj = {"status": SessionStatus.ACTIVE.value}
+        if deployment_id is not None:
+            filter_obj["deployment_id"] = deployment_id
+        while True:
+            result = await self.entities.list(
+                AgentSession,
+                workspace="-",
+                filter_obj=filter_obj,
+                page=page,
+                page_size=_SESSION_LIST_PAGE_SIZE,
+            )
+            sessions.extend(result.data)
+            if result.pagination is None or page >= result.pagination.total_pages:
+                return sessions
+            page += 1
+
+    async def _reconcile_sessions_after_controller_start(self) -> None:
+        """Conservatively invalidate invoked sessions after controller startup."""
+        self._startup_sessions_reconciled = await self._reconcile_sessions_after_restart()
+        if self._startup_sessions_reconciled:
+            logger.info("Reconciled active sessions after agents controller startup.")
+
+    async def _reconcile_sessions_after_restart(
+        self,
+        *,
+        deployment_id: str | None = None,
+        at: datetime | None = None,
+    ) -> bool:
+        """Expire or lose invoked active sessions, returning whether the pass completed."""
         try:
-            while True:
-                result = await self.entities.list(
-                    AgentSession,
-                    workspace="-",
-                    filter_obj={"status": SessionStatus.ACTIVE.value},
-                    page=page,
-                    page_size=_SESSION_LIST_PAGE_SIZE,
-                )
-                sessions.extend(result.data)
-                if result.pagination is None or page >= result.pagination.total_pages:
-                    return sessions
-                page += 1
+            sessions = await self._list_active_sessions(deployment_id=deployment_id)
         except Exception:
-            logger.exception("Failed to list active sessions across all workspaces")
-            return []
+            logger.exception(
+                "Failed to list active sessions while reconciling runtime restart%s.",
+                f" for deployment ID '{deployment_id}'" if deployment_id is not None else "",
+            )
+            return False
+
+        reconciliation_time = (at or datetime.now(UTC)).astimezone(UTC)
+        reconciled = True
+        for session in sessions:
+            if self.stop_requested():
+                return False
+            try:
+                await self._transition_session_after_restart(session, at=reconciliation_time)
+            except NemoEntityNotFoundError:
+                logger.debug(
+                    "Session '%s' in workspace '%s' disappeared during restart reconciliation.",
+                    session.name,
+                    session.workspace,
+                )
+            except NemoEntityConflictError:
+                reconciled = False
+                logger.debug(
+                    "Optimistic lock conflict reconciling restarted session '%s' in workspace '%s' — "
+                    "will retry next cycle.",
+                    session.name,
+                    session.workspace,
+                )
+            except Exception:
+                reconciled = False
+                logger.exception(
+                    "Failed to reconcile restarted session '%s' in workspace '%s'.",
+                    session.name,
+                    session.workspace,
+                )
+        return reconciled
+
+    async def _transition_session_after_restart(
+        self,
+        session: AgentSession,
+        *,
+        at: datetime,
+    ) -> AgentSession | None:
+        """Move an invoked active session to expired or lost with one conflict retry."""
+        session_to_update = session
+        for attempt in range(2):
+            if session_to_update.status is not SessionStatus.ACTIVE:
+                return session_to_update
+            if session_to_update.last_active_at is None and session_to_update.expires_at is None:
+                return None
+
+            new_status = (
+                SessionStatus.EXPIRED if session_expiration_is_due(session_to_update, at=at) else SessionStatus.LOST
+            )
+            session_to_update.status = new_status
+            try:
+                reconciled_session = await self.entities.update(session_to_update)
+            except NemoEntityConflictError:
+                if attempt == 1:
+                    raise
+                session_to_update = await self.entities.get_by_id(AgentSession, session.id)
+                continue
+
+            await cleanup_fabric_runtime(self.entities, reconciled_session)
+            return reconciled_session
+
+        raise RuntimeError("Session restart retry loop exited unexpectedly.")  # pragma: no cover
+
+    async def _reconcile_deployment_sessions_after_restart(self, dep: AgentDeployment) -> bool:
+        """Reconcile active sessions bound to one restarted Fabric deployment."""
+        if not _is_fabric_deployment(dep):
+            return True
+        if dep.id is None:
+            logger.warning("Cannot reconcile sessions for deployment '%s' without an entity ID.", dep.name)
+            return False
+        reconciled = await self._reconcile_sessions_after_restart(deployment_id=dep.id)
+        if reconciled:
+            self._pending_restart_deployment_ids.discard(dep.id)
+        else:
+            self._pending_restart_deployment_ids.add(dep.id)
+        return reconciled
+
+    async def _retry_pending_restart_reconciliations(self) -> None:
+        """Retry deployment-scoped restart passes whose prior attempt was incomplete."""
+        for deployment_id in list(self._pending_restart_deployment_ids):
+            if self.stop_requested():
+                return
+            if await self._reconcile_sessions_after_restart(deployment_id=deployment_id):
+                self._pending_restart_deployment_ids.discard(deployment_id)
+
+    async def _observe_runtime_instance(self, dep: AgentDeployment) -> None:
+        """Detect a Fabric server process replacement from its health identity."""
+        if not _is_fabric_deployment(dep):
+            return
+        current_instance_id = await self._read_runtime_instance_id(dep)
+        if current_instance_id is None:
+            return
+
+        key = (dep.workspace, dep.name)
+        previous_instance_id = self._runtime_instance_ids.get(key)
+        if previous_instance_id is None:
+            self._runtime_instance_ids[key] = current_instance_id
+            return
+        if previous_instance_id == current_instance_id:
+            return
+
+        if await self._reconcile_deployment_sessions_after_restart(dep):
+            self._runtime_instance_ids[key] = current_instance_id
+            logger.warning(
+                "Fabric runtime instance changed for deployment '%s/%s'; active sessions were reconciled.",
+                dep.workspace,
+                dep.name,
+            )
+
+    async def _read_runtime_instance_id(self, dep: AgentDeployment) -> str | None:
+        """Read the current Fabric server process identity without persisting it."""
+        endpoint = get_deployment_endpoint(dep)
+        if endpoint is None:
+            return None
+        if self._runtime_health_client is None:
+            self._runtime_health_client = httpx.AsyncClient(
+                timeout=_RUNTIME_HEALTH_TIMEOUT_SECONDS,
+                follow_redirects=False,
+            )
+        try:
+            response = await self._runtime_health_client.get(f"{endpoint.rstrip('/')}/health")
+            response.raise_for_status()
+            runtime_instance_id = response.json().get("runtime_instance_id")
+        except Exception:
+            logger.debug(
+                "Could not read Fabric runtime instance for deployment '%s/%s'.",
+                dep.workspace,
+                dep.name,
+                exc_info=True,
+            )
+            return None
+        return runtime_instance_id if isinstance(runtime_instance_id, str) and runtime_instance_id else None
 
     async def _expire_session_if_due(
         self,
@@ -286,6 +469,7 @@ class AgentDeploymentController(NemoController):
 
     async def _start_deployment(self, dep: AgentDeployment) -> None:
         """pending -> starting: allocate port (subprocess) and spawn via the mode backend."""
+        await self._reconcile_deployment_sessions_after_restart(dep)
         t0 = time.perf_counter()
         backend = self._backend_for(dep)
         port = backend.allocate_port()
@@ -398,6 +582,7 @@ class AgentDeploymentController(NemoController):
                 dep.status = "running"
                 dep.endpoint = ""
                 self._starting_since.pop((dep.workspace, dep.name), None)
+                await self._observe_runtime_instance(dep)
                 await self._save(dep)
                 logger.info(
                     "Deployment '%s' is running (container mode, endpoints=%s, took %.1fs).",
@@ -423,6 +608,7 @@ class AgentDeploymentController(NemoController):
         if healthy:
             dep.status = "running"
             self._starting_since.pop((dep.workspace, dep.name), None)
+            await self._observe_runtime_instance(dep)
             await self._save(dep)
             logger.info(
                 "Deployment '%s' is running at %s (took %.1fs).",
@@ -437,6 +623,7 @@ class AgentDeploymentController(NemoController):
         """Mark failed if the runtime disappeared; subprocess may restart via pending."""
         info = await self._backend_for(dep).get_deployment_status(dep.workspace, dep.name)
         if info is None:
+            await self._reconcile_deployment_sessions_after_restart(dep)
             if is_container_deployment_mode(dep.deployment_mode):
                 # Do not bounce to pending — that would recreate plugin entities while a
                 # container may still be running / mid-teardown.
@@ -447,13 +634,20 @@ class AgentDeploymentController(NemoController):
                 dep.error = "Process not found in backend (attempting to restart)."
             await self._save(dep)
         elif info.status == "failed":
+            await self._reconcile_deployment_sessions_after_restart(dep)
             dep.status = "failed"
             dep.error = info.error or "Process exited unexpectedly."
             await self._save(dep)
             logger.warning("Deployment '%s' failed: %s", dep.name, dep.error)
-        elif is_container_deployment_mode(dep.deployment_mode) and info.endpoints != dep.endpoints:
-            dep.endpoints = list(info.endpoints)
-            await self._save(dep)
+        else:
+            if info.status == "starting":
+                await self._reconcile_deployment_sessions_after_restart(dep)
+            endpoints_changed = is_container_deployment_mode(dep.deployment_mode) and info.endpoints != dep.endpoints
+            if endpoints_changed:
+                dep.endpoints = list(info.endpoints)
+                await self._save(dep)
+            if info.status == "running":
+                await self._observe_runtime_instance(dep)
 
     async def _delete_deployment(self, dep: AgentDeployment) -> None:
         """deleting → (removed): terminate runtime and delete entity when teardown completes."""
@@ -477,6 +671,9 @@ class AgentDeploymentController(NemoController):
             return
 
         self._starting_since.pop((dep.workspace, dep.name), None)
+        self._runtime_instance_ids.pop((dep.workspace, dep.name), None)
+        if dep.id is not None:
+            self._pending_restart_deployment_ids.discard(dep.id)
         try:
             await self.entities.delete(
                 AgentDeployment,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -25,16 +25,24 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import UTC, datetime
 from typing import ClassVar, cast
 
 from nemo_agents_plugin.config import ControllerConfig
-from nemo_agents_plugin.entities import AgentDeployment, is_container_deployment_mode
+from nemo_agents_plugin.entities import AgentDeployment, AgentSession, SessionStatus, is_container_deployment_mode
 from nemo_agents_plugin.runner.backend import RunnerBackend
 from nemo_agents_plugin.runner.registry import RunnerBackendRegistry
+from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime, session_expiration_is_due
 from nemo_platform_plugin.controller import NemoController
-from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityConflictError
+from nemo_platform_plugin.entity_client import (
+    NemoEntitiesClient,
+    NemoEntityConflictError,
+    NemoEntityNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
+
+_SESSION_LIST_PAGE_SIZE = 100
 
 
 class AgentDeploymentController(NemoController):
@@ -148,6 +156,22 @@ class AgentDeploymentController(NemoController):
             logger.exception("Failed to list deployments across all workspaces")
             return []
 
+    async def reconcile(self) -> None:
+        """Reconcile deployments, then independently expire due sessions."""
+        await self._reconcile_deployments()
+        if not self.stop_requested():
+            await self._reconcile_expired_sessions()
+
+    async def _reconcile_deployments(self) -> None:
+        """Reconcile each deployment with per-entity error isolation."""
+        for deployment in await self.list_objects():
+            if self.stop_requested():
+                return
+            try:
+                await self.reconcile_one(deployment)
+            except Exception:
+                logger.exception("Failed to reconcile deployment %s", deployment)
+
     async def reconcile_one(self, obj: object) -> None:
         """Drive the state machine for a single deployment entity.
 
@@ -174,6 +198,91 @@ class AgentDeploymentController(NemoController):
             await self._verify_running(dep)
         elif dep.status == "deleting":
             await self._delete_deployment(dep)
+
+    async def _reconcile_expired_sessions(self) -> None:
+        """Persist expiration and clean up runtimes for sessions past their deadline."""
+        sessions = await self._list_active_sessions()
+        reconciliation_time = datetime.now(UTC)
+        for session in sessions:
+            if self.stop_requested():
+                return
+            try:
+                await self._expire_session_if_due(session, at=reconciliation_time)
+            except NemoEntityNotFoundError:
+                logger.debug(
+                    "Session '%s' in workspace '%s' disappeared during expiration reconciliation.",
+                    session.name,
+                    session.workspace,
+                )
+            except NemoEntityConflictError:
+                logger.debug(
+                    "Optimistic lock conflict expiring session '%s' in workspace '%s' — will retry next cycle.",
+                    session.name,
+                    session.workspace,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to reconcile expiration for session '%s' in workspace '%s'.",
+                    session.name,
+                    session.workspace,
+                )
+
+    async def _list_active_sessions(self) -> list[AgentSession]:
+        """List every active session across workspaces, following pagination."""
+        sessions: list[AgentSession] = []
+        page = 1
+        try:
+            while True:
+                result = await self.entities.list(
+                    AgentSession,
+                    workspace="-",
+                    filter_obj={"status": SessionStatus.ACTIVE.value},
+                    page=page,
+                    page_size=_SESSION_LIST_PAGE_SIZE,
+                )
+                sessions.extend(result.data)
+                if result.pagination is None or page >= result.pagination.total_pages:
+                    return sessions
+                page += 1
+        except Exception:
+            logger.exception("Failed to list active sessions across all workspaces")
+            return []
+
+    async def _expire_session_if_due(
+        self,
+        session: AgentSession,
+        *,
+        at: datetime,
+    ) -> AgentSession | None:
+        """Transition one due session to expired with one optimistic retry.
+
+        The persisted deadline is authoritative even when an invocation is still
+        running. That invocation may finish, but its completion cannot reactivate
+        the terminal session.
+        """
+        session_to_update = session
+        for attempt in range(2):
+            if session_to_update.status is not SessionStatus.ACTIVE:
+                if session_to_update.status is SessionStatus.EXPIRED:
+                    await cleanup_fabric_runtime(self.entities, session_to_update)
+                    return session_to_update
+                return None
+            if not session_expiration_is_due(session_to_update, at=at):
+                return None
+
+            session_to_update.status = SessionStatus.EXPIRED
+            try:
+                expired_session = await self.entities.update(session_to_update)
+            except NemoEntityConflictError:
+                if attempt == 1:
+                    raise
+                session_to_update = await self.entities.get_by_id(AgentSession, session.id)
+                continue
+
+            await cleanup_fabric_runtime(self.entities, expired_session)
+            return expired_session
+
+        raise RuntimeError("Session expiration retry loop exited unexpectedly.")  # pragma: no cover
 
     async def _start_deployment(self, dep: AgentDeployment) -> None:
         """pending -> starting: allocate port (subprocess) and spawn via the mode backend."""

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -23,6 +23,7 @@ State machine::
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import UTC, datetime
@@ -81,8 +82,11 @@ class AgentDeploymentController(NemoController):
         self._starting_since: dict[tuple[str, str], float] = {}
         self._runtime_instance_ids: dict[tuple[str, str], str] = {}
         self._pending_restart_deployment_ids: set[str] = set()
+        self._pending_restart_reconciliation_times: dict[str, datetime] = {}
+        self._runtime_cleanup_tasks: set[asyncio.Task[None]] = set()
         self._runtime_health_client: httpx.AsyncClient | None = None
         self._startup_sessions_reconciled = False
+        self._startup_session_reconciliation_at: datetime | None = None
         self._interval_seconds: float = 5.0  # default; overwritten in on_startup
 
     # ------------------------------------------------------------------
@@ -125,6 +129,7 @@ class AgentDeploymentController(NemoController):
 
     async def on_startup(self) -> None:
         """Initialise the entity client and runner backends from config."""
+        self._startup_session_reconciliation_at = datetime.now(UTC)
         # Imports deferred intentionally: these modules pull in the SDK,
         # entity-store client, and HTTP machinery.  Importing at module level
         # would add ~1s to every `nemo` CLI invocation during plugin discovery,
@@ -161,6 +166,11 @@ class AgentDeploymentController(NemoController):
 
     async def on_shutdown(self) -> None:
         """Shut down the runner backends."""
+        cleanup_tasks = list(self._runtime_cleanup_tasks)
+        for task in cleanup_tasks:
+            task.cancel()
+        if cleanup_tasks:
+            await asyncio.gather(*cleanup_tasks, return_exceptions=True)
         if self._runtime_health_client is not None:
             await self._runtime_health_client.aclose()
             self._runtime_health_client = None
@@ -280,7 +290,11 @@ class AgentDeploymentController(NemoController):
 
     async def _reconcile_sessions_after_controller_start(self) -> None:
         """Conservatively invalidate invoked sessions after controller startup."""
-        self._startup_sessions_reconciled = await self._reconcile_sessions_after_restart()
+        if self._startup_session_reconciliation_at is None:
+            self._startup_session_reconciliation_at = datetime.now(UTC)
+        self._startup_sessions_reconciled = await self._reconcile_sessions_after_restart(
+            at=self._startup_session_reconciliation_at
+        )
         if self._startup_sessions_reconciled:
             logger.info("Reconciled active sessions after agents controller startup.")
 
@@ -337,7 +351,7 @@ class AgentDeploymentController(NemoController):
         at: datetime,
     ) -> AgentSession | None:
         """Move an invoked active session to expired or lost with one conflict retry."""
-        from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime, session_expiration_is_due
+        from nemo_agents_plugin.session_lifecycle import session_expiration_is_due
 
         session_to_update = session
         for attempt in range(2):
@@ -345,6 +359,12 @@ class AgentDeploymentController(NemoController):
                 return session_to_update
             if session_to_update.last_active_at is None and session_to_update.expires_at is None:
                 return None
+            if session_to_update.last_active_at is not None:
+                last_active_at = session_to_update.last_active_at
+                if last_active_at.tzinfo is None or last_active_at.utcoffset() is None:
+                    last_active_at = last_active_at.replace(tzinfo=UTC)
+                if last_active_at >= at:
+                    return None
 
             new_status = (
                 SessionStatus.EXPIRED if session_expiration_is_due(session_to_update, at=at) else SessionStatus.LOST
@@ -358,23 +378,36 @@ class AgentDeploymentController(NemoController):
                 session_to_update = await self.entities.get_by_id(AgentSession, session.id)
                 continue
 
-            await cleanup_fabric_runtime(self.entities, reconciled_session)
+            self._schedule_runtime_cleanup(reconciled_session)
             return reconciled_session
 
         raise RuntimeError("Session restart retry loop exited unexpectedly.")  # pragma: no cover
 
-    async def _reconcile_deployment_sessions_after_restart(self, dep: AgentDeployment) -> bool:
+    async def _reconcile_deployment_sessions_after_restart(
+        self,
+        dep: AgentDeployment,
+        *,
+        at: datetime | None = None,
+    ) -> bool:
         """Reconcile active sessions bound to one restarted Fabric deployment."""
         if not _is_fabric_deployment(dep):
             return True
         if dep.id is None:
             logger.warning("Cannot reconcile sessions for deployment '%s' without an entity ID.", dep.name)
             return False
-        reconciled = await self._reconcile_sessions_after_restart(deployment_id=dep.id)
+        reconciliation_time = self._pending_restart_reconciliation_times.get(dep.id)
+        if reconciliation_time is None:
+            reconciliation_time = (at or datetime.now(UTC)).astimezone(UTC)
+        reconciled = await self._reconcile_sessions_after_restart(
+            deployment_id=dep.id,
+            at=reconciliation_time,
+        )
         if reconciled:
             self._pending_restart_deployment_ids.discard(dep.id)
+            self._pending_restart_reconciliation_times.pop(dep.id, None)
         else:
             self._pending_restart_deployment_ids.add(dep.id)
+            self._pending_restart_reconciliation_times.setdefault(dep.id, reconciliation_time)
         return reconciled
 
     async def _retry_pending_restart_reconciliations(self) -> None:
@@ -382,8 +415,13 @@ class AgentDeploymentController(NemoController):
         for deployment_id in list(self._pending_restart_deployment_ids):
             if self.stop_requested():
                 return
-            if await self._reconcile_sessions_after_restart(deployment_id=deployment_id):
+            reconciliation_time = self._pending_restart_reconciliation_times[deployment_id]
+            if await self._reconcile_sessions_after_restart(
+                deployment_id=deployment_id,
+                at=reconciliation_time,
+            ):
                 self._pending_restart_deployment_ids.discard(deployment_id)
+                self._pending_restart_reconciliation_times.pop(deployment_id, None)
 
     async def _observe_runtime_instance(self, dep: AgentDeployment) -> None:
         """Detect a Fabric server process replacement from its health identity."""
@@ -401,8 +439,8 @@ class AgentDeploymentController(NemoController):
         if previous_instance_id == current_instance_id:
             return
 
+        self._runtime_instance_ids[key] = current_instance_id
         if await self._reconcile_deployment_sessions_after_restart(dep):
-            self._runtime_instance_ids[key] = current_instance_id
             logger.warning(
                 "Fabric runtime instance changed for deployment '%s/%s'; active sessions were reconciled.",
                 dep.workspace,
@@ -449,13 +487,13 @@ class AgentDeploymentController(NemoController):
         running. That invocation may finish, but its completion cannot reactivate
         the terminal session.
         """
-        from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime, session_expiration_is_due
+        from nemo_agents_plugin.session_lifecycle import session_expiration_is_due
 
         session_to_update = session
         for attempt in range(2):
             if session_to_update.status is not SessionStatus.ACTIVE:
                 if session_to_update.status is SessionStatus.EXPIRED:
-                    await cleanup_fabric_runtime(self.entities, session_to_update)
+                    self._schedule_runtime_cleanup(session_to_update)
                     return session_to_update
                 return None
             if not session_expiration_is_due(session_to_update, at=at):
@@ -470,10 +508,38 @@ class AgentDeploymentController(NemoController):
                 session_to_update = await self.entities.get_by_id(AgentSession, session.id)
                 continue
 
-            await cleanup_fabric_runtime(self.entities, expired_session)
+            self._schedule_runtime_cleanup(expired_session)
             return expired_session
 
         raise RuntimeError("Session expiration retry loop exited unexpectedly.")  # pragma: no cover
+
+    def _schedule_runtime_cleanup(
+        self,
+        session: AgentSession,
+    ) -> None:
+        """Run best-effort runtime cleanup outside the reconciliation critical path."""
+        from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime
+
+        task = asyncio.create_task(
+            cleanup_fabric_runtime(self.entities, session),
+            name=f"cleanup-agent-session-{session.id}",
+        )
+        self._runtime_cleanup_tasks.add(task)
+        task.add_done_callback(self._runtime_cleanup_finished)
+
+    def _runtime_cleanup_finished(self, task: asyncio.Task[None]) -> None:
+        """Release a completed cleanup task and consume any unexpected exception."""
+        self._runtime_cleanup_tasks.discard(task)
+        if task.cancelled():
+            return
+        try:
+            task.result()
+        except Exception as exc:  # pragma: no cover - cleanup helper contains its own failures
+            logger.error(
+                "Unexpected failure in runtime cleanup task '%s'.",
+                task.get_name(),
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     async def _start_deployment(self, dep: AgentDeployment) -> None:
         """pending -> starting: allocate port (subprocess) and spawn via the mode backend."""

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -356,13 +356,19 @@ class AgentDeploymentController(NemoController):
         for attempt in range(2):
             if session_to_update.status is not SessionStatus.ACTIVE:
                 return session_to_update
-            if session_to_update.last_active_at is None and session_to_update.expires_at is None:
+            if (
+                session_to_update.first_active_at is None
+                and session_to_update.last_active_at is None
+                and session_to_update.expires_at is None
+            ):
                 return None
-            if session_to_update.last_active_at is not None:
-                last_active_at = session_to_update.last_active_at
-                if last_active_at.tzinfo is None or last_active_at.utcoffset() is None:
-                    last_active_at = last_active_at.replace(tzinfo=UTC)
-                if last_active_at >= at:
+            if session_to_update.first_active_at is not None:
+                first_active_at = session_to_update.first_active_at
+                if first_active_at.tzinfo is None or first_active_at.utcoffset() is None:
+                    first_active_at = first_active_at.replace(tzinfo=UTC)
+                else:
+                    first_active_at = first_active_at.astimezone(UTC)
+                if first_active_at >= at:
                     return None
 
             new_status = (
@@ -394,9 +400,11 @@ class AgentDeploymentController(NemoController):
         if dep.id is None:
             logger.warning("Cannot reconcile sessions for deployment '%s' without an entity ID.", dep.name)
             return False
-        reconciliation_time = self._pending_restart_reconciliations.get(dep.id)
+        reconciliation_time = (
+            at.astimezone(UTC) if at is not None else self._pending_restart_reconciliations.get(dep.id)
+        )
         if reconciliation_time is None:
-            reconciliation_time = (at or datetime.now(UTC)).astimezone(UTC)
+            reconciliation_time = datetime.now(UTC)
         reconciled = await self._reconcile_sessions_after_restart(
             deployment_id=dep.id,
             at=reconciliation_time,
@@ -404,7 +412,7 @@ class AgentDeploymentController(NemoController):
         if reconciled:
             self._pending_restart_reconciliations.pop(dep.id, None)
         else:
-            self._pending_restart_reconciliations.setdefault(dep.id, reconciliation_time)
+            self._pending_restart_reconciliations[dep.id] = reconciliation_time
         return reconciled
 
     async def _retry_pending_restart_reconciliations(self) -> None:
@@ -422,9 +430,10 @@ class AgentDeploymentController(NemoController):
         """Detect a Fabric server process replacement from its health identity."""
         if not _is_fabric_deployment(dep):
             return
-        current_instance_id = await self._read_runtime_instance_id(dep)
-        if current_instance_id is None:
+        current_runtime = await self._read_runtime_instance(dep)
+        if current_runtime is None:
             return
+        current_instance_id, runtime_started_at = current_runtime
 
         key = (dep.workspace, dep.name)
         previous_instance_id = self._runtime_instance_ids.get(key)
@@ -435,14 +444,14 @@ class AgentDeploymentController(NemoController):
             return
 
         self._runtime_instance_ids[key] = current_instance_id
-        if await self._reconcile_deployment_sessions_after_restart(dep):
+        if await self._reconcile_deployment_sessions_after_restart(dep, at=runtime_started_at):
             logger.warning(
                 "Fabric runtime instance changed for deployment '%s/%s'; active sessions were reconciled.",
                 dep.workspace,
                 dep.name,
             )
 
-    async def _read_runtime_instance_id(self, dep: AgentDeployment) -> str | None:
+    async def _read_runtime_instance(self, dep: AgentDeployment) -> tuple[str, datetime] | None:
         """Read the current Fabric server process identity without persisting it."""
         from nemo_agents_plugin.deployment_routing import get_deployment_endpoint
 
@@ -459,7 +468,9 @@ class AgentDeploymentController(NemoController):
         try:
             response = await self._runtime_health_client.get(f"{endpoint.rstrip('/')}/health")
             response.raise_for_status()
-            runtime_instance_id = response.json().get("runtime_instance_id")
+            health = response.json()
+            runtime_instance_id = health.get("runtime_instance_id")
+            runtime_started_at = datetime.fromisoformat(health.get("runtime_started_at", ""))
         except Exception:
             logger.debug(
                 "Could not read Fabric runtime instance for deployment '%s/%s'.",
@@ -468,7 +479,11 @@ class AgentDeploymentController(NemoController):
                 exc_info=True,
             )
             return None
-        return runtime_instance_id if isinstance(runtime_instance_id, str) and runtime_instance_id else None
+        if not isinstance(runtime_instance_id, str) or not runtime_instance_id:
+            return None
+        if runtime_started_at.tzinfo is None or runtime_started_at.utcoffset() is None:
+            return None
+        return runtime_instance_id, runtime_started_at.astimezone(UTC)
 
     async def _expire_session_if_due(
         self,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -26,11 +26,9 @@ from __future__ import annotations
 import logging
 import time
 from datetime import UTC, datetime
-from typing import ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
-import httpx
 from nemo_agents_plugin.config import ControllerConfig
-from nemo_agents_plugin.deployment_routing import get_deployment_endpoint
 from nemo_agents_plugin.entities import (
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
     AgentDeployment,
@@ -40,13 +38,15 @@ from nemo_agents_plugin.entities import (
 )
 from nemo_agents_plugin.runner.backend import RunnerBackend
 from nemo_agents_plugin.runner.registry import RunnerBackendRegistry
-from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime, session_expiration_is_due
 from nemo_platform_plugin.controller import NemoController
 from nemo_platform_plugin.entity_client import (
     NemoEntitiesClient,
     NemoEntityConflictError,
     NemoEntityNotFoundError,
 )
+
+if TYPE_CHECKING:
+    import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +181,7 @@ class AgentDeploymentController(NemoController):
         """Reconcile deployments, then independently expire due sessions."""
         if not self._startup_sessions_reconciled:
             await self._reconcile_sessions_after_controller_start()
-            if not self._startup_sessions_reconciled or self.stop_requested():
+            if self.stop_requested():
                 return
         await self._reconcile_deployments()
         if not self.stop_requested():
@@ -337,6 +337,8 @@ class AgentDeploymentController(NemoController):
         at: datetime,
     ) -> AgentSession | None:
         """Move an invoked active session to expired or lost with one conflict retry."""
+        from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime, session_expiration_is_due
+
         session_to_update = session
         for attempt in range(2):
             if session_to_update.status is not SessionStatus.ACTIVE:
@@ -409,10 +411,14 @@ class AgentDeploymentController(NemoController):
 
     async def _read_runtime_instance_id(self, dep: AgentDeployment) -> str | None:
         """Read the current Fabric server process identity without persisting it."""
+        from nemo_agents_plugin.deployment_routing import get_deployment_endpoint
+
         endpoint = get_deployment_endpoint(dep)
         if endpoint is None:
             return None
         if self._runtime_health_client is None:
+            import httpx
+
             self._runtime_health_client = httpx.AsyncClient(
                 timeout=_RUNTIME_HEALTH_TIMEOUT_SECONDS,
                 follow_redirects=False,
@@ -443,6 +449,8 @@ class AgentDeploymentController(NemoController):
         running. That invocation may finish, but its completion cannot reactivate
         the terminal session.
         """
+        from nemo_agents_plugin.session_lifecycle import cleanup_fabric_runtime, session_expiration_is_due
+
         session_to_update = session
         for attempt in range(2):
             if session_to_update.status is not SessionStatus.ACTIVE:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -310,6 +310,8 @@ def _fabric_config_mount_path(config_mount_path: str) -> str:
 
 
 def _fabric_server_cli_args(*, config_path: str, port: int) -> list[str]:
+    # If this launch path forwards an idle-timeout override, the gateway must
+    # use the same deployment-sourced value when computing ``expires_at``.
     return [
         "-m",
         _FABRIC_SERVER_MODULE,

--- a/plugins/nemo-agents/src/nemo_agents_plugin/session_lifecycle.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/session_lifecycle.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared persisted-session lifecycle helpers."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from urllib.parse import quote
+
+import httpx
+from nemo_agents_plugin.deployment_routing import get_deployment_endpoint
+from nemo_agents_plugin.entities import AgentDeployment, AgentSession
+from nemo_platform_plugin.entity_client import NemoEntitiesClient
+
+logger = logging.getLogger(__name__)
+
+_FABRIC_CLEANUP_TIMEOUT_SECONDS = 5.0
+
+
+def session_expiration_is_due(session: AgentSession, *, at: datetime) -> bool:
+    """Return whether an active session has reached its persisted idle deadline."""
+    expires_at = session.expires_at
+    if expires_at is None:
+        return False
+    if expires_at.tzinfo is None or expires_at.utcoffset() is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    return expires_at <= at.astimezone(UTC)
+
+
+async def cleanup_fabric_runtime(
+    entity_client: NemoEntitiesClient,
+    session: AgentSession,
+) -> None:
+    """Best-effort removal of a session's process-local Fabric runtime."""
+    try:
+        deployment = await entity_client.find_one(
+            AgentDeployment,
+            workspace=session.workspace,
+            filter_obj={"id": session.deployment_id},
+        )
+    except Exception:
+        logger.warning(
+            "Could not resolve deployment ID '%s' while cleaning up session ID '%s'.",
+            session.deployment_id,
+            session.id,
+            exc_info=True,
+        )
+        return
+
+    if deployment.id != session.deployment_id or deployment.workspace != session.workspace:
+        logger.warning(
+            "Resolved deployment did not match session ID '%s'; skipping Fabric runtime cleanup.",
+            session.id,
+        )
+        return
+
+    endpoint = get_deployment_endpoint(deployment)
+    if endpoint is None:
+        logger.warning(
+            "Deployment ID '%s' has no endpoint; skipping cleanup for session ID '%s'.",
+            deployment.id,
+            session.id,
+        )
+        return
+
+    cleanup_url = f"{endpoint.rstrip('/')}/v1/sessions/{quote(session.id, safe='')}"
+    try:
+        async with httpx.AsyncClient(
+            timeout=_FABRIC_CLEANUP_TIMEOUT_SECONDS,
+            follow_redirects=False,
+        ) as client:
+            response = await client.delete(cleanup_url)
+    except Exception:
+        logger.warning(
+            "Fabric runtime cleanup request failed for session ID '%s'.",
+            session.id,
+            exc_info=True,
+        )
+        return
+
+    # A missing runtime is already clean: the session may never have been invoked or may
+    # have expired from the deployment's process-local registry.
+    if response.status_code == 404 or 200 <= response.status_code < 300:
+        return
+    logger.warning(
+        "Fabric runtime cleanup returned HTTP %s for session ID '%s'.",
+        response.status_code,
+        session.id,
+    )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/session_lifecycle.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/session_lifecycle.py
@@ -26,6 +26,8 @@ def session_expiration_is_due(session: AgentSession, *, at: datetime) -> bool:
         return False
     if expires_at.tzinfo is None or expires_at.utcoffset() is None:
         expires_at = expires_at.replace(tzinfo=UTC)
+    else:
+        expires_at = expires_at.astimezone(UTC)
     return expires_at <= at.astimezone(UTC)
 
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/session_lifecycle.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/session_lifecycle.py
@@ -29,40 +29,53 @@ def session_expiration_is_due(session: AgentSession, *, at: datetime) -> bool:
     return expires_at <= at.astimezone(UTC)
 
 
+def _log_cleanup_failure(
+    session: AgentSession,
+    reason: str,
+    *,
+    exc_info: bool = False,
+) -> None:
+    """Record a non-blocking runtime-cleanup failure with entity context."""
+    logger.warning(
+        "Fabric runtime cleanup failed for session ID '%s' in workspace '%s' (deployment ID '%s'): %s.",
+        session.id,
+        session.workspace,
+        session.deployment_id,
+        reason,
+        exc_info=exc_info,
+    )
+
+
 async def cleanup_fabric_runtime(
     entity_client: NemoEntitiesClient,
     session: AgentSession,
 ) -> None:
-    """Best-effort removal of a session's process-local Fabric runtime."""
+    """Best-effort removal of a session's process-local Fabric runtime.
+
+    Cleanup never changes the persisted terminal state and never raises. Failures
+    are observable through a contextual warning; Fabric idle eviction or a runtime
+    restart provides eventual cleanup when the immediate request cannot complete.
+    """
     try:
         deployment = await entity_client.find_one(
             AgentDeployment,
             workspace=session.workspace,
             filter_obj={"id": session.deployment_id},
         )
-    except Exception:
-        logger.warning(
-            "Could not resolve deployment ID '%s' while cleaning up session ID '%s'.",
-            session.deployment_id,
-            session.id,
-            exc_info=True,
-        )
+    except Exception as exc:
+        _log_cleanup_failure(session, f"could not resolve deployment: {exc}", exc_info=True)
         return
 
     if deployment.id != session.deployment_id or deployment.workspace != session.workspace:
-        logger.warning(
-            "Resolved deployment did not match session ID '%s'; skipping Fabric runtime cleanup.",
-            session.id,
+        _log_cleanup_failure(
+            session,
+            "resolved deployment did not match the session binding",
         )
         return
 
     endpoint = get_deployment_endpoint(deployment)
     if endpoint is None:
-        logger.warning(
-            "Deployment ID '%s' has no endpoint; skipping cleanup for session ID '%s'.",
-            deployment.id,
-            session.id,
-        )
+        _log_cleanup_failure(session, "deployment has no routable endpoint")
         return
 
     cleanup_url = f"{endpoint.rstrip('/')}/v1/sessions/{quote(session.id, safe='')}"
@@ -72,20 +85,12 @@ async def cleanup_fabric_runtime(
             follow_redirects=False,
         ) as client:
             response = await client.delete(cleanup_url)
-    except Exception:
-        logger.warning(
-            "Fabric runtime cleanup request failed for session ID '%s'.",
-            session.id,
-            exc_info=True,
-        )
+    except Exception as exc:
+        _log_cleanup_failure(session, f"request failed: {exc}", exc_info=True)
         return
 
     # A missing runtime is already clean: the session may never have been invoked or may
     # have expired from the deployment's process-local registry.
     if response.status_code == 404 or 200 <= response.status_code < 300:
         return
-    logger.warning(
-        "Fabric runtime cleanup returned HTTP %s for session ID '%s'.",
-        response.status_code,
-        session.id,
-    )
+    _log_cleanup_failure(session, f"request returned HTTP {response.status_code}")

--- a/plugins/nemo-agents/tests/unit/test_entities.py
+++ b/plugins/nemo-agents/tests/unit/test_entities.py
@@ -206,6 +206,7 @@ class TestAgentSessionEntity:
         session = AgentSession(name="session", workspace="default", deployment_id="deployment-id")
 
         assert session.status is SessionStatus.ACTIVE
+        assert session.first_active_at is None
         assert session.last_active_at is None
         assert session.expires_at is None
 
@@ -276,10 +277,12 @@ class TestAgentSessionEntity:
             name="session",
             workspace="default",
             deployment_id="deployment-id",
+            first_active_at=NOW,
             last_active_at=NOW,
             expires_at=NOW,
         )
 
+        assert session.first_active_at == NOW
         assert session.last_active_at == NOW
         assert session.expires_at == NOW
 

--- a/plugins/nemo-agents/tests/unit/test_entities.py
+++ b/plugins/nemo-agents/tests/unit/test_entities.py
@@ -209,15 +209,56 @@ class TestAgentSessionEntity:
         assert session.last_active_at is None
         assert session.expires_at is None
 
-    def test_closed_status(self) -> None:
+    @pytest.mark.parametrize("status", list(SessionStatus))
+    def test_lifecycle_status(self, status: SessionStatus) -> None:
         session = AgentSession(
             name="session",
             workspace="default",
             deployment_id="deployment-id",
-            status=SessionStatus.CLOSED,
+            status=status,
         )
 
-        assert session.status is SessionStatus.CLOSED
+        assert session.status is status
+
+    @pytest.mark.parametrize(
+        ("current_status", "new_status"),
+        [
+            (SessionStatus.ACTIVE, SessionStatus.EXPIRED),
+            (SessionStatus.ACTIVE, SessionStatus.LOST),
+            (SessionStatus.ACTIVE, SessionStatus.CLOSED),
+            (SessionStatus.EXPIRED, SessionStatus.CLOSED),
+            (SessionStatus.LOST, SessionStatus.CLOSED),
+        ],
+    )
+    def test_allowed_status_transitions(
+        self,
+        current_status: SessionStatus,
+        new_status: SessionStatus,
+    ) -> None:
+        assert current_status.can_transition_to(new_status)
+
+    @pytest.mark.parametrize("status", list(SessionStatus))
+    def test_same_status_transition_is_idempotent(self, status: SessionStatus) -> None:
+        assert status.can_transition_to(status)
+
+    @pytest.mark.parametrize(
+        ("current_status", "new_status"),
+        [
+            (SessionStatus.EXPIRED, SessionStatus.ACTIVE),
+            (SessionStatus.EXPIRED, SessionStatus.LOST),
+            (SessionStatus.LOST, SessionStatus.ACTIVE),
+            (SessionStatus.LOST, SessionStatus.EXPIRED),
+            (SessionStatus.CLOSED, SessionStatus.ACTIVE),
+            (SessionStatus.CLOSED, SessionStatus.EXPIRED),
+            (SessionStatus.CLOSED, SessionStatus.LOST),
+        ],
+    )
+    def test_disallowed_status_transitions(
+        self,
+        current_status: SessionStatus,
+        new_status: SessionStatus,
+    ) -> None:
+        assert not current_status.can_transition_to(new_status)
 
     def test_invalid_status_rejected(self) -> None:
         with pytest.raises(ValidationError):

--- a/plugins/nemo-agents/tests/unit/test_fabric_server.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -122,9 +123,13 @@ def test_startup_loads_and_validates_agent_config(
 
     with TestClient(app) as client:
         response = client.get("/health")
+        repeated_response = client.get("/health")
 
         assert response.status_code == 200
-        assert response.json() == {"status": "ok"}
+        health = response.json()
+        assert health["status"] == "ok"
+        assert uuid.UUID(health["runtime_instance_id"])
+        assert repeated_response.json()["runtime_instance_id"] == health["runtime_instance_id"]
         assert app.state.agent_config.name == "test-agent"
         assert app.state.base_dir == tmp_path
         assert app.state.validation_result is not None

--- a/plugins/nemo-agents/tests/unit/test_fabric_server.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_server.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -130,6 +131,8 @@ def test_startup_loads_and_validates_agent_config(
         assert health["status"] == "ok"
         assert uuid.UUID(health["runtime_instance_id"])
         assert repeated_response.json()["runtime_instance_id"] == health["runtime_instance_id"]
+        assert datetime.fromisoformat(health["runtime_started_at"]).tzinfo is not None
+        assert repeated_response.json()["runtime_started_at"] == health["runtime_started_at"]
         assert app.state.agent_config.name == "test-agent"
         assert app.state.base_dir == tmp_path
         assert app.state.validation_result is not None

--- a/plugins/nemo-agents/tests/unit/test_fabric_session_manager.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_session_manager.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -12,7 +11,7 @@ import pytest
 from nemo_agents_plugin.agent_config import AgentConfig
 from nemo_agents_plugin.fabric import session_manager
 from nemo_agents_plugin.fabric.runtime import FabricInvocationRequest, FabricRuntimeResult
-from nemo_agents_plugin.fabric.session_manager import FabricSessionActivity, FabricSessionManager
+from nemo_agents_plugin.fabric.session_manager import FabricSessionManager
 from nemo_agents_plugin.fabric.session_registry import (
     FabricSessionNotFoundError,
     FabricSessionRegistry,
@@ -533,98 +532,6 @@ async def test_invoke_session_refreshes_activity(
 
 
 @pytest.mark.asyncio
-async def test_reports_attachment_and_invocation_activity_timestamps(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(session_manager, "translate_agent_config", lambda config: _FakeFabricConfig())
-    runtime = _FakeRuntime()
-    timestamps = iter(
-        [
-            datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
-            datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
-            datetime(2026, 8, 25, 12, 2, tzinfo=UTC),
-            datetime(2026, 8, 25, 12, 3, tzinfo=UTC),
-            datetime(2026, 8, 25, 12, 4, tzinfo=UTC),
-        ]
-    )
-    activity: list[FabricSessionActivity] = []
-
-    async def report_activity(update: FabricSessionActivity) -> None:
-        activity.append(update)
-
-    async def invoke_fabric_runtime(runtime: Any, request: FabricInvocationRequest) -> FabricRuntimeResult:
-        return FabricRuntimeResult(status="succeeded", response=request.input)
-
-    monkeypatch.setattr(session_manager, "invoke_fabric_runtime", invoke_fabric_runtime)
-    manager = FabricSessionManager(
-        _agent_config(),
-        base_dir=tmp_path,
-        session_registry=FabricSessionRegistry(),
-        fabric=cast(Any, _FakeFabric(runtime)),
-        idle_session_timeout_seconds=30.0,
-        activity_callback=report_activity,
-        clock=lambda: next(timestamps),
-    )
-
-    session = await manager.resolve_session("session-1")
-    await manager.invoke_session(session, FabricInvocationRequest(input="first"))
-    await manager.invoke_session(session, FabricInvocationRequest(input="second"))
-
-    expected_timestamps = [
-        datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
-        datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
-        datetime(2026, 8, 25, 12, 2, tzinfo=UTC),
-        datetime(2026, 8, 25, 12, 3, tzinfo=UTC),
-        datetime(2026, 8, 25, 12, 4, tzinfo=UTC),
-    ]
-    assert [update.last_active_at for update in activity] == expected_timestamps
-    assert [update.expires_at for update in activity] == [
-        timestamp + timedelta(seconds=30) for timestamp in expected_timestamps
-    ]
-    assert {update.session_id for update in activity} == {"session-1"}
-
-
-@pytest.mark.asyncio
-async def test_failed_invocation_reports_start_and_finish_activity(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry = FabricSessionRegistry()
-    session = await registry.register(cast(Any, _FakeRuntime()), session_id="session-1")
-    timestamps = iter(
-        [
-            datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
-            datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
-        ]
-    )
-    activity: list[FabricSessionActivity] = []
-
-    async def report_activity(update: FabricSessionActivity) -> None:
-        activity.append(update)
-
-    async def invoke_fabric_runtime(runtime: Any, request: FabricInvocationRequest) -> FabricRuntimeResult:
-        raise RuntimeError("invoke failed")
-
-    monkeypatch.setattr(session_manager, "invoke_fabric_runtime", invoke_fabric_runtime)
-    manager = FabricSessionManager(
-        _agent_config(),
-        base_dir=tmp_path,
-        session_registry=registry,
-        activity_callback=report_activity,
-        clock=lambda: next(timestamps),
-    )
-
-    with pytest.raises(RuntimeError, match="invoke failed"):
-        await manager.invoke_session(session, FabricInvocationRequest(input="hello"))
-
-    assert [update.last_active_at for update in activity] == [
-        datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
-        datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
-    ]
-
-
-@pytest.mark.asyncio
 async def test_stream_session_refreshes_activity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -652,43 +559,6 @@ async def test_stream_session_refreshes_activity(
         assert resolved_stream is stream
 
     assert refresh_calls == [session]
-
-
-@pytest.mark.asyncio
-async def test_interrupted_stream_reports_start_and_finish_activity(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    registry = FabricSessionRegistry()
-    session = await registry.register(cast(Any, _FakeRuntime()), session_id="session-1")
-    timestamps = iter(
-        [
-            datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
-            datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
-        ]
-    )
-    activity: list[FabricSessionActivity] = []
-
-    async def report_activity(update: FabricSessionActivity) -> None:
-        activity.append(update)
-
-    monkeypatch.setattr(session_manager, "stream_fabric_runtime", lambda runtime, request: object())
-    manager = FabricSessionManager(
-        _agent_config(),
-        base_dir=tmp_path,
-        session_registry=registry,
-        activity_callback=report_activity,
-        clock=lambda: next(timestamps),
-    )
-
-    with pytest.raises(RuntimeError, match="stream interrupted"):
-        async with manager.stream_session(session, FabricInvocationRequest(input="hello")):
-            raise RuntimeError("stream interrupted")
-
-    assert [update.last_active_at for update in activity] == [
-        datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
-        datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
-    ]
 
 
 @pytest.mark.asyncio
@@ -826,17 +696,11 @@ async def test_invoke_session_releases_lock_after_cancellation(
 ) -> None:
     registry = FabricSessionRegistry()
     session = await registry.register(cast(Any, _FakeRuntime()), session_id="session-1")
-    activity: list[FabricSessionActivity] = []
-
-    async def report_activity(update: FabricSessionActivity) -> None:
-        activity.append(update)
-
     manager = FabricSessionManager(
         _agent_config(),
         base_dir=tmp_path,
         session_registry=registry,
         fabric=cast(Any, _FakeFabric(_FakeRuntime())),
-        activity_callback=report_activity,
     )
     invocation_started = asyncio.Event()
 
@@ -859,9 +723,6 @@ async def test_invoke_session_releases_lock_after_cancellation(
     result = await manager.invoke_session(session, FabricInvocationRequest(input="next"))
 
     assert result.response == "recovered"
-    assert len(activity) == 4
-    assert all(update.last_active_at.tzinfo is UTC for update in activity)
-    assert all(update.expires_at > update.last_active_at for update in activity)
 
 
 def test_rejects_negative_concurrency_limit(tmp_path: Path) -> None:
@@ -871,16 +732,6 @@ def test_rejects_negative_concurrency_limit(tmp_path: Path) -> None:
             base_dir=tmp_path,
             session_registry=FabricSessionRegistry(),
             max_concurrent_invocations=-1,
-        )
-
-
-def test_rejects_non_positive_idle_session_timeout(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="idle_session_timeout_seconds must be greater than zero"):
-        FabricSessionManager(
-            _agent_config(),
-            base_dir=tmp_path,
-            session_registry=FabricSessionRegistry(),
-            idle_session_timeout_seconds=0,
         )
 
 

--- a/plugins/nemo-agents/tests/unit/test_fabric_session_manager.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_session_manager.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -11,7 +12,7 @@ import pytest
 from nemo_agents_plugin.agent_config import AgentConfig
 from nemo_agents_plugin.fabric import session_manager
 from nemo_agents_plugin.fabric.runtime import FabricInvocationRequest, FabricRuntimeResult
-from nemo_agents_plugin.fabric.session_manager import FabricSessionManager
+from nemo_agents_plugin.fabric.session_manager import FabricSessionActivity, FabricSessionManager
 from nemo_agents_plugin.fabric.session_registry import (
     FabricSessionNotFoundError,
     FabricSessionRegistry,
@@ -532,6 +533,98 @@ async def test_invoke_session_refreshes_activity(
 
 
 @pytest.mark.asyncio
+async def test_reports_attachment_and_invocation_activity_timestamps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(session_manager, "translate_agent_config", lambda config: _FakeFabricConfig())
+    runtime = _FakeRuntime()
+    timestamps = iter(
+        [
+            datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
+            datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
+            datetime(2026, 8, 25, 12, 2, tzinfo=UTC),
+            datetime(2026, 8, 25, 12, 3, tzinfo=UTC),
+            datetime(2026, 8, 25, 12, 4, tzinfo=UTC),
+        ]
+    )
+    activity: list[FabricSessionActivity] = []
+
+    async def report_activity(update: FabricSessionActivity) -> None:
+        activity.append(update)
+
+    async def invoke_fabric_runtime(runtime: Any, request: FabricInvocationRequest) -> FabricRuntimeResult:
+        return FabricRuntimeResult(status="succeeded", response=request.input)
+
+    monkeypatch.setattr(session_manager, "invoke_fabric_runtime", invoke_fabric_runtime)
+    manager = FabricSessionManager(
+        _agent_config(),
+        base_dir=tmp_path,
+        session_registry=FabricSessionRegistry(),
+        fabric=cast(Any, _FakeFabric(runtime)),
+        idle_session_timeout_seconds=30.0,
+        activity_callback=report_activity,
+        clock=lambda: next(timestamps),
+    )
+
+    session = await manager.resolve_session("session-1")
+    await manager.invoke_session(session, FabricInvocationRequest(input="first"))
+    await manager.invoke_session(session, FabricInvocationRequest(input="second"))
+
+    expected_timestamps = [
+        datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
+        datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
+        datetime(2026, 8, 25, 12, 2, tzinfo=UTC),
+        datetime(2026, 8, 25, 12, 3, tzinfo=UTC),
+        datetime(2026, 8, 25, 12, 4, tzinfo=UTC),
+    ]
+    assert [update.last_active_at for update in activity] == expected_timestamps
+    assert [update.expires_at for update in activity] == [
+        timestamp + timedelta(seconds=30) for timestamp in expected_timestamps
+    ]
+    assert {update.session_id for update in activity} == {"session-1"}
+
+
+@pytest.mark.asyncio
+async def test_failed_invocation_reports_start_and_finish_activity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = FabricSessionRegistry()
+    session = await registry.register(cast(Any, _FakeRuntime()), session_id="session-1")
+    timestamps = iter(
+        [
+            datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
+            datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
+        ]
+    )
+    activity: list[FabricSessionActivity] = []
+
+    async def report_activity(update: FabricSessionActivity) -> None:
+        activity.append(update)
+
+    async def invoke_fabric_runtime(runtime: Any, request: FabricInvocationRequest) -> FabricRuntimeResult:
+        raise RuntimeError("invoke failed")
+
+    monkeypatch.setattr(session_manager, "invoke_fabric_runtime", invoke_fabric_runtime)
+    manager = FabricSessionManager(
+        _agent_config(),
+        base_dir=tmp_path,
+        session_registry=registry,
+        activity_callback=report_activity,
+        clock=lambda: next(timestamps),
+    )
+
+    with pytest.raises(RuntimeError, match="invoke failed"):
+        await manager.invoke_session(session, FabricInvocationRequest(input="hello"))
+
+    assert [update.last_active_at for update in activity] == [
+        datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
+        datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stream_session_refreshes_activity(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -559,6 +652,43 @@ async def test_stream_session_refreshes_activity(
         assert resolved_stream is stream
 
     assert refresh_calls == [session]
+
+
+@pytest.mark.asyncio
+async def test_interrupted_stream_reports_start_and_finish_activity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = FabricSessionRegistry()
+    session = await registry.register(cast(Any, _FakeRuntime()), session_id="session-1")
+    timestamps = iter(
+        [
+            datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
+            datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
+        ]
+    )
+    activity: list[FabricSessionActivity] = []
+
+    async def report_activity(update: FabricSessionActivity) -> None:
+        activity.append(update)
+
+    monkeypatch.setattr(session_manager, "stream_fabric_runtime", lambda runtime, request: object())
+    manager = FabricSessionManager(
+        _agent_config(),
+        base_dir=tmp_path,
+        session_registry=registry,
+        activity_callback=report_activity,
+        clock=lambda: next(timestamps),
+    )
+
+    with pytest.raises(RuntimeError, match="stream interrupted"):
+        async with manager.stream_session(session, FabricInvocationRequest(input="hello")):
+            raise RuntimeError("stream interrupted")
+
+    assert [update.last_active_at for update in activity] == [
+        datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
+        datetime(2026, 8, 25, 12, 1, tzinfo=UTC),
+    ]
 
 
 @pytest.mark.asyncio
@@ -696,11 +826,17 @@ async def test_invoke_session_releases_lock_after_cancellation(
 ) -> None:
     registry = FabricSessionRegistry()
     session = await registry.register(cast(Any, _FakeRuntime()), session_id="session-1")
+    activity: list[FabricSessionActivity] = []
+
+    async def report_activity(update: FabricSessionActivity) -> None:
+        activity.append(update)
+
     manager = FabricSessionManager(
         _agent_config(),
         base_dir=tmp_path,
         session_registry=registry,
         fabric=cast(Any, _FakeFabric(_FakeRuntime())),
+        activity_callback=report_activity,
     )
     invocation_started = asyncio.Event()
 
@@ -723,6 +859,9 @@ async def test_invoke_session_releases_lock_after_cancellation(
     result = await manager.invoke_session(session, FabricInvocationRequest(input="next"))
 
     assert result.response == "recovered"
+    assert len(activity) == 4
+    assert all(update.last_active_at.tzinfo is UTC for update in activity)
+    assert all(update.expires_at > update.last_active_at for update in activity)
 
 
 def test_rejects_negative_concurrency_limit(tmp_path: Path) -> None:
@@ -732,6 +871,16 @@ def test_rejects_negative_concurrency_limit(tmp_path: Path) -> None:
             base_dir=tmp_path,
             session_registry=FabricSessionRegistry(),
             max_concurrent_invocations=-1,
+        )
+
+
+def test_rejects_non_positive_idle_session_timeout(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="idle_session_timeout_seconds must be greater than zero"):
+        FabricSessionManager(
+            _agent_config(),
+            base_dir=tmp_path,
+            session_registry=FabricSessionRegistry(),
+            idle_session_timeout_seconds=0,
         )
 
 

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -794,6 +794,31 @@ class TestSessionAwareRouting:
         assert resp.status_code == 409
         assert resp.json()["detail"] == (f"Session ID 'session-1' has status '{status.value}' and cannot be invoked.")
 
+    def test_active_session_at_expiration_deadline_returns_409(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        deadline = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
+        session = _make_session(session_id="session-1")
+        session.expires_at = deadline
+        mock_entity_client.find_one = AsyncMock(return_value=session)
+
+        with (
+            patch.object(gateway_module, "_utc_now", return_value=deadline),
+            patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient") as httpx_client,
+        ):
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-1"},
+                json={},
+            )
+
+        assert response.status_code == 409
+        assert "status 'expired'" in response.json()["error"]["message"]
+        mock_entity_client.update.assert_not_awaited()
+        httpx_client.assert_not_called()
+
     def test_empty_session_header_returns_400(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         resp = client.post(
             "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -23,6 +23,7 @@ The mock replicates the async-context-manager chain::
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
@@ -43,7 +44,7 @@ from nemo_agents_plugin.entities import (
 )
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 from nemo_platform_plugin.dependencies import get_effective_principal_id
-from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
+from nemo_platform_plugin.entity_client import NemoEntityConflictError, NemoEntityNotFoundError
 
 OWNER_PRINCIPAL_ID = "session-owner"
 
@@ -168,7 +169,9 @@ def _make_httpx_mock(
 
 @pytest.fixture
 def mock_entity_client() -> AsyncMock:
-    return AsyncMock()
+    client = AsyncMock()
+    client.update.side_effect = lambda entity: entity
+    return client
 
 
 @pytest.fixture
@@ -449,6 +452,52 @@ class TestProxyByAgentName:
 
 
 class TestSessionAwareRouting:
+    @pytest.mark.parametrize(
+        ("content_type", "body"),
+        [
+            ("application/json", b'{"ok": true}'),
+            ("text/event-stream", b"data: done\n\n"),
+        ],
+    )
+    def test_persists_session_activity_at_proxy_start_and_finish(
+        self,
+        content_type: str,
+        body: bytes,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        session = _make_session(session_id="session-1", deployment_id="deployment-1")
+        deployment = _make_deployment(deployment_id="deployment-1")
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, deployment])
+        updates: list[AgentSession] = []
+
+        async def update(entity: AgentSession) -> AgentSession:
+            updates.append(entity.model_copy(deep=True))
+            return entity
+
+        mock_entity_client.update.side_effect = update
+        timestamps = [
+            datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
+            datetime(2026, 8, 25, 12, 5, tzinfo=UTC),
+        ]
+        httpx_mock = _make_httpx_mock(200, body, content_type)
+
+        with (
+            patch.object(gateway_module, "_utc_now", side_effect=timestamps),
+            patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock),
+        ):
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-1"},
+                json={"stream": content_type == "text/event-stream"},
+            )
+
+        assert response.status_code == 200
+        assert [update.last_active_at for update in updates] == timestamps
+        assert [update.expires_at for update in updates] == [
+            timestamp + timedelta(seconds=30 * 60) for timestamp in timestamps
+        ]
+
     def test_agent_route_uses_session_bound_deployment(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         session = _make_session(session_id="session-2", deployment_id="deployment-2")
         bound_deployment = _make_deployment(
@@ -481,6 +530,162 @@ class TestSessionAwareRouting:
         stream_call = httpx_mock.__aenter__.return_value.stream.call_args
         assert stream_call.kwargs["url"] == "http://localhost:9002/v1/chat/completions"
         assert stream_call.kwargs["headers"][SESSION_ID_HEADER] == "session-2"
+
+    def test_retries_start_activity_once_after_optimistic_conflict(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        session = _make_session(session_id="session-1", deployment_id="deployment-1")
+        deployment = _make_deployment(deployment_id="deployment-1")
+        refreshed = _make_session(session_id="session-1", deployment_id="deployment-1")
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, deployment])
+        mock_entity_client.get_by_id = AsyncMock(return_value=refreshed)
+        update_count = 0
+
+        async def update(entity: AgentSession) -> AgentSession:
+            nonlocal update_count
+            update_count += 1
+            if update_count == 1:
+                raise NemoEntityConflictError("conflict")
+            return entity
+
+        mock_entity_client.update.side_effect = update
+        httpx_mock = _make_httpx_mock(200, b'{"ok": true}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-1"},
+                json={},
+            )
+
+        assert response.status_code == 200
+        assert update_count == 3
+        mock_entity_client.get_by_id.assert_awaited_once_with(AgentSession, "session-1")
+
+    def test_terminal_state_wins_start_activity_conflict(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        session = _make_session(session_id="session-1", deployment_id="deployment-1")
+        deployment = _make_deployment(deployment_id="deployment-1")
+        closed = _make_session(
+            session_id="session-1",
+            deployment_id="deployment-1",
+            status=SessionStatus.CLOSED,
+        )
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, deployment])
+        mock_entity_client.update.side_effect = NemoEntityConflictError("conflict")
+        mock_entity_client.get_by_id = AsyncMock(return_value=closed)
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient") as httpx_client:
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-1"},
+                json={},
+            )
+
+        assert response.status_code == 409
+        assert "closed" in response.json()["error"]["message"]
+        httpx_client.assert_not_called()
+
+    def test_start_activity_failure_prevents_invocation(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        session = _make_session(session_id="session-1", deployment_id="deployment-1")
+        deployment = _make_deployment(deployment_id="deployment-1")
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, deployment])
+        mock_entity_client.update.side_effect = RuntimeError("entity store unavailable")
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient") as httpx_client:
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-1"},
+                json={},
+            )
+
+        assert response.status_code == 503
+        assert "persist activity" in response.json()["error"]["message"]
+        httpx_client.assert_not_called()
+
+    def test_finish_activity_failure_does_not_replace_successful_response(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        session = _make_session(session_id="session-1", deployment_id="deployment-1")
+        deployment = _make_deployment(deployment_id="deployment-1")
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, deployment])
+        update_count = 0
+
+        async def update(entity: AgentSession) -> AgentSession:
+            nonlocal update_count
+            update_count += 1
+            if update_count == 2:
+                raise RuntimeError("entity store unavailable")
+            return entity
+
+        mock_entity_client.update.side_effect = update
+        httpx_mock = _make_httpx_mock(200, b'{"ok": true}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-1"},
+                json={},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        assert update_count == 2
+
+    def test_proxy_failure_still_records_finish_activity(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        session = _make_session(session_id="session-1", deployment_id="deployment-1")
+        deployment = _make_deployment(deployment_id="deployment-1")
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, deployment])
+        client_context = MagicMock()
+        client_context.__aenter__ = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        client_context.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=client_context):
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-1"},
+                json={},
+            )
+
+        assert response.status_code == 502
+        assert mock_entity_client.update.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_delayed_activity_does_not_move_timestamps_backward(
+        self,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        last_active_at = datetime(2026, 8, 25, 12, 5, tzinfo=UTC)
+        expires_at = last_active_at + timedelta(minutes=30)
+        session = _make_session(session_id="session-1")
+        session.last_active_at = last_active_at
+        session.expires_at = expires_at
+
+        updated = await gateway_module._persist_session_activity(
+            mock_entity_client,
+            session,
+            activity_at=datetime(2026, 8, 25, 12, 0, tzinfo=UTC),
+        )
+
+        assert updated is session
+        assert updated.last_active_at == last_active_at
+        assert updated.expires_at == expires_at
+        mock_entity_client.update.assert_not_awaited()
 
     def test_direct_route_accepts_session_for_same_deployment(
         self, client: TestClient, mock_entity_client: AsyncMock

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -564,6 +564,41 @@ class TestSessionAwareRouting:
         assert update_count == 3
         mock_entity_client.get_by_id.assert_awaited_once_with(AgentSession, "session-1")
 
+    def test_due_session_wins_start_activity_conflict(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        activity_at = datetime(2026, 8, 25, 12, 0, tzinfo=UTC)
+        session = _make_session(session_id="session-1", deployment_id="deployment-1")
+        session.expires_at = activity_at + timedelta(minutes=1)
+        deployment = _make_deployment(deployment_id="deployment-1")
+        refreshed = _make_session(session_id="session-1", deployment_id="deployment-1")
+        refreshed.expires_at = activity_at
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, deployment])
+        mock_entity_client.update.side_effect = NemoEntityConflictError("conflict")
+        mock_entity_client.get_by_id = AsyncMock(return_value=refreshed)
+
+        with (
+            patch.object(
+                gateway_module,
+                "_utc_now",
+                side_effect=[activity_at - timedelta(seconds=1), activity_at],
+            ),
+            patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient") as httpx_client,
+        ):
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-1"},
+                json={},
+            )
+
+        assert response.status_code == 409
+        assert "status 'expired'" in response.json()["error"]["message"]
+        mock_entity_client.update.assert_awaited_once()
+        mock_entity_client.get_by_id.assert_awaited_once_with(AgentSession, "session-1")
+        httpx_client.assert_not_called()
+
     def test_terminal_state_wins_start_activity_conflict(
         self,
         client: TestClient,
@@ -818,6 +853,25 @@ class TestSessionAwareRouting:
         assert "status 'expired'" in response.json()["error"]["message"]
         mock_entity_client.update.assert_not_awaited()
         httpx_client.assert_not_called()
+
+    def test_read_only_proxy_does_not_refresh_session_activity(
+        self,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        session = _make_session(session_id="session-1", deployment_id="deployment-1")
+        deployment = _make_deployment(deployment_id="deployment-1")
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, deployment])
+        httpx_mock = _make_httpx_mock(200, b'{"status": "ok"}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            response = client.get(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/health",
+                headers={SESSION_ID_HEADER: "session-1"},
+            )
+
+        assert response.status_code == 200
+        mock_entity_client.update.assert_not_awaited()
 
     def test_empty_session_header_returns_400(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         resp = client.post(

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -493,6 +493,7 @@ class TestSessionAwareRouting:
             )
 
         assert response.status_code == 200
+        assert [update.first_active_at for update in updates] == [timestamps[0], timestamps[0]]
         assert [update.last_active_at for update in updates] == timestamps
         assert [update.expires_at for update in updates] == [
             timestamp + timedelta(seconds=30 * 60) for timestamp in timestamps

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -594,7 +594,7 @@ class TestSessionAwareRouting:
             )
 
         assert response.status_code == 409
-        assert "status 'expired'" in response.json()["error"]["message"]
+        assert "has expired" in response.json()["error"]["message"]
         mock_entity_client.update.assert_awaited_once()
         mock_entity_client.get_by_id.assert_awaited_once_with(AgentSession, "session-1")
         httpx_client.assert_not_called()
@@ -850,7 +850,7 @@ class TestSessionAwareRouting:
             )
 
         assert response.status_code == 409
-        assert "status 'expired'" in response.json()["error"]["message"]
+        assert "has expired" in response.json()["error"]["message"]
         mock_entity_client.update.assert_not_awaited()
         httpx_client.assert_not_called()
 

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -568,10 +568,17 @@ class TestSessionAwareRouting:
             filter_obj={"id": "session-1", "created_by": OWNER_PRINCIPAL_ID},
         )
 
-    def test_closed_session_returns_409(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
-        mock_entity_client.find_one = AsyncMock(
-            return_value=_make_session(session_id="session-1", status=SessionStatus.CLOSED)
-        )
+    @pytest.mark.parametrize(
+        "status",
+        [SessionStatus.EXPIRED, SessionStatus.LOST, SessionStatus.CLOSED],
+    )
+    def test_non_active_session_returns_409(
+        self,
+        status: SessionStatus,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        mock_entity_client.find_one = AsyncMock(return_value=_make_session(session_id="session-1", status=status))
 
         resp = client.post(
             "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
@@ -580,7 +587,7 @@ class TestSessionAwareRouting:
         )
 
         assert resp.status_code == 409
-        assert "closed" in resp.json()["detail"].lower()
+        assert resp.json()["detail"] == (f"Session ID 'session-1' has status '{status.value}' and cannot be invoked.")
 
     def test_empty_session_header_returns_400(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
         resp = client.post(

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -16,13 +16,13 @@ Pin the contracts callers depend on:
 
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
-from nemo_agents_plugin import session_lifecycle as session_lifecycle_module
 from nemo_agents_plugin.config import AgentsConfig, ControllerConfig
 from nemo_agents_plugin.entities import (
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
@@ -77,9 +77,32 @@ async def test_startup_session_reconciliation_retries_after_entity_list_failure(
 
     await ctrl._reconcile_sessions_after_controller_start()
     assert ctrl._startup_sessions_reconciled is False
+    reconciliation_time = ctrl._startup_session_reconciliation_at
 
     await ctrl._reconcile_sessions_after_controller_start()
     assert ctrl._startup_sessions_reconciled is True
+    assert ctrl._startup_session_reconciliation_at == reconciliation_time
+
+
+@pytest.mark.asyncio
+async def test_startup_retry_preserves_activity_from_current_runtime() -> None:
+    ctrl, _ = _make_controller()
+    current_generation = _make_session(
+        last_active_at=EXPIRATION_NOW,
+        expires_at=EXPIRATION_NOW + timedelta(minutes=30),
+    )
+    active_page = MagicMock(data=[current_generation], pagination=None)
+    ctrl.entities.list = AsyncMock(side_effect=[RuntimeError("unavailable"), active_page])
+    ctrl.entities.update = AsyncMock()
+    ctrl._startup_sessions_reconciled = False
+    ctrl._startup_session_reconciliation_at = EXPIRATION_NOW
+
+    await ctrl._reconcile_sessions_after_controller_start()
+    await ctrl._reconcile_sessions_after_controller_start()
+
+    assert ctrl._startup_sessions_reconciled is True
+    assert current_generation.status is SessionStatus.ACTIVE
+    ctrl.entities.update.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -211,16 +234,16 @@ async def test_restart_reconciliation_expires_loses_and_preserves_never_invoked_
         return_value=[lost, expired, never_invoked]
     )
     ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
+    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
 
-    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
-        reconciled = await ctrl._reconcile_sessions_after_restart(at=EXPIRATION_NOW)
+    reconciled = await ctrl._reconcile_sessions_after_restart(at=EXPIRATION_NOW)
 
     assert reconciled is True
     assert lost.status is SessionStatus.LOST
     assert expired.status is SessionStatus.EXPIRED
     assert never_invoked.status is SessionStatus.ACTIVE
     assert ctrl.entities.update.await_args_list == [call(lost), call(expired)]
-    assert cleanup.await_args_list == [call(ctrl.entities, lost), call(ctrl.entities, expired)]
+    assert ctrl._schedule_runtime_cleanup.call_args_list == [call(lost), call(expired)]
 
 
 @pytest.mark.asyncio
@@ -231,19 +254,63 @@ async def test_restart_wins_activity_conflict_for_refetched_invoked_session() ->
         expires_at=EXPIRATION_NOW + timedelta(minutes=28),
     )
     refreshed = _make_session(
-        last_active_at=EXPIRATION_NOW,
-        expires_at=EXPIRATION_NOW + timedelta(minutes=30),
+        last_active_at=EXPIRATION_NOW - timedelta(seconds=1),
+        expires_at=EXPIRATION_NOW + timedelta(minutes=30) - timedelta(seconds=1),
     )
     ctrl.entities.update = AsyncMock(side_effect=[NemoEntityConflictError("conflict"), refreshed])
     ctrl.entities.get_by_id = AsyncMock(return_value=refreshed)
+    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
 
-    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
-        result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
+    result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
 
     assert result is refreshed
     assert refreshed.status is SessionStatus.LOST
     assert ctrl.entities.update.await_count == 2
-    cleanup.assert_awaited_once_with(ctrl.entities, refreshed)
+    ctrl._schedule_runtime_cleanup.assert_called_once_with(refreshed)
+
+
+@pytest.mark.asyncio
+async def test_activity_from_current_runtime_wins_restart_reconciliation() -> None:
+    ctrl, _ = _make_controller()
+    current_generation = _make_session(
+        last_active_at=EXPIRATION_NOW,
+        expires_at=EXPIRATION_NOW + timedelta(minutes=30),
+    )
+    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
+
+    result = await ctrl._transition_session_after_restart(current_generation, at=EXPIRATION_NOW)
+
+    assert result is None
+    assert current_generation.status is SessionStatus.ACTIVE
+    ctrl.entities.update.assert_not_called()
+    ctrl._schedule_runtime_cleanup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_restart_reconciliation_does_not_wait_for_runtime_cleanup() -> None:
+    ctrl, _ = _make_controller()
+    session = _make_session(
+        last_active_at=EXPIRATION_NOW - timedelta(minutes=1),
+        expires_at=EXPIRATION_NOW + timedelta(minutes=29),
+    )
+    ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def blocking_cleanup(*_args: object) -> None:
+        cleanup_started.set()
+        await release_cleanup.wait()
+
+    with patch("nemo_agents_plugin.session_lifecycle.cleanup_fabric_runtime", side_effect=blocking_cleanup):
+        result = await ctrl._transition_session_after_restart(session, at=EXPIRATION_NOW)
+        assert result is session
+        assert session.status is SessionStatus.LOST
+
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+        cleanup_tasks = list(ctrl._runtime_cleanup_tasks)
+        assert len(cleanup_tasks) == 1
+        release_cleanup.set()
+        await asyncio.gather(*cleanup_tasks)
 
 
 @pytest.mark.asyncio
@@ -257,14 +324,14 @@ async def test_terminal_state_wins_restart_conflict(terminal_status: SessionStat
     terminal = _make_session(status=terminal_status)
     ctrl.entities.update = AsyncMock(side_effect=NemoEntityConflictError("conflict"))
     ctrl.entities.get_by_id = AsyncMock(return_value=terminal)
+    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
 
-    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
-        result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
+    result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
 
     assert result is terminal
     assert terminal.status is terminal_status
     ctrl.entities.update.assert_awaited_once_with(stale)
-    cleanup.assert_not_awaited()
+    ctrl._schedule_runtime_cleanup.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -287,21 +354,22 @@ async def test_runtime_instance_change_reconciles_bound_sessions() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_instance_change_is_retained_until_reconciliation_succeeds() -> None:
+async def test_runtime_instance_change_queues_failed_reconciliation() -> None:
     ctrl, _ = _make_controller()
     deployment = _make_fabric_deployment()
     key = (deployment.workspace, deployment.name)
     ctrl._runtime_instance_ids[key] = "runtime-1"
     ctrl._read_runtime_instance_id = AsyncMock(return_value="runtime-2")  # type: ignore[method-assign]
     ctrl._reconcile_deployment_sessions_after_restart = AsyncMock(  # type: ignore[method-assign]
-        side_effect=[False, True]
+        return_value=False
     )
 
     await ctrl._observe_runtime_instance(deployment)
-    assert ctrl._runtime_instance_ids[key] == "runtime-1"
+    assert ctrl._runtime_instance_ids[key] == "runtime-2"
 
     await ctrl._observe_runtime_instance(deployment)
     assert ctrl._runtime_instance_ids[key] == "runtime-2"
+    ctrl._reconcile_deployment_sessions_after_restart.assert_awaited_once_with(deployment)
 
 
 @pytest.mark.asyncio
@@ -339,12 +407,18 @@ async def test_failed_restart_reconciliation_is_queued_and_retried() -> None:
         side_effect=[False, True]
     )
 
-    reconciled = await ctrl._reconcile_deployment_sessions_after_restart(deployment)
+    reconciled = await ctrl._reconcile_deployment_sessions_after_restart(deployment, at=EXPIRATION_NOW)
     assert reconciled is False
     assert deployment.id in ctrl._pending_restart_deployment_ids
+    assert ctrl._pending_restart_reconciliation_times[deployment.id] == EXPIRATION_NOW
 
     await ctrl._retry_pending_restart_reconciliations()
     assert deployment.id not in ctrl._pending_restart_deployment_ids
+    assert deployment.id not in ctrl._pending_restart_reconciliation_times
+    assert ctrl._reconcile_sessions_after_restart.await_args_list == [
+        call(deployment_id=deployment.id, at=EXPIRATION_NOW),
+        call(deployment_id=deployment.id, at=EXPIRATION_NOW),
+    ]
 
 
 @pytest.mark.asyncio
@@ -477,14 +551,14 @@ async def test_expire_session_transitions_due_session_and_cleans_runtime() -> No
     ctrl, _ = _make_controller()
     session = _make_session(expires_at=EXPIRATION_NOW)
     ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
+    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
 
-    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
-        result = await ctrl._expire_session_if_due(session, at=EXPIRATION_NOW)
+    result = await ctrl._expire_session_if_due(session, at=EXPIRATION_NOW)
 
     assert result is session
     assert session.status is SessionStatus.EXPIRED
     ctrl.entities.update.assert_awaited_once_with(session)
-    cleanup.assert_awaited_once_with(ctrl.entities, session)
+    ctrl._schedule_runtime_cleanup.assert_called_once_with(session)
 
 
 @pytest.mark.asyncio
@@ -492,17 +566,17 @@ async def test_expire_session_transitions_due_session_and_cleans_runtime() -> No
 async def test_expire_session_leaves_session_before_deadline_active(expires_at: datetime | None) -> None:
     ctrl, _ = _make_controller()
     session = _make_session(expires_at=expires_at)
+    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
 
-    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
-        result = await ctrl._expire_session_if_due(
-            session,
-            at=EXPIRATION_NOW,
-        )
+    result = await ctrl._expire_session_if_due(
+        session,
+        at=EXPIRATION_NOW,
+    )
 
     assert result is None
     assert session.status is SessionStatus.ACTIVE
     ctrl.entities.update.assert_not_called()
-    cleanup.assert_not_awaited()
+    ctrl._schedule_runtime_cleanup.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -529,9 +603,9 @@ async def test_expiration_conflict_resolves_from_refetched_session(
     )
     ctrl.entities.update = AsyncMock(side_effect=[NemoEntityConflictError("conflict"), refreshed])
     ctrl.entities.get_by_id = AsyncMock(return_value=refreshed)
+    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
 
-    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
-        result = await ctrl._expire_session_if_due(stale, at=EXPIRATION_NOW)
+    result = await ctrl._expire_session_if_due(stale, at=EXPIRATION_NOW)
 
     assert (result is refreshed) is expected_cleanup
     expected_status = (
@@ -543,9 +617,9 @@ async def test_expiration_conflict_resolves_from_refetched_session(
     assert ctrl.entities.update.await_count == expected_updates
     ctrl.entities.get_by_id.assert_awaited_once_with(AgentSession, stale.id)
     if expected_cleanup:
-        cleanup.assert_awaited_once_with(ctrl.entities, refreshed)
+        ctrl._schedule_runtime_cleanup.assert_called_once_with(refreshed)
     else:
-        cleanup.assert_not_awaited()
+        ctrl._schedule_runtime_cleanup.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -158,6 +158,12 @@ def _make_controller() -> tuple[AgentDeploymentController, Any]:
     return ctrl, cast(Any, backend)
 
 
+def _mock_runtime_cleanup(ctrl: AgentDeploymentController) -> MagicMock:
+    cleanup = MagicMock()
+    ctrl._schedule_runtime_cleanup = cleanup  # type: ignore[method-assign]
+    return cleanup
+
+
 def _make_session(
     *,
     name: str = "session-one",
@@ -234,7 +240,7 @@ async def test_restart_reconciliation_expires_loses_and_preserves_never_invoked_
         return_value=[lost, expired, never_invoked]
     )
     ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
-    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
+    cleanup = _mock_runtime_cleanup(ctrl)
 
     reconciled = await ctrl._reconcile_sessions_after_restart(at=EXPIRATION_NOW)
 
@@ -243,7 +249,7 @@ async def test_restart_reconciliation_expires_loses_and_preserves_never_invoked_
     assert expired.status is SessionStatus.EXPIRED
     assert never_invoked.status is SessionStatus.ACTIVE
     assert ctrl.entities.update.await_args_list == [call(lost), call(expired)]
-    assert ctrl._schedule_runtime_cleanup.call_args_list == [call(lost), call(expired)]
+    assert cleanup.call_args_list == [call(lost), call(expired)]
 
 
 @pytest.mark.asyncio
@@ -259,14 +265,14 @@ async def test_restart_wins_activity_conflict_for_refetched_invoked_session() ->
     )
     ctrl.entities.update = AsyncMock(side_effect=[NemoEntityConflictError("conflict"), refreshed])
     ctrl.entities.get_by_id = AsyncMock(return_value=refreshed)
-    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
+    cleanup = _mock_runtime_cleanup(ctrl)
 
     result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
 
     assert result is refreshed
     assert refreshed.status is SessionStatus.LOST
     assert ctrl.entities.update.await_count == 2
-    ctrl._schedule_runtime_cleanup.assert_called_once_with(refreshed)
+    cleanup.assert_called_once_with(refreshed)
 
 
 @pytest.mark.asyncio
@@ -276,14 +282,14 @@ async def test_activity_from_current_runtime_wins_restart_reconciliation() -> No
         last_active_at=EXPIRATION_NOW,
         expires_at=EXPIRATION_NOW + timedelta(minutes=30),
     )
-    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
+    cleanup = _mock_runtime_cleanup(ctrl)
 
     result = await ctrl._transition_session_after_restart(current_generation, at=EXPIRATION_NOW)
 
     assert result is None
     assert current_generation.status is SessionStatus.ACTIVE
     ctrl.entities.update.assert_not_called()
-    ctrl._schedule_runtime_cleanup.assert_not_called()
+    cleanup.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -324,14 +330,14 @@ async def test_terminal_state_wins_restart_conflict(terminal_status: SessionStat
     terminal = _make_session(status=terminal_status)
     ctrl.entities.update = AsyncMock(side_effect=NemoEntityConflictError("conflict"))
     ctrl.entities.get_by_id = AsyncMock(return_value=terminal)
-    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
+    cleanup = _mock_runtime_cleanup(ctrl)
 
     result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
 
     assert result is terminal
     assert terminal.status is terminal_status
     ctrl.entities.update.assert_awaited_once_with(stale)
-    ctrl._schedule_runtime_cleanup.assert_not_called()
+    cleanup.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -354,7 +360,7 @@ async def test_runtime_instance_change_reconciles_bound_sessions() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_instance_change_queues_failed_reconciliation() -> None:
+async def test_runtime_instance_change_is_recorded_before_retry() -> None:
     ctrl, _ = _make_controller()
     deployment = _make_fabric_deployment()
     key = (deployment.workspace, deployment.name)
@@ -409,12 +415,10 @@ async def test_failed_restart_reconciliation_is_queued_and_retried() -> None:
 
     reconciled = await ctrl._reconcile_deployment_sessions_after_restart(deployment, at=EXPIRATION_NOW)
     assert reconciled is False
-    assert deployment.id in ctrl._pending_restart_deployment_ids
-    assert ctrl._pending_restart_reconciliation_times[deployment.id] == EXPIRATION_NOW
+    assert ctrl._pending_restart_reconciliations[deployment.id] == EXPIRATION_NOW
 
     await ctrl._retry_pending_restart_reconciliations()
-    assert deployment.id not in ctrl._pending_restart_deployment_ids
-    assert deployment.id not in ctrl._pending_restart_reconciliation_times
+    assert deployment.id not in ctrl._pending_restart_reconciliations
     assert ctrl._reconcile_sessions_after_restart.await_args_list == [
         call(deployment_id=deployment.id, at=EXPIRATION_NOW),
         call(deployment_id=deployment.id, at=EXPIRATION_NOW),
@@ -551,14 +555,14 @@ async def test_expire_session_transitions_due_session_and_cleans_runtime() -> No
     ctrl, _ = _make_controller()
     session = _make_session(expires_at=EXPIRATION_NOW)
     ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
-    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
+    cleanup = _mock_runtime_cleanup(ctrl)
 
     result = await ctrl._expire_session_if_due(session, at=EXPIRATION_NOW)
 
     assert result is session
     assert session.status is SessionStatus.EXPIRED
     ctrl.entities.update.assert_awaited_once_with(session)
-    ctrl._schedule_runtime_cleanup.assert_called_once_with(session)
+    cleanup.assert_called_once_with(session)
 
 
 @pytest.mark.asyncio
@@ -566,7 +570,7 @@ async def test_expire_session_transitions_due_session_and_cleans_runtime() -> No
 async def test_expire_session_leaves_session_before_deadline_active(expires_at: datetime | None) -> None:
     ctrl, _ = _make_controller()
     session = _make_session(expires_at=expires_at)
-    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
+    cleanup = _mock_runtime_cleanup(ctrl)
 
     result = await ctrl._expire_session_if_due(
         session,
@@ -576,7 +580,7 @@ async def test_expire_session_leaves_session_before_deadline_active(expires_at: 
     assert result is None
     assert session.status is SessionStatus.ACTIVE
     ctrl.entities.update.assert_not_called()
-    ctrl._schedule_runtime_cleanup.assert_not_called()
+    cleanup.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -603,7 +607,7 @@ async def test_expiration_conflict_resolves_from_refetched_session(
     )
     ctrl.entities.update = AsyncMock(side_effect=[NemoEntityConflictError("conflict"), refreshed])
     ctrl.entities.get_by_id = AsyncMock(return_value=refreshed)
-    ctrl._schedule_runtime_cleanup = MagicMock()  # type: ignore[method-assign]
+    cleanup = _mock_runtime_cleanup(ctrl)
 
     result = await ctrl._expire_session_if_due(stale, at=EXPIRATION_NOW)
 
@@ -617,9 +621,9 @@ async def test_expiration_conflict_resolves_from_refetched_session(
     assert ctrl.entities.update.await_count == expected_updates
     ctrl.entities.get_by_id.assert_awaited_once_with(AgentSession, stale.id)
     if expected_cleanup:
-        ctrl._schedule_runtime_cleanup.assert_called_once_with(refreshed)
+        cleanup.assert_called_once_with(refreshed)
     else:
-        ctrl._schedule_runtime_cleanup.assert_not_called()
+        cleanup.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -22,6 +22,7 @@ from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from nemo_agents_plugin import session_lifecycle as session_lifecycle_module
 from nemo_agents_plugin.config import AgentsConfig, ControllerConfig
 from nemo_agents_plugin.entities import (
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
@@ -29,7 +30,6 @@ from nemo_agents_plugin.entities import (
     AgentSession,
     SessionStatus,
 )
-from nemo_agents_plugin.runner import controller as controller_module
 from nemo_agents_plugin.runner.backend import DeploymentInfo
 from nemo_agents_plugin.runner.controller import AgentDeploymentController
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
@@ -80,6 +80,37 @@ async def test_startup_session_reconciliation_retries_after_entity_list_failure(
 
     await ctrl._reconcile_sessions_after_controller_start()
     assert ctrl._startup_sessions_reconciled is True
+
+
+@pytest.mark.asyncio
+async def test_reconcile_continues_deployments_while_startup_session_retry_is_pending() -> None:
+    ctrl, _ = _make_controller()
+    ctrl._startup_sessions_reconciled = False
+    ctrl._reconcile_sessions_after_controller_start = AsyncMock()  # type: ignore[method-assign]
+    ctrl._reconcile_deployments = AsyncMock()  # type: ignore[method-assign]
+    ctrl._retry_pending_restart_reconciliations = AsyncMock()  # type: ignore[method-assign]
+    ctrl._reconcile_expired_sessions = AsyncMock()  # type: ignore[method-assign]
+
+    await ctrl.reconcile()
+
+    ctrl._reconcile_sessions_after_controller_start.assert_awaited_once_with()
+    ctrl._reconcile_deployments.assert_awaited_once_with()
+    ctrl._retry_pending_restart_reconciliations.assert_awaited_once_with()
+    ctrl._reconcile_expired_sessions.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_stops_after_startup_session_retry_when_stop_is_requested() -> None:
+    ctrl, _ = _make_controller()
+    ctrl._startup_sessions_reconciled = False
+    ctrl._reconcile_sessions_after_controller_start = AsyncMock()  # type: ignore[method-assign]
+    ctrl._reconcile_deployments = AsyncMock()  # type: ignore[method-assign]
+    ctrl.stop_requested = MagicMock(return_value=True)  # type: ignore[method-assign]
+
+    await ctrl.reconcile()
+
+    ctrl._reconcile_sessions_after_controller_start.assert_awaited_once_with()
+    ctrl._reconcile_deployments.assert_not_awaited()
 
 
 def _make_controller() -> tuple[AgentDeploymentController, Any]:
@@ -181,7 +212,7 @@ async def test_restart_reconciliation_expires_loses_and_preserves_never_invoked_
     )
     ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
 
-    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
         reconciled = await ctrl._reconcile_sessions_after_restart(at=EXPIRATION_NOW)
 
     assert reconciled is True
@@ -206,7 +237,7 @@ async def test_restart_wins_activity_conflict_for_refetched_invoked_session() ->
     ctrl.entities.update = AsyncMock(side_effect=[NemoEntityConflictError("conflict"), refreshed])
     ctrl.entities.get_by_id = AsyncMock(return_value=refreshed)
 
-    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
         result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
 
     assert result is refreshed
@@ -227,7 +258,7 @@ async def test_terminal_state_wins_restart_conflict(terminal_status: SessionStat
     ctrl.entities.update = AsyncMock(side_effect=NemoEntityConflictError("conflict"))
     ctrl.entities.get_by_id = AsyncMock(return_value=terminal)
 
-    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
         result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
 
     assert result is terminal
@@ -447,7 +478,7 @@ async def test_expire_session_transitions_due_session_and_cleans_runtime() -> No
     session = _make_session(expires_at=EXPIRATION_NOW)
     ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
 
-    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
         result = await ctrl._expire_session_if_due(session, at=EXPIRATION_NOW)
 
     assert result is session
@@ -462,7 +493,7 @@ async def test_expire_session_leaves_session_before_deadline_active(expires_at: 
     ctrl, _ = _make_controller()
     session = _make_session(expires_at=expires_at)
 
-    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
         result = await ctrl._expire_session_if_due(
             session,
             at=EXPIRATION_NOW,
@@ -499,7 +530,7 @@ async def test_expiration_conflict_resolves_from_refetched_session(
     ctrl.entities.update = AsyncMock(side_effect=[NemoEntityConflictError("conflict"), refreshed])
     ctrl.entities.get_by_id = AsyncMock(return_value=refreshed)
 
-    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+    with patch.object(session_lifecycle_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
         result = await ctrl._expire_session_if_due(stale, at=EXPIRATION_NOW)
 
     assert (result is refreshed) is expected_cleanup

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -88,6 +88,7 @@ async def test_startup_session_reconciliation_retries_after_entity_list_failure(
 async def test_startup_retry_preserves_activity_from_current_runtime() -> None:
     ctrl, _ = _make_controller()
     current_generation = _make_session(
+        first_active_at=EXPIRATION_NOW,
         last_active_at=EXPIRATION_NOW,
         expires_at=EXPIRATION_NOW + timedelta(minutes=30),
     )
@@ -168,6 +169,7 @@ def _make_session(
     *,
     name: str = "session-one",
     deployment_id: str = "deployment-id",
+    first_active_at: datetime | None = None,
     last_active_at: datetime | None = None,
     expires_at: datetime | None = None,
     status: SessionStatus = SessionStatus.ACTIVE,
@@ -177,6 +179,7 @@ def _make_session(
         workspace="default",
         deployment_id=deployment_id,
         status=status,
+        first_active_at=first_active_at,
         last_active_at=last_active_at,
         expires_at=expires_at,
     )
@@ -227,11 +230,13 @@ async def test_restart_reconciliation_expires_loses_and_preserves_never_invoked_
     ctrl, _ = _make_controller()
     lost = _make_session(
         name="lost",
+        first_active_at=EXPIRATION_NOW - timedelta(minutes=10),
         last_active_at=EXPIRATION_NOW - timedelta(minutes=5),
         expires_at=EXPIRATION_NOW + timedelta(minutes=25),
     )
     expired = _make_session(
         name="expired",
+        first_active_at=EXPIRATION_NOW - timedelta(hours=1),
         last_active_at=EXPIRATION_NOW - timedelta(minutes=31),
         expires_at=EXPIRATION_NOW - timedelta(minutes=1),
     )
@@ -279,6 +284,7 @@ async def test_restart_wins_activity_conflict_for_refetched_invoked_session() ->
 async def test_activity_from_current_runtime_wins_restart_reconciliation() -> None:
     ctrl, _ = _make_controller()
     current_generation = _make_session(
+        first_active_at=EXPIRATION_NOW,
         last_active_at=EXPIRATION_NOW,
         expires_at=EXPIRATION_NOW + timedelta(minutes=30),
     )
@@ -290,6 +296,48 @@ async def test_activity_from_current_runtime_wins_restart_reconciliation() -> No
     assert current_generation.status is SessionStatus.ACTIVE
     ctrl.entities.update.assert_not_called()
     cleanup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_activity_between_runtime_start_and_controller_observation_stays_active() -> None:
+    ctrl, _ = _make_controller()
+    runtime_started_at = EXPIRATION_NOW
+    first_activity_at = runtime_started_at + timedelta(seconds=1)
+    controller_observed_at = runtime_started_at + timedelta(seconds=2)
+    current_generation = _make_session(
+        first_active_at=first_activity_at,
+        last_active_at=first_activity_at,
+        expires_at=first_activity_at + timedelta(minutes=30),
+    )
+    cleanup = _mock_runtime_cleanup(ctrl)
+
+    result = await ctrl._transition_session_after_restart(current_generation, at=runtime_started_at)
+
+    assert first_activity_at < controller_observed_at
+    assert result is None
+    assert current_generation.status is SessionStatus.ACTIVE
+    ctrl.entities.update.assert_not_called()
+    cleanup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_new_runtime_activity_does_not_rebind_old_session() -> None:
+    ctrl, _ = _make_controller()
+    runtime_started_at = EXPIRATION_NOW
+    old_session = _make_session(
+        first_active_at=runtime_started_at - timedelta(minutes=5),
+        last_active_at=runtime_started_at + timedelta(seconds=1),
+        expires_at=runtime_started_at + timedelta(minutes=30),
+    )
+    ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
+    cleanup = _mock_runtime_cleanup(ctrl)
+
+    result = await ctrl._transition_session_after_restart(old_session, at=runtime_started_at)
+
+    assert result is old_session
+    assert old_session.status is SessionStatus.LOST
+    ctrl.entities.update.assert_awaited_once_with(old_session)
+    cleanup.assert_called_once_with(old_session)
 
 
 @pytest.mark.asyncio
@@ -344,8 +392,13 @@ async def test_terminal_state_wins_restart_conflict(terminal_status: SessionStat
 async def test_runtime_instance_change_reconciles_bound_sessions() -> None:
     ctrl, _ = _make_controller()
     deployment = _make_fabric_deployment()
-    ctrl._read_runtime_instance_id = AsyncMock(  # type: ignore[method-assign]
-        side_effect=["runtime-1", "runtime-1", "runtime-2"]
+    runtime_started_at = EXPIRATION_NOW - timedelta(seconds=2)
+    ctrl._read_runtime_instance = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            ("runtime-1", EXPIRATION_NOW - timedelta(minutes=10)),
+            ("runtime-1", EXPIRATION_NOW - timedelta(minutes=10)),
+            ("runtime-2", runtime_started_at),
+        ]
     )
     ctrl._reconcile_deployment_sessions_after_restart = AsyncMock(  # type: ignore[method-assign]
         return_value=True
@@ -356,7 +409,10 @@ async def test_runtime_instance_change_reconciles_bound_sessions() -> None:
     await ctrl._observe_runtime_instance(deployment)
 
     assert ctrl._runtime_instance_ids[(deployment.workspace, deployment.name)] == "runtime-2"
-    ctrl._reconcile_deployment_sessions_after_restart.assert_awaited_once_with(deployment)
+    ctrl._reconcile_deployment_sessions_after_restart.assert_awaited_once_with(
+        deployment,
+        at=runtime_started_at,
+    )
 
 
 @pytest.mark.asyncio
@@ -365,7 +421,10 @@ async def test_runtime_instance_change_is_recorded_before_retry() -> None:
     deployment = _make_fabric_deployment()
     key = (deployment.workspace, deployment.name)
     ctrl._runtime_instance_ids[key] = "runtime-1"
-    ctrl._read_runtime_instance_id = AsyncMock(return_value="runtime-2")  # type: ignore[method-assign]
+    runtime_started_at = EXPIRATION_NOW
+    ctrl._read_runtime_instance = AsyncMock(  # type: ignore[method-assign]
+        return_value=("runtime-2", runtime_started_at)
+    )
     ctrl._reconcile_deployment_sessions_after_restart = AsyncMock(  # type: ignore[method-assign]
         return_value=False
     )
@@ -375,22 +434,30 @@ async def test_runtime_instance_change_is_recorded_before_retry() -> None:
 
     await ctrl._observe_runtime_instance(deployment)
     assert ctrl._runtime_instance_ids[key] == "runtime-2"
-    ctrl._reconcile_deployment_sessions_after_restart.assert_awaited_once_with(deployment)
+    ctrl._reconcile_deployment_sessions_after_restart.assert_awaited_once_with(
+        deployment,
+        at=runtime_started_at,
+    )
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("payload", "expected"),
     [
-        ({"runtime_instance_id": "runtime-1"}, "runtime-1"),
-        ({"runtime_instance_id": ""}, None),
-        ({"runtime_instance_id": 1}, None),
+        (
+            {"runtime_instance_id": "runtime-1", "runtime_started_at": EXPIRATION_NOW.isoformat()},
+            ("runtime-1", EXPIRATION_NOW),
+        ),
+        ({"runtime_instance_id": "", "runtime_started_at": EXPIRATION_NOW.isoformat()}, None),
+        ({"runtime_instance_id": 1, "runtime_started_at": EXPIRATION_NOW.isoformat()}, None),
+        ({"runtime_instance_id": "runtime-1", "runtime_started_at": "not-a-timestamp"}, None),
+        ({"runtime_instance_id": "runtime-1", "runtime_started_at": "2026-08-26T12:00:00"}, None),
         ({}, None),
     ],
 )
-async def test_read_runtime_instance_id_validates_health_response(
+async def test_read_runtime_instance_validates_health_response(
     payload: dict[str, object],
-    expected: str | None,
+    expected: tuple[str, datetime] | None,
 ) -> None:
     ctrl, _ = _make_controller()
     deployment = _make_fabric_deployment()
@@ -400,7 +467,7 @@ async def test_read_runtime_instance_id_validates_health_response(
     client.get = AsyncMock(return_value=response)
     ctrl._runtime_health_client = client
 
-    assert await ctrl._read_runtime_instance_id(deployment) == expected
+    assert await ctrl._read_runtime_instance(deployment) == expected
     client.get.assert_awaited_once_with("http://localhost:9001/health")
     response.raise_for_status.assert_called_once_with()
 
@@ -423,6 +490,27 @@ async def test_failed_restart_reconciliation_is_queued_and_retried() -> None:
         call(deployment_id=deployment.id, at=EXPIRATION_NOW),
         call(deployment_id=deployment.id, at=EXPIRATION_NOW),
     ]
+
+
+@pytest.mark.asyncio
+async def test_newer_runtime_replacement_supersedes_pending_reconciliation_cutoff() -> None:
+    ctrl, _ = _make_controller()
+    deployment = _make_fabric_deployment()
+    newer_runtime_started_at = EXPIRATION_NOW + timedelta(minutes=1)
+    ctrl._pending_restart_reconciliations[deployment.id] = EXPIRATION_NOW
+    ctrl._reconcile_sessions_after_restart = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    reconciled = await ctrl._reconcile_deployment_sessions_after_restart(
+        deployment,
+        at=newer_runtime_started_at,
+    )
+
+    assert reconciled is False
+    assert ctrl._pending_restart_reconciliations[deployment.id] == newer_runtime_started_at
+    ctrl._reconcile_sessions_after_restart.assert_awaited_once_with(
+        deployment_id=deployment.id,
+        at=newer_runtime_started_at,
+    )
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -17,15 +17,20 @@ Pin the contracts callers depend on:
 from __future__ import annotations
 
 import time
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from nemo_agents_plugin.config import AgentsConfig, ControllerConfig
-from nemo_agents_plugin.entities import AgentDeployment
+from nemo_agents_plugin.entities import AgentDeployment, AgentSession, SessionStatus
+from nemo_agents_plugin.runner import controller as controller_module
 from nemo_agents_plugin.runner.backend import DeploymentInfo
 from nemo_agents_plugin.runner.controller import AgentDeploymentController
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
+from nemo_platform_plugin.entity_client import NemoEntityConflictError
+
+EXPIRATION_NOW = datetime(2026, 8, 26, 12, 0, tzinfo=UTC)
 
 
 def test_agent_deployment_controller_declares_entities_dependency() -> None:
@@ -74,6 +79,38 @@ def _make_controller() -> tuple[AgentDeploymentController, Any]:
     ctrl._controller_config = ControllerConfig(health_check_timeout_seconds=120)
     ctrl._save = AsyncMock()  # type: ignore[method-assign]
     return ctrl, cast(Any, backend)
+
+
+def _make_session(
+    *,
+    name: str = "session-one",
+    expires_at: datetime | None = None,
+    status: SessionStatus = SessionStatus.ACTIVE,
+) -> AgentSession:
+    session = AgentSession(
+        name=name,
+        workspace="default",
+        deployment_id="deployment-id",
+        status=status,
+        expires_at=expires_at,
+    )
+    session._id = f"{name}-id"
+    return session
+
+
+@pytest.mark.asyncio
+async def test_reconcile_runs_expiration_after_isolated_deployment_failures() -> None:
+    ctrl, _ = _make_controller()
+    first = AgentDeployment(name="first", workspace="default", agent="calc")
+    second = AgentDeployment(name="second", workspace="default", agent="calc")
+    ctrl.list_objects = AsyncMock(return_value=[first, second])  # type: ignore[method-assign]
+    ctrl.reconcile_one = AsyncMock(side_effect=[RuntimeError("failed"), None])  # type: ignore[method-assign]
+    ctrl._reconcile_expired_sessions = AsyncMock()  # type: ignore[method-assign]
+
+    await ctrl.reconcile()
+
+    assert ctrl.reconcile_one.await_args_list == [call(first), call(second)]
+    ctrl._reconcile_expired_sessions.assert_awaited_once_with()
 
 
 # ---------------------------------------------------------------------------
@@ -179,3 +216,114 @@ async def test_check_health_marks_running_when_healthy() -> None:
     await ctrl._check_health(dep)
 
     assert dep.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# Persisted session expiration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_expire_session_transitions_due_session_and_cleans_runtime() -> None:
+    ctrl, _ = _make_controller()
+    session = _make_session(expires_at=EXPIRATION_NOW)
+    ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
+
+    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+        result = await ctrl._expire_session_if_due(session, at=EXPIRATION_NOW)
+
+    assert result is session
+    assert session.status is SessionStatus.EXPIRED
+    ctrl.entities.update.assert_awaited_once_with(session)
+    cleanup.assert_awaited_once_with(ctrl.entities, session)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("expires_at", [None, EXPIRATION_NOW + timedelta(seconds=1)])
+async def test_expire_session_leaves_session_before_deadline_active(expires_at: datetime | None) -> None:
+    ctrl, _ = _make_controller()
+    session = _make_session(expires_at=expires_at)
+
+    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+        result = await ctrl._expire_session_if_due(
+            session,
+            at=EXPIRATION_NOW,
+        )
+
+    assert result is None
+    assert session.status is SessionStatus.ACTIVE
+    ctrl.entities.update.assert_not_called()
+    cleanup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("refreshed_status", "deadline_delta_seconds", "expected_updates", "expected_cleanup"),
+    [
+        pytest.param(SessionStatus.ACTIVE, 30 * 60, 1, False, id="renewed-activity-wins"),
+        pytest.param(SessionStatus.ACTIVE, -1, 2, True, id="still-due-retries"),
+        pytest.param(SessionStatus.CLOSED, -1, 1, False, id="closed-wins"),
+        pytest.param(SessionStatus.EXPIRED, -1, 1, True, id="concurrent-expiration-is-idempotent"),
+    ],
+)
+async def test_expiration_conflict_resolves_from_refetched_session(
+    refreshed_status: SessionStatus,
+    deadline_delta_seconds: int,
+    expected_updates: int,
+    expected_cleanup: bool,
+) -> None:
+    ctrl, _ = _make_controller()
+    stale = _make_session(expires_at=EXPIRATION_NOW - timedelta(seconds=2))
+    refreshed = _make_session(
+        expires_at=EXPIRATION_NOW + timedelta(seconds=deadline_delta_seconds),
+        status=refreshed_status,
+    )
+    ctrl.entities.update = AsyncMock(side_effect=[NemoEntityConflictError("conflict"), refreshed])
+    ctrl.entities.get_by_id = AsyncMock(return_value=refreshed)
+
+    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+        result = await ctrl._expire_session_if_due(stale, at=EXPIRATION_NOW)
+
+    assert (result is refreshed) is expected_cleanup
+    expected_status = (
+        SessionStatus.EXPIRED
+        if refreshed_status is SessionStatus.ACTIVE and deadline_delta_seconds <= 0
+        else refreshed_status
+    )
+    assert refreshed.status is expected_status
+    assert ctrl.entities.update.await_count == expected_updates
+    ctrl.entities.get_by_id.assert_awaited_once_with(AgentSession, stale.id)
+    if expected_cleanup:
+        cleanup.assert_awaited_once_with(ctrl.entities, refreshed)
+    else:
+        cleanup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_active_session_listing_follows_pagination() -> None:
+    ctrl, _ = _make_controller()
+    first = MagicMock(data=[_make_session(name="one")])
+    first.pagination = MagicMock(total_pages=2)
+    second = MagicMock(data=[_make_session(name="two")])
+    second.pagination = MagicMock(total_pages=2)
+    ctrl.entities.list = AsyncMock(side_effect=[first, second])
+
+    sessions = await ctrl._list_active_sessions()
+
+    assert [session.name for session in sessions] == ["one", "two"]
+    assert ctrl.entities.list.await_args_list == [
+        call(
+            AgentSession,
+            workspace="-",
+            filter_obj={"status": SessionStatus.ACTIVE.value},
+            page=1,
+            page_size=100,
+        ),
+        call(
+            AgentSession,
+            workspace="-",
+            filter_obj={"status": SessionStatus.ACTIVE.value},
+            page=2,
+            page_size=100,
+        ),
+    ]

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -23,7 +23,12 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from nemo_agents_plugin.config import AgentsConfig, ControllerConfig
-from nemo_agents_plugin.entities import AgentDeployment, AgentSession, SessionStatus
+from nemo_agents_plugin.entities import (
+    NEMO_AGENTS_SPEC_CONFIG_FORMAT,
+    AgentDeployment,
+    AgentSession,
+    SessionStatus,
+)
 from nemo_agents_plugin.runner import controller as controller_module
 from nemo_agents_plugin.runner.backend import DeploymentInfo
 from nemo_agents_plugin.runner.controller import AgentDeploymentController
@@ -42,6 +47,8 @@ async def test_controller_startup_adapts_sdk_to_typed_entities_client() -> None:
     sdk = MagicMock()
     typed_client = MagicMock()
     entity_client = MagicMock()
+    empty_page = MagicMock(data=[], pagination=None)
+    entity_client.list = AsyncMock(return_value=empty_page)
 
     with (
         patch("nemo_agents_plugin.config.AgentsConfig.get", return_value=AgentsConfig()),
@@ -58,6 +65,21 @@ async def test_controller_startup_adapts_sdk_to_typed_entities_client() -> None:
     mock_adapter.assert_called_once_with(sdk, AsyncEntitiesClient)
     mock_entity_client.assert_called_once_with(typed_client)
     assert controller._entities is entity_client
+    assert controller._startup_sessions_reconciled is True
+
+
+@pytest.mark.asyncio
+async def test_startup_session_reconciliation_retries_after_entity_list_failure() -> None:
+    ctrl, _ = _make_controller()
+    empty_page = MagicMock(data=[], pagination=None)
+    ctrl.entities.list = AsyncMock(side_effect=[RuntimeError("unavailable"), empty_page])
+    ctrl._startup_sessions_reconciled = False
+
+    await ctrl._reconcile_sessions_after_controller_start()
+    assert ctrl._startup_sessions_reconciled is False
+
+    await ctrl._reconcile_sessions_after_controller_start()
+    assert ctrl._startup_sessions_reconciled is True
 
 
 def _make_controller() -> tuple[AgentDeploymentController, Any]:
@@ -77,6 +99,7 @@ def _make_controller() -> tuple[AgentDeploymentController, Any]:
     ctrl._registry = registry
     ctrl._entities = MagicMock()
     ctrl._controller_config = ControllerConfig(health_check_timeout_seconds=120)
+    ctrl._startup_sessions_reconciled = True
     ctrl._save = AsyncMock()  # type: ignore[method-assign]
     return ctrl, cast(Any, backend)
 
@@ -84,18 +107,39 @@ def _make_controller() -> tuple[AgentDeploymentController, Any]:
 def _make_session(
     *,
     name: str = "session-one",
+    deployment_id: str = "deployment-id",
+    last_active_at: datetime | None = None,
     expires_at: datetime | None = None,
     status: SessionStatus = SessionStatus.ACTIVE,
 ) -> AgentSession:
     session = AgentSession(
         name=name,
         workspace="default",
-        deployment_id="deployment-id",
+        deployment_id=deployment_id,
         status=status,
+        last_active_at=last_active_at,
         expires_at=expires_at,
     )
     session._id = f"{name}-id"
     return session
+
+
+def _make_fabric_deployment(
+    *,
+    name: str = "fabric-deployment",
+    status: str = "running",
+    deployment_id: str = "deployment-id",
+) -> AgentDeployment:
+    deployment = AgentDeployment(
+        name=name,
+        workspace="default",
+        agent="calc",
+        status=cast(Any, status),
+        endpoint="http://localhost:9001",
+        config={"config_format": NEMO_AGENTS_SPEC_CONFIG_FORMAT},
+    )
+    deployment._id = deployment_id
+    return deployment
 
 
 @pytest.mark.asyncio
@@ -111,6 +155,180 @@ async def test_reconcile_runs_expiration_after_isolated_deployment_failures() ->
 
     assert ctrl.reconcile_one.await_args_list == [call(first), call(second)]
     ctrl._reconcile_expired_sessions.assert_awaited_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Runtime restart reconciliation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_restart_reconciliation_expires_loses_and_preserves_never_invoked_sessions() -> None:
+    ctrl, _ = _make_controller()
+    lost = _make_session(
+        name="lost",
+        last_active_at=EXPIRATION_NOW - timedelta(minutes=5),
+        expires_at=EXPIRATION_NOW + timedelta(minutes=25),
+    )
+    expired = _make_session(
+        name="expired",
+        last_active_at=EXPIRATION_NOW - timedelta(minutes=31),
+        expires_at=EXPIRATION_NOW - timedelta(minutes=1),
+    )
+    never_invoked = _make_session(name="never-invoked")
+    ctrl._list_active_sessions = AsyncMock(  # type: ignore[method-assign]
+        return_value=[lost, expired, never_invoked]
+    )
+    ctrl.entities.update = AsyncMock(side_effect=lambda entity: entity)
+
+    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+        reconciled = await ctrl._reconcile_sessions_after_restart(at=EXPIRATION_NOW)
+
+    assert reconciled is True
+    assert lost.status is SessionStatus.LOST
+    assert expired.status is SessionStatus.EXPIRED
+    assert never_invoked.status is SessionStatus.ACTIVE
+    assert ctrl.entities.update.await_args_list == [call(lost), call(expired)]
+    assert cleanup.await_args_list == [call(ctrl.entities, lost), call(ctrl.entities, expired)]
+
+
+@pytest.mark.asyncio
+async def test_restart_wins_activity_conflict_for_refetched_invoked_session() -> None:
+    ctrl, _ = _make_controller()
+    stale = _make_session(
+        last_active_at=EXPIRATION_NOW - timedelta(minutes=2),
+        expires_at=EXPIRATION_NOW + timedelta(minutes=28),
+    )
+    refreshed = _make_session(
+        last_active_at=EXPIRATION_NOW,
+        expires_at=EXPIRATION_NOW + timedelta(minutes=30),
+    )
+    ctrl.entities.update = AsyncMock(side_effect=[NemoEntityConflictError("conflict"), refreshed])
+    ctrl.entities.get_by_id = AsyncMock(return_value=refreshed)
+
+    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+        result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
+
+    assert result is refreshed
+    assert refreshed.status is SessionStatus.LOST
+    assert ctrl.entities.update.await_count == 2
+    cleanup.assert_awaited_once_with(ctrl.entities, refreshed)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", [SessionStatus.EXPIRED, SessionStatus.LOST, SessionStatus.CLOSED])
+async def test_terminal_state_wins_restart_conflict(terminal_status: SessionStatus) -> None:
+    ctrl, _ = _make_controller()
+    stale = _make_session(
+        last_active_at=EXPIRATION_NOW - timedelta(minutes=2),
+        expires_at=EXPIRATION_NOW + timedelta(minutes=28),
+    )
+    terminal = _make_session(status=terminal_status)
+    ctrl.entities.update = AsyncMock(side_effect=NemoEntityConflictError("conflict"))
+    ctrl.entities.get_by_id = AsyncMock(return_value=terminal)
+
+    with patch.object(controller_module, "cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+        result = await ctrl._transition_session_after_restart(stale, at=EXPIRATION_NOW)
+
+    assert result is terminal
+    assert terminal.status is terminal_status
+    ctrl.entities.update.assert_awaited_once_with(stale)
+    cleanup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_runtime_instance_change_reconciles_bound_sessions() -> None:
+    ctrl, _ = _make_controller()
+    deployment = _make_fabric_deployment()
+    ctrl._read_runtime_instance_id = AsyncMock(  # type: ignore[method-assign]
+        side_effect=["runtime-1", "runtime-1", "runtime-2"]
+    )
+    ctrl._reconcile_deployment_sessions_after_restart = AsyncMock(  # type: ignore[method-assign]
+        return_value=True
+    )
+
+    await ctrl._observe_runtime_instance(deployment)
+    await ctrl._observe_runtime_instance(deployment)
+    await ctrl._observe_runtime_instance(deployment)
+
+    assert ctrl._runtime_instance_ids[(deployment.workspace, deployment.name)] == "runtime-2"
+    ctrl._reconcile_deployment_sessions_after_restart.assert_awaited_once_with(deployment)
+
+
+@pytest.mark.asyncio
+async def test_runtime_instance_change_is_retained_until_reconciliation_succeeds() -> None:
+    ctrl, _ = _make_controller()
+    deployment = _make_fabric_deployment()
+    key = (deployment.workspace, deployment.name)
+    ctrl._runtime_instance_ids[key] = "runtime-1"
+    ctrl._read_runtime_instance_id = AsyncMock(return_value="runtime-2")  # type: ignore[method-assign]
+    ctrl._reconcile_deployment_sessions_after_restart = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[False, True]
+    )
+
+    await ctrl._observe_runtime_instance(deployment)
+    assert ctrl._runtime_instance_ids[key] == "runtime-1"
+
+    await ctrl._observe_runtime_instance(deployment)
+    assert ctrl._runtime_instance_ids[key] == "runtime-2"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"runtime_instance_id": "runtime-1"}, "runtime-1"),
+        ({"runtime_instance_id": ""}, None),
+        ({"runtime_instance_id": 1}, None),
+        ({}, None),
+    ],
+)
+async def test_read_runtime_instance_id_validates_health_response(
+    payload: dict[str, object],
+    expected: str | None,
+) -> None:
+    ctrl, _ = _make_controller()
+    deployment = _make_fabric_deployment()
+    response = MagicMock()
+    response.json.return_value = payload
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    ctrl._runtime_health_client = client
+
+    assert await ctrl._read_runtime_instance_id(deployment) == expected
+    client.get.assert_awaited_once_with("http://localhost:9001/health")
+    response.raise_for_status.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_failed_restart_reconciliation_is_queued_and_retried() -> None:
+    ctrl, _ = _make_controller()
+    deployment = _make_fabric_deployment()
+    ctrl._reconcile_sessions_after_restart = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[False, True]
+    )
+
+    reconciled = await ctrl._reconcile_deployment_sessions_after_restart(deployment)
+    assert reconciled is False
+    assert deployment.id in ctrl._pending_restart_deployment_ids
+
+    await ctrl._retry_pending_restart_reconciliations()
+    assert deployment.id not in ctrl._pending_restart_deployment_ids
+
+
+@pytest.mark.asyncio
+async def test_backend_runtime_disappearance_reconciles_sessions_before_restart() -> None:
+    ctrl, backend = _make_controller()
+    deployment = _make_fabric_deployment()
+    backend.get_deployment_status = AsyncMock(return_value=None)
+    ctrl._reconcile_deployment_sessions_after_restart = AsyncMock(  # type: ignore[method-assign]
+        return_value=True
+    )
+
+    await ctrl._verify_running(deployment)
+
+    ctrl._reconcile_deployment_sessions_after_restart.assert_awaited_once_with(deployment)
+    assert deployment.status == "pending"
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-agents/tests/unit/test_session_lifecycle.py
+++ b/plugins/nemo-agents/tests/unit/test_session_lifecycle.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for persisted agent-session lifecycle helpers."""
+
+from datetime import UTC, datetime, timedelta, timezone
+
+import pytest
+from nemo_agents_plugin.entities import AgentSession
+from nemo_agents_plugin.session_lifecycle import session_expiration_is_due
+
+
+@pytest.mark.parametrize(
+    ("at", "expected"),
+    [
+        (datetime(2026, 8, 31, 16, 59, tzinfo=UTC), False),
+        (datetime(2026, 8, 31, 17, 0, tzinfo=UTC), True),
+    ],
+)
+def test_session_expiration_normalizes_non_utc_deadline(at: datetime, expected: bool) -> None:
+    session = AgentSession(
+        name="session-one",
+        workspace="default",
+        deployment_id="deployment-id",
+        expires_at=datetime(2026, 8, 31, 12, 0, tzinfo=timezone(-timedelta(hours=5))),
+    )
+
+    assert session_expiration_is_due(session, at=at) is expected

--- a/plugins/nemo-agents/tests/unit/test_sessions_api.py
+++ b/plugins/nemo-agents/tests/unit/test_sessions_api.py
@@ -231,8 +231,17 @@ class TestGetSession:
 
 
 class TestCloseSession:
-    def test_close_active_session(self, client: TestClient, mock_entity_client: AsyncMock) -> None:
-        mock_entity_client.get.return_value = _make_session()
+    @pytest.mark.parametrize(
+        "status",
+        [SessionStatus.ACTIVE, SessionStatus.EXPIRED, SessionStatus.LOST],
+    )
+    def test_close_session(
+        self,
+        status: SessionStatus,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        mock_entity_client.get.return_value = _make_session(status=status)
         mock_entity_client.update.side_effect = lambda session: session
 
         with patch.object(sessions_router_module, "_cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:

--- a/plugins/nemo-agents/tests/unit/test_sessions_api.py
+++ b/plugins/nemo-agents/tests/unit/test_sessions_api.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from nemo_agents_plugin import session_lifecycle as session_lifecycle_module
 from nemo_agents_plugin.api.v2 import sessions as sessions_router_module
 from nemo_agents_plugin.api.v2.dependencies import get_entity_client
 from nemo_agents_plugin.entities import AgentDeployment, AgentSession, SessionStatus
@@ -370,7 +371,7 @@ class TestFabricRuntimeCleanup:
             return httpx.Response(204)
 
         cleanup_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
-        with patch.object(sessions_router_module.httpx, "AsyncClient", return_value=cleanup_client):
+        with patch.object(session_lifecycle_module.httpx, "AsyncClient", return_value=cleanup_client):
             await sessions_router_module._cleanup_fabric_runtime(mock_entity_client, session)
 
         assert len(requests) == 1
@@ -387,7 +388,7 @@ class TestFabricRuntimeCleanup:
             return httpx.Response(404)
 
         cleanup_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
-        with patch.object(sessions_router_module.httpx, "AsyncClient", return_value=cleanup_client):
+        with patch.object(session_lifecycle_module.httpx, "AsyncClient", return_value=cleanup_client):
             await sessions_router_module._cleanup_fabric_runtime(mock_entity_client, session)
 
     async def test_cleanup_ignores_connection_failure(self, mock_entity_client: AsyncMock) -> None:
@@ -400,5 +401,5 @@ class TestFabricRuntimeCleanup:
             raise httpx.ConnectError("refused", request=request)
 
         cleanup_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
-        with patch.object(sessions_router_module.httpx, "AsyncClient", return_value=cleanup_client):
+        with patch.object(session_lifecycle_module.httpx, "AsyncClient", return_value=cleanup_client):
             await sessions_router_module._cleanup_fabric_runtime(mock_entity_client, session)

--- a/plugins/nemo-agents/tests/unit/test_sessions_api.py
+++ b/plugins/nemo-agents/tests/unit/test_sessions_api.py
@@ -299,6 +299,35 @@ class TestCloseSession:
         assert mock_entity_client.get.await_count == 2
         cleanup.assert_awaited_once_with(mock_entity_client, closed_session)
 
+    @pytest.mark.parametrize("concurrent_status", [SessionStatus.EXPIRED, SessionStatus.LOST])
+    def test_close_retries_after_concurrent_terminal_transition(
+        self,
+        concurrent_status: SessionStatus,
+        client: TestClient,
+        mock_entity_client: AsyncMock,
+    ) -> None:
+        active_session = _make_session()
+        concurrently_updated_session = _make_session(status=concurrent_status)
+        mock_entity_client.get.side_effect = [active_session, concurrently_updated_session]
+        update_count = 0
+
+        async def update(session: AgentSession) -> AgentSession:
+            nonlocal update_count
+            update_count += 1
+            if update_count == 1:
+                raise NemoEntityConflictError("conflict")
+            return session
+
+        mock_entity_client.update.side_effect = update
+
+        with patch.object(sessions_router_module, "_cleanup_fabric_runtime", new_callable=AsyncMock) as cleanup:
+            response = client.post(f"{BASE}/session-one/close")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "closed"
+        assert mock_entity_client.update.await_count == 2
+        cleanup.assert_awaited_once_with(mock_entity_client, concurrently_updated_session)
+
     def test_close_returns_409_for_other_concurrent_update(
         self, client: TestClient, mock_entity_client: AsyncMock
     ) -> None:
@@ -311,6 +340,7 @@ class TestCloseSession:
 
         assert response.status_code == 409
         assert mock_entity_client.get.await_count == 2
+        assert mock_entity_client.update.await_count == 2
 
 
 class TestDeleteSession:

--- a/plugins/nemo-agents/tests/unit/test_sessions_api.py
+++ b/plugins/nemo-agents/tests/unit/test_sessions_api.py
@@ -378,7 +378,11 @@ class TestFabricRuntimeCleanup:
         assert requests[0].method == "DELETE"
         assert str(requests[0].url) == "http://localhost:9001/v1/sessions/session-session%2Fone-id"
 
-    async def test_cleanup_ignores_missing_runtime(self, mock_entity_client: AsyncMock) -> None:
+    async def test_cleanup_ignores_missing_runtime(
+        self,
+        mock_entity_client: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         deployment = _make_deployment()
         deployment.endpoint = "http://localhost:9001"
         mock_entity_client.find_one.return_value = deployment
@@ -391,15 +395,67 @@ class TestFabricRuntimeCleanup:
         with patch.object(session_lifecycle_module.httpx, "AsyncClient", return_value=cleanup_client):
             await sessions_router_module._cleanup_fabric_runtime(mock_entity_client, session)
 
-    async def test_cleanup_ignores_connection_failure(self, mock_entity_client: AsyncMock) -> None:
+        assert "Fabric runtime cleanup failed" not in caplog.text
+
+    async def test_cleanup_connection_failure_is_observable_and_not_retried(
+        self,
+        mock_entity_client: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
         deployment = _make_deployment()
         deployment.endpoint = "http://localhost:9001"
         mock_entity_client.find_one.return_value = deployment
         session = _make_session()
+        attempts = 0
 
         async def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal attempts
+            attempts += 1
             raise httpx.ConnectError("refused", request=request)
 
         cleanup_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
         with patch.object(session_lifecycle_module.httpx, "AsyncClient", return_value=cleanup_client):
             await sessions_router_module._cleanup_fabric_runtime(mock_entity_client, session)
+
+        assert attempts == 1
+        assert (
+            "Fabric runtime cleanup failed for session ID 'session-session-one-id' in workspace 'default' "
+            "(deployment ID 'deployment-id'): request failed: refused."
+        ) in caplog.text
+
+    async def test_cleanup_http_failure_is_observable(
+        self,
+        mock_entity_client: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        deployment = _make_deployment()
+        deployment.endpoint = "http://localhost:9001"
+        mock_entity_client.find_one.return_value = deployment
+        session = _make_session()
+
+        async def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503)
+
+        cleanup_client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        with patch.object(session_lifecycle_module.httpx, "AsyncClient", return_value=cleanup_client):
+            await sessions_router_module._cleanup_fabric_runtime(mock_entity_client, session)
+
+        assert (
+            "Fabric runtime cleanup failed for session ID 'session-session-one-id' in workspace 'default' "
+            "(deployment ID 'deployment-id'): request returned HTTP 503."
+        ) in caplog.text
+
+    async def test_cleanup_entity_lookup_failure_is_observable(
+        self,
+        mock_entity_client: AsyncMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        mock_entity_client.find_one.side_effect = RuntimeError("entity store unavailable")
+        session = _make_session()
+
+        await sessions_router_module._cleanup_fabric_runtime(mock_entity_client, session)
+
+        assert (
+            "Fabric runtime cleanup failed for session ID 'session-session-one-id' in workspace 'default' "
+            "(deployment ID 'deployment-id'): could not resolve deployment: entity store unavailable."
+        ) in caplog.text


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Defines and enforces the persisted lifecycle for deployment-backed Fabric agent sessions. Sessions now record activity and expiration deadlines, become `EXPIRED` after idle timeout, and become `LOST` when their process-local Fabric runtime is lost after a deployment-server restart.

## Related Issue

[AIRCORE-949: Define persisted Fabric RuntimeSession status and recovery model](https://linear.app/nvidia/issue/AIRCORE-949/define-persisted-fabric-runtimesession-status-and-recovery-model)

## Changes

- Add persisted `ACTIVE`, `EXPIRED`, `LOST`, and `CLOSED` session states with explicit allowed transitions.
- Persist immutable `first_active_at`, rolling `last_active_at`, and `expires_at` when mutating session invocations run, without per-token entity updates or activity refreshes from read-only health requests.
- Reject terminal or deadline-expired sessions before proxying an invocation and recheck the deadline immediately before activity persistence, including after an optimistic-conflict reload.
- Reconcile idle expiration across workspaces and best-effort remove the associated process-local Fabric runtime.
- Expose a stable process-local runtime UUID and start timestamp from Fabric health and use them to detect deployment-server replacement and identify its activity generation.
- Reconcile previously invoked sessions after runtime or controller restart: due sessions become `EXPIRED`, other invoked sessions become `LOST`, and never-invoked sessions remain `ACTIVE`.
- Anchor replacement reconciliation to the new Fabric runtime's start time and keep that cutoff across failed passes, avoiding false loss for sessions first invoked before the controller observes the replacement.
- Handle activity, expiration, restart, close, and terminal-state races with optimistic retries and terminal-state precedence.
- Run best-effort runtime cleanup outside API-response and controller-reconciliation critical paths, logging failures with workspace, session, deployment, and failure context.

## Design Decisions

- **Reuse the deployment controller for session reconciliation.** Fabric sessions are backed by runtimes inside a deployment, so expiration and loss are coupled to deployment health and restart detection. The existing controller already owns the periodic loop, service-principal entity access, and deployment backend state. Adding explicit deployment, restart-retry, and session-expiration phases there keeps ordering visible and avoids a second controller competing over the same lifecycle.
- **Keep activity persistence in the authenticated gateway.** The gateway already resolves session ownership and can make the required invocation-start update before proxying. Only mutating proxy requests count as invocation activity. Completion and failure updates remain best-effort so persistence errors cannot replace an upstream response.
- **Do not add another runtime binding or deployment field.** `deployment_id` remains the persisted relationship. The immutable `first_active_at` identifies the runtime generation in which a session was first invoked, while `last_active_at` and `expires_at` retain rolling activity and expiration semantics. Fabric exposes process-local boot identity and time through health, while the controller tracks observations in memory. Consequently, controller startup still conservatively invalidates previously invoked sessions even if a container survived unchanged.
- **Make terminal state authoritative.** `EXPIRED` and `LOST` cannot return to `ACTIVE`; continuation requires a new session. Optimistic conflict handling reloads current state so concurrent terminal transitions win, permitted `EXPIRED`/`LOST` to `CLOSED` transitions can still complete, and delayed activity cannot move timestamps backward.
- **Do not rebind old sessions through new activity.** A replacement runtime means a new logical session is required for conversations that were already invoked. Reconciliation compares immutable `first_active_at` with the replacement runtime's `runtime_started_at`: sessions first invoked on the new runtime stay `ACTIVE`, while sessions first invoked on the replaced runtime become `LOST` even if they were invoked again before the controller observed the replacement. Never-invoked sessions remain `ACTIVE`.
- **Keep restart retries generation-aware without persisting runtime IDs.** Deployment-restart reconciliation retains the Fabric-provided `runtime_started_at` cutoff across retries. A later replacement supersedes an older pending cutoff. This covers the interval between runtime startup and controller observation without allowing mutable activity to rebind an old session.
- **Keep runtime cleanup best-effort.** Session state is persisted before cleanup. API routes use response background tasks, while the deployment controller tracks cleanup tasks for shutdown. Cleanup failures do not block close, deletion, expiration, or loss and are not retried indefinitely without durable cleanup state; Fabric idle eviction or runtime restart provides eventual cleanup.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] Branch-scoped pre-commit and pre-push hooks pass
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Final entity, gateway, Fabric server, session API, lifecycle, and controller regression suite — 262 passed.
- `.venv/bin/pytest plugins/nemo-agents/tests/unit -q` — 1,404 passed; one unrelated execute-job environment-serialization assertion failed.
- Focused Ruff linting, formatting, and `ty` type checking passed.
- The checked-in Agents OpenAPI schema includes `first_active_at`; the repository-wide generator timed out after rewriting unrelated plugin specs, so those unrelated rewrites were discarded.
- `git diff --check` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added `expired` and `lost` session statuses.
  - Session activity now refreshes rolling expiration deadlines during write operations.
  - Added automatic detection and reconciliation of expired sessions and runtime restarts.
  - Health checks now include runtime identity and startup timestamp.

- **Bug Fixes**
  - Improved handling of inactive, expired, and terminal sessions.
  - Session closure validates lifecycle transitions and handles concurrent updates safely.
  - Runtime cleanup runs asynchronously and handles missing resources and service failures more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
