### PR TITLE
fix(data-designer): Clean up missed references to the legacy CLI comm…

### DIFF
--- a/docs/data-designer/index.mdx
+++ b/docs/data-designer/index.mdx
@@ -7,7 +7,7 @@ description: ""
 ---
 <a id="data-designer"></a>
 
-Data Designer on NeMo Platform enables high-quality synthetic data generation through the NeMo Data Designer plugin. You can execute workloads locally from the CLI, submit them to a running NeMo Services cluster, or call the Data Designer API from the SDK.
+Data Designer on NeMo Platform enables high-quality synthetic data generation through the NeMo Data Designer plugin. You can submit workloads to a running NeMo Services cluster using the CLI or SDK.
 
 ## Overview
 

--- a/plugins/nemo-data-designer/.agents/skills/refresh-data-designer-skill/SKILL.md
+++ b/plugins/nemo-data-designer/.agents/skills/refresh-data-designer-skill/SKILL.md
@@ -56,23 +56,16 @@ Stage the fetched files in a temp directory before adapting.
 
 Apply the translation rules below to every fetched markdown file. Leave non-markdown files (e.g., `scripts/get_person_object_schema.py`) byte-identical to upstream.
 
-**Single core rule:** prepend `nemo ` to every CLI invocation of the `data-designer` binary. For most subcommands (`agent`, `config`, `validate`), `nemo data-designer …` accepts the same arguments as the upstream library's CLI, so subcommand names, flags, and positional arguments stay identical.
+**Single core rule:** prepend `nemo ` to every CLI invocation of the `data-designer` binary. For most subcommands (`agent`, `validate`), `nemo data-designer …` accepts the same arguments as the upstream library's CLI, so subcommand names, flags, and positional arguments stay identical.
 
-**Exception — `preview` and `create` require a mode subcommand.** The plugin makes `preview` and `create` into command groups with two execution modes: `run` (local, in-process) and `submit` (cluster, over HTTP). Default to `run` for skill instructions — local execution fits the iterative agent workflow. Insert `run` after the subcommand name and before any positional args / flags. So:
-
-- `data-designer preview <path> --save-results` → `nemo data-designer preview run <path> --save-results`
-- `data-designer create <path> --num-records <N>` → `nemo data-designer create run <path> --num-records <N>`
-- Even prose references like ``the `data-designer preview` command`` should become ``the `nemo data-designer preview run` command`` for consistency with the actual invocation.
-
-**`create` does not accept `--dataset-name` or `--artifact-path`.** Upstream's `create` exposes these flags to name and locate the local artifact folder. The plugin's `create` (both `run` and `submit`) stores artifacts at a Jobs-service-managed path, so there's no local folder to name or relocate. Strip `--dataset-name` and `--artifact-path` (and any related flag values) from upstream `create` invocations during refresh; preserve other flags like `--num-records` as-is.
+**`create` does not accept `--dataset-name` or `--artifact-path`.** Upstream's `create` exposes these flags to name and locate the local artifact folder. The plugin's `create` stores artifacts at a Jobs-service-managed path, so there's no local folder to name or relocate. Strip `--dataset-name` and `--artifact-path` (and any related flag values) from upstream `create` invocations during refresh; preserve other flags like `--num-records` as-is.
 
 This applies to every shell-prompt and backticked invocation of:
 
 - `data-designer agent context` (and other `agent …` subcommands) → just prepend `nemo `
-- `data-designer config providers|models|…` → just prepend `nemo `
 - `data-designer validate <path>` → just prepend `nemo `
-- `data-designer preview <path>` (and any flags after) → prepend `nemo ` AND insert `run`
-- `data-designer create <path>` (and any flags after) → prepend `nemo ` AND insert `run`
+- `data-designer preview <path>` (and any flags after) → prepend `nemo `
+- `data-designer create <path>` (and any flags after) → prepend `nemo `
 
 Do **not** rewrite prose mentions of the project name (e.g., "the Data Designer library", "Data Designer columns"). Only shell-shaped invocations.
 
@@ -140,15 +133,6 @@ grep -RhoE 'nemo data-designer [a-z][a-z -]*' "$SKILLS" \
 ```
 
 Any `MISSING:` line indicates upstream changed the command surface or `nemo data-designer` has drifted from upstream's CLI shape — investigate before merging.
-
-**Every `preview` / `create` invocation has a mode subcommand.** The plugin requires `run` or `submit` after `preview` and `create`. This grep catches missed insertions:
-
-```bash
-grep -RnE 'nemo data-designer (preview|create) ' "$SKILLS" \
-  | grep -vE '(preview|create) (run|submit)[^a-z]'
-```
-
-A clean run produces no output. The trailing `[^a-z]` allows backtick-bounded references like ``the `nemo data-designer preview run` command`` to pass without a trailing space.
 
 ## Notes
 

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/renderers.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/cli/renderers.py
@@ -52,7 +52,7 @@ _PREVIEW_FRAME_ADAPTER: TypeAdapter[PreviewFrame] = TypeAdapter(PreviewFrame)
 
 
 def _coerce_preview_frame(frame: Any) -> BaseModel | None:
-    """Turn a raw frame (BaseModel from local run, dict from HTTP) into a typed frame.
+    """Turn a raw frame into a typed frame.
 
     Returns ``None`` if the frame can't be parsed (unknown ``kind`` etc.) so
     the renderer can silently skip it instead of raising.
@@ -68,7 +68,7 @@ def _coerce_preview_frame(frame: Any) -> BaseModel | None:
 
 
 class PreviewRenderer(CLIRenderer):
-    """Renderer for ``nemo data-designer preview {run,submit}``.
+    """Renderer for ``nemo data-designer preview``.
 
     Streams log frames as colored Rich output during execution; on completion
     shows the dataset, analysis report, and a success summary. On error,
@@ -258,7 +258,7 @@ class PreviewRenderer(CLIRenderer):
 
 
 class CreateRenderer(CLIRenderer):
-    """Renderer for ``nemo data-designer create {run,submit}``.
+    """Renderer for ``nemo data-designer create``.
 
     Wraps the synchronous job result with header / success messaging. The
     full result dict is still echoed at the end so users can copy job IDs
@@ -270,8 +270,8 @@ class CreateRenderer(CLIRenderer):
 
     def on_frame(self, frame: Any, *, ctx: RendererContext) -> None:
         # Jobs are non-streaming; on_frame fires exactly once with the
-        # scheduler's result for run, or the submission response for submit.
-        # Print it directly so useful artifact paths stay visible.
+        # submission response. Print it directly so useful artifact
+        # paths stay visible.
         console.print()
         console.print(frame)
 

--- a/skills/nemo-data-designer-plugin/SKILL.md
+++ b/skills/nemo-data-designer-plugin/SKILL.md
@@ -83,9 +83,8 @@ def generator_function(row: dict) -> dict:
 
 def load_config_builder() -> dd.DataDesignerConfigBuilder:
     config_builder = dd.DataDesignerConfigBuilder(
-        # Declaring model configs programmatically here is the portable path:
-        # it works for both local `run` and cluster `submit`, while the local
-        # YAML registry alternative only works for `run`. The provider below
+        # Declaring model configs programmatically here is optional in the upstream
+        # library, but required for workloads running on NeMo Platform. The provider below
         # is a common default created during `nemo setup` — confirm it (or
         # discover others) with `nemo inference providers list`. See
         # references/nemo-platform-plugin-additions.md for the local-YAML alternative.
@@ -108,4 +107,4 @@ def load_config_builder() -> dd.DataDesignerConfigBuilder:
     return config_builder
 ```
 
-Only include Pydantic models, custom generators, seed datasets, and extra dependencies when the task requires them. Prefer including `model_configs` when the dataset uses LLM columns — declaring it in the script keeps the config portable between local `run` and cluster `submit`, while the local YAML registry alternative only works for `run`.
+Only include Pydantic models, custom generators, seed datasets, and extra dependencies when the task requires them.

--- a/skills/nemo-data-designer-plugin/workflows/autopilot.md
+++ b/skills/nemo-data-designer-plugin/workflows/autopilot.md
@@ -6,7 +6,7 @@ In this mode, make reasonable design decisions autonomously based on the dataset
   - If the output is a path, use `<path> data-designer` as the command prefix for all `nemo data-designer …` invocations in this workflow.
   - If the output is `CLI_NOT_FOUND`, STOP and follow the Troubleshooting section in SKILL.md. Do not continue to the next step.
 2. **Learn** — Run `nemo data-designer agent context`.
-  - `agent context` only inspects the local `~/.data-designer/` registry; it does not see IGW-managed providers or in-script `ModelConfig`s. Whether or not it lists usable aliases, read `references/nemo-platform-plugin-additions.md` for the model-config options before proceeding. Default to declaring `model_configs` programmatically with an IGW provider — that path is portable across local `run` and cluster `submit`. Note your provider choice as one of the key decisions in step 3.
+  - `agent context` only inspects the local `~/.data-designer/` registry; it does not see IGW-managed providers or in-script `ModelConfig`s. Whether or not it lists usable aliases, read `references/nemo-platform-plugin-additions.md` for the model-config options before proceeding. `model_configs` must be declared programmatically with IGW providers. Note your provider choice as one of the key decisions in step 3.
   - Inspect schemas for every column, sampler type, validator, and processor you plan to use.
   - Never guess types or parameters — read the relevant config files first.
   - Always read `base.py` for inherited fields shared by all config objects.
@@ -19,11 +19,11 @@ In this mode, make reasonable design decisions autonomously based on the dataset
 4. **Plan** — Determine columns, samplers, processors, validators, and other dataset features needed.
 5. **Build** — Write the Python script with `load_config_builder()` returning a `DataDesignerConfigBuilder` (see Output Template in SKILL.md).
 6. **Validate** — Run `nemo data-designer validate <path>`. Address any warnings or errors and re-validate until it passes.
-7. **Preview** — Run `nemo data-designer preview run <path> --save-results` to generate sample records as HTML files.
-  - Note the sample records directory printed by the `nemo data-designer preview run` command
+7. **Preview** — Run `nemo data-designer preview <path> --save-results` to generate sample records as HTML files.
+  - Note the sample records directory printed by the `nemo data-designer preview` command
   - Give the user a clickable link: `file://<sample-records-dir>/sample_records_browser.html`
 8. **Create** — If the user specified a record count:
-  - Run `nemo data-designer create run <path> --num-records <N>`.
+  - Run `nemo data-designer create <path> --num-records <N>`.
   - Generation speed depends heavily on the dataset configuration and the user's inference setup. For larger datasets, warn the user and ask for confirmation before running.
   - If no record count was specified, skip this step.
 9. **Present** — Summarize what was built: columns, samplers used, key design choices. If the create command was run, share the results. Ask the user if they want any changes. If so, edit the script, re-validate, re-preview, and iterate.

--- a/skills/nemo-data-designer-plugin/workflows/interactive.md
+++ b/skills/nemo-data-designer-plugin/workflows/interactive.md
@@ -12,7 +12,7 @@ This is an interactive, iterative design process. Do not disengage from the loop
   - Always read `base.py` for inherited fields shared by all config objects.
 3. **Clarify** — Ask the user clarifying questions to narrow down precisely what they want.
   - Optimize for a great user experience: prefer a structured question tool over plain text if one is available, batch related questions together, keep the set short, provide concrete options/examples/defaults where possible, and use structured inputs (single-select, multi-select, free text, etc.) when they make answering easier.
-  - If the dataset uses LLM columns, confirm with the user which provider/model(s) to use. Default to declaring `model_configs` programmatically with an IGW provider (portable across local `run` and cluster `submit`); see `references/nemo-platform-plugin-additions.md`. Use `nemo inference providers list` to discover what IGW has registered.
+  - If the dataset uses LLM columns, confirm with the user which provider/model(s) to use. `model_configs` must be delcared programmatically with IGW providers; see `references/nemo-platform-plugin-additions.md`. Use `nemo inference providers list` to discover what IGW has registered.
   - Common things to make precise:
     - What the "axes of diversity" are — what should be well represented and diverse in the resulting dataset.
     - The kind and nature of any input data.
@@ -23,14 +23,14 @@ This is an interactive, iterative design process. Do not disengage from the loop
 4. **Plan** — Determine columns, samplers, processors, validators, and other dataset features needed. Present the plan to the user and ask if they want any changes before generating a preview.
 5. **Build** — Write the Python script with `load_config_builder()` returning a `DataDesignerConfigBuilder` (see Output Template in SKILL.md).
 6. **Validate** — Run `nemo data-designer validate <path>`. Address any warnings or errors and re-validate until it passes.
-7. **Preview** — Run `nemo data-designer preview run <path> --save-results` to generate sample records as HTML files.
-  - Note the sample records directory printed by the `nemo data-designer preview run` command
+7. **Preview** — Run `nemo data-designer preview <path> --save-results` to generate sample records as HTML files.
+  - Note the sample records directory printed by the `nemo data-designer preview` command
   - Give the user a clickable link: `file://<sample-records-dir>/sample_records_browser.html`
 8. **Iterate**
    - Ask the user for feedback.
    - Offer to review the records yourself and suggest improvements. If the user accepts, read `references/preview-review.md` for guidance.
    - Apply changes, re-validate, and re-preview. Repeat until the user is satisfied.
 9. **Finalize** — Once the user is happy, tell them they can run the following command to create the dataset:
-  - `nemo data-designer create run <path> --num-records <N>`.
+  - `nemo data-designer create <path> --num-records <N>`.
   - Caution the user that generation speed depends heavily on the dataset configuration and their inference setup.
   - Do not run this command yourself — the user should control when it runs.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Cleans up a few missed references to the legacy CLI commands that escaped #1519 


## Changes
Cleans up stale `run/submit` language in docs, docstrings, skill content.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [x] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included
