### PR TITLE
chore: gitignore per-project .cmux/ workspace config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ iron-swarm.yaml
 docs/superpowers/
 # Per-worker fatal-signal tracebacks (PYTEST_CRASH_DUMP_DIR)
 crash-dumps/
+
+# cmux per-project workspace config (machine/user-local, not shared)
+.cmux/


### PR DESCRIPTION
## Problem / context

[cmux](https://cmux.com) (the terminal several of us use for agent management) supports per-project workspace layouts via a `.cmux/cmux.json` file. That file is machine/user-local (personal pane layouts, cwd shortcuts) and should not be committed.

## Change

Adds `.cmux/` to `.gitignore` so nobody accidentally commits their personal cmux workspace config.

## Definition of done

- [x] `.cmux/` ignored (`git check-ignore .cmux/cmux.json` passes)
- [x] No other files touched

One-line `.gitignore` change; no code impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded local per-project workspace configuration from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->