### PR TITLE
feat(eval-author): measure capability coverage

### DIFF
--- a/plugins/nemo-eval-author/README.md
+++ b/plugins/nemo-eval-author/README.md
@@ -16,11 +16,12 @@ copied skill tree, not published as a package API.
 ## Prerequisites
 
 Discovery imports nothing beyond the standard library and Harbor itself, so it
-runs on whatever Python the customer already has. Audit validation needs PyYAML
-to read the marked YAML block and jsonschema to enforce
-`schemas/audit.schema.json`. Trace inspection requires the supported `nemo` CLI,
-an explicit workspace, and read access to a configured local or remote NeMo
-Platform instance.
+runs on whatever Python the customer already has. Audit generation and
+validation need PyYAML to read YAML and jsonschema to enforce
+`schemas/audit.schema.json`; audit measurement and reporting use
+`skills/eval-author-audit/requirements.txt`. Trace inspection requires the
+supported `nemo` CLI, an explicit workspace, and read access to a configured
+local or remote NeMo Platform instance.
 
 `tests/test_skill_contract.py` holds to the same boundary and imports nothing
 from the platform, so `pytest`, `pyyaml`, and `jsonschema` are enough to run it.
@@ -46,8 +47,12 @@ visible and worth committing: a teammate who reads it skips the discovery pass.
 exact read commands. Findings use `behavior`, `issue`, `recovery`, and
 `uncertainty` categories.
 
-The bundled scripts write no files. They report to stdout, and the skill tells
-the agent where to save. Trace inspection contains instructions only.
+Discovery scripts write no files. Audit scripts write only the requested
+`.eval-author/` artifacts and report JSON summaries to stdout. Trace inspection
+contains instructions only.
+Capability measurement can also consume a local skill-authored judgment sidecar
+for non-tool evidence; deterministic tool requirements still come from ATIF
+traces.
 
 ## Why skills instead of an agent
 

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -248,6 +248,9 @@ structured judgment file under `.eval-author/` using
 capability `name` plus the zero-based `evidence_required` index, copy the
 evidence `kind` and `description` exactly, and judge only non-tool evidence. Do
 not write judgments for `tool_call`; the script measures those deterministically.
+Set the sidecar's required `trace_sha256` to `sha256:` followed by the lowercase
+SHA-256 digest of the exact ATIF trajectory file you inspected. Measurement
+rejects the sidecar if those trace bytes have changed or another trace is used.
 Use the capability description, evidence description, and concrete trace content
 as the rubric: mark `satisfied` only when the trace clearly demonstrates the
 requirement, `missing` when it clearly does not, and `unclear` when the trace is
@@ -272,7 +275,8 @@ uv run --with-requirements <skill_dir>/requirements.txt \
 Capability coverage is conjunctive: every deterministic requirement must be
 satisfied, and every judged evidence requirement must be satisfied. Missing
 judgments leave the capability uncovered. Stale judgments fail measurement
-before the script writes a coverage report.
+before the script writes a coverage report, including judgments bound to a
+different trace digest.
 
 The script writes one folder per task, run, and method. Task and run ids are
 encoded as single path components so ids containing `/` cannot create nested or

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -339,8 +339,10 @@ Treat that list as the input for a later task-generation step.
 
 - For audit-generation inputs and reconciliation modes, return to
   [Step 2: Generate Or Reconcile Audit.md](#step-2-generate-or-reconcile-auditmd).
-- When aggregate `uncovered_items` includes actionable tools
+- When aggregate `uncovered_items` includes actionable items
   (`reason: not_covered_by_any_input_report`), hand off to
   [`eval-author-task-create`](../eval-author-task-create/SKILL.md) to scaffold
-  and prove one gap at a time. Capability or failure-case items with
-  `reason: not_measured_by_any_method` stay audit findings only in v1.
+  and prove one gap at a time. Items with
+  `reason: not_measured_by_any_method`, such as failure-case items and
+  capability items measured without the `capabilities` method, stay audit
+  findings only in v1.

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -64,8 +64,8 @@ existing evals, source-of-truth documents, or `ETHOS.md`.
 Audit-spec mechanics live under `scripts/audit_spec/`:
 
 Read `scripts/audit_spec/README.md` for the current measurement assumptions:
-ATIF input, Harbor trajectory parsing, v1 `tool_calls` coverage only, and
-coverage aggregation from `coverage.json` files.
+ATIF input, Harbor trajectory parsing, v1 `tool_calls` and `capabilities`
+coverage, and coverage aggregation from `coverage.json` files.
 
 | Script | Use it to |
 |---|---|
@@ -74,19 +74,8 @@ coverage aggregation from `coverage.json` files.
 | `scripts/audit_spec/report.py` | Aggregate per-trace `coverage.json` files into one coverage report with uncovered audit items |
 | `scripts/audit_spec/validate.py` | Validate the marked audit-spec block in `audit.md` |
 
-Shared helpers are private modules in the same tree:
-`scripts/audit_spec/_schema.py` and `scripts/audit_spec/_markdown.py`.
-Measurement uses Harbor's `harbor.models.trajectories.Trajectory` to read ATIF
-files. Measurement methods live under `scripts/audit_spec/measurements/`; v1 ships
-`scripts/audit_spec/measurements/tool_calls.py`.
-Shared coverage output is defined by `schemas/audit_coverage.schema.json`.
-Aggregate coverage output is defined by
-`schemas/audit_coverage_report.schema.json`.
-Tool-call debug output is defined by
-`schemas/audit_tool_calls_details.schema.json`.
-Concrete instances live under `examples/schemas/tool_calls.coverage.json`,
-`examples/schemas/tool_calls.details.json`, and
-`examples/schemas/coverage_report.json`.
+Shared helpers, measurement method contracts, schemas, and examples are
+documented in `scripts/audit_spec/README.md`.
 Runtime dependencies are listed in `requirements.txt`.
 
 ## Step 1: Draft Or Update Audit Items
@@ -246,17 +235,52 @@ uv run --with-requirements <skill_dir>/requirements.txt \
 ```
 
 `--measure` may be passed more than once or as CSV, for example
-`--measure tool_calls,boundary`. The script loads the trajectory once, then runs
-each selected method against the same parsed Harbor trajectory model. Unknown
-method names fail before the trace is loaded.
+`--measure tool_calls,capabilities`. The default is `tool_calls`; include
+`capabilities` when the user wants the same trace to count against capability
+items. The script loads the trajectory once, then runs each selected method
+against the same parsed Harbor trajectory model. Unknown method names fail
+before the trace is loaded.
+
+When capability evidence contains non-tool kinds such as `user_intent`, `output`,
+`outcome`, `policy_boundary`, or `verifier`, inspect the trace and write a
+structured judgment file under `.eval-author/` using
+`schemas/audit_capability_judgments.schema.json`. Each judgment must target the
+capability `name` plus the zero-based `evidence_required` index, copy the
+evidence `kind` and `description` exactly, and judge only non-tool evidence. Do
+not write judgments for `tool_call`; the script measures those deterministically.
+Use the capability description, evidence description, and concrete trace content
+as the rubric: mark `satisfied` only when the trace clearly demonstrates the
+requirement, `missing` when it clearly does not, and `unclear` when the trace is
+ambiguous or insufficient. Include brief rationale and supporting trace
+references when available. A subjective judgment can satisfy only the non-tool
+evidence it targets; it cannot override missing required tools or missing
+`tool_call` evidence.
+Pass the sidecar when measuring capabilities:
+
+```bash
+uv run --with-requirements <skill_dir>/requirements.txt \
+  <skill_dir>/scripts/audit_spec/measure.py \
+  --audit .eval-author/audit.md \
+  --trace <path-to>/trajectory.json \
+  --task-id <task-id> \
+  --run-id <run-id> \
+  --measure capabilities \
+  --capability-judgments .eval-author/capability-judgments.json \
+  --out-dir .eval-author/audit-measurements
+```
+
+Capability coverage is conjunctive: every deterministic requirement must be
+satisfied, and every judged evidence requirement must be satisfied. Missing
+judgments leave the capability uncovered. Stale judgments fail measurement
+before the script writes a coverage report.
 
 The script writes one folder per task, run, and method. Task and run ids are
 encoded as single path components so ids containing `/` cannot create nested or
 escaping paths:
 
 ```text
-.eval-author/audit-measurements/task=<encoded-task-id>/run=<encoded-run-id>/tool_calls/coverage.json
-.eval-author/audit-measurements/task=<encoded-task-id>/run=<encoded-run-id>/tool_calls/details.json
+.eval-author/audit-measurements/task=<encoded-task-id>/run=<encoded-run-id>/<method>/coverage.json
+.eval-author/audit-measurements/task=<encoded-task-id>/run=<encoded-run-id>/<method>/details.json
 ```
 
 `coverage.json` uses the shared coverage schema and contains only the stable
@@ -267,11 +291,8 @@ aggregation should consume this file and ignore method-specific debug details.
 `details.json` is specific to the selected method and carries traceability data
 for humans.
 
-The only v1 measurement method is `tool_calls`. It covers only audit items whose
-`kind` is `tool` by matching each tool item's `name` against ATIF
-`steps[].tool_calls[].function_name`, including embedded subagent trajectories.
-It does not judge capabilities, failure cases, user intent, output quality, or
-other evidence kinds.
+For current method semantics and details schemas, see
+`scripts/audit_spec/README.md`.
 
 The script validates `coverage.json` against `schemas/audit_coverage.schema.json`
 and validates `details.json` against the selected method's details schema before

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capabilities.coverage.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capabilities.coverage.json
@@ -1,0 +1,24 @@
+{
+  "schema": "nemo.eval_author.audit_coverage.v1",
+  "audit": {
+    "path": ".eval-author/audit.md",
+    "schema": "nemo.eval_author.audit.v1",
+    "agent": "support-agent",
+    "status": "draft",
+    "item_count": 5
+  },
+  "subject": {
+    "trace": ".harbor/runs/account-recovery/trials/trial-001/agent/trajectory.json",
+    "trace_format": "atif",
+    "task_id": "account-recovery",
+    "run_id": "trial-001"
+  },
+  "method": {
+    "name": "capabilities"
+  },
+  "item_kind": "capability",
+  "item_kind_count": 1,
+  "covered": [
+    "account_recovery"
+  ]
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capabilities.details.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capabilities.details.json
@@ -1,0 +1,145 @@
+{
+  "schema": "nemo.eval_author.audit_capabilities_details.v1",
+  "audit": {
+    "path": ".eval-author/audit.md",
+    "schema": "nemo.eval_author.audit.v1",
+    "agent": "support-agent",
+    "status": "draft",
+    "item_count": 5
+  },
+  "subject": {
+    "trace": ".harbor/runs/account-recovery/trials/trial-001/agent/trajectory.json",
+    "trace_format": "atif",
+    "task_id": "account-recovery",
+    "run_id": "trial-001"
+  },
+  "method": {
+    "name": "capabilities"
+  },
+  "item_kind": "capability",
+  "audit_capabilities": [
+    "account_recovery"
+  ],
+  "covered": [
+    "account_recovery"
+  ],
+  "missing": [],
+  "judgment_input": {
+    "provided": true,
+    "schema": "nemo.eval_author.audit_capability_judgments.v1",
+    "judged_by": "eval-author-audit skill",
+    "judgment_count": 1
+  },
+  "judged_evidence_kinds": [
+    "user_intent"
+  ],
+  "unjudged_evidence_kinds": [],
+  "unsupported_evidence_kinds": [],
+  "observed_tool_calls": [
+    {
+      "tool": "customer.lookup",
+      "step_id": 2,
+      "tool_call_id": "call-001",
+      "trajectory_id": "root-trajectory",
+      "trajectory_path": "$"
+    },
+    {
+      "tool": "password.reset",
+      "step_id": 4,
+      "tool_call_id": "call-002",
+      "trajectory_id": "root-trajectory",
+      "trajectory_path": "$"
+    }
+  ],
+  "tool_call_counts": {
+    "customer.lookup": 1,
+    "password.reset": 1
+  },
+  "capability_results": {
+    "account_recovery": {
+      "name": "account_recovery",
+      "covered": true,
+      "required_tools": [
+        "customer.lookup",
+        "password.reset"
+      ],
+      "required_tool_results": [
+        {
+          "tool": "customer.lookup",
+          "status": "satisfied",
+          "matches": [
+            {
+              "tool": "customer.lookup",
+              "step_id": 2,
+              "tool_call_id": "call-001",
+              "trajectory_id": "root-trajectory",
+              "trajectory_path": "$"
+            }
+          ]
+        },
+        {
+          "tool": "password.reset",
+          "status": "satisfied",
+          "matches": [
+            {
+              "tool": "password.reset",
+              "step_id": 4,
+              "tool_call_id": "call-002",
+              "trajectory_id": "root-trajectory",
+              "trajectory_path": "$"
+            }
+          ]
+        }
+      ],
+      "evidence_results": [
+        {
+          "kind": "user_intent",
+          "evidence_index": 0,
+          "description": "User is trying to recover account access.",
+          "measurement": "judged",
+          "status": "satisfied",
+          "confidence": "high",
+          "rationale": "The user request asks for help recovering account access.",
+          "supporting_trace_refs": [
+            "$.steps[0].message"
+          ]
+        },
+        {
+          "kind": "tool_call",
+          "evidence_index": 1,
+          "description": "Trace shows a lookup before account recovery.",
+          "measurement": "deterministic",
+          "status": "satisfied",
+          "tool": "customer.lookup",
+          "matches": [
+            {
+              "tool": "customer.lookup",
+              "step_id": 2,
+              "tool_call_id": "call-001",
+              "trajectory_id": "root-trajectory",
+              "trajectory_path": "$"
+            }
+          ]
+        },
+        {
+          "kind": "tool_call",
+          "evidence_index": 2,
+          "description": "Trace shows a password reset call.",
+          "measurement": "deterministic",
+          "status": "satisfied",
+          "tool": "password.reset",
+          "matches": [
+            {
+              "tool": "password.reset",
+              "step_id": 4,
+              "tool_call_id": "call-002",
+              "trajectory_id": "root-trajectory",
+              "trajectory_path": "$"
+            }
+          ]
+        }
+      ],
+      "missing_reasons": []
+    }
+  }
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capabilities.details.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capabilities.details.json
@@ -16,10 +16,6 @@
   "method": {
     "name": "capabilities"
   },
-  "item_kind": "capability",
-  "audit_capabilities": [
-    "account_recovery"
-  ],
   "covered": [
     "account_recovery"
   ],
@@ -31,11 +27,6 @@
     "judged_by": "eval-author-audit skill",
     "judgment_count": 1
   },
-  "judged_evidence_kinds": [
-    "user_intent"
-  ],
-  "unjudged_evidence_kinds": [],
-  "unsupported_evidence_kinds": [],
   "observed_tool_calls": [
     {
       "tool": "customer.lookup",
@@ -58,12 +49,7 @@
   },
   "capability_results": {
     "account_recovery": {
-      "name": "account_recovery",
       "covered": true,
-      "required_tools": [
-        "customer.lookup",
-        "password.reset"
-      ],
       "required_tool_results": [
         {
           "tool": "customer.lookup",

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capabilities.details.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capabilities.details.json
@@ -27,6 +27,7 @@
   "judgment_input": {
     "provided": true,
     "schema": "nemo.eval_author.audit_capability_judgments.v1",
+    "trace_sha256": "sha256:6f0419aa86229c2895d7d8bc22e4f7e55258979a1168dee8cd60608b6cda5a33",
     "judged_by": "eval-author-audit skill",
     "judgment_count": 1
   },
@@ -107,7 +108,7 @@
         {
           "kind": "tool_call",
           "evidence_index": 1,
-          "description": "Trace shows a lookup before account recovery.",
+          "description": "Trace shows a customer lookup call.",
           "measurement": "deterministic",
           "status": "satisfied",
           "tool": "customer.lookup",

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capability_judgments.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capability_judgments.json
@@ -1,5 +1,6 @@
 {
   "schema": "nemo.eval_author.audit_capability_judgments.v1",
+  "trace_sha256": "sha256:6f0419aa86229c2895d7d8bc22e4f7e55258979a1168dee8cd60608b6cda5a33",
   "judged_by": "eval-author-audit skill",
   "instructions": "Judge only non-tool capability evidence from the inspected ATIF trace. Do not judge tool_call evidence.",
   "judgments": [

--- a/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capability_judgments.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/examples/schemas/capability_judgments.json
@@ -1,0 +1,19 @@
+{
+  "schema": "nemo.eval_author.audit_capability_judgments.v1",
+  "judged_by": "eval-author-audit skill",
+  "instructions": "Judge only non-tool capability evidence from the inspected ATIF trace. Do not judge tool_call evidence.",
+  "judgments": [
+    {
+      "capability": "account_recovery",
+      "evidence_index": 0,
+      "kind": "user_intent",
+      "description": "User is trying to recover account access.",
+      "status": "satisfied",
+      "confidence": "high",
+      "rationale": "The user asks for help recovering account access.",
+      "supporting_trace_refs": [
+        "$.steps[0].message"
+      ]
+    }
+  ]
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capabilities_details.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capabilities_details.schema.json
@@ -10,14 +10,9 @@
     "audit",
     "subject",
     "method",
-    "item_kind",
-    "audit_capabilities",
     "covered",
     "missing",
     "judgment_input",
-    "judged_evidence_kinds",
-    "unjudged_evidence_kinds",
-    "unsupported_evidence_kinds",
     "observed_tool_calls",
     "tool_call_counts",
     "capability_results"
@@ -48,14 +43,6 @@
         }
       }
     },
-    "item_kind": {
-      "description": "Audit item kind measured by capability coverage.",
-      "const": "capability"
-    },
-    "audit_capabilities": {
-      "description": "Capability item names declared by the audit denominator.",
-      "$ref": "#/$defs/nameList"
-    },
     "covered": {
       "description": "Capability names covered by deterministic evidence and any required skill-authored judgments.",
       "$ref": "#/$defs/nameList"
@@ -67,18 +54,6 @@
     "judgment_input": {
       "description": "Summary of the optional judgment sidecar consumed by this measurement.",
       "$ref": "#/$defs/judgmentInput"
-    },
-    "judged_evidence_kinds": {
-      "description": "Non-tool evidence kinds evaluated by skill-authored judgments.",
-      "$ref": "#/$defs/stringList"
-    },
-    "unjudged_evidence_kinds": {
-      "description": "Judgeable non-tool evidence kinds that lacked a supplied judgment and therefore blocked coverage.",
-      "$ref": "#/$defs/stringList"
-    },
-    "unsupported_evidence_kinds": {
-      "description": "Evidence kinds this method neither measures deterministically nor accepts from judgment input.",
-      "$ref": "#/$defs/stringList"
     },
     "observed_tool_calls": {
       "description": "All tool calls found in the ATIF trace.",
@@ -479,22 +454,14 @@
         }
       ],
       "required": [
-        "name",
         "covered",
-        "required_tools",
         "required_tool_results",
         "evidence_results",
         "missing_reasons"
       ],
       "properties": {
-        "name": {
-          "$ref": "#/$defs/itemName"
-        },
         "covered": {
           "type": "boolean"
-        },
-        "required_tools": {
-          "$ref": "#/$defs/nameList"
         },
         "required_tool_results": {
           "type": "array",

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capabilities_details.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capabilities_details.schema.json
@@ -115,6 +115,10 @@
       "type": "string",
       "pattern": "\\S"
     },
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    },
     "itemName": {
       "description": "Stable machine-readable audit item or tool name.",
       "type": "string",
@@ -219,6 +223,9 @@
         "schema": {
           "const": "nemo.eval_author.audit_capability_judgments.v1"
         },
+        "trace_sha256": {
+          "$ref": "#/$defs/sha256Digest"
+        },
         "judged_by": {
           "$ref": "#/$defs/nonEmptyString"
         },
@@ -226,7 +233,24 @@
           "type": "integer",
           "minimum": 0
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "provided": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "schema",
+              "trace_sha256"
+            ]
+          }
+        }
+      ]
     },
     "toolCall": {
       "type": "object",

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capabilities_details.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capabilities_details.schema.json
@@ -1,0 +1,493 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://developer.nvidia.com/nemo/eval-author/audit_capabilities_details.schema.json",
+  "title": "NeMo Eval Author capability measurement details",
+  "description": "Method-specific details for composite capability coverage measurement.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "audit",
+    "subject",
+    "method",
+    "item_kind",
+    "audit_capabilities",
+    "covered",
+    "missing",
+    "judgment_input",
+    "judged_evidence_kinds",
+    "unjudged_evidence_kinds",
+    "unsupported_evidence_kinds",
+    "observed_tool_calls",
+    "tool_call_counts",
+    "capability_results"
+  ],
+  "properties": {
+    "schema": {
+      "description": "Version marker for capability measurement details.",
+      "const": "nemo.eval_author.audit_capabilities_details.v1"
+    },
+    "audit": {
+      "description": "Audit spec metadata for the denominator used by this measurement.",
+      "$ref": "#/$defs/audit"
+    },
+    "subject": {
+      "description": "Provider-neutral identity of the measured task/run artifact.",
+      "$ref": "#/$defs/subject"
+    },
+    "method": {
+      "description": "Measurement method that produced this details file.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "const": "capabilities"
+        }
+      }
+    },
+    "item_kind": {
+      "description": "Audit item kind measured by capability coverage.",
+      "const": "capability"
+    },
+    "audit_capabilities": {
+      "description": "Capability item names declared by the audit denominator.",
+      "$ref": "#/$defs/nameList"
+    },
+    "covered": {
+      "description": "Capability names covered by deterministic evidence and any required skill-authored judgments.",
+      "$ref": "#/$defs/nameList"
+    },
+    "missing": {
+      "description": "Capability names not covered by deterministic evidence or required skill-authored judgments.",
+      "$ref": "#/$defs/nameList"
+    },
+    "judgment_input": {
+      "description": "Summary of the optional judgment sidecar consumed by this measurement.",
+      "$ref": "#/$defs/judgmentInput"
+    },
+    "judged_evidence_kinds": {
+      "description": "Non-tool evidence kinds evaluated by skill-authored judgments.",
+      "$ref": "#/$defs/stringList"
+    },
+    "unjudged_evidence_kinds": {
+      "description": "Judgeable non-tool evidence kinds that lacked a supplied judgment and therefore blocked coverage.",
+      "$ref": "#/$defs/stringList"
+    },
+    "unsupported_evidence_kinds": {
+      "description": "Evidence kinds this method neither measures deterministically nor accepts from judgment input.",
+      "$ref": "#/$defs/stringList"
+    },
+    "observed_tool_calls": {
+      "description": "All tool calls found in the ATIF trace.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/toolCall"
+      }
+    },
+    "tool_call_counts": {
+      "description": "Observed tool call counts keyed by tool name.",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/nonEmptyString"
+      },
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 1
+      }
+    },
+    "capability_results": {
+      "description": "Per-capability evidence results keyed by capability name.",
+      "type": "object",
+      "propertyNames": {
+        "$ref": "#/$defs/itemName"
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/capabilityResult"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "description": "String value that must contain at least one non-whitespace character.",
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "itemName": {
+      "description": "Stable machine-readable audit item or tool name.",
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_.:/-]*$"
+    },
+    "pathString": {
+      "description": "Local file or directory path recorded as a string.",
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "nameList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/itemName"
+      }
+    },
+    "stringList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "audit": {
+      "description": "Identity and status of the audit denominator used for this measurement. Details readers use this to connect method-specific evidence back to the same denominator as coverage.json.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path",
+        "schema",
+        "agent",
+        "status",
+        "item_count"
+      ],
+      "properties": {
+        "path": {
+          "description": "Path to the audit.md file measured against.",
+          "$ref": "#/$defs/pathString"
+        },
+        "schema": {
+          "description": "Schema version of the audit denominator.",
+          "const": "nemo.eval_author.audit.v1"
+        },
+        "agent": {
+          "description": "Agent name declared by the audit denominator.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "description": "Review state of the audit denominator when this measurement was produced.",
+          "enum": [
+            "draft",
+            "approved"
+          ]
+        },
+        "item_count": {
+          "description": "Number of audit items in the denominator when this measurement was produced.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "subject": {
+      "description": "The measured task or run. Keep this provider-neutral so coverage and details files can be read without understanding the runner that produced the trace.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "trace",
+        "trace_format",
+        "task_id",
+        "run_id"
+      ],
+      "properties": {
+        "trace": {
+          "description": "Path to the interaction trace that was measured.",
+          "$ref": "#/$defs/pathString"
+        },
+        "trace_format": {
+          "description": "Trace serialization format understood by the measurement method.",
+          "const": "atif"
+        },
+        "task_id": {
+          "description": "Stable task, scenario, or case identifier for grouping measurements.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "run_id": {
+          "description": "Identifier for the specific run, trial, attempt, or repetition measured.",
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "judgmentInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provided",
+        "judgment_count"
+      ],
+      "properties": {
+        "provided": {
+          "type": "boolean"
+        },
+        "schema": {
+          "const": "nemo.eval_author.audit_capability_judgments.v1"
+        },
+        "judged_by": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "judgment_count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "toolCall": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tool",
+        "trajectory_path"
+      ],
+      "properties": {
+        "tool": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "trajectory_path": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "step_id": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "tool_call_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "trajectory_id": {
+          "$ref": "#/$defs/nonEmptyString"
+        }
+      }
+    },
+    "toolResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tool",
+        "status",
+        "matches"
+      ],
+      "properties": {
+        "tool": {
+          "$ref": "#/$defs/itemName"
+        },
+        "status": {
+          "enum": [
+            "satisfied",
+            "missing"
+          ]
+        },
+        "matches": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolCall"
+          }
+        }
+      }
+    },
+    "evidenceResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "evidence_index",
+        "description",
+        "measurement",
+        "status"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "evidence_index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "description": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "measurement": {
+          "enum": [
+            "deterministic",
+            "judged",
+            "judgment_required",
+            "unsupported"
+          ]
+        },
+        "status": {
+          "enum": [
+            "satisfied",
+            "missing",
+            "unclear",
+            "unjudged",
+            "unsupported"
+          ]
+        },
+        "tool": {
+          "$ref": "#/$defs/itemName"
+        },
+        "matches": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolCall"
+          }
+        },
+        "confidence": {
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "rationale": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "supporting_trace_refs": {
+          "$ref": "#/$defs/stringList"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "deterministic"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "satisfied",
+                  "missing"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "judged"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "enum": [
+                  "satisfied",
+                  "missing",
+                  "unclear"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "judgment_required"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "const": "unjudged"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "measurement": {
+                "const": "unsupported"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "status": {
+                "const": "unsupported"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "capabilityResult": {
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "covered": {
+                "const": true
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "missing_reasons": {
+                "maxItems": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "covered": {
+                "const": false
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "missing_reasons": {
+                "minItems": 1
+              }
+            }
+          }
+        }
+      ],
+      "required": [
+        "name",
+        "covered",
+        "required_tools",
+        "required_tool_results",
+        "evidence_results",
+        "missing_reasons"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/itemName"
+        },
+        "covered": {
+          "type": "boolean"
+        },
+        "required_tools": {
+          "$ref": "#/$defs/nameList"
+        },
+        "required_tool_results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/toolResult"
+          }
+        },
+        "evidence_results": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/evidenceResult"
+          }
+        },
+        "missing_reasons": {
+          "$ref": "#/$defs/stringList"
+        }
+      }
+    }
+  }
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capability_judgments.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capability_judgments.schema.json
@@ -7,12 +7,17 @@
   "additionalProperties": false,
   "required": [
     "schema",
+    "trace_sha256",
     "judgments"
   ],
   "properties": {
     "schema": {
       "description": "Version marker for capability judgment sidecars.",
       "const": "nemo.eval_author.audit_capability_judgments.v1"
+    },
+    "trace_sha256": {
+      "description": "SHA-256 digest of the exact ATIF trajectory bytes inspected for these judgments.",
+      "$ref": "#/$defs/sha256Digest"
     },
     "judged_by": {
       "description": "Human-readable identifier for the skill, model, or reviewer that authored these judgments.",
@@ -35,6 +40,10 @@
       "description": "String value that must contain at least one non-whitespace character.",
       "type": "string",
       "pattern": "\\S"
+    },
+    "sha256Digest": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
     },
     "itemName": {
       "description": "Stable machine-readable audit item or tool name.",

--- a/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capability_judgments.schema.json
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/schemas/audit_capability_judgments.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://developer.nvidia.com/nemo/eval-author/audit_capability_judgments.schema.json",
+  "title": "NeMo Eval Author capability judgments",
+  "description": "Structured skill-authored judgments for non-tool capability evidence in one trace.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "judgments"
+  ],
+  "properties": {
+    "schema": {
+      "description": "Version marker for capability judgment sidecars.",
+      "const": "nemo.eval_author.audit_capability_judgments.v1"
+    },
+    "judged_by": {
+      "description": "Human-readable identifier for the skill, model, or reviewer that authored these judgments.",
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "instructions": {
+      "description": "Optional note about the judging rubric or prompt used to produce these judgments.",
+      "$ref": "#/$defs/nonEmptyString"
+    },
+    "judgments": {
+      "description": "Judgments keyed back to capability evidence requirements by capability name and evidence index.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/judgment"
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "description": "String value that must contain at least one non-whitespace character.",
+      "type": "string",
+      "pattern": "\\S"
+    },
+    "itemName": {
+      "description": "Stable machine-readable audit item or tool name.",
+      "type": "string",
+      "pattern": "^[A-Za-z][A-Za-z0-9_.:/-]*$"
+    },
+    "stringList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "judgment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capability",
+        "evidence_index",
+        "kind",
+        "description",
+        "status",
+        "confidence",
+        "rationale"
+      ],
+      "properties": {
+        "capability": {
+          "description": "Capability item name containing the judged evidence requirement.",
+          "$ref": "#/$defs/itemName"
+        },
+        "evidence_index": {
+          "description": "Zero-based index into the capability's evidence_required list.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "kind": {
+          "description": "Non-tool evidence kind being judged. tool_call evidence is intentionally excluded.",
+          "enum": [
+            "environment_state",
+            "outcome",
+            "output",
+            "policy_boundary",
+            "state_change",
+            "trace_span",
+            "user_intent",
+            "verifier"
+          ]
+        },
+        "description": {
+          "description": "Exact description from the audit evidence requirement, used to reject stale judgments.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "status": {
+          "description": "Whether the trace satisfies this non-tool evidence requirement.",
+          "enum": [
+            "satisfied",
+            "missing",
+            "unclear"
+          ]
+        },
+        "confidence": {
+          "description": "Confidence in the subjective judgment.",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "rationale": {
+          "description": "Brief explanation grounded in the inspected trace.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "supporting_trace_refs": {
+          "description": "Optional trace locations, message ids, or step references that support the judgment.",
+          "$ref": "#/$defs/stringList"
+        }
+      }
+    }
+  }
+}

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/README.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/README.md
@@ -21,7 +21,9 @@ Current assumptions:
   Harbor.
 - Capability measurement may also consume a local skill-authored judgment
   sidecar with `--capability-judgments`. That sidecar is for non-tool evidence
-  only; deterministic tool requirements still come from the ATIF trace.
+  only; deterministic tool requirements still come from the ATIF trace. The
+  sidecar's required `trace_sha256` binds its judgments to the exact ATIF bytes
+  that were inspected, and measurement rejects a digest mismatch.
 - Reports are written under encoded path components:
   `<out-dir>/task=<task-id>/run=<run-id>/<method>/coverage.json` and
   `details.json`. The raw `task_id` and `run_id` remain in the JSON payloads.
@@ -101,5 +103,6 @@ Private shared helpers live in `scripts/audit_spec/_schema.py`,
 judgment can satisfy non-tool evidence kinds such as `user_intent`, `output`,
 `outcome`, `policy_boundary`, and `verifier`, but it cannot cover a capability
 when required tools or `tool_call` evidence are missing. Missing judgments are
-reported as `unjudged` and leave the capability uncovered. Unknown evidence kinds
-remain `unsupported`.
+reported as `unjudged` and leave the capability uncovered. Judgments bound to a
+different trace digest are rejected before reports are written. Unknown evidence
+kinds remain `unsupported`.

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/README.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/README.md
@@ -19,6 +19,9 @@ Current assumptions:
 - Harbor is a required dependency for measurement. Use `requirements.txt` when
   running `measure.py` outside a repository environment that already provides
   Harbor.
+- Capability measurement may also consume a local skill-authored judgment
+  sidecar with `--capability-judgments`. That sidecar is for non-tool evidence
+  only; deterministic tool requirements still come from the ATIF trace.
 - Reports are written under encoded path components:
   `<out-dir>/task=<task-id>/run=<run-id>/<method>/coverage.json` and
   `details.json`. The raw `task_id` and `run_id` remain in the JSON payloads.
@@ -50,10 +53,53 @@ Current assumptions:
   version before Harbor models are updated. If that happens, prefer contributing
   or adopting a permissive Harbor consumer reader before maintaining a local ATIF
   parser here.
-- The only implemented measurement method is `tool_calls`. It covers audit items
-  with `kind: tool` by matching each tool item `name` against Harbor trajectory
-  `ToolCall.function_name` values.
-- Capability, flow, failure-case, boundary, policy, and LLM-judged coverage are
-  intentionally out of scope for the current measurement method. Add those as
-  separate methods that emit the same shared `coverage.json` shape plus their own
-  method-specific `details.json`.
+- Failure-case coverage and richer deterministic predicates such as argument,
+  output, state, verifier, and ordering checks remain out of scope. For
+  capability coverage, keep additional gates inside the composite capability
+  method unless aggregation learns prerequisite-aware merging.
+
+## Script Inventory
+
+| Script | Use it to |
+|---|---|
+| `scripts/audit_spec/generate.py` | Create, reconcile, replace, or preview `.eval-author/audit.md` from `ETHOS.md` and reviewed item proposals |
+| `scripts/audit_spec/measure.py` | Measure one ATIF trace or Harbor trial directory against `audit.md` and write coverage/details files for each selected method |
+| `scripts/audit_spec/report.py` | Aggregate per-trace `coverage.json` files into one coverage report with uncovered audit items |
+| `scripts/audit_spec/validate.py` | Validate the marked audit-spec block in `audit.md` |
+
+Private shared helpers live in `scripts/audit_spec/_schema.py`,
+`scripts/audit_spec/_markdown.py`, and
+`scripts/audit_spec/measurements/trace_tools.py`. Measurement methods live under
+`scripts/audit_spec/measurements/`; v1 ships
+`scripts/audit_spec/measurements/tool_calls.py` and
+`scripts/audit_spec/measurements/capabilities.py`.
+
+## Schemas And Examples
+
+| Artifact | Path |
+|---|---|
+| Shared coverage schema | `schemas/audit_coverage.schema.json` |
+| Capability judgment input schema | `schemas/audit_capability_judgments.schema.json` |
+| Aggregate coverage report schema | `schemas/audit_coverage_report.schema.json` |
+| Capability details schema | `schemas/audit_capabilities_details.schema.json` |
+| Tool-call details schema | `schemas/audit_tool_calls_details.schema.json` |
+| Tool-call coverage example | `examples/schemas/tool_calls.coverage.json` |
+| Tool-call details example | `examples/schemas/tool_calls.details.json` |
+| Capability judgment input example | `examples/schemas/capability_judgments.json` |
+| Capability coverage example | `examples/schemas/capabilities.coverage.json` |
+| Capability details example | `examples/schemas/capabilities.details.json` |
+| Aggregate coverage report example | `examples/schemas/coverage_report.json` |
+
+## Measurement Methods
+
+| Method | Covers | Evidence |
+|---|---|---|
+| `tool_calls` | `tool` items | Matches each tool item's `name` against ATIF `steps[].tool_calls[].function_name`, including embedded subagent trajectories |
+| `capabilities` | `capability` items | Requires every declared `required_tools` value and every `tool_call` evidence predicate to appear in the trace; non-tool evidence can be satisfied by a structured skill-authored judgment sidecar |
+
+`capabilities` treats deterministic requirements as hard gates. A supplied
+judgment can satisfy non-tool evidence kinds such as `user_intent`, `output`,
+`outcome`, `policy_boundary`, and `verifier`, but it cannot cover a capability
+when required tools or `tool_call` evidence are missing. Missing judgments are
+reported as `unjudged` and leave the capability uncovered. Unknown evidence kinds
+remain `unsupported`.

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py
@@ -28,16 +28,25 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from _markdown import AuditMarkdownError  # noqa: E402
 from _schema import AuditEnvironmentError, AuditSpecError, item_counts, load_audit_spec  # noqa: E402
-from measurements import tool_calls  # noqa: E402
+from measurements import capabilities, tool_calls  # noqa: E402
 
 JsonObject: TypeAlias = dict[str, Any]
 
 COVERAGE_SCHEMA = "nemo.eval_author.audit_coverage.v1"
 SCHEMAS_DIR = Path(__file__).resolve().parents[2] / "schemas"
 COVERAGE_SCHEMA_PATH = SCHEMAS_DIR / "audit_coverage.schema.json"
+CAPABILITY_JUDGMENTS_SCHEMA_PATH = SCHEMAS_DIR / "audit_capability_judgments.schema.json"
 DETAIL_SCHEMA_PATHS = {
+    capabilities.DETAILS_SCHEMA: SCHEMAS_DIR / "audit_capabilities_details.schema.json",
     tool_calls.DETAILS_SCHEMA: SCHEMAS_DIR / "audit_tool_calls_details.schema.json",
 }
+
+
+@dataclass(frozen=True)
+class MeasurementInputs:
+    """Optional sidecar inputs shared by selected measurement methods."""
+
+    capability_judgments: JsonObject | None
 
 
 @dataclass(frozen=True)
@@ -46,15 +55,30 @@ class MeasurementMethod:
 
     name: str
     details_schema: str
-    measure: Callable[[JsonObject, Trajectory], JsonObject]
+    measure: Callable[[JsonObject, Trajectory, MeasurementInputs], JsonObject]
+
+
+def _measure_capabilities(audit: JsonObject, trajectory: Trajectory, inputs: MeasurementInputs) -> JsonObject:
+    """Run capability coverage with optional skill-authored judgments."""
+    return capabilities.measure(audit, trajectory, judgments=inputs.capability_judgments)
+
+
+def _measure_tool_calls(audit: JsonObject, trajectory: Trajectory, _inputs: MeasurementInputs) -> JsonObject:
+    """Run tool-call coverage without sidecar inputs."""
+    return tool_calls.measure(audit, trajectory)
 
 
 METHODS: dict[str, MeasurementMethod] = {
+    capabilities.METHOD_NAME: MeasurementMethod(
+        name=capabilities.METHOD_NAME,
+        details_schema=capabilities.DETAILS_SCHEMA,
+        measure=_measure_capabilities,
+    ),
     tool_calls.METHOD_NAME: MeasurementMethod(
         name=tool_calls.METHOD_NAME,
         details_schema=tool_calls.DETAILS_SCHEMA,
-        measure=tool_calls.measure,
-    )
+        measure=_measure_tool_calls,
+    ),
 }
 
 
@@ -149,11 +173,17 @@ def main(argv: list[str] | None = None) -> int:
         action="append",
         help=f"comma-separated measurement methods to run (default: {tool_calls.METHOD_NAME})",
     )
+    parser.add_argument(
+        "--capability-judgments",
+        type=Path,
+        help="JSON file of skill-authored judgments for non-tool capability evidence",
+    )
     parser.add_argument("--compact", action="store_true", help="emit compact JSON")
     args = parser.parse_args(argv)
 
     try:
         method_names = _measurement_methods(args.measure)
+        inputs = _measurement_inputs(args, method_names)
         audit = load_audit_spec(args.audit)
         pending_subject = _subject(args)
         loaded_trace = _load_harbor_trajectory(pending_subject.trace_path)
@@ -164,6 +194,7 @@ def main(argv: list[str] | None = None) -> int:
             trajectory=loaded_trace.trajectory,
             subject=subject_info,
             method_names=method_names,
+            inputs=inputs,
         )
         _validate_reports(reports)
         written_reports = _write_reports(reports, out_dir=args.out_dir, subject=subject_info, compact=args.compact)
@@ -311,6 +342,32 @@ def _measurement_methods(measure_values: list[str] | None) -> list[str]:
     return list(dict.fromkeys(method_names))
 
 
+def _measurement_inputs(args: argparse.Namespace, method_names: list[str]) -> MeasurementInputs:
+    """Load optional sidecar inputs and ensure they apply to the selected methods."""
+    if args.capability_judgments is not None and capabilities.METHOD_NAME not in method_names:
+        raise AuditMeasurementError("--capability-judgments requires --measure capabilities")
+    return MeasurementInputs(capability_judgments=_load_capability_judgments(args.capability_judgments))
+
+
+def _load_capability_judgments(path: Path | None) -> JsonObject | None:
+    """Read and validate optional skill-authored capability judgments."""
+    if path is None:
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise AuditMeasurementError(f"could not read capability judgments at {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise AuditMeasurementError(f"capability judgments at {path} must be a JSON object")
+    _validate_report(
+        payload,
+        schema_path=CAPABILITY_JUDGMENTS_SCHEMA_PATH,
+        label="capability judgments",
+        generated=False,
+    )
+    return payload
+
+
 def _measure_all(
     *,
     audit: JsonObject,
@@ -318,10 +375,18 @@ def _measure_all(
     trajectory: Trajectory,
     subject: Subject,
     method_names: list[str],
+    inputs: MeasurementInputs,
 ) -> list[MeasurementReport]:
     """Fan the shared trajectory into each selected measurement method."""
     return [
-        _measure(audit=audit, audit_path=audit_path, trajectory=trajectory, subject=subject, method_name=method_name)
+        _measure(
+            audit=audit,
+            audit_path=audit_path,
+            trajectory=trajectory,
+            subject=subject,
+            method_name=method_name,
+            inputs=inputs,
+        )
         for method_name in method_names
     ]
 
@@ -333,10 +398,14 @@ def _measure(
     trajectory: Trajectory,
     subject: Subject,
     method_name: str,
+    inputs: MeasurementInputs,
 ) -> MeasurementReport:
     """Wrap one method's raw result in the shared coverage/details envelope."""
     method = METHODS[method_name]
-    measurement = method.measure(audit, trajectory)
+    try:
+        measurement = method.measure(audit, trajectory, inputs)
+    except ValueError as exc:
+        raise AuditMeasurementError(str(exc)) from exc
     audit_info = _audit_info(audit, audit_path)
     subject_info = subject.to_json()
     method_info = {"name": method.name}
@@ -435,8 +504,8 @@ def _details_schema_path(details: JsonObject) -> Path:
     return DETAIL_SCHEMA_PATHS[schema]
 
 
-def _validate_report(report: JsonObject, *, schema_path: Path, label: str) -> None:
-    """Validate generated JSON against the schema committed with the skill."""
+def _validate_report(report: JsonObject, *, schema_path: Path, label: str, generated: bool = True) -> None:
+    """Validate JSON against a schema committed with the skill."""
     try:
         from jsonschema import Draft202012Validator  # ty: ignore[unresolved-import]
         from jsonschema.exceptions import SchemaError  # ty: ignore[unresolved-import]
@@ -457,14 +526,19 @@ def _validate_report(report: JsonObject, *, schema_path: Path, label: str) -> No
         key=lambda error: (list(error.absolute_path), error.message),
     )
     if errors:
+        prefix = f"generated {label} report" if generated else label
         raise AuditMeasurementError(
-            f"generated {label} report failed its JSON Schema: "
+            f"{prefix} failed its JSON Schema: "
             + "\n".join(f"{list(error.absolute_path)}: {error.message}" for error in errors)
         )
 
 
 def _string(value: object) -> str | None:
-    return value if isinstance(value, str) and value else None
+    """Return stripped non-empty strings and drop every other value."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
 
 
 def _json(payload: JsonObject, *, compact: bool) -> str:

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measure.py
@@ -187,6 +187,7 @@ def main(argv: list[str] | None = None) -> int:
         audit = load_audit_spec(args.audit)
         pending_subject = _subject(args)
         loaded_trace = _load_harbor_trajectory(pending_subject.trace_path)
+        _validate_capability_judgment_trace(inputs, loaded_trace)
         subject_info = _finalize_subject(pending_subject, loaded_trace)
         reports = _measure_all(
             audit=audit,
@@ -366,6 +367,19 @@ def _load_capability_judgments(path: Path | None) -> JsonObject | None:
         generated=False,
     )
     return payload
+
+
+def _validate_capability_judgment_trace(inputs: MeasurementInputs, loaded_trace: LoadedTrace) -> None:
+    """Reject a judgment sidecar authored for different ATIF content."""
+    judgments = inputs.capability_judgments
+    if judgments is None:
+        return
+    expected = f"sha256:{loaded_trace.content_sha256}"
+    actual = judgments["trace_sha256"]
+    if actual != expected:
+        raise AuditMeasurementError(
+            f"capability judgments trace_sha256 {actual!r} does not match measured trace {expected!r}"
+        )
 
 
 def _measure_all(

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composite audit coverage for capability items."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, TypeAlias
+
+from measurements.trace_tools import collect_tool_calls, tool_call_counts
+
+try:
+    from harbor.models.trajectories import Trajectory  # ty: ignore[unresolved-import]
+except ImportError:
+    Trajectory = Any  # type: ignore[assignment,misc]
+
+JsonObject: TypeAlias = dict[str, Any]
+
+METHOD_NAME = "capabilities"
+ITEM_KIND = "capability"
+DETAILS_SCHEMA = "nemo.eval_author.audit_capabilities_details.v1"
+JUDGMENTS_SCHEMA = "nemo.eval_author.audit_capability_judgments.v1"
+DETERMINISTIC_EVIDENCE_KINDS = frozenset({"tool_call"})
+JUDGEABLE_EVIDENCE_KINDS = frozenset(
+    {
+        "environment_state",
+        "outcome",
+        "output",
+        "policy_boundary",
+        "state_change",
+        "trace_span",
+        "user_intent",
+        "verifier",
+    }
+)
+EvidenceTarget: TypeAlias = tuple[str, int]
+
+
+def measure(audit: JsonObject, trajectory: Trajectory, *, judgments: JsonObject | None = None) -> JsonObject:
+    """Measure capability items from deterministic trace evidence plus optional judgments."""
+    audit_capabilities = [item for item in audit["items"] if item["kind"] == ITEM_KIND]
+    observed_tool_calls = collect_tool_calls(trajectory)
+    calls_by_tool = _calls_by_tool(observed_tool_calls)
+    judgments_by_target = _judgments_by_target(audit_capabilities, judgments)
+    capability_results = {
+        item["name"]: _capability_result(
+            item,
+            calls_by_tool=calls_by_tool,
+            judgments_by_target=judgments_by_target,
+        )
+        for item in audit_capabilities
+    }
+    covered = [name for name, result in capability_results.items() if result["covered"]]
+    missing = [name for name in capability_results if name not in covered]
+    return {
+        "item_kind": ITEM_KIND,
+        "covered": covered,
+        "details": {
+            "schema": DETAILS_SCHEMA,
+            "item_kind": ITEM_KIND,
+            "audit_capabilities": [item["name"] for item in audit_capabilities],
+            "covered": covered,
+            "missing": missing,
+            "judgment_input": _judgment_input_summary(judgments),
+            "judged_evidence_kinds": _evidence_kinds_with_status(
+                capability_results.values(),
+                statuses={"satisfied", "missing", "unclear"},
+                measurements={"judged"},
+            ),
+            "unjudged_evidence_kinds": _evidence_kinds_with_status(
+                capability_results.values(),
+                statuses={"unjudged"},
+            ),
+            "unsupported_evidence_kinds": _unsupported_evidence_kinds(capability_results.values()),
+            "observed_tool_calls": observed_tool_calls,
+            "tool_call_counts": tool_call_counts(observed_tool_calls),
+            "capability_results": capability_results,
+        },
+    }
+
+
+def _capability_result(
+    item: JsonObject,
+    *,
+    calls_by_tool: dict[str, list[JsonObject]],
+    judgments_by_target: dict[EvidenceTarget, JsonObject],
+) -> JsonObject:
+    """Return per-capability evidence status after applying deterministic and judged evidence."""
+    required_tools = _dedupe_names(item["required_tools"])
+    required_tool_results = [_required_tool_result(tool, calls_by_tool=calls_by_tool) for tool in required_tools]
+    evidence_results = [
+        _evidence_result(
+            item["name"],
+            evidence_index,
+            evidence,
+            calls_by_tool=calls_by_tool,
+            judgments_by_target=judgments_by_target,
+        )
+        for evidence_index, evidence in enumerate(item["evidence_required"])
+    ]
+    missing_reasons = _missing_reasons(
+        required_tool_results=required_tool_results,
+        evidence_results=evidence_results,
+    )
+    return {
+        "name": item["name"],
+        "covered": not missing_reasons,
+        "required_tools": required_tools,
+        "required_tool_results": required_tool_results,
+        "evidence_results": evidence_results,
+        "missing_reasons": missing_reasons,
+    }
+
+
+def _required_tool_result(tool: str, *, calls_by_tool: dict[str, list[JsonObject]]) -> JsonObject:
+    """Return whether a capability's declared required tool appeared in the trace."""
+    matches = calls_by_tool.get(tool, [])
+    return {
+        "tool": tool,
+        "status": "satisfied" if matches else "missing",
+        "matches": matches,
+    }
+
+
+def _evidence_result(
+    capability_name: str,
+    evidence_index: int,
+    evidence: JsonObject,
+    *,
+    calls_by_tool: dict[str, list[JsonObject]],
+    judgments_by_target: dict[EvidenceTarget, JsonObject],
+) -> JsonObject:
+    """Return deterministic or judged status for one evidence requirement."""
+    kind = evidence["kind"]
+    result: JsonObject = {
+        "kind": kind,
+        "evidence_index": evidence_index,
+        "description": evidence["description"],
+    }
+    if kind in DETERMINISTIC_EVIDENCE_KINDS:
+        tool = evidence["tool"]
+        matches = calls_by_tool.get(tool, [])
+        result.update(
+            {
+                "measurement": "deterministic",
+                "tool": tool,
+                "status": "satisfied" if matches else "missing",
+                "matches": matches,
+            }
+        )
+        return result
+
+    if kind in JUDGEABLE_EVIDENCE_KINDS:
+        judgment = judgments_by_target.get((capability_name, evidence_index))
+        if judgment is None:
+            result.update(
+                {
+                    "measurement": "judgment_required",
+                    "status": "unjudged",
+                }
+            )
+            return result
+        result.update(
+            {
+                "measurement": "judged",
+                "status": judgment["status"],
+                "confidence": judgment["confidence"],
+                "rationale": judgment["rationale"],
+            }
+        )
+        if "supporting_trace_refs" in judgment:
+            result["supporting_trace_refs"] = judgment["supporting_trace_refs"]
+        return result
+
+    result["measurement"] = "unsupported"
+    result["status"] = "unsupported"
+    return result
+
+
+def _missing_reasons(
+    *,
+    required_tool_results: list[JsonObject],
+    evidence_results: list[JsonObject],
+) -> list[str]:
+    """Return stable reason codes for why a capability was not covered."""
+    reasons: list[str] = []
+    if any(result["status"] == "missing" for result in required_tool_results):
+        reasons.append("missing_required_tool")
+    if any(result["measurement"] == "deterministic" and result["status"] == "missing" for result in evidence_results):
+        reasons.append("missing_tool_call_evidence")
+    if any(result["status"] == "unjudged" for result in evidence_results):
+        reasons.append("unjudged_evidence")
+    if any(result["measurement"] == "judged" and result["status"] != "satisfied" for result in evidence_results):
+        reasons.append("judged_evidence_not_satisfied")
+    if any(result["status"] == "unsupported" for result in evidence_results):
+        reasons.append("unsupported_evidence_kind")
+    return reasons
+
+
+def _judgments_by_target(
+    audit_capabilities: list[JsonObject], judgments: JsonObject | None
+) -> dict[EvidenceTarget, JsonObject]:
+    """Index capability judgments and reject stale or unsafe targets."""
+    if judgments is None:
+        return {}
+
+    capabilities_by_name = {item["name"]: item for item in audit_capabilities}
+    indexed: dict[EvidenceTarget, JsonObject] = {}
+    errors: list[str] = []
+    for index, judgment in enumerate(judgments["judgments"]):
+        capability_name = judgment["capability"]
+        evidence_index = judgment["evidence_index"]
+        target = (capability_name, evidence_index)
+        capability = capabilities_by_name.get(capability_name)
+        if capability is None:
+            errors.append(f"judgments[{index}] references unknown capability {capability_name!r}")
+            continue
+        evidence_items = capability["evidence_required"]
+        if evidence_index < 0 or evidence_index >= len(evidence_items):
+            errors.append(f"judgments[{index}] references missing evidence index {evidence_index}")
+            continue
+        evidence = evidence_items[evidence_index]
+        if evidence["kind"] in DETERMINISTIC_EVIDENCE_KINDS:
+            errors.append(f"judgments[{index}] targets deterministic evidence kind {evidence['kind']!r}")
+        if evidence["kind"] != judgment["kind"]:
+            errors.append(
+                f"judgments[{index}] kind {judgment['kind']!r} does not match audit evidence kind {evidence['kind']!r}"
+            )
+        if evidence["description"] != judgment["description"]:
+            errors.append(f"judgments[{index}] description does not match audit evidence description")
+        if target in indexed:
+            errors.append(
+                f"judgments[{index}] duplicates capability {capability_name!r} evidence index {evidence_index}"
+            )
+        indexed[target] = judgment
+
+    if errors:
+        raise ValueError("invalid capability judgments:\n" + "\n".join(errors))
+    return indexed
+
+
+def _judgment_input_summary(judgments: JsonObject | None) -> JsonObject:
+    """Return reproducibility metadata about the optional judgment input."""
+    if judgments is None:
+        return {"provided": False, "judgment_count": 0}
+    summary: JsonObject = {
+        "provided": True,
+        "schema": judgments["schema"],
+        "judgment_count": len(judgments["judgments"]),
+    }
+    judged_by = judgments.get("judged_by")
+    if isinstance(judged_by, str) and judged_by.strip():
+        summary["judged_by"] = judged_by.strip()
+    return summary
+
+
+def _evidence_kinds_with_status(
+    results: Iterable[JsonObject],
+    *,
+    statuses: set[str],
+    measurements: set[str] | None = None,
+) -> list[str]:
+    """Return evidence kinds matching status and optional measurement filters."""
+    kinds: list[str] = []
+    for result in results:
+        for evidence in result["evidence_results"]:
+            if evidence["status"] not in statuses:
+                continue
+            if measurements is not None and evidence["measurement"] not in measurements:
+                continue
+            kinds.append(evidence["kind"])
+    return list(dict.fromkeys(kinds))
+
+
+def _unsupported_evidence_kinds(results: Iterable[JsonObject]) -> list[str]:
+    """Return unsupported evidence kinds observed across capability results."""
+    kinds: list[str] = []
+    for result in results:
+        for evidence in result["evidence_results"]:
+            if evidence["status"] == "unsupported":
+                kinds.append(evidence["kind"])
+    return list(dict.fromkeys(kinds))
+
+
+def _dedupe_names(names: Iterable[str]) -> list[str]:
+    """Dedupe declared names while preserving audit order."""
+    return list(dict.fromkeys(names))
+
+
+def _calls_by_tool(tool_calls: list[JsonObject]) -> dict[str, list[JsonObject]]:
+    """Group observed ATIF tool calls by function name."""
+    grouped: dict[str, list[JsonObject]] = {}
+    for call in tool_calls:
+        grouped.setdefault(call["tool"], []).append(call)
+    return grouped

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py
@@ -59,21 +59,9 @@ def measure(audit: JsonObject, trajectory: Trajectory, *, judgments: JsonObject 
         "covered": covered,
         "details": {
             "schema": DETAILS_SCHEMA,
-            "item_kind": ITEM_KIND,
-            "audit_capabilities": [item["name"] for item in audit_capabilities],
             "covered": covered,
             "missing": missing,
             "judgment_input": _judgment_input_summary(judgments),
-            "judged_evidence_kinds": _evidence_kinds_with_status(
-                capability_results.values(),
-                statuses={"satisfied", "missing", "unclear"},
-                measurements={"judged"},
-            ),
-            "unjudged_evidence_kinds": _evidence_kinds_with_status(
-                capability_results.values(),
-                statuses={"unjudged"},
-            ),
-            "unsupported_evidence_kinds": _unsupported_evidence_kinds(capability_results.values()),
             "observed_tool_calls": observed_tool_calls,
             "tool_call_counts": tool_call_counts(observed_tool_calls),
             "capability_results": capability_results,
@@ -105,9 +93,7 @@ def _capability_result(
         evidence_results=evidence_results,
     )
     return {
-        "name": item["name"],
         "covered": not missing_reasons,
-        "required_tools": required_tools,
         "required_tool_results": required_tool_results,
         "evidence_results": evidence_results,
         "missing_reasons": missing_reasons,
@@ -255,34 +241,6 @@ def _judgment_input_summary(judgments: JsonObject | None) -> JsonObject:
     if isinstance(judged_by, str) and judged_by.strip():
         summary["judged_by"] = judged_by.strip()
     return summary
-
-
-def _evidence_kinds_with_status(
-    results: Iterable[JsonObject],
-    *,
-    statuses: set[str],
-    measurements: set[str] | None = None,
-) -> list[str]:
-    """Return evidence kinds matching status and optional measurement filters."""
-    kinds: list[str] = []
-    for result in results:
-        for evidence in result["evidence_results"]:
-            if evidence["status"] not in statuses:
-                continue
-            if measurements is not None and evidence["measurement"] not in measurements:
-                continue
-            kinds.append(evidence["kind"])
-    return list(dict.fromkeys(kinds))
-
-
-def _unsupported_evidence_kinds(results: Iterable[JsonObject]) -> list[str]:
-    """Return unsupported evidence kinds observed across capability results."""
-    kinds: list[str] = []
-    for result in results:
-        for evidence in result["evidence_results"]:
-            if evidence["status"] == "unsupported":
-                kinds.append(evidence["kind"])
-    return list(dict.fromkeys(kinds))
 
 
 def _dedupe_names(names: Iterable[str]) -> list[str]:

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/capabilities.py
@@ -248,6 +248,7 @@ def _judgment_input_summary(judgments: JsonObject | None) -> JsonObject:
     summary: JsonObject = {
         "provided": True,
         "schema": judgments["schema"],
+        "trace_sha256": judgments["trace_sha256"],
         "judgment_count": len(judgments["judgments"]),
     }
     judged_by = judgments.get("judged_by")

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/tool_calls.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/tool_calls.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any, TypeAlias
 
+from measurements.trace_tools import collect_tool_calls, tool_call_counts
+
 try:
     from harbor.models.trajectories import Trajectory  # ty: ignore[unresolved-import]
 except ImportError:
@@ -23,7 +25,7 @@ DETAILS_SCHEMA = "nemo.eval_author.audit_tool_calls_details.v1"
 def measure(audit: JsonObject, trajectory: Trajectory) -> JsonObject:
     """Measure audit tool items against the tool calls present in an ATIF trace."""
     audit_tools = [item["name"] for item in audit["items"] if item["kind"] == ITEM_KIND]
-    observed_tool_calls = _tool_calls(trajectory, trajectory_path="$")
+    observed_tool_calls = collect_tool_calls(trajectory)
     matches = {tool: [call for call in observed_tool_calls if call["tool"] == tool] for tool in audit_tools}
     covered = [tool for tool in audit_tools if matches[tool]]
     missing = [tool for tool in audit_tools if tool not in covered]
@@ -37,45 +39,7 @@ def measure(audit: JsonObject, trajectory: Trajectory) -> JsonObject:
             "covered": covered,
             "missing": missing,
             "observed_tool_calls": observed_tool_calls,
-            "tool_call_counts": _tool_call_counts(observed_tool_calls),
+            "tool_call_counts": tool_call_counts(observed_tool_calls),
             "matches": matches,
         },
     }
-
-
-def _tool_calls(trajectory: Trajectory, *, trajectory_path: str) -> list[JsonObject]:
-    calls: list[JsonObject] = []
-    trajectory_id = _optional_string(trajectory.trajectory_id)
-    for step_index, step in enumerate(trajectory.steps or [], start=1):
-        step_id = step.step_id or step_index
-        for tool_call in step.tool_calls or []:
-            function_name = tool_call.function_name
-            if not isinstance(function_name, str) or not function_name.strip():
-                continue
-            call: JsonObject = {
-                "tool": function_name.strip(),
-                "step_id": step_id,
-                "trajectory_path": trajectory_path,
-            }
-            tool_call_id = _optional_string(getattr(tool_call, "tool_call_id", None))
-            if tool_call_id is not None:
-                call["tool_call_id"] = tool_call_id
-            if trajectory_id is not None:
-                call["trajectory_id"] = trajectory_id
-            calls.append(call)
-
-    for index, subagent in enumerate(trajectory.subagent_trajectories or []):
-        calls.extend(_tool_calls(subagent, trajectory_path=f"{trajectory_path}.subagent_trajectories[{index}]"))
-    return calls
-
-
-def _tool_call_counts(tool_calls: list[JsonObject]) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for call in tool_calls:
-        tool = call["tool"]
-        counts[tool] = counts.get(tool, 0) + 1
-    return counts
-
-
-def _optional_string(value: object) -> str | None:
-    return value if isinstance(value, str) and value else None

--- a/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/trace_tools.py
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/scripts/audit_spec/measurements/trace_tools.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared ATIF trace helpers for deterministic audit measurement."""
+
+from __future__ import annotations
+
+from typing import Any, TypeAlias
+
+try:
+    from harbor.models.trajectories import Trajectory  # ty: ignore[unresolved-import]
+except ImportError:
+    Trajectory = Any  # type: ignore[assignment,misc]
+
+JsonObject: TypeAlias = dict[str, Any]
+
+
+def collect_tool_calls(trajectory: Trajectory, *, trajectory_path: str = "$") -> list[JsonObject]:
+    """Return all ATIF tool calls, including embedded subagent trajectories."""
+    calls: list[JsonObject] = []
+    trajectory_id = optional_string(trajectory.trajectory_id)
+    for step_index, step in enumerate(trajectory.steps or [], start=1):
+        step_id = step.step_id or step_index
+        for tool_call in step.tool_calls or []:
+            function_name = tool_call.function_name
+            if not isinstance(function_name, str) or not function_name.strip():
+                continue
+            call: JsonObject = {
+                "tool": function_name.strip(),
+                "step_id": step_id,
+                "trajectory_path": trajectory_path,
+            }
+            tool_call_id = optional_string(getattr(tool_call, "tool_call_id", None))
+            if tool_call_id is not None:
+                call["tool_call_id"] = tool_call_id
+            if trajectory_id is not None:
+                call["trajectory_id"] = trajectory_id
+            calls.append(call)
+
+    for index, subagent in enumerate(trajectory.subagent_trajectories or []):
+        calls.extend(collect_tool_calls(subagent, trajectory_path=f"{trajectory_path}.subagent_trajectories[{index}]"))
+    return calls
+
+
+def tool_call_counts(tool_calls: list[JsonObject]) -> dict[str, int]:
+    """Return observed tool call counts keyed by tool name."""
+    counts: dict[str, int] = {}
+    for call in tool_calls:
+        tool = call["tool"]
+        counts[tool] = counts.get(tool, 0) + 1
+    return counts
+
+
+def optional_string(value: object) -> str | None:
+    """Return stripped non-empty strings and drop every other value."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -78,10 +78,15 @@ _AUDIT_TEMPLATE = _AUDIT_DIR / "templates" / "audit.md"
 _AUDIT_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit.schema.json"
 _AUDIT_COVERAGE_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_coverage.schema.json"
 _AUDIT_COVERAGE_REPORT_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_coverage_report.schema.json"
+_AUDIT_CAPABILITY_JUDGMENTS_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_capability_judgments.schema.json"
+_AUDIT_CAPABILITIES_DETAILS_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_capabilities_details.schema.json"
 _AUDIT_TOOL_CALLS_DETAILS_JSON_SCHEMA = _AUDIT_DIR / "schemas" / "audit_tool_calls_details.schema.json"
-_AUDIT_COVERAGE_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "tool_calls.coverage.json"
+_AUDIT_TOOL_CALLS_COVERAGE_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "tool_calls.coverage.json"
+_AUDIT_CAPABILITIES_COVERAGE_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "capabilities.coverage.json"
+_AUDIT_CAPABILITY_JUDGMENTS_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "capability_judgments.json"
 _AUDIT_COVERAGE_REPORT_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "coverage_report.json"
 _AUDIT_TOOL_CALLS_DETAILS_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "tool_calls.details.json"
+_AUDIT_CAPABILITIES_DETAILS_EXAMPLE = _AUDIT_DIR / "examples" / "schemas" / "capabilities.details.json"
 _MLFLOW_TO_ATIF = _MLFLOW_TO_ATIF_SCRIPTS_DIR / "convert_mlflow_to_atif.py"
 
 _REQUIRED_FRONTMATTER = (
@@ -363,6 +368,50 @@ def _write_audit(tmp_path: Path, transform: Callable[[str], str] | None = None) 
         text = transform(text)
     audit.write_text(text, encoding="utf-8")
     return audit
+
+
+def _without_user_intent_evidence(text: str) -> str:
+    """Make the template capability coverable by deterministic tool-call evidence only."""
+    return text.replace(
+        "      - kind: user_intent\n        description: User is trying to recover account access.\n",
+        "",
+        1,
+    )
+
+
+def _write_capability_judgments(
+    path: Path,
+    *,
+    capability: str = "account_recovery",
+    evidence_index: int = 0,
+    kind: str = "user_intent",
+    description: str = "User is trying to recover account access.",
+    status: str = "satisfied",
+    confidence: str = "high",
+) -> None:
+    """Write a skill-authored capability judgment sidecar."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "nemo.eval_author.audit_capability_judgments.v1",
+                "judged_by": "eval-author-audit skill",
+                "judgments": [
+                    {
+                        "capability": capability,
+                        "evidence_index": evidence_index,
+                        "kind": kind,
+                        "description": description,
+                        "status": status,
+                        "confidence": confidence,
+                        "rationale": "The trace shows the user asking for help recovering account access.",
+                        "supporting_trace_refs": ["$.steps[0].message"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 def _run_script(script: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -1035,8 +1084,11 @@ def test_mlflow_to_atif_output_validates_with_harbor(tmp_path: Path) -> None:
     assert summary["validated_with_harbor"] is True
 
 
-def test_every_audit_spec_path_the_skill_names_exists() -> None:
-    _, body = _frontmatter_and_body(_AUDIT_DIR)
+def test_every_audit_spec_path_the_skill_or_reference_readme_names_exists() -> None:
+    _, skill_body = _frontmatter_and_body(_AUDIT_DIR)
+    readme_body = (_AUDIT_DIR / "scripts" / "audit_spec" / "README.md").read_text(encoding="utf-8")
+    docs = f"{skill_body}\n{readme_body}"
+    assert "scripts/audit_spec/README.md" in skill_body
     for relative in (
         "scripts/audit_spec/README.md",
         "scripts/audit_spec/generate.py",
@@ -1045,19 +1097,26 @@ def test_every_audit_spec_path_the_skill_names_exists() -> None:
         "scripts/audit_spec/validate.py",
         "scripts/audit_spec/_schema.py",
         "scripts/audit_spec/_markdown.py",
+        "scripts/audit_spec/measurements/capabilities.py",
+        "scripts/audit_spec/measurements/trace_tools.py",
         "scripts/audit_spec/measurements/tool_calls.py",
         "schemas/audit.schema.json",
+        "schemas/audit_capability_judgments.schema.json",
+        "schemas/audit_capabilities_details.schema.json",
         "schemas/audit_coverage.schema.json",
         "schemas/audit_coverage_report.schema.json",
         "schemas/audit_tool_calls_details.schema.json",
+        "examples/schemas/capability_judgments.json",
+        "examples/schemas/capabilities.coverage.json",
+        "examples/schemas/capabilities.details.json",
         "examples/schemas/coverage_report.json",
         "examples/schemas/tool_calls.coverage.json",
         "examples/schemas/tool_calls.details.json",
         "requirements.txt",
         "templates/audit.md",
     ):
-        assert relative in body, f"SKILL.md no longer documents {relative}"
-        assert (_AUDIT_DIR / relative).exists(), f"SKILL.md names {relative}, which is missing on disk"
+        assert relative in docs, f"audit docs no longer document {relative}"
+        assert (_AUDIT_DIR / relative).exists(), f"audit docs name {relative}, which is missing on disk"
 
 
 def test_audit_skill_reads_schema_before_drafting_items() -> None:
@@ -1139,6 +1198,8 @@ def test_audit_json_schema_is_valid() -> None:
     (
         _AUDIT_COVERAGE_JSON_SCHEMA,
         _AUDIT_COVERAGE_REPORT_JSON_SCHEMA,
+        _AUDIT_CAPABILITY_JUDGMENTS_JSON_SCHEMA,
+        _AUDIT_CAPABILITIES_DETAILS_JSON_SCHEMA,
         _AUDIT_TOOL_CALLS_DETAILS_JSON_SCHEMA,
     ),
 )
@@ -1151,9 +1212,12 @@ def test_audit_measurement_json_schemas_are_valid(schema_path: Path) -> None:
 @pytest.mark.parametrize(
     ("schema_path", "example_path"),
     (
-        (_AUDIT_COVERAGE_JSON_SCHEMA, _AUDIT_COVERAGE_EXAMPLE),
+        (_AUDIT_COVERAGE_JSON_SCHEMA, _AUDIT_TOOL_CALLS_COVERAGE_EXAMPLE),
+        (_AUDIT_COVERAGE_JSON_SCHEMA, _AUDIT_CAPABILITIES_COVERAGE_EXAMPLE),
         (_AUDIT_COVERAGE_REPORT_JSON_SCHEMA, _AUDIT_COVERAGE_REPORT_EXAMPLE),
+        (_AUDIT_CAPABILITY_JUDGMENTS_JSON_SCHEMA, _AUDIT_CAPABILITY_JUDGMENTS_EXAMPLE),
         (_AUDIT_TOOL_CALLS_DETAILS_JSON_SCHEMA, _AUDIT_TOOL_CALLS_DETAILS_EXAMPLE),
+        (_AUDIT_CAPABILITIES_DETAILS_JSON_SCHEMA, _AUDIT_CAPABILITIES_DETAILS_EXAMPLE),
     ),
 )
 def test_audit_measurement_schema_examples_validate(schema_path: Path, example_path: Path) -> None:
@@ -1163,6 +1227,40 @@ def test_audit_measurement_schema_examples_validate(schema_path: Path, example_p
     example = json.loads(example_path.read_text(encoding="utf-8"))
 
     Draft202012Validator(schema).validate(example)
+
+
+def test_audit_capabilities_details_schema_rejects_invalid_measurement_status_pair() -> None:
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import ValidationError
+
+    schema = json.loads(_AUDIT_CAPABILITIES_DETAILS_JSON_SCHEMA.read_text(encoding="utf-8"))
+    example = json.loads(_AUDIT_CAPABILITIES_DETAILS_EXAMPLE.read_text(encoding="utf-8"))
+    example["capability_results"]["account_recovery"]["evidence_results"][1]["status"] = "unjudged"
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(example)
+
+
+@pytest.mark.parametrize(
+    ("covered", "missing_reasons"),
+    (
+        (True, ["missing_required_tool"]),
+        (False, []),
+    ),
+)
+def test_audit_capabilities_details_schema_rejects_inconsistent_covered_reasons(
+    covered: bool, missing_reasons: list[str]
+) -> None:
+    from jsonschema import Draft202012Validator
+    from jsonschema.exceptions import ValidationError
+
+    schema = json.loads(_AUDIT_CAPABILITIES_DETAILS_JSON_SCHEMA.read_text(encoding="utf-8"))
+    example = json.loads(_AUDIT_CAPABILITIES_DETAILS_EXAMPLE.read_text(encoding="utf-8"))
+    example["capability_results"]["account_recovery"]["covered"] = covered
+    example["capability_results"]["account_recovery"]["missing_reasons"] = missing_reasons
+
+    with pytest.raises(ValidationError):
+        Draft202012Validator(schema).validate(example)
 
 
 def test_audit_file_with_matching_source_digest_validates(tmp_path: Path) -> None:
@@ -1966,6 +2064,433 @@ def test_audit_measure_reports_missing_tool_calls_as_not_covered(tmp_path: Path)
 
 
 @_needs_harbor
+def test_audit_measure_omits_whitespace_only_optional_trace_identifiers(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    trace = tmp_path / "trajectory.json"
+    trace.write_text(
+        json.dumps(
+            {
+                "schema_version": "ATIF-v1.7",
+                "session_id": "   ",
+                "trajectory_id": "   ",
+                "agent": {"name": "example-agent", "version": "1.0.0"},
+                "steps": [
+                    {"step_id": 1, "source": "user", "message": "Help me recover my account."},
+                    {
+                        "step_id": 2,
+                        "source": "agent",
+                        "message": "I will inspect the account.",
+                        "tool_calls": [
+                            {"tool_call_id": "   ", "function_name": "  customer.lookup  ", "arguments": {}}
+                        ],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    assert summary["run_id"].startswith("trace-sha256-")
+    measurement_dir = _measurement_dir(out_dir, "account-recovery", summary["run_id"])
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+
+    assert details["covered"] == ["customer.lookup"]
+    assert details["matches"]["customer.lookup"] == [
+        {
+            "step_id": 2,
+            "tool": "customer.lookup",
+            "trajectory_path": "$",
+        }
+    ]
+
+
+@_needs_harbor
+def test_audit_measure_reports_capability_coverage_from_tool_call_evidence(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path, _without_user_intent_evidence)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "capabilities",
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="capabilities")
+    coverage = json.loads((measurement_dir / "coverage.json").read_text(encoding="utf-8"))
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    capability = details["capability_results"]["account_recovery"]
+
+    assert summary["methods"] == ["capabilities"]
+    assert summary["measurements"][0]["item_kind"] == "capability"
+    assert summary["measurements"][0]["covered"] == ["account_recovery"]
+    assert coverage["method"] == {"name": "capabilities"}
+    assert coverage["item_kind"] == "capability"
+    assert coverage["item_kind_count"] == 1
+    assert coverage["covered"] == ["account_recovery"]
+    assert details["schema"] == "nemo.eval_author.audit_capabilities_details.v1"
+    assert details["audit_capabilities"] == ["account_recovery"]
+    assert details["covered"] == ["account_recovery"]
+    assert details["missing"] == []
+    assert details["judgment_input"] == {"provided": False, "judgment_count": 0}
+    assert details["judged_evidence_kinds"] == []
+    assert details["unjudged_evidence_kinds"] == []
+    assert details["unsupported_evidence_kinds"] == []
+    assert details["tool_call_counts"] == {"customer.lookup": 1}
+    assert capability["covered"] is True
+    assert capability["missing_reasons"] == []
+    assert capability["required_tool_results"] == [
+        {
+            "tool": "customer.lookup",
+            "status": "satisfied",
+            "matches": [
+                {
+                    "step_id": 2,
+                    "tool": "customer.lookup",
+                    "tool_call_id": "root-call-1",
+                    "trajectory_id": "root-trajectory",
+                    "trajectory_path": "$",
+                }
+            ],
+        }
+    ]
+    assert capability["evidence_results"] == [
+        {
+            "kind": "tool_call",
+            "evidence_index": 0,
+            "description": "Agent grounds the request in customer profile data.",
+            "tool": "customer.lookup",
+            "measurement": "deterministic",
+            "status": "satisfied",
+            "matches": [
+                {
+                    "step_id": 2,
+                    "tool": "customer.lookup",
+                    "tool_call_id": "root-call-1",
+                    "trajectory_id": "root-trajectory",
+                    "trajectory_path": "$",
+                }
+            ],
+        }
+    ]
+
+
+@_needs_harbor
+def test_audit_measure_reports_capability_missing_required_tool(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path, _without_user_intent_evidence)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["ticket.create"])
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "capabilities",
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="capabilities")
+    coverage = json.loads((measurement_dir / "coverage.json").read_text(encoding="utf-8"))
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    capability = details["capability_results"]["account_recovery"]
+
+    assert summary["measurements"][0]["covered"] == []
+    assert coverage["covered"] == []
+    assert details["covered"] == []
+    assert details["missing"] == ["account_recovery"]
+    assert details["tool_call_counts"] == {"ticket.create": 1}
+    assert capability["covered"] is False
+    assert capability["required_tool_results"][0]["status"] == "missing"
+    assert capability["evidence_results"][0]["status"] == "missing"
+    assert capability["missing_reasons"] == ["missing_required_tool", "missing_tool_call_evidence"]
+
+
+@_needs_harbor
+def test_audit_measure_dedupes_capability_required_tools(tmp_path: Path) -> None:
+    audit = _write_audit(
+        tmp_path,
+        lambda text: _without_user_intent_evidence(text).replace(
+            "    required_tools:\n      - customer.lookup\n",
+            "    required_tools:\n      - customer.lookup\n      - customer.lookup\n",
+            1,
+        ),
+    )
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "capabilities",
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="capabilities")
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    capability = details["capability_results"]["account_recovery"]
+
+    assert capability["required_tools"] == ["customer.lookup"]
+    assert len(capability["required_tool_results"]) == 1
+    assert capability["covered"] is True
+
+
+@_needs_harbor
+def test_audit_measure_reports_capability_unjudged_evidence_without_covering(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "capabilities",
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="capabilities")
+    coverage = json.loads((measurement_dir / "coverage.json").read_text(encoding="utf-8"))
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    capability = details["capability_results"]["account_recovery"]
+
+    assert summary["measurements"][0]["covered"] == []
+    assert coverage["covered"] == []
+    assert details["covered"] == []
+    assert details["missing"] == ["account_recovery"]
+    assert details["judgment_input"] == {"provided": False, "judgment_count": 0}
+    assert details["judged_evidence_kinds"] == []
+    assert details["unjudged_evidence_kinds"] == ["user_intent"]
+    assert details["unsupported_evidence_kinds"] == []
+    assert capability["covered"] is False
+    assert capability["required_tool_results"][0]["status"] == "satisfied"
+    assert capability["evidence_results"][0] == {
+        "kind": "user_intent",
+        "evidence_index": 0,
+        "description": "User is trying to recover account access.",
+        "measurement": "judgment_required",
+        "status": "unjudged",
+    }
+    assert capability["evidence_results"][1]["status"] == "satisfied"
+    assert capability["evidence_results"][1]["measurement"] == "deterministic"
+    assert capability["missing_reasons"] == ["unjudged_evidence"]
+
+
+@_needs_harbor
+def test_audit_measure_uses_capability_judgments_for_non_tool_evidence(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    judgments = tmp_path / ".eval-author" / "capability-judgments.json"
+    _write_capability_judgments(judgments)
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "capabilities",
+        "--capability-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="capabilities")
+    coverage = json.loads((measurement_dir / "coverage.json").read_text(encoding="utf-8"))
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    capability = details["capability_results"]["account_recovery"]
+
+    assert summary["measurements"][0]["covered"] == ["account_recovery"]
+    assert coverage["covered"] == ["account_recovery"]
+    assert details["covered"] == ["account_recovery"]
+    assert details["missing"] == []
+    assert details["judgment_input"] == {
+        "provided": True,
+        "schema": "nemo.eval_author.audit_capability_judgments.v1",
+        "judged_by": "eval-author-audit skill",
+        "judgment_count": 1,
+    }
+    assert details["judged_evidence_kinds"] == ["user_intent"]
+    assert details["unjudged_evidence_kinds"] == []
+    assert details["unsupported_evidence_kinds"] == []
+    assert capability["covered"] is True
+    assert capability["missing_reasons"] == []
+    assert capability["evidence_results"][0] == {
+        "kind": "user_intent",
+        "evidence_index": 0,
+        "description": "User is trying to recover account access.",
+        "measurement": "judged",
+        "status": "satisfied",
+        "confidence": "high",
+        "rationale": "The trace shows the user asking for help recovering account access.",
+        "supporting_trace_refs": ["$.steps[0].message"],
+    }
+    assert capability["evidence_results"][1]["measurement"] == "deterministic"
+    assert capability["evidence_results"][1]["status"] == "satisfied"
+
+
+@_needs_harbor
+def test_audit_measure_capability_judgment_does_not_override_missing_tool_evidence(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace)
+    judgments = tmp_path / ".eval-author" / "capability-judgments.json"
+    _write_capability_judgments(judgments)
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "capabilities",
+        "--capability-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    measurement_dir = _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="capabilities")
+    coverage = json.loads((measurement_dir / "coverage.json").read_text(encoding="utf-8"))
+    details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
+    capability = details["capability_results"]["account_recovery"]
+
+    assert coverage["covered"] == []
+    assert details["covered"] == []
+    assert capability["covered"] is False
+    assert capability["required_tool_results"][0]["status"] == "missing"
+    assert capability["evidence_results"][0]["status"] == "satisfied"
+    assert capability["evidence_results"][0]["measurement"] == "judged"
+    assert capability["evidence_results"][1]["status"] == "missing"
+    assert capability["evidence_results"][1]["measurement"] == "deterministic"
+    assert capability["missing_reasons"] == ["missing_required_tool", "missing_tool_call_evidence"]
+
+
+@_needs_harbor
+def test_audit_measure_rejects_stale_capability_judgments_without_writing(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    judgments = tmp_path / ".eval-author" / "capability-judgments.json"
+    _write_capability_judgments(judgments, description="Old user-intent wording.")
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, report, _ = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "capabilities",
+        "--capability-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 1
+    assert report["valid"] is True
+    assert report["written"] is False
+    assert report["error_type"] == "measurement"
+    assert "description does not match audit evidence description" in report["error"]
+    assert not out_dir.exists()
+
+
+@_needs_harbor
+def test_audit_measure_batches_tool_call_and_capability_methods(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path, _without_user_intent_evidence)
+    trace = tmp_path / "trajectory.json"
+    _write_atif_trace(trace, tool_calls=["customer.lookup"])
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "tool_calls,capabilities",
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 0, stderr or summary
+    assert summary["methods"] == ["tool_calls", "capabilities"]
+    assert summary["measurements"][0]["item_kind"] == "tool"
+    assert summary["measurements"][1]["item_kind"] == "capability"
+    assert (_measurement_dir(out_dir, "account-recovery", "root-trajectory") / "coverage.json").exists()
+    assert (
+        _measurement_dir(out_dir, "account-recovery", "root-trajectory", method="capabilities") / "coverage.json"
+    ).exists()
+
+
+@_needs_harbor
 def test_audit_measure_reads_harbor_trial_metadata(tmp_path: Path) -> None:
     audit = _write_audit(tmp_path)
     trial_dir = tmp_path / "job" / "account-recovery__abc"
@@ -2151,6 +2676,66 @@ def test_audit_measure_rejects_unknown_measurement_method_before_trace_load(tmp_
     assert not out_dir.exists()
 
 
+def test_audit_measure_rejects_capability_judgments_without_capability_method(tmp_path: Path) -> None:
+    judgments = tmp_path / ".eval-author" / "capability-judgments.json"
+    _write_capability_judgments(judgments)
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, report, _ = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(tmp_path / "missing-audit.md"),
+        "--trace",
+        str(tmp_path / "missing-trace.json"),
+        "--measure",
+        "tool_calls",
+        "--capability-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 1
+    assert report["valid"] is True
+    assert report["written"] is False
+    assert report["error_type"] == "measurement"
+    assert "--capability-judgments requires --measure capabilities" in report["error"]
+    assert not out_dir.exists()
+
+
+def test_audit_measure_rejects_tool_call_capability_judgments_before_trace_load(tmp_path: Path) -> None:
+    judgments = tmp_path / ".eval-author" / "capability-judgments.json"
+    _write_capability_judgments(
+        judgments,
+        evidence_index=1,
+        kind="tool_call",
+        description="Agent grounds the request in customer profile data.",
+    )
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, report, _ = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(tmp_path / "missing-audit.md"),
+        "--trace",
+        str(tmp_path / "missing-trace.json"),
+        "--measure",
+        "capabilities",
+        "--capability-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 1
+    assert report["valid"] is True
+    assert report["written"] is False
+    assert report["error_type"] == "measurement"
+    assert "capability judgments failed its JSON Schema" in report["error"]
+    assert "tool_call" in report["error"]
+    assert not out_dir.exists()
+
+
 @pytest.mark.parametrize("measure_value", ("", ",,"))
 def test_audit_measure_rejects_empty_measure_selection_before_trace_load(tmp_path: Path, measure_value: str) -> None:
     out_dir = tmp_path / ".eval-author" / "audit-measurements"
@@ -2195,7 +2780,7 @@ def test_audit_measure_reports_write_failures_as_environment_json(
         measure_module.MeasurementMethod(
             name="tool_calls",
             details_schema="test.details",
-            measure=lambda audit, trajectory: {
+            measure=lambda audit, trajectory, inputs: {
                 "item_kind": "tool",
                 "covered": [],
                 "details": {"schema": "test.details"},
@@ -2251,7 +2836,7 @@ def test_audit_measure_reports_unknown_method_item_kind_as_measurement_json(
         measure_module.MeasurementMethod(
             name="boundary",
             details_schema="test.details",
-            measure=lambda audit, trajectory: {"item_kind": "boundary", "covered": [], "details": {}},
+            measure=lambda audit, trajectory, inputs: {"item_kind": "boundary", "covered": [], "details": {}},
         ),
     )
 
@@ -2375,6 +2960,50 @@ def test_audit_report_aggregates_coverage_and_formats_generation_gaps(tmp_path: 
     assert (
         "identity is not verified" in gaps_by_name["account_recovery_unverified_identity"]["audit_item"]["description"]
     )
+
+
+def test_audit_report_aggregates_capability_coverage(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    coverage_dir = tmp_path / ".eval-author" / "audit-measurements"
+    tool_coverage_path = _measurement_dir(coverage_dir, "account-recovery", "trial-001") / "coverage.json"
+    capability_coverage_path = (
+        _measurement_dir(coverage_dir, "account-recovery", "trial-001", method="capabilities") / "coverage.json"
+    )
+    _write_coverage(tool_coverage_path, audit=audit, covered=["customer.lookup"])
+    _write_coverage(
+        capability_coverage_path,
+        audit=audit,
+        item_kind="capability",
+        method="capabilities",
+        covered=["account_recovery"],
+    )
+    out = tmp_path / ".eval-author" / "audit-coverage-report.json"
+
+    code, summary, stderr = _run_json_script(
+        _AUDIT_REPORT,
+        "--audit",
+        str(audit),
+        "--coverage-dir",
+        str(coverage_dir),
+        "--out",
+        str(out),
+    )
+
+    report = json.loads(out.read_text(encoding="utf-8"))
+    gaps_by_name = {item["name"]: item for item in report["uncovered_items"]}
+
+    assert code == 0, stderr or summary
+    assert summary["measured_kinds"] == ["capability", "tool"]
+    assert summary["covered_count"] == 2
+    assert summary["uncovered"] == ["account_recovery_unverified_identity"]
+    assert report["covered"] == ["customer.lookup", "account_recovery"]
+    assert report["coverage"]["by_kind"]["capability"] == {
+        "item_count": 1,
+        "covered_count": 1,
+        "uncovered_count": 0,
+    }
+    assert "account_recovery" not in gaps_by_name
+    assert gaps_by_name["account_recovery_unverified_identity"]["reason"] == "not_measured_by_any_method"
 
 
 def test_audit_report_dedupes_generation_needed_tools(tmp_path: Path) -> None:

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -382,6 +382,7 @@ def _without_user_intent_evidence(text: str) -> str:
 def _write_capability_judgments(
     path: Path,
     *,
+    trace: Path | None = None,
     capability: str = "account_recovery",
     evidence_index: int = 0,
     kind: str = "user_intent",
@@ -395,6 +396,7 @@ def _write_capability_judgments(
         json.dumps(
             {
                 "schema": "nemo.eval_author.audit_capability_judgments.v1",
+                "trace_sha256": _digest(trace) if trace is not None else "sha256:" + ("0" * 64),
                 "judged_by": "eval-author-audit skill",
                 "judgments": [
                     {
@@ -2330,7 +2332,7 @@ def test_audit_measure_uses_capability_judgments_for_non_tool_evidence(tmp_path:
     trace = tmp_path / "trajectory.json"
     _write_atif_trace(trace, tool_calls=["customer.lookup"])
     judgments = tmp_path / ".eval-author" / "capability-judgments.json"
-    _write_capability_judgments(judgments)
+    _write_capability_judgments(judgments, trace=trace)
     out_dir = tmp_path / ".eval-author" / "audit-measurements"
 
     code, summary, stderr = _run_json_script(
@@ -2362,6 +2364,7 @@ def test_audit_measure_uses_capability_judgments_for_non_tool_evidence(tmp_path:
     assert details["judgment_input"] == {
         "provided": True,
         "schema": "nemo.eval_author.audit_capability_judgments.v1",
+        "trace_sha256": _digest(trace),
         "judged_by": "eval-author-audit skill",
         "judgment_count": 1,
     }
@@ -2390,7 +2393,7 @@ def test_audit_measure_capability_judgment_does_not_override_missing_tool_eviden
     trace = tmp_path / "trajectory.json"
     _write_atif_trace(trace)
     judgments = tmp_path / ".eval-author" / "capability-judgments.json"
-    _write_capability_judgments(judgments)
+    _write_capability_judgments(judgments, trace=trace)
     out_dir = tmp_path / ".eval-author" / "audit-measurements"
 
     code, summary, stderr = _run_json_script(
@@ -2432,7 +2435,7 @@ def test_audit_measure_rejects_stale_capability_judgments_without_writing(tmp_pa
     trace = tmp_path / "trajectory.json"
     _write_atif_trace(trace, tool_calls=["customer.lookup"])
     judgments = tmp_path / ".eval-author" / "capability-judgments.json"
-    _write_capability_judgments(judgments, description="Old user-intent wording.")
+    _write_capability_judgments(judgments, trace=trace, description="Old user-intent wording.")
     out_dir = tmp_path / ".eval-author" / "audit-measurements"
 
     code, report, _ = _run_json_script(
@@ -2456,6 +2459,41 @@ def test_audit_measure_rejects_stale_capability_judgments_without_writing(tmp_pa
     assert report["written"] is False
     assert report["error_type"] == "measurement"
     assert "description does not match audit evidence description" in report["error"]
+    assert not out_dir.exists()
+
+
+@_needs_harbor
+def test_audit_measure_rejects_capability_judgments_from_another_trace(tmp_path: Path) -> None:
+    audit = _write_audit(tmp_path)
+    judged_trace = tmp_path / "judged-trajectory.json"
+    _write_atif_trace(judged_trace, tool_calls=["customer.lookup"])
+    judgments = tmp_path / ".eval-author" / "capability-judgments.json"
+    _write_capability_judgments(judgments, trace=judged_trace)
+    measured_trace = tmp_path / "measured-trajectory.json"
+    _write_atif_trace(measured_trace, tool_calls=["customer.lookup"], trajectory_id="different-trajectory")
+    out_dir = tmp_path / ".eval-author" / "audit-measurements"
+
+    code, report, _ = _run_json_script(
+        _AUDIT_MEASURE,
+        "--audit",
+        str(audit),
+        "--trace",
+        str(measured_trace),
+        "--task-id",
+        "account-recovery",
+        "--measure",
+        "capabilities",
+        "--capability-judgments",
+        str(judgments),
+        "--out-dir",
+        str(out_dir),
+    )
+
+    assert code == 1
+    assert report["valid"] is True
+    assert report["written"] is False
+    assert report["error_type"] == "measurement"
+    assert "does not match measured trace" in report["error"]
     assert not out_dir.exists()
 
 

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -2155,13 +2155,9 @@ def test_audit_measure_reports_capability_coverage_from_tool_call_evidence(tmp_p
     assert coverage["item_kind_count"] == 1
     assert coverage["covered"] == ["account_recovery"]
     assert details["schema"] == "nemo.eval_author.audit_capabilities_details.v1"
-    assert details["audit_capabilities"] == ["account_recovery"]
     assert details["covered"] == ["account_recovery"]
     assert details["missing"] == []
     assert details["judgment_input"] == {"provided": False, "judgment_count": 0}
-    assert details["judged_evidence_kinds"] == []
-    assert details["unjudged_evidence_kinds"] == []
-    assert details["unsupported_evidence_kinds"] == []
     assert details["tool_call_counts"] == {"customer.lookup": 1}
     assert capability["covered"] is True
     assert capability["missing_reasons"] == []
@@ -2272,8 +2268,8 @@ def test_audit_measure_dedupes_capability_required_tools(tmp_path: Path) -> None
     details = json.loads((measurement_dir / "details.json").read_text(encoding="utf-8"))
     capability = details["capability_results"]["account_recovery"]
 
-    assert capability["required_tools"] == ["customer.lookup"]
     assert len(capability["required_tool_results"]) == 1
+    assert capability["required_tool_results"][0]["tool"] == "customer.lookup"
     assert capability["covered"] is True
 
 
@@ -2309,9 +2305,6 @@ def test_audit_measure_reports_capability_unjudged_evidence_without_covering(tmp
     assert details["covered"] == []
     assert details["missing"] == ["account_recovery"]
     assert details["judgment_input"] == {"provided": False, "judgment_count": 0}
-    assert details["judged_evidence_kinds"] == []
-    assert details["unjudged_evidence_kinds"] == ["user_intent"]
-    assert details["unsupported_evidence_kinds"] == []
     assert capability["covered"] is False
     assert capability["required_tool_results"][0]["status"] == "satisfied"
     assert capability["evidence_results"][0] == {
@@ -2368,9 +2361,6 @@ def test_audit_measure_uses_capability_judgments_for_non_tool_evidence(tmp_path:
         "judged_by": "eval-author-audit skill",
         "judgment_count": 1,
     }
-    assert details["judged_evidence_kinds"] == ["user_intent"]
-    assert details["unjudged_evidence_kinds"] == []
-    assert details["unsupported_evidence_kinds"] == []
     assert capability["covered"] is True
     assert capability["missing_reasons"] == []
     assert capability["evidence_results"][0] == {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Adds composite capability coverage measurement for eval-author audit specs. Capability items are measured from deterministic ATIF evidence for required tools and `tool_call` evidence, plus an optional skill-authored judgment sidecar for non-tool evidence such as `user_intent`, `output`, `outcome`, `policy_boundary`, and `verifier`.

Deterministic requirements remain hard gates. Subjective judgments can satisfy only their targeted non-tool evidence, cannot override missing tool evidence, and are bound to the exact inspected trace by SHA-256 so they cannot be reused for another run.

## Changes
- Add the `capabilities` measurement method and register it in `measure.py`.
- Add `--capability-judgments` input validation for structured, local skill-authored non-tool evidence judgments.
- Reject stale or unsafe judgments by matching capability name, zero-based evidence index, evidence kind, exact evidence description, and exact ATIF content digest.
- Report deterministic, judged, unjudged, and unsupported evidence statuses in capability details.
- Share recursive ATIF tool-call extraction between tool and capability measurement.
- Add capability details and capability judgment schemas/examples.
- Simplify capability details to one per-capability source of truth while retaining useful coverage summaries and tool-call diagnostics.
- Update eval-author audit documentation and contract tests for capability measurement, judgment sidecars, trace binding, and aggregation.
- Address automated review feedback by normalizing optional trace/tool-call identifiers, keeping deterministic examples within measured semantics, enforcing consistent schema states, and classifying actionable gaps by measurement reason.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Current PR head is `87e17ea4bdd8b8e4074eabda9326ef9b1eae4a7a`; refreshed canonical base is `ba499d403d772236aa126fa5ba98a5b581b0afb9`.
- `uv run --frozen pytest plugins/nemo-eval-author/tests/test_skill_contract.py -v` — passed, `153 passed`.
- `uv run --frozen ruff check` on the four changed measurement modules and `test_skill_contract.py` — passed.
- `uv run --frozen ruff format --check` on the four changed measurement modules and `test_skill_contract.py` — passed, `5 files already formatted`.
- `git diff --check origin/main...HEAD` — passed.
- DCO audit over `origin/main..HEAD` — passed for all four PR commits.
- `uv run --frozen pre-commit run -a` — passed with the repository-pinned `uv 0.9.14`, `yq 4.53.3`, and `helm-docs 1.14.2` toolchain.

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->
