### PR TITLE
feat(studio): add duration column to completed evaluations table (ASTD-479)

### DIFF
--- a/web/packages/common/src/utils/date.test.ts
+++ b/web/packages/common/src/utils/date.test.ts
@@ -69,6 +69,19 @@ describe('formatDurationMs', () => {
     expect(formatDurationMs(0)).toBe('0ms');
     expect(formatDurationMs(-5)).toBe('0ms');
   });
+
+  describe('hideMsAboveMinute', () => {
+    it('drops the ms component once the total reaches a minute', () => {
+      expect(formatDurationMs(612_013, { hideMsAboveMinute: true })).toBe('10m 12s');
+      expect(formatDurationMs(3_661_013, { hideMsAboveMinute: true })).toBe('1h 1m 1s');
+      expect(formatDurationMs(60_034, { hideMsAboveMinute: true })).toBe('1m');
+    });
+
+    it('keeps ms for sub-minute durations', () => {
+      expect(formatDurationMs(12_034, { hideMsAboveMinute: true })).toBe('12s 34ms');
+      expect(formatDurationMs(999, { hideMsAboveMinute: true })).toBe('999ms');
+    });
+  });
 });
 
 describe('utcToLocalDate', () => {

--- a/web/packages/common/src/utils/date.ts
+++ b/web/packages/common/src/utils/date.ts
@@ -51,13 +51,21 @@ const EMPTY_DURATION = '—';
  * `1h 0m 5s` renders as `1h 5s`), matching {@link formatTimeInSeconds}. Values
  * under one millisecond keep two decimals (`0.34ms`) so span timings are not
  * rounded to zero. Returns an em dash for null/undefined.
+ *
+ * With `hideMsAboveMinute`, the millisecond component is dropped once the total
+ * reaches a minute (`10m 12s`, not `10m 12s 13ms`); sub-minute durations still
+ * show ms. Use it where sub-second precision is noise past a minute.
  */
-export const formatDurationMs = (ms?: number | null): string => {
+export const formatDurationMs = (
+  ms?: number | null,
+  { hideMsAboveMinute = false }: { hideMsAboveMinute?: boolean } = {}
+): string => {
   if (ms == null) return EMPTY_DURATION;
   if (ms <= 0) return '0ms';
   if (ms < 1) return `${Number(ms.toFixed(2))}ms`;
 
   const total = Math.round(ms);
+  const dropMs = hideMsAboveMinute && total >= 60_000;
   const units: [number, string][] = [
     [Math.floor(total / 3_600_000), 'h'],
     [Math.floor((total % 3_600_000) / 60_000), 'm'],
@@ -65,7 +73,7 @@ export const formatDurationMs = (ms?: number | null): string => {
     [total % 1_000, 'ms'],
   ];
   return units
-    .filter(([value]) => value > 0)
+    .filter(([value, unit]) => value > 0 && !(dropMs && unit === 'ms'))
     .map(([value, unit]) => `${value}${unit}`)
     .join(' ');
 };

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.test.tsx
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { EvaluationsTable } from '@studio/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable';
+import type { AgentEvaluationRow } from '@studio/routes/agents/AgentDetailRoute/useAgentDetails';
+import { LG_SELECTOR_TIMEOUT } from '@studio/tests/util/constants';
+import { TestProviders } from '@studio/tests/util/TestProviders';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+const makeEval = (overrides: Partial<AgentEvaluationRow> & { name: string }): AgentEvaluationRow =>
+  ({
+    experimentName: null,
+    created_at: '2024-12-17T16:08:56.880768',
+    metadata: {},
+    ...overrides,
+  }) as AgentEvaluationRow;
+
+const renderTable = (evaluations: AgentEvaluationRow[]) =>
+  render(
+    <TestProviders>
+      <MemoryRouter>
+        <EvaluationsTable workspace="default" evaluations={evaluations} jobs={[]} />
+      </MemoryRouter>
+    </TestProviders>
+  );
+
+describe('EvaluationsTable Duration column', () => {
+  it('formats the recorded run duration from eval_duration_sec metadata', async () => {
+    renderTable([makeEval({ name: 'eval-with-duration', metadata: { eval_duration_sec: '12' } })]);
+
+    expect(
+      await screen.findByText('Duration', undefined, { timeout: LG_SELECTOR_TIMEOUT })
+    ).toBeInTheDocument();
+    // 12s only comes from eval_duration_sec=12 -> 12000ms -> formatDurationMs -> "12s".
+    expect(
+      await screen.findByText('12s', undefined, { timeout: LG_SELECTOR_TIMEOUT })
+    ).toBeInTheDocument();
+  });
+});

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.test.tsx
@@ -29,22 +29,24 @@ describe('EvaluationsTable Duration column', () => {
   it('formats the recorded run duration from eval_duration_sec metadata', async () => {
     renderTable([makeEval({ name: 'eval-with-duration', metadata: { eval_duration_sec: '12' } })]);
 
+    // StudioDataView renders the header label (column/filter menu) and each cell in more than one
+    // place (a responsive duplicate view), so neither text is unique — assert presence, not count.
     expect(
-      await screen.findByText('Duration', undefined, { timeout: LG_SELECTOR_TIMEOUT })
-    ).toBeInTheDocument();
+      (await screen.findAllByText('Duration', undefined, { timeout: LG_SELECTOR_TIMEOUT })).length
+    ).toBeGreaterThan(0);
     // 12s only comes from eval_duration_sec=12 -> 12000ms -> formatDurationMs -> "12s".
     expect(
-      await screen.findByText('12s', undefined, { timeout: LG_SELECTOR_TIMEOUT })
-    ).toBeInTheDocument();
+      (await screen.findAllByText('12s', undefined, { timeout: LG_SELECTOR_TIMEOUT })).length
+    ).toBeGreaterThan(0);
   });
 
   it('drops sub-second precision once the run reaches a minute', async () => {
     // 612.013s -> 612013ms -> "10m 12s" (the 13ms is dropped past a minute).
     renderTable([makeEval({ name: 'long-eval', metadata: { eval_duration_sec: '612.013' } })]);
 
-    // Exact-match: if the 13ms were not dropped this would render "10m 12s 13ms" and miss.
+    // Exact-match: if the 13ms were not dropped every cell would read "10m 12s 13ms" and match zero.
     expect(
-      await screen.findByText('10m 12s', undefined, { timeout: LG_SELECTOR_TIMEOUT })
-    ).toBeInTheDocument();
+      (await screen.findAllByText('10m 12s', undefined, { timeout: LG_SELECTOR_TIMEOUT })).length
+    ).toBeGreaterThan(0);
   });
 });

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.test.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.test.tsx
@@ -37,4 +37,14 @@ describe('EvaluationsTable Duration column', () => {
       await screen.findByText('12s', undefined, { timeout: LG_SELECTOR_TIMEOUT })
     ).toBeInTheDocument();
   });
+
+  it('drops sub-second precision once the run reaches a minute', async () => {
+    // 612.013s -> 612013ms -> "10m 12s" (the 13ms is dropped past a minute).
+    renderTable([makeEval({ name: 'long-eval', metadata: { eval_duration_sec: '612.013' } })]);
+
+    // Exact-match: if the 13ms were not dropped this would render "10m 12s 13ms" and miss.
+    expect(
+      await screen.findByText('10m 12s', undefined, { timeout: LG_SELECTOR_TIMEOUT })
+    ).toBeInTheDocument();
+  });
 });

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
@@ -129,7 +129,11 @@ export const EvaluationsTable: FC<EvaluationsTableProps> = ({ workspace, evaluat
           id: 'duration',
           header: 'Duration',
           enableSorting: false,
-          cell: ({ getValue }) => <Text>{formatDurationMs(getValue<number | undefined>())}</Text>,
+          cell: ({ getValue }) => (
+            <Text>
+              {formatDurationMs(getValue<number | undefined>(), { hideMsAboveMinute: true })}
+            </Text>
+          ),
         }),
         accessor('created_at', {
           header: 'Created',

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
@@ -125,6 +125,12 @@ export const EvaluationsTable: FC<EvaluationsTableProps> = ({ workspace, evaluat
           enableSorting: false,
           cell: ({ getValue }) => <Text>{formatDurationMs(getValue<number | undefined>())}</Text>,
         }),
+        accessor((row) => evalDurationMs(row.metadata), {
+          id: 'duration',
+          header: 'Duration',
+          enableSorting: false,
+          cell: ({ getValue }) => <Text>{formatDurationMs(getValue<number | undefined>())}</Text>,
+        }),
         accessor('created_at', {
           header: 'Created',
           cell: ({ row }) =>

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/JobsTable.tsx
@@ -40,7 +40,7 @@ const DurationCell: FC<{ row: EvalJobRow; durationMs?: number }> = ({ row, durat
     enabled: !isTerminal,
   });
   if (!isTerminal) return <Text>{formatTimeInSeconds(liveSeconds)}</Text>;
-  return <Text>{formatDurationMs(durationMs)}</Text>;
+  return <Text>{formatDurationMs(durationMs, { hideMsAboveMinute: true })}</Text>;
 };
 
 interface JobsTableProps {


### PR DESCRIPTION
## Summary

The Completed Evaluations table on the agent entity page's Evaluations tab did not show how long each run took, while the Active jobs table above it already surfaces a Duration column. This adds a Duration column to the completed table so a published evaluation's run duration (finished − started) is visible at a glance, formatted consistently with the Active jobs table.

## Related Issue

Show evaluation run duration in the evaluations table (Linear ASTD-479).

## Changes

- Add a `Duration` column to `EvaluationsTable` (agent entity page → Evaluations tab → Completed Evaluations), placed after `Cost` and before `Created`.
- Reuse the existing, already-tested `evalDurationMs` (reads the `eval_duration_sec` metadata stamped at publish time) and `formatDurationMs` helpers — the same primitives the Active jobs table uses — so formatting stays consistent and an em dash renders when no duration was recorded.
- Add `EvaluationsTable.test.tsx` covering the new column's wiring (metadata → formatted duration).
- Add an opt-in `hideMsAboveMinute` flag to `formatDurationMs` and apply it to both the completed Duration column and the Active jobs terminal cell: a run of `10m 12s` renders as `10m 12s`, not `10m 12s 13ms`. Millisecond precision still shows for sub-minute runs. Default behavior is unchanged for all other callers (span/trace/latency).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs cover this table; the column mirrors the existing Active jobs Duration column.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation (from `web/`):

- `@nemo/common` + `nemo-studio-ui` `typecheck` (tsc --noEmit) — passed
- eslint (`--max-warnings 0`) + prettier on all touched files — passed
- `vitest --run src/utils/date.test.ts` (`@nemo/common`) — 23 tests passed (incl. new `hideMsAboveMinute` cases)
- `vitest --run .../evaluations/EvaluationsTable.test.tsx` (`nemo-studio-ui`) — 2 tests passed (formats duration; drops ms past a minute)
- `uv run pre-commit run -a` — all code hooks passed (ruff, ruff format, ty, config-reference, copyright headers, UI lint-staged, uv.lock drift, plugin-import, merge-conflicts). Four hooks are blocked locally by missing tooling only, unrelated to this web-only change: `helm-docs` and `yq` are not installed, and the local uv is 0.9.18 vs the pinned 0.9.14. No Helm, config, or dependency files are touched by this PR; CI runs these with the pinned toolchain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Improvements

- Evaluation durations now use recorded timing metadata.
- Durations under one minute retain millisecond precision.
- Durations of one minute or longer display without milliseconds for improved readability.
- Completed job durations now follow the same consistent formatting.
- The evaluations table includes a clearly labeled **Duration** column for easier review of run times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->