### PR TITLE
fix: fixes for recursive issue with response object, e2e diagnostics

### DIFF
--- a/e2e/test_safe_synthesizer.py
+++ b/e2e/test_safe_synthesizer.py
@@ -28,6 +28,7 @@ import traceback
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import suppress
+from enum import Enum
 from pathlib import Path
 from types import ModuleType
 from typing import Any, cast
@@ -38,6 +39,7 @@ from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.files.types import CreateFilesetRequest
 from nemo_platform_plugin.jobs.client import JobsClient
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 
 pytestmark = [
     pytest.mark.timeout(600),
@@ -408,6 +410,12 @@ def _status_details(sdk: NeMoPlatform, workspace: str, job_name: str) -> str:
     return "\n".join(details)
 
 
+def _status_value(status: object) -> str:
+    if isinstance(status, Enum):
+        return str(status.value)
+    return str(status or "")
+
+
 def _wait_for_status(
     sdk: NeMoPlatform,
     workspace: str,
@@ -426,7 +434,7 @@ def _wait_for_status(
     while time.monotonic() < deadline:
         try:
             status_info = jobs.get_job_status(name=job_name, workspace=workspace).data()
-            status = str(status_info.status)
+            status = _status_value(status_info.status)
             if not history or history[-1] != status:
                 history.append(status)
                 _write_nss_debug_json(job_name, "status-history.json", {"history": history})
@@ -592,6 +600,11 @@ def test_safe_synthesizer_api_health(sdk: NeMoPlatform, workspace: str) -> None:
 
     jobs = _list_nss_jobs(sdk, workspace)
     assert isinstance(jobs.get("data"), list)
+
+
+def test_safe_synthesizer_status_value_accepts_sdk_status_enum() -> None:
+    assert _status_value(PlatformJobStatus.CANCELLED) == "cancelled"
+    assert _status_value("completed") == "completed"
 
 
 def test_safe_synthesizer_fileset_upload_download_round_trips(

--- a/e2e/test_safe_synthesizer.py
+++ b/e2e/test_safe_synthesizer.py
@@ -37,6 +37,7 @@ from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.files.client import FilesClient
 from nemo_platform_plugin.files.types import CreateFilesetRequest
+from nemo_platform_plugin.jobs.client import JobsClient
 
 pytestmark = [
     pytest.mark.timeout(600),

--- a/e2e/test_safe_synthesizer.py
+++ b/e2e/test_safe_synthesizer.py
@@ -24,6 +24,7 @@ import io
 import json
 import os
 import time
+import traceback
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import suppress
@@ -115,6 +116,83 @@ def _string_headers(sdk: NeMoPlatform) -> dict[str, str]:
 
 def _nss_url(sdk: NeMoPlatform, workspace: str, path: str) -> str:
     return f"{str(sdk.base_url).rstrip('/')}/apis/safe-synthesizer/v2/workspaces/{workspace}/{path.lstrip('/')}"
+
+
+def _jobs_url(sdk: NeMoPlatform, workspace: str, path: str) -> str:
+    return f"{str(sdk.base_url).rstrip('/')}/apis/jobs/v2/workspaces/{workspace}/{path.lstrip('/')}"
+
+
+def _safe_artifact_name(value: str) -> str:
+    return "".join(char if char.isalnum() or char in "._-" else "_" for char in value)
+
+
+def _nss_debug_dir(job_name: str) -> Path | None:
+    root = os.environ.get("NSS_E2E_DEBUG_DIR") or os.environ.get("JOB_LOGS_DIR")
+    if not root:
+        return None
+    debug_dir = Path(root) / "safe-synthesizer" / _safe_artifact_name(job_name)
+    try:
+        debug_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+    return debug_dir
+
+
+def _write_nss_debug_text(job_name: str, filename: str, content: str) -> None:
+    debug_dir = _nss_debug_dir(job_name)
+    if debug_dir is None:
+        return
+    with suppress(Exception):
+        (debug_dir / filename).write_text(content, encoding="utf-8")
+
+
+def _write_nss_debug_json(job_name: str, filename: str, payload: object) -> None:
+    _write_nss_debug_text(job_name, filename, json.dumps(payload, indent=2, default=str))
+
+
+def _capture_raw_response(sdk: NeMoPlatform, job_name: str, filename: str, url: str) -> None:
+    with suppress(Exception):
+        response = sdk._client.get(
+            url,
+            headers=_string_headers(sdk),
+            timeout=60.0,
+        )
+        _write_nss_debug_json(
+            job_name,
+            filename,
+            {
+                "url": str(response.url),
+                "status_code": response.status_code,
+                "body": response.text,
+            },
+        )
+
+
+def _capture_nss_debug_artifacts(
+    sdk: NeMoPlatform,
+    workspace: str,
+    job_name: str,
+    reason: str,
+    *,
+    history: list[str],
+    error: BaseException | None = None,
+) -> None:
+    diagnostic: dict[str, object] = {
+        "reason": reason,
+        "history": history,
+    }
+    if error is not None:
+        diagnostic["error"] = repr(error)
+        diagnostic["traceback"] = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    _write_nss_debug_json(job_name, "diagnostic.json", diagnostic)
+    _capture_raw_response(
+        sdk, job_name, "jobs-status-response.json", _jobs_url(sdk, workspace, f"jobs/{job_name}/status")
+    )
+    _capture_raw_response(sdk, job_name, "jobs-logs-response.json", _jobs_url(sdk, workspace, f"jobs/{job_name}/logs"))
+    _capture_raw_response(sdk, job_name, "nss-job-response.json", _nss_url(sdk, workspace, f"jobs/{job_name}"))
+    _capture_raw_response(
+        sdk, job_name, "nss-results-response.json", _nss_url(sdk, workspace, f"jobs/{job_name}/results")
+    )
 
 
 def _files_client(sdk: NeMoPlatform) -> FilesClient:
@@ -342,22 +420,49 @@ def _wait_for_status(
     deadline = time.monotonic() + timeout_seconds
     history: list[str] = []
     last_error: BaseException | None = None
+    jobs = client_from_platform(sdk, JobsClient)
 
     while time.monotonic() < deadline:
         try:
-            status_info = sdk.jobs.get_status(job_name, workspace=workspace)
+            status_info = jobs.get_job_status(name=job_name, workspace=workspace).data()
             status = str(status_info.status)
             if not history or history[-1] != status:
                 history.append(status)
+                _write_nss_debug_json(job_name, "status-history.json", {"history": history})
+            if status == "error":
+                _capture_nss_debug_artifacts(
+                    sdk,
+                    workspace,
+                    job_name,
+                    "job reached error status",
+                    history=history,
+                )
             if status in target_statuses:
                 return status, history
         except Exception as exc:
             last_error = exc
+            _capture_nss_debug_artifacts(
+                sdk,
+                workspace,
+                job_name,
+                "polling raised an exception",
+                history=history,
+                error=exc,
+            )
         time.sleep(poll_interval_seconds)
 
+    _capture_nss_debug_artifacts(
+        sdk,
+        workspace,
+        job_name,
+        "timed out waiting for target status",
+        history=history,
+        error=last_error,
+    )
     detail = _status_details(sdk, workspace, job_name)
     if last_error is not None:
-        detail = f"{detail}\nLast polling error: {last_error!r}"
+        last_traceback = "".join(traceback.format_exception(type(last_error), last_error, last_error.__traceback__))
+        detail = f"{detail}\nLast polling error: {last_error!r}\nLast polling traceback:\n{last_traceback}"
     raise TimeoutError(
         f"Timed out waiting for {job_name} to reach {sorted(target_statuses)}; history={history}\n{detail}"
     )
@@ -370,6 +475,14 @@ def _assert_job_completed(sdk: NeMoPlatform, workspace: str, job_name: str) -> l
         job_name,
         timeout_seconds=K8S_JOB_TIMEOUT_SECONDS,
     )
+    if status != "completed":
+        _capture_nss_debug_artifacts(
+            sdk,
+            workspace,
+            job_name,
+            f"expected completed status, got {status}",
+            history=history,
+        )
     assert status == "completed", _status_details(sdk, workspace, job_name)
     assert any(seen in STARTED_STATUSES for seen in history), f"Unexpected job status history: {history}"
     return history

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/response.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/client/response.py
@@ -98,7 +98,7 @@ class NemoResponse(Generic[ResponseT]):
         own attributes (``body``, ``http_response``, ``request``, ``data``)
         always win.
         """
-        body = self.__dict__.get("body")
+        body = object.__getattribute__(self, "body")
         if body is None:
             raise AttributeError(name)
         return getattr(body, name)

--- a/packages/nemo_platform_plugin/tests/client/test_client.py
+++ b/packages/nemo_platform_plugin/tests/client/test_client.py
@@ -168,6 +168,17 @@ def test_data_success() -> None:
     assert item.name == "alice"
 
 
+def test_response_delegates_unknown_attributes_to_body() -> None:
+    response = NemoResponse(
+        http_response=httpx.Response(200, request=httpx.Request("GET", f"{BASE}/apis/test/v2/items/alice")),
+        body=ItemResponse(id=1, name="alice"),
+        request=GET_ITEM(name="alice"),
+    )
+
+    assert response.id == 1
+    assert response.name == "alice"
+
+
 def test_base_url_trailing_slash_stripped() -> None:
     mock_http = MagicMock(spec=httpx.Client)
     mock_http.request.return_value = httpx.Response(


### PR DESCRIPTION
## Summary
Capture Safe Synthesizer E2E diagnostics when job polling fails or reaches an unexpected terminal state. This writes raw Jobs API and Safe Synthesizer API responses into the existing E2E log artifact directory so CI failures can be debugged from uploaded artifacts. Pairs with NVIDIA-NeMo/Platform-Deploy#216, which uploads the richer runtime-side logs.

## Changes
- Add per-job debug artifacts under `JOB_LOGS_DIR/safe-synthesizer/<job-name>/` or `NSS_E2E_DEBUG_DIR/safe-synthesizer/<job-name>/`.
- Capture raw job status, job logs, Safe Synthesizer job, and Safe Synthesizer results responses on polling exceptions, timeouts, or error statuses.
- Include the last polling traceback in timeout details.
- Unwrap the typed JobsClient status response with `.data()` in the polling loop.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: this changes the Safe Synthesizer E2E test helper itself; the GPU-backed paths require the private CI runner.
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: diagnostic-only E2E artifact behavior.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen ruff check e2e/test_safe_synthesizer.py` — passed.
- `uv run --frozen ruff format --check e2e/test_safe_synthesizer.py` — passed.
- `uv run --frozen pytest e2e/test_safe_synthesizer.py::test_safe_synthesizer_pii_replacement_config_validates -q --run-e2e` — passed.
- `git diff --check` — passed.
- DCO audit for `origin/main..HEAD` — passed.
- `uv run pre-commit run -a` — partially blocked by local toolchain: missing `helm-docs`, missing `yq`, local uv is `0.9.30` while the hook requires `0.9.14`, and local Studio tooling reports unsupported Node/lint-staged setup. Python Ruff and ty hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for jobs that fail, encounter polling errors, or time out.
  * Added status history and traceback details to timeout information.
  * Captured relevant responses and generated diagnostic artifacts before reporting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->