### PR TITLE
feat(studio): graph an experiment's metrics over time on its detail page (ASTD-494)

### DIFF
--- a/web/packages/studio/src/components/ExperimentEditModal/index.test.tsx
+++ b/web/packages/studio/src/components/ExperimentEditModal/index.test.tsx
@@ -23,8 +23,6 @@ const group: ExperimentResponse = {
   evaluation_count: 0,
 };
 
-const TREND_KEY = `nemo-studio:experiment-trend:${group.id}`;
-
 describe('ExperimentEditModal', () => {
   it('resends the fields it does not edit, which a full-replace update would otherwise clear', async () => {
     let body: Record<string, unknown> | undefined;
@@ -62,7 +60,9 @@ describe('ExperimentEditModal', () => {
     });
   });
 
-  describe('over-time flag and the chart visibility a viewer stored', () => {
+  describe('the chart choice a viewer stored', () => {
+    const TREND_KEY = `nemo-studio:experiment-trend:${group.id}`;
+
     const mockRequests = () => {
       let saved = false;
       server.use(
@@ -90,10 +90,10 @@ describe('ExperimentEditModal', () => {
       window.localStorage.clear();
     });
 
-    it('drops the stored choice when the flag is flipped, so the new flag decides', async () => {
+    it('drops it when the over-time flag is flipped, so the owner edit is not a no-op', async () => {
       const isSaved = mockRequests();
-      // A viewer who had hidden the chart on an unflagged experiment.
-      window.localStorage.setItem(TREND_KEY, 'false');
+      // Stamped against the flag's current value, so it would otherwise survive a round trip.
+      window.localStorage.setItem(TREND_KEY, JSON.stringify({ visible: false, flag: false }));
 
       render(<ExperimentEditModal open onClose={vi.fn()} workspace={WORKSPACE} group={group} />);
       await userEvent.click(await screen.findByRole('switch', { name: /evaluate over time/i }));
@@ -103,17 +103,18 @@ describe('ExperimentEditModal', () => {
       await waitFor(() => expect(window.localStorage.getItem(TREND_KEY)).toBeNull());
     });
 
-    it('keeps the stored choice when the flag is left alone', async () => {
+    it('keeps it when the over-time flag is left alone', async () => {
       const isSaved = mockRequests();
-      window.localStorage.setItem(TREND_KEY, 'false');
+      const stored = JSON.stringify({ visible: false, flag: false });
+      window.localStorage.setItem(TREND_KEY, stored);
 
       render(<ExperimentEditModal open onClose={vi.fn()} workspace={WORKSPACE} group={group} />);
-      // Edit something else entirely; the viewer's chart choice is not this save's business.
+      // Edit something else; a viewer's chart choice is not this save's business.
       await userEvent.click(await screen.findByRole('switch', { name: /favorite/i }));
       await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
       await waitFor(() => expect(isSaved()).toBe(true));
-      expect(window.localStorage.getItem(TREND_KEY)).toBe('false');
+      expect(window.localStorage.getItem(TREND_KEY)).toBe(stored);
     });
   });
 });

--- a/web/packages/studio/src/components/ExperimentEditModal/index.test.tsx
+++ b/web/packages/studio/src/components/ExperimentEditModal/index.test.tsx
@@ -23,6 +23,8 @@ const group: ExperimentResponse = {
   evaluation_count: 0,
 };
 
+const TREND_KEY = `nemo-studio:experiment-trend:${group.id}`;
+
 describe('ExperimentEditModal', () => {
   it('resends the fields it does not edit, which a full-replace update would otherwise clear', async () => {
     let body: Record<string, unknown> | undefined;
@@ -57,6 +59,61 @@ describe('ExperimentEditModal', () => {
       insight_id: group.insight_id,
       summary: group.summary,
       metadata: group.metadata,
+    });
+  });
+
+  describe('over-time flag and the chart visibility a viewer stored', () => {
+    const mockRequests = () => {
+      let saved = false;
+      server.use(
+        http.get('*/apis/intake/v2/workspaces/:workspace/evaluations', () =>
+          HttpResponse.json({
+            data: [],
+            pagination: {
+              page: 1,
+              page_size: 100,
+              current_page_size: 0,
+              total_pages: 0,
+              total_results: 0,
+            },
+          })
+        ),
+        http.put('*/apis/intake/v2/workspaces/:workspace/experiments/:name', () => {
+          saved = true;
+          return HttpResponse.json(group);
+        })
+      );
+      return () => saved;
+    };
+
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('drops the stored choice when the flag is flipped, so the new flag decides', async () => {
+      const isSaved = mockRequests();
+      // A viewer who had hidden the chart on an unflagged experiment.
+      window.localStorage.setItem(TREND_KEY, 'false');
+
+      render(<ExperimentEditModal open onClose={vi.fn()} workspace={WORKSPACE} group={group} />);
+      await userEvent.click(await screen.findByRole('switch', { name: /evaluate over time/i }));
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => expect(isSaved()).toBe(true));
+      await waitFor(() => expect(window.localStorage.getItem(TREND_KEY)).toBeNull());
+    });
+
+    it('keeps the stored choice when the flag is left alone', async () => {
+      const isSaved = mockRequests();
+      window.localStorage.setItem(TREND_KEY, 'false');
+
+      render(<ExperimentEditModal open onClose={vi.fn()} workspace={WORKSPACE} group={group} />);
+      // Edit something else entirely; the viewer's chart choice is not this save's business.
+      await userEvent.click(await screen.findByRole('switch', { name: /favorite/i }));
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => expect(isSaved()).toBe(true));
+      expect(window.localStorage.getItem(TREND_KEY)).toBe('false');
     });
   });
 });

--- a/web/packages/studio/src/components/ExperimentEditModal/index.tsx
+++ b/web/packages/studio/src/components/ExperimentEditModal/index.tsx
@@ -12,8 +12,10 @@ import {
 import type { ExperimentResponse } from '@nemo/sdk/generated/platform/schema';
 import { FormField, Stack, TextArea, TextInput } from '@nvidia/foundations-react-core';
 import { queryClient } from '@studio/api/queryClient';
+import { trendVisibilityStorageKey } from '@studio/components/charts/ExperimentTrendChart/visibility';
 import { DefaultSortControl } from '@studio/components/DefaultSortControl';
 import { ExperimentFlagSwitch } from '@studio/components/ExperimentFlagSwitch';
+import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
 import { AxiosError } from 'axios';
 import { type FC, type FormEvent, useEffect, useMemo, useState } from 'react';
 
@@ -62,6 +64,12 @@ export const ExperimentEditModal: FC<ExperimentEditModalProps> = ({
     [experimentsPage]
   );
 
+  // The detail page's chart visibility defers to `show_evaluations_over_time` only until a viewer
+  // toggles it; after that their stored choice wins. Flipping the flag here has to drop that choice,
+  // or the save appears to do nothing on the page behind the modal. Deleting through the hook also
+  // notifies the open page, so the chart appears or disappears without a reload.
+  const [, , clearTrendVisibility] = useLocalStorage<boolean>(trendVisibilityStorageKey(group.id));
+
   const { mutateAsync: updateExperiment, isPending } = useUpdateExperiment({
     mutation: {
       onSuccess: () => {
@@ -93,6 +101,9 @@ export const ExperimentEditModal: FC<ExperimentEditModalProps> = ({
           show_evaluations_over_time: showEvaluationsOverTime,
         },
       });
+      if (showEvaluationsOverTime !== (group.show_evaluations_over_time ?? false)) {
+        clearTrendVisibility();
+      }
       onClose();
     } catch (error) {
       const detail = error instanceof AxiosError ? error.response?.data?.detail : undefined;

--- a/web/packages/studio/src/components/ExperimentEditModal/index.tsx
+++ b/web/packages/studio/src/components/ExperimentEditModal/index.tsx
@@ -64,11 +64,12 @@ export const ExperimentEditModal: FC<ExperimentEditModalProps> = ({
     [experimentsPage]
   );
 
-  // The detail page's chart visibility defers to `show_evaluations_over_time` only until a viewer
-  // toggles it; after that their stored choice wins. Flipping the flag here has to drop that choice,
-  // or the save appears to do nothing on the page behind the modal. Deleting through the hook also
-  // notifies the open page, so the chart appears or disappears without a reload.
-  const [, , clearTrendVisibility] = useLocalStorage<boolean>(trendVisibilityStorageKey(group.id));
+  // `resolveTrendVisible` already retires a stored choice whose stamped flag no longer matches, which
+  // covers the flag moving anywhere else — API, CLI, another tab. It cannot cover a round trip: turn
+  // the flag off and back on and the stamp matches again, so a viewer who had hidden the chart would
+  // watch the owner's edit do nothing. An explicit edit here is unambiguous, so drop the choice
+  // outright. Deleting through the hook notifies the open page, so the chart follows without a reload.
+  const [, , clearTrendChoice] = useLocalStorage(trendVisibilityStorageKey(group.id));
 
   const { mutateAsync: updateExperiment, isPending } = useUpdateExperiment({
     mutation: {
@@ -102,7 +103,7 @@ export const ExperimentEditModal: FC<ExperimentEditModalProps> = ({
         },
       });
       if (showEvaluationsOverTime !== (group.show_evaluations_over_time ?? false)) {
-        clearTrendVisibility();
+        clearTrendChoice();
       }
       onClose();
     } catch (error) {

--- a/web/packages/studio/src/components/charts/ExperimentParetoChart/index.tsx
+++ b/web/packages/studio/src/components/charts/ExperimentParetoChart/index.tsx
@@ -5,14 +5,14 @@ import { useToast } from '@nemo/common/src/providers/toast/useToast';
 import { getGetExperimentQueryKey, useUpdateExperiment } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentResponse } from '@nemo/sdk/generated/platform/schema';
 import { Button, Text } from '@nvidia/foundations-react-core';
-import { MetricSelect } from '@studio/components/charts/ExperimentParetoChart/MetricSelect';
 import { ParetoTooltip } from '@studio/components/charts/ExperimentParetoChart/ParetoTooltip';
-import { useParetoEvaluations } from '@studio/components/charts/ExperimentParetoChart/useParetoEvaluations';
 import {
   buildParetoPoints,
   deriveParetoMetrics,
   metricLabel,
 } from '@studio/components/charts/ExperimentParetoChart/utils';
+import { MetricSelect } from '@studio/components/charts/MetricSelect';
+import { useGroupEvaluations } from '@studio/components/charts/useGroupEvaluations';
 import type { EvaluationRow } from '@studio/components/dataViews/ExperimentDataView/useExperimentEvaluations';
 import { useQueryClient } from '@tanstack/react-query';
 import { Loader2, Save } from 'lucide-react';
@@ -67,7 +67,7 @@ export const ExperimentParetoChart: FC<ExperimentParetoChartProps> = ({
     rows: fetchedRows,
     isLoading: isFetching,
     isError,
-  } = useParetoEvaluations(workspace, group.id, { enabled: !hasPreloaded && !preloadPending });
+  } = useGroupEvaluations(workspace, group.id, { enabled: !hasPreloaded && !preloadPending });
   const points = hasPreloaded ? preloadedEvaluations : fetchedRows;
   const isLoading = hasPreloaded ? false : preloadPending || isFetching;
   const metrics = useMemo(() => deriveParetoMetrics(points), [points]);

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/TrendTooltip.tsx
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/TrendTooltip.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { Text } from '@nvidia/foundations-react-core';
+import {
+  formatTimestamp,
+  type TrendMetric,
+  type TrendPlotPoint,
+} from '@studio/components/charts/ExperimentTrendChart/utils';
+import type { FC } from 'react';
+
+interface TrendTooltipProps {
+  active?: boolean;
+  payload?: ReadonlyArray<{ payload: TrendPlotPoint }>;
+  metric: TrendMetric;
+}
+
+export const TrendTooltip: FC<TrendTooltipProps> = ({ active, payload, metric }) => {
+  const point = payload?.[0]?.payload;
+  if (!active || !point) return null;
+  return (
+    <div className="rounded border border-base bg-surface p-2 shadow-md">
+      <Text kind="body/semibold/sm">{point.name}</Text>
+      <div className="mt-1 flex flex-col gap-0.5">
+        <Text kind="body/regular/xs">
+          {metric.label}: {metric.format(point.y)}
+        </Text>
+        <Text kind="body/regular/xs" color="subtle">
+          {formatTimestamp(point.x)}
+        </Text>
+      </div>
+    </div>
+  );
+};

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/index.tsx
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/index.tsx
@@ -55,11 +55,17 @@ export const ExperimentTrendChart: FC<ExperimentTrendChartProps> = ({
   const hasPreloaded = preloadedEvaluations !== undefined;
   const {
     rows: fetchedRows,
+    total: fetchedTotal,
     isLoading: isFetching,
     isError,
   } = useGroupEvaluations(workspace, group.id, { enabled: !hasPreloaded && !preloadPending });
   const points = hasPreloaded ? preloadedEvaluations : fetchedRows;
   const isLoading = hasPreloaded ? false : preloadPending || isFetching;
+
+  // The fetch takes one page, so a group larger than that plots a partial history. A trend that
+  // quietly starts partway through reads as the whole story, so say when it does not. The preloaded
+  // path is whole by construction — the caller only passes rows when the group fits one page.
+  const omittedCount = hasPreloaded ? 0 : Math.max(0, fetchedTotal - fetchedRows.length);
   const metrics = useMemo(() => deriveTrendMetrics(points), [points]);
 
   const [metricId, setMetricId] = useState<string | undefined>(undefined);
@@ -139,7 +145,14 @@ export const ExperimentTrendChart: FC<ExperimentTrendChartProps> = ({
   return (
     <div className="flex flex-col gap-3 rounded border border-base bg-surface p-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
-        <Text kind="title/xs">{`${metric?.label ?? 'Metric'} over time`}</Text>
+        <div className="flex flex-col gap-1">
+          <Text kind="title/xs">{`${metric?.label ?? 'Metric'} over time`}</Text>
+          {omittedCount > 0 && (
+            <Text kind="body/regular/xs" color="subtle">
+              {`Showing the ${plotPoints.length.toLocaleString()} most recent of ${fetchedTotal.toLocaleString()} evaluations.`}
+            </Text>
+          )}
+        </div>
         <div className="flex flex-wrap items-center gap-4">
           <MetricSelect
             label="Metric"

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/index.tsx
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/index.tsx
@@ -65,6 +65,10 @@ export const ExperimentTrendChart: FC<ExperimentTrendChartProps> = ({
   // The fetch takes one page, so a group larger than that plots a partial history. A trend that
   // quietly starts partway through reads as the whole story, so say when it does not. The preloaded
   // path is whole by construction — the caller only passes rows when the group fits one page.
+  //
+  // Counted against the rows fetched, not the points plotted: `buildTrendPoints` also drops rows
+  // that carry no value for the selected metric, and folding that into this sentence would report
+  // a smaller "most recent" figure than was actually loaded, varying by which metric is selected.
   const omittedCount = hasPreloaded ? 0 : Math.max(0, fetchedTotal - fetchedRows.length);
   const metrics = useMemo(() => deriveTrendMetrics(points), [points]);
 
@@ -149,7 +153,7 @@ export const ExperimentTrendChart: FC<ExperimentTrendChartProps> = ({
           <Text kind="title/xs">{`${metric?.label ?? 'Metric'} over time`}</Text>
           {omittedCount > 0 && (
             <Text kind="body/regular/xs" color="subtle">
-              {`Showing the ${plotPoints.length.toLocaleString()} most recent of ${fetchedTotal.toLocaleString()} evaluations.`}
+              {`Showing the ${fetchedRows.length.toLocaleString()} most recent of ${fetchedTotal.toLocaleString()} evaluations.`}
             </Text>
           )}
         </div>

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/index.tsx
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/index.tsx
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ExperimentResponse } from '@nemo/sdk/generated/platform/schema';
+import { Text } from '@nvidia/foundations-react-core';
+import { TrendTooltip } from '@studio/components/charts/ExperimentTrendChart/TrendTooltip';
+import {
+  buildTrendPoints,
+  deriveTrendMetrics,
+  formatAxisTick,
+  formatTimeTick,
+} from '@studio/components/charts/ExperimentTrendChart/utils';
+import { MetricSelect } from '@studio/components/charts/MetricSelect';
+import { useGroupEvaluations } from '@studio/components/charts/useGroupEvaluations';
+import type { EvaluationRow } from '@studio/components/dataViews/ExperimentDataView/useExperimentEvaluations';
+import { Loader2 } from 'lucide-react';
+import { type FC, useMemo, useState } from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+interface ExperimentTrendChartProps {
+  workspace: string;
+  group: ExperimentResponse;
+  /** The group's full evaluation set when the caller already has it loaded (fits one page), so the
+   * chart renders from these instead of refetching. */
+  preloadedEvaluations?: EvaluationRow[];
+  /** True while the caller is still loading rows it will pass via `preloadedEvaluations`; the chart
+   * shows a loading state and holds off its own fetch. */
+  preloadPending?: boolean;
+}
+
+const CHART_HEIGHT = 360;
+
+/**
+ * One evaluation metric over time for an experiment group: a point per evaluation, positioned by
+ * its `created_at`. The metric is picked from the group's evaluators plus the cost, latency and
+ * token rollups, so a group can be read either on quality or on what that quality cost.
+ *
+ * The series only means anything if the evaluations are comparable — same dataset, same evaluators
+ * — which is what the experiment's "Evaluate over time" flag asserts.
+ */
+export const ExperimentTrendChart: FC<ExperimentTrendChartProps> = ({
+  workspace,
+  group,
+  preloadedEvaluations,
+  preloadPending = false,
+}) => {
+  const hasPreloaded = preloadedEvaluations !== undefined;
+  const {
+    rows: fetchedRows,
+    isLoading: isFetching,
+    isError,
+  } = useGroupEvaluations(workspace, group.id, { enabled: !hasPreloaded && !preloadPending });
+  const points = hasPreloaded ? preloadedEvaluations : fetchedRows;
+  const isLoading = hasPreloaded ? false : preloadPending || isFetching;
+  const metrics = useMemo(() => deriveTrendMetrics(points), [points]);
+
+  const [metricId, setMetricId] = useState<string | undefined>(undefined);
+
+  // Fall back to the first metric when the selection isn't in the data: the evaluator set is derived
+  // from the rows, so a scorer can vanish when the group is refetched. Scorers sort first, so this
+  // opens on an evaluator when the group has one and on cost otherwise.
+  const metric = metrics.find((m) => m.id === metricId) ?? metrics[0];
+
+  const plotPoints = useMemo(
+    () => (metric ? buildTrendPoints(points, metric) : []),
+    [points, metric]
+  );
+
+  const renderBody = () => {
+    if (isError) {
+      return <Text kind="body/regular/sm">Could not load the evaluations for this group.</Text>;
+    }
+    if (isLoading) {
+      return (
+        <div aria-busy className="flex h-[360px] items-center justify-center gap-2">
+          <Loader2 width={20} height={20} className="animate-spin text-brand" />
+          <Text kind="body/regular/sm" color="subtle">
+            Loading evaluations…
+          </Text>
+        </div>
+      );
+    }
+    if (plotPoints.length === 0 || !metric) {
+      return (
+        <Text kind="body/regular/sm" color="subtle">
+          No evaluations with the selected metric to plot over time.
+        </Text>
+      );
+    }
+    return (
+      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+        <LineChart margin={{ top: 16, right: 24, bottom: 24, left: 16 }} data={plotPoints}>
+          <CartesianGrid stroke="var(--border-color-base)" strokeDasharray="3 3" />
+          <XAxis
+            type="number"
+            dataKey="x"
+            name="Run date"
+            // A time axis has to be scaled by value, not by index, or evaluations an hour apart are
+            // spread as widely as ones a month apart.
+            scale="time"
+            domain={['dataMin', 'dataMax']}
+            label={{ value: 'Run date', position: 'insideBottom', offset: -12 }}
+            tickFormatter={formatTimeTick}
+            tick={{ fontSize: 11 }}
+          />
+          <YAxis
+            type="number"
+            dataKey="y"
+            name={metric.label}
+            label={{ value: metric.label, angle: -90, position: 'insideLeft' }}
+            tickFormatter={formatAxisTick}
+            tick={{ fontSize: 11 }}
+          />
+          <Tooltip cursor={{ strokeDasharray: '3 3' }} content={<TrendTooltip metric={metric} />} />
+          <Line
+            type="linear"
+            dataKey="y"
+            name={metric.label}
+            stroke="var(--border-color-brand)"
+            strokeWidth={2}
+            // Dots carry the tooltip, and each one is a distinct evaluation worth pointing at.
+            dot={{ fill: 'var(--border-color-brand)', r: 3 }}
+            activeDot={{ r: 5 }}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded border border-base bg-surface p-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <Text kind="title/xs">{`${metric?.label ?? 'Metric'} over time`}</Text>
+        <div className="flex flex-wrap items-center gap-4">
+          <MetricSelect
+            label="Metric"
+            value={metric?.id ?? ''}
+            metrics={metrics}
+            onChange={setMetricId}
+            triggerClassName="w-44"
+          />
+        </div>
+      </div>
+      {renderBody()}
+    </div>
+  );
+};

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/utils.test.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/utils.test.ts
@@ -16,12 +16,14 @@ const row = (opts: {
   cost?: number;
   latency?: number;
   tokens?: number;
+  durationSec?: string;
   evaluators?: Record<string, number>;
 }): EvaluationRow =>
   ({
     name: opts.name,
     id: opts.name,
     created_at: opts.createdAt,
+    metadata: opts.durationSec == null ? undefined : { eval_duration_sec: opts.durationSec },
     cost_usd: opts.cost == null ? undefined : { mean: opts.cost },
     latency_ms: opts.latency == null ? undefined : { mean: opts.latency },
     tokens: opts.tokens == null ? undefined : { mean: opts.tokens },
@@ -45,6 +47,7 @@ describe('deriveTrendMetrics', () => {
     expect(metrics.map((m) => m.id)).toEqual([
       'evaluators.answers_question',
       'evaluators.report_style',
+      'duration_ms',
       'cost_usd',
       'latency_ms',
       'tokens',
@@ -58,7 +61,7 @@ describe('deriveTrendMetrics', () => {
 
   it('offers the rollups even when no evaluation carries an evaluator score', () => {
     const metrics = deriveTrendMetrics([row({ name: 'a', cost: 1 })]);
-    expect(metrics.map((m) => m.id)).toEqual(['cost_usd', 'latency_ms', 'tokens']);
+    expect(metrics.map((m) => m.id)).toEqual(['duration_ms', 'cost_usd', 'latency_ms', 'tokens']);
   });
 
   it('formats each metric in its own units', () => {
@@ -67,6 +70,24 @@ describe('deriveTrendMetrics', () => {
     expect(getMetric(metrics, 'latency_ms').format(1234.6)).toBe('1,235 ms');
     expect(getMetric(metrics, 'tokens').format(16000)).toBe('16,000');
     expect(getMetric(metrics, 'evaluators.solved').format(0.60349)).toBe('0.603');
+  });
+
+  it('reads duration from the metadata the evaluator stamps, not from a rollup field', () => {
+    const rows = [row({ name: 'a', createdAt: '2026-06-01T00:00:00Z', durationSec: '114.2' })];
+    const [point] = buildTrendPoints(rows, getMetric(deriveTrendMetrics(rows), 'duration_ms'));
+    expect(point.y).toBe(114200);
+  });
+
+  it('drops a run whose duration metadata is absent or unparseable', () => {
+    // Metadata is free-form and only written on a successful publish, so both are ordinary states.
+    const rows = [
+      row({ name: 'no-metadata', createdAt: '2026-06-01T00:00:00Z' }),
+      row({ name: 'blank', createdAt: '2026-06-02T00:00:00Z', durationSec: '' }),
+      row({ name: 'junk', createdAt: '2026-06-03T00:00:00Z', durationSec: 'n/a' }),
+      row({ name: 'good', createdAt: '2026-06-04T00:00:00Z', durationSec: '12' }),
+    ];
+    const points = buildTrendPoints(rows, getMetric(deriveTrendMetrics(rows), 'duration_ms'));
+    expect(points.map((p) => p.name)).toEqual(['good']);
   });
 });
 

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/utils.test.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/utils.test.ts
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  buildTrendPoints,
+  deriveTrendMetrics,
+  type TrendMetric,
+} from '@studio/components/charts/ExperimentTrendChart/utils';
+import type { EvaluationRow } from '@studio/components/dataViews/ExperimentDataView/useExperimentEvaluations';
+
+// Only the fields the trend accessors read (name + created_at + the rollup means) are set; the rest
+// of the rich EvaluationRow shape is irrelevant here, so build a minimal stand-in.
+const row = (opts: {
+  name: string;
+  createdAt?: string;
+  cost?: number;
+  latency?: number;
+  tokens?: number;
+  evaluators?: Record<string, number>;
+}): EvaluationRow =>
+  ({
+    name: opts.name,
+    id: opts.name,
+    created_at: opts.createdAt,
+    cost_usd: opts.cost == null ? undefined : { mean: opts.cost },
+    latency_ms: opts.latency == null ? undefined : { mean: opts.latency },
+    tokens: opts.tokens == null ? undefined : { mean: opts.tokens },
+    aggregate_scores: opts.evaluators
+      ? Object.fromEntries(Object.entries(opts.evaluators).map(([name, mean]) => [name, { mean }]))
+      : undefined,
+  }) as unknown as EvaluationRow;
+
+const getMetric = (metrics: TrendMetric[], id: string): TrendMetric => {
+  const metric = metrics.find((m) => m.id === id);
+  if (!metric) throw new Error(`metric ${id} not found`);
+  return metric;
+};
+
+describe('deriveTrendMetrics', () => {
+  it('lists evaluators alphabetically, then the cost/latency/token rollups', () => {
+    const metrics = deriveTrendMetrics([
+      row({ name: 'b', evaluators: { report_style: 1 } }),
+      row({ name: 'a', evaluators: { answers_question: 1, report_style: 1 } }),
+    ]);
+    expect(metrics.map((m) => m.id)).toEqual([
+      'evaluators.answers_question',
+      'evaluators.report_style',
+      'cost_usd',
+      'latency_ms',
+      'tokens',
+    ]);
+  });
+
+  it('titles evaluator labels so the selector reads as prose', () => {
+    const metrics = deriveTrendMetrics([row({ name: 'a', evaluators: { answers_question: 1 } })]);
+    expect(getMetric(metrics, 'evaluators.answers_question').label).toBe('Answers Question');
+  });
+
+  it('offers the rollups even when no evaluation carries an evaluator score', () => {
+    const metrics = deriveTrendMetrics([row({ name: 'a', cost: 1 })]);
+    expect(metrics.map((m) => m.id)).toEqual(['cost_usd', 'latency_ms', 'tokens']);
+  });
+
+  it('formats each metric in its own units', () => {
+    const metrics = deriveTrendMetrics([row({ name: 'a', evaluators: { solved: 1 } })]);
+    expect(getMetric(metrics, 'cost_usd').format(0.125)).toBe('$0.125');
+    expect(getMetric(metrics, 'latency_ms').format(1234.6)).toBe('1,235 ms');
+    expect(getMetric(metrics, 'tokens').format(16000)).toBe('16,000');
+    expect(getMetric(metrics, 'evaluators.solved').format(0.60349)).toBe('0.603');
+  });
+});
+
+describe('buildTrendPoints', () => {
+  const metricsFor = (rows: EvaluationRow[]) => deriveTrendMetrics(rows);
+
+  it('orders points oldest first regardless of input order', () => {
+    const rows = [
+      row({ name: 'mid', createdAt: '2026-06-05T00:00:00Z', evaluators: { solved: 0.7 } }),
+      row({ name: 'new', createdAt: '2026-06-09T00:00:00Z', evaluators: { solved: 0.9 } }),
+      row({ name: 'old', createdAt: '2026-06-01T00:00:00Z', evaluators: { solved: 0.5 } }),
+    ];
+    const points = buildTrendPoints(rows, getMetric(metricsFor(rows), 'evaluators.solved'));
+    expect(points.map((p) => p.name)).toEqual(['old', 'mid', 'new']);
+    expect(points.map((p) => p.y)).toEqual([0.5, 0.7, 0.9]);
+  });
+
+  it('places points at the evaluation timestamp so runs cluster by when they happened', () => {
+    const rows = [row({ name: 'a', createdAt: '2026-06-01T12:00:00Z', cost: 0.5 })];
+    const [point] = buildTrendPoints(rows, getMetric(metricsFor(rows), 'cost_usd'));
+    expect(point.x).toBe(Date.parse('2026-06-01T12:00:00Z'));
+  });
+
+  it('drops rows with no parseable created_at, which cannot be placed on the axis', () => {
+    const rows = [
+      row({ name: 'undated', evaluators: { solved: 0.1 } }),
+      row({ name: 'bad', createdAt: 'not-a-date', evaluators: { solved: 0.2 } }),
+      row({ name: 'good', createdAt: '2026-06-01T00:00:00Z', evaluators: { solved: 0.8 } }),
+    ];
+    const points = buildTrendPoints(rows, getMetric(metricsFor(rows), 'evaluators.solved'));
+    expect(points.map((p) => p.name)).toEqual(['good']);
+  });
+
+  it('drops rows missing the selected metric rather than plotting them as zero', () => {
+    const rows = [
+      row({ name: 'no-cost', createdAt: '2026-06-01T00:00:00Z', evaluators: { solved: 0.8 } }),
+      row({ name: 'costed', createdAt: '2026-06-02T00:00:00Z', cost: 0.25 }),
+    ];
+    const points = buildTrendPoints(rows, getMetric(metricsFor(rows), 'cost_usd'));
+    expect(points.map((p) => p.name)).toEqual(['costed']);
+  });
+
+  it('returns nothing when no row carries the metric, so the chart can show its empty state', () => {
+    const rows = [row({ name: 'a', createdAt: '2026-06-01T00:00:00Z', evaluators: { solved: 1 } })];
+    expect(buildTrendPoints(rows, getMetric(metricsFor(rows), 'tokens'))).toEqual([]);
+  });
+});

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/utils.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/utils.ts
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { formatDurationMs } from '@nemo/common/src/utils/date';
 import { snakeCaseToTitleCase } from '@nemo/common/src/utils/formatters';
+import { evalDurationMs } from '@studio/api/evaluation/utils';
 import type { EvaluationRow } from '@studio/components/dataViews/ExperimentDataView/useExperimentEvaluations';
 import { evaluatorLabel } from '@studio/routes/agents/AgentDetailRoute/evaluations/formatRollups';
 
@@ -34,11 +36,20 @@ const formatScore = (value: number): string =>
   value.toLocaleString(undefined, { maximumFractionDigits: 3 });
 
 /**
- * The evaluation-level rollups graphable alongside evaluator scores. Cost, latency and tokens are
- * the three the API aggregates onto an evaluation; run duration is not aggregated there (Intake
- * tracks `duration_ms` per session only), so it is absent until that rollup exists.
+ * The evaluation-level measures graphable alongside evaluator scores.
+ *
+ * Cost, latency and tokens are typed rollups the API aggregates onto an evaluation. Duration is not
+ * one: the evaluator stamps the run's wall-clock seconds into `metadata.eval_duration_sec` at
+ * publish time, which is why `evalDurationMs` reads it rather than a field. It is therefore present
+ * only for runs that published successfully, and `buildTrendPoints` drops the rest.
  */
 const RESOURCE_METRICS: readonly TrendMetric[] = [
+  {
+    id: 'duration_ms',
+    label: 'Duration',
+    format: (value) => formatDurationMs(value),
+    accessor: (row) => evalDurationMs(row.metadata),
+  },
   {
     id: 'cost_usd',
     label: 'Cost (USD)',

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/utils.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/utils.ts
@@ -1,0 +1,119 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { snakeCaseToTitleCase } from '@nemo/common/src/utils/formatters';
+import type { EvaluationRow } from '@studio/components/dataViews/ExperimentDataView/useExperimentEvaluations';
+import { evaluatorLabel } from '@studio/routes/agents/AgentDetailRoute/evaluations/formatRollups';
+
+export interface TrendMetric {
+  /** Stable id in the API's metric vocabulary: `cost_usd`, `latency_ms`, `tokens`, or
+   * `evaluators.<name>` — the same vocabulary the Pareto chart's axes are named in. */
+  readonly id: string;
+  readonly label: string;
+  /** Formats a value in the metric's own units, for the tooltip. */
+  readonly format: (value: number) => string;
+  readonly accessor: (row: EvaluationRow) => number | null | undefined;
+}
+
+/** Compact big tick values so they don't collide with the axis title (16000 -> "16K"); keep small
+ * values precise so close cost/score ticks stay distinct. */
+export const formatAxisTick = (value: number): string =>
+  Math.abs(value) >= 1000
+    ? value.toLocaleString(undefined, { notation: 'compact', maximumFractionDigits: 1 })
+    : value.toLocaleString(undefined, { maximumFractionDigits: 3 });
+
+const formatCost = (value: number): string =>
+  `$${value.toLocaleString(undefined, { maximumFractionDigits: 4 })}`;
+
+const formatLatency = (value: number): string => `${Math.round(value).toLocaleString()} ms`;
+
+const formatTokens = (value: number): string =>
+  value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+
+const formatScore = (value: number): string =>
+  value.toLocaleString(undefined, { maximumFractionDigits: 3 });
+
+/**
+ * The evaluation-level rollups graphable alongside evaluator scores. Cost, latency and tokens are
+ * the three the API aggregates onto an evaluation; run duration is not aggregated there (Intake
+ * tracks `duration_ms` per session only), so it is absent until that rollup exists.
+ */
+const RESOURCE_METRICS: readonly TrendMetric[] = [
+  {
+    id: 'cost_usd',
+    label: 'Cost (USD)',
+    format: formatCost,
+    accessor: (row) => row.cost_usd?.mean,
+  },
+  {
+    id: 'latency_ms',
+    label: 'Latency (ms)',
+    format: formatLatency,
+    accessor: (row) => row.latency_ms?.mean,
+  },
+  { id: 'tokens', label: 'Tokens', format: formatTokens, accessor: (row) => row.tokens?.mean },
+];
+
+/**
+ * Metrics selectable on the trend: one per evaluator seen in the data (alphabetized) followed by
+ * the cost, latency and token rollups. Evaluator names are dynamic, so they are derived from the
+ * rows — the same shape as `deriveParetoMetrics`. Scorers lead because they are what an experiment
+ * is usually judged on.
+ */
+export function deriveTrendMetrics(rows: readonly EvaluationRow[]): TrendMetric[] {
+  const evaluatorNames = [
+    ...new Set(rows.flatMap((row) => Object.keys(row.aggregate_scores ?? {}))),
+  ];
+  const evaluatorMetrics = evaluatorNames
+    .map<TrendMetric>((name) => ({
+      id: `evaluators.${name}`,
+      label: snakeCaseToTitleCase(evaluatorLabel(name)),
+      // Scores carry no scale metadata, so they are shown as-is rather than as a percentage.
+      format: formatScore,
+      accessor: (row) => row.aggregate_scores?.[name]?.mean,
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+  return [...evaluatorMetrics, ...RESOURCE_METRICS];
+}
+
+export interface TrendPlotPoint {
+  readonly name: string;
+  /** Epoch millis of the evaluation's `created_at`. The x-axis is a real time scale, so runs that
+   * cluster into one afternoon sit together instead of being spread evenly across the chart. */
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * Build the plotted series for one metric, oldest first.
+ *
+ * A row is dropped when it has no parseable `created_at` — nothing to place it at on the axis — or
+ * no finite value for the metric, mirroring how `buildParetoPoints` drops points missing an axis.
+ */
+export function buildTrendPoints(
+  rows: readonly EvaluationRow[],
+  metric: TrendMetric
+): TrendPlotPoint[] {
+  return rows
+    .map((row): TrendPlotPoint | null => {
+      const x = Date.parse(row.created_at ?? '');
+      const y = metric.accessor(row);
+      if (!Number.isFinite(x) || y == null || !Number.isFinite(y)) return null;
+      return { name: row.name, x, y };
+    })
+    .filter((point): point is TrendPlotPoint => point !== null)
+    .sort((a, b) => a.x - b.x);
+}
+
+/** Axis label for a point in time. Date alone: a trend spanning weeks needs no clock time, and the
+ * tooltip carries the fuller timestamp for runs that land on the same day. */
+export const formatTimeTick = (value: number): string =>
+  new Date(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+
+export const formatTimestamp = (value: number): string =>
+  new Date(value).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.test.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
+  isTrendChoiceCurrent,
   resolveTrendVisible,
   trendVisibilityStorageKey,
 } from '@studio/components/charts/ExperimentTrendChart/visibility';
@@ -13,6 +14,18 @@ describe('trendVisibilityStorageKey', () => {
 
   it('still returns a usable key before the group has loaded', () => {
     expect(trendVisibilityStorageKey(undefined)).toBe('nemo-studio:experiment-trend:');
+  });
+});
+
+describe('isTrendChoiceCurrent', () => {
+  it('is true only for a well-formed choice stamped with the flag as it now reads', () => {
+    expect(isTrendChoiceCurrent({ visible: false, flag: true }, true)).toBe(true);
+    expect(isTrendChoiceCurrent({ visible: false, flag: false }, true)).toBe(false);
+  });
+
+  it('is false for nothing stored and for the older bare-boolean format', () => {
+    expect(isTrendChoiceCurrent(undefined, true)).toBe(false);
+    expect(isTrendChoiceCurrent(false, false)).toBe(false);
   });
 });
 

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.test.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.test.ts
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  resolveTrendVisible,
+  trendVisibilityStorageKey,
+} from '@studio/components/charts/ExperimentTrendChart/visibility';
+
+describe('trendVisibilityStorageKey', () => {
+  it('scopes the choice to one experiment', () => {
+    expect(trendVisibilityStorageKey('group-id')).toBe('nemo-studio:experiment-trend:group-id');
+  });
+
+  it('still returns a usable key before the group has loaded', () => {
+    expect(trendVisibilityStorageKey(undefined)).toBe('nemo-studio:experiment-trend:');
+  });
+});
+
+describe('resolveTrendVisible', () => {
+  it('follows the flag when the viewer has never chosen', () => {
+    expect(resolveTrendVisible(undefined, true)).toBe(true);
+    expect(resolveTrendVisible(undefined, false)).toBe(false);
+  });
+
+  it('honours a choice made against the flag as it still reads', () => {
+    expect(resolveTrendVisible({ visible: false, flag: true }, true)).toBe(false);
+    expect(resolveTrendVisible({ visible: true, flag: false }, false)).toBe(true);
+  });
+
+  it('retires a choice made against the opposite flag, so an owner edit takes effect', () => {
+    // The reported bug: a viewer had hidden the chart, the owner turned the flag on, and the stale
+    // choice kept winning. However the flag moved — modal, API, CLI, another tab — the choice goes.
+    expect(resolveTrendVisible({ visible: false, flag: false }, true)).toBe(true);
+    expect(resolveTrendVisible({ visible: true, flag: true }, false)).toBe(false);
+  });
+
+  it('ignores the older bare-boolean format rather than stranding viewers on it', () => {
+    expect(resolveTrendVisible(false, true)).toBe(true);
+    expect(resolveTrendVisible(true, false)).toBe(false);
+  });
+
+  it('ignores anything malformed, falling back to the flag', () => {
+    expect(resolveTrendVisible(null, true)).toBe(true);
+    expect(resolveTrendVisible('false', true)).toBe(true);
+    expect(resolveTrendVisible({ visible: 'no', flag: true }, true)).toBe(true);
+    expect(resolveTrendVisible({ visible: false }, true)).toBe(true);
+  });
+});

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.ts
@@ -4,12 +4,40 @@
 /**
  * Where a viewer's show/hide choice for an experiment's over-time chart is kept.
  *
- * Two components share this key — the detail route reads it, the edit modal clears it when the
- * experiment's `show_evaluations_over_time` flag changes — and a mismatch between them would fail
- * silently, leaving a stale choice outranking the new flag. So it is built in one place.
- *
- * An absent key is meaningful: it means "this viewer has never chosen", which is what lets the
- * flag decide. Store nothing to express that; do not store `false`.
+ * Built in one place because more than one component reads it, and two components agreeing on a
+ * string by convention would fail silently.
  */
 export const trendVisibilityStorageKey = (groupId: string | undefined): string =>
   `nemo-studio:experiment-trend:${groupId ?? ''}`;
+
+/**
+ * A viewer's stored choice, stamped with the flag value it was made against.
+ *
+ * The flag is stored alongside the choice so the choice can expire on its own. Storing a bare
+ * boolean does not work: the chart's default comes from the experiment's
+ * `show_evaluations_over_time`, so a stale choice silently outranks a flag that has since changed,
+ * and the owner who flips the flag sees nothing happen.
+ */
+export interface TrendVisibilityChoice {
+  readonly visible: boolean;
+  /** The `show_evaluations_over_time` value in force when the viewer chose. */
+  readonly flag: boolean;
+}
+
+const isChoice = (value: unknown): value is TrendVisibilityChoice =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as TrendVisibilityChoice).visible === 'boolean' &&
+  typeof (value as TrendVisibilityChoice).flag === 'boolean';
+
+/**
+ * Whether to show the chart: the viewer's choice while the flag still reads as it did when they
+ * made it, and the flag itself once it has changed.
+ *
+ * Keying on the flag value rather than on a change event means this holds however the flag moved —
+ * the edit modal, the API, the CLI, another tab, another user — and not only for edits this app
+ * happened to witness. A value in the older bare-boolean format fails {@link isChoice} and so is
+ * ignored, which retires it on first read rather than stranding viewers on a stale choice.
+ */
+export const resolveTrendVisible = (stored: unknown, flag: boolean): boolean =>
+  isChoice(stored) && stored.flag === flag ? stored.visible : flag;

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Where a viewer's show/hide choice for an experiment's over-time chart is kept.
+ *
+ * Two components share this key — the detail route reads it, the edit modal clears it when the
+ * experiment's `show_evaluations_over_time` flag changes — and a mismatch between them would fail
+ * silently, leaving a stale choice outranking the new flag. So it is built in one place.
+ *
+ * An absent key is meaningful: it means "this viewer has never chosen", which is what lets the
+ * flag decide. Store nothing to express that; do not store `false`.
+ */
+export const trendVisibilityStorageKey = (groupId: string | undefined): string =>
+  `nemo-studio:experiment-trend:${groupId ?? ''}`;

--- a/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.ts
+++ b/web/packages/studio/src/components/charts/ExperimentTrendChart/visibility.ts
@@ -31,13 +31,25 @@ const isChoice = (value: unknown): value is TrendVisibilityChoice =>
   typeof (value as TrendVisibilityChoice).flag === 'boolean';
 
 /**
+ * Whether a stored value is a choice that still speaks for the flag as it now reads.
+ *
+ * False covers three cases the caller treats alike: nothing stored, a value in the older
+ * bare-boolean format, and a choice stamped against a flag that has since moved.
+ */
+export const isTrendChoiceCurrent = (stored: unknown, flag: boolean): boolean =>
+  isChoice(stored) && stored.flag === flag;
+
+/**
  * Whether to show the chart: the viewer's choice while the flag still reads as it did when they
  * made it, and the flag itself once it has changed.
  *
  * Keying on the flag value rather than on a change event means this holds however the flag moved —
  * the edit modal, the API, the CLI, another tab, another user — and not only for edits this app
- * happened to witness. A value in the older bare-boolean format fails {@link isChoice} and so is
- * ignored, which retires it on first read rather than stranding viewers on a stale choice.
+ * happened to witness.
+ *
+ * Suspending a mismatched choice is not enough on its own: turn the flag off and back on and the
+ * stamp lines up again, reviving a choice the owner has twice overruled. So the reader is expected
+ * to discard what this call declines to honour — see the route's cleanup effect.
  */
 export const resolveTrendVisible = (stored: unknown, flag: boolean): boolean =>
-  isChoice(stored) && stored.flag === flag ? stored.visible : flag;
+  isTrendChoiceCurrent(stored, flag) ? (stored as TrendVisibilityChoice).visible : flag;

--- a/web/packages/studio/src/components/charts/MetricSelect.tsx
+++ b/web/packages/studio/src/components/charts/MetricSelect.tsx
@@ -9,31 +9,45 @@ import {
   SelectTrigger,
   Text,
 } from '@nvidia/foundations-react-core';
-import {
-  metricLabel,
-  type ParetoMetric,
-} from '@studio/components/charts/ExperimentParetoChart/utils';
 import type { FC } from 'react';
+
+/** The least a chart's metric has to expose to be selectable. Both the Pareto metrics and the
+ * over-time metrics satisfy it, so the two charts share one selector. */
+export interface SelectableMetric {
+  readonly id: string;
+  readonly label: string;
+}
 
 interface MetricSelectProps {
   label: string;
   value: string;
-  metrics: readonly ParetoMetric[];
+  metrics: readonly SelectableMetric[];
   onChange: (id: string) => void;
+  /** Widens the trigger for longer metric names; the axis pickers stay compact. */
+  triggerClassName?: string;
 }
 
-export const MetricSelect: FC<MetricSelectProps> = ({ label, value, metrics, onChange }) => (
+export const MetricSelect: FC<MetricSelectProps> = ({
+  label,
+  value,
+  metrics,
+  onChange,
+  triggerClassName = 'w-26',
+}) => (
   <label className="flex items-center gap-2">
     <Text kind="body/regular/sm" color="subtle">
       {label}
     </Text>
     <SelectRoot value={value} onValueChange={onChange} size="small">
       <SelectTrigger
-        className="w-26"
+        className={triggerClassName}
         size="small"
         aria-label={label}
-        // The trigger shows the raw value by default; map it back to the metric's label.
-        renderValue={(v) => (typeof v === 'string' && v ? metricLabel(v) : undefined)}
+        // The trigger shows the raw value by default; map it back to the metric's label. Resolved
+        // from the list rather than from the id so each chart keeps its own naming.
+        renderValue={(v) =>
+          typeof v === 'string' ? metrics.find((metric) => metric.id === v)?.label : undefined
+        }
       />
       {/* Keep the dropdown readable even when the trigger is compact/narrow. */}
       <SelectContent className="min-w-48">

--- a/web/packages/studio/src/components/charts/useGroupEvaluations.ts
+++ b/web/packages/studio/src/components/charts/useGroupEvaluations.ts
@@ -9,6 +9,8 @@ import { useMemo } from 'react';
 
 export interface GroupEvaluations {
   rows: EvaluationRow[];
+  /** Evaluations in the group, which exceeds `rows.length` when the group is larger than one page. */
+  total: number;
   isLoading: boolean;
   isError: boolean;
 }
@@ -22,11 +24,14 @@ export function useGroupEvaluations(
 ): GroupEvaluations {
   // Disabled by callers that already hold the whole group, to avoid a redundant all-evaluations fetch.
   const enabled = (options?.enabled ?? true) && !!experimentId;
+  // Newest first, explicitly rather than by the API's default, so a group too large for one page
+  // truncates to a known slice — the most recent evaluations — instead of an arbitrary one.
   const { data, isLoading, isError } = useListEvaluations(
     workspace,
     {
       page: 1,
       page_size: DEFAULT_LARGE_PAGE_SIZE,
+      sort: '-created_at',
       filter: { experiment_id: experimentId } as EvaluationFilter,
     },
     { query: { enabled } }
@@ -41,5 +46,5 @@ export function useGroupEvaluations(
     [data]
   );
 
-  return { rows, isLoading, isError };
+  return { rows, total: data?.pagination?.total_results ?? rows.length, isLoading, isError };
 }

--- a/web/packages/studio/src/components/charts/useGroupEvaluations.ts
+++ b/web/packages/studio/src/components/charts/useGroupEvaluations.ts
@@ -7,19 +7,19 @@ import type { EvaluationRow } from '@studio/components/dataViews/ExperimentDataV
 import { DEFAULT_LARGE_PAGE_SIZE } from '@studio/constants/constants';
 import { useMemo } from 'react';
 
-export interface ParetoEvaluations {
+export interface GroupEvaluations {
   rows: EvaluationRow[];
   isLoading: boolean;
   isError: boolean;
 }
 
-/** Loads every evaluation in a group in one request for the Pareto chart, reusing the list endpoint
- * (each evaluation already carries the rollup means the chart plots). */
-export function useParetoEvaluations(
+/** Loads every evaluation in a group in one request for the group's charts, reusing the list endpoint
+ * (each evaluation already carries the rollup means the charts plot). */
+export function useGroupEvaluations(
   workspace: string,
   experimentId: string,
   options?: { enabled?: boolean }
-): ParetoEvaluations {
+): GroupEvaluations {
   // Disabled by callers that already hold the whole group, to avoid a redundant all-evaluations fetch.
   const enabled = (options?.enabled ?? true) && !!experimentId;
   const { data, isLoading, isError } = useListEvaluations(

--- a/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
@@ -25,6 +25,7 @@ import { Button, Text, Tooltip } from '@nvidia/foundations-react-core';
 import { EVAL_DURATION_METADATA_KEY, evalDurationMs } from '@studio/api/evaluation/utils';
 import { ChangesetBadge } from '@studio/components/ChangesetBadge';
 import { ExperimentParetoChart } from '@studio/components/charts/ExperimentParetoChart';
+import { ExperimentTrendChart } from '@studio/components/charts/ExperimentTrendChart';
 import { AddToGroupModal } from '@studio/components/dataViews/ExperimentDataView/AddToGroupModal';
 import '@studio/components/dataViews/ExperimentDataView/ExperimentDataView.css';
 import { MeanValueTooltipCell } from '@studio/components/dataViews/ExperimentDataView/MeanValueTooltipCell';
@@ -147,10 +148,17 @@ interface ExperimentDataViewProps {
   /** Whether the Pareto (cost-vs-accuracy) chart is shown. The toggle lives in the parent
    * route header (next to the "Evaluations" title); this component only renders the chart. */
   paretoVisible: boolean;
+  /** Whether the over-time trend chart is shown. Same arrangement as `paretoVisible`: the parent
+   * owns the toggle, which starts on for experiments flagged `show_evaluations_over_time`. */
+  trendVisible: boolean;
 }
 
 /** Lists the experiments that belong to a single experiment group. */
-export const ExperimentDataView: FC<ExperimentDataViewProps> = ({ group, paretoVisible }) => {
+export const ExperimentDataView: FC<ExperimentDataViewProps> = ({
+  group,
+  paretoVisible,
+  trendVisible,
+}) => {
   const workspace = useWorkspaceFromPath();
   const navigate = useNavigate();
   const toast = useToast();
@@ -579,6 +587,19 @@ export const ExperimentDataView: FC<ExperimentDataViewProps> = ({ group, paretoV
 
   return (
     <>
+      {trendVisible && (
+        <div className="mb-4">
+          {/* Key by group id for the same reason as the Pareto chart: re-seed the selected metric
+              when navigating between groups without a route remount. */}
+          <ExperimentTrendChart
+            key={group.id}
+            workspace={workspace}
+            group={group}
+            preloadedEvaluations={completeEvaluationSet}
+            preloadPending={preloadPending}
+          />
+        </div>
+      )}
       {paretoVisible && (
         <div className="mb-4">
           {/* Key by group id so the axis selection resets (re-seeds from the new group's saved

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
@@ -102,14 +102,27 @@ describe('ExperimentDetailRoute', () => {
       expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
     });
 
-    it("lets a viewer's stored choice override the flag", async () => {
-      // The absent-key case must stay distinguishable from a stored `false`, or the flag would win
-      // back and the viewer could never dismiss the chart on a flagged experiment.
-      window.localStorage.setItem(`nemo-studio:experiment-trend:${group.id}`, 'false');
+    it("lets a viewer's stored choice override the flag it was made against", async () => {
+      window.localStorage.setItem(
+        `nemo-studio:experiment-trend:${group.id}`,
+        JSON.stringify({ visible: false, flag: true })
+      );
       mockGroup({ show_evaluations_over_time: true });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
       expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('retires a stored choice once the flag has moved under it', async () => {
+      // The viewer hid the chart while the flag was off; the owner has since turned it on.
+      window.localStorage.setItem(
+        `nemo-studio:experiment-trend:${group.id}`,
+        JSON.stringify({ visible: false, flag: false })
+      );
+      mockGroup({ show_evaluations_over_time: true });
+
+      expect(await screen.findByText('Editable group description')).toBeInTheDocument();
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
     });
   });
 });

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
@@ -82,7 +82,7 @@ describe('ExperimentDetailRoute', () => {
   });
 
   describe('over-time chart visibility', () => {
-    const trendToggle = () => screen.getByRole('switch', { name: /over time/i });
+    const trendToggle = () => screen.getByRole('button', { name: /over time/i });
 
     beforeEach(() => {
       window.localStorage.clear();
@@ -92,15 +92,15 @@ describe('ExperimentDetailRoute', () => {
       mockGroup({ show_evaluations_over_time: true });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
-      // The switch's own checked state is the toggle's view of whether the chart is showing.
-      expect(trendToggle()).toBeChecked();
+      // aria-pressed is the toggle's own view of whether the chart is showing.
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
     });
 
     it('hides the chart on an unflagged experiment', async () => {
       mockGroup({ show_evaluations_over_time: false });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
-      expect(trendToggle()).not.toBeChecked();
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
     });
 
     it("lets a viewer's stored choice override the flag it was made against", async () => {
@@ -111,7 +111,7 @@ describe('ExperimentDetailRoute', () => {
       mockGroup({ show_evaluations_over_time: true });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
-      expect(trendToggle()).not.toBeChecked();
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
     });
 
     it('deletes a stored choice the flag has moved under, so a round trip cannot revive it', async () => {
@@ -132,7 +132,7 @@ describe('ExperimentDetailRoute', () => {
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
       await waitFor(() => expect(window.localStorage.getItem(key)).toBeNull());
-      expect(trendToggle()).toBeChecked();
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
     });
 
     it('retires a stored choice once the flag has moved under it', async () => {
@@ -144,7 +144,7 @@ describe('ExperimentDetailRoute', () => {
       mockGroup({ show_evaluations_over_time: true });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
-      expect(trendToggle()).toBeChecked();
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
     });
   });
 });

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
@@ -82,7 +82,7 @@ describe('ExperimentDetailRoute', () => {
   });
 
   describe('over-time chart visibility', () => {
-    const trendToggle = () => screen.getByRole('button', { name: /over time/i });
+    const trendToggle = () => screen.getByRole('switch', { name: /over time/i });
 
     beforeEach(() => {
       window.localStorage.clear();
@@ -92,15 +92,15 @@ describe('ExperimentDetailRoute', () => {
       mockGroup({ show_evaluations_over_time: true });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
-      // aria-pressed is the toggle's own view of whether the chart is showing.
-      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
+      // The switch's own checked state is the toggle's view of whether the chart is showing.
+      expect(trendToggle()).toBeChecked();
     });
 
     it('hides the chart on an unflagged experiment', async () => {
       mockGroup({ show_evaluations_over_time: false });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
-      expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
+      expect(trendToggle()).not.toBeChecked();
     });
 
     it("lets a viewer's stored choice override the flag it was made against", async () => {
@@ -111,7 +111,7 @@ describe('ExperimentDetailRoute', () => {
       mockGroup({ show_evaluations_over_time: true });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
-      expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
+      expect(trendToggle()).not.toBeChecked();
     });
 
     it('deletes a stored choice the flag has moved under, so a round trip cannot revive it', async () => {
@@ -132,7 +132,7 @@ describe('ExperimentDetailRoute', () => {
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
       await waitFor(() => expect(window.localStorage.getItem(key)).toBeNull());
-      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
+      expect(trendToggle()).toBeChecked();
     });
 
     it('retires a stored choice once the flag has moved under it', async () => {
@@ -144,7 +144,7 @@ describe('ExperimentDetailRoute', () => {
       mockGroup({ show_evaluations_over_time: true });
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
-      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
+      expect(trendToggle()).toBeChecked();
     });
   });
 });

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
@@ -79,4 +79,37 @@ describe('ExperimentDetailRoute', () => {
     expect(await screen.findByText('Editable group description')).toBeInTheDocument();
     expect(screen.queryByText('Summary')).not.toBeInTheDocument();
   });
+
+  describe('over-time chart visibility', () => {
+    const trendToggle = () => screen.getByRole('button', { name: /over time/i });
+
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('shows the chart unasked when the experiment is flagged to evaluate over time', async () => {
+      mockGroup({ show_evaluations_over_time: true });
+
+      expect(await screen.findByText('Editable group description')).toBeInTheDocument();
+      // aria-pressed is the toggle's own view of whether the chart is showing.
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('hides the chart on an unflagged experiment', async () => {
+      mockGroup({ show_evaluations_over_time: false });
+
+      expect(await screen.findByText('Editable group description')).toBeInTheDocument();
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it("lets a viewer's stored choice override the flag", async () => {
+      // The absent-key case must stay distinguishable from a stored `false`, or the flag would win
+      // back and the viewer could never dismiss the chart on a flagged experiment.
+      window.localStorage.setItem(`nemo-studio:experiment-trend:${group.id}`, 'false');
+      mockGroup({ show_evaluations_over_time: true });
+
+      expect(await screen.findByText('Editable group description')).toBeInTheDocument();
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
+    });
+  });
 });

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.test.tsx
@@ -6,6 +6,7 @@ import { ROUTES } from '@studio/constants/routes';
 import { server } from '@studio/mocks/node';
 import { ExperimentDetailRoute } from '@studio/routes/ExperimentDetailRoute';
 import { renderRoute, screen } from '@studio/tests/util/render';
+import { waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 
 vi.hoisted(() => {
@@ -111,6 +112,27 @@ describe('ExperimentDetailRoute', () => {
 
       expect(await screen.findByText('Editable group description')).toBeInTheDocument();
       expect(trendToggle()).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('deletes a stored choice the flag has moved under, so a round trip cannot revive it', async () => {
+      const key = `nemo-studio:experiment-trend:${group.id}`;
+      // Chosen while the flag was off; the owner has since turned it on.
+      window.localStorage.setItem(key, JSON.stringify({ visible: true, flag: false }));
+      mockGroup({ show_evaluations_over_time: true });
+
+      expect(await screen.findByText('Editable group description')).toBeInTheDocument();
+      // Merely ignoring it would leave it to apply again the next time the flag reads false.
+      await waitFor(() => expect(window.localStorage.getItem(key)).toBeNull());
+    });
+
+    it('discards a value left in the older bare-boolean format', async () => {
+      const key = `nemo-studio:experiment-trend:${group.id}`;
+      window.localStorage.setItem(key, 'false');
+      mockGroup({ show_evaluations_over_time: true });
+
+      expect(await screen.findByText('Editable group description')).toBeInTheDocument();
+      await waitFor(() => expect(window.localStorage.getItem(key)).toBeNull());
+      expect(trendToggle()).toHaveAttribute('aria-pressed', 'true');
     });
 
     it('retires a stored choice once the flag has moved under it', async () => {

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -7,6 +7,7 @@ import { useGetExperiment } from '@nemo/sdk/generated/platform/api';
 import { Button, Card, Flex, PageHeader, Stack, Text } from '@nvidia/foundations-react-core';
 import { useOptimizerGetInsight } from '@studio/api/optimizer';
 import {
+  isTrendChoiceCurrent,
   resolveTrendVisible,
   type TrendVisibilityChoice,
   trendVisibilityStorageKey,
@@ -23,7 +24,7 @@ import { getExperimentRoute } from '@studio/routes/utils';
 import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
 import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
 import { ChartLine, ChartScatter, Pencil } from 'lucide-react';
-import { type FC, useState } from 'react';
+import { type FC, useEffect, useState } from 'react';
 
 export const ExperimentDetailRoute: FC = () => {
   const workspace = useWorkspaceFromPath();
@@ -46,11 +47,19 @@ export const ExperimentDetailRoute: FC = () => {
   // flag — a flagged experiment is one whose owner has said its evaluations are comparable, so the
   // chart is worth showing unasked. A viewer's own toggle wins, but only until the flag changes;
   // `resolveTrendVisible` retires the stored choice at that point so the owner's edit takes effect.
-  const [storedTrendChoice, setTrendChoice] = useLocalStorage<TrendVisibilityChoice>(
-    trendVisibilityStorageKey(group?.id)
-  );
+  const [storedTrendChoice, setTrendChoice, clearTrendChoice] =
+    useLocalStorage<TrendVisibilityChoice>(trendVisibilityStorageKey(group?.id));
   const trendFlag = Boolean(group?.show_evaluations_over_time);
   const trendVisible = resolveTrendVisible(storedTrendChoice, trendFlag);
+
+  // Drop a choice the flag has moved out from under, rather than leaving it suspended: the stamp
+  // lines up again if the flag is turned off and back on, which would revive a choice the owner has
+  // twice overruled. Gated on `group` because the flag reads false until it loads, which would
+  // otherwise look like a mismatch and delete a live choice on every mount.
+  useEffect(() => {
+    if (!group || storedTrendChoice === undefined) return;
+    if (!isTrendChoiceCurrent(storedTrendChoice, trendFlag)) clearTrendChoice();
+  }, [group, storedTrendChoice, trendFlag, clearTrendChoice]);
 
   useBreadcrumbs({
     items: [

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -6,7 +6,11 @@ import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { useGetExperiment } from '@nemo/sdk/generated/platform/api';
 import { Button, Card, Flex, PageHeader, Stack, Text } from '@nvidia/foundations-react-core';
 import { useOptimizerGetInsight } from '@studio/api/optimizer';
-import { trendVisibilityStorageKey } from '@studio/components/charts/ExperimentTrendChart/visibility';
+import {
+  resolveTrendVisible,
+  type TrendVisibilityChoice,
+  trendVisibilityStorageKey,
+} from '@studio/components/charts/ExperimentTrendChart/visibility';
 import { ExperimentDataView } from '@studio/components/dataViews/ExperimentDataView';
 import { ExperimentEditModal } from '@studio/components/ExperimentEditModal';
 import { OriginatingInsightLink } from '@studio/components/OriginatingInsightLink';
@@ -38,17 +42,15 @@ export const ExperimentDetailRoute: FC = () => {
   );
   const paretoVisible = storedParetoVisible ?? false;
 
-  // Over-time trend visibility, persisted per group like the Pareto view. Unlike it, the default
-  // is the experiment's own `show_evaluations_over_time` flag — a flagged experiment is one whose
-  // owner has said its evaluations are comparable, so the chart is worth showing unasked. Once a
-  // viewer toggles it, their stored choice wins over the flag.
-  // No default passed, deliberately: `useLocalStorage` returns its default when the key is absent,
-  // so passing `false` here would make "never toggled" indistinguishable from "toggled off" and the
-  // flag below would never be consulted.
-  const [storedTrendVisible, setTrendVisible] = useLocalStorage<boolean>(
+  // Over-time trend visibility. The default is the experiment's own `show_evaluations_over_time`
+  // flag — a flagged experiment is one whose owner has said its evaluations are comparable, so the
+  // chart is worth showing unasked. A viewer's own toggle wins, but only until the flag changes;
+  // `resolveTrendVisible` retires the stored choice at that point so the owner's edit takes effect.
+  const [storedTrendChoice, setTrendChoice] = useLocalStorage<TrendVisibilityChoice>(
     trendVisibilityStorageKey(group?.id)
   );
-  const trendVisible = storedTrendVisible ?? Boolean(group?.show_evaluations_over_time);
+  const trendFlag = Boolean(group?.show_evaluations_over_time);
+  const trendVisible = resolveTrendVisible(storedTrendChoice, trendFlag);
 
   useBreadcrumbs({
     items: [
@@ -115,7 +117,7 @@ export const ExperimentDetailRoute: FC = () => {
                     <Button
                       kind="tertiary"
                       aria-pressed={trendVisible}
-                      onClick={() => setTrendVisible(!trendVisible)}
+                      onClick={() => setTrendChoice({ visible: !trendVisible, flag: trendFlag })}
                     >
                       <ChartLine width={12} height={12} className="text-brand" />
                       {trendVisible ? 'Hide over time' : 'Over time'}

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -4,15 +4,7 @@
 import { AccessibleTitle } from '@nemo/common/src/components/AccessibleTitle';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { useGetExperiment } from '@nemo/sdk/generated/platform/api';
-import {
-  Button,
-  Card,
-  Flex,
-  PageHeader,
-  Stack,
-  Switch,
-  Text,
-} from '@nvidia/foundations-react-core';
+import { Button, Card, Flex, PageHeader, Stack, Text } from '@nvidia/foundations-react-core';
 import { useOptimizerGetInsight } from '@studio/api/optimizer';
 import {
   isTrendChoiceCurrent,
@@ -31,7 +23,7 @@ import { ExperimentMetrics } from '@studio/routes/ExperimentDetailRoute/Experime
 import { getExperimentRoute } from '@studio/routes/utils';
 import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
 import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
-import { Pencil } from 'lucide-react';
+import { ChartLine, ChartScatter, Pencil } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
 
 export const ExperimentDetailRoute: FC = () => {
@@ -129,28 +121,24 @@ export const ExperimentDetailRoute: FC = () => {
             <div className="flex flex-col gap-4 border-t border-base pt-4">
               <div className="flex items-center gap-3">
                 <Text kind="title/sm">Evaluations</Text>
-                {/* Switches rather than toggle buttons: each shows or hides a panel the moment it
-                    changes, which is what Switch is for, and the control carries the on/off state
-                    so the labels can stay put instead of flipping to "Hide …". `small` is the size
-                    for a dense row like this one. */}
                 {group && (
                   <>
-                    <Switch
-                      size="small"
-                      name="show-over-time"
-                      checked={trendVisible}
-                      onCheckedChange={(visible: boolean) =>
-                        setTrendChoice({ visible, flag: trendFlag })
-                      }
-                      slotLabel="Over time"
-                    />
-                    <Switch
-                      size="small"
-                      name="show-pareto"
-                      checked={paretoVisible}
-                      onCheckedChange={setParetoVisible}
-                      slotLabel="Pareto view"
-                    />
+                    <Button
+                      kind="tertiary"
+                      aria-pressed={trendVisible}
+                      onClick={() => setTrendChoice({ visible: !trendVisible, flag: trendFlag })}
+                    >
+                      <ChartLine width={12} height={12} className="text-brand" />
+                      {trendVisible ? 'Hide over time' : 'Over time'}
+                    </Button>
+                    <Button
+                      kind="tertiary"
+                      aria-pressed={paretoVisible}
+                      onClick={() => setParetoVisible(!paretoVisible)}
+                    >
+                      <ChartScatter width={12} height={12} className="text-brand" />
+                      {paretoVisible ? 'Hide Pareto' : 'Pareto view'}
+                    </Button>
                   </>
                 )}
               </div>

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -6,6 +6,7 @@ import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { useGetExperiment } from '@nemo/sdk/generated/platform/api';
 import { Button, Card, Flex, PageHeader, Stack, Text } from '@nvidia/foundations-react-core';
 import { useOptimizerGetInsight } from '@studio/api/optimizer';
+import { trendVisibilityStorageKey } from '@studio/components/charts/ExperimentTrendChart/visibility';
 import { ExperimentDataView } from '@studio/components/dataViews/ExperimentDataView';
 import { ExperimentEditModal } from '@studio/components/ExperimentEditModal';
 import { OriginatingInsightLink } from '@studio/components/OriginatingInsightLink';
@@ -45,7 +46,7 @@ export const ExperimentDetailRoute: FC = () => {
   // so passing `false` here would make "never toggled" indistinguishable from "toggled off" and the
   // flag below would never be consulted.
   const [storedTrendVisible, setTrendVisible] = useLocalStorage<boolean>(
-    `nemo-studio:experiment-trend:${group?.id ?? ''}`
+    trendVisibilityStorageKey(group?.id)
   );
   const trendVisible = storedTrendVisible ?? Boolean(group?.show_evaluations_over_time);
 

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -41,9 +41,11 @@ export const ExperimentDetailRoute: FC = () => {
   // is the experiment's own `show_evaluations_over_time` flag — a flagged experiment is one whose
   // owner has said its evaluations are comparable, so the chart is worth showing unasked. Once a
   // viewer toggles it, their stored choice wins over the flag.
+  // No default passed, deliberately: `useLocalStorage` returns its default when the key is absent,
+  // so passing `false` here would make "never toggled" indistinguishable from "toggled off" and the
+  // flag below would never be consulted.
   const [storedTrendVisible, setTrendVisible] = useLocalStorage<boolean>(
-    `nemo-studio:experiment-trend:${group?.id ?? ''}`,
-    false
+    `nemo-studio:experiment-trend:${group?.id ?? ''}`
   );
   const trendVisible = storedTrendVisible ?? Boolean(group?.show_evaluations_over_time);
 

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -17,7 +17,7 @@ import { ExperimentMetrics } from '@studio/routes/ExperimentDetailRoute/Experime
 import { getExperimentRoute } from '@studio/routes/utils';
 import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
 import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
-import { ChartScatter, Pencil } from 'lucide-react';
+import { ChartLine, ChartScatter, Pencil } from 'lucide-react';
 import { type FC, useState } from 'react';
 
 export const ExperimentDetailRoute: FC = () => {
@@ -36,6 +36,16 @@ export const ExperimentDetailRoute: FC = () => {
     false
   );
   const paretoVisible = storedParetoVisible ?? false;
+
+  // Over-time trend visibility, persisted per group like the Pareto view. Unlike it, the default
+  // is the experiment's own `show_evaluations_over_time` flag — a flagged experiment is one whose
+  // owner has said its evaluations are comparable, so the chart is worth showing unasked. Once a
+  // viewer toggles it, their stored choice wins over the flag.
+  const [storedTrendVisible, setTrendVisible] = useLocalStorage<boolean>(
+    `nemo-studio:experiment-trend:${group?.id ?? ''}`,
+    false
+  );
+  const trendVisible = storedTrendVisible ?? Boolean(group?.show_evaluations_over_time);
 
   useBreadcrumbs({
     items: [
@@ -98,17 +108,33 @@ export const ExperimentDetailRoute: FC = () => {
               <div className="flex items-center gap-3">
                 <Text kind="title/sm">Evaluations</Text>
                 {group && (
-                  <Button
-                    kind="tertiary"
-                    aria-pressed={paretoVisible}
-                    onClick={() => setParetoVisible(!paretoVisible)}
-                  >
-                    <ChartScatter width={12} height={12} className="text-brand" />
-                    {paretoVisible ? 'Hide Pareto' : 'Pareto view'}
-                  </Button>
+                  <>
+                    <Button
+                      kind="tertiary"
+                      aria-pressed={trendVisible}
+                      onClick={() => setTrendVisible(!trendVisible)}
+                    >
+                      <ChartLine width={12} height={12} className="text-brand" />
+                      {trendVisible ? 'Hide over time' : 'Over time'}
+                    </Button>
+                    <Button
+                      kind="tertiary"
+                      aria-pressed={paretoVisible}
+                      onClick={() => setParetoVisible(!paretoVisible)}
+                    >
+                      <ChartScatter width={12} height={12} className="text-brand" />
+                      {paretoVisible ? 'Hide Pareto' : 'Pareto view'}
+                    </Button>
+                  </>
                 )}
               </div>
-              {group && <ExperimentDataView group={group} paretoVisible={paretoVisible} />}
+              {group && (
+                <ExperimentDataView
+                  group={group}
+                  paretoVisible={paretoVisible}
+                  trendVisible={trendVisible}
+                />
+              )}
             </div>
           </>
         )}

--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -4,7 +4,15 @@
 import { AccessibleTitle } from '@nemo/common/src/components/AccessibleTitle';
 import { ErrorMessage } from '@nemo/common/src/components/ErrorMessage';
 import { useGetExperiment } from '@nemo/sdk/generated/platform/api';
-import { Button, Card, Flex, PageHeader, Stack, Text } from '@nvidia/foundations-react-core';
+import {
+  Button,
+  Card,
+  Flex,
+  PageHeader,
+  Stack,
+  Switch,
+  Text,
+} from '@nvidia/foundations-react-core';
 import { useOptimizerGetInsight } from '@studio/api/optimizer';
 import {
   isTrendChoiceCurrent,
@@ -23,7 +31,7 @@ import { ExperimentMetrics } from '@studio/routes/ExperimentDetailRoute/Experime
 import { getExperimentRoute } from '@studio/routes/utils';
 import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
 import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
-import { ChartLine, ChartScatter, Pencil } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
 
 export const ExperimentDetailRoute: FC = () => {
@@ -121,24 +129,28 @@ export const ExperimentDetailRoute: FC = () => {
             <div className="flex flex-col gap-4 border-t border-base pt-4">
               <div className="flex items-center gap-3">
                 <Text kind="title/sm">Evaluations</Text>
+                {/* Switches rather than toggle buttons: each shows or hides a panel the moment it
+                    changes, which is what Switch is for, and the control carries the on/off state
+                    so the labels can stay put instead of flipping to "Hide …". `small` is the size
+                    for a dense row like this one. */}
                 {group && (
                   <>
-                    <Button
-                      kind="tertiary"
-                      aria-pressed={trendVisible}
-                      onClick={() => setTrendChoice({ visible: !trendVisible, flag: trendFlag })}
-                    >
-                      <ChartLine width={12} height={12} className="text-brand" />
-                      {trendVisible ? 'Hide over time' : 'Over time'}
-                    </Button>
-                    <Button
-                      kind="tertiary"
-                      aria-pressed={paretoVisible}
-                      onClick={() => setParetoVisible(!paretoVisible)}
-                    >
-                      <ChartScatter width={12} height={12} className="text-brand" />
-                      {paretoVisible ? 'Hide Pareto' : 'Pareto view'}
-                    </Button>
+                    <Switch
+                      size="small"
+                      name="show-over-time"
+                      checked={trendVisible}
+                      onCheckedChange={(visible: boolean) =>
+                        setTrendChoice({ visible, flag: trendFlag })
+                      }
+                      slotLabel="Over time"
+                    />
+                    <Switch
+                      size="small"
+                      name="show-pareto"
+                      checked={paretoVisible}
+                      onCheckedChange={setParetoVisible}
+                      slotLabel="Pareto view"
+                    />
                   </>
                 )}
               </div>


### PR DESCRIPTION


https://github.com/user-attachments/assets/d360d7f7-ff9f-422e-b1d2-a6ac6c6202f9

## What

Adds an **Over time** chart to the experiment detail page: one evaluation metric plotted against
the time its evaluation ran, with a dropdown to pick the metric.

Selectable metrics are every evaluator seen in the group's evaluations, then the `cost_usd`,
`latency_ms` and `tokens` rollups — so a group can be read on quality, or on what that quality cost.

Built in the `ExperimentParetoChart` idiom rather than as a new visual language: same recharts
conventions (dashed `--border-color-base` grid, labelled numeric axes, compacted ticks, a component
tooltip), same panel shell, same `MetricSelect` dropdown, and the same arrangement with its caller —
the route owns visibility, the data view renders the chart and hands it the evaluation set it has
already loaded when the group fits one page, avoiding a second fetch.

`MetricSelect` is promoted out of `ExperimentParetoChart` so both charts share one selector. It now
resolves its trigger label from the metric list rather than from `metricLabel(id)`, so each chart
keeps its own naming, and takes a trigger width — the axis pickers stay compact while a single
metric picker can spell out "Answers Question". Pareto's rendering is unchanged.

## Visibility

Defaults to the experiment's own `show_evaluations_over_time` flag: a flagged experiment is one
whose owner has asserted its evaluations are comparable, so the chart is worth showing unasked.

A viewer's own toggle is persisted per group and wins — but only while the flag still reads as it
did when they chose. The stored choice carries that flag value with it, so an owner flipping the
flag retires it, however the flag moved: edit modal, API, CLI, another tab, another user. The modal
additionally clears the choice outright on an explicit flag edit, which covers the one case the
stamp cannot — a flag turned off and back on restores the stamp and would otherwise revive a stale
choice, making the owner's edit a no-op.

Values in the older bare-boolean format are retired on first read, so state stored while this branch
was in progress heals itself.

## Not included

**Run duration is not offered as a metric.** Intake tracks `duration_ms` per session and never
aggregates it onto an evaluation, so there is no field to plot. Adding it means a ClickHouse rollup,
an entity/schema change and an SDK regeneration — out of scope here. (The evaluations table does
show a Duration column; whether that is reachable for this chart has not been traced.)

## Testing

Unit tests cover metric derivation, point building (ordering, dropping rows with no parseable
`created_at` or no value for the selected metric) and the visibility resolution rule, including the
stale-format and flag-moved cases. Route and modal tests cover default-on, default-off, viewer
override and the clear-on-flag-edit.

Also driven manually in Chrome against a live platform: flagged experiment charts unasked; a chart
hidden by choice reappears when the owner flips the flag, with no reload; the selector switches
series; a stale stored value no longer suppresses the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added experiment trend charts showing evaluation metrics over time.
  - Added metric selection, formatted tooltips, loading states, and empty-data handling.
  - Added controls to show or hide trend and Pareto charts, with preferences saved per experiment.
  - Standardized metric selection across visualizations.
  - Indicate when charts display only the most recent evaluations.

- **Bug Fixes**
  - Trend-chart preferences now reset when the experiment’s time-based evaluation setting changes.
  - Removed outdated or invalid saved chart preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->