### PR TITLE
feat(agents): accept inline agent definitions on ExecuteAgent jobs

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -6871,7 +6871,6 @@ nemo agents execute run [OPTIONS]
 
 **Job Spec:**
 
-* `--agent`: Agent entity name or workspace/name ref.
 * `--input`: Prompt to pass to the agent.
 * `--workdir.base-workdir`: Optional Files reference for the initial working directory.
 * `--timeout-seconds <FLOAT>`: Maximum time to wait for Fabric to return an execution result.
@@ -6897,7 +6896,6 @@ nemo agents execute submit [OPTIONS]
 
 **Job Spec:**
 
-* `--agent`: Agent entity name or workspace/name ref.
 * `--input`: Prompt to pass to the agent.
 * `--workdir.base-workdir`: Optional Files reference for the initial working directory.
 * `--timeout-seconds <FLOAT>`: Maximum time to wait for Fabric to return an execution result.

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -6573,6 +6573,11 @@ nemo agents analyze run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the AnalyzeBatchConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `format`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo agents analyze submit
 
 Submit to a cluster.
@@ -6606,6 +6611,11 @@ nemo agents analyze submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the AnalyzeBatchConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `format`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo agents analyze explain
 
@@ -6673,6 +6683,9 @@ nemo agents evaluate run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the EvaluateAgentSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+​
+
 ##### nemo agents evaluate submit
 
 Submit to a cluster.
@@ -6707,6 +6720,11 @@ nemo agents evaluate submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the EvaluateAgentSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `workspace`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo agents evaluate explain
 
@@ -6777,6 +6795,11 @@ nemo agents evaluate-suite run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the EvaluateSuiteSubmitConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `runner`, `prefer`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo agents evaluate-suite submit
 
 Submit to a cluster.
@@ -6815,6 +6838,11 @@ nemo agents evaluate-suite submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the EvaluateSuiteSubmitConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `runner`, `prefer`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo agents evaluate-suite explain
 
@@ -6871,7 +6899,9 @@ nemo agents execute run [OPTIONS]
 
 **Job Spec:**
 
+* `--agent`: Agent to execute: an Agent entity name or workspace/name ref, or an inline agent definition for a config composed at request time. This flag accepts the string form only; use --spec or --spec-file for the other union form(s).
 * `--input`: Prompt to pass to the agent.
+* `--environment`: AgentEnvironment to run under: a "workspace/name" ref to a stored AgentEnvironment, an inline environment, or None. Its EnvironmentSpec is merged into the agent config and its ComputeSpec/secret refs are snapshotted onto the job step at creation time. This flag accepts the string form only; use --spec or --spec-file for the other union form(s).
 * `--workdir.base-workdir`: Optional Files reference for the initial working directory.
 * `--timeout-seconds <FLOAT>`: Maximum time to wait for Fabric to return an execution result.
 
@@ -6879,6 +6909,11 @@ nemo agents execute run [OPTIONS]
 
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
+
+Job Spec flags are generated from the ExecuteAgentJobConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `agent (other union forms)`, `environment (other union forms)`, `workdir.artifact_mounts`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo agents execute submit
 
@@ -6896,7 +6931,9 @@ nemo agents execute submit [OPTIONS]
 
 **Job Spec:**
 
+* `--agent`: Agent to execute: an Agent entity name or workspace/name ref, or an inline agent definition for a config composed at request time. This flag accepts the string form only; use --spec or --spec-file for the other union form(s).
 * `--input`: Prompt to pass to the agent.
+* `--environment`: AgentEnvironment to run under: a "workspace/name" ref to a stored AgentEnvironment, an inline environment, or None. Its EnvironmentSpec is merged into the agent config and its ComputeSpec/secret refs are snapshotted onto the job step at creation time. This flag accepts the string form only; use --spec or --spec-file for the other union form(s).
 * `--workdir.base-workdir`: Optional Files reference for the initial working directory.
 * `--timeout-seconds <FLOAT>`: Maximum time to wait for Fabric to return an execution result.
 
@@ -6913,6 +6950,11 @@ nemo agents execute submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the ExecuteAgentJobConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `agent (other union forms)`, `environment (other union forms)`, `workdir.artifact_mounts`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo agents execute explain
 
@@ -6981,6 +7023,9 @@ nemo agents optimize run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the OptimizeSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+​
+
 ##### nemo agents optimize submit
 
 Submit to a cluster.
@@ -7015,6 +7060,11 @@ nemo agents optimize submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the OptimizeSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `workspace`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo agents optimize explain
 
@@ -7115,6 +7165,11 @@ nemo agents optimize-skills run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the OptimizeSkillsConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `trace_parser`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo agents optimize-skills submit
 
 Submit to a cluster.
@@ -7158,6 +7213,11 @@ nemo agents optimize-skills submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the OptimizeSkillsConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `trace_parser`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo agents optimize-skills explain
 
@@ -7233,6 +7293,9 @@ nemo agents package-agent run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the PackageAgentInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+​
+
 ##### nemo agents package-agent submit
 
 Submit to a cluster.
@@ -7276,6 +7339,9 @@ nemo agents package-agent submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the PackageAgentInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+​
 
 ##### nemo agents package-agent explain
 
@@ -8510,6 +8576,11 @@ nemo auditor audit run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the AuditInputSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `config`, `target`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo auditor audit submit
 
 Submit to a cluster.
@@ -8542,6 +8613,11 @@ nemo auditor audit submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the AuditInputSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `config`, `target`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo auditor audit explain
 
@@ -8654,6 +8730,8 @@ nemo anonymizer preview [OPTIONS]
 * `--request-id`: Set the X-Request-ID header (echoed back in ctx.request_id).
 
 Function Spec flags are generated from the PreviewRequest Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `config.detect.entity_labels`, `config.replace`, `model_configs`, `selected_models.detection`, `selected_models.replace`, `selected_models.rewrite`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
 ​
 
 #### nemo anonymizer run
@@ -8700,6 +8778,11 @@ nemo anonymizer run [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the AnonymizerRequest Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `config.detect.entity_labels`, `config.replace`, `model_configs`, `selected_models.detection`, `selected_models.replace`, `selected_models.rewrite`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ### nemo evaluator
 
@@ -8807,6 +8890,11 @@ nemo evaluator agent-evaluate run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the AgentEvalInputSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `target`, `trials`, `labels`, `tasks`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo evaluator agent-evaluate submit
 
 Submit to a cluster.
@@ -8843,6 +8931,11 @@ nemo evaluator agent-evaluate submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the AgentEvalInputSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `target`, `trials`, `labels`, `tasks`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo evaluator agent-evaluate explain
 
@@ -8899,6 +8992,7 @@ nemo evaluator evaluate run [OPTIONS]
 
 **Job Spec:**
 
+* `--prompt-template`: Optional prompt template for online target generation. This flag accepts the string form only; use --spec or --spec-file for the other union form(s).
 * `--publication.intake.evaluation-id`: Name of the existing Evaluation to publish under. Must already exist; the job does not create it.
 * `--publication.intake.agent-name`: Agent name recorded on each published trajectory. Derived from the target when it names one; required otherwise.
 * `--publication.intake.agent-version`: Agent version recorded on each published trajectory. Neither a Model nor an Agent carries a version, so this defaults to 'unknown' unless the submitter supplies one.
@@ -8909,6 +9003,11 @@ nemo evaluator evaluate run [OPTIONS]
 
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
+
+Job Spec flags are generated from the EvaluateInputSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `dataset`, `params`, `target`, `prompt_template (other union forms)`, `field_mapping.input`, `field_mapping.output`, `field_mapping.context`, `field_mapping.reference`, `field_mapping.trajectory`, `field_mapping.messages`, `field_mapping.tool_calls`, `field_mapping.tools`, `field_mapping.custom`, `metrics`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo evaluator evaluate submit
 
@@ -8926,6 +9025,7 @@ nemo evaluator evaluate submit [OPTIONS]
 
 **Job Spec:**
 
+* `--prompt-template`: Optional prompt template for online target generation. This flag accepts the string form only; use --spec or --spec-file for the other union form(s).
 * `--publication.intake.evaluation-id`: Name of the existing Evaluation to publish under. Must already exist; the job does not create it.
 * `--publication.intake.agent-name`: Agent name recorded on each published trajectory. Derived from the target when it names one; required otherwise.
 * `--publication.intake.agent-version`: Agent version recorded on each published trajectory. Neither a Model nor an Agent carries a version, so this defaults to 'unknown' unless the submitter supplies one.
@@ -8945,6 +9045,11 @@ nemo evaluator evaluate submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the EvaluateInputSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `dataset`, `params`, `target`, `prompt_template (other union forms)`, `field_mapping.input`, `field_mapping.output`, `field_mapping.context`, `field_mapping.reference`, `field_mapping.trajectory`, `field_mapping.messages`, `field_mapping.tool_calls`, `field_mapping.tools`, `field_mapping.custom`, `metrics`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo evaluator evaluate explain
 
@@ -9326,6 +9431,11 @@ nemo customization automodel.jobs run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the AutomodelJobInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `training.training_type`, `training.finetuning_type`, `training.lora.target_modules`, `training.lora.exclude_modules`, `training.precision`, `training.attn_implementation`, `training.teacher_precision`, `schedule.progress_reporting.time_series_metrics`, `optimizer.optimizer`, `optimizer.lr_decay_style`, `integrations.wandb.tags`, `integrations.mlflow.tags`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo customization automodel.jobs submit
 
 Submit to a cluster.
@@ -9408,6 +9518,11 @@ nemo customization automodel.jobs submit [OPTIONS]
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
 
+Job Spec flags are generated from the AutomodelJobInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `training.training_type`, `training.finetuning_type`, `training.lora.target_modules`, `training.lora.exclude_modules`, `training.precision`, `training.attn_implementation`, `training.teacher_precision`, `schedule.progress_reporting.time_series_metrics`, `optimizer.optimizer`, `optimizer.lr_decay_style`, `integrations.wandb.tags`, `integrations.mlflow.tags`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo customization automodel.jobs explain
 
 Show input/output schemas.
@@ -9484,6 +9599,11 @@ nemo customization rl.jobs run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the RlJobInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `training`, `integrations.wandb.tags`, `integrations.mlflow.tags`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo customization rl.jobs submit
 
 Submit to a cluster.
@@ -9529,6 +9649,11 @@ nemo customization rl.jobs submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the RlJobInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `training`, `integrations.wandb.tags`, `integrations.mlflow.tags`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo customization rl.jobs explain
 
@@ -9602,6 +9727,8 @@ nemo customization unsloth.jobs run [OPTIONS]
 * `--training.lora.use-rslora`: Override `training.lora.use_rslora` in the spec.
 * `--training.lora.random-state <INTEGER>`: Override `training.lora.random_state` in the spec.
 * `--training.lora.use-dora`: DoRA (weight-decomposed LoRA). Improves quality at low ranks; adds training overhead.
+* `--training.lora.layers-to-transform <INTEGER>`: Restrict LoRA to specific layer index(es). None applies to all layers. This flag accepts the integer form only; use --spec or --spec-file for the other union form(s).
+* `--training.lora.init-lora-weights`: LoRA weight init scheme. True = PEFT default; 'pissa'/'olora'/'loftq' for advanced inits. This flag accepts the boolean form only; use --spec or --spec-file for the other union form(s).
 * `--schedule.epochs <INTEGER>`: Override `schedule.epochs` in the spec.
 * `--schedule.max-steps <INTEGER>`: Override `schedule.max_steps` in the spec.
 * `--schedule.warmup-steps <INTEGER>`: Override `schedule.warmup_steps` in the spec.
@@ -9634,11 +9761,17 @@ nemo customization unsloth.jobs run [OPTIONS]
 * `--integrations.mlflow.tracking-uri`: MLflow tracking server URI (e.g., 'http://mlflow.mycompany.com:5000'). Can also be set via MLFLOW_TRACKING_URI environment variable.
 * `--output.name`: Override `output.name` in the spec.
 * `--output.description`: Override `output.description` in the spec.
+* `--deployment-config`: Deployment configuration for auto-deploying the model after training. Pass a string to reference an existing ModelDeploymentConfig by name ('my-config' or 'workspace/my-config'). An object provides inline NIM deployment parameters. Omit to skip deployment. This flag accepts the string form only; use --spec or --spec-file for the other union form(s).
 
 **Spec Source:**
 
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
+
+Job Spec flags are generated from the UnslothJobInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `model.dtype`, `model.device_map`, `model.rope_scaling`, `training.training_type`, `training.finetuning_type`, `training.lora.target_modules`, `training.lora.bias`, `training.lora.loftq_config`, `training.lora.modules_to_save`, `training.lora.layers_to_transform (other union forms)`, `training.lora.layer_replication`, `training.lora.init_lora_weights (other union forms)`, `training.use_gradient_checkpointing`, `schedule.lr_scheduler_type`, `schedule.progress_reporting.time_series_metrics`, `schedule.lr_scheduler_kwargs`, `optimizer.optim`, `hardware.precision`, `integrations.wandb.tags`, `integrations.mlflow.tags`, `output.save_method`, `deployment_config (other union forms)`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo customization unsloth.jobs submit
 
@@ -9673,6 +9806,8 @@ nemo customization unsloth.jobs submit [OPTIONS]
 * `--training.lora.use-rslora`: Override `training.lora.use_rslora` in the spec.
 * `--training.lora.random-state <INTEGER>`: Override `training.lora.random_state` in the spec.
 * `--training.lora.use-dora`: DoRA (weight-decomposed LoRA). Improves quality at low ranks; adds training overhead.
+* `--training.lora.layers-to-transform <INTEGER>`: Restrict LoRA to specific layer index(es). None applies to all layers. This flag accepts the integer form only; use --spec or --spec-file for the other union form(s).
+* `--training.lora.init-lora-weights`: LoRA weight init scheme. True = PEFT default; 'pissa'/'olora'/'loftq' for advanced inits. This flag accepts the boolean form only; use --spec or --spec-file for the other union form(s).
 * `--schedule.epochs <INTEGER>`: Override `schedule.epochs` in the spec.
 * `--schedule.max-steps <INTEGER>`: Override `schedule.max_steps` in the spec.
 * `--schedule.warmup-steps <INTEGER>`: Override `schedule.warmup_steps` in the spec.
@@ -9705,6 +9840,7 @@ nemo customization unsloth.jobs submit [OPTIONS]
 * `--integrations.mlflow.tracking-uri`: MLflow tracking server URI (e.g., 'http://mlflow.mycompany.com:5000'). Can also be set via MLFLOW_TRACKING_URI environment variable.
 * `--output.name`: Override `output.name` in the spec.
 * `--output.description`: Override `output.description` in the spec.
+* `--deployment-config`: Deployment configuration for auto-deploying the model after training. Pass a string to reference an existing ModelDeploymentConfig by name ('my-config' or 'workspace/my-config'). An object provides inline NIM deployment parameters. Omit to skip deployment. This flag accepts the string form only; use --spec or --spec-file for the other union form(s).
 
 **Spec Source:**
 
@@ -9719,6 +9855,11 @@ nemo customization unsloth.jobs submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the UnslothJobInput Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `model.dtype`, `model.device_map`, `model.rope_scaling`, `training.training_type`, `training.finetuning_type`, `training.lora.target_modules`, `training.lora.bias`, `training.lora.loftq_config`, `training.lora.modules_to_save`, `training.lora.layers_to_transform (other union forms)`, `training.lora.layer_replication`, `training.lora.init_lora_weights (other union forms)`, `training.use_gradient_checkpointing`, `schedule.lr_scheduler_type`, `schedule.progress_reporting.time_series_metrics`, `schedule.lr_scheduler_kwargs`, `optimizer.optim`, `hardware.precision`, `integrations.wandb.tags`, `integrations.mlflow.tags`, `output.save_method`, `deployment_config (other union forms)`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo customization unsloth.jobs explain
 
@@ -9892,6 +10033,11 @@ nemo insights analyze-job run [OPTIONS]
 * `--spec`: Spec as a JSON string. [default: \{}]
 * `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
 
+Job Spec flags are generated from the AnalyzeSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `since`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
+
 ##### nemo insights analyze-job submit
 
 Submit to a cluster.
@@ -9928,6 +10074,11 @@ nemo insights analyze-job submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the AnalyzeSpec Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `base_url`, `since`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ##### nemo insights analyze-job explain
 
@@ -9989,6 +10140,7 @@ nemo safe-synthesizer generate [OPTIONS]
 * `--data-source`: The data source for the job.
 * `--config.data.group-training-examples-by`: Column to group training examples by. This is useful when you want the model to learn inter-record correlations for a given grouping of records.
 * `--config.data.order-training-examples-by`: Column to order training examples by. This is useful when you want the model to learn sequential relationships for a given ordering of records. If you provide this parameter, you must also provide ``group_training_examples_by``.
+* `--config.data.max-sequences-per-example <INTEGER>`: If specified, adds at most this number of sequences per example. Supports 'auto', which resolves to 1 when differential privacy is enabled, None for time-series mode (each example fills the context window), and 10 otherwise. If set to None, fills up the context window. Required for DP to limit contribution of each example. This flag accepts the integer form only; use --spec or --spec-file for the other union form(s).
 * `--config.data.holdout <FLOAT>`: Amount of records to hold out for evaluation. If this is a float between 0 and 1, that ratio of records is held out. If an integer greater than 1, that number of records is held out. If the value is equal to zero, no holdout will be performed. Must be >= 0.
 * `--config.data.max-holdout <INTEGER>`: Maximum number of records to hold out. Overrides any behavior set by ``holdout``. Must be >= 0.
 * `--config.data.random-state <INTEGER>`: Random state for holdout split to ensure reproducibility.
@@ -10000,13 +10152,16 @@ nemo safe-synthesizer generate [OPTIONS]
 * `--config.evaluation.enabled`: Enable or disable evaluation.
 * `--config.evaluation.quasi-identifier-count <INTEGER>`: Number of quasi-identifiers to sample for privacy attacks.
 * `--config.evaluation.pii-replay-enabled`: Enable PII Replay detection.
+* `--config.training.num-input-records-to-sample <INTEGER>`: Number of records the model will see during training. This parameter is a proxy for training time. For example, if its value is the same size as the input dataset, this is like training for a single epoch. If its value is larger, this is like training for multiple (possibly fractional) epochs. If its value is smaller, this is like training for a fraction of an epoch. Supports 'auto' where a reasonable value is chosen based on other config params and data. This flag accepts the integer form only; use --spec or --spec-file for the other union form(s).
 * `--config.training.batch-size <INTEGER>`: The batch size per device for training. Must be >= 1.
 * `--config.training.gradient-accumulation-steps <INTEGER>`: Number of update steps to accumulate the gradients for, before performing a backward/update pass. This technique increases the effective batch size that will fit into GPU memory. Must be >= 1.
 * `--config.training.weight-decay <FLOAT>`: The weight decay to apply to all layers except all bias and LayerNorm weights in the AdamW optimizer. Must be in (0, 1).
 * `--config.training.warmup-ratio <FLOAT>`: Ratio of total training steps used for a linear warmup from 0 to the learning rate. Must be > 0.
 * `--config.training.lr-scheduler`: The scheduler type to use. See the HuggingFace documentation of ``SchedulerType`` for all possible values.
+* `--config.training.learning-rate <FLOAT>`: The initial learning rate for `AdamW` optimizer. Must be in (0, 1). Setting to 'auto' uses a model-specific default if one exists. This flag accepts the number form only; use --spec or --spec-file for the other union form(s).
 * `--config.training.lora-r <INTEGER>`: The rank of the LoRA update matrices. Lower rank results in smaller update matrices with fewer trainable parameters. Must be > 0.
 * `--config.training.lora-alpha-over-r <FLOAT>`: The ratio of the LoRA scaling factor (alpha) to the LoRA rank. Empirically, this parameter works well when set to 0.5, 1, or 2. Must be in [0.5, 3].
+* `--config.training.rope-scaling-factor <INTEGER>`: Scale the base LLM's context length by this factor using RoPE scaling. Must be >= 1 or 'auto'. This flag accepts the integer form only; use --spec or --spec-file for the other union form(s).
 * `--config.training.validation-ratio <FLOAT>`: The fraction of the training data used for validation. Must be in [0, 1]. If set to 0, no validation will be performed. If set larger than 0, validation loss will be computed and reported throughout training.
 * `--config.training.validation-steps <INTEGER>`: The number of steps between validation checks for the HF Trainer arguments. Must be > 0.
 * `--config.training.pretrained-model`: Pretrained model to use for fine-tuning. Defaults to SmolLM3. May be a Hugging Face model ID (loaded from the Hugging Face Hub or cache) or a local path. See security note in docs before using untrusted sources.
@@ -10031,6 +10186,7 @@ nemo safe-synthesizer generate [OPTIONS]
 * `--config.generation.attention-backend`: The attention backend for the vLLM engine. Common values: 'FLASHINFER', 'FLASH_ATTN', 'TRITON_ATTN', 'FLEX_ATTENTION'. If ``None`` or 'auto', vLLM will auto-select the best available backend.
 * `--config.privacy.dp-enabled`: Enable differentially-private training with DP-SGD.
 * `--config.privacy.epsilon <FLOAT>`: Target privacy budget -- lower values provide stronger privacy. Must be > 0.
+* `--config.privacy.delta <FLOAT>`: Probability of accidentally leaking information. Should be much smaller than 1/n where n is the number of training records. Setting to 'auto' uses delta of 1/n^1.2. Must be in [0, 1) or 'auto'. This flag accepts the number form only; use --spec or --spec-file for the other union form(s).
 * `--config.privacy.per-sample-max-grad-norm <FLOAT>`: Maximum L2 norm for per-sample gradient clipping. Must be > 0.
 * `--config.time-series.is-timeseries`: Whether to treat the dataset as time series. When enabled, either ``timestamp_column`` or ``timestamp_interval_seconds`` is required. For grouped time series, ``group_training_examples_by`` needs to be set.
 * `--config.time-series.timestamp-column`: Name of the column containing timestamps used to order records when ``is_timeseries`` is ``True``. Required only when ``is_timeseries`` is ``True`` and ``timestamp_interval_seconds`` is not provided.
@@ -10067,6 +10223,11 @@ nemo safe-synthesizer generate [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
+
+Job Spec flags are generated from the SafeSynthesizerJobConfig Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
+
+Some spec fields cannot be represented as CLI flags: `config.data.max_sequences_per_example (other union forms)`, `config.evaluation.pii_replay_entities`, `config.evaluation.pii_replay_columns`, `config.training.num_input_records_to_sample (other union forms)`, `config.training.learning_rate (other union forms)`, `config.training.lora_target_modules`, `config.training.rope_scaling_factor (other union forms)`, `config.training.quantization_bits`, `config.generation.structured_generation.backend`, `config.generation.structured_generation.schema_method`, `config.privacy.delta (other union forms)`, `config.time_series.start_timestamp`, `config.time_series.stop_timestamp`, `config.replace_pii.globals.locales`, `config.replace_pii.globals.classify.entities`, `config.replace_pii.globals.ner.ner_entities`, `config.replace_pii.globals.lock_columns`, `config.replace_pii.steps`, `config.preflight.disabled_checks`. Supply them with --spec or --spec-file. Individual flags override values from the supplied spec.
+​
 
 ### nemo experiments
 

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/_spec_flags.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/_spec_flags.py
@@ -96,6 +96,10 @@ class SpecLeafField:
             (wins unconditionally) or from each union arm's
             ``__cli_metavar__`` class attribute (joined with ``" | "``)
             when every arm declares one.
+        partial: ``True`` when *python_type* covers only one arm of a
+            mixed scalar/model union (e.g. ``str | AgentInline`` emits
+            a flag for the ``str`` arm only). The other arm(s) remain
+            reachable solely through ``--spec`` / ``--spec-file``.
     """
 
     path: tuple[str, ...]
@@ -105,6 +109,7 @@ class SpecLeafField:
     description: str
     required: bool
     metavar: str | None = None
+    partial: bool = False
 
     @property
     def flag(self) -> str:
@@ -116,14 +121,19 @@ def walk_spec_leaves(
     model: type[BaseModel] | None,
     *,
     reserved: Iterable[str] = (),
+    unavailable: list[str] | None = None,
 ) -> list[SpecLeafField]:
     """Walk *model* recursively and return one entry per scalar leaf.
 
     Returns an empty list when *model* is ``None``. Skips fields whose
     types aren't currently supported (lists, dicts, multi-type unions
-    that don't share a scalar base, ``Literal``, ``Path``, plain
-    ``BaseModel`` references that aren't nested submodels, ...) — these
-    remain accessible via the JSON ``--spec`` / ``--spec-file`` path.
+    that don't share a scalar base and don't reduce to a single scalar
+    arm, ``Literal``, ``Path``, plain ``BaseModel`` references that
+    aren't nested submodels, ...) — these remain accessible via the
+    JSON ``--spec`` / ``--spec-file`` path. A union that mixes exactly
+    one scalar arm with one or more model/unsupported arms (e.g.
+    ``str | AgentInline``) still emits a flag for the scalar arm; see
+    :attr:`SpecLeafField.partial`.
 
     Args:
         model: A Pydantic v2 ``BaseModel`` subclass, or ``None``.
@@ -131,6 +141,12 @@ def walk_spec_leaves(
             flags) to skip. The set is verb-specific. A field whose
             name matches one of *reserved* falls through to ``--spec`` /
             ``--spec-file`` for value passing.
+        unavailable: When given, appended in place with one dotted
+            path per field (or union arm) not fully representable as a
+            flag — fields skipped entirely, plus the non-scalar arm of
+            each :attr:`SpecLeafField.partial` leaf. Callers use this
+            to build a ``--help`` note pointing at ``--spec`` /
+            ``--spec-file`` for those paths.
 
     Returns:
         Flat list of :class:`SpecLeafField` in declaration order.
@@ -139,7 +155,7 @@ def walk_spec_leaves(
         return []
     reserved_set = frozenset(reserved)
     leaves: list[SpecLeafField] = []
-    _walk(model, prefix=(), out=leaves, used_param_names=set(), reserved=reserved_set)
+    _walk(model, prefix=(), out=leaves, used_param_names=set(), reserved=reserved_set, unavailable=unavailable)
     return leaves
 
 
@@ -150,21 +166,31 @@ def _walk(
     out: list[SpecLeafField],
     used_param_names: set[str],
     reserved: frozenset[str],
+    unavailable: list[str] | None,
 ) -> None:
     for name, info in model.model_fields.items():
         path = (*prefix, name)
         annotation = info.annotation
-        unwrapped = _strip_optional(annotation)
+        unwrapped, is_partial = _strip_optional(annotation)
         if unwrapped is None:
             logger.debug(
                 "Skipping field %s on %s: unsupported union or unannotated.",
                 ".".join(path),
                 model.__name__,
             )
+            if unavailable is not None:
+                unavailable.append(".".join(path))
             continue
 
         if isinstance(unwrapped, type) and issubclass(unwrapped, BaseModel):
-            _walk(unwrapped, prefix=path, out=out, used_param_names=used_param_names, reserved=reserved)
+            _walk(
+                unwrapped,
+                prefix=path,
+                out=out,
+                used_param_names=used_param_names,
+                reserved=reserved,
+                unavailable=unavailable,
+            )
             continue
 
         if not _is_supported_scalar(unwrapped):
@@ -174,6 +200,8 @@ def _walk(
                 model.__name__,
                 unwrapped,
             )
+            if unavailable is not None:
+                unavailable.append(".".join(path))
             continue
 
         param_name = _path_to_param_name(path, used=used_param_names)
@@ -184,8 +212,21 @@ def _walk(
                 ".".join(path),
                 param_name,
             )
+            if unavailable is not None:
+                unavailable.append(".".join(path))
             continue
         used_param_names.add(param_name)
+
+        if is_partial:
+            logger.debug(
+                "Field %s on %s is a mixed scalar/model union: emitting --%s for the "
+                "scalar arm only. Other shapes require --spec / --spec-file.",
+                ".".join(path),
+                model.__name__,
+                param_name,
+            )
+            if unavailable is not None:
+                unavailable.append(f"{'.'.join(path)} (inline form)")
 
         out.append(
             SpecLeafField(
@@ -196,34 +237,59 @@ def _walk(
                 description=info.description or "",
                 required=_is_required(info),
                 metavar=_derive_metavar(annotation, info),
+                partial=is_partial,
             )
         )
 
 
-def _strip_optional(annotation: Any) -> Any | None:
-    """Return the inner CLI-renderable type for *annotation*.
+def _strip_optional(annotation: Any) -> tuple[Any | None, bool]:
+    """Return the inner CLI-renderable type for *annotation*, and whether it's partial.
 
-    Handles three union shapes:
+    Handles four union shapes:
 
-    - ``Optional[X]`` / ``X | None``: returns ``X``, except when ``X``
-      is a strict subclass of a supported scalar
+    - ``Optional[X]`` / ``X | None``: returns ``(X, False)``, except
+      when ``X`` is a strict subclass of a supported scalar
       (``str``/``int``/``float``/``bool``) — in that case returns the
       scalar base so Typer can build a flag from a type it knows how
       to render.  Subclass identity is preserved at parse time by the
       Pydantic validator on the spec model.
     - A union of two or more non-``None`` arms that all subclass the
-      same supported scalar base: returns that base.
-    - Anything else: returns ``None`` to signal "skip this field".
+      same supported scalar base: returns ``(base, False)``.
+    - A union of two or more non-``None`` arms where exactly one arm
+      is scalar-compatible and the rest aren't (e.g.
+      ``str | AgentInline``): returns ``(scalar_base, True)`` — the
+      flag covers only that arm; the others are only reachable via
+      ``--spec`` / ``--spec-file``.
+    - Anything else: returns ``(None, False)`` to signal "skip this
+      field entirely".
     """
     if annotation is None:
-        return None
+        return None, False
     origin = get_origin(annotation)
     if origin is Union or origin is types.UnionType:
         non_none = [a for a in get_args(annotation) if a is not type(None)]
         if len(non_none) == 1:
-            return _scalar_base_or_self(non_none[0])
-        return _common_scalar_base(non_none)
-    return _scalar_base_or_self(annotation)
+            return _scalar_base_or_self(non_none[0]), False
+        base = _common_scalar_base(non_none)
+        if base is not None:
+            return base, False
+        return _partial_scalar_arm(non_none)
+    return _scalar_base_or_self(annotation), False
+
+
+def _partial_scalar_arm(types_: list[Any]) -> tuple[type | None, bool]:
+    """Return the lone scalar arm of a mixed union, marked partial.
+
+    Applies only when exactly one arm collapses to a supported scalar
+    base and at least one other arm doesn't (a model type, another
+    unsupported shape, ...). Two or more differently-based scalar arms
+    (``str | int | AgentInline``) are ambiguous as to which flag type
+    to expose, so those still fall through to "skip this field".
+    """
+    scalar_arms = [t for t in types_ if _is_supported_scalar(_scalar_base_or_self(t))]
+    if len(scalar_arms) != 1:
+        return None, False
+    return _scalar_base_or_self(scalar_arms[0]), True
 
 
 def _scalar_base_or_self(tp: Any) -> Any:
@@ -454,6 +520,14 @@ def _optional_of(tp: object) -> Any:
     return Optional[tp]  # ty: ignore[invalid-type-form]
 
 
+_SCALAR_TYPE_NAMES: dict[type, str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+}
+
+
 def make_field_param(
     leaf: SpecLeafField,
     *,
@@ -471,6 +545,11 @@ def make_field_param(
     """
     annotation: Any = _optional_of(leaf.python_type)
     help_text = leaf.description or f"Override `{'.'.join(leaf.path)}` in the spec."
+    if leaf.partial:
+        scalar_name = _SCALAR_TYPE_NAMES.get(leaf.python_type, leaf.python_type.__name__)
+        help_text = (
+            f"{help_text} This flag accepts the {scalar_name} form only; use --spec or --spec-file for the object form."
+        ).strip()
     if leaf.required and leaf.default is PydanticUndefined:
         help_text = f"[required] {help_text}".strip()
     option_kwargs: dict[str, Any] = {
@@ -540,6 +619,11 @@ _EPILOG_NO_FLAGS = (
     "{kind} has no spec_schema fields the CLI knows how to expose, so "
     "no per-field flags are generated."
 )
+_UNAVAILABLE_NOTE = (
+    "Some spec fields cannot be represented as CLI flags: {fields}. "
+    "Supply them with --spec or --spec-file. Individual flags override "
+    "values from the supplied spec."
+)
 
 
 def build_epilog(
@@ -547,6 +631,7 @@ def build_epilog(
     schema: type[BaseModel] | None,
     leaves: Sequence[SpecLeafField],
     kind: str,
+    unavailable: Sequence[str] = (),
 ) -> str:
     """Compose the multi-line block rendered under all panels in ``--help``.
 
@@ -564,10 +649,19 @@ def build_epilog(
             as "no flags".)
         kind: Capitalised label inserted into both templates — typically
             ``"Function"`` or ``"Job"``.
+        unavailable: Dotted paths (from :func:`walk_spec_leaves`'s
+            ``unavailable`` out-param) not fully representable as
+            flags — fields skipped entirely, and the non-scalar arm of
+            each partial mixed-union leaf. Rendered as an extra
+            paragraph naming them so their absence from --help isn't
+            silent.
     """
     body = (
         _EPILOG_WITH_FLAGS.format(kind=kind, schema=schema.__name__)
         if (leaves and schema is not None)
         else _EPILOG_NO_FLAGS.format(kind=kind)
     )
+    if unavailable:
+        fields = ", ".join(f"`{path}`" for path in unavailable)
+        body = f"{body}\n\n{_UNAVAILABLE_NOTE.format(fields=fields)}"
     return body + "\n\u200b"

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/_spec_flags.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/_spec_flags.py
@@ -226,7 +226,7 @@ def _walk(
                 param_name,
             )
             if unavailable is not None:
-                unavailable.append(f"{'.'.join(path)} (inline form)")
+                unavailable.append(f"{'.'.join(path)} (other union forms)")
 
         out.append(
             SpecLeafField(
@@ -548,7 +548,7 @@ def make_field_param(
     if leaf.partial:
         scalar_name = _SCALAR_TYPE_NAMES.get(leaf.python_type, leaf.python_type.__name__)
         help_text = (
-            f"{help_text} This flag accepts the {scalar_name} form only; use --spec or --spec-file for the object form."
+            f"{help_text} This flag accepts the {scalar_name} form only; use --spec or --spec-file for the other union form(s)."
         ).strip()
     if leaf.required and leaf.default is PydanticUndefined:
         help_text = f"[required] {help_text}".strip()

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
@@ -400,7 +400,8 @@ def _add_run_command(
     when no renderer is supplied.
     """
     schema = _job_input_schema(job_cls)
-    leaves = walk_spec_leaves(schema, reserved=_JOB_RUN_RESERVED_FLAGS)
+    unavailable: list[str] = []
+    leaves = walk_spec_leaves(schema, reserved=_JOB_RUN_RESERVED_FLAGS, unavailable=unavailable)
 
     def _run(typer_ctx: typer.Context, **kwargs: object) -> None:
         original_kwargs = dict(kwargs)
@@ -447,8 +448,9 @@ def _add_run_command(
             renderer.on_complete(ctx=rctx)
 
     help_text = "Run locally, in-process."
+    epilog = build_epilog(schema=schema, leaves=leaves, kind="Job", unavailable=unavailable)
     setattr(_run, "__signature__", _build_job_run_signature(leaves))
-    group.command(name="run", help=help_text)(_run)
+    group.command(name="run", help=help_text, epilog=epilog)(_run)
 
 
 def _build_job_run_signature(leaves: list[SpecLeafField]) -> inspect.Signature:
@@ -554,7 +556,8 @@ def _add_submit_command(
     ``on_complete``.
     """
     schema = _job_input_schema(job_cls)
-    leaves = walk_spec_leaves(schema, reserved=_JOB_SUBMIT_RESERVED_FLAGS)
+    unavailable: list[str] = []
+    leaves = walk_spec_leaves(schema, reserved=_JOB_SUBMIT_RESERVED_FLAGS, unavailable=unavailable)
 
     def _submit(typer_ctx: typer.Context, **kwargs: object) -> None:
         original_kwargs = dict(kwargs)
@@ -626,8 +629,9 @@ def _add_submit_command(
             renderer.on_complete(ctx=rctx)
 
     help_text = "Submit to a cluster."
+    epilog = build_epilog(schema=schema, leaves=leaves, kind="Job", unavailable=unavailable)
     setattr(_submit, "__signature__", _build_job_submit_signature(leaves))
-    group.command(name=command_name, help=help_text, rich_help_panel=rich_help_panel)(_submit)
+    group.command(name=command_name, help=help_text, epilog=epilog, rich_help_panel=rich_help_panel)(_submit)
 
 
 def _build_job_submit_signature(leaves: list[SpecLeafField]) -> inspect.Signature:
@@ -924,7 +928,8 @@ def _add_function_run_command(
     (and ``--output-format json`` is not set), the renderer's lifecycle
     drives the streamed output instead of the default per-frame echo.
     """
-    leaves = walk_spec_leaves(fn_cls.spec_schema, reserved=_FN_RUN_RESERVED_FLAGS)
+    unavailable: list[str] = []
+    leaves = walk_spec_leaves(fn_cls.spec_schema, reserved=_FN_RUN_RESERVED_FLAGS, unavailable=unavailable)
 
     def _run(typer_ctx: typer.Context, **kwargs: object) -> None:
         original_kwargs = dict(kwargs)
@@ -973,7 +978,7 @@ def _add_function_run_command(
             renderer.on_complete(ctx=rctx)
 
     help_text = f"Run {fn_cls.name} locally, in-process."
-    epilog = build_epilog(schema=fn_cls.spec_schema, leaves=leaves, kind="Function")
+    epilog = build_epilog(schema=fn_cls.spec_schema, leaves=leaves, kind="Function", unavailable=unavailable)
     setattr(_run, "__signature__", _build_function_run_signature(leaves))
     group.command(name="run", help=help_text, epilog=epilog)(_run)
 
@@ -1125,7 +1130,8 @@ def _add_function_submit_command(
     (and ``--output-format json`` is not set), the renderer's lifecycle drives
     the streamed NDJSON response instead of the default per-line echo.
     """
-    leaves = walk_spec_leaves(fn_cls.spec_schema, reserved=_FN_SUBMIT_RESERVED_FLAGS)
+    unavailable: list[str] = []
+    leaves = walk_spec_leaves(fn_cls.spec_schema, reserved=_FN_SUBMIT_RESERVED_FLAGS, unavailable=unavailable)
 
     def _submit(typer_ctx: typer.Context, **kwargs: object) -> None:
         original_kwargs = dict(kwargs)
@@ -1179,7 +1185,7 @@ def _add_function_submit_command(
             raise typer.Exit(code=2) from exc
 
     help_text = f"Submit {fn_cls.name} over HTTP."
-    epilog = build_epilog(schema=fn_cls.spec_schema, leaves=leaves, kind="Function")
+    epilog = build_epilog(schema=fn_cls.spec_schema, leaves=leaves, kind="Function", unavailable=unavailable)
     setattr(_submit, "__signature__", _build_function_submit_signature(leaves))
     group.command(name=command_name, help=help_text, epilog=epilog, rich_help_panel=rich_help_panel)(_submit)
 

--- a/packages/nemo_platform_plugin/tests/test_spec_flags.py
+++ b/packages/nemo_platform_plugin/tests/test_spec_flags.py
@@ -95,6 +95,52 @@ class TestWalkSpecLeaves:
         leaf = walk_spec_leaves(_Custom)[0]
         assert leaf.metavar == "USER_NAME"
 
+    def test_mixed_scalar_model_union_keeps_scalar_arm_flag(self) -> None:
+        # ``str | SomeModel`` used to be dropped entirely (no shared
+        # scalar base across arms). The scalar arm should still surface
+        # a flag; the model arm stays reachable via --spec/--spec-file.
+        class _Inline(BaseModel):
+            value: str
+
+        class _Mixed(BaseModel):
+            agent: str | _Inline
+
+        leaves = {leaf.flag: leaf for leaf in walk_spec_leaves(_Mixed)}
+        assert leaves["--agent"].python_type is str
+        assert leaves["--agent"].partial is True
+
+    def test_mixed_scalar_model_union_reports_unavailable(self) -> None:
+        class _Inline(BaseModel):
+            value: str
+
+        class _Mixed(BaseModel):
+            agent: str | _Inline
+
+        unavailable: list[str] = []
+        walk_spec_leaves(_Mixed, unavailable=unavailable)
+        assert unavailable == ["agent (inline form)"]
+
+    def test_two_scalar_arms_plus_model_arm_is_skipped(self) -> None:
+        # Ambiguous which scalar flag type to expose, so this remains
+        # skipped entirely, same as before.
+        class _Inline(BaseModel):
+            value: str
+
+        class _Ambiguous(BaseModel):
+            field: str | int | _Inline
+
+        leaves = walk_spec_leaves(_Ambiguous)
+        assert leaves == []
+
+    def test_fully_unsupported_field_reports_unavailable(self) -> None:
+        class _WithList(BaseModel):
+            tags: list[str] = []
+            name: str = "x"
+
+        unavailable: list[str] = []
+        walk_spec_leaves(_WithList, unavailable=unavailable)
+        assert unavailable == ["tags"]
+
     def test_nested_path_to_param_name_is_unique(self) -> None:
         # Two leaves at different paths must not collide on the
         # synthetic param name — the walker disambiguates with a
@@ -189,6 +235,17 @@ class TestEpilog:
     def test_falls_back_to_no_flags_message(self) -> None:
         text = build_epilog(schema=_Spec, leaves=[], kind="Function")
         assert "no per-field flags" in text
+
+    def test_unavailable_paths_render_as_extra_note(self) -> None:
+        leaves = walk_spec_leaves(_Spec)
+        text = build_epilog(schema=_Spec, leaves=leaves, kind="Function", unavailable=["agent (inline form)"])
+        assert "agent (inline form)" in text
+        assert "--spec or --spec-file" in text
+
+    def test_no_unavailable_paths_omits_note(self) -> None:
+        leaves = walk_spec_leaves(_Spec)
+        text = build_epilog(schema=_Spec, leaves=leaves, kind="Function")
+        assert "cannot be represented as CLI flags" not in text
 
     @pytest.mark.parametrize("kind", ["Function", "Job"])
     def test_kind_is_capitalised_label(self, kind: str) -> None:

--- a/packages/nemo_platform_plugin/tests/test_spec_flags.py
+++ b/packages/nemo_platform_plugin/tests/test_spec_flags.py
@@ -118,7 +118,7 @@ class TestWalkSpecLeaves:
 
         unavailable: list[str] = []
         walk_spec_leaves(_Mixed, unavailable=unavailable)
-        assert unavailable == ["agent (inline form)"]
+        assert unavailable == ["agent (other union forms)"]
 
     def test_two_scalar_arms_plus_model_arm_is_skipped(self) -> None:
         # Ambiguous which scalar flag type to expose, so this remains
@@ -238,8 +238,8 @@ class TestEpilog:
 
     def test_unavailable_paths_render_as_extra_note(self) -> None:
         leaves = walk_spec_leaves(_Spec)
-        text = build_epilog(schema=_Spec, leaves=leaves, kind="Function", unavailable=["agent (inline form)"])
-        assert "agent (inline form)" in text
+        text = build_epilog(schema=_Spec, leaves=leaves, kind="Function", unavailable=["agent (other union forms)"])
+        assert "agent (other union forms)" in text
         assert "--spec or --spec-file" in text
 
     def test_no_unavailable_paths_omits_note(self) -> None:

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -3627,20 +3627,6 @@ components:
   schemas:
     Agent:
       properties:
-        name:
-          type: string
-          title: Name
-          description: Entity name within the workspace
-          default: ''
-        workspace:
-          type: string
-          pattern: ^[\w\-\+.@:]+$
-          title: Workspace
-          description: Workspace identifier
-        project:
-          title: Project
-          description: The name of the project associated with this entity.
-          type: string
         description:
           type: string
           title: Description
@@ -3658,6 +3644,20 @@ components:
             `nat-workflow-v1` is the default legacy NAT workflow format; `nemo-agents-spec-v1`
             identifies the Platform-owned agent.yaml spec format.
           default: nat-workflow-v1
+        name:
+          type: string
+          title: Name
+          description: Entity name within the workspace
+          default: ''
+        workspace:
+          type: string
+          pattern: ^[\w\-\+.@:]+$
+          title: Workspace
+          description: Workspace identifier
+        project:
+          title: Project
+          description: The name of the project associated with this entity.
+          type: string
         id:
           type: string
           title: Id
@@ -4241,6 +4241,37 @@ components:
         Entity type: ``agent_environment_spec``
 
         Referenced by an AgentEnvironment''s ``environment_spec`` (by name or inline).'
+    AgentInline:
+      properties:
+        description:
+          type: string
+          title: Description
+          description: Human-readable description of the agent.
+          default: ''
+        config:
+          additionalProperties: true
+          type: object
+          title: Config
+          description: Agent config dict interpreted according to config_format.
+        config_format:
+          type: string
+          title: Config Format
+          description: platform-internal schema version tag for the agent config dict.
+            `nat-workflow-v1` is the default legacy NAT workflow format; `nemo-agents-spec-v1`
+            identifies the Platform-owned agent.yaml spec format.
+          default: nat-workflow-v1
+      type: object
+      title: AgentInline
+      description: "Inline Agent - an agent definition without entity identity.\n\n\
+        The shared shape behind the :class:`Agent` entity: the entity embeds these\n\
+        fields and adds name/workspace, and a field that accepts an agent can take\n\
+        either a ``\"workspace/name\"`` ref string or this model. Lets a caller\n\
+        execute an agent it composes at request time \u2014 models chosen per request,\n\
+        settings scoped to one run \u2014 without first persisting an Agent.\n\nDeliberately\
+        \ as permissive as the entity: consumers impose their own\nrequirements rather\
+        \ than this model narrowing them for everyone. The\n``agents.execute`` job,\
+        \ for example, accepts only ``nemo-agents-spec-v1``\nand rejects a config\
+        \ that is not a valid agent spec."
     AgentSession:
       properties:
         name:
@@ -5464,10 +5495,14 @@ components:
     ExecuteAgentJobConfig:
       properties:
         agent:
-          type: string
-          pattern: ^[\w\-.]+(/[\w\-.]+)?$
+          anyOf:
+          - type: string
+            title: Reference
+            description: A reference to AgentInline.
+          - $ref: '#/components/schemas/AgentInline'
           title: Agent
-          description: Agent entity name or workspace/name ref.
+          description: 'Agent to execute: an Agent entity name or workspace/name ref,
+            or an inline agent definition for a config composed at request time.'
         input:
           type: string
           title: Input

--- a/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/entities.py
@@ -279,6 +279,37 @@ NAT_WORKFLOW_CONFIG_FORMAT = "nat-workflow-v1"
 NEMO_AGENTS_SPEC_CONFIG_FORMAT = "nemo-agents-spec-v1"
 """Canonical format tag for the Platform-owned agent.yaml spec format."""
 
+
+class AgentInline(BaseModel):
+    """Inline Agent - an agent definition without entity identity.
+
+    The shared shape behind the :class:`Agent` entity: the entity embeds these
+    fields and adds name/workspace, and a field that accepts an agent can take
+    either a ``"workspace/name"`` ref string or this model. Lets a caller
+    execute an agent it composes at request time — models chosen per request,
+    settings scoped to one run — without first persisting an Agent.
+
+    Deliberately as permissive as the entity: consumers impose their own
+    requirements rather than this model narrowing them for everyone. The
+    ``agents.execute`` job, for example, accepts only ``nemo-agents-spec-v1``
+    and rejects a config that is not a valid agent spec.
+    """
+
+    description: str = Field(default="", description="Human-readable description of the agent.")
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Agent config dict interpreted according to config_format.",
+    )
+    config_format: str = Field(
+        default=NAT_WORKFLOW_CONFIG_FORMAT,
+        description=(
+            "platform-internal schema version tag for the agent config dict. "
+            "`nat-workflow-v1` is the default legacy NAT workflow format; "
+            "`nemo-agents-spec-v1` identifies the Platform-owned agent.yaml spec format."
+        ),
+    )
+
+
 # Container deployments deliver the Ethos fileset through a ConfigMap (k8s) or a
 # single env var (docker), both of which cap out around 1MiB. Bound the tree at
 # both ends of the pipe so an agent root pointed at a whole checkout fails at
@@ -349,7 +380,7 @@ class AgentEnvironment(NemoEntity, AgentEnvironmentInline, entity_type="agent_en
 
 # TODO: first-class environment, sandbox, and harness specs are planned for the
 # Agent entity. Add those specs to this object once the contract is finalized.
-class Agent(NemoEntity, entity_type="agent"):
+class Agent(NemoEntity, AgentInline, entity_type="agent"):
     """An agent definition — stores agent config and metadata.
 
     Entity type: ``agent``
@@ -360,20 +391,6 @@ class Agent(NemoEntity, entity_type="agent"):
     are **not** stored on the entity because the paths are fully derivable
     from ``(workspace, name)``.
     """
-
-    description: str = Field(default="", description="Human-readable description of the agent.")
-    config: dict[str, Any] = Field(
-        default_factory=dict,
-        description="Agent config dict interpreted according to config_format.",
-    )
-    config_format: str = Field(
-        default=NAT_WORKFLOW_CONFIG_FORMAT,
-        description=(
-            "platform-internal schema version tag for the agent config dict. "
-            "`nat-workflow-v1` is the default legacy NAT workflow format; "
-            "`nemo-agents-spec-v1` identifies the Platform-owned agent.yaml spec format."
-        ),
-    )
 
 
 class AgentDeployment(NemoEntity, entity_type="agent_deployment"):

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import re
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, ClassVar, cast
@@ -19,6 +20,7 @@ from nemo_agents_plugin.entities import (
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
     Agent,
     AgentEnvironmentInline,
+    AgentInline,
     ComputeSpecInline,
 )
 from nemo_agents_plugin.environment_resolution import (
@@ -69,7 +71,7 @@ from nemo_platform_plugin.jobs.constants import (
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
 from nemo_platform_plugin.jobs.image import get_qualified_image
 from nemo_platform_plugin.refs import ENTITY_REF_PATTERN, parse_entity_ref
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +133,12 @@ _RESERVED_ENV_VAR_NAMES = frozenset(
 class ExecuteAgentJobConfig(BaseModel):
     model_config = {"json_schema_mode_override": "validation"}
 
-    agent: str = Field(pattern=ENTITY_REF_PATTERN, description="Agent entity name or workspace/name ref.")
+    agent: str | AgentInline = Field(
+        description=(
+            "Agent to execute: an Agent entity name or workspace/name ref, or an inline "
+            "agent definition for a config composed at request time."
+        ),
+    )
     input: str = Field(description="Prompt to pass to the agent.")
     environment: str | AgentEnvironmentInline | None = Field(
         default=None,
@@ -151,6 +158,28 @@ class ExecuteAgentJobConfig(BaseModel):
         gt=0,
         description="Maximum time to wait for Fabric to return an execution result.",
     )
+
+    @field_validator("agent")
+    @classmethod
+    def _validate_agent(cls, value: str | AgentInline) -> str | AgentInline:
+        """Apply this job's own requirements to whichever arm the caller used.
+
+        ``AgentInline`` is deliberately as permissive as the ``Agent`` entity it
+        backs, so the narrowing lives here rather than on the shared model: an
+        entity can legitimately hold a NAT workflow config, but this job cannot
+        run one.
+        """
+        if isinstance(value, str):
+            # The ref pattern moved off the field so the union's other arm can
+            # carry a config; keep enforcing it for the string arm.
+            if not re.fullmatch(ENTITY_REF_PATTERN, value):
+                raise ValueError(f"Agent ref {value!r} must be an entity name or a 'workspace/name' ref.")
+            return value
+
+        _validate_agent_config_format(value.config_format)
+        if not value.config:
+            raise ValueError("Inline agent definitions require a non-empty config.")
+        return value
 
 
 class ResolvedAgentConfig(BaseModel):
@@ -206,19 +235,15 @@ class ExecuteAgentJob(NemoJob):
         """
         del is_local
         request = cast(ExecuteAgentJobConfig, input_spec)
-        agent_ref = parse_entity_ref(request.agent, default_workspace=workspace)
         typed_entity_client = cast(Any, entity_client)
-        try:
-            agent = await typed_entity_client.get(Agent, name=agent_ref.name, workspace=agent_ref.workspace)
-        except NemoEntityNotFoundError as exc:
-            raise ValueError(f"Agent '{request.agent}' not found.") from exc
+        source = await _resolve_agent_source(request.agent, workspace=workspace, entity_client=typed_entity_client)
 
-        _validate_agent_config_format(agent.config_format)
+        _validate_agent_config_format(source.config_format)
         resolved_agent_config = resolve_agent_config_for_deployment(
-            agent.config_format,
-            agent.config,
-            workspace=agent.workspace,
-            agent_name=agent.name,
+            source.config_format,
+            source.config,
+            workspace=source.workspace,
+            agent_name=source.name,
         )
 
         # Resolve and merge the referenced AgentEnvironment. The EnvironmentSpec is
@@ -250,10 +275,10 @@ class ExecuteAgentJob(NemoJob):
         return ExecuteAgentStepConfig(
             request=request,
             agent=ResolvedAgentConfig(
-                name=agent.name,
-                workspace=agent.workspace,
+                name=source.name,
+                workspace=source.workspace,
                 config=merged.config,
-                config_format=agent.config_format,
+                config_format=source.config_format,
             ),
             workdir=workdir,
             compute=resolved_env.compute_spec,
@@ -407,6 +432,61 @@ class ExecuteAgentJob(NemoJob):
             _save_json_result(ctx, FABRIC_ERROR_RESULT_NAME, ctx.storage.ephemeral / FABRIC_ERROR_FILENAME, payload)
         except Exception:
             logger.warning("Failed to save Fabric error result.", exc_info=True)
+
+
+class _AgentSource(BaseModel):
+    """The agent definition to execute, however the request supplied it."""
+
+    name: str
+    workspace: str
+    config: dict[str, Any]
+    config_format: str
+
+
+async def _resolve_agent_source(
+    agent: str | AgentInline,
+    *,
+    workspace: str,
+    entity_client: Any,
+) -> _AgentSource:
+    """Resolve the request's agent arm into one shape the rest of ``to_spec`` uses.
+
+    An inline config is not persisted anywhere: it is validated here so a bad
+    definition fails on the create request, then snapshotted onto the step config
+    exactly as an entity-backed config is. Its name comes from the config itself
+    and it is attributed to the job's workspace.
+
+    NOTE: an inline config is currently gated only by the job's own
+    ``agents.execute.create`` permission, whereas reaching the same outcome
+    through an entity additionally requires ``agents.agents.create``. Closing
+    that gap needs a body-conditional permission, which the shared jobs route
+    factory has no hook for today.
+    """
+    if isinstance(agent, AgentInline):
+        # Format and non-emptiness are already enforced by
+        # ``ExecuteAgentJobConfig._validate_agent``; this is the spec check.
+        try:
+            inline_config = AgentConfig.model_validate(agent.config)
+        except Exception as exc:
+            raise ValueError(f"Inline agent config is invalid: {exc}") from exc
+        return _AgentSource(
+            name=inline_config.name,
+            workspace=workspace,
+            config=agent.config,
+            config_format=agent.config_format,
+        )
+
+    agent_ref = parse_entity_ref(agent, default_workspace=workspace)
+    try:
+        entity = await entity_client.get(Agent, name=agent_ref.name, workspace=agent_ref.workspace)
+    except NemoEntityNotFoundError as exc:
+        raise ValueError(f"Agent '{agent}' not found.") from exc
+    return _AgentSource(
+        name=entity.name,
+        workspace=entity.workspace,
+        config=entity.config,
+        config_format=entity.config_format,
+    )
 
 
 def _has_workdir_inputs(workdir: AgentWorkdir) -> bool:

--- a/plugins/nemo-agents/tests/unit/test_execute_job.py
+++ b/plugins/nemo-agents/tests/unit/test_execute_job.py
@@ -18,6 +18,7 @@ from nemo_agents_plugin.entities import (
     AgentEnvironment,
     AgentEnvironmentInline,
     AgentEnvironmentSpec,
+    AgentInline,
     ComputeResources,
     ComputeSpecInline,
     EnvironmentSpecInline,
@@ -1160,3 +1161,142 @@ def test_execute_job_create_route_maps_reserved_secret_env_to_422() -> None:
 
     assert response.status_code == 422, response.text
     assert "reserved job env var name" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Inline agent definitions
+# ---------------------------------------------------------------------------
+
+
+def test_job_config_accepts_an_inline_agent_definition() -> None:
+    config = ExecuteAgentJobConfig(
+        agent=AgentInline(config=_agent_config(), config_format="nemo-agents-spec-v1"), input="hello"
+    )
+
+    assert isinstance(config.agent, AgentInline)
+    assert config.agent.config_format == "nemo-agents-spec-v1"
+
+
+def test_job_config_still_rejects_a_malformed_agent_ref() -> None:
+    """The ref pattern moved into a validator; the string arm must keep enforcing it."""
+    with pytest.raises(ValueError, match="must be an entity name or a 'workspace/name' ref"):
+        ExecuteAgentJobConfig(agent="not a valid ref!", input="hello")
+
+
+@pytest.mark.asyncio
+async def test_to_spec_resolves_an_inline_agent_without_touching_the_entity_store() -> None:
+    entity_client = AsyncMock()
+
+    spec = await ExecuteAgentJob.to_spec(
+        ExecuteAgentJobConfig(
+            agent=AgentInline(config=_agent_config(), config_format="nemo-agents-spec-v1"), input="hello"
+        ),
+        workspace="research",
+        entity_client=entity_client,
+        async_sdk=_sdk_with_files(),
+        is_local=False,
+    )
+
+    step_config = ExecuteAgentStepConfig.model_validate(spec)
+    # Name comes from the config; the run is attributed to the job's workspace.
+    assert step_config.agent.name == "calc"
+    assert step_config.agent.workspace == "research"
+    assert step_config.agent.config_format == "nemo-agents-spec-v1"
+    entity_client.get.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_to_spec_snapshots_the_inline_config_like_an_entity_backed_one() -> None:
+    """Provenance parity: the resolved config is stored on the step either way."""
+    spec = await ExecuteAgentJob.to_spec(
+        ExecuteAgentJobConfig(
+            agent=AgentInline(config=_agent_config(), config_format="nemo-agents-spec-v1"), input="hello"
+        ),
+        workspace="default",
+        entity_client=AsyncMock(),
+        async_sdk=_sdk_with_files(),
+        is_local=False,
+    )
+
+    step_config = ExecuteAgentStepConfig.model_validate(spec)
+    assert (
+        step_config.agent.config["models"]["default"]["base_url"]
+        == "http://localhost:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_to_spec_rejects_a_malformed_inline_agent_config() -> None:
+    with pytest.raises(ValueError, match="Inline agent config is invalid"):
+        await ExecuteAgentJob.to_spec(
+            ExecuteAgentJobConfig(
+                agent=AgentInline(config={"config_format": "nemo-agents-spec-v1"}, config_format="nemo-agents-spec-v1"),
+                input="x",
+            ),
+            workspace="default",
+            entity_client=AsyncMock(),
+            async_sdk=_sdk_with_files(),
+            is_local=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_to_spec_rejects_a_non_fabric_inline_config_format() -> None:
+    with pytest.raises(ValueError, match="is not supported"):
+        await ExecuteAgentJob.to_spec(
+            ExecuteAgentJobConfig(
+                agent=AgentInline(config={"workflow": {}}, config_format="nat-workflow-v1"), input="x"
+            ),
+            workspace="default",
+            entity_client=AsyncMock(),
+            async_sdk=_sdk_with_files(),
+            is_local=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_to_spec_merges_an_environment_into_an_inline_agent() -> None:
+    """Inline configs go through the same environment merge as entity-backed ones."""
+    spec = await ExecuteAgentJob.to_spec(
+        ExecuteAgentJobConfig(
+            agent=AgentInline(config=_agent_config(), config_format="nemo-agents-spec-v1"),
+            input="hello",
+            environment=AgentEnvironmentInline(
+                environment_spec=EnvironmentSpecInline(env={"FEATURE_FLAG": "on"}),
+            ),
+        ),
+        workspace="default",
+        entity_client=AsyncMock(),
+        async_sdk=_sdk_with_files(),
+        is_local=False,
+    )
+
+    step_config = ExecuteAgentStepConfig.model_validate(spec)
+    assert step_config.agent.config["environment"]["env"]["FEATURE_FLAG"] == "on"
+
+
+def test_agent_inline_matches_the_agent_entity_shape() -> None:
+    """AgentInline is the Agent entity's fields without identity, so Agent inherits it."""
+    assert issubclass(Agent, AgentInline)
+    for field, info in AgentInline.model_fields.items():
+        entity_field = Agent.model_fields[field]
+        assert entity_field.is_required() == info.is_required(), field
+        assert entity_field.default == info.default, field
+
+
+def test_inline_agent_rejects_a_non_fabric_config_format_at_request_time() -> None:
+    """The narrowing lives on the job, not on the shared AgentInline model."""
+    with pytest.raises(ValueError, match="only support 'nemo-agents-spec-v1'"):
+        ExecuteAgentJobConfig(agent=AgentInline(config={"workflow": {}}), input="hello")
+
+
+def test_inline_agent_rejects_an_empty_config() -> None:
+    with pytest.raises(ValueError, match="require a non-empty config"):
+        ExecuteAgentJobConfig(agent=AgentInline(config={}, config_format="nemo-agents-spec-v1"), input="hello")
+
+
+def test_agent_entity_may_still_hold_a_nat_workflow_config() -> None:
+    """AgentInline stays permissive so the entity keeps its legacy default."""
+    entity = Agent(name="legacy", workspace="default", config={"workflow": {}})
+
+    assert entity.config_format == "nat-workflow-v1"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Adds support for passing an inline agent definition to the execution job, as an alternative to referencing an existing agent entity



## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [s] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Execute agent jobs now support inline agent configurations alongside saved agent references.
  - Added options for execution environments, evaluator prompt templates, LoRA training, deployment, privacy, and data settings.
- **Bug Fixes**
  - Improved validation for inline agents, malformed references, unsupported formats, and incomplete configurations.
  - Preserved compatibility with saved agents and legacy workflow entities.
- **Documentation**
  - Expanded CLI references with schema-derived flag guidance and clearer `--spec`/`--spec-file` limitations.
  - Improved command help for partially supported union-based options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->