### PR TITLE
fix(igw): rewrite served_model_name in upstream error response bodies

### DIFF
--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 import logging
+import re
 import uuid
 from collections.abc import AsyncIterable
 from dataclasses import dataclass
@@ -27,6 +28,7 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareError,
     InferenceResponse,
 )
+from nemo_platform_plugin.refs import ENTITY_REF_PATTERN
 from nemo_platform_plugin.secrets.client import AsyncSecretsClient
 from nmp.common.entities.utils import parse_model_entity_ref
 from nmp.core.inference_gateway.api.backend_format import resolve_backend_format
@@ -57,6 +59,13 @@ ResponseResult = Union[dict[str, Any], AsyncIterator[dict[str, Any]]]
 logger = logging.getLogger(__name__)
 
 DEFAULT_CHUNK_SIZE = 4096
+
+# A model name safe to blind-substring-replace inside an error body: the entity-ref
+# shape (``[\w.-]`` segments with an optional ``/``), which both the entity store
+# (ENTITY_REF_PATTERN) and HuggingFace repo ids conform to. Its character set has no
+# JSON-structural characters, so replacing it can't corrupt a JSON body. See
+# _rewrite_model_field_in_error_body.
+_SAFE_MODEL_NAME = re.compile(ENTITY_REF_PATTERN)
 
 # OpenAPI extra configuration for proxy endpoints that accept arbitrary JSON bodies.
 # This is used to generate proper requestBody schema in OpenAPI spec for POST/PUT/PATCH
@@ -676,42 +685,35 @@ def _rewrite_model_field_in_error_body(
     leaks in error cases (rate-limit messages, content-policy blocks, "model not
     found", etc.). This restores parity with the happy-path rewrite.
 
-    Two body shapes are handled:
+    This is **best-effort UX scrubbing**, not a guarantee. It does a single
+    substring replacement over the raw body, so it is format-agnostic — it works
+    the same whether the body is a JSON object, plain text, or something we can't
+    parse — and, because it makes exactly one pass over the *original* string, it
+    cannot double-apply the swap (a parse-then-blanket-replace approach mangles
+    ``model-1`` → ``default/model-1`` → ``default/default/model-1`` whenever the
+    restored id contains the served name, which is the common case).
 
-    * **JSON object** — parsed, run through :func:`_rewrite_model_field` (so the
-      same top-level / ``message`` / ``response`` locations are covered), and
-      re-serialized. This catches the structured ``model`` field OpenAI- and
-      Anthropic-shaped error bodies echo back.
-    * **Anything else** (plain text, a JSON scalar/array, or unparseable text) —
-      a plain substring replacement of *served_model_name* with
-      *restored_model_id*, which covers free-form messages like
-      ``"The model `served-name` does not exist"``.
-
-    The JSON path additionally does a substring pass over the re-serialized text
-    so a served name embedded in a *message string* (e.g. OpenAI's
-    ``"error": {"message": "The model `served-name` does not exist ..."}``) is
-    scrubbed too, not just a structured ``model`` field. Both passes are strict
-    substring/equality swaps, so an empty *error_body* or one that never mentions
-    the served name is returned unchanged.
+    To keep that blind replacement from corrupting a JSON body, both names must be
+    plain model ids — they are matched against :data:`ENTITY_REF_PATTERN`
+    (``[\\w.-]`` segments with an optional ``/``), the same shape the entity store
+    and HuggingFace both use, whose character set contains no JSON-structural
+    characters (no quotes, braces, brackets, colons, backslashes). If either name
+    falls outside that shape (or is empty), the scrub is skipped entirely and the
+    body is returned untouched — the served name persists rather than risk mangling
+    the response.
     """
-    if not error_body:
+    if not error_body or not served_model_name:
         return error_body
 
-    try:
-        parsed = json.loads(error_body)
-    except (json.JSONDecodeError, ValueError):
-        return error_body.replace(served_model_name, restored_model_id)
+    if not (_SAFE_MODEL_NAME.match(served_model_name) and _SAFE_MODEL_NAME.match(restored_model_id)):
+        logger.warning(
+            "Skipping error-body model-name scrub: a model name is not a plain model id "
+            "(served=%r restored=%r); leaving the body untouched to avoid corrupting it.",
+            served_model_name,
+            restored_model_id,
+        )
+        return error_body
 
-    if isinstance(parsed, dict):
-        _rewrite_model_field(parsed, served_model_name, restored_model_id)
-        reserialized = json.dumps(parsed)
-        # Also scrub the served name out of any free-form message strings that
-        # _rewrite_model_field (which only touches structured `model` fields)
-        # would miss.
-        return reserialized.replace(served_model_name, restored_model_id)
-
-    # A JSON scalar or array — no structured `model` field to target, so fall
-    # back to a substring replace over the original text.
     return error_body.replace(served_model_name, restored_model_id)
 
 

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -504,11 +504,15 @@ async def fetch_proxy_response(
     leak. Other responses are buffered and parsed as JSON.
 
     When *served_model_name* and *restored_model_id* are both supplied, upstream
-    error bodies (4xx/5xx, including a non-2xx status returned mid-stream) have
-    the served model name rewritten to the entity ref before the body is placed
-    on the ``HTTPException`` — matching the happy-path rewrite so
-    ``served_model_name`` never leaks in error cases. See
-    :func:`_rewrite_model_field_in_error_body`.
+    error bodies (a 4xx/5xx *status* response) have the served model name rewritten
+    to the entity ref before the body is placed on the ``HTTPException`` — matching
+    the happy-path rewrite so ``served_model_name`` never leaks in these error cases.
+    See :func:`_rewrite_model_field_in_error_body`. This is best-effort UX scrubbing,
+    not a hard guarantee: an error a provider delivers *inside* an HTTP-200 SSE stream
+    (an error event mid-stream) does not pass through here — such events only have
+    their structured ``model`` fields rewritten by
+    :func:`_rewrite_model_field_in_stream`, so a served name embedded in that event's
+    free-form message string is not scrubbed.
 
     Returns:
         A ``(response_result, headers, status_code)`` tuple.
@@ -539,9 +543,9 @@ async def fetch_proxy_response(
                 error_body,
             )
             # Rewrite the served model name out of the error body so the caller
-            # never sees the upstream's served_model_name in error cases, matching
-            # the happy-path rewrite. A non-2xx returned mid-stream lands here too,
-            # because the status check precedes the SSE branch below.
+            # never sees the upstream's served_model_name for a non-2xx *status*
+            # response, matching the happy-path rewrite. (An error delivered inside
+            # an HTTP-200 SSE stream does not reach here; see the docstring.)
             if served_model_name is not None and restored_model_id is not None:
                 error_body = _rewrite_model_field_in_error_body(error_body, served_model_name, restored_model_id)
             if response.status in (401, 403, 404):

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/proxy.py
@@ -488,6 +488,8 @@ async def _parse_sse_stream(response: aiohttp.ClientResponse) -> AsyncIterator[d
 async def fetch_proxy_response(
     http_client: ClientSession,
     next_request_info: NextRequestInfo,
+    served_model_name: str | None = None,
+    restored_model_id: str | None = None,
 ) -> tuple[ResponseResult, CIMultiDict[str], int]:
     """Execute a proxied HTTP request and return the response as a ``ResponseResult``.
 
@@ -500,6 +502,13 @@ async def fetch_proxy_response(
     path. ``Content-Type: text/event-stream`` responses remain backed by the live
     response, so the iterator **must** be fully consumed or the connection will
     leak. Other responses are buffered and parsed as JSON.
+
+    When *served_model_name* and *restored_model_id* are both supplied, upstream
+    error bodies (4xx/5xx, including a non-2xx status returned mid-stream) have
+    the served model name rewritten to the entity ref before the body is placed
+    on the ``HTTPException`` — matching the happy-path rewrite so
+    ``served_model_name`` never leaks in error cases. See
+    :func:`_rewrite_model_field_in_error_body`.
 
     Returns:
         A ``(response_result, headers, status_code)`` tuple.
@@ -529,6 +538,12 @@ async def fetch_proxy_response(
                 next_request_info.url,
                 error_body,
             )
+            # Rewrite the served model name out of the error body so the caller
+            # never sees the upstream's served_model_name in error cases, matching
+            # the happy-path rewrite. A non-2xx returned mid-stream lands here too,
+            # because the status check precedes the SSE branch below.
+            if served_model_name is not None and restored_model_id is not None:
+                error_body = _rewrite_model_field_in_error_body(error_body, served_model_name, restored_model_id)
             if response.status in (401, 403, 404):
                 detail = (
                     f"Backend returned {response.status}: {error_body}"
@@ -642,6 +657,58 @@ def _rewrite_model_field(payload: Any, served_model_name: str, restored_model_id
     nested_response = payload.get("response")
     if isinstance(nested_response, dict) and nested_response.get("model") == served_model_name:
         nested_response["model"] = restored_model_id
+
+
+def _rewrite_model_field_in_error_body(
+    error_body: str,
+    served_model_name: str,
+    restored_model_id: str,
+) -> str:
+    """Rewrite ``served_model_name`` -> ``restored_model_id`` inside an upstream error body.
+
+    Error responses never reach :func:`_rewrite_model_field` on the happy path
+    because :func:`fetch_proxy_response` raises before the response body is handed
+    to the middleware pipeline. Without this, the upstream ``served_model_name``
+    leaks in error cases (rate-limit messages, content-policy blocks, "model not
+    found", etc.). This restores parity with the happy-path rewrite.
+
+    Two body shapes are handled:
+
+    * **JSON object** — parsed, run through :func:`_rewrite_model_field` (so the
+      same top-level / ``message`` / ``response`` locations are covered), and
+      re-serialized. This catches the structured ``model`` field OpenAI- and
+      Anthropic-shaped error bodies echo back.
+    * **Anything else** (plain text, a JSON scalar/array, or unparseable text) —
+      a plain substring replacement of *served_model_name* with
+      *restored_model_id*, which covers free-form messages like
+      ``"The model `served-name` does not exist"``.
+
+    The JSON path additionally does a substring pass over the re-serialized text
+    so a served name embedded in a *message string* (e.g. OpenAI's
+    ``"error": {"message": "The model `served-name` does not exist ..."}``) is
+    scrubbed too, not just a structured ``model`` field. Both passes are strict
+    substring/equality swaps, so an empty *error_body* or one that never mentions
+    the served name is returned unchanged.
+    """
+    if not error_body:
+        return error_body
+
+    try:
+        parsed = json.loads(error_body)
+    except (json.JSONDecodeError, ValueError):
+        return error_body.replace(served_model_name, restored_model_id)
+
+    if isinstance(parsed, dict):
+        _rewrite_model_field(parsed, served_model_name, restored_model_id)
+        reserialized = json.dumps(parsed)
+        # Also scrub the served name out of any free-form message strings that
+        # _rewrite_model_field (which only touches structured `model` fields)
+        # would miss.
+        return reserialized.replace(served_model_name, restored_model_id)
+
+    # A JSON scalar or array — no structured `model` field to target, so fall
+    # back to a substring replace over the original text.
+    return error_body.replace(served_model_name, restored_model_id)
 
 
 async def _rewrite_model_field_in_stream(
@@ -992,7 +1059,10 @@ async def virtual_model_proxy(
                 request_headers=modified_request.headers,
             )
             proxy_response_result, response_headers, response_status = await fetch_proxy_response(
-                http_client, next_request_info
+                http_client,
+                next_request_info,
+                served_model_name=resolved_served_model_name,
+                restored_model_id=f"{modified_model_ref.workspace}/{modified_model_ref.name}",
             )
             json_body["model"] = f"{modified_model_ref.workspace}/{modified_model_ref.name}"
 

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -41,6 +41,7 @@ from nmp.core.inference_gateway.api.proxy import (
     _build_inference_response_with_annotations,
     _parse_sse_stream,
     _rewrite_model_field,
+    _rewrite_model_field_in_error_body,
     _rewrite_model_field_in_stream,
     build_next_request,
     fetch_proxy_response,
@@ -1856,6 +1857,278 @@ def test_rewrite_model_field_partial_match_only():
     payload = {"model": "served-name-suffixed"}
     _rewrite_model_field(payload, "served-name", "ws/entity")
     assert payload["model"] == "served-name-suffixed"
+
+
+# ---------------------------------------------------------------------------
+# Error-body rewrite: served_model_name must not leak in 4xx/5xx error cases,
+# matching the happy-path rewrite. Covers structured JSON error bodies and
+# free-form plain-text bodies.
+# ---------------------------------------------------------------------------
+
+
+def test_rewrite_error_body_json_structured_model_field():
+    """A structured ``model`` field in a JSON error body is rewritten."""
+    body = json.dumps({"error": {"message": "boom"}, "model": "served-name"})
+    out = _rewrite_model_field_in_error_body(body, "served-name", "ws/entity")
+    assert json.loads(out)["model"] == "ws/entity"
+    assert "served-name" not in out
+
+
+def test_rewrite_error_body_json_model_in_message_string():
+    """OpenAI-shaped 'model not found' errors carry the served name inside the
+    error *message* string, not a structured field; it must still be scrubbed."""
+    body = json.dumps(
+        {
+            "error": {
+                "message": "The model `served-name` does not exist or you do not have access to it.",
+                "type": "invalid_request_error",
+                "code": "model_not_found",
+            }
+        }
+    )
+    out = _rewrite_model_field_in_error_body(body, "served-name", "ws/entity")
+    assert "served-name" not in out
+    assert "ws/entity" in json.loads(out)["error"]["message"]
+
+
+def test_rewrite_error_body_plain_text_substring_replace():
+    """A non-JSON plain-text error body is handled by substring replacement."""
+    body = "Upstream error: model served-name is overloaded, retry later."
+    out = _rewrite_model_field_in_error_body(body, "served-name", "ws/entity")
+    assert out == "Upstream error: model ws/entity is overloaded, retry later."
+
+
+def test_rewrite_error_body_empty_is_noop():
+    """An empty error body is returned unchanged."""
+    assert _rewrite_model_field_in_error_body("", "served-name", "ws/entity") == ""
+
+
+def test_rewrite_error_body_no_match_passthrough():
+    """A body that never mentions the served name is returned unchanged."""
+    body = json.dumps({"error": {"message": "rate limit exceeded"}})
+    assert _rewrite_model_field_in_error_body(body, "served-name", "ws/entity") == body
+
+
+def test_rewrite_error_body_json_scalar_falls_back_to_substring():
+    """A JSON scalar/array (no dict to target) falls back to substring replace."""
+    body = json.dumps("served-name is unavailable")
+    out = _rewrite_model_field_in_error_body(body, "served-name", "ws/entity")
+    assert "served-name" not in out
+    assert "ws/entity" in out
+
+
+def _error_response(status: int, body: bytes, *, content_type: str = "application/json") -> Mock:
+    """Build a mock aiohttp error response returning *body* with *status*."""
+    resp = Mock(spec=aiohttp.ClientResponse)
+    resp.status = status
+    resp.closed = False
+    resp.headers = CIMultiDict({"content-type": content_type})
+    resp.read = AsyncMock(return_value=body)
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_rewrites_openai_model_not_found_400(mock_proxy_client, next_request_info):
+    """OpenAI 400 model-not-found: the served name is scrubbed from the error detail."""
+    body = json.dumps(
+        {
+            "error": {
+                "message": "The model `served-name` does not exist or you do not have access to it.",
+                "type": "invalid_request_error",
+                "code": "model_not_found",
+            }
+        }
+    ).encode()
+    mock_proxy_client.request = AsyncMock(return_value=_error_response(400, body))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(
+            mock_proxy_client,
+            next_request_info,
+            served_model_name="served-name",
+            restored_model_id="ws/entity",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "served-name" not in exc_info.value.detail
+    assert "ws/entity" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_rewrites_anthropic_error_400(mock_proxy_client, next_request_info):
+    """Anthropic 400: the served name is scrubbed from the Anthropic-shaped error body."""
+    body = json.dumps(
+        {
+            "type": "error",
+            "error": {
+                "type": "not_found_error",
+                "message": "model: served-name",
+            },
+        }
+    ).encode()
+    mock_proxy_client.request = AsyncMock(return_value=_error_response(400, body))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(
+            mock_proxy_client,
+            next_request_info,
+            served_model_name="served-name",
+            restored_model_id="ws/entity",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "served-name" not in exc_info.value.detail
+    assert "ws/entity" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_rewrites_rate_limit_429(mock_proxy_client, next_request_info):
+    """429 rate-limit: served name scrubbed from the message, status passed through."""
+    body = json.dumps(
+        {"error": {"message": "Rate limit reached for model served-name", "type": "rate_limit_error"}}
+    ).encode()
+    mock_proxy_client.request = AsyncMock(return_value=_error_response(429, body))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(
+            mock_proxy_client,
+            next_request_info,
+            served_model_name="served-name",
+            restored_model_id="ws/entity",
+        )
+
+    assert exc_info.value.status_code == 429
+    assert "served-name" not in exc_info.value.detail
+    assert "ws/entity" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_rewrites_plain_text_5xx(mock_proxy_client, next_request_info):
+    """OpenAI plain-text 5xx: substring replacement scrubs the served name."""
+    body = b"Internal server error while serving model served-name; please retry."
+    mock_proxy_client.request = AsyncMock(return_value=_error_response(500, body, content_type="text/plain"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(
+            mock_proxy_client,
+            next_request_info,
+            served_model_name="served-name",
+            restored_model_id="ws/entity",
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "served-name" not in exc_info.value.detail
+    assert "ws/entity" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_rewrites_401_wrapped_in_502(mock_proxy_client, next_request_info):
+    """A 401 is wrapped as 502; the served name is still scrubbed from the wrapped detail."""
+    body = json.dumps({"error": {"message": "invalid key for served-name"}}).encode()
+    mock_proxy_client.request = AsyncMock(return_value=_error_response(401, body))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(
+            mock_proxy_client,
+            next_request_info,
+            served_model_name="served-name",
+            restored_model_id="ws/entity",
+        )
+
+    assert exc_info.value.status_code == 502
+    assert "served-name" not in exc_info.value.detail
+    assert "ws/entity" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_fetch_proxy_response_error_rewrite_noop_without_names(mock_proxy_client, next_request_info):
+    """With no served/restored names supplied, the error body is passed through verbatim."""
+    body = json.dumps({"error": {"message": "served-name is down"}}).encode()
+    mock_proxy_client.request = AsyncMock(return_value=_error_response(500, body))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fetch_proxy_response(mock_proxy_client, next_request_info)
+
+    assert exc_info.value.status_code == 500
+    assert "served-name" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_virtual_model_proxy_scrubs_served_name_on_upstream_error(mock_proxy_client, mock_proxy_response):
+    """End-to-end error path: an upstream 400 flows through virtual_model_proxy and the
+    HTTPException detail carries the entity ref, never the served_model_name. This covers
+    the streaming-request case too: a non-2xx status is detected before the SSE branch,
+    so a request that asked for ``stream: True`` but got an error is scrubbed the same way.
+    """
+    workspace = "e2e-test"
+    vm_name = "error-rewrite-router"
+    model_entity_id = f"{workspace}/meta_llama-3.2-1b-instruct"
+    served_model_name = "meta/llama-3.2-1b-instruct"
+
+    error_body = json.dumps(
+        {
+            "error": {
+                "message": f"The model `{served_model_name}` does not exist or you do not have access to it.",
+                "type": "invalid_request_error",
+                "code": "model_not_found",
+            }
+        }
+    ).encode()
+    mock_proxy_response.status = 400
+    mock_proxy_response.read = AsyncMock(return_value=error_body)
+
+    model_cache = ModelCache()
+    model_cache.update_model_info(
+        ModelProviderInfo(
+            model_provider=ModelProvider(
+                workspace="default",
+                name="nim",
+                host_url="http://nim.local",
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                served_models=[
+                    ServedModelMapping(
+                        model_entity_id=model_entity_id,
+                        served_model_name=served_model_name,
+                    )
+                ],
+                status="READY",
+            )
+        )
+    )
+    model_cache.rebuild_model_entity_map()
+
+    request = Mock(spec=Request)
+    request.method = "POST"
+    request.headers = {"content-type": "application/json"}
+    request.query_params = {}
+
+    with pytest.raises(HTTPException) as exc_info:
+        await virtual_model_proxy(
+            request=request,
+            workspace=workspace,
+            vm_name=vm_name,
+            virtual_model=SDKVirtualModel(
+                id=f"{workspace}/{vm_name}",
+                entity_id=f"{workspace}/{vm_name}",
+                name=vm_name,
+                workspace=workspace,
+                parent=workspace,
+                db_version=1,
+                created_at="2026-01-01T00:00:00Z",
+                updated_at="2026-01-01T00:00:00Z",
+                default_model_entity=model_entity_id,
+            ),
+            trailing_uri="v1/chat/completions",
+            json_body={"model": vm_name, "stream": True, "messages": [{"role": "user", "content": "hi"}]},
+            http_client=mock_proxy_client,
+            model_cache=model_cache,
+            registry=MiddlewareRegistry(),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert served_model_name not in exc_info.value.detail
+    assert model_entity_id in exc_info.value.detail
 
 
 @pytest.mark.asyncio

--- a/services/core/inference-gateway/tests/unit/test_proxy.py
+++ b/services/core/inference-gateway/tests/unit/test_proxy.py
@@ -1868,10 +1868,29 @@ def test_rewrite_model_field_partial_match_only():
 
 def test_rewrite_error_body_json_structured_model_field():
     """A structured ``model`` field in a JSON error body is rewritten."""
-    body = json.dumps({"error": {"message": "boom"}, "model": "served-name"})
-    out = _rewrite_model_field_in_error_body(body, "served-name", "ws/entity")
-    assert json.loads(out)["model"] == "ws/entity"
-    assert "served-name" not in out
+    body = json.dumps({"error": {"message": "boom"}, "model": "model-1"})
+    out = _rewrite_model_field_in_error_body(body, "model-1", "default/model-1")
+    assert json.loads(out)["model"] == "default/model-1"
+
+
+def test_rewrite_error_body_no_double_application_when_restored_contains_served():
+    """Regression: the served name is applied exactly once even when the restored id
+    *contains* it (the common ``model-1`` -> ``default/model-1`` case). A parse-then-
+    blanket-replace approach would re-hit the already-rewritten value and produce
+    ``default/default/model-1``; a single pass over the original must not.
+
+    Covers a served name appearing BOTH as a structured ``model`` field and inside a
+    free-form error message string in the same body.
+    """
+    served, restored = "model-1", "default/model-1"
+    body = json.dumps({"model": served, "error": {"message": f"{served} is unavailable"}})
+    out = _rewrite_model_field_in_error_body(body, served, restored)
+
+    parsed = json.loads(out)  # still valid JSON
+    assert parsed["model"] == restored
+    assert parsed["error"]["message"] == f"{restored} is unavailable"
+    # The doubled-prefix mangling must not appear anywhere.
+    assert "default/default/" not in out
 
 
 def test_rewrite_error_body_json_model_in_message_string():
@@ -1880,41 +1899,61 @@ def test_rewrite_error_body_json_model_in_message_string():
     body = json.dumps(
         {
             "error": {
-                "message": "The model `served-name` does not exist or you do not have access to it.",
+                "message": "The model `model-1` does not exist or you do not have access to it.",
                 "type": "invalid_request_error",
                 "code": "model_not_found",
             }
         }
     )
-    out = _rewrite_model_field_in_error_body(body, "served-name", "ws/entity")
-    assert "served-name" not in out
-    assert "ws/entity" in json.loads(out)["error"]["message"]
+    out = _rewrite_model_field_in_error_body(body, "model-1", "default/model-1")
+    parsed = json.loads(out)  # substring swap kept the body valid JSON
+    assert "default/model-1" in parsed["error"]["message"]
+    assert "`model-1`" not in parsed["error"]["message"]
 
 
 def test_rewrite_error_body_plain_text_substring_replace():
     """A non-JSON plain-text error body is handled by substring replacement."""
-    body = "Upstream error: model served-name is overloaded, retry later."
-    out = _rewrite_model_field_in_error_body(body, "served-name", "ws/entity")
-    assert out == "Upstream error: model ws/entity is overloaded, retry later."
+    body = "Upstream error: model model-1 is overloaded, retry later."
+    out = _rewrite_model_field_in_error_body(body, "model-1", "default/model-1")
+    assert out == "Upstream error: model default/model-1 is overloaded, retry later."
 
 
 def test_rewrite_error_body_empty_is_noop():
     """An empty error body is returned unchanged."""
-    assert _rewrite_model_field_in_error_body("", "served-name", "ws/entity") == ""
+    assert _rewrite_model_field_in_error_body("", "model-1", "default/model-1") == ""
+
+
+def test_rewrite_error_body_empty_served_name_is_noop():
+    """An empty *served_model_name* is a no-op: ``str.replace("", ...)`` would otherwise
+    splice the restored id between every character and corrupt the whole body."""
+    body = json.dumps({"error": {"message": "boom"}})
+    assert _rewrite_model_field_in_error_body(body, "", "default/model-1") == body
 
 
 def test_rewrite_error_body_no_match_passthrough():
     """A body that never mentions the served name is returned unchanged."""
     body = json.dumps({"error": {"message": "rate limit exceeded"}})
-    assert _rewrite_model_field_in_error_body(body, "served-name", "ws/entity") == body
+    assert _rewrite_model_field_in_error_body(body, "model-1", "default/model-1") == body
 
 
-def test_rewrite_error_body_json_scalar_falls_back_to_substring():
-    """A JSON scalar/array (no dict to target) falls back to substring replace."""
-    body = json.dumps("served-name is unavailable")
-    out = _rewrite_model_field_in_error_body(body, "served-name", "ws/entity")
-    assert "served-name" not in out
-    assert "ws/entity" in out
+def test_rewrite_error_body_skips_when_name_has_json_unsafe_char():
+    """If a model name isn't a plain entity-ref/model id (e.g. it carries a quote or
+    brace), the blind substring swap could corrupt a JSON body — so the scrub is
+    skipped entirely and the body (served name included) is returned untouched.
+    """
+    body = json.dumps({"model": 'weird"name', "error": {"message": 'weird"name failed'}})
+    # served name contains a double-quote -> outside ENTITY_REF_PATTERN -> skip
+    assert _rewrite_model_field_in_error_body(body, 'weird"name', "default/model-1") == body
+    # restored id malformed (contains a brace) -> also skip
+    body2 = json.dumps({"model": "model-1"})
+    assert _rewrite_model_field_in_error_body(body2, "model-1", "default/{model-1}") == body2
+
+
+def test_rewrite_error_body_scalar_json_string_is_scrubbed():
+    """A JSON scalar (a bare quoted string body) is still scrubbed by the single pass."""
+    body = json.dumps("model-1 is unavailable")
+    out = _rewrite_model_field_in_error_body(body, "model-1", "default/model-1")
+    assert out == json.dumps("default/model-1 is unavailable")
 
 
 def _error_response(status: int, body: bytes, *, content_type: str = "application/json") -> Mock:


### PR DESCRIPTION
## Summary

IGW's response model-rewrite (`_rewrite_model_field`) only ran on the happy path. When an upstream returned 4xx/5xx, `fetch_proxy_response` raised `HTTPException` with the raw upstream error body and the rewrite never ran, so the upstream `served_model_name` leaked in error cases (rate-limit messages, content-policy blocks, "model not found", etc.). This change scrubs the served name out of error bodies too, so callers see the model entity reference in errors exactly as they do on success.

## Changes

- Add `_rewrite_model_field_in_error_body(error_body, served_model_name, restored_model_id)`: parses JSON-object bodies through the existing `_rewrite_model_field` (plus a substring pass so a served name embedded in a free-form error *message* string is caught, not just a structured `model` field), and falls back to a plain substring replace for plain-text / non-object / unparseable bodies. Empty or non-matching bodies are returned unchanged.
- Thread optional `served_model_name` / `restored_model_id` into `fetch_proxy_response`; its `response.status >= 400` branch runs the rewrite before raising. Because that status check precedes the SSE branch, a non-2xx returned mid-stream is scrubbed the same way. The 401/403/404→502 wrap path is covered too.
- Wire the two names in at the `virtual_model_proxy` call site (reusing the same entity ref the happy path restores).
- Tests: helper unit tests (structured JSON, message-string JSON, plain text, empty/no-match, JSON-scalar fallback) and `fetch_proxy_response` error cases (OpenAI 400 model-not-found, Anthropic 400, 429 rate-limit, plain-text 5xx, 401→502 wrap, no-op without names), plus an end-to-end `virtual_model_proxy` error-path test.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: internal error-handling fix; no user-facing docs describe the leaked field.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run ruff check <proxy.py> <test_proxy.py>` → All checks passed
- `uv run ruff format --check ...` → 2 files already formatted
- `uv run --frozen ty check tests/unit/test_proxy.py` → only pre-existing SDK-typing diagnostics (the `created_at`/`updated_at` `datetime` vs ISO-string convention every existing `virtual_model_proxy` test in this file already shares); no new real diagnostics.
- `uv run --frozen pytest services/core/inference-gateway/tests/unit` → 478 passed, 5 skipped.
- Note: the ticket named `make test-unit-core-inference-gateway`, which does not exist as a Make target; ran the service's unit tests directly instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proxy error responses by replacing eligible internal model identifiers with the served model name.
  - Updated rewriting across structured JSON, plain-text messages, scalar responses, and array-based error bodies.
  - Applied consistent handling to common authorization, rate-limit, client, server, and provider-specific errors.
  - Streaming requests now receive clearer model references in applicable error responses.
  - Added safeguards to avoid rewriting invalid or missing model identifiers, improving error-response reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->