### PR TITLE
feat(eval-author): create Harbor tasks from audit coverage gaps

### DIFF
--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -314,7 +314,8 @@ Treat that list as the input for a later task-generation step.
 
 - For audit-generation inputs and reconciliation modes, return to
   [Step 2: Generate Or Reconcile Audit.md](#step-2-generate-or-reconcile-auditmd).
-- For task-generation planning, read the parent
-  [Eval Author task boundary](../eval-author/SKILL.md#sub-flows), then treat
-  aggregate report `uncovered_items` as planning input only. This skill does not
-  create runnable tasks yet.
+- When aggregate `uncovered_items` includes actionable tools
+  (`reason: not_covered_by_any_input_report`), hand off to
+  [`eval-author-task-create`](../eval-author-task-create/SKILL.md) to scaffold
+  and prove one gap at a time. Capability or failure-case items with
+  `reason: not_measured_by_any_method` stay audit findings only in v1.

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
@@ -55,7 +55,7 @@ Work on one tool gap at a time. Keep every generated artifact under
 |---|---|
 | `select` | Lists only tool items with `reason: not_covered_by_any_input_report` and emits a deterministic `task_slug` plus artifact paths |
 | `scaffold` | Calls Harbor's own `harbor task init`, requires matching draft/proposal names for that slug, and installs the supplied instruction |
-| `verify` | Exits 0 only when the selected tool was uncovered before and covered in every repeated after-report |
+| `verify` | Exits 0 only when the selected tool was uncovered before and covered in two distinct repeated after-reports |
 
 The script prints one JSON object. Exit code 0 is success; do not replace its
 verdict with model judgment.

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
@@ -53,8 +53,8 @@ Work on one tool gap at a time. Keep every generated artifact under
 
 | Command | Verdict |
 |---|---|
-| `select` | Lists only tool items with `reason: not_covered_by_any_input_report` |
-| `scaffold` | Calls Harbor's own `harbor task init`, requires a draft path under `.eval-author/task-drafts/`, and installs the supplied instruction |
+| `select` | Lists only tool items with `reason: not_covered_by_any_input_report` and emits a deterministic `task_slug` plus artifact paths |
+| `scaffold` | Calls Harbor's own `harbor task init`, requires matching draft/proposal names for that slug, and installs the supplied instruction |
 | `verify` | Exits 0 only when the selected tool was uncovered before and covered in every repeated after-report |
 
 The script prints one JSON object. Exit code 0 is success; do not replace its
@@ -71,6 +71,11 @@ Choose one item from `actionable_tools`. Stop when the list is empty. Capability
 or failure-case items with `reason: not_measured_by_any_method` are not task
 generation inputs in v1.
 
+Each actionable tool includes a deterministic `task_slug` of the form
+`cover-<tool-name>` and a `paths` object for the proposal, draft, and
+measurement directories. Use those paths verbatim for the rest of this flow.
+Do not invent alternate slugs or filenames.
+
 ## Step 2: design the smallest objective task
 
 Read the selected item's `description`, `focus`, `needed_tools`, and
@@ -78,9 +83,10 @@ Read the selected item's `description`, `focus`, `needed_tools`, and
 copy its directory: a sibling can carry an obsolete Harbor schema, placeholder
 verifier, or unrelated solution.
 
-Draft an instruction under `.eval-author/proposals/`. State the observable goal,
-paths, and constraints without naming the target tool or leaking verifier logic.
-The task should naturally require the selected tool and no unrelated capability.
+Write the instruction only to `paths.proposal` from Step 1. State the observable
+goal, paths, and constraints without naming the target tool or leaking verifier
+logic. The task should naturally require the selected tool and no unrelated
+capability.
 
 Decide the verifier before scaffolding. Prefer deterministic shell or pytest.
 The verifier must grade the task outcome, not the tool call; ATIF measurement
@@ -98,6 +104,9 @@ uv run <skill_dir>/scripts/task_pipeline.py scaffold \
   --author "<author>" \
   --instruction-file .eval-author/proposals/<task-slug>-instruction.md
 ```
+
+Use the Step 1 `task_slug` for `<task-slug>` in every path above. `scaffold`
+rejects mismatched draft, task-name, or proposal filenames.
 
 Then complete Harbor's generated files:
 

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
@@ -55,7 +55,7 @@ Work on one tool gap at a time. Keep every generated artifact under
 |---|---|
 | `select` | Lists only tool items with `reason: not_covered_by_any_input_report` and emits a deterministic `task_slug` plus artifact paths |
 | `scaffold` | Calls Harbor's own `harbor task init`, requires matching draft/proposal names for that slug, and installs the supplied instruction |
-| `verify` | Exits 0 only when the selected tool was uncovered before and covered in two distinct repeated after-reports |
+| `verify` | Exits 0 only when the selected tool was uncovered before and covered in two distinct repeated after-reports with distinct ATIF `subject.run_id` values |
 
 The script prints one JSON object. Exit code 0 is success; do not replace its
 verdict with model judgment.

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
@@ -1,0 +1,176 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: eval-author-task-create
+description: >-
+  Create one Harbor task from one actionable uncovered tool in an Eval Author
+  audit coverage report, prove the task with Harbor's Oracle, run it repeatedly
+  with the repository's real agent when authorized, and accept it only when
+  measured ATIF closes the selected gap every time. Use when the user asks to
+  fill an eval gap, turn audit uncovered_items into a Harbor task, or add missing
+  tool coverage. Writes drafts and measurements only under `.eval-author/`.
+triggers:
+  - create a Harbor task from an audit gap
+  - fill an uncovered eval tool
+  - generate missing eval tasks
+  - close audit coverage gaps
+  - turn uncovered_items into Harbor tasks
+not-for:
+  - eval-author (use for the shared standard and routing)
+  - eval-author-audit (use to create the denominator and coverage report)
+  - eval-author-discover (use to prove an existing suite is runnable)
+  - nemo-evaluator (use to run an existing benchmark without authoring tasks)
+compatibility: >-
+  Python 3.11 or later and a Harbor CLI compatible with `harbor task init`.
+  Docker is required for Oracle and Docker-backed real-agent runs. Real-agent
+  runs may require provider credentials and explicit user approval.
+maturity: alpha
+license: Apache-2.0
+user-invocable: true
+allowed-tools: [Bash, Read, Write, Grep, Glob]
+---
+
+# Eval Author: create task
+
+Read `eval-author` for the shared evidence standard and boundaries. Read
+`eval-author-audit` for measurement and aggregation. This sub-flow owns only:
+
+```text
+actionable uncovered tool
+  → Harbor-native draft
+  → Oracle reward 1
+  → repeated real-agent ATIF
+  → target tool covered in every report
+```
+
+Work on one tool gap at a time. Keep every generated artifact under
+`.eval-author/`; do not edit existing tasks or customer source.
+
+## Script
+
+`scripts/task_pipeline.py` has three deterministic commands:
+
+| Command | Verdict |
+|---|---|
+| `select` | Lists only tool items with `reason: not_covered_by_any_input_report` |
+| `scaffold` | Calls Harbor's own `harbor task init`, requires a draft path under `.eval-author/task-drafts/`, and installs the supplied instruction |
+| `verify` | Exits 0 only when the selected tool was uncovered before and covered in every repeated after-report |
+
+The script prints one JSON object. Exit code 0 is success; do not replace its
+verdict with model judgment.
+
+## Step 1: select one actionable gap
+
+```bash
+uv run <skill_dir>/scripts/task_pipeline.py select \
+  --report .eval-author/audit-coverage-report.json
+```
+
+Choose one item from `actionable_tools`. Stop when the list is empty. Capability
+or failure-case items with `reason: not_measured_by_any_method` are not task
+generation inputs in v1.
+
+## Step 2: design the smallest objective task
+
+Read the selected item's `description`, `focus`, `needed_tools`, and
+`evidence_required`. Read one nearby task for domain conventions only. Do not
+copy its directory: a sibling can carry an obsolete Harbor schema, placeholder
+verifier, or unrelated solution.
+
+Draft an instruction under `.eval-author/proposals/`. State the observable goal,
+paths, and constraints without naming the target tool or leaking verifier logic.
+The task should naturally require the selected tool and no unrelated capability.
+
+Decide the verifier before scaffolding. Prefer deterministic shell or pytest.
+The verifier must grade the task outcome, not the tool call; ATIF measurement
+proves tool coverage separately.
+
+## Step 3: scaffold with Harbor
+
+```bash
+uv run <skill_dir>/scripts/task_pipeline.py scaffold \
+  --report .eval-author/audit-coverage-report.json \
+  --target <tool-name> \
+  --out .eval-author/task-drafts/<task-slug> \
+  --task-name <org>/<task-slug> \
+  --description "<one-line description>" \
+  --author "<author>" \
+  --instruction-file .eval-author/proposals/<task-slug>-instruction.md
+```
+
+Then complete Harbor's generated files:
+
+- `environment/Dockerfile`: task prerequisites, never the solution.
+- `tests/test.sh`: deterministic reward writer using absolute paths.
+- `solution/solve.sh`: executable Oracle solution.
+- `task.toml`: nonempty keywords, metadata, realistic timeouts and resources.
+- `README.md`: purpose, environment, verifier, layout, and run commands.
+
+Do not leave generated placeholders, `pass`, unconditional reward 1, or empty
+keywords.
+
+## Step 4: prove task correctness with Oracle
+
+Run Harbor's Oracle before spending model credentials:
+
+```bash
+harbor run -p .eval-author/task-drafts/<task-slug> -a oracle
+```
+
+Continue only when Harbor reports no exception and reward 1.0. Fix the task,
+solution, or verifier when Oracle fails; do not weaken the verifier merely to
+make it pass.
+
+## Step 5: run the real agent twice
+
+Running a model spends credentials. Do it only when the user asked for the run
+or approved it. Use the repository's proven agent configuration, point it at the
+draft, and set `n_attempts: 2`. Keep the resulting job under `.eval-author/`.
+
+Require both trials to:
+
+1. finish without an exception,
+2. receive the intended verifier reward, and
+3. contain `agent/trajectory.json` accepted as ATIF by the audit `measure.py`.
+
+`SUPPORTS_ATIF = true` is not evidence that the emitted JSON matches Harbor's
+current schema. A `measure.py` parse failure is an agent-adapter defect, not a
+coverage result.
+
+## Step 6: measure and aggregate each trial
+
+Run `eval-author-audit`'s `measure.py` and `report.py` separately for each
+trial. Keep repeat outputs separate so one successful run cannot hide another:
+
+```bash
+uv run --with-requirements <audit_skill_dir>/requirements.txt \
+  <audit_skill_dir>/scripts/audit_spec/measure.py \
+  --audit .eval-author/audit.md \
+  --trial-dir <job-dir>/<trial-1> \
+  --task-id <task-slug> \
+  --run-id repeat-1 \
+  --out-dir .eval-author/task-measurements/<task-slug>/repeat-1
+
+uv run --with-requirements <audit_skill_dir>/requirements.txt \
+  <audit_skill_dir>/scripts/audit_spec/report.py \
+  --audit .eval-author/audit.md \
+  --coverage-dir .eval-author/task-measurements/<task-slug>/repeat-1 \
+  --out .eval-author/task-measurements/<task-slug>/repeat-1-report.json
+```
+
+Repeat for trial 2.
+
+## Step 7: accept only deterministic closure
+
+```bash
+uv run <skill_dir>/scripts/task_pipeline.py verify \
+  --before .eval-author/audit-coverage-report.json \
+  --after .eval-author/task-measurements/<task-slug>/repeat-1-report.json \
+  --after .eval-author/task-measurements/<task-slug>/repeat-2-report.json \
+  --target <tool-name>
+```
+
+Accept the draft only when `accepted` is `true`. Report Oracle reward, both
+real-agent rewards, both trial paths, and the verify JSON. If either repeat
+misses the tool, revise the task and rerun both attempts.

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
@@ -37,7 +37,7 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 
 def task_slug_for_tool(tool_name: str) -> str:
-    """Return the stable Harbor artifact slug for one uncovered audit tool."""
+    """Return the base Harbor artifact slug for one uncovered audit tool name."""
     normalized = tool_name.strip()
     if not normalized:
         raise PipelineError("tool name is empty")
@@ -46,6 +46,27 @@ def task_slug_for_tool(tool_name: str) -> str:
     if not slug_body or not slug_body[0].isalpha():
         slug_body = f"tool-{slug_body}" if slug_body else "tool"
     return f"{_SLUG_PREFIX}{slug_body}"
+
+
+def _assign_unique_task_slugs(gaps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return gaps with unique ``task_slug`` values, suffixing ``-2``, ``-3``, ... on collisions."""
+    usage: dict[str, int] = {}
+    enriched: list[dict[str, Any]] = []
+    for gap in sorted(gaps, key=lambda item: str(item["name"])):
+        base_slug = task_slug_for_tool(str(gap["name"]))
+        collisions = usage.get(base_slug, 0)
+        task_slug = base_slug if collisions == 0 else f"{base_slug}-{collisions + 1}"
+        usage[base_slug] = collisions + 1
+        enriched.append({**gap, "task_slug": task_slug, "paths": _artifact_paths(task_slug)})
+    return enriched
+
+
+def _task_slug_for_target(report: dict[str, Any], target: str) -> str:
+    """Return the assigned task slug for one actionable uncovered tool in ``report``."""
+    for gap in _actionable_tools(report):
+        if gap["name"] == target:
+            return gap["task_slug"]
+    raise PipelineError(f"{target!r} is not an actionable uncovered tool")
 
 
 def _artifact_paths(task_slug: str) -> dict[str, str]:
@@ -58,38 +79,30 @@ def _artifact_paths(task_slug: str) -> dict[str, str]:
     }
 
 
-def _enrich_gap(gap: dict[str, Any]) -> dict[str, Any]:
-    """Attach ``task_slug`` and ``paths`` to one actionable tool gap record."""
-    tool_name = gap.get("name")
-    if not isinstance(tool_name, str) or not tool_name.strip():
-        raise PipelineError("actionable tool gap is missing a tool name")
-    task_slug = task_slug_for_tool(tool_name)
-    return {**gap, "task_slug": task_slug, "paths": _artifact_paths(task_slug)}
+def _gap_from_uncovered_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Build one actionable tool gap record from an aggregate ``uncovered_items`` entry."""
+    generation = item.get("generation") or {}
+    return {
+        "name": item.get("name"),
+        "kind": "tool",
+        "reason": item.get("reason"),
+        "description": item.get("description"),
+        "focus": generation.get("focus"),
+        "needed_tools": generation.get("needed_tools") or [],
+        "evidence_required": generation.get("evidence_required") or [],
+    }
 
 
 def _actionable_tools(report: dict[str, Any]) -> list[dict[str, Any]]:
     """Return uncovered tool items that are eligible for task generation."""
-    gaps = []
+    gaps: list[dict[str, Any]] = []
     for item in report.get("uncovered_items") or []:
         if not isinstance(item, dict):
             continue
         if item.get("kind") != "tool" or item.get("reason") != _ACTIONABLE_REASON:
             continue
-        generation = item.get("generation") or {}
-        gaps.append(
-            _enrich_gap(
-                {
-                    "name": item.get("name"),
-                    "kind": "tool",
-                    "reason": item.get("reason"),
-                    "description": item.get("description"),
-                    "focus": generation.get("focus"),
-                    "needed_tools": generation.get("needed_tools") or [],
-                    "evidence_required": generation.get("evidence_required") or [],
-                }
-            )
-        )
-    return sorted(gaps, key=lambda gap: str(gap["name"]))
+        gaps.append(_gap_from_uncovered_item(item))
+    return _assign_unique_task_slugs(gaps)
 
 
 def _select(report_path: Path, target: str | None) -> dict[str, Any]:
@@ -149,8 +162,8 @@ def _scaffold(
     instruction_file: Path,
 ) -> dict[str, Any]:
     """Initialize a Harbor-native draft and install the supplied instruction."""
-    _select(report_path, target)
-    task_slug = task_slug_for_tool(target)
+    report = _read_json(report_path)
+    task_slug = _task_slug_for_target(report, target)
     _require_draft_destination(output)
     _require_task_slug_paths(
         task_slug=task_slug,
@@ -207,11 +220,9 @@ def _scaffold(
 
 
 def _verify(before_path: Path, after_paths: list[Path], target: str) -> tuple[int, dict[str, Any]]:
-    """Accept only when ``target`` was uncovered before and covered in every repeat report."""
+    """Accept only when ``target`` was an actionable gap before and covered in every repeat report."""
     before = _read_json(before_path)
-    before_uncovered = set(before.get("uncovered") or [])
-    if target not in before_uncovered:
-        raise PipelineError(f"{target!r} was not uncovered in the before report")
+    _task_slug_for_target(before, target)
     if len(after_paths) < _MIN_VERIFY_REPORTS:
         raise PipelineError(f"at least {_MIN_VERIFY_REPORTS} --after reports are required")
     resolved_paths = [path.resolve() for path in after_paths]

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Select actionable audit gaps, scaffold Harbor drafts, and verify closure."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+_ACTIONABLE_REASON = "not_covered_by_any_input_report"
+_DRAFT_PARTS = (".eval-author", "task-drafts")
+
+
+class PipelineError(ValueError):
+    """A user-correctable pipeline input error."""
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PipelineError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise PipelineError(f"expected a JSON object: {path}")
+    return payload
+
+
+def _actionable_tools(report: dict[str, Any]) -> list[dict[str, Any]]:
+    gaps = []
+    for item in report.get("uncovered_items") or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("kind") != "tool" or item.get("reason") != _ACTIONABLE_REASON:
+            continue
+        generation = item.get("generation") or {}
+        gaps.append(
+            {
+                "name": item.get("name"),
+                "kind": "tool",
+                "reason": item.get("reason"),
+                "description": item.get("description"),
+                "focus": generation.get("focus"),
+                "needed_tools": generation.get("needed_tools") or [],
+                "evidence_required": generation.get("evidence_required") or [],
+            }
+        )
+    return sorted(gaps, key=lambda gap: str(gap["name"]))
+
+
+def _select(report_path: Path, target: str | None) -> dict[str, Any]:
+    gaps = _actionable_tools(_read_json(report_path))
+    if target is not None:
+        gaps = [gap for gap in gaps if gap["name"] == target]
+        if not gaps:
+            raise PipelineError(f"{target!r} is not an actionable uncovered tool in {report_path}")
+    return {
+        "schema": "nemo.eval_author.task_gap_selection.v1",
+        "report": str(report_path),
+        "actionable_count": len(gaps),
+        "actionable_tools": gaps,
+        "valid": True,
+    }
+
+
+def _require_draft_destination(path: Path) -> None:
+    parts = path.resolve().parts
+    for index in range(len(parts) - 1):
+        if parts[index : index + 2] == _DRAFT_PARTS:
+            return
+    raise PipelineError("draft output must be under .eval-author/task-drafts/")
+
+
+def _scaffold(
+    *,
+    report_path: Path,
+    target: str,
+    output: Path,
+    task_name: str,
+    description: str,
+    author: str,
+    instruction_file: Path,
+) -> dict[str, Any]:
+    _select(report_path, target)
+    _require_draft_destination(output)
+    if output.exists():
+        raise PipelineError(f"draft output already exists: {output}")
+    if Path(task_name).name != output.name:
+        raise PipelineError("draft directory name must match the final component of --task-name")
+    try:
+        instruction = instruction_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise PipelineError(f"cannot read instruction {instruction_file}: {exc}") from exc
+    if not instruction.strip():
+        raise PipelineError("instruction file is empty")
+    harbor = shutil.which("harbor")
+    if harbor is None:
+        raise PipelineError("harbor executable is not available")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    result = subprocess.run(
+        [
+            harbor,
+            "task",
+            "init",
+            task_name,
+            "--tasks-dir",
+            str(output.parent),
+            "--description",
+            description,
+            "--author",
+            author,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise PipelineError(f"harbor task init failed: {result.stderr or result.stdout}")
+    if not output.is_dir():
+        raise PipelineError(f"harbor did not create the expected draft: {output}")
+    (output / "instruction.md").write_text(instruction, encoding="utf-8")
+    return {
+        "schema": "nemo.eval_author.harbor_task_draft.v1",
+        "target_tool": target,
+        "draft": str(output),
+        "task_name": task_name,
+        "scaffolder": "harbor task init",
+        "valid": True,
+        "written": True,
+    }
+
+
+def _verify(before_path: Path, after_paths: list[Path], target: str) -> tuple[int, dict[str, Any]]:
+    before = _read_json(before_path)
+    before_uncovered = set(before.get("uncovered") or [])
+    if target not in before_uncovered:
+        raise PipelineError(f"{target!r} was not uncovered in the before report")
+    if not after_paths:
+        raise PipelineError("at least one --after report is required")
+
+    runs = []
+    all_covered = True
+    for path in after_paths:
+        report = _read_json(path)
+        covered = target in set(report.get("covered") or [])
+        still_uncovered = target in set(report.get("uncovered") or [])
+        passed = covered and not still_uncovered
+        all_covered = all_covered and passed
+        runs.append({"report": str(path), "covered": covered, "passed": passed})
+
+    payload = {
+        "schema": "nemo.eval_author.task_gap_verification.v1",
+        "target_tool": target,
+        "before": str(before_path),
+        "repeat_count": len(runs),
+        "runs": runs,
+        "accepted": all_covered,
+        "valid": True,
+    }
+    return (0 if all_covered else 1), payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    select = subparsers.add_parser("select", help="list actionable uncovered tool gaps")
+    select.add_argument("--report", type=Path, required=True)
+    select.add_argument("--target")
+
+    scaffold = subparsers.add_parser("scaffold", help="initialize a Harbor-native task draft")
+    scaffold.add_argument("--report", type=Path, required=True)
+    scaffold.add_argument("--target", required=True)
+    scaffold.add_argument("--out", type=Path, required=True)
+    scaffold.add_argument("--task-name", required=True)
+    scaffold.add_argument("--description", required=True)
+    scaffold.add_argument("--author", required=True)
+    scaffold.add_argument("--instruction-file", type=Path, required=True)
+
+    verify = subparsers.add_parser("verify", help="require every repeat to close one gap")
+    verify.add_argument("--before", type=Path, required=True)
+    verify.add_argument("--after", type=Path, action="append", required=True)
+    verify.add_argument("--target", required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "select":
+            payload = _select(args.report, args.target)
+            exit_code = 0
+        elif args.command == "scaffold":
+            payload = _scaffold(
+                report_path=args.report,
+                target=args.target,
+                output=args.out,
+                task_name=args.task_name,
+                description=args.description,
+                author=args.author,
+                instruction_file=args.instruction_file,
+            )
+            exit_code = 0
+        else:
+            exit_code, payload = _verify(args.before, args.after, args.target)
+    except PipelineError as exc:
+        payload = {"valid": False, "error": str(exc)}
+        exit_code = 1
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
@@ -222,6 +222,27 @@ def _scaffold(
     }
 
 
+def _run_ids_from_report(report: dict[str, Any], *, report_path: Path) -> list[str]:
+    """Return ATIF ``subject.run_id`` values recorded in one aggregate coverage report."""
+    input_reports = report.get("input_reports")
+    if not isinstance(input_reports, list) or not input_reports:
+        raise PipelineError(f"after report must include input_reports with subject.run_id: {report_path}")
+    run_ids: list[str] = []
+    for index, entry in enumerate(input_reports):
+        if not isinstance(entry, dict):
+            raise PipelineError(f"after report input_reports[{index}] must be an object: {report_path}")
+        subject = entry.get("subject")
+        if not isinstance(subject, dict):
+            raise PipelineError(f"after report input_reports[{index}] must include subject: {report_path}")
+        run_id = subject.get("run_id")
+        if not isinstance(run_id, str) or not run_id.strip():
+            raise PipelineError(
+                f"after report input_reports[{index}].subject.run_id must be a non-empty string: {report_path}"
+            )
+        run_ids.append(run_id)
+    return run_ids
+
+
 def _verify(before_path: Path, after_paths: list[Path], target: str) -> tuple[int, dict[str, Any]]:
     """Accept only when ``target`` was an actionable gap before and covered in every repeat report."""
     before = _read_json(before_path)
@@ -234,13 +255,26 @@ def _verify(before_path: Path, after_paths: list[Path], target: str) -> tuple[in
 
     runs = []
     all_covered = True
+    run_ids: list[str] = []
     for path in after_paths:
         report = _read_json(path)
+        report_run_ids = _run_ids_from_report(report, report_path=path)
+        run_ids.extend(report_run_ids)
         covered = target in set(report.get("covered") or [])
         still_uncovered = target in set(report.get("uncovered") or [])
         passed = covered and not still_uncovered
         all_covered = all_covered and passed
-        runs.append({"report": str(path), "covered": covered, "passed": passed})
+        runs.append(
+            {
+                "report": str(path),
+                "run_ids": report_run_ids,
+                "covered": covered,
+                "passed": passed,
+            }
+        )
+
+    if len(set(run_ids)) != len(run_ids):
+        raise PipelineError("--after reports must come from distinct ATIF subject.run_id values")
 
     payload = {
         "schema": "nemo.eval_author.task_gap_verification.v1",

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -15,6 +16,8 @@ from typing import Any
 
 _ACTIONABLE_REASON = "not_covered_by_any_input_report"
 _DRAFT_PARTS = (".eval-author", "task-drafts")
+_PROPOSAL_PARTS = (".eval-author", "proposals")
+_SLUG_PREFIX = "cover-"
 
 
 class PipelineError(ValueError):
@@ -31,6 +34,35 @@ def _read_json(path: Path) -> dict[str, Any]:
     return payload
 
 
+def task_slug_for_tool(tool_name: str) -> str:
+    """Return the stable Harbor artifact slug for one uncovered audit tool."""
+    normalized = tool_name.strip()
+    if not normalized:
+        raise PipelineError("tool name is empty")
+    slug_body = re.sub(r"[^A-Za-z0-9]+", "-", normalized.replace(".", "-").replace(":", "-"))
+    slug_body = slug_body.strip("-").lower()
+    if not slug_body or not slug_body[0].isalpha():
+        slug_body = f"tool-{slug_body}" if slug_body else "tool"
+    return f"{_SLUG_PREFIX}{slug_body}"
+
+
+def _artifact_paths(task_slug: str) -> dict[str, str]:
+    return {
+        "proposal": f".eval-author/proposals/{task_slug}-instruction.md",
+        "draft": f".eval-author/task-drafts/{task_slug}",
+        "measurements": f".eval-author/task-measurements/{task_slug}",
+        "task_id": task_slug,
+    }
+
+
+def _enrich_gap(gap: dict[str, Any]) -> dict[str, Any]:
+    tool_name = gap.get("name")
+    if not isinstance(tool_name, str) or not tool_name.strip():
+        raise PipelineError("actionable tool gap is missing a tool name")
+    task_slug = task_slug_for_tool(tool_name)
+    return {**gap, "task_slug": task_slug, "paths": _artifact_paths(task_slug)}
+
+
 def _actionable_tools(report: dict[str, Any]) -> list[dict[str, Any]]:
     gaps = []
     for item in report.get("uncovered_items") or []:
@@ -40,15 +72,17 @@ def _actionable_tools(report: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         generation = item.get("generation") or {}
         gaps.append(
-            {
-                "name": item.get("name"),
-                "kind": "tool",
-                "reason": item.get("reason"),
-                "description": item.get("description"),
-                "focus": generation.get("focus"),
-                "needed_tools": generation.get("needed_tools") or [],
-                "evidence_required": generation.get("evidence_required") or [],
-            }
+            _enrich_gap(
+                {
+                    "name": item.get("name"),
+                    "kind": "tool",
+                    "reason": item.get("reason"),
+                    "description": item.get("description"),
+                    "focus": generation.get("focus"),
+                    "needed_tools": generation.get("needed_tools") or [],
+                    "evidence_required": generation.get("evidence_required") or [],
+                }
+            )
         )
     return sorted(gaps, key=lambda gap: str(gap["name"]))
 
@@ -76,6 +110,25 @@ def _require_draft_destination(path: Path) -> None:
     raise PipelineError("draft output must be under .eval-author/task-drafts/")
 
 
+def _require_proposal_destination(path: Path) -> None:
+    parts = path.resolve().parts
+    for index in range(len(parts) - 1):
+        if parts[index : index + 2] == _PROPOSAL_PARTS:
+            return
+    raise PipelineError("instruction file must be under .eval-author/proposals/")
+
+
+def _require_task_slug_paths(*, task_slug: str, output: Path, task_name: str, instruction_file: Path) -> None:
+    if output.name != task_slug:
+        raise PipelineError(f"draft directory must be named {task_slug!r} for the selected tool, got {output.name!r}")
+    if Path(task_name).name != task_slug:
+        raise PipelineError("draft directory name must match the final component of --task-name")
+    expected_instruction = f"{task_slug}-instruction.md"
+    if instruction_file.name != expected_instruction:
+        raise PipelineError(f"instruction file must be named {expected_instruction!r}, got {instruction_file.name!r}")
+    _require_proposal_destination(instruction_file)
+
+
 def _scaffold(
     *,
     report_path: Path,
@@ -87,11 +140,16 @@ def _scaffold(
     instruction_file: Path,
 ) -> dict[str, Any]:
     _select(report_path, target)
+    task_slug = task_slug_for_tool(target)
     _require_draft_destination(output)
+    _require_task_slug_paths(
+        task_slug=task_slug,
+        output=output,
+        task_name=task_name,
+        instruction_file=instruction_file,
+    )
     if output.exists():
         raise PipelineError(f"draft output already exists: {output}")
-    if Path(task_name).name != output.name:
-        raise PipelineError("draft directory name must match the final component of --task-name")
     try:
         instruction = instruction_file.read_text(encoding="utf-8")
     except OSError as exc:
@@ -128,6 +186,8 @@ def _scaffold(
     return {
         "schema": "nemo.eval_author.harbor_task_draft.v1",
         "target_tool": target,
+        "task_slug": task_slug,
+        "paths": _artifact_paths(task_slug),
         "draft": str(output),
         "task_name": task_name,
         "scaffolder": "harbor task init",

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
@@ -50,13 +50,16 @@ def task_slug_for_tool(tool_name: str) -> str:
 
 def _assign_unique_task_slugs(gaps: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Return gaps with unique ``task_slug`` values, suffixing ``-2``, ``-3``, ... on collisions."""
-    usage: dict[str, int] = {}
+    assigned: set[str] = set()
     enriched: list[dict[str, Any]] = []
     for gap in sorted(gaps, key=lambda item: str(item["name"])):
         base_slug = task_slug_for_tool(str(gap["name"]))
-        collisions = usage.get(base_slug, 0)
-        task_slug = base_slug if collisions == 0 else f"{base_slug}-{collisions + 1}"
-        usage[base_slug] = collisions + 1
+        task_slug = base_slug
+        suffix = 2
+        while task_slug in assigned:
+            task_slug = f"{base_slug}-{suffix}"
+            suffix += 1
+        assigned.add(task_slug)
         enriched.append({**gap, "task_slug": task_slug, "paths": _artifact_paths(task_slug)})
     return enriched
 

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/scripts/task_pipeline.py
@@ -18,6 +18,7 @@ _ACTIONABLE_REASON = "not_covered_by_any_input_report"
 _DRAFT_PARTS = (".eval-author", "task-drafts")
 _PROPOSAL_PARTS = (".eval-author", "proposals")
 _SLUG_PREFIX = "cover-"
+_MIN_VERIFY_REPORTS = 2
 
 
 class PipelineError(ValueError):
@@ -25,6 +26,7 @@ class PipelineError(ValueError):
 
 
 def _read_json(path: Path) -> dict[str, Any]:
+    """Load one JSON object from ``path`` or raise ``PipelineError``."""
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
@@ -47,6 +49,7 @@ def task_slug_for_tool(tool_name: str) -> str:
 
 
 def _artifact_paths(task_slug: str) -> dict[str, str]:
+    """Return the canonical ``.eval-author/`` paths for one task slug."""
     return {
         "proposal": f".eval-author/proposals/{task_slug}-instruction.md",
         "draft": f".eval-author/task-drafts/{task_slug}",
@@ -56,6 +59,7 @@ def _artifact_paths(task_slug: str) -> dict[str, str]:
 
 
 def _enrich_gap(gap: dict[str, Any]) -> dict[str, Any]:
+    """Attach ``task_slug`` and ``paths`` to one actionable tool gap record."""
     tool_name = gap.get("name")
     if not isinstance(tool_name, str) or not tool_name.strip():
         raise PipelineError("actionable tool gap is missing a tool name")
@@ -64,6 +68,7 @@ def _enrich_gap(gap: dict[str, Any]) -> dict[str, Any]:
 
 
 def _actionable_tools(report: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return uncovered tool items that are eligible for task generation."""
     gaps = []
     for item in report.get("uncovered_items") or []:
         if not isinstance(item, dict):
@@ -88,6 +93,7 @@ def _actionable_tools(report: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _select(report_path: Path, target: str | None) -> dict[str, Any]:
+    """List actionable uncovered tools from one aggregate coverage report."""
     gaps = _actionable_tools(_read_json(report_path))
     if target is not None:
         gaps = [gap for gap in gaps if gap["name"] == target]
@@ -103,6 +109,7 @@ def _select(report_path: Path, target: str | None) -> dict[str, Any]:
 
 
 def _require_draft_destination(path: Path) -> None:
+    """Require ``path`` to live under ``.eval-author/task-drafts/``."""
     parts = path.resolve().parts
     for index in range(len(parts) - 1):
         if parts[index : index + 2] == _DRAFT_PARTS:
@@ -111,6 +118,7 @@ def _require_draft_destination(path: Path) -> None:
 
 
 def _require_proposal_destination(path: Path) -> None:
+    """Require ``path`` to live under ``.eval-author/proposals/``."""
     parts = path.resolve().parts
     for index in range(len(parts) - 1):
         if parts[index : index + 2] == _PROPOSAL_PARTS:
@@ -119,6 +127,7 @@ def _require_proposal_destination(path: Path) -> None:
 
 
 def _require_task_slug_paths(*, task_slug: str, output: Path, task_name: str, instruction_file: Path) -> None:
+    """Require draft, Harbor task name, and proposal filenames to match ``task_slug``."""
     if output.name != task_slug:
         raise PipelineError(f"draft directory must be named {task_slug!r} for the selected tool, got {output.name!r}")
     if Path(task_name).name != task_slug:
@@ -139,6 +148,7 @@ def _scaffold(
     author: str,
     instruction_file: Path,
 ) -> dict[str, Any]:
+    """Initialize a Harbor-native draft and install the supplied instruction."""
     _select(report_path, target)
     task_slug = task_slug_for_tool(target)
     _require_draft_destination(output)
@@ -197,12 +207,16 @@ def _scaffold(
 
 
 def _verify(before_path: Path, after_paths: list[Path], target: str) -> tuple[int, dict[str, Any]]:
+    """Accept only when ``target`` was uncovered before and covered in every repeat report."""
     before = _read_json(before_path)
     before_uncovered = set(before.get("uncovered") or [])
     if target not in before_uncovered:
         raise PipelineError(f"{target!r} was not uncovered in the before report")
-    if not after_paths:
-        raise PipelineError("at least one --after report is required")
+    if len(after_paths) < _MIN_VERIFY_REPORTS:
+        raise PipelineError(f"at least {_MIN_VERIFY_REPORTS} --after reports are required")
+    resolved_paths = [path.resolve() for path in after_paths]
+    if len(set(resolved_paths)) != len(resolved_paths):
+        raise PipelineError("--after reports must be distinct")
 
     runs = []
     all_covered = True
@@ -227,6 +241,7 @@ def _verify(before_path: Path, after_paths: list[Path], target: str) -> tuple[in
 
 
 def _parser() -> argparse.ArgumentParser:
+    """Build the ``select``, ``scaffold``, and ``verify`` subcommand parser."""
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -243,7 +258,7 @@ def _parser() -> argparse.ArgumentParser:
     scaffold.add_argument("--author", required=True)
     scaffold.add_argument("--instruction-file", type=Path, required=True)
 
-    verify = subparsers.add_parser("verify", help="require every repeat to close one gap")
+    verify = subparsers.add_parser("verify", help="require two distinct repeats to close one gap")
     verify.add_argument("--before", type=Path, required=True)
     verify.add_argument("--after", type=Path, action="append", required=True)
     verify.add_argument("--target", required=True)
@@ -251,6 +266,7 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Run one pipeline subcommand and print a JSON verdict on stdout."""
     args = _parser().parse_args(argv)
     try:
         if args.command == "select":

--- a/plugins/nemo-eval-author/skills/eval-author/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author/SKILL.md
@@ -21,14 +21,16 @@ triggers:
 not-for:
   - eval-author-discover (use to run the discovery pass and get a runnable verdict)
   - eval-author-audit (use to generate, validate, measure, or aggregate audit.md coverage)
+  - eval-author-task-create (use to create and prove one Harbor task from an actionable audit gap)
   - eval-author-inspect-trace (use after this skill selects the trace sub-flow)
   - nemo-intake (use to instrument agents, ingest telemetry, or query Intake outside Eval Author)
   - nemo-experimentalist (use to run insight-driven optimization end to end, which drives the Eval Author agent itself)
   - nemo-evaluator (use to run an existing benchmark rather than work on a repository's own suite)
 compatibility: >-
-  Reading only. Discovery and audit use the local checkout. Trace inspection
-  requires the nemo CLI, an explicit workspace, and read access to configured
-  Intake.
+  The router is read-only. Discovery, audit, and task creation use the local
+  checkout. Task execution requires Harbor and may require Docker and provider
+  credentials. Trace inspection requires the nemo CLI, an explicit workspace,
+  and read access to configured Intake.
 maturity: alpha
 license: Apache-2.0
 user-invocable: true
@@ -53,6 +55,8 @@ The authority depends on the sub-flow:
   doesn't prove that Harbor accepts it.
 - For audit-spec validation, the bundled schema and validator judge the finite
   `audit.md` coverage denominator.
+- For task creation, Harbor's Oracle judges task solvability and verifier
+  correctness; measured ATIF proves whether repeated runs close the selected gap.
 - For trace inspection, Intake establishes what happened. Local source code can
   explain behavior, but it can't replace recorded trace evidence.
 
@@ -83,30 +87,33 @@ and the boundaries; the sub-flow carries the steps.
 |---|---|
 | `eval-author-discover` | Establish whether a repository's evaluations run, name the rung that fails, and get the exact command to run them |
 | `eval-author-audit` | Generate and validate a finite `audit.md` coverage denominator, write per-method coverage/details files for one ATIF trace, then aggregate coverage reports |
+| `eval-author-task-create` | Create one Harbor-native task from one actionable uncovered tool, prove it with Oracle, and accept it only when repeated measured runs close the gap |
 | `eval-author-inspect-trace` | Understand one Intake trace without presuming that the trace contains a failure. Not user-invocable; this skill selects it |
 
-Runnable tasks and verifier metrics are not built yet.
 `eval-author-audit` works one level above tasks: it generates and validates the
 coverage denominator, measures traces against it, and aggregates deterministic
-coverage reports. When a user asks for new runnable tasks, say so plainly rather
-than improvising a task layout by hand. A task written against a guessed
-convention scores nothing and costs a full evaluation run to discover.
+coverage reports. `eval-author-task-create` consumes only actionable tool gaps
+from that report and uses Harbor's native task scaffolder rather than guessing a
+task layout.
 
 ## Boundaries
 
 These hold for every sub-flow. They exist because the repository belongs to the
 user, not to you.
 
-- **Propose, never mutate.** Read the user's source and report on it. Do not edit,
-  move, or reformat any of it, including its `.gitignore`. The only files you add
-  belong under `.eval-author/`, which is theirs to commit or ignore.
+- **Propose, never mutate customer source.** Read the user's source and report on
+  it. Do not edit, move, or reformat any of it, including its `.gitignore`. The
+  only files you add belong under `.eval-author/`, which is theirs to commit or
+  ignore.
   `eval-author-discover` scripts write nothing; `eval-author-audit` writes only
-  the audit artifact paths the user explicitly requested.
+  requested audit artifacts; `eval-author-task-create` writes only drafts,
+  proposals, job outputs, and measurements there.
 - **A missing tool is a finding, not a task.** When the provider is not installed,
   say so and stop short of proving anything. Report what you found regardless, and
   do not install the provider into the user's environment.
-- **Do not run the suite.** Prove it can run and hand over the command. Starting a
-  job spends the user's compute and credentials on a decision they did not make.
+- **Do not run without approval.** Discovery proves an existing suite can run and
+  hands over the command. Task creation may run Oracle locally, then starts
+  real-agent jobs only when the user explicitly asked for or approved that spend.
 - **Trusted repositories only.** Validating a config can execute repository code,
   because an agent named by import path gets imported. If the repository is not
   trusted, say so and stop.

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -4,9 +4,9 @@
 """Contract tests for the bundled Eval Author skills.
 
 ``eval-author`` is the core skill: it owns the standard, the vocabulary, the
-boundaries, and the routing. ``eval-author-discover`` and ``eval-author-audit``
-bundle scripts. ``eval-author-inspect-trace`` uses the provider's supported
-commands. Sub-flows defer the standard to the core.
+boundaries, and the routing. ``eval-author-discover``, ``eval-author-audit``,
+and ``eval-author-task-create`` bundle scripts. ``eval-author-inspect-trace``
+uses the provider's supported commands. Sub-flows defer the standard to the core.
 
 These tests are that enforcement:
 
@@ -57,12 +57,14 @@ _SKILLS_DIR = Path(__file__).resolve().parents[1] / "skills"
 _CORE_DIR = _SKILLS_DIR / "eval-author"
 _DISCOVER_DIR = _SKILLS_DIR / "eval-author-discover"
 _AUDIT_DIR = _SKILLS_DIR / "eval-author-audit"
+_TASK_CREATE_DIR = _SKILLS_DIR / "eval-author-task-create"
 _INSPECT_DIR = _SKILLS_DIR / "eval-author-inspect-trace"
-_SKILL_DIRS = (_CORE_DIR, _DISCOVER_DIR, _AUDIT_DIR, _INSPECT_DIR)
-_SUB_FLOW_DIRS = (_DISCOVER_DIR, _AUDIT_DIR, _INSPECT_DIR)
+_SKILL_DIRS = (_CORE_DIR, _DISCOVER_DIR, _AUDIT_DIR, _TASK_CREATE_DIR, _INSPECT_DIR)
+_SUB_FLOW_DIRS = (_DISCOVER_DIR, _AUDIT_DIR, _TASK_CREATE_DIR, _INSPECT_DIR)
 _DISCOVER_SCRIPTS_DIR = _DISCOVER_DIR / "scripts"
 _AUDIT_SPEC_DIR = _AUDIT_DIR / "scripts" / "audit_spec"
-_SCRIPT_DIRS = (_DISCOVER_SCRIPTS_DIR, _AUDIT_SPEC_DIR)
+_TASK_CREATE_SCRIPTS_DIR = _TASK_CREATE_DIR / "scripts"
+_SCRIPT_DIRS = (_DISCOVER_SCRIPTS_DIR, _AUDIT_SPEC_DIR, _TASK_CREATE_SCRIPTS_DIR)
 _DISCOVER = _DISCOVER_SCRIPTS_DIR / "discover.py"
 _LADDER = _DISCOVER_SCRIPTS_DIR / "providers" / "harbor" / "_ladder.py"
 _AUDIT_VALIDATE = _AUDIT_SPEC_DIR / "validate.py"
@@ -447,6 +449,7 @@ def test_the_core_routes_and_the_sub_flow_executes() -> None:
     core_tools = set(_frontmatter_and_body(_CORE_DIR)[0]["allowed-tools"])
     discover_tools = set(_frontmatter_and_body(_DISCOVER_DIR)[0]["allowed-tools"])
     audit_tools = set(_frontmatter_and_body(_AUDIT_DIR)[0]["allowed-tools"])
+    task_create_tools = set(_frontmatter_and_body(_TASK_CREATE_DIR)[0]["allowed-tools"])
     inspect_tools = set(_frontmatter_and_body(_INSPECT_DIR)[0]["allowed-tools"])
 
     assert not {"Bash", "Write"} & core_tools, f"the core routes and explains; {sorted(core_tools)} is too broad"
@@ -455,6 +458,9 @@ def test_the_core_routes_and_the_sub_flow_executes() -> None:
     )
     assert {"Bash", "Write"} <= audit_tools, (
         f"{_AUDIT_DIR.name} generates and validates audit files; it has {sorted(audit_tools)}"
+    )
+    assert {"Bash", "Write"} <= task_create_tools, (
+        f"{_TASK_CREATE_DIR.name} generates and proves task drafts; it has {sorted(task_create_tools)}"
     )
     assert {"Bash", "Write"} <= inspect_tools, (
         f"{_INSPECT_DIR.name} runs provider commands and saves a report; it has {sorted(inspect_tools)}"
@@ -560,6 +566,13 @@ def test_every_bundled_path_the_skill_names_exists() -> None:
     ):
         assert relative in body, f"SKILL.md no longer documents {relative}"
         assert (_DISCOVER_DIR / relative).exists(), f"SKILL.md names {relative}, which is missing on disk"
+
+
+def test_task_create_script_the_skill_names_exists() -> None:
+    _, body = _frontmatter_and_body(_TASK_CREATE_DIR)
+    relative = "scripts/task_pipeline.py"
+    assert relative in body
+    assert (_TASK_CREATE_DIR / relative).is_file()
 
 
 def test_every_audit_spec_path_the_skill_names_exists() -> None:

--- a/plugins/nemo-eval-author/tests/test_task_pipeline.py
+++ b/plugins/nemo-eval-author/tests/test_task_pipeline.py
@@ -27,7 +27,31 @@ def _run(*args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _write_report(path: Path, *, covered: list[str], uncovered: list[str]) -> None:
+def _coverage_input_report(*, run_id: str, covered: list[str]) -> dict[str, Any]:
+    """Build one aggregate ``input_reports`` entry for verify tests."""
+    return {
+        "path": f".eval-author/task-measurements/run={run_id}/tool_calls/coverage.json",
+        "method": "tool_calls",
+        "item_kind": "tool",
+        "item_kind_count": max(len(covered), 1),
+        "subject": {
+            "trace": f".harbor/runs/trial/{run_id}/agent/trajectory.json",
+            "trace_format": "atif",
+            "task_id": "cover-read",
+            "run_id": run_id,
+        },
+        "covered": covered,
+        "covered_count": len(covered),
+    }
+
+
+def _write_report(
+    path: Path,
+    *,
+    covered: list[str],
+    uncovered: list[str],
+    run_id: str | None = None,
+) -> None:
     """Write a minimal aggregate coverage report JSON file for tests."""
     items = [
         {
@@ -43,16 +67,22 @@ def _write_report(path: Path, *, covered: list[str], uncovered: list[str]) -> No
         }
         for name in uncovered
     ]
-    _write_report_with_items(path, covered=covered, uncovered_items=items)
+    _write_report_with_items(path, covered=covered, uncovered_items=items, run_id=run_id)
 
 
-def _write_report_with_items(path: Path, *, covered: list[str], uncovered_items: list[dict[str, Any]]) -> None:
+def _write_report_with_items(
+    path: Path,
+    *,
+    covered: list[str],
+    uncovered_items: list[dict[str, Any]],
+    run_id: str | None = None,
+) -> None:
     """Write an aggregate coverage report with explicit ``uncovered_items`` entries."""
     uncovered = [str(item["name"]) for item in uncovered_items]
-    path.write_text(
-        json.dumps({"covered": covered, "uncovered": uncovered, "uncovered_items": uncovered_items}),
-        encoding="utf-8",
-    )
+    payload: dict[str, Any] = {"covered": covered, "uncovered": uncovered, "uncovered_items": uncovered_items}
+    if run_id is not None:
+        payload["input_reports"] = [_coverage_input_report(run_id=run_id, covered=covered)]
+    path.write_text(json.dumps(payload), encoding="utf-8")
 
 
 def test_task_slug_for_tool_is_deterministic() -> None:
@@ -235,6 +265,32 @@ def test_verify_rejects_duplicate_after_reports(tmp_path: Path) -> None:
     assert "distinct" in payload["error"]
 
 
+def test_verify_rejects_copied_after_reports_with_same_run_id(tmp_path: Path) -> None:
+    """Verify rejects two paths that record the same ATIF subject.run_id."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "repeat-1-report.json"
+    second = tmp_path / "repeat-1-copy-report.json"
+    _write_report(before, covered=["write"], uncovered=["read"])
+    _write_report(first, covered=["read"], uncovered=[], run_id="repeat-1")
+    second.write_text(first.read_text(encoding="utf-8"), encoding="utf-8")
+
+    result = _run(
+        "verify",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        "read",
+    )
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert "distinct ATIF subject.run_id" in payload["error"]
+
+
 def test_verify_rejects_non_actionable_uncovered_item(tmp_path: Path) -> None:
     """Verify rejects targets that are uncovered but not actionable tool gaps."""
     before = tmp_path / "before.json"
@@ -268,8 +324,8 @@ def test_verify_rejects_non_actionable_uncovered_item(tmp_path: Path) -> None:
             },
         ],
     )
-    _write_report(first, covered=["read"], uncovered=[])
-    _write_report(second, covered=["read"], uncovered=[])
+    _write_report(first, covered=["read"], uncovered=[], run_id="repeat-1")
+    _write_report(second, covered=["read"], uncovered=[], run_id="repeat-1")
 
     result = _run(
         "verify",
@@ -294,8 +350,8 @@ def test_verify_requires_every_repeat_to_cover_target(tmp_path: Path) -> None:
     first = tmp_path / "first.json"
     second = tmp_path / "second.json"
     _write_report(before, covered=["write"], uncovered=["read"])
-    _write_report(first, covered=["read"], uncovered=[])
-    _write_report(second, covered=["read"], uncovered=[])
+    _write_report(first, covered=["read"], uncovered=[], run_id="repeat-1")
+    _write_report(second, covered=["read"], uncovered=[], run_id="repeat-2")
 
     result = _run(
         "verify",
@@ -313,7 +369,7 @@ def test_verify_requires_every_repeat_to_cover_target(tmp_path: Path) -> None:
     assert payload["accepted"] is True
     assert payload["repeat_count"] == 2
 
-    _write_report(second, covered=[], uncovered=["read"])
+    _write_report(second, covered=[], uncovered=["read"], run_id="repeat-2")
     failed = _run(
         "verify",
         "--before",

--- a/plugins/nemo-eval-author/tests/test_task_pipeline.py
+++ b/plugins/nemo-eval-author/tests/test_task_pipeline.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -42,13 +43,20 @@ def _write_report(path: Path, *, covered: list[str], uncovered: list[str]) -> No
         }
         for name in uncovered
     ]
+    _write_report_with_items(path, covered=covered, uncovered_items=items)
+
+
+def _write_report_with_items(path: Path, *, covered: list[str], uncovered_items: list[dict[str, Any]]) -> None:
+    """Write an aggregate coverage report with explicit ``uncovered_items`` entries."""
+    uncovered = [str(item["name"]) for item in uncovered_items]
     path.write_text(
-        json.dumps({"covered": covered, "uncovered": uncovered, "uncovered_items": items}),
+        json.dumps({"covered": covered, "uncovered": uncovered, "uncovered_items": uncovered_items}),
         encoding="utf-8",
     )
 
 
 def test_task_slug_for_tool_is_deterministic() -> None:
+    """Base slugs are stable for common runtime tool names."""
     sys.path.insert(0, str(_SCRIPT.parent))
     try:
         from task_pipeline import task_slug_for_tool
@@ -60,6 +68,7 @@ def test_task_slug_for_tool_is_deterministic() -> None:
 
 
 def test_select_returns_task_slug_and_paths(tmp_path: Path) -> None:
+    """Select attaches canonical artifact paths for one actionable tool gap."""
     report = tmp_path / "report.json"
     _write_report(report, covered=["write"], uncovered=["read"])
     payload = json.loads(_run("select", "--report", str(report)).stdout)
@@ -84,8 +93,21 @@ def test_select_returns_task_slug_and_paths(tmp_path: Path) -> None:
     ]
 
 
+def test_select_assigns_deduped_slugs_for_colliding_tool_names(tmp_path: Path) -> None:
+    """Colliding base slugs receive deterministic ``-2``, ``-3``, ... suffixes."""
+    report = tmp_path / "report.json"
+    _write_report(report, covered=[], uncovered=["server:foo", "server.foo"])
+    payload = json.loads(_run("select", "--report", str(report)).stdout)
+    slugs = {gap["name"]: gap["task_slug"] for gap in payload["actionable_tools"]}
+    assert slugs == {
+        "server.foo": "cover-server-foo",
+        "server:foo": "cover-server-foo-2",
+    }
+
+
 @_needs_harbor
 def test_scaffold_uses_harbor_native_task_layout(tmp_path: Path) -> None:
+    """Scaffold installs the proposal into a Harbor-native task draft layout."""
     report = tmp_path / "report.json"
     _write_report(report, covered=["write"], uncovered=["read"])
     proposals = tmp_path / ".eval-author" / "proposals"
@@ -125,6 +147,7 @@ def test_scaffold_uses_harbor_native_task_layout(tmp_path: Path) -> None:
 
 
 def test_scaffold_rejects_mismatched_proposal_filename(tmp_path: Path) -> None:
+    """Scaffold rejects proposal filenames that do not match the assigned task slug."""
     report = tmp_path / "report.json"
     _write_report(report, covered=["write"], uncovered=["read"])
     proposals = tmp_path / ".eval-author" / "proposals"
@@ -157,6 +180,7 @@ def test_scaffold_rejects_mismatched_proposal_filename(tmp_path: Path) -> None:
 
 
 def test_verify_rejects_single_after_report(tmp_path: Path) -> None:
+    """Verify requires at least two after-reports."""
     before = tmp_path / "before.json"
     first = tmp_path / "first.json"
     _write_report(before, covered=["write"], uncovered=["read"])
@@ -178,6 +202,7 @@ def test_verify_rejects_single_after_report(tmp_path: Path) -> None:
 
 
 def test_verify_rejects_duplicate_after_reports(tmp_path: Path) -> None:
+    """Verify rejects duplicate after-report paths."""
     before = tmp_path / "before.json"
     first = tmp_path / "first.json"
     _write_report(before, covered=["write"], uncovered=["read"])
@@ -200,7 +225,61 @@ def test_verify_rejects_duplicate_after_reports(tmp_path: Path) -> None:
     assert "distinct" in payload["error"]
 
 
+def test_verify_rejects_non_actionable_uncovered_item(tmp_path: Path) -> None:
+    """Verify rejects targets that are uncovered but not actionable tool gaps."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_report_with_items(
+        before,
+        covered=["write"],
+        uncovered_items=[
+            {
+                "name": "read",
+                "kind": "tool",
+                "reason": "not_covered_by_any_input_report",
+                "description": "Use read.",
+                "generation": {
+                    "focus": "Exercise read.",
+                    "needed_tools": ["read"],
+                    "evidence_required": [{"kind": "tool_call", "tool": "read"}],
+                },
+            },
+            {
+                "name": "account_recovery",
+                "kind": "capability",
+                "reason": "not_measured_by_any_method",
+                "description": "Recover account access.",
+                "generation": {
+                    "focus": "Exercise capability account_recovery.",
+                    "needed_tools": ["read"],
+                    "evidence_required": [],
+                },
+            },
+        ],
+    )
+    _write_report(first, covered=["read"], uncovered=[])
+    _write_report(second, covered=["read"], uncovered=[])
+
+    result = _run(
+        "verify",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        "account_recovery",
+    )
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert "not an actionable uncovered tool" in payload["error"]
+
+
 def test_verify_requires_every_repeat_to_cover_target(tmp_path: Path) -> None:
+    """Verify accepts only when every distinct after-report covers the target tool."""
     before = tmp_path / "before.json"
     first = tmp_path / "first.json"
     second = tmp_path / "second.json"

--- a/plugins/nemo-eval-author/tests/test_task_pipeline.py
+++ b/plugins/nemo-eval-author/tests/test_task_pipeline.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PLUGIN = Path(__file__).resolve().parents[1]
+_SCRIPT = _PLUGIN / "skills" / "eval-author-task-create" / "scripts" / "task_pipeline.py"
+_needs_harbor = pytest.mark.skipif(shutil.which("harbor") is None, reason="Harbor is not installed")
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_report(path: Path, *, covered: list[str], uncovered: list[str]) -> None:
+    items = [
+        {
+            "name": name,
+            "kind": "tool",
+            "reason": "not_covered_by_any_input_report",
+            "description": f"Use {name}.",
+            "generation": {
+                "focus": f"Exercise {name}.",
+                "needed_tools": [name],
+                "evidence_required": [{"kind": "tool_call", "tool": name}],
+            },
+        }
+        for name in uncovered
+    ]
+    path.write_text(
+        json.dumps({"covered": covered, "uncovered": uncovered, "uncovered_items": items}),
+        encoding="utf-8",
+    )
+
+
+def test_select_returns_only_actionable_tool_gaps(tmp_path: Path) -> None:
+    report = tmp_path / "report.json"
+    _write_report(report, covered=["write"], uncovered=["read"])
+    payload = json.loads(_run("select", "--report", str(report)).stdout)
+    assert payload["valid"] is True
+    assert payload["actionable_tools"] == [
+        {
+            "description": "Use read.",
+            "evidence_required": [{"kind": "tool_call", "tool": "read"}],
+            "focus": "Exercise read.",
+            "kind": "tool",
+            "name": "read",
+            "needed_tools": ["read"],
+            "reason": "not_covered_by_any_input_report",
+        }
+    ]
+
+
+@_needs_harbor
+def test_scaffold_uses_harbor_native_task_layout(tmp_path: Path) -> None:
+    report = tmp_path / "report.json"
+    _write_report(report, covered=["write"], uncovered=["read"])
+    instruction = tmp_path / "read-instruction.md"
+    instruction.write_text("Read seed.txt and report its content.\n", encoding="utf-8")
+    draft = tmp_path / ".eval-author" / "task-drafts" / "read-file"
+
+    result = _run(
+        "scaffold",
+        "--report",
+        str(report),
+        "--target",
+        "read",
+        "--out",
+        str(draft),
+        "--task-name",
+        "example/read-file",
+        "--description",
+        "Read a fixture file.",
+        "--author",
+        "Test Author",
+        "--instruction-file",
+        str(instruction),
+    )
+    assert result.returncode == 0, result.stdout
+    assert (draft / "instruction.md").read_text(encoding="utf-8") == instruction.read_text(encoding="utf-8")
+    task_toml = (draft / "task.toml").read_text(encoding="utf-8")
+    assert 'schema_version = "1.3"' in task_toml
+    assert 'name = "example/read-file"' in task_toml
+    assert (draft / "environment" / "Dockerfile").is_file()
+    assert (draft / "solution" / "solve.sh").is_file()
+    assert (draft / "tests" / "test.sh").is_file()
+
+
+def test_verify_requires_every_repeat_to_cover_target(tmp_path: Path) -> None:
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_report(before, covered=["write"], uncovered=["read"])
+    _write_report(first, covered=["read"], uncovered=[])
+    _write_report(second, covered=["read"], uncovered=[])
+
+    result = _run(
+        "verify",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        "read",
+    )
+    payload = json.loads(result.stdout)
+    assert result.returncode == 0
+    assert payload["accepted"] is True
+    assert payload["repeat_count"] == 2
+
+    _write_report(second, covered=[], uncovered=["read"])
+    failed = _run(
+        "verify",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        "read",
+    )
+    assert failed.returncode == 1
+    assert json.loads(failed.stdout)["accepted"] is False

--- a/plugins/nemo-eval-author/tests/test_task_pipeline.py
+++ b/plugins/nemo-eval-author/tests/test_task_pipeline.py
@@ -94,7 +94,7 @@ def test_select_returns_task_slug_and_paths(tmp_path: Path) -> None:
 
 
 def test_select_assigns_deduped_slugs_for_colliding_tool_names(tmp_path: Path) -> None:
-    """Colliding base slugs receive deterministic ``-2``, ``-3``, ... suffixes."""
+    """Colliding base and final slugs receive deterministic ``-2``, ``-3``, ... suffixes."""
     report = tmp_path / "report.json"
     _write_report(report, covered=[], uncovered=["server:foo", "server.foo"])
     payload = json.loads(_run("select", "--report", str(report)).stdout)
@@ -102,6 +102,16 @@ def test_select_assigns_deduped_slugs_for_colliding_tool_names(tmp_path: Path) -
     assert slugs == {
         "server.foo": "cover-server-foo",
         "server:foo": "cover-server-foo-2",
+    }
+
+    report_three = tmp_path / "report-three.json"
+    _write_report(report_three, covered=[], uncovered=["server:foo", "server.foo-2", "server.foo"])
+    payload_three = json.loads(_run("select", "--report", str(report_three)).stdout)
+    slugs_three = {gap["name"]: gap["task_slug"] for gap in payload_three["actionable_tools"]}
+    assert slugs_three == {
+        "server.foo": "cover-server-foo",
+        "server.foo-2": "cover-server-foo-2",
+        "server:foo": "cover-server-foo-3",
     }
 
 

--- a/plugins/nemo-eval-author/tests/test_task_pipeline.py
+++ b/plugins/nemo-eval-author/tests/test_task_pipeline.py
@@ -46,7 +46,18 @@ def _write_report(path: Path, *, covered: list[str], uncovered: list[str]) -> No
     )
 
 
-def test_select_returns_only_actionable_tool_gaps(tmp_path: Path) -> None:
+def test_task_slug_for_tool_is_deterministic() -> None:
+    sys.path.insert(0, str(_SCRIPT.parent))
+    try:
+        from task_pipeline import task_slug_for_tool
+    finally:
+        sys.path.pop(0)
+
+    assert task_slug_for_tool("read") == "cover-read"
+    assert task_slug_for_tool("customer.lookup") == "cover-customer-lookup"
+
+
+def test_select_returns_task_slug_and_paths(tmp_path: Path) -> None:
     report = tmp_path / "report.json"
     _write_report(report, covered=["write"], uncovered=["read"])
     payload = json.loads(_run("select", "--report", str(report)).stdout)
@@ -59,7 +70,14 @@ def test_select_returns_only_actionable_tool_gaps(tmp_path: Path) -> None:
             "kind": "tool",
             "name": "read",
             "needed_tools": ["read"],
+            "paths": {
+                "draft": ".eval-author/task-drafts/cover-read",
+                "measurements": ".eval-author/task-measurements/cover-read",
+                "proposal": ".eval-author/proposals/cover-read-instruction.md",
+                "task_id": "cover-read",
+            },
             "reason": "not_covered_by_any_input_report",
+            "task_slug": "cover-read",
         }
     ]
 
@@ -68,9 +86,11 @@ def test_select_returns_only_actionable_tool_gaps(tmp_path: Path) -> None:
 def test_scaffold_uses_harbor_native_task_layout(tmp_path: Path) -> None:
     report = tmp_path / "report.json"
     _write_report(report, covered=["write"], uncovered=["read"])
-    instruction = tmp_path / "read-instruction.md"
+    proposals = tmp_path / ".eval-author" / "proposals"
+    proposals.mkdir(parents=True)
+    instruction = proposals / "cover-read-instruction.md"
     instruction.write_text("Read seed.txt and report its content.\n", encoding="utf-8")
-    draft = tmp_path / ".eval-author" / "task-drafts" / "read-file"
+    draft = tmp_path / ".eval-author" / "task-drafts" / "cover-read"
 
     result = _run(
         "scaffold",
@@ -81,7 +101,7 @@ def test_scaffold_uses_harbor_native_task_layout(tmp_path: Path) -> None:
         "--out",
         str(draft),
         "--task-name",
-        "example/read-file",
+        "example/cover-read",
         "--description",
         "Read a fixture file.",
         "--author",
@@ -89,14 +109,49 @@ def test_scaffold_uses_harbor_native_task_layout(tmp_path: Path) -> None:
         "--instruction-file",
         str(instruction),
     )
-    assert result.returncode == 0, result.stdout
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["task_slug"] == "cover-read"
+    assert payload["paths"]["proposal"] == ".eval-author/proposals/cover-read-instruction.md"
     assert (draft / "instruction.md").read_text(encoding="utf-8") == instruction.read_text(encoding="utf-8")
     task_toml = (draft / "task.toml").read_text(encoding="utf-8")
     assert 'schema_version = "1.3"' in task_toml
-    assert 'name = "example/read-file"' in task_toml
+    assert 'name = "example/cover-read"' in task_toml
     assert (draft / "environment" / "Dockerfile").is_file()
     assert (draft / "solution" / "solve.sh").is_file()
     assert (draft / "tests" / "test.sh").is_file()
+
+
+def test_scaffold_rejects_mismatched_proposal_filename(tmp_path: Path) -> None:
+    report = tmp_path / "report.json"
+    _write_report(report, covered=["write"], uncovered=["read"])
+    proposals = tmp_path / ".eval-author" / "proposals"
+    proposals.mkdir(parents=True)
+    instruction = proposals / "read-file-instruction.md"
+    instruction.write_text("Read seed.txt and report its content.\n", encoding="utf-8")
+    draft = tmp_path / ".eval-author" / "task-drafts" / "cover-read"
+
+    result = _run(
+        "scaffold",
+        "--report",
+        str(report),
+        "--target",
+        "read",
+        "--out",
+        str(draft),
+        "--task-name",
+        "example/cover-read",
+        "--description",
+        "Read a fixture file.",
+        "--author",
+        "Test Author",
+        "--instruction-file",
+        str(instruction),
+    )
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert "cover-read-instruction.md" in payload["error"]
 
 
 def test_verify_requires_every_repeat_to_cover_target(tmp_path: Path) -> None:

--- a/plugins/nemo-eval-author/tests/test_task_pipeline.py
+++ b/plugins/nemo-eval-author/tests/test_task_pipeline.py
@@ -17,6 +17,7 @@ _needs_harbor = pytest.mark.skipif(shutil.which("harbor") is None, reason="Harbo
 
 
 def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke ``task_pipeline.py`` with ``args`` and return the completed process."""
     return subprocess.run(
         [sys.executable, str(_SCRIPT), *args],
         capture_output=True,
@@ -26,6 +27,7 @@ def _run(*args: str) -> subprocess.CompletedProcess[str]:
 
 
 def _write_report(path: Path, *, covered: list[str], uncovered: list[str]) -> None:
+    """Write a minimal aggregate coverage report JSON file for tests."""
     items = [
         {
             "name": name,
@@ -152,6 +154,50 @@ def test_scaffold_rejects_mismatched_proposal_filename(tmp_path: Path) -> None:
     assert result.returncode == 1
     assert payload["valid"] is False
     assert "cover-read-instruction.md" in payload["error"]
+
+
+def test_verify_rejects_single_after_report(tmp_path: Path) -> None:
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    _write_report(before, covered=["write"], uncovered=["read"])
+    _write_report(first, covered=["read"], uncovered=[])
+
+    result = _run(
+        "verify",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--target",
+        "read",
+    )
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert "at least 2 --after reports are required" in payload["error"]
+
+
+def test_verify_rejects_duplicate_after_reports(tmp_path: Path) -> None:
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    _write_report(before, covered=["write"], uncovered=["read"])
+    _write_report(first, covered=["read"], uncovered=[])
+
+    result = _run(
+        "verify",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(first),
+        "--target",
+        "read",
+    )
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["valid"] is False
+    assert "distinct" in payload["error"]
 
 
 def test_verify_requires_every_repeat_to_cover_target(tmp_path: Path) -> None:

--- a/plugins/nemo-eval-author/tests/test_task_pipeline.py
+++ b/plugins/nemo-eval-author/tests/test_task_pipeline.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import shutil
 import subprocess
@@ -85,13 +86,19 @@ def _write_report_with_items(
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _load_task_pipeline_module():
+    """Load ``task_pipeline.py`` as a module without putting scripts/ on ``sys.path``."""
+    spec = importlib.util.spec_from_file_location("eval_author_task_pipeline", _SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load task pipeline module from {_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_task_slug_for_tool_is_deterministic() -> None:
     """Base slugs are stable for common runtime tool names."""
-    sys.path.insert(0, str(_SCRIPT.parent))
-    try:
-        from task_pipeline import task_slug_for_tool
-    finally:
-        sys.path.pop(0)
+    task_slug_for_tool = _load_task_pipeline_module().task_slug_for_tool
 
     assert task_slug_for_tool("read") == "cover-read"
     assert task_slug_for_tool("customer.lookup") == "cover-customer-lookup"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Adds the `eval-author-task-create` skill and `task_pipeline.py` to turn actionable uncovered tool gaps from an audit coverage report into Harbor-native task drafts, prove them with Oracle, and accept them only when repeated measured ATIF runs close the selected gap. Builds on the merged audit coverage aggregate report (#1539).

## Related Issue

<!-- No tracked issue yet. -->

## Changes

- Add `eval-author-task-create` skill with a seven-step gap-to-task workflow.
- Add `task_pipeline.py` commands: `select`, `scaffold` (`harbor task init`), and `verify`.
- Emit deterministic `cover-<tool>` task slugs and artifact paths from `select`; enforce them in `scaffold`.
- Require two distinct `--after` reports in `verify` (CodeRabbit follow-up).
- Route the new sub-flow from `eval-author` and extend skill contract tests.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Skill markdown is the user-facing documentation for this alpha sub-flow; no separate docs site change.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```bash
uv run --frozen pytest plugins/nemo-eval-author/tests/test_task_pipeline.py plugins/nemo-eval-author/tests/test_skill_contract.py -q
# 115 passed, 1 skipped (Harbor scaffold when harbor CLI absent)
```

### Manual end-to-end workflow (rho-agent fixture, not committed)

Kicked off in Cursor by asking the agent to run Eval Author on the rho-agent fixture at `tmp/nemo-eval-author-fixtures/cases/rho-agent/repo/` (minimal agent repo with an existing Harbor sample task). Each table row lists the skill that owns that step. The agent read `eval-author` to route between sub-flows; the listed sub-flow skills then drove execution of the audit scripts, `task_pipeline.py`, and Harbor commands—`eval-author` itself routes only and does not run tooling. Ran with Harbor 0.20, Docker, and fixture-only rho adapters (`rho_harbor_agent.py` + `rho_atif_compat.py`, not in this PR).

| Step | Work | Skill(s) |
| --- | --- | --- |
| 1 | Wrote `ETHOS.md` for `rho-agent` (filesystem `read`/`write` tools, principles, success criteria) | `nemo-explore` → `nemo-ethos` (NeMo Platform repo skills; upstream of Eval Author) |
| 2 | Drafted `.eval-author/audit-items.yaml`; `generate.py` → `.eval-author/audit.md`; `validate.py` | `eval-author-audit` (Steps 1–3) |
| 3 | Ran existing Harbor task `datasets/terminal-bench-sample/task-0` (write-only) with the agent; `measure.py` + `report.py` → baseline `audit-coverage-report.json` (`write` covered, `read` uncovered) | Baseline Harbor run: manual / existing suite. Measurement: `eval-author-audit` (Steps 4–5) |
| 4 | `task_pipeline.py select` → actionable `read`, `task_slug: cover-read`, artifact paths | `eval-author-task-create` (Step 1) |
| 5 | Wrote `.eval-author/proposals/cover-read-instruction.md` | `eval-author-task-create` (Step 2; LLM-authored instruction) |
| 6 | `task_pipeline.py scaffold` → `.eval-author/task-drafts/cover-read/`; completed Dockerfile, verifier, Oracle solution | `eval-author-task-create` (Steps 3–3 cont.) |
| 7 | `harbor run -p …/cover-read -a oracle` → reward **1.0** | `eval-author-task-create` (Step 4) |
| 8 | Two rho-agent trials via `harbor jobs start` → Pass@2 **1.0**, valid ATIF traces | `eval-author-task-create` (Step 5) |
| 9 | Per-trial `measure.py` + `report.py` under `.eval-author/task-measurements/cover-read/repeat-{1,2}/` | `eval-author-audit` (Step 4) invoked from `eval-author-task-create` (Step 6) |
| 10 | `task_pipeline.py verify --target read` with two distinct after-reports → **`accepted: true`** | `eval-author-task-create` (Step 7) |

NB: Parent `eval-author` should re-aggregate suite-wide audit coverage after task-create accepts a draft (follow-up, not this PR).
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a guided workflow for turning uncovered tool gaps into evaluation tasks.
  * Added task selection, draft scaffolding, validation, and repeat-run verification.
  * Added stable task naming and collision-safe artifact handling.
  * Added Oracle validation and measured real-agent trial requirements before task acceptance.

* **Documentation**
  * Updated authoring and audit guidance for task creation and evidence requirements.

* **Tests**
  * Added coverage for routing, selection, validation, scaffolding, and repeat verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
