### PR TITLE
fix(quickstart): persist dev secrets key config

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py
@@ -310,9 +310,10 @@ class ContainerManager:
         # Database in mounted /data so it persists across container restarts
         env["DATABASE_URL"] = "sqlite:////data/nmp-platform.db"
 
-        # Secrets: allow key creation and persist key in /data so it survives restarts
-        env["NMP_SECRETS_ALLOW_KEY_CREATION"] = "1"
-        env["NMP_SECRETS_LOCAL_KEY_CREATION_PATH"] = "/data/nmp-encryption-key.txt"
+        # Secrets: allow key creation and persist key in /data so it survives restarts.
+        # Keep explicit PlatformConfig env mappings if the caller supplied them.
+        env.setdefault("NMP_SECRETS_ALLOW_KEY_CREATION", "1")
+        env.setdefault("NMP_SECRETS_LOCAL_KEY_CREATION_PATH", "/data/nmp-encryption-key.txt")
 
         # Seed the platform on startup with entities
         env["NMP_SEED_ON_STARTUP"] = "true"

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/platform_config.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/platform_config.py
@@ -12,6 +12,24 @@ from pydantic import BaseModel, Field
 from typing_extensions import Self
 
 
+class SecretsConfig(BaseModel):
+    """Secrets service configuration for quickstart development/demo runs."""
+
+    model_config = {"extra": "allow"}
+
+    allow_key_creation: bool = Field(
+        default=True,
+        description=(
+            "Allow quickstart to create a local encryption key when no explicit "
+            "secrets encryption provider is configured."
+        ),
+    )
+    local_key_creation_path: str = Field(
+        default="/data/nmp-encryption-key.txt",
+        description="Container path where quickstart persists the local secrets encryption key.",
+    )
+
+
 class PlatformConfig(BaseModel):
     """Platform configuration passed to the nmp-api container.
 
@@ -20,9 +38,15 @@ class PlatformConfig(BaseModel):
     2. Mounted YAML file at /etc/nmp/platform-config.yaml
     """
 
+    model_config = {"extra": "allow"}
+
     nvidia_api_key: str | None = Field(
         default=None,
         description="NVIDIA API key for inference services",
+    )
+    secrets: SecretsConfig = Field(
+        default_factory=SecretsConfig,
+        description="Secrets service configuration for quickstart.",
     )
 
     @classmethod
@@ -78,5 +102,9 @@ class PlatformConfig(BaseModel):
 
         if self.nvidia_api_key:
             env["NVIDIA_API_KEY"] = self.nvidia_api_key
+
+        env["NMP_SECRETS_ALLOW_KEY_CREATION"] = "1" if self.secrets.allow_key_creation else "0"
+        if self.secrets.local_key_creation_path:
+            env["NMP_SECRETS_LOCAL_KEY_CREATION_PATH"] = self.secrets.local_key_creation_path
 
         return env

--- a/packages/nemo_platform_ext/tests/quickstart/test_container.py
+++ b/packages/nemo_platform_ext/tests/quickstart/test_container.py
@@ -214,6 +214,19 @@ class TestCreateEnvironmentGPU:
         assert env["NEMO_DEPLOYMENTS_DOCKER_NETWORK"] == "test-network"
         assert env["NEMO_DEPLOYMENTS_DOCKER_ENDPOINT_MODE"] == "network"
 
+    def test_explicit_platform_config_secret_env_vars_are_preserved(self):
+        manager = self._make_manager()
+        mock_platform_config = MagicMock()
+        mock_platform_config.to_env_vars.return_value = {
+            "NMP_SECRETS_ALLOW_KEY_CREATION": "0",
+            "NMP_SECRETS_LOCAL_KEY_CREATION_PATH": "/custom/key.txt",
+        }
+
+        env = manager._create_environment(mock_platform_config)
+
+        assert env["NMP_SECRETS_ALLOW_KEY_CREATION"] == "0"
+        assert env["NMP_SECRETS_LOCAL_KEY_CREATION_PATH"] == "/custom/key.txt"
+
 
 class TestCreateEnvironmentRegistryCredentials:
     """Tests for registry credential env var passthrough."""

--- a/packages/nemo_platform_ext/tests/quickstart/test_platform_config.py
+++ b/packages/nemo_platform_ext/tests/quickstart/test_platform_config.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for quickstart platform configuration."""
+
+from pathlib import Path
+
+import yaml
+from nemo_platform_ext.quickstart.platform_config import PlatformConfig
+
+
+def test_default_platform_config_persists_dev_secrets_key_creation(tmp_path: Path) -> None:
+    path = tmp_path / "platform-config.yaml"
+
+    PlatformConfig.get_default().save(path)
+
+    config = yaml.safe_load(path.read_text())
+    assert config["secrets"] == {
+        "allow_key_creation": True,
+        "local_key_creation_path": "/data/nmp-encryption-key.txt",
+    }
+
+
+def test_default_platform_config_exports_dev_secrets_env_vars() -> None:
+    env = PlatformConfig.get_default().to_env_vars()
+
+    assert env["NMP_SECRETS_ALLOW_KEY_CREATION"] == "1"
+    assert env["NMP_SECRETS_LOCAL_KEY_CREATION_PATH"] == "/data/nmp-encryption-key.txt"
+
+
+def test_platform_config_can_disable_quickstart_key_creation(tmp_path: Path) -> None:
+    path = tmp_path / "platform-config.yaml"
+    path.write_text("secrets:\n  allow_key_creation: false\n")
+
+    config = PlatformConfig.load(path)
+
+    assert config.secrets.allow_key_creation is False
+    assert config.to_env_vars()["NMP_SECRETS_ALLOW_KEY_CREATION"] == "0"
+
+
+def test_platform_config_preserves_custom_secrets_encryption_config(tmp_path: Path) -> None:
+    path = tmp_path / "platform-config.yaml"
+    path.write_text(
+        """
+secrets:
+  encryption:
+    current_provider: local_v1
+    providers:
+      secret_key:
+        local_v1:
+          from_env: NMP_SECRETS_DEFAULT_ENCRYPTION_KEY
+""".lstrip()
+    )
+
+    config = PlatformConfig.load(path)
+    output_path = tmp_path / "saved-platform-config.yaml"
+    config.save(output_path)
+
+    saved = yaml.safe_load(output_path.read_text())
+    assert saved["secrets"]["encryption"] == {
+        "current_provider": "local_v1",
+        "providers": {
+            "secret_key": {
+                "local_v1": {
+                    "from_env": "NMP_SECRETS_DEFAULT_ENCRYPTION_KEY",
+                },
+            },
+        },
+    }


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->
Quickstart now persists the development/demo secrets encryption fallback in generated `platform-config.yaml` and exports the matching container environment variables. This prevents secrets operations from failing when `encryption.current_provider` is empty while preserving explicit secrets configuration for non-default setups.

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->
Source spreadsheet row ID: 7

## Changes
<!-- List the concrete changes included in this pull request. -->
- Add quickstart `secrets.allow_key_creation` and `secrets.local_key_creation_path` defaults to `PlatformConfig`.
- Preserve extra top-level and secrets fields when loading and saving quickstart platform config YAML.
- Keep caller-supplied secrets env vars in `ContainerManager` instead of overwriting them with quickstart defaults.
- Add unit coverage for default persistence/env export, disabling key creation, custom secrets config preservation, and explicit env passthrough.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: bug fix keeps quickstart's generated config aligned with its existing development/demo runtime fallback; production secrets guidance is unchanged.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->
- `flox -q activate -- uv run pre-commit run -a` — passed.
- `uv run ruff check packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/platform_config.py packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py packages/nemo_platform_ext/tests/quickstart/test_platform_config.py packages/nemo_platform_ext/tests/quickstart/test_container.py` — passed.
- `uv run ruff format --check packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/platform_config.py packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/container.py packages/nemo_platform_ext/tests/quickstart/test_platform_config.py packages/nemo_platform_ext/tests/quickstart/test_container.py` — passed.
- `uv run --frozen ty check packages/nemo_platform_ext/src/nemo_platform_ext/quickstart/platform_config.py packages/nemo_platform_ext/tests/quickstart/test_platform_config.py` — passed.
- `uv run --frozen pytest packages/nemo_platform_ext/tests/quickstart/test_platform_config.py packages/nemo_platform_ext/tests/quickstart/test_container.py -v` — passed, 59 tests.
- `uv run --frozen pytest services/core/secrets/tests/test_encryptor.py -v` — passed, 6 tests.
- DCO audit for `origin/release/0.5..HEAD` — passed for `40e4d8817645967d5ec46dfff5d7e9a99492fe08` and `0d435464ca4d6a2418412c2a95b98857abb8b85f`.