### PR TITLE
feat(studio): clean up agent eval table columns

### DIFF
--- a/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
@@ -25,6 +25,7 @@ import type {
 import { Text, Tooltip } from '@nvidia/foundations-react-core';
 import { IntakePayloadPreviewCell } from '@studio/components/IntakeLists/IntakePayloadPreviewCell';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
+import { evaluatorLabel } from '@studio/routes/agents/AgentDetailRoute/evaluations/formatRollups';
 import { getEvaluationSessionTraceDetailRoute } from '@studio/routes/utils';
 import { tooltipClassName } from '@studio/styles/common';
 import { formatInteger } from '@studio/util/intakeTelemetry';
@@ -76,7 +77,6 @@ const SESSION_SORT_FIELD_MAP: Readonly<Record<string, string>> = {
   latency_ms: 'latency_ms',
   status: 'status',
   tokens: 'tokens',
-  cost_total_usd: 'cost_total_usd',
 };
 
 // Converts the table's multi-column sorting state to the comma-separated `sort` API param.
@@ -195,27 +195,6 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
         );
       },
     }),
-    accessor('input', {
-      header: 'Input',
-      enableSorting: false,
-      size: 400,
-      cell: ({ row }) => <IntakePayloadPreviewCell value={row.original.input} emptyValue="-" />,
-    }),
-    accessor('output', {
-      header: 'Output',
-      enableSorting: false,
-      size: 400,
-      cell: ({ row }) => <IntakePayloadPreviewCell value={row.original.output} emptyValue="-" />,
-    }),
-    accessor('latency_ms', {
-      header: 'Duration',
-      enableSorting: true,
-      meta: { alignment: 'right' },
-      cell: ({ row }) => {
-        const ms = row.original.latency_ms;
-        return <Text>{ms != null ? formatDurationMs(ms) : '-'}</Text>;
-      },
-    }),
     accessor('status', {
       header: 'Status',
       enableSorting: true,
@@ -232,6 +211,27 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
         },
       },
       cell: ({ row }) => <StatusBadge status={mapStatusForBadge(row.original.status)} />,
+    }),
+    accessor('latency_ms', {
+      header: 'Duration',
+      enableSorting: true,
+      meta: { alignment: 'right' },
+      cell: ({ row }) => {
+        const ms = row.original.latency_ms;
+        return <Text>{ms != null ? formatDurationMs(ms) : '-'}</Text>;
+      },
+    }),
+    accessor('input', {
+      header: 'Input',
+      enableSorting: false,
+      size: 400,
+      cell: ({ row }) => <IntakePayloadPreviewCell value={row.original.input} emptyValue="-" />,
+    }),
+    accessor('output', {
+      header: 'Output',
+      enableSorting: false,
+      size: 400,
+      cell: ({ row }) => <IntakePayloadPreviewCell value={row.original.output} emptyValue="-" />,
     }),
     accessor(
       (original) =>
@@ -250,19 +250,10 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
         },
       }
     ),
-    accessor('cost_total_usd', {
-      header: 'Cost',
-      enableSorting: true,
-      meta: { alignment: 'right' },
-      cell: ({ row }) => {
-        const cost = row.original.cost_total_usd;
-        return <Text>{cost != null ? `$${cost.toFixed(3)}` : '-'}</Text>;
-      },
-    }),
     ...evaluatorNames.map((name, index) =>
       accessor((original) => original.evaluator_scores?.[name], {
         id: `score-${index}`,
-        header: snakeCaseToTitleCase(name),
+        header: snakeCaseToTitleCase(evaluatorLabel(name)),
         enableSorting: false,
         size: 130,
         meta: { alignment: 'right' },

--- a/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
@@ -7,7 +7,6 @@ import {
 } from '@nemo/common/src/components/DataView/internal';
 import { StudioDataView } from '@nemo/common/src/components/DataView/StudioDataView';
 import { EntityEmptyState } from '@nemo/common/src/components/EntityEmptyState';
-import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { StatusBadge } from '@nemo/common/src/components/StatusBadge';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
 import { formatDurationMs } from '@nemo/common/src/utils/date';
@@ -74,8 +73,6 @@ const listEvaluationSessionsWithModeFallback = async (
 // translation is needed beyond listing the sortable ids.
 const SESSION_SORT_FIELD_MAP: Readonly<Record<string, string>> = {
   test_case_name: 'test_case_name',
-  started_at: 'started_at',
-  ended_at: 'ended_at',
   latency_ms: 'latency_ms',
   status: 'status',
   tokens: 'tokens',
@@ -210,24 +207,8 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
       size: 400,
       cell: ({ row }) => <IntakePayloadPreviewCell value={row.original.output} emptyValue="-" />,
     }),
-    accessor('started_at', {
-      header: 'Started at',
-      enableSorting: true,
-      cell: ({ row }) =>
-        row.original.started_at ? (
-          <RelativeTime datetime={row.original.started_at} />
-        ) : (
-          <Text>-</Text>
-        ),
-    }),
-    accessor('ended_at', {
-      header: 'Ended at',
-      enableSorting: true,
-      cell: ({ row }) =>
-        row.original.ended_at ? <RelativeTime datetime={row.original.ended_at} /> : <Text>-</Text>,
-    }),
     accessor('latency_ms', {
-      header: 'Latency',
+      header: 'Duration',
       enableSorting: true,
       meta: { alignment: 'right' },
       cell: ({ row }) => {

--- a/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/EvaluationSessionsDataView/index.tsx
@@ -25,7 +25,6 @@ import type {
 import { Text, Tooltip } from '@nvidia/foundations-react-core';
 import { IntakePayloadPreviewCell } from '@studio/components/IntakeLists/IntakePayloadPreviewCell';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
-import { evaluatorLabel } from '@studio/routes/agents/AgentDetailRoute/evaluations/formatRollups';
 import { getEvaluationSessionTraceDetailRoute } from '@studio/routes/utils';
 import { tooltipClassName } from '@studio/styles/common';
 import { formatInteger } from '@studio/util/intakeTelemetry';
@@ -253,7 +252,7 @@ export const EvaluationSessionsDataView: FC<EvaluationSessionsDataViewProps> = (
     ...evaluatorNames.map((name, index) =>
       accessor((original) => original.evaluator_scores?.[name], {
         id: `score-${index}`,
-        header: snakeCaseToTitleCase(evaluatorLabel(name)),
+        header: snakeCaseToTitleCase(name),
         enableSorting: false,
         size: 130,
         meta: { alignment: 'right' },

--- a/web/packages/studio/src/routes/EvaluationDetailRoute/EvaluationDetailMetrics.tsx
+++ b/web/packages/studio/src/routes/EvaluationDetailRoute/EvaluationDetailMetrics.tsx
@@ -5,11 +5,11 @@ import { KVPair } from '@nemo/common/src/components/KVPair';
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { formatDurationMs } from '@nemo/common/src/utils/date';
 import { useGetEvaluation } from '@nemo/sdk/generated/platform/api';
-import { Divider, Flex, Text, Tooltip } from '@nvidia/foundations-react-core';
+import { Divider, Flex, Tooltip } from '@nvidia/foundations-react-core';
 import { ChangesetBadge } from '@studio/components/ChangesetBadge';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { tooltipClassName } from '@studio/styles/common';
-import { type FC, type ReactNode } from 'react';
+import { type FC } from 'react';
 
 interface EvaluationDetailMetricsProps {
   evaluationName: string;
@@ -19,11 +19,8 @@ export const EvaluationDetailMetrics: FC<EvaluationDetailMetricsProps> = ({ eval
   const workspace = useWorkspaceFromPath();
   const { data: experiment, isLoading } = useGetEvaluation(workspace, evaluationName);
 
-  const avgCost =
-    experiment?.cost_usd?.mean != null ? `$${experiment.cost_usd.mean.toFixed(3)}` : undefined;
-
   // formatDurationMs returns '—' for null/undefined, which is also KVPair's default empty value.
-  const avgLatency = formatDurationMs(experiment?.latency_ms?.mean);
+  const avgDuration = formatDurationMs(experiment?.latency_ms?.mean);
 
   const tokenSum = experiment?.tokens?.sum;
   const totalTokens =
@@ -33,19 +30,6 @@ export const EvaluationDetailMetrics: FC<EvaluationDetailMetricsProps> = ({ eval
           maximumFractionDigits: 0,
         })
       : undefined;
-
-  const modelNames = experiment?.model_names ?? [];
-  const modelNamesJoined = modelNames.length > 0 ? modelNames.join(', ') : undefined;
-  const modelNamesValue: ReactNode = modelNamesJoined ? (
-    modelNames.length > 1 ? (
-      // Truncate + tooltip for the multi-model case to keep the header KV row compact.
-      <Tooltip slotContent={modelNamesJoined} className={tooltipClassName} side="bottom">
-        <Text className="cursor-default truncate max-w-[200px] block">{modelNamesJoined}</Text>
-      </Tooltip>
-    ) : (
-      modelNamesJoined
-    )
-  ) : undefined;
 
   return (
     <Flex align="stretch" justify="between" gap="density-3xl">
@@ -101,13 +85,14 @@ export const EvaluationDetailMetrics: FC<EvaluationDetailMetricsProps> = ({ eval
         />
       </Flex>
       <Flex align="stretch" gap="density-3xl">
-        <KVPair label="Models" value={modelNamesValue} loading={isLoading} orientation="vertical" />
-        <Divider orientation="vertical" className="grow-0 self-stretch" />
-        <KVPair label="Avg Cost" value={avgCost} loading={isLoading} orientation="vertical" />
-        <Divider orientation="vertical" className="grow-0 self-stretch" />
         <KVPair label="Tokens" value={totalTokens} loading={isLoading} orientation="vertical" />
         <Divider orientation="vertical" className="grow-0 self-stretch" />
-        <KVPair label="Avg Latency" value={avgLatency} loading={isLoading} orientation="vertical" />
+        <KVPair
+          label="Avg Duration"
+          value={avgDuration}
+          loading={isLoading}
+          orientation="vertical"
+        />
       </Flex>
     </Flex>
   );

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/EvaluationsTable.tsx
@@ -8,15 +8,12 @@ import {
 import { RelativeTime } from '@nemo/common/src/components/RelativeTime';
 import { TableEmptyState } from '@nemo/common/src/components/TableEmptyState';
 import { useStudioDataViewState } from '@nemo/common/src/hooks/useStudioDataViewState';
+import { formatDurationMs } from '@nemo/common/src/utils/date';
 import { deleteEvaluation, getListEvaluationsQueryKey } from '@nemo/sdk/generated/platform/api';
 import { Button, Flex, Text } from '@nvidia/foundations-react-core';
-import { type EvalJobRow, evalJobDetailRoute } from '@studio/api/evaluation/utils';
+import { type EvalJobRow, evalDurationMs, evalJobDetailRoute } from '@studio/api/evaluation/utils';
 import { BulkDeleteModal } from '@studio/components/BulkDeleteModal';
-import {
-  evaluatorScores,
-  formatCost,
-  formatLatency,
-} from '@studio/routes/agents/AgentDetailRoute/evaluations/formatRollups';
+import { evaluatorScores } from '@studio/routes/agents/AgentDetailRoute/evaluations/formatRollups';
 import {
   type AgentEvaluationRow,
   primaryExperimentName,
@@ -75,10 +72,6 @@ export const EvaluationsTable: FC<EvaluationsTableProps> = ({ workspace, evaluat
           header: 'Evaluation',
           cell: ({ row }) => <Text title={row.original.name}>{row.original.name}</Text>,
         }),
-        accessor('run_count', {
-          header: 'Runs',
-          cell: ({ row }) => <Text>{row.original.run_count ?? 0}</Text>,
-        }),
         accessor('test_case_count', {
           header: 'Test cases',
           cell: ({ row }) => <Text>{row.original.test_case_count ?? 0}</Text>,
@@ -108,15 +101,29 @@ export const EvaluationsTable: FC<EvaluationsTableProps> = ({ workspace, evaluat
             );
           },
         }),
-        accessor('latency_ms', {
-          header: 'Avg latency',
+        accessor((original) => original.tokens?.mean, {
+          id: 'tokens',
+          header: 'Avg tokens',
           enableSorting: false,
-          cell: ({ row }) => <Text>{formatLatency(row.original.latency_ms?.mean)}</Text>,
+          cell: ({ row }) => {
+            const mean = row.original.tokens?.mean;
+            return <Text>{mean != null ? Math.round(mean).toLocaleString() : '—'}</Text>;
+          },
         }),
-        accessor('cost_usd', {
-          header: 'Cost',
+        accessor((original) => original.tokens?.sum, {
+          id: 'total_tokens',
+          header: 'Total tokens',
           enableSorting: false,
-          cell: ({ row }) => <Text>{formatCost(row.original.cost_usd?.sum)}</Text>,
+          cell: ({ row }) => {
+            const sum = row.original.tokens?.sum;
+            return <Text>{sum != null ? Math.round(sum).toLocaleString() : '—'}</Text>;
+          },
+        }),
+        accessor((original) => evalDurationMs(original.metadata), {
+          id: 'eval_duration',
+          header: 'Duration',
+          enableSorting: false,
+          cell: ({ getValue }) => <Text>{formatDurationMs(getValue<number | undefined>())}</Text>,
         }),
         accessor('created_at', {
           header: 'Created',

--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/formatRollups.ts
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/evaluations/formatRollups.ts
@@ -7,12 +7,6 @@ import type { AgentEvaluationRow } from '@studio/routes/agents/AgentDetailRoute/
 export const formatScore = (value: number | null | undefined): string =>
   typeof value === 'number' ? value.toFixed(2) : '—';
 
-export const formatLatency = (ms: number | null | undefined): string =>
-  typeof ms !== 'number' ? '—' : ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
-
-export const formatCost = (usd: number | null | undefined): string =>
-  typeof usd !== 'number' ? '—' : `$${usd < 0.01 ? usd.toFixed(4) : usd.toFixed(2)}`;
-
 /** Evaluator keys arrive as ``<metric-type>.<score-name>``, which reads as a stutter whenever the
  *  score is unnamed and repeats its type (``number-check.number-check``). Keep the part that
  *  carries meaning: the score name when it adds one, the type otherwise. */


### PR DESCRIPTION
## BEFORE

<img width="1478" height="520" alt="agent-evals-table-BEFORE" src="https://github.com/user-attachments/assets/c85b1f5c-ac3a-4073-9927-b31c17ea35a1" />


## AFTER

<img width="1477" height="494" alt="agent-evals-table-AFTER" src="https://github.com/user-attachments/assets/222b24e1-aa20-457d-b838-84540a40480f" />

<img width="1480" height="766" alt="Screenshot 2026-08-26 at 10 10 37 PM" src="https://github.com/user-attachments/assets/0de8b56c-4e84-467b-9364-bfb740149535" />



## Polish evaluation tables

Removes columns and tiles that structurally cannot show a value, adds the ones that can, and
shortens stuttering metric headers. Studio-only — no backend or SDK changes, no new API calls.

Every value was checked against a live instance first; field-present is not value-present.

### Agent details → Completed Evaluations

| | |
|---|---|
| Removed | `Runs`, `Cost`, `Avg latency` |
| Added | `Avg tokens`, `Total tokens`, `Duration` |

- **Runs** is not actually redundant with Test cases (`run_count` counts sessions, `test_case_count`
  counts distinct test cases), but they're equal for every row Studio can currently produce.
- **Cost** is `null` on the wire — not because telemetry is missing, but because nothing prices the
  tokens. Tokens themselves are populated.
- **Avg latency** is structurally always `0`. See #nmp-v5r.

### Evaluation detail → session table

- `Started at` + `Ended at` merged into a single **Duration**. This was a deletion, not new code —
  the table already had a `latency_ms` column, and `latency_ms` *is* `ended_at - started_at`
  computed backend-side. Dropped both timestamps, renamed Latency → Duration.
- Reordered: **Test case · Status · Duration · Input · Output · Tokens** (+ per-evaluator scores).
- Removed **Cost** (`cost_total_usd` null on every row).
- Metric headers now use `evaluatorLabel()`, so `string-check.string-check` renders **String-Check**
  instead of **String-Check.String-Check**. Matches how the agent-details score chips already render.

### Evaluation detail → header tiles

- Removed **Models** (`model_names` is `[]`) and **Avg Cost** (`cost_usd` is `null`).
- **Avg Latency** → **Avg Duration**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Evaluation views now emphasize duration and token usage instead of timestamps, costs, and model details.
  * Updated evaluation tables to show average tokens, total tokens, and evaluation duration.
  * Added clearer evaluator labels and formatted evaluator scores.
  * Token values are rounded and localized, with unavailable values shown as “—”.
  * Renamed latency metrics to duration for improved consistency across evaluation screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->