### PR TITLE
fix(inference-gateway): strip client x-api-key before proxying upstream

### DIFF
--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -91,6 +91,8 @@ REQUEST_HEADERS_TO_DROP = frozenset(
     {
         "host",  # upstream shouldn't see the host header of our server
         "authorization",  # any auth to upstreams should be from Secrets, not the request
+        "x-api-key",  # like authorization: upstream auth comes from Secrets. Anthropic/Bedrock
+        # backends read this header, so a client's placeholder (e.g. "not-used") would 401 upstream.
         "x-forwarded-host",  # some backends (e.g. LiteLLM) use this to alter routing
         "x-forwarded-proto",
         "x-forwarded-for",

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -1159,6 +1159,44 @@ async def test_build_next_request_request_headers_override_drops_sensitive_heade
 
 
 @pytest.mark.asyncio
+async def test_build_next_request_drops_x_api_key(mock_request):
+    """A client-supplied x-api-key is dropped so it never reaches the upstream.
+
+    The platform injects provider auth from Secrets; forwarding a client placeholder
+    x-api-key (e.g. "not-used") makes Anthropic/Bedrock backends 401. It must be
+    stripped like ``authorization``.
+    """
+    mock_request.headers = {
+        "content-type": "application/json",
+        "x-api-key": "not-used",
+    }
+
+    result = await build_next_request(mock_request, "http://example.com", "v1/messages")
+
+    assert "x-api-key" not in result.headers  # provider auth injected separately
+    assert result.headers["content-type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_build_next_request_request_headers_override_drops_x_api_key(mock_request):
+    """x-api-key is filtered from a request_headers override too (the model-scoped path)."""
+    middleware_headers = {
+        "x-custom": "keep-me",
+        "x-api-key": "not-used",
+    }
+
+    result = await build_next_request(
+        mock_request,
+        "http://example.com",
+        "v1/messages",
+        request_headers=middleware_headers,
+    )
+
+    assert result.headers["x-custom"] == "keep-me"
+    assert "x-api-key" not in result.headers  # provider auth injected separately
+
+
+@pytest.mark.asyncio
 async def test_build_next_request_request_headers_none_falls_back_to_request(mock_request):
     """When request_headers is None (the default), request.headers is used as before."""
     mock_request.headers = {"x-from-request": "yes", "content-type": "application/json"}


### PR DESCRIPTION
## Summary

The inference gateway stripped a client's `Authorization` header before proxying (upstream auth is injected from Secrets) but forwarded the `x-api-key` header verbatim. Anthropic/Bedrock backends read `x-api-key`, so when a client sent the platform's placeholder credential (e.g. `not-used`), IGW forwarded it and the upstream returned `401`, surfaced to the caller as a `502`. This adds `x-api-key` to the drop list so it is discarded like `Authorization`, letting IGW's injected provider auth reach the upstream.

Before: `x-api-key: not-used` on the model-scoped Anthropic Messages route → `502 Backend returned 401: invalid_credential`.
After: the client `x-api-key` is dropped; IGW's Secrets-backed provider auth is used → `200`.

## Changes

- Add `x-api-key` to `REQUEST_HEADERS_TO_DROP` in `services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py`. This list is enforced in `build_next_request`, which the model-scoped route (`model_entity_proxy` → `virtual_model_proxy` → `build_next_request`) uses to construct outgoing headers, so the placeholder `x-api-key` is now discarded on that route.
- Add unit coverage for `x-api-key` stripping on both the direct request-header path and the `request_headers` override path (mirroring the existing `authorization` sensitive-header tests).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: internal header-forwarding behavior; no user-facing docs describe the drop list.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run ruff check <proxy.py> <test_proxy.py>` → All checks passed
- `uv run ruff format --check <proxy.py> <test_proxy.py>` → 2 files already formatted
- `uv run --frozen ty check <proxy.py>` → 1 diagnostic, pre-existing on the clean tree (unrelated `dict.update` overload in `stream_response_result`); not introduced by this change
- `uv run --frozen pytest services/core/inference-gateway/tests/unit/` → 467 passed, 5 skipped (includes 2 new x-api-key tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Client-provided `x-api-key` headers are now removed before requests are forwarded upstream, including headers supplied through request overrides.
  - Other request headers continue to be preserved during proxying.
- **Security**
  - Prevents client-supplied API keys from being unintentionally passed to upstream services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->