### PR TITLE
fix(jobs): preserve terminal task state during docker sync

### DIFF
--- a/services/core/jobs/src/nmp/core/jobs/app/dispatcher.py
+++ b/services/core/jobs/src/nmp/core/jobs/app/dispatcher.py
@@ -1210,7 +1210,24 @@ class JobDispatcher:
                 extra={"task": task.id, "job": job_name, "step": step.name, "workspace": step.workspace},
             )
         else:
-            task.status = task_update.status
+            current_status = PlatformJobStatus(task.status)
+            new_status = PlatformJobStatus(task_update.status)
+            if not current_status.can_transition_to(new_status):
+                logger.info(
+                    "Ignoring invalid job task status transition",
+                    extra={
+                        "task": task.id,
+                        "job": job_name,
+                        "step": step.name,
+                        "workspace": step.workspace,
+                        "current_status": current_status,
+                        "new_status": new_status,
+                    },
+                )
+                operations_counter.add(1, attributes={"operation": "create_or_update_task"})
+                return task
+
+            task.status = new_status
 
             if task_update.error_details:
                 task.error_details = task_update.error_details

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -1647,8 +1647,45 @@ chmod -R 777 {job_vol}/{storage_subpath}
         else:
             return self.create_step_update(step, container)
 
+    def _get_terminal_task_fallback_update(self, step: PlatformJobStepWithContext) -> JobUpdate | None:
+        try:
+            tasks = self._jobs.list_job_step_tasks(
+                name=step.name,
+                job=step.job,
+                workspace=step.workspace,
+            ).data()
+        except Exception:
+            logger.warning(
+                "Failed to fetch tasks for Docker missing-container fallback",
+                extra={"job": step.job, "step": step.name, "workspace": step.workspace},
+            )
+            return None
+
+        if not tasks.data:
+            return None
+
+        latest_task = max(
+            tasks.data,
+            key=lambda task: (
+                task.updated_at or task.created_at or datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
+            ),
+        )
+        status = PlatformJobStatus(latest_task.status)
+        if not status.is_terminal():
+            return None
+
+        return JobUpdate(
+            status=status,
+            status_details=latest_task.status_details,
+            error_details=latest_task.error_details or {},
+        )
+
     def sync_active(self, step: PlatformJobStepWithContext, container: Container | None) -> JobUpdate:
         if container is None:
+            task_fallback = self._get_terminal_task_fallback_update(step)
+            if task_fallback is not None:
+                return task_fallback
+
             container_name = self.name_for_step(step)
             logger.error("Container not found while syncing active step: %s", container_name)
             return JobUpdate(

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -1512,6 +1512,10 @@ chmod -R 777 {job_vol}/{storage_subpath}
     def _sync(self, step: PlatformJobStepWithContext) -> JobUpdate:
         container: Container | None = self.get_container(step)
         if step.status == PlatformJobStatus.ACTIVE:
+            if container is None:
+                task_fallback = self._get_terminal_task_fallback_update(step)
+                if task_fallback is not None:
+                    return task_fallback
             if result := self.enforce_sync_ttl(
                 step, self._execution_profile_config.ttl_seconds_active, container, before_active=False
             ):
@@ -1648,6 +1652,7 @@ chmod -R 777 {job_vol}/{storage_subpath}
             return self.create_step_update(step, container)
 
     def _get_terminal_task_fallback_update(self, step: PlatformJobStepWithContext) -> JobUpdate | None:
+        """Return the latest persisted terminal task status for a missing Docker container."""
         try:
             tasks = self._jobs.list_job_step_tasks(
                 name=step.name,

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -474,6 +474,37 @@ def test_docker_job_sync_active_missing_container_uses_terminal_task_fallback(
     mock_jobs_client.update_job_step_task.assert_not_called()
 
 
+def test_docker_job_sync_active_missing_container_prefers_terminal_task_over_ttl(
+    docker_job, docker_client_mock, mock_jobs_client, test_job_step
+):
+    """Terminal task state wins even when active-step TTL is exceeded."""
+    ttl_seconds = docker_job._execution_profile_config.ttl_seconds_active
+    old_timestamp = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=ttl_seconds + 60)
+    test_job_step.status = PlatformJobStatus.ACTIVE
+    test_job_step.created_at = old_timestamp
+    test_job_step.updated_at = old_timestamp
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(
+        SimpleNamespace(
+            data=[
+                SimpleNamespace(
+                    status=PlatformJobStatus.COMPLETED,
+                    status_details={"message": "Download complete"},
+                    error_details={},
+                    created_at=old_timestamp,
+                    updated_at=old_timestamp,
+                )
+            ]
+        )
+    )
+    docker_client_mock.containers.get.side_effect = NotFound("Container not found")
+
+    update = docker_job.sync(test_job_step)
+
+    assert update.status == PlatformJobStatus.COMPLETED
+    assert update.error_details == {}
+    mock_jobs_client.update_job_step_task.assert_not_called()
+
+
 def test_docker_job_sync_pausing_sigterm(docker_job, docker_client_mock, test_job_step):
     """Test that the cancel method stops the container."""
 

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -375,7 +375,7 @@ def test_docker_job_with_persistence_schedule(docker_job, docker_client_mock, te
     created_containers[1].start.assert_called_once()  # job container
 
 
-def test_docker_job_sync(docker_job, docker_client_mock, test_job_step):
+def test_docker_job_sync(docker_job, docker_client_mock, mock_jobs_client, test_job_step):
     """Test that the sync method correctly interprets container status."""
     # Setup container mock with "running" status
     container_mock = MagicMock()
@@ -433,8 +433,45 @@ def test_docker_job_sync(docker_job, docker_client_mock, test_job_step):
 
     # Test sync with container not found and job not in pending state
     test_job_step.status = PlatformJobStatus.ACTIVE
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(SimpleNamespace(data=[]))
     update = docker_job.sync(test_job_step)
     assert update.status == "error"
+
+
+def test_docker_job_sync_active_missing_container_uses_terminal_task_fallback(
+    docker_job, docker_client_mock, mock_jobs_client, test_job_step
+):
+    """A removed Docker container should not fail a step whose task already finished."""
+    test_job_step.status = PlatformJobStatus.ACTIVE
+    now = datetime.datetime.now(datetime.timezone.utc)
+    mock_jobs_client.list_job_step_tasks.return_value = data_response(
+        SimpleNamespace(
+            data=[
+                SimpleNamespace(
+                    status=PlatformJobStatus.ACTIVE,
+                    status_details={"message": "Job is running"},
+                    error_details={},
+                    created_at=now - datetime.timedelta(seconds=2),
+                    updated_at=now - datetime.timedelta(seconds=2),
+                ),
+                SimpleNamespace(
+                    status=PlatformJobStatus.COMPLETED,
+                    status_details={"message": "Download complete"},
+                    error_details={},
+                    created_at=now,
+                    updated_at=now,
+                ),
+            ]
+        )
+    )
+    docker_client_mock.containers.get.side_effect = NotFound("Container not found")
+
+    update = docker_job.sync(test_job_step)
+
+    assert update.status == PlatformJobStatus.COMPLETED
+    assert update.status_details == {"message": "Download complete"}
+    assert update.error_details == {}
+    mock_jobs_client.update_job_step_task.assert_not_called()
 
 
 def test_docker_job_sync_pausing_sigterm(docker_job, docker_client_mock, test_job_step):

--- a/services/core/jobs/tests/test_dispatcher.py
+++ b/services/core/jobs/tests/test_dispatcher.py
@@ -24,6 +24,7 @@ from nmp.common.jobs.schemas import PlatformJobStatus
 from nmp.core.jobs.api.v2.jobs.schemas import (
     CreatePlatformJobRequest,
     PlatformJobResponse,
+    PlatformJobTaskUpdate,
 )
 from nmp.core.jobs.app.dispatcher import JobDispatcher
 from nmp.core.jobs.app.schemas import (
@@ -185,6 +186,35 @@ async def test_delete_job_nonexistent_job(mock_dispatcher: JobDispatcher):
     # This should return False when the job doesn't exist
     deleted = await mock_dispatcher.delete_job("nonexistent-job-id", DEFAULT_WORKSPACE)
     assert deleted is False
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_task_ignores_invalid_terminal_transition(
+    mock_dispatcher: JobDispatcher, mock_store: EntityClient
+):
+    """Terminal task states must not be overwritten by stale backend polls."""
+    _, job_name, _, step_id, task_id, _ = await create_test_job_data(mock_store, "terminal-task-job")
+    step = await mock_store.get_by_id(PlatformJobStep, step_id)
+    task = await mock_store.get_by_id(PlatformJobTask, task_id)
+
+    updated = await mock_dispatcher.create_or_update_task(
+        job_name,
+        task.name,
+        DEFAULT_WORKSPACE,
+        PlatformJobTaskUpdate(
+            status=PlatformJobStatus.ACTIVE,
+            status_details={"message": "Job is running"},
+        ),
+        step,
+    )
+
+    assert updated.id == task.id
+    assert updated.status == PlatformJobStatus.COMPLETED
+    assert updated.status_details == {}
+
+    stored_task = await mock_store.get_by_id(PlatformJobTask, task_id)
+    assert stored_task.status == PlatformJobStatus.COMPLETED
+    assert stored_task.status_details == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Preserve terminal job task states when Docker reconciliation races with task-completion updates. If an active Docker step no longer has a container, fall back to the latest persisted terminal task state before TTL handling instead of failing the step as missing.

## Changes
- Reject invalid task status regressions such as `completed -> active` in the jobs dispatcher.
- Add a Docker missing-container fallback that returns the latest persisted terminal task status.
- Prefer the terminal task fallback before active-step TTL handling when the Docker container is already gone.
- Add dispatcher and Docker backend regression coverage for stale active polls after task completion and expired TTL ordering.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal jobs reconciliation behavior only.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen pytest services/core/jobs/tests/test_dispatcher.py::test_create_or_update_task_ignores_invalid_terminal_transition -q` — passed, 1 test.
- `uv run --frozen pytest services/core/jobs/tests/controllers/test_docker_backend.py::test_docker_job_sync services/core/jobs/tests/controllers/test_docker_backend.py::test_docker_job_sync_active_missing_container_uses_terminal_task_fallback -q` — passed, 2 tests.
- `uv run --frozen pytest services/core/jobs/tests/controllers/test_docker_backend.py::test_docker_job_sync_active_missing_container_uses_terminal_task_fallback services/core/jobs/tests/controllers/test_docker_backend.py::test_docker_job_sync_active_missing_container_prefers_terminal_task_over_ttl -q` — passed, 2 tests.
- `uv run --frozen pytest services/core/jobs/tests/controllers/test_docker_backend.py -q` — passed, 74 tests.
- `uv run --frozen pytest services/core/jobs/tests/test_dispatcher.py -q` — passed, 43 tests.
- `uv run ruff check services/core/jobs/src/nmp/core/jobs/app/dispatcher.py services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py services/core/jobs/tests/test_dispatcher.py services/core/jobs/tests/controllers/test_docker_backend.py` — passed.
- `flox -q activate -- uv run pre-commit run -a` — passed.
- DCO audit over `origin/main..HEAD` — passed for `ff6b09e4773e149f3a08826e7885863997e49995` and `e4d04722bdfbec7c7c5892e29ed4c1bdcb606034`.
- Platform-Deploy customizer validation against this branch: https://github.com/NVIDIA-NeMo/Platform-Deploy/actions/runs/33022291043 — in progress.