### PR TITLE
fix(studio): render single MetricTrend datapoint as a flat reference line (ASTD-493)

### DIFF
--- a/web/packages/studio/src/components/charts/MetricTrend/index.tsx
+++ b/web/packages/studio/src/components/charts/MetricTrend/index.tsx
@@ -7,7 +7,15 @@ import { useNvColorMode } from '@studio/components/DagCanvas/useNvColorMode';
 import { StackedSkeleton } from '@studio/components/StackedSkeleton';
 import { Triangle } from 'lucide-react';
 import { FC, useId, useMemo, useState } from 'react';
-import { Area, AreaChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import {
+  Area,
+  AreaChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 
 export interface MetricTrendPoint {
   /** X-axis label for the point, shown in the tooltip. */
@@ -103,6 +111,9 @@ export const MetricTrend: FC<MetricTrendProps> = ({
   const lineColor = isNegative ? 'var(--text-color-accent-red)' : 'var(--text-color-brand)';
   const colorMode = useNvColorMode();
   const gradient = colorMode === 'dark' ? AREA_GRADIENT.dark : AREA_GRADIENT.light;
+  // A single datapoint has no line to draw, so an AreaChart shows only a lone dot. Render a
+  // flat ReferenceLine across the surface instead, per the design.
+  const isSingle = active?.points.length === 1;
 
   return (
     <Flex align="center" gap="density-2xl" className={className}>
@@ -159,7 +170,14 @@ export const MetricTrend: FC<MetricTrendProps> = ({
                   </linearGradient>
                 </defs>
                 <XAxis dataKey="label" hide />
-                <YAxis domain={['dataMin', 'dataMax']} hide />
+                <YAxis
+                  domain={
+                    isSingle
+                      ? [active.points[0].value - 1, active.points[0].value + 1]
+                      : ['dataMin', 'dataMax']
+                  }
+                  hide
+                />
                 <Tooltip
                   cursor={{ stroke: 'var(--border-color-base)', strokeWidth: 1 }}
                   formatter={(value: number) => [formatValue(value), active.label]}
@@ -179,9 +197,17 @@ export const MetricTrend: FC<MetricTrendProps> = ({
                   stroke={lineColor}
                   strokeWidth={2}
                   fill={`url(#${gradientId})`}
-                  dot={active.points.length <= 2}
+                  dot={!isSingle && active.points.length <= 2}
                   isAnimationActive={false}
                 />
+                {isSingle && (
+                  <ReferenceLine
+                    y={active.points[0].value}
+                    stroke={lineColor}
+                    strokeWidth={2}
+                    ifOverflow="extendDomain"
+                  />
+                )}
               </AreaChart>
             </ResponsiveContainer>
           )}

--- a/web/packages/studio/src/components/charts/MetricTrendPanel/MetricTrendPanel.stories.tsx
+++ b/web/packages/studio/src/components/charts/MetricTrendPanel/MetricTrendPanel.stories.tsx
@@ -77,6 +77,16 @@ export const ValueCaption: Story = {
   },
 };
 
+export const SingleDatapoint: Story = {
+  args: {
+    comparisonLabel: undefined,
+    valueLabel: 'Latest result',
+    series: [
+      { id: 'solved', label: 'Solved', value: 78.4, points: [{ label: 'Day 1', value: 78.4 }] },
+    ],
+  },
+};
+
 export const Loading: Story = {
   args: { isPending: true },
 };


### PR DESCRIPTION

<img width="1948" height="652" alt="pr-astd-493-metrictrend-single-datapoint-20260827" src="https://github.com/user-attachments/assets/c5f32c86-284f-44ff-90f3-e92cdfdd89de" />

## Summary

A MetricTrend series with a single datapoint rendered as a lone dot in the AreaChart, which reads poorly. It now draws a flat Recharts `ReferenceLine` across the full chart surface with the Y domain padded so the line sits centered. Multi-point series are unchanged.

## Related Issue

ASTD-493

## Changes

- `MetricTrend/index.tsx`: when the active series has exactly one point, render a `ReferenceLine` at that value across the surface and pad the Y domain (`[v-1, v+1]`) so it's centered.
- Added a `SingleDatapoint` story to `MetricTrendPanel.stories.tsx`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Existing tests cover changed behavior — justification: rendering is a Recharts SVG geometry concern not observable in jsdom; verified visually in Storybook. Existing `MetricTrendPanel` tests cover the surrounding component contract.
- [x] Documentation not applicable — justification: internal chart component, no user-facing docs.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `tsc --noEmit` (studio) — passed
- `eslint --fix` on changed files — passed, 0 warnings
- `vitest --run MetricTrendPanel.test.tsx` — 6/6 passed
- Visual: Storybook `Charts/MetricTrendPanel > SingleDatapoint` renders a flat line across the surface
- Full `pre-commit run -a` not run locally; commit-stage hooks (DCO, merge-conflict) passed on commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved metric trend charts with a single data point by displaying a clear horizontal reference line at the recorded value.
  * Single-point charts now use a bounded vertical scale and hide the isolated data marker for cleaner presentation.
  * Charts with multiple data points continue to display as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->