### PR TITLE
chore(guardrails): fix typo in test comment

### DIFF
--- a/services/guardrails/tests/services/configs/test_multi_namespace_config.py
+++ b/services/guardrails/tests/services/configs/test_multi_namespace_config.py
@@ -33,7 +33,7 @@ def rails_service(config_registry, rails_registry):
 @pytest.fixture
 def mock_db():
     """Create a mock database with methods for testing."""
-    # TODO: check wether nmp_persistence has such fixture
+    # TODO: check whether nmp_persistence has such fixture
 
     db = MagicMock()
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Fix a spelling error in a Guardrails test comment. This is a comment-only change with no runtime behavior impact.

## Changes
<!-- List the concrete changes included in this pull request. -->

- Correct `wether` to `whether` in `test_multi_namespace_config.py`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: Comment-only spelling correction with no executable behavior change.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: No user-visible behavior or product documentation changed.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `git diff --check` — passed.
- `uv run ruff check services/guardrails/tests/services/configs/test_multi_namespace_config.py` — passed.
- `uv run ruff format --check services/guardrails/tests/services/configs/test_multi_namespace_config.py` — passed.
- `uv run pre-commit run -a` — Ruff, Ruff format, ty, config-reference, lock-drift, version consistency, copyright, import-boundary, merge-conflict, and Flox-lock checks passed. The full gate did not complete successfully because this host lacks `helm-docs`, uses uv 0.11.26 instead of the repository-pinned 0.9.14, and lacks the pinned Node/pnpm environment needed for `studio-lint-staged`.

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->
