### PR TITLE
fix(agents): preserve custom image entrypoints

### DIFF
--- a/docs/agents/deploy-agents.mdx
+++ b/docs/agents/deploy-agents.mdx
@@ -177,10 +177,7 @@ secrets. Pass the image with `--image`, or set
 
 For hand-built images that already contain an agent server, pass
 `--use-image-entrypoint` so the deployment preserves the image ENTRYPOINT/CMD
-instead of injecting the platform-packaged agent server command. The platform
-still mounts the agent config and sets `PORT`, the runtime `NMP_*` environment
-variables, and the matching config path variable (`AGENT_CONFIG_PATH` for
-`nemo-agents-spec-v1`, `NAT_CONFIG_PATH` for NAT workflow configs).
+instead of injecting the platform-packaged agent server command.
 
 </Note>
 

--- a/docs/agents/deploy-agents.mdx
+++ b/docs/agents/deploy-agents.mdx
@@ -178,6 +178,8 @@ secrets. Pass the image with `--image`, or set
 For hand-built images that already contain an agent server, pass
 `--use-image-entrypoint` so the deployment preserves the image ENTRYPOINT/CMD
 instead of injecting the platform-packaged agent server command.
+The image must bind `0.0.0.0:$PORT`, serve `/health`, and read config from
+`AGENT_CONFIG_PATH` for Fabric or `NAT_CONFIG_PATH` for NAT.
 
 </Note>
 

--- a/docs/agents/deploy-agents.mdx
+++ b/docs/agents/deploy-agents.mdx
@@ -175,6 +175,13 @@ image pre-loaded onto the nodes) — the k8s backend does not use image pull
 secrets. Pass the image with `--image`, or set
 `agents.deployments.default_image` in the platform configuration.
 
+For hand-built images that already contain an agent server, pass
+`--use-image-entrypoint` so the deployment preserves the image ENTRYPOINT/CMD
+instead of injecting the platform-packaged agent server command. The platform
+still mounts the agent config and sets `PORT`, the runtime `NMP_*` environment
+variables, and the matching config path variable (`AGENT_CONFIG_PATH` for
+`nemo-agents-spec-v1`, `NAT_CONFIG_PATH` for NAT workflow configs).
+
 </Note>
 
 **2. A configured deployments executor.** The platform operator defines named

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -3888,6 +3888,12 @@ components:
           description: Container image for docker/k8s modes. Empty for subprocess;
             falls back to AgentsConfig.deployments.default_image.
           default: ''
+        use_image_entrypoint:
+          type: boolean
+          title: Use Image Entrypoint
+          description: 'Container modes only: preserve the image ENTRYPOINT/CMD instead
+            of injecting the platform-owned NAT/Fabric server command.'
+          default: false
         plugin_deployment:
           type: string
           title: Plugin Deployment
@@ -4640,6 +4646,12 @@ components:
           title: Image
           description: Container image for docker/k8s modes. Ignored for subprocess.
           default: ''
+        use_image_entrypoint:
+          type: boolean
+          title: Use Image Entrypoint
+          description: For docker/k8s modes, leave the container command and args
+            empty so the image's ENTRYPOINT/CMD starts the agent server.
+          default: false
         environment:
           anyOf:
           - type: string

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
@@ -88,6 +88,12 @@ async def create_deployment(
     # 2. Build deployment name (auto-generate if not provided)
     deployment_name = body.name or f"{body.agent}-{secrets.token_hex(4)}"
 
+    if body.use_image_entrypoint and not is_container_deployment_mode(body.deployment_mode):
+        raise HTTPException(
+            status_code=400,
+            detail="use_image_entrypoint requires deployment_mode 'docker' or 'k8s'.",
+        )
+
     # 3. Resolve deployment-time config. NAT workflows need legacy injection;
     # Platform-owned agent configs stay strict and are translated by the runner.
     resolved_config = _resolve_deployment_config(agent, workspace=workspace)
@@ -114,6 +120,7 @@ async def create_deployment(
         status="pending",
         deployment_mode=body.deployment_mode,
         image=body.image,
+        use_image_entrypoint=body.use_image_entrypoint,
         plugin_deployment=deployment_name if is_container_deployment_mode(body.deployment_mode) else "",
     )
     try:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -944,6 +944,14 @@ def _register_platform_commands(app: typer.Typer) -> None:
             "-i",
             help="Container image for docker/k8s modes (falls back to deployments.default_image).",
         ),
+        use_image_entrypoint: bool = typer.Option(
+            False,
+            "--use-image-entrypoint",
+            help=(
+                "For docker/k8s modes, preserve the image ENTRYPOINT/CMD instead of "
+                "injecting the platform-owned agent server command."
+            ),
+        ),
         environment: Optional[str] = typer.Option(
             None,
             "--environment",
@@ -998,6 +1006,9 @@ def _register_platform_commands(app: typer.Typer) -> None:
         if image and mode == "subprocess":
             typer.echo("--image requires --mode docker or k8s.", err=True)
             raise typer.Exit(code=2)
+        if use_image_entrypoint and mode == "subprocess":
+            typer.echo("--use-image-entrypoint requires --mode docker or k8s.", err=True)
+            raise typer.Exit(code=2)
 
         base_url = _resolve_base_url(base_url)
         if environment is not None and not environment.strip():
@@ -1008,6 +1019,8 @@ def _register_platform_commands(app: typer.Typer) -> None:
             payload["name"] = name
         if image:
             payload["image"] = image
+        if use_image_entrypoint:
+            payload["use_image_entrypoint"] = True
         if environment is not None:
             payload["environment"] = environment
         resp = _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/deployments", json_body=payload)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
@@ -430,6 +430,13 @@ class AgentDeployment(NemoEntity, entity_type="agent_deployment"):
         default="",
         description="Container image for docker/k8s modes. Empty for subprocess; falls back to AgentsConfig.deployments.default_image.",
     )
+    use_image_entrypoint: bool = Field(
+        default=False,
+        description=(
+            "Container modes only: preserve the image ENTRYPOINT/CMD instead of injecting "
+            "the platform-owned NAT/Fabric server command."
+        ),
+    )
     plugin_deployment: str = Field(
         default="",
         description=(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/backend.py
@@ -99,6 +99,7 @@ class RunnerBackend(ABC):
         created_by: str | None = None,
         resources: ComputeResources | None = None,
         secrets: dict[str, str] | None = None,
+        use_image_entrypoint: bool = False,
     ) -> DeploymentInfo:
         """Start the agent process; returns status="starting".
 
@@ -117,6 +118,10 @@ class RunnerBackend(ABC):
         resolved environment. Container backends compile these into secret-backed
         container env vars (never plaintext); the deployments-plugin substrate
         materializes/mounts them. Subprocess mode ignores it.
+
+        ``use_image_entrypoint`` is only meaningful for container backends. When
+        true, those backends preserve the image ENTRYPOINT/CMD instead of
+        injecting the platform-owned server command.
         """
         ...
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -192,6 +192,7 @@ class AgentDeploymentController(NemoController):
                 created_by=dep.created_by,
                 resources=dep.compute.resources if dep.compute is not None else None,
                 secrets=dep.secrets or None,
+                use_image_entrypoint=dep.use_image_entrypoint,
             )
         except Exception as exc:
             logger.exception("Failed to start agent for deployment '%s'", dep.name)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py
@@ -90,6 +90,7 @@ _RESERVED_ENV_VAR_NAMES = frozenset(
         _NAT_CONFIG_ENV,
     }
 )
+_IMAGE_ENTRYPOINT_RESERVED_ENV_VAR_NAMES = _RESERVED_ENV_VAR_NAMES | {"PORT"}
 
 
 # On delete, wait up to this long for the deployments controller to tear down the
@@ -273,7 +274,12 @@ class ReservedSecretEnvVarError(ValueError):
     """A secret env var name collides with a platform-generated container env var."""
 
 
-def _secret_env_vars(secrets: dict[str, str] | None, *, workspace: str) -> list[EnvVar]:
+def _secret_env_vars(
+    secrets: dict[str, str] | None,
+    *,
+    workspace: str,
+    reserved_env_var_names: frozenset[str] = _RESERVED_ENV_VAR_NAMES,
+) -> list[EnvVar]:
     """Compile resolved secret references into secret-backed container env vars.
 
     ``secrets`` maps ENV_VAR_NAME -> "workspace/secret-name" (an unqualified
@@ -288,12 +294,12 @@ def _secret_env_vars(secrets: dict[str, str] | None, *, workspace: str) -> list[
     """
     if not secrets:
         return []
-    reserved = sorted(name for name in secrets if name in _RESERVED_ENV_VAR_NAMES)
+    reserved = sorted(name for name in secrets if name in reserved_env_var_names)
     if reserved:
         raise ReservedSecretEnvVarError(
             "Environment secret variable name(s) collide with platform-reserved container env vars: "
             f"{', '.join(reserved)}. Rename the secret env var(s) to avoid "
-            f"{', '.join(sorted(_RESERVED_ENV_VAR_NAMES))}."
+            f"{', '.join(sorted(reserved_env_var_names))}."
         )
     env_vars: list[EnvVar] = []
     for env_name, ref in secrets.items():
@@ -373,6 +379,7 @@ def build_deployment_config(
     config_files: list[ConfigFile] | None = None,
     resources: ComputeResources | None = None,
     secrets: dict[str, str] | None = None,
+    use_image_entrypoint: bool = False,
 ) -> DeploymentConfig:
     """Compile an agent into a long-running ``DeploymentConfig`` (Always).
 
@@ -380,10 +387,12 @@ def build_deployment_config(
     NAT workflow configs start ``nat start fastapi`` with workflow YAML at
     *config_mount_path*. Fabric configs start
     ``python -m nemo_agents_plugin.fabric.server`` with ``agent.yaml`` beside the
-    NAT config directory. Docker mode materializes config from env because the
-    docker backend ignores ``config_files``; k8s mounts ``config_files`` via
-    ConfigMap subPath. The main container binds ``0.0.0.0`` and exposes a
-    readiness probe on ``/health``.
+    NAT config directory. When ``use_image_entrypoint`` is true, the generated
+    DeploymentConfig leaves command/args empty so the image ENTRYPOINT/CMD runs
+    instead. Docker mode materializes config from env because the docker backend
+    ignores ``config_files``; k8s mounts ``config_files`` via ConfigMap subPath.
+    The main container binds ``0.0.0.0`` and exposes a readiness probe on
+    ``/health``.
 
     The caller is responsible for rebasing inference ``base_url`` values in
     *agent_config* to a container-reachable gateway before calling this helper.
@@ -413,7 +422,10 @@ def build_deployment_config(
     # Secret-backed env vars from the resolved environment: emitted as
     # secret_ref (never plaintext). The deployments-plugin substrate resolves
     # them (docker) or mounts a managed Secret via envFrom (k8s).
-    env.extend(_secret_env_vars(secrets, workspace=workspace))
+    reserved_env_var_names = (
+        _IMAGE_ENTRYPOINT_RESERVED_ENV_VAR_NAMES if use_image_entrypoint else _RESERVED_ENV_VAR_NAMES
+    )
+    env.extend(_secret_env_vars(secrets, workspace=workspace, reserved_env_var_names=reserved_env_var_names))
     volume_mounts: list[VolumeMount] = []
     init_containers: list[Container] = []
 
@@ -441,7 +453,11 @@ def build_deployment_config(
         )
         env.append(EnvVar(name="PYTHONPATH", value=_PLUGIN_WHEELS_MOUNT))
 
-    if is_fabric:
+    if use_image_entrypoint:
+        server_command = []
+        server_args = []
+        env.append(EnvVar(name="PORT", value=str(port)))
+    elif is_fabric:
         server_command = ["python"]
         server_args = _fabric_server_cli_args(config_path=config_path, port=port)
     else:
@@ -523,6 +539,7 @@ class DeploymentsRunnerBackend(RunnerBackend):
         created_by: str | None = None,
         resources: ComputeResources | None = None,
         secrets: dict[str, str] | None = None,
+        use_image_entrypoint: bool = False,
     ) -> DeploymentInfo:
         """Create DeploymentConfig + Deployment entities for the agent container."""
         del port  # Host port is allocated by the deployments executor, not agents.
@@ -629,6 +646,7 @@ class DeploymentsRunnerBackend(RunnerBackend):
                 config_files=staged_config_files,
                 resources=resources,
                 secrets=secrets,
+                use_image_entrypoint=use_image_entrypoint,
             )
         except ReservedSecretEnvVarError as exc:
             logger.error("Refusing to deploy agent %r: %s", name, exc)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py
@@ -232,6 +232,7 @@ class InMemoryRunnerBackend(RunnerBackend):
         created_by: str | None = None,
         resources: ComputeResources | None = None,
         secrets: dict[str, str] | None = None,
+        use_image_entrypoint: bool = False,
     ) -> DeploymentInfo:
         """Start a local deployment for NAT workflows or Platform-owned agents."""
         # created_by drives on-behalf-of delegation only for container modes (via
@@ -240,7 +241,7 @@ class InMemoryRunnerBackend(RunnerBackend):
         # resources (compute spec) and secrets (secret-env refs) only apply to
         # container modes; subprocess runs in-process on the platform host with no
         # resource isolation and injects no managed secrets.
-        del image, deployment_mode, created_by, resources, secrets
+        del image, deployment_mode, created_by, resources, secrets, use_image_entrypoint
         if config.get("config_format") == NEMO_AGENTS_SPEC_CONFIG_FORMAT:
             return await self._create_fabric_deployment(workspace, name, config, port, agent=agent)
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/schema.py
@@ -69,6 +69,13 @@ class CreateDeploymentRequest(BaseModel):
         default="",
         description="Container image for docker/k8s modes. Ignored for subprocess.",
     )
+    use_image_entrypoint: bool = Field(
+        default=False,
+        description=(
+            "For docker/k8s modes, leave the container command and args empty so the image's "
+            "ENTRYPOINT/CMD starts the agent server."
+        ),
+    )
     environment: str | AgentEnvironmentInline | None = Field(
         default=None,
         description=(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/sdk.py
@@ -296,6 +296,7 @@ class _DeploymentResource:
         name: str | None = None,
         deployment_mode: str = "subprocess",
         image: str | None = None,
+        use_image_entrypoint: bool = False,
         environment: str | dict[str, Any] | None = None,
         workspace: str | None = None,
     ) -> dict[str, Any]:
@@ -311,6 +312,9 @@ class _DeploymentResource:
             image: Container image for ``docker``/``k8s`` modes. Falls back to
                 ``agents.deployments.default_image`` when omitted. Rejected in
                 ``subprocess`` mode.
+            use_image_entrypoint: For ``docker``/``k8s`` modes, preserve the
+                image ENTRYPOINT/CMD instead of injecting the platform-owned
+                agent server command.
             environment: Optional AgentEnvironment to deploy under — a
                 ``"workspace/name"`` ref to a stored AgentEnvironment, or an
                 inline environment dict. Its EnvironmentSpec is merged into the
@@ -323,11 +327,15 @@ class _DeploymentResource:
         """
         if image and deployment_mode == "subprocess":
             raise ValueError("image requires deployment_mode='docker' or 'k8s'.")
+        if use_image_entrypoint and deployment_mode == "subprocess":
+            raise ValueError("use_image_entrypoint requires deployment_mode='docker' or 'k8s'.")
         payload: dict[str, Any] = {"agent": agent, "deployment_mode": deployment_mode}
         if name:
             payload["name"] = name
         if image:
             payload["image"] = image
+        if use_image_entrypoint:
+            payload["use_image_entrypoint"] = True
         if environment is not None:
             payload["environment"] = environment
         return self._parent._post(f"/v2/workspaces/{self._parent._workspace(workspace)}/deployments", payload)

--- a/plugins/nemo-agents/tests/unit/test_cli.py
+++ b/plugins/nemo-agents/tests/unit/test_cli.py
@@ -937,6 +937,62 @@ def test_deploy_forwards_environment_ref() -> None:
     assert body["environment"] == "default/env1"
 
 
+def test_deploy_forwards_image_entrypoint_mode() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = req.read()
+        return httpx.Response(201, json={"name": "d1", "status": "pending"})
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler):
+        result = CliRunner().invoke(
+            app,
+            [
+                "deploy",
+                "--agent",
+                "a1",
+                "--mode",
+                "docker",
+                "--image",
+                "hand-built-agent:latest",
+                "--use-image-entrypoint",
+                "--no-wait",
+                "--base-url",
+                "http://test",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    import json as _j
+
+    body = _j.loads(captured["body"])
+    assert body["agent"] == "a1"
+    assert body["deployment_mode"] == "docker"
+    assert body["image"] == "hand-built-agent:latest"
+    assert body["use_image_entrypoint"] is True
+
+
+def test_deploy_rejects_image_entrypoint_for_subprocess() -> None:
+    called = False
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(201, json={"name": "d1", "status": "pending"})
+
+    app = AgentsCLI().get_cli()
+    with _install_mock_transport(handler):
+        result = CliRunner().invoke(
+            app,
+            ["deploy", "--agent", "a1", "--use-image-entrypoint", "--no-wait", "--base-url", "http://test"],
+        )
+
+    assert result.exit_code == 2
+    assert "--use-image-entrypoint requires --mode docker or k8s." in result.stderr
+    assert not called
+
+
 def test_deploy_rejects_empty_environment() -> None:
     called = False
 

--- a/plugins/nemo-agents/tests/unit/test_deployments_api.py
+++ b/plugins/nemo-agents/tests/unit/test_deployments_api.py
@@ -116,6 +116,49 @@ class TestCreateDeployment:
         assert "functions" not in created_deployment.config
         assert "workflow" not in created_deployment.config
 
+    def test_create_snapshots_image_entrypoint_mode(self) -> None:
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+
+        async def _save_deployment(deployment: AgentDeployment) -> AgentDeployment:
+            deployment._id = f"deployment-{deployment.name}-id"
+            deployment._created_at = NOW
+            return deployment
+
+        mock_entity_client.create = AsyncMock(side_effect=_save_deployment)
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={
+                "agent": "fabric-agent",
+                "name": "fabric-dep",
+                "deployment_mode": "docker",
+                "image": "hand-built-agent:latest",
+                "use_image_entrypoint": True,
+            },
+        )
+
+        assert resp.status_code == 201
+        created_deployment: AgentDeployment = mock_entity_client.create.call_args[0][0]
+        assert created_deployment.deployment_mode == "docker"
+        assert created_deployment.image == "hand-built-agent:latest"
+        assert created_deployment.use_image_entrypoint is True
+
+    def test_create_rejects_image_entrypoint_for_subprocess(self) -> None:
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={"agent": "fabric-agent", "name": "fabric-dep", "use_image_entrypoint": True},
+        )
+
+        assert resp.status_code == 400
+        assert "use_image_entrypoint requires deployment_mode" in resp.json()["detail"]
+        mock_entity_client.create.assert_not_called()
+
     def test_create_with_environment_ref_snapshots_config_and_compute(self) -> None:
         agent = _make_agent()
         environment = AgentEnvironment(

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -120,6 +120,31 @@ async def test_start_deployment_writes_runtime_fields_to_entity() -> None:
     assert starting_key in ctrl._starting_since
 
 
+@pytest.mark.asyncio
+async def test_start_deployment_forwards_image_entrypoint_mode() -> None:
+    ctrl, backend = _make_controller()
+    backend.allocate_port = MagicMock(return_value=0)
+    backend.create_deployment = AsyncMock(return_value=DeploymentInfo(name="dep-1", status="starting"))
+    dep = AgentDeployment(
+        name="dep-1",
+        workspace="default",
+        agent="calc",
+        status="pending",
+        deployment_mode="docker",
+        image="hand-built-agent:latest",
+        use_image_entrypoint=True,
+    )
+
+    await ctrl._start_deployment(dep)
+
+    kwargs = backend.create_deployment.await_args.kwargs
+    assert kwargs["image"] == "hand-built-agent:latest"
+    assert kwargs["deployment_mode"] == "docker"
+    assert kwargs["use_image_entrypoint"] is True
+    assert dep.endpoint == ""
+    assert dep.plugin_deployment == "dep-1"
+
+
 # ---------------------------------------------------------------------------
 # _check_health: dead process takes precedence over health probe
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-agents/tests/unit/test_runner_deployments.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_deployments.py
@@ -380,6 +380,22 @@ def test_build_deployment_config_rejects_secret_name_colliding_with_reserved(res
         )
 
 
+def test_build_deployment_config_rejects_port_secret_when_using_image_entrypoint() -> None:
+    with pytest.raises(ReservedSecretEnvVarError, match="PORT"):
+        build_deployment_config(
+            name="hello-dep",
+            workspace="default",
+            image="custom-agent:latest",
+            port=8000,
+            agent_config={},
+            platform_base_url="http://nmp-api:8080",
+            config_mount_path="/workspace/config.yaml",
+            mode="docker",
+            secrets={"PORT": "default/some-secret"},
+            use_image_entrypoint=True,
+        )
+
+
 def test_build_deployment_config_k8s_uses_nat_entrypoint() -> None:
     cfg = build_deployment_config(
         name="hello-dep",
@@ -472,6 +488,30 @@ def test_build_deployment_config_fabric_docker_uses_fabric_server() -> None:
         PLATFORM_IGW_API_KEY_PLACEHOLDER
     )
     assert cfg.config_files[0].path == "/tmp/nemo/agent.yaml"
+    assert container.readiness_probe is not None
+    assert container.readiness_probe.http_get is not None
+    assert container.readiness_probe.http_get.path == "/health"
+
+
+def test_build_deployment_config_fabric_can_preserve_image_entrypoint() -> None:
+    cfg = build_deployment_config(
+        name="fabric-dep",
+        workspace="default",
+        image="custom-fabric-runtime:latest",
+        port=8000,
+        agent_config=_FABRIC_AGENT_CONFIG,
+        platform_base_url="http://host.docker.internal:8080",
+        config_mount_path="/tmp/nemo/config.yaml",
+        mode="docker",
+        use_image_entrypoint=True,
+    )
+    container = cfg.containers[0]
+    assert container.command == []
+    assert container.args == []
+    assert any(e.name == "AGENT_CONFIG_PATH" and e.value == "/tmp/nemo/agent.yaml" for e in container.env)
+    assert any(e.name == "PORT" and e.value == "8000" for e in container.env)
+    assert cfg.config_files[0].path == "/tmp/nemo/agent.yaml"
+    assert "nemo_agents_plugin.fabric.server" not in " ".join(container.command + container.args)
     assert container.readiness_probe is not None
     assert container.readiness_probe.http_get is not None
     assert container.readiness_probe.http_get.path == "/health"
@@ -863,6 +903,45 @@ async def test_create_deployment_fabric_docker_rewrites_model_base_url() -> None
     assert created_config.labels["nemo.agents/runtime"] == "fabric"
     assert created_config.containers[0].command == ["python"]
     assert "nemo_agents_plugin.fabric.server" in created_config.containers[0].args
+
+
+@pytest.mark.asyncio
+async def test_create_deployment_fabric_can_preserve_image_entrypoint() -> None:
+    backend = _backend(default_image="fabric:latest", default_executor="local-docker")
+    entities = AsyncMock()
+    backend._entities = entities
+    config = {
+        "config_format": "nemo-agents-spec-v1",
+        "name": "fabric-agent",
+        "default_harness": "main",
+        "harnesses": {
+            "main": {
+                "provider": "codex",
+                "model": {
+                    "provider": "openai",
+                    "model": "test-model",
+                    "base_url": "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1",
+                },
+            }
+        },
+    }
+    with patch("nemo_agents_plugin.runner.deployments_backend.get_base_url", return_value="http://localhost:8080"):
+        info = await backend.create_deployment(
+            workspace="default",
+            name="fabric-dep",
+            config=config,
+            port=0,
+            deployment_mode="docker",
+            image="hand-built-agent:latest",
+            use_image_entrypoint=True,
+        )
+    assert info.status == "starting"
+    created_config = entities.create.await_args_list[0].args[0]
+    container = created_config.containers[0]
+    assert container.image == "hand-built-agent:latest"
+    assert container.command == []
+    assert container.args == []
+    assert any(e.name == "PORT" and e.value == "8000" for e in container.env)
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-agents/tests/unit/test_sdk.py
+++ b/plugins/nemo-agents/tests/unit/test_sdk.py
@@ -82,6 +82,41 @@ def test_deployments_create_uses_client_workspace_by_default() -> None:
     assert captured["body"] == {"agent": "calc", "deployment_mode": "k8s", "image": "repo/calc:1.0"}
 
 
+def test_deployments_create_forwards_image_entrypoint_mode() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(req.read())
+        return httpx.Response(201, json={"name": "calc-dep"})
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+
+    with _install_mock_transport(handler):
+        client.deployments.create(
+            agent="calc",
+            deployment_mode="docker",
+            image="repo/calc:1.0",
+            use_image_entrypoint=True,
+        )
+
+    assert captured["body"] == {
+        "agent": "calc",
+        "deployment_mode": "docker",
+        "image": "repo/calc:1.0",
+        "use_image_entrypoint": True,
+    }
+
+
+def test_deployments_create_rejects_image_entrypoint_for_subprocess() -> None:
+    def handler(_req: httpx.Request) -> httpx.Response:
+        raise AssertionError("should not POST image entrypoint mode for subprocess")
+
+    client = AgentsResource(SimpleNamespace(base_url="http://test", workspace="team-a"))
+
+    with _install_mock_transport(handler), pytest.raises(ValueError, match="use_image_entrypoint"):
+        client.deployments.create(agent="calc", use_image_entrypoint=True)
+
+
 def test_invoke_sends_session_id_as_header() -> None:
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
Adds an explicit opt-in path for containerized agent deployments to preserve a hand-built image's ENTRYPOINT/CMD. By default, platform-packaged NAT/Fabric images still get the platform-owned server command.

## Changes
- Added `use_image_entrypoint` to the agents deployment request, persisted `AgentDeployment`, CLI deploy command, and hand-written agents SDK helper.
- Compiled container `DeploymentConfig` with empty command/args plus `PORT` when image-entrypoint mode is requested.
- Added API, CLI, controller, SDK, and deployments-runner unit coverage for forwarding, validation, and generated container config behavior.
- Regenerated `plugins/nemo-agents/openapi/openapi.yaml` and documented the custom-image flag and server contract in the agent deployment docs.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `make refresh-openapi` — passed; regenerated the agents plugin OpenAPI spec.
- `uv run ruff format --check plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py plugins/nemo-agents/src/nemo_agents_plugin/cli.py plugins/nemo-agents/src/nemo_agents_plugin/entities.py plugins/nemo-agents/src/nemo_agents_plugin/runner/backend.py plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py plugins/nemo-agents/src/nemo_agents_plugin/schema.py plugins/nemo-agents/src/nemo_agents_plugin/sdk.py plugins/nemo-agents/tests/unit/test_cli.py plugins/nemo-agents/tests/unit/test_deployments_api.py plugins/nemo-agents/tests/unit/test_runner_controller.py plugins/nemo-agents/tests/unit/test_runner_deployments.py plugins/nemo-agents/tests/unit/test_sdk.py` — passed.
- `uv run ruff check plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py plugins/nemo-agents/src/nemo_agents_plugin/cli.py plugins/nemo-agents/src/nemo_agents_plugin/entities.py plugins/nemo-agents/src/nemo_agents_plugin/runner/backend.py plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py plugins/nemo-agents/src/nemo_agents_plugin/runner/deployments_backend.py plugins/nemo-agents/src/nemo_agents_plugin/runner/in_memory.py plugins/nemo-agents/src/nemo_agents_plugin/schema.py plugins/nemo-agents/src/nemo_agents_plugin/sdk.py plugins/nemo-agents/tests/unit/test_cli.py plugins/nemo-agents/tests/unit/test_deployments_api.py plugins/nemo-agents/tests/unit/test_runner_controller.py plugins/nemo-agents/tests/unit/test_runner_deployments.py plugins/nemo-agents/tests/unit/test_sdk.py` — passed.
- `uv run --frozen pytest plugins/nemo-agents/tests/unit/test_runner_deployments.py plugins/nemo-agents/tests/unit/test_deployments_api.py plugins/nemo-agents/tests/unit/test_cli.py plugins/nemo-agents/tests/unit/test_runner_controller.py plugins/nemo-agents/tests/unit/test_sdk.py -v` — passed, 149 tests.
- `make docs-check` — passed after the docs review updates.
- `make docs-broken-links` — ran; command exited 0 but reported 7 existing broken links in unrelated Helm/Studio docs. The touched `docs/agents/deploy-agents.mdx` was not implicated.
- `flox -q activate --dir /home/mkornfield/wt-np-agent-image-entrypoint -- uv run pre-commit run -a` — passed.
- `flox -q activate --dir /home/mkornfield/wt-np-agent-image-entrypoint -- bash -c 'cd web && pnpm --filter @nemo/sdk gen:all-force && pnpm --filter @nemo/sdk typecheck'` — passed.
- DCO audit over `origin/release/0.5..HEAD` — passed for `bce8ee5febf4a44d8f51437d7f149675ee81cff8`, `4df60e19697d1333139a07d52496426b852a34de`, and `28f7cc154e96e57949450feb1eb8cb38ac6c3a77`.
