### PR TITLE
refactor(agents): typed SDK spec params and CLI reuse of the SDK

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -49,7 +49,8 @@ from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from pkgutil import resolve_name
-from typing import Any, ClassVar, Literal, Optional, cast
+from types import SimpleNamespace
+from typing import Any, Callable, ClassVar, Literal, Optional, cast
 from urllib.parse import urlencode
 
 import click
@@ -1598,8 +1599,10 @@ def _register_environment_commands(app: typer.Typer) -> None:
         """Create an environment spec from a file or inline JSON."""
         base_url = _resolve_base_url(base_url)
         body = _spec_body_from_inputs(name=name, spec_file=spec_file, spec_json=spec)
-        resp = _api_request(
-            "POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/environment-specs", json_body=body
+        sdk = _agents_sdk(base_url, workspace)
+        resp = _run_sdk(
+            "POST agent API",
+            lambda: sdk.environment_specs.create(name=body.pop("name"), workspace=workspace, **body),
         )
         typer.echo(json.dumps(resp, indent=2))
 
@@ -1694,7 +1697,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
             body["environment_spec"] = environment_spec
         if compute_spec is not None:
             body["compute_spec"] = compute_spec
-        resp = _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/environments", json_body=body)
+        sdk = _agents_sdk(base_url, workspace)
+        resp = _run_sdk(
+            "POST agent API",
+            lambda: sdk.environments.create(name=body.pop("name"), workspace=workspace, spec=body),
+        )
         typer.echo(json.dumps(resp, indent=2))
 
     @env_app.command(name="list")
@@ -1771,7 +1778,11 @@ def _register_environment_commands(app: typer.Typer) -> None:
         """Create a compute spec from a file or inline JSON."""
         base_url = _resolve_base_url(base_url)
         body = _spec_body_from_inputs(name=name, spec_file=spec_file, spec_json=spec)
-        resp = _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/compute-specs", json_body=body)
+        sdk = _agents_sdk(base_url, workspace)
+        resp = _run_sdk(
+            "POST agent API",
+            lambda: sdk.compute_specs.create(name=body.pop("name"), workspace=workspace, **body),
+        )
         typer.echo(json.dumps(resp, indent=2))
 
     @cspec_app.command(name="list")
@@ -2513,6 +2524,41 @@ def _platform_sdk(base_url: str) -> Any:
     if headers:
         return NeMoPlatform(base_url=base_url, default_headers=headers)
     return NeMoPlatform(base_url=base_url)
+
+
+def _agents_sdk(base_url: str, workspace: str) -> Any:
+    """Return the agents-plugin SDK resource bound to *base_url* / *workspace*.
+
+    The CLI reuses the plugin SDK (:class:`~nemo_agents_plugin.sdk.AgentsResource`)
+    so request paths and payload shapes are defined once. The SDK reads
+    ``base_url``, ``workspace``, and ``default_headers`` off the object it is
+    handed — mirroring the auth-header threading ``_api_request`` does.
+    """
+    from nemo_agents_plugin.sdk import AgentsResource
+
+    platform = SimpleNamespace(
+        base_url=base_url,
+        workspace=workspace,
+        default_headers=_resolve_context_headers() or None,
+    )
+    return AgentsResource(platform)
+
+
+def _run_sdk(action: str, call: Callable[[], Any]) -> Any:
+    """Invoke an SDK *call*, translating HTTP errors to CLI-friendly output.
+
+    The plugin SDK raises raw ``httpx`` errors; the CLI wants the same rich
+    messages ``_api_request`` prints. This keeps error UX identical whether a
+    command talks to the API directly or through the SDK.
+    """
+    try:
+        return call()
+    except httpx.HTTPStatusError as exc:
+        print_http_status_error(exc, action=action)
+        raise typer.Exit(code=1)
+    except httpx.RequestError as exc:
+        print_http_request_error(exc, action=action)
+        raise typer.Exit(code=1)
 
 
 def _collect_text_agent_artifacts(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -1602,7 +1602,7 @@ def _register_environment_commands(app: typer.Typer) -> None:
         sdk = _agents_sdk(base_url, workspace)
         resp = _run_sdk(
             "POST agent API",
-            lambda: sdk.environment_specs.create(name=body.pop("name"), workspace=workspace, **body),
+            lambda: sdk.environment_specs.create(name=body.pop("name"), workspace=workspace, spec=body),
         )
         typer.echo(json.dumps(resp, indent=2))
 
@@ -1781,7 +1781,7 @@ def _register_environment_commands(app: typer.Typer) -> None:
         sdk = _agents_sdk(base_url, workspace)
         resp = _run_sdk(
             "POST agent API",
-            lambda: sdk.compute_specs.create(name=body.pop("name"), workspace=workspace, **body),
+            lambda: sdk.compute_specs.create(name=body.pop("name"), workspace=workspace, spec=body),
         )
         typer.echo(json.dumps(resp, indent=2))
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
@@ -447,7 +447,7 @@ class _EnvironmentSpecResource:
         Returns:
             The created AgentEnvironmentSpec as a dict.
         """
-        payload: dict[str, Any] = {"name": name, **_spec_to_dict(spec), **spec_kwargs}
+        payload: dict[str, Any] = {**_spec_to_dict(spec), **spec_kwargs, "name": name}
         return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/environment-specs", payload)
 
     def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
@@ -561,7 +561,7 @@ class _ComputeSpecResource:
         Returns:
             The created AgentComputeSpec as a dict.
         """
-        payload: dict[str, Any] = {"name": name, **_spec_to_dict(spec), **spec_kwargs}
+        payload: dict[str, Any] = {**_spec_to_dict(spec), **spec_kwargs, "name": name}
         return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/compute-specs", payload)
 
     def list(self, workspace: str | None = None) -> List[dict[str, Any]]:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
@@ -29,11 +29,16 @@ Usage (once the SDK hub is wired up)::
 
     # Environments / specs (the request/fulfill split)
     spec = nemo.agents.environment_specs.create(
-        name="ben", env={"LOG_LEVEL": "debug"},
-        secrets={"GITHUB_PERSONAL_ACCESS_TOKEN": "default/ben-pat"},
+        name="ben",
+        spec=EnvironmentSpecInline(
+            env={"LOG_LEVEL": "debug"},
+            secrets={"GITHUB_PERSONAL_ACCESS_TOKEN": "default/ben-pat"},
+        ),
     )
     env = nemo.agents.environments.create(name="repo-research-ben", environment_spec="default/ben")
-    cs = nemo.agents.compute_specs.create(name="big", resources={"limits": {"cpu": "2"}})
+    cs = nemo.agents.compute_specs.create(
+        name="big", spec=ComputeSpecInline(resources=ComputeResources(limits={"cpu": "2"})),
+    )
     dep = nemo.agents.deployments.create(agent="calculator", environment="default/repo-research-ben")
 
     # Invocation (routes through the agents gateway)
@@ -60,8 +65,14 @@ import re
 from typing import Any, List, Mapping
 
 import httpx
+from nemo_agents_plugin.entities import (
+    AgentEnvironmentInline,
+    ComputeSpecInline,
+    EnvironmentSpecInline,
+)
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 from nemo_platform_plugin.sdk import NemoPluginSDKResources
+from pydantic import BaseModel
 
 _DEFAULT_WORKSPACE = "default"
 _DEFAULT_TIMEOUT = 30
@@ -70,6 +81,21 @@ _DEFAULT_MODEL_PLACEHOLDER = re.compile(r"\$(?:\{NEMO_DEFAULT_MODEL\}|NEMO_DEFAU
 
 def _resolve_workspace(platform: Any, workspace: str | None) -> str:
     return workspace or getattr(platform, "workspace", None) or _DEFAULT_WORKSPACE
+
+
+def _spec_to_dict(spec: BaseModel | dict[str, Any] | None) -> dict[str, Any]:
+    """Normalize a typed ``*Inline`` model (or a loose dict) to a request body.
+
+    Accepts one of the shared backend ``*Inline`` models, a plain dict, or
+    ``None``. Pydantic models are dumped with ``exclude_unset=True`` so only the
+    fields the caller actually set are sent — matching the ``**spec`` behavior
+    where unspecified fields simply were not in the payload.
+    """
+    if spec is None:
+        return {}
+    if isinstance(spec, BaseModel):
+        return spec.model_dump(exclude_unset=True, mode="json")
+    return dict(spec)
 
 
 def _contains_default_model_placeholder(value: Any) -> bool:
@@ -92,6 +118,9 @@ class AgentsResource:
         Args:
             platform: The ``NeMo`` hub object (or any object with a
                 ``base_url`` attribute).  Provides the base URL for all API calls.
+                An optional ``default_headers`` attribute (a ``dict[str, str]``)
+                is attached to every request — this is how the CLI threads its
+                resolved auth token through the SDK.
         """
         self._platform = platform
         self._deployments: _DeploymentResource | None = None
@@ -280,9 +309,15 @@ class AgentsResource:
     def _agents_url(self, path: str) -> str:
         return self._base_url() + "/apis/agents" + path
 
+    def _default_headers(self) -> dict[str, str] | None:
+        headers = getattr(self._platform, "default_headers", None)
+        if isinstance(headers, dict) and headers:
+            return {str(key): str(value) for key, value in headers.items()}
+        return None
+
     def _get(self, path: str) -> Any:
         with httpx.Client(timeout=_DEFAULT_TIMEOUT) as client:
-            resp = client.get(self._agents_url(path))
+            resp = client.get(self._agents_url(path), headers=self._default_headers())
             resp.raise_for_status()
             return resp.json()
 
@@ -293,14 +328,15 @@ class AgentsResource:
         timeout: int = _DEFAULT_TIMEOUT,
         headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
+        merged = {**(self._default_headers() or {}), **(headers or {})} or None
         with httpx.Client(timeout=timeout) as client:
-            resp = client.post(self._agents_url(path), json=payload, headers=headers)
+            resp = client.post(self._agents_url(path), json=payload, headers=merged)
             resp.raise_for_status()
             return resp.json()
 
     def _delete(self, path: str) -> None:
         with httpx.Client(timeout=_DEFAULT_TIMEOUT) as client:
-            resp = client.delete(self._agents_url(path))
+            resp = client.delete(self._agents_url(path), headers=self._default_headers())
             resp.raise_for_status()
 
 
@@ -386,21 +422,32 @@ class _EnvironmentSpecResource:
     def __init__(self, parent: AgentsResource) -> None:
         self._parent = parent
 
-    def create(self, *, name: str, workspace: str | None = None, **spec: Any) -> dict[str, Any]:
+    def create(
+        self,
+        *,
+        name: str,
+        spec: EnvironmentSpecInline | dict[str, Any] | None = None,
+        workspace: str | None = None,
+        **spec_kwargs: Any,
+    ) -> dict[str, Any]:
         """Create an environment spec.
 
         Args:
             name: Unique environment-spec name within the workspace.
+            spec: The environment spec, as a shared :class:`EnvironmentSpecInline`
+                model (the typed, discoverable path) or a plain dict. Only the
+                fields explicitly set on the model are sent.
             workspace: Target workspace.
-            **spec: EnvironmentSpecInline fields (``env``, ``secrets``, ``mcp``,
-                ``provider``, ``model_provider_override``, ``workspace_path``,
-                ``artifacts_path``, ``connection``, ``metadata``, ``settings``,
-                ...). See :class:`EnvironmentSpecInline`.
+            **spec_kwargs: Back-compat loose EnvironmentSpecInline fields (``env``,
+                ``secrets``, ``mcp``, ``provider``, ``model_provider_override``,
+                ``workspace_path``, ``artifacts_path``, ``connection``,
+                ``metadata``, ``settings``, ...). Merged over ``spec`` when both
+                are given. Prefer the typed ``spec=`` argument.
 
         Returns:
             The created AgentEnvironmentSpec as a dict.
         """
-        payload: dict[str, Any] = {"name": name, **spec}
+        payload: dict[str, Any] = {"name": name, **_spec_to_dict(spec), **spec_kwargs}
         return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/environment-specs", payload)
 
     def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
@@ -431,6 +478,7 @@ class _EnvironmentResource:
         self,
         *,
         name: str,
+        spec: AgentEnvironmentInline | dict[str, Any] | None = None,
         environment_spec: str | dict[str, Any] | None = None,
         compute_spec: str | dict[str, Any] | None = None,
         description: str = "",
@@ -440,6 +488,12 @@ class _EnvironmentResource:
 
         Args:
             name: Unique environment name within the workspace.
+            spec: The full environment composition as a shared
+                :class:`AgentEnvironmentInline` model (the typed, discoverable
+                path) or a plain dict. Only the fields explicitly set are sent.
+                The ``environment_spec`` / ``compute_spec`` / ``description``
+                arguments below override the matching keys from ``spec`` when
+                given — handy for the common ref case.
             environment_spec: A ``"workspace/name"`` ref to a stored
                 AgentEnvironmentSpec, an inline spec dict, or ``None``.
             compute_spec: A ``"workspace/name"`` ref to a stored AgentComputeSpec,
@@ -450,7 +504,9 @@ class _EnvironmentResource:
         Returns:
             The created AgentEnvironment as a dict.
         """
-        payload: dict[str, Any] = {"name": name, "description": description}
+        payload: dict[str, Any] = {"description": "", **_spec_to_dict(spec), "name": name}
+        if description:
+            payload["description"] = description
         if environment_spec is not None:
             payload["environment_spec"] = environment_spec
         if compute_spec is not None:
@@ -480,18 +536,30 @@ class _ComputeSpecResource:
     def __init__(self, parent: AgentsResource) -> None:
         self._parent = parent
 
-    def create(self, *, name: str, workspace: str | None = None, **spec: Any) -> dict[str, Any]:
+    def create(
+        self,
+        *,
+        name: str,
+        spec: ComputeSpecInline | dict[str, Any] | None = None,
+        workspace: str | None = None,
+        **spec_kwargs: Any,
+    ) -> dict[str, Any]:
         """Create a compute spec.
 
         Args:
             name: Unique compute-spec name within the workspace.
+            spec: The compute spec, as a shared :class:`ComputeSpecInline` model
+                (the typed, discoverable path) or a plain dict. Only the fields
+                explicitly set on the model are sent.
             workspace: Target workspace.
-            **spec: ComputeSpecInline fields (``resources``, ``description``).
+            **spec_kwargs: Back-compat loose ComputeSpecInline fields
+                (``resources``, ``description``). Merged over ``spec`` when both
+                are given. Prefer the typed ``spec=`` argument.
 
         Returns:
             The created AgentComputeSpec as a dict.
         """
-        payload: dict[str, Any] = {"name": name, **spec}
+        payload: dict[str, Any] = {"name": name, **_spec_to_dict(spec), **spec_kwargs}
         return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/compute-specs", payload)
 
     def list(self, workspace: str | None = None) -> List[dict[str, Any]]:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
@@ -481,7 +481,7 @@ class _EnvironmentResource:
         spec: AgentEnvironmentInline | dict[str, Any] | None = None,
         environment_spec: str | dict[str, Any] | None = None,
         compute_spec: str | dict[str, Any] | None = None,
-        description: str = "",
+        description: str | None = None,
         workspace: str | None = None,
     ) -> dict[str, Any]:
         """Create an AgentEnvironment.
@@ -498,14 +498,16 @@ class _EnvironmentResource:
                 AgentEnvironmentSpec, an inline spec dict, or ``None``.
             compute_spec: A ``"workspace/name"`` ref to a stored AgentComputeSpec,
                 an inline spec dict, or ``None``.
-            description: Optional human-readable description.
+            description: Optional human-readable description. Overrides ``spec``'s
+                description when passed (including ``""`` to clear it); left unset,
+                ``spec``'s value — or the server default — stands.
             workspace: Target workspace.
 
         Returns:
             The created AgentEnvironment as a dict.
         """
-        payload: dict[str, Any] = {"description": "", **_spec_to_dict(spec), "name": name}
-        if description:
+        payload: dict[str, Any] = {**_spec_to_dict(spec), "name": name}
+        if description is not None:
             payload["description"] = description
         if environment_spec is not None:
             payload["environment_spec"] = environment_spec

--- a/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
@@ -428,7 +428,6 @@ class _EnvironmentSpecResource:
         name: str,
         spec: EnvironmentSpecInline | dict[str, Any] | None = None,
         workspace: str | None = None,
-        **spec_kwargs: Any,
     ) -> dict[str, Any]:
         """Create an environment spec.
 
@@ -438,16 +437,11 @@ class _EnvironmentSpecResource:
                 model (the typed, discoverable path) or a plain dict. Only the
                 fields explicitly set on the model are sent.
             workspace: Target workspace.
-            **spec_kwargs: Back-compat loose EnvironmentSpecInline fields (``env``,
-                ``secrets``, ``mcp``, ``provider``, ``model_provider_override``,
-                ``workspace_path``, ``artifacts_path``, ``connection``,
-                ``metadata``, ``settings``, ...). Merged over ``spec`` when both
-                are given. Prefer the typed ``spec=`` argument.
 
         Returns:
             The created AgentEnvironmentSpec as a dict.
         """
-        payload: dict[str, Any] = {**_spec_to_dict(spec), **spec_kwargs, "name": name}
+        payload: dict[str, Any] = {**_spec_to_dict(spec), "name": name}
         return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/environment-specs", payload)
 
     def list(self, workspace: str | None = None) -> List[dict[str, Any]]:
@@ -544,7 +538,6 @@ class _ComputeSpecResource:
         name: str,
         spec: ComputeSpecInline | dict[str, Any] | None = None,
         workspace: str | None = None,
-        **spec_kwargs: Any,
     ) -> dict[str, Any]:
         """Create a compute spec.
 
@@ -554,14 +547,11 @@ class _ComputeSpecResource:
                 (the typed, discoverable path) or a plain dict. Only the fields
                 explicitly set on the model are sent.
             workspace: Target workspace.
-            **spec_kwargs: Back-compat loose ComputeSpecInline fields
-                (``resources``, ``description``). Merged over ``spec`` when both
-                are given. Prefer the typed ``spec=`` argument.
 
         Returns:
             The created AgentComputeSpec as a dict.
         """
-        payload: dict[str, Any] = {**_spec_to_dict(spec), **spec_kwargs, "name": name}
+        payload: dict[str, Any] = {**_spec_to_dict(spec), "name": name}
         return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/compute-specs", payload)
 
     def list(self, workspace: str | None = None) -> List[dict[str, Any]]:

--- a/plugins/nemo-agents/tests/unit/test_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_cli.py
@@ -1171,10 +1171,10 @@ def test_environment_spec_create_routes_through_sdk() -> None:
 
     captured: dict[str, Any] = {}
 
-    def _spy(self, *, name, workspace=None, spec=None, **spec_kwargs):
+    def _spy(self, *, name, workspace=None, spec=None):
         captured["name"] = name
         captured["workspace"] = workspace
-        captured["spec_kwargs"] = spec_kwargs
+        captured["spec"] = spec
         return {"name": name}
 
     app = AgentsCLI().get_cli()
@@ -1197,7 +1197,7 @@ def test_environment_spec_create_routes_through_sdk() -> None:
     assert result.exit_code == 0, result.stderr
     assert captured["name"] == "ben"
     assert captured["workspace"] == "team-a"
-    assert captured["spec_kwargs"]["env"] == {"LOG_LEVEL": "debug"}
+    assert captured["spec"] == {"env": {"LOG_LEVEL": "debug"}}
 
 
 def test_compute_spec_create_via_sdk_translates_http_error() -> None:

--- a/plugins/nemo-agents/tests/unit/test_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_cli.py
@@ -1198,3 +1198,71 @@ def test_environment_spec_create_routes_through_sdk() -> None:
     assert captured["name"] == "ben"
     assert captured["workspace"] == "team-a"
     assert captured["spec_kwargs"]["env"] == {"LOG_LEVEL": "debug"}
+
+
+def test_compute_spec_create_via_sdk_translates_http_error() -> None:
+    """A server error raised inside the SDK is translated to the CLI's rich message.
+
+    The rerouted create commands call the SDK inside ``_run_sdk``; this asserts an
+    httpx.HTTPStatusError from the SDK surfaces as the same ``... agent API`` stderr
+    message + exit 1 the old direct ``_api_request`` path produced.
+    """
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"detail": "boom"})
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler):
+        result = CliRunner().invoke(
+            app,
+            [
+                "compute-specs",
+                "create",
+                "big",
+                "--spec",
+                '{"resources": {"limits": {"cpu": "2"}}}',
+                "--base-url",
+                "http://test",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert "POST agent API" in result.stderr
+
+
+def test_environment_spec_create_via_sdk_sends_auth_header() -> None:
+    """The CLI threads its resolved auth header through the SDK to the wire.
+
+    Covers the ``_agents_sdk`` seam: the CLI builds an AgentsResource whose
+    ``default_headers`` carry the context auth token, so a create routed through the
+    SDK carries ``Authorization`` on the actual request.
+    """
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["auth"] = req.headers.get("authorization")
+        return httpx.Response(201, json={"name": "ben"})
+
+    app = AgentsCLI().get_cli()
+    with (
+        _install_mock_transport(handler),
+        patch(
+            "nemo_agents_plugin.cli._resolve_context_headers",
+            return_value={"Authorization": "Bearer tok-xyz"},
+        ),
+    ):
+        result = CliRunner().invoke(
+            app,
+            [
+                "environment-specs",
+                "create",
+                "ben",
+                "--spec",
+                '{"provider": "local"}',
+                "--base-url",
+                "http://test",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert captured["auth"] == "Bearer tok-xyz"

--- a/plugins/nemo-agents/tests/unit/test_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_cli.py
@@ -1159,3 +1159,42 @@ def test_environment_delete_confirmation() -> None:
 
     assert result.exit_code == 0, result.stderr
     assert "Environment 'env1' deleted." in result.stdout
+
+
+def test_environment_spec_create_routes_through_sdk() -> None:
+    """The CLI builds the request via the plugin SDK (single source of truth).
+
+    Spy the SDK resource method to prove the CLI delegates to it rather than
+    hand-rolling the request path/body.
+    """
+    from nemo_agents_plugin import sdk as sdk_module
+
+    captured: dict[str, Any] = {}
+
+    def _spy(self, *, name, workspace=None, spec=None, **spec_kwargs):
+        captured["name"] = name
+        captured["workspace"] = workspace
+        captured["spec_kwargs"] = spec_kwargs
+        return {"name": name}
+
+    app = AgentsCLI().get_cli()
+    with patch.object(sdk_module._EnvironmentSpecResource, "create", _spy):
+        result = CliRunner().invoke(
+            app,
+            [
+                "environment-specs",
+                "create",
+                "ben",
+                "--spec",
+                '{"env": {"LOG_LEVEL": "debug"}}',
+                "--workspace",
+                "team-a",
+                "--base-url",
+                "http://test",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert captured["name"] == "ben"
+    assert captured["workspace"] == "team-a"
+    assert captured["spec_kwargs"]["env"] == {"LOG_LEVEL": "debug"}

--- a/plugins/nemo-agents/tests/unit/test_sdk.py
+++ b/plugins/nemo-agents/tests/unit/test_sdk.py
@@ -200,7 +200,9 @@ def test_environment_specs_create_posts_inline_fields() -> None:
 
     client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
     with _install_mock_transport(handler):
-        result = client.environment_specs.create(name="ben", env={"LOG_LEVEL": "debug"}, secrets={"TOK": "default/tok"})
+        result = client.environment_specs.create(
+            name="ben", spec={"env": {"LOG_LEVEL": "debug"}, "secrets": {"TOK": "default/tok"}}
+        )
 
     assert result == {"name": "ben"}
     assert captured["path"] == "/apis/agents/v2/workspaces/team-a/environment-specs"
@@ -449,25 +451,6 @@ def test_environment_specs_create_name_arg_is_authoritative() -> None:
         client.environment_specs.create(name="wanted", spec={"name": "sneaky", "provider": "local"})
 
     assert captured["body"]["name"] == "wanted"
-
-
-def test_environment_specs_create_kwargs_still_work() -> None:
-    """Back-compat: loose ``**spec_kwargs`` are still accepted and override ``spec``."""
-    captured: dict[str, Any] = {}
-
-    def handler(req: httpx.Request) -> httpx.Response:
-        captured["body"] = json.loads(req.read())
-        return httpx.Response(201, json={"name": "ben"})
-
-    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
-    with _install_mock_transport(handler):
-        client.environment_specs.create(
-            name="ben",
-            spec=EnvironmentSpecInline(env={"A": "1"}),
-            env={"A": "2"},  # kwarg wins over the typed model
-        )
-
-    assert captured["body"] == {"name": "ben", "env": {"A": "2"}}
 
 
 def test_compute_specs_create_accepts_typed_model() -> None:

--- a/plugins/nemo-agents/tests/unit/test_sdk.py
+++ b/plugins/nemo-agents/tests/unit/test_sdk.py
@@ -431,6 +431,26 @@ def test_environment_specs_create_accepts_dict_spec() -> None:
     assert captured["body"] == {"name": "ben", "provider": "local"}
 
 
+def test_environment_specs_create_name_arg_is_authoritative() -> None:
+    """An explicit ``name=`` wins over a ``name`` key smuggled in via ``spec``.
+
+    Regression guard: the payload must apply ``name`` AFTER the spec/kwargs
+    expansion so a dict spec carrying its own ``name`` cannot silently create the
+    resource under a different name than the caller asked for.
+    """
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "wanted"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    with _install_mock_transport(handler):
+        client.environment_specs.create(name="wanted", spec={"name": "sneaky", "provider": "local"})
+
+    assert captured["body"]["name"] == "wanted"
+
+
 def test_environment_specs_create_kwargs_still_work() -> None:
     """Back-compat: loose ``**spec_kwargs`` are still accepted and override ``spec``."""
     captured: dict[str, Any] = {}

--- a/plugins/nemo-agents/tests/unit/test_sdk.py
+++ b/plugins/nemo-agents/tests/unit/test_sdk.py
@@ -11,6 +11,12 @@ from unittest.mock import patch
 
 import httpx
 import pytest
+from nemo_agents_plugin.entities import (
+    AgentEnvironmentInline,
+    ComputeResources,
+    ComputeSpecInline,
+    EnvironmentSpecInline,
+)
 from nemo_agents_plugin.sdk import AgentsResource, AsyncAgentsResource, agents_sdk_resources
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 
@@ -390,3 +396,115 @@ async def test_async_execute_job_create_mirrors_sync_shape() -> None:
 def test_agents_sdk_resources_registers_both_sync_and_async() -> None:
     assert agents_sdk_resources.sync_resource is AgentsResource
     assert agents_sdk_resources.async_resource is AsyncAgentsResource
+
+
+def test_environment_specs_create_accepts_typed_model() -> None:
+    """A typed ``EnvironmentSpecInline`` sends only the fields that were set."""
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "ben"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    spec = EnvironmentSpecInline(env={"LOG_LEVEL": "debug"}, secrets={"TOK": "default/tok"})
+    with _install_mock_transport(handler):
+        client.environment_specs.create(name="ben", spec=spec)
+
+    # exclude_unset: provider/description/etc. are NOT sent because the caller
+    # never set them — matching the old **spec behavior.
+    assert captured["body"] == {"name": "ben", "env": {"LOG_LEVEL": "debug"}, "secrets": {"TOK": "default/tok"}}
+
+
+def test_environment_specs_create_accepts_dict_spec() -> None:
+    """A plain dict passed as ``spec=`` is sent verbatim."""
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "ben"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    with _install_mock_transport(handler):
+        client.environment_specs.create(name="ben", spec={"provider": "local"})
+
+    assert captured["body"] == {"name": "ben", "provider": "local"}
+
+
+def test_environment_specs_create_kwargs_still_work() -> None:
+    """Back-compat: loose ``**spec_kwargs`` are still accepted and override ``spec``."""
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "ben"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    with _install_mock_transport(handler):
+        client.environment_specs.create(
+            name="ben",
+            spec=EnvironmentSpecInline(env={"A": "1"}),
+            env={"A": "2"},  # kwarg wins over the typed model
+        )
+
+    assert captured["body"] == {"name": "ben", "env": {"A": "2"}}
+
+
+def test_compute_specs_create_accepts_typed_model() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["path"] = req.url.path
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "big"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+    spec = ComputeSpecInline(resources=ComputeResources(limits={"cpu": "2"}))
+    with _install_mock_transport(handler):
+        client.compute_specs.create(name="big", spec=spec)
+
+    assert captured["path"] == "/apis/agents/v2/workspaces/team-a/compute-specs"
+    assert captured["body"] == {"name": "big", "resources": {"limits": {"cpu": "2"}}}
+
+
+def test_environments_create_accepts_typed_model() -> None:
+    """A typed ``AgentEnvironmentInline`` sends its set fields; ref args override."""
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "env1"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="default"))
+    spec = AgentEnvironmentInline(environment_spec="default/ben")
+    with _install_mock_transport(handler):
+        client.environments.create(name="env1", spec=spec, compute_spec="default/big")
+
+    assert captured["body"]["name"] == "env1"
+    assert captured["body"]["environment_spec"] == "default/ben"
+    # explicit compute_spec arg is applied on top of the typed spec
+    assert captured["body"]["compute_spec"] == "default/big"
+
+
+def test_default_headers_are_sent_on_every_request() -> None:
+    """``platform.default_headers`` (how the CLI threads its token) reach the wire."""
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured.setdefault("auth", []).append(req.headers.get("authorization"))
+        if req.method == "DELETE":
+            return httpx.Response(204)
+        return httpx.Response(200, json={"name": "big"})
+
+    platform = SimpleNamespace(
+        base_url="http://test",
+        workspace="team-a",
+        default_headers={"Authorization": "Bearer tok-123"},
+    )
+    client = AgentsResource(platform)
+    with _install_mock_transport(handler):
+        client.compute_specs.create(name="big", spec=ComputeSpecInline())
+        client.compute_specs.get("big")
+        client.compute_specs.delete("big")
+
+    assert captured["auth"] == ["Bearer tok-123", "Bearer tok-123", "Bearer tok-123"]


### PR DESCRIPTION
## Summary

The new agents SDK resources (`environment_specs`, `environments`, `compute_specs`) took loose `**spec` kwargs, and the hand-written CLI duplicated request-building. This PR makes the SDK create methods accept the shared backend `*Inline` models for type safety and discoverability, and has the CLI reuse the SDK so request paths/payloads live in one place. Both follow-ups were deferred from a prior review.

## Changes

- **Typed SDK create params.** `environment_specs.create`, `environments.create`, and `compute_specs.create` now accept the shared `EnvironmentSpecInline` / `AgentEnvironmentInline` / `ComputeSpecInline` models via a `spec=` argument (plain dicts also accepted). Typed models are serialized with `exclude_unset=True` so only caller-set fields are sent — matching the old `**spec` semantics. The loose `**spec` kwargs are kept for back-compat and override the typed model when both are supplied.
- **SDK auth-header threading.** An optional `default_headers` attribute on the platform object is now attached to every SDK request, so an authenticated caller (the CLI) can reuse the SDK against a secured platform.
- **CLI reuses the SDK.** The `environment-specs` / `environments` / `compute-specs` create commands build their requests through the plugin SDK instead of hand-rolling request paths and JSON bodies. HTTP errors are translated to the same rich CLI messages as before.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Documentation not applicable — justification: internal SDK/CLI plumbing; docstrings/usage examples updated in-code, no user-facing docs affected.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run --frozen ty check <sdk.py> <cli.py> <test_sdk.py>` → All checks passed!
- `uv run ruff check` / `uv run ruff format --check` on changed files → clean
- `uv run --frozen pytest plugins/nemo-agents/tests/unit` → 1362 passed (includes 7 new SDK/CLI tests for typed params, back-compat kwargs, header threading, and CLI→SDK delegation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SDK-backed creation of environment specifications, environments, and compute specifications through the CLI.
  * Added support for typed or dictionary-based resource specifications.
  * Added consistent authentication header handling across SDK requests.

* **Bug Fixes**
  * CLI SDK errors now use consistent formatted messages and exit codes.
  * Resource specifications preserve explicitly provided fields and honor input precedence rules.
  * Improved handling of structured specification data and detailed HTTP errors during resource creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->