### PR TITLE
fix(auditor): better docker-local defaults

### DIFF
--- a/packages/nmp_platform/config/local.yaml
+++ b/packages/nmp_platform/config/local.yaml
@@ -75,7 +75,9 @@ jobs:
         ttl_seconds_after_finished: 300
     # Auditor jobs always run as Docker containers (auditor-tasks image). Using a
     # dedicated profile "auditor" avoids the cpu→subprocess translation that the
-    # subprocess/default entry above enables for profile "default".
+    # subprocess/default entry above enables for profile "default". The `auditor:`
+    # plugin config block below points AuditJob at this profile instead of the
+    # (locally subprocess-diverted) default.
     - provider: cpu
       profile: auditor
       backend: docker
@@ -123,6 +125,13 @@ evaluator:
   recreate_existing_system_entities: True
 
 safe_synthesizer: {}
+
+# Audit jobs need real Docker containers (auditor-tasks image with garak). cpu/default is
+# diverted to the subprocess backend above for local dev, so point auditor jobs at the
+# dedicated cpu/auditor Docker profile registered under jobs.executors instead. Not needed
+# on Kubernetes/CI, where cpu/default already resolves to a real container backend.
+auditor:
+  job_executor_profile: auditor
 
 deployments:
   executors:

--- a/plugins/nemo-auditor/src/nemo_auditor/config.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/config.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration for the Auditor plugin."""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from nemo_platform_plugin.config import NemoConfig
+
+
+class AuditorPluginConfig(NemoConfig):
+    plugin_name: ClassVar[str] = "auditor"
+    plugin_description: ClassVar[str] = "Auditor plugin configuration"
+
+    # "default" is registered out of the box on every runtime (Docker and Kubernetes),
+    # so audit jobs work without extra config in CI/k8s. Deployments that redirect
+    # cpu/default to a non-container backend (e.g. local dev's subprocess translation
+    # workaround, see packages/nmp_platform/config/local.yaml) should register a
+    # dedicated container-backed profile and point this at it instead.
+    job_executor_profile: str = "default"
+
+
+def get_config() -> AuditorPluginConfig:
+    return AuditorPluginConfig.get()

--- a/plugins/nemo-auditor/src/nemo_auditor/jobs/audit.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/jobs/audit.py
@@ -426,7 +426,7 @@ class AuditJob(NemoJob):
                 PlatformJobStep(
                     name="audit-job",
                     executor=CPUExecutionProviderSpec(
-                        profile=profile or "default",
+                        profile=profile or "auditor",
                         provider="cpu",
                         container=ContainerSpec(
                             image=get_qualified_image("auditor-tasks"),

--- a/plugins/nemo-auditor/src/nemo_auditor/jobs/audit.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/jobs/audit.py
@@ -411,6 +411,7 @@ class AuditJob(NemoJob):
         profile: str | None = None,
         options: dict | None = None,
     ) -> object:
+        from nemo_auditor.config import get_config
         from nemo_platform_plugin.jobs.api_factory import (
             ContainerSpec,
             CPUExecutionProviderSpec,
@@ -426,7 +427,7 @@ class AuditJob(NemoJob):
                 PlatformJobStep(
                     name="audit-job",
                     executor=CPUExecutionProviderSpec(
-                        profile=profile or "auditor",
+                        profile=profile or get_config().job_executor_profile,
                         provider="cpu",
                         container=ContainerSpec(
                             image=get_qualified_image("auditor-tasks"),

--- a/plugins/nemo-auditor/src/nemo_auditor/service.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/service.py
@@ -64,7 +64,7 @@ class AuditorPluginService(NemoService):
                 prefix=crud_prefix,
             ),
             RouterSpec(
-                add_job_routes(AuditJob, authz=scope.child("audit")),
+                add_job_routes(AuditJob, authz=scope.child("audit"), default_profile="auditor"),
                 tag="Auditor Jobs",
                 description="Audit job submission and retrieval.",
                 prefix=crud_prefix,

--- a/plugins/nemo-auditor/src/nemo_auditor/service.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/service.py
@@ -64,7 +64,7 @@ class AuditorPluginService(NemoService):
                 prefix=crud_prefix,
             ),
             RouterSpec(
-                add_job_routes(AuditJob, authz=scope.child("audit"), default_profile="auditor"),
+                add_job_routes(AuditJob, authz=scope.child("audit")),
                 tag="Auditor Jobs",
                 description="Audit job submission and retrieval.",
                 prefix=crud_prefix,

--- a/plugins/nemo-auditor/tests/test_audit_job.py
+++ b/plugins/nemo-auditor/tests/test_audit_job.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import yaml
+from nemo_auditor.config import AuditorPluginConfig
 from nemo_auditor.entities import (
     AuditConfig,
     AuditPluginsData,
@@ -38,6 +39,7 @@ from nemo_auditor.jobs.audit import (
     _rewrite_options_uris,
 )
 from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.config import clear_nemo_config_override, set_nemo_config_override
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
@@ -698,6 +700,9 @@ class TestAuditJobRun:
 
 
 class TestCompileProfileDefault:
+    def teardown_method(self) -> None:
+        clear_nemo_config_override(AuditorPluginConfig)
+
     def _compile(self, profile: str | None) -> dict:
         result = asyncio.run(
             AuditJob.compile(
@@ -711,11 +716,25 @@ class TestCompileProfileDefault:
         )
         return cast(dict, result)
 
-    def test_defaults_to_auditor_profile_when_unset(self) -> None:
+    def test_defaults_to_default_profile_when_unset(self) -> None:
+        """ "default" is registered out of the box everywhere (Docker and Kubernetes),
+        so audit jobs work without extra config in CI/k8s."""
+        result = self._compile(None)
+        assert result["steps"][0]["executor"]["profile"] == "default"
+
+    def test_explicit_profile_overrides_default(self) -> None:
+        result = self._compile("gpu-pool")
+        assert result["steps"][0]["executor"]["profile"] == "gpu-pool"
+
+    def test_plugin_config_overrides_unset_profile(self) -> None:
+        """Deployments (e.g. local dev) that need a dedicated container-backed profile
+        can point audit jobs at it via the auditor plugin config."""
+        set_nemo_config_override(AuditorPluginConfig(job_executor_profile="auditor"))
         result = self._compile(None)
         assert result["steps"][0]["executor"]["profile"] == "auditor"
 
-    def test_explicit_profile_overrides_default(self) -> None:
+    def test_explicit_profile_wins_over_plugin_config(self) -> None:
+        set_nemo_config_override(AuditorPluginConfig(job_executor_profile="auditor"))
         result = self._compile("gpu-pool")
         assert result["steps"][0]["executor"]["profile"] == "gpu-pool"
 

--- a/plugins/nemo-auditor/tests/test_audit_job.py
+++ b/plugins/nemo-auditor/tests/test_audit_job.py
@@ -37,6 +37,7 @@ from nemo_auditor.jobs.audit import (
     _garak_config_dict,
     _rewrite_options_uris,
 )
+from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nemo_platform_plugin.entity_client import NemoEntityNotFoundError
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
@@ -692,6 +693,34 @@ class TestAuditJobRun:
 
 
 # ---------------------------------------------------------------------------
+# AuditJob.compile — profile defaulting
+# ---------------------------------------------------------------------------
+
+
+class TestCompileProfileDefault:
+    def _compile(self, profile: str | None) -> dict:
+        result = asyncio.run(
+            AuditJob.compile(
+                workspace="default",
+                spec=_make_config(),
+                entity_client=None,
+                job_name=None,
+                async_sdk=cast(AsyncNeMoPlatform, None),
+                profile=profile,
+            )
+        )
+        return cast(dict, result)
+
+    def test_defaults_to_auditor_profile_when_unset(self) -> None:
+        result = self._compile(None)
+        assert result["steps"][0]["executor"]["profile"] == "auditor"
+
+    def test_explicit_profile_overrides_default(self) -> None:
+        result = self._compile("gpu-pool")
+        assert result["steps"][0]["executor"]["profile"] == "gpu-pool"
+
+
+# ---------------------------------------------------------------------------
 # Schema-level tests
 # ---------------------------------------------------------------------------
 
@@ -1284,19 +1313,22 @@ class TestToSpec:
 
     def test_task_options_pass_through_to_spec(self) -> None:
         """max_probe_retries and fail_job_on_retries_exhausted are forwarded to AuditSpec."""
-        out = asyncio.run(
-            AuditJob.to_spec(
-                AuditInputSpec(
-                    config=_make_config(),
-                    target=_make_target(),
-                    max_probe_retries=3,
-                    fail_job_on_retries_exhausted=False,
-                ),
-                workspace="default",
-                entity_client=None,
-                async_sdk=None,
-                is_local=True,
-            )
+        out = cast(
+            AuditSpec,
+            asyncio.run(
+                AuditJob.to_spec(
+                    AuditInputSpec(
+                        config=_make_config(),
+                        target=_make_target(),
+                        max_probe_retries=3,
+                        fail_job_on_retries_exhausted=False,
+                    ),
+                    workspace="default",
+                    entity_client=None,
+                    async_sdk=None,
+                    is_local=True,
+                )
+            ),
         )
         assert out.max_probe_retries == 3
         assert out.fail_job_on_retries_exhausted is False

--- a/plugins/nemo-auditor/tests/test_config.py
+++ b/plugins/nemo-auditor/tests/test_config.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``config.py`` plugin config module."""
+
+from __future__ import annotations
+
+from nemo_auditor.config import AuditorPluginConfig
+
+
+def test_default_job_executor_profile() -> None:
+    """ "default" is registered out of the box on every runtime (Docker and Kubernetes),
+    so audit jobs work without extra config in CI/k8s."""
+    cfg = AuditorPluginConfig()
+    assert cfg.job_executor_profile == "default"
+
+
+def test_job_executor_profile_override() -> None:
+    cfg = AuditorPluginConfig(job_executor_profile="auditor")
+    assert cfg.job_executor_profile == "auditor"

--- a/plugins/nemo-auditor/tests/test_service.py
+++ b/plugins/nemo-auditor/tests/test_service.py
@@ -5,6 +5,9 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
+from fastapi import APIRouter
 from fastapi.routing import APIRoute
 from nemo_auditor.jobs.audit import AuditJob
 from nemo_auditor.service import AuditorPluginService
@@ -16,10 +19,21 @@ def _mounted_post_paths() -> set[str]:
     paths: set[str] = set()
     for spec in service.get_routers():
         for route in spec.router.routes:
-            if isinstance(route, APIRoute) and "POST" in route.methods:
+            if isinstance(route, APIRoute) and route.methods is not None and "POST" in route.methods:
                 paths.add(f"/apis/auditor{spec.prefix}{route.path}")
     return paths
 
 
 def test_audit_job_submit_route_is_mounted() -> None:
     assert submit_path_for(AuditJob, workspace="{workspace}") in _mounted_post_paths()
+
+
+def test_audit_job_routes_default_to_auditor_profile() -> None:
+    """Jobs submitted without an explicit --profile land on the "auditor" profile,
+    not the platform-wide "default" one."""
+    with patch("nemo_auditor.service.add_job_routes") as mock_add_job_routes:
+        mock_add_job_routes.return_value = APIRouter()
+        AuditorPluginService().get_routers()
+
+    mock_add_job_routes.assert_called_once()
+    assert mock_add_job_routes.call_args.kwargs["default_profile"] == "auditor"

--- a/plugins/nemo-auditor/tests/test_service.py
+++ b/plugins/nemo-auditor/tests/test_service.py
@@ -28,12 +28,13 @@ def test_audit_job_submit_route_is_mounted() -> None:
     assert submit_path_for(AuditJob, workspace="{workspace}") in _mounted_post_paths()
 
 
-def test_audit_job_routes_default_to_auditor_profile() -> None:
-    """Jobs submitted without an explicit --profile land on the "auditor" profile,
-    not the platform-wide "default" one."""
+def test_audit_job_routes_do_not_override_default_profile() -> None:
+    """The execution profile audit jobs land on is controlled by the auditor plugin
+    config (see AuditJob.compile / nemo_auditor.config), not by add_job_routes'
+    default_profile — that would be dead code, since compile() always sets a profile."""
     with patch("nemo_auditor.service.add_job_routes") as mock_add_job_routes:
         mock_add_job_routes.return_value = APIRouter()
         AuditorPluginService().get_routers()
 
     mock_add_job_routes.assert_called_once()
-    assert mock_add_job_routes.call_args.kwargs["default_profile"] == "auditor"
+    assert "default_profile" not in mock_add_job_routes.call_args.kwargs


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Tweak the defaults for auditor so that it's easier to run locally in docker.

## Type of Change

- [X] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [X] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [X] Documentation not applicable — justification: This is already what the user would expect from existing documentation.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [X] Pull request title follows the repository's Conventional Commit format
- [X] Every commit includes an appropriate `Signed-off-by:` trailer
- [X] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [X] Targeted tests pass, or tests are marked not applicable above
- [X] No secrets, API keys, or credentials are included




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable job execution profiles for auditor tasks.
  * Auditor jobs now use the configured executor profile, with a standard default and support for dedicated local Docker execution.
  * Explicitly selected profiles continue to take precedence over configuration.

* **Bug Fixes**
  * Improved auditor service route handling when route methods are unspecified.
  * Ensured auditor route setup no longer applies an unintended default profile override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->