### PR TITLE
feat(agents): allow fully-qualified fabric adapter id and multiple models

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/translator.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/translator.py
@@ -23,6 +23,14 @@ HARNESS_ADAPTER_IDS = {
     "hermes": "nvidia.fabric.hermes",
 }
 
+# A harness kind carrying this prefix is already a fully-qualified Fabric
+# adapter id and is passed through verbatim. Plugin-owned adapters ship their
+# own descriptor to <sys.prefix>/share/nemo-fabric/adapters/ and are resolved
+# there by Fabric at runtime, so nemo-agents does not need a short-name entry
+# for each one. A bad id therefore surfaces as a Fabric resolution error rather
+# than a translation error here.
+FABRIC_ADAPTER_ID_PREFIX = "nvidia.fabric."
+
 PLATFORM_RUNTIME_ENV_VARS = ("NEMO_BASE_URL", "NMP_BASE_URL", "NMP_WORKSPACE")
 
 
@@ -34,10 +42,10 @@ def translate_agent_config(config: AgentConfig, harness_name: str | None = None)
     """Translate Platform-owned agent config into a typed in-memory FabricConfig."""
     selected_harness_name, harness = _select_harness(config, harness_name)
     model = _resolve_model(config, selected_harness_name, harness)
-    model_payload = bind_platform_gateway_model_credential(_model_payload(model))
+    model_payloads = _model_payloads(config, model)
     runtime_env = {
         **_platform_runtime_env(),
-        **platform_gateway_credential_env({"models": {"default": model_payload}}),
+        **_gateway_credential_env(model_payloads),
     }
     _validate_untranslated_shared_fields(config)
 
@@ -48,9 +56,7 @@ def translate_agent_config(config: AgentConfig, harness_name: str | None = None)
             resolution="preinstalled",
             settings=harness.settings,
         ),
-        models={
-            "default": fabric.ModelConfig(**model_payload),
-        },
+        models={key: fabric.ModelConfig(**payload) for key, payload in model_payloads.items()},
         instructions=_instructions_config(config),
         runtime=fabric.RuntimeConfig(**config.runtime.model_dump(exclude_none=True)),
         environment=_environment_config(config, runtime_env),
@@ -110,10 +116,15 @@ def _select_harness(config: AgentConfig, harness_name: str | None) -> tuple[str,
 
 
 def _adapter_id_for_harness(harness: HarnessConfig) -> str:
+    if harness.kind.startswith(FABRIC_ADAPTER_ID_PREFIX):
+        return harness.kind
     adapter_id = HARNESS_ADAPTER_IDS.get(harness.kind)
     if adapter_id is None:
         available = ", ".join(sorted(HARNESS_ADAPTER_IDS))
-        raise FabricTranslationError(f"Unsupported harness kind {harness.kind!r}. Supported harness kinds: {available}")
+        raise FabricTranslationError(
+            f"Unsupported harness kind {harness.kind!r}. Supported harness kinds: {available}; "
+            f"or a fully-qualified Fabric adapter id starting with {FABRIC_ADAPTER_ID_PREFIX!r}."
+        )
     return adapter_id
 
 
@@ -127,6 +138,38 @@ def _resolve_model(config: AgentConfig, harness_name: str, harness: HarnessConfi
             f"Harness {harness_name!r} does not define a model and no models.default is configured."
         )
     return model
+
+
+def _model_payloads(config: AgentConfig, selected: ModelConfig) -> dict[str, dict[str, Any]]:
+    """Translate every configured model, keyed as the Platform config keys them.
+
+    ``FabricConfig.models`` and the adapter contract's ``AgentConfig.models`` are
+    both keyed maps, so the whole map is forwarded rather than just the harness's
+    primary model. An adapter that reads a secondary key (the Insights analyst
+    reads ``fast`` for context summarization) would otherwise see it silently
+    missing and fall back to ``default``.
+
+    ``selected`` is always published as ``default`` — that is the key adapters
+    treat as the primary model, and ``harness.model`` outranks ``models.default``
+    when both are set.
+    """
+    payloads = {
+        key: bind_platform_gateway_model_credential(_model_payload(model)) for key, model in config.models.items()
+    }
+    payloads["default"] = bind_platform_gateway_model_credential(_model_payload(selected))
+    return payloads
+
+
+def _gateway_credential_env(model_payloads: dict[str, dict[str, Any]]) -> dict[str, str]:
+    """Union the runtime-only IGW credential env over every forwarded model.
+
+    Each Platform-gateway-routed model needs its ``api_key_env`` present in the
+    child process, not just the primary one.
+    """
+    env: dict[str, str] = {}
+    for payload in model_payloads.values():
+        env.update(platform_gateway_credential_env({"models": {"default": payload}}))
+    return env
 
 
 def _model_payload(model: ModelConfig) -> dict[str, Any]:

--- a/plugins/nemo-agents/tests/unit/test_fabric_translator.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_translator.py
@@ -306,6 +306,83 @@ class TestTranslateAgentConfig:
         assert harness is not None
         assert harness.adapter_id == adapter_id
 
+    def test_every_configured_model_is_forwarded(self) -> None:
+        """FabricConfig.models is a keyed map; secondary keys must survive translation."""
+        payload = _example_yaml_config()
+        payload["models"]["fast"] = {"provider": "openai", "model": "openai/gpt-5.4-mini"}
+        payload["models"]["judge"] = {"provider": "openai", "model": "openai/gpt-5.4-judge"}
+        config = AgentConfig.model_validate(payload)
+
+        fabric_config = translate_agent_config(config)
+
+        assert set(fabric_config.models) == {"default", "fast", "judge"}
+        assert fabric_config.models["fast"].model == "openai/gpt-5.4-mini"
+        assert fabric_config.models["judge"].model == "openai/gpt-5.4-judge"
+
+    def test_selected_harness_model_is_published_as_default(self) -> None:
+        """harness.model outranks models.default, and lands on the "default" key."""
+        payload = _example_yaml_config()
+        payload["models"]["fast"] = {"provider": "openai", "model": "openai/gpt-5.4-mini"}
+        config = AgentConfig.model_validate(payload)
+
+        fabric_config = translate_agent_config(config)
+
+        # The hermes harness declares its own model; models.default is shadowed.
+        assert fabric_config.models["default"].model == "nvidia/nemotron-3-nano-30b-a3b"
+        assert fabric_config.models["fast"].model == "openai/gpt-5.4-mini"
+
+    def test_models_default_is_published_when_the_harness_declares_no_model(self) -> None:
+        payload = _example_yaml_config()
+        payload["default_harness"] = "codex"
+        payload["models"]["fast"] = {"provider": "openai", "model": "openai/gpt-5.4-mini"}
+        config = AgentConfig.model_validate(payload)
+
+        fabric_config = translate_agent_config(config)
+
+        assert fabric_config.models["default"].model == "openai/gpt-5.4"
+        assert fabric_config.models["fast"].model == "openai/gpt-5.4-mini"
+
+    def test_gateway_credential_bound_on_every_routed_model(self) -> None:
+        """A secondary IGW-routed model needs its api_key_env too, not just the primary."""
+        payload = _example_yaml_config()
+        payload["default_harness"] = "codex"
+        payload["models"]["fast"] = {
+            "provider": "openai",
+            "model": "openai/gpt-5.4-mini",
+            "base_url": "http://platform:8080/apis/inference-gateway/v2/workspaces/default/openai/-/v1",
+        }
+        config = AgentConfig.model_validate(payload)
+
+        fabric_config = translate_agent_config(config)
+
+        assert fabric_config.models["fast"].api_key_env == PLATFORM_IGW_API_KEY_ENV
+        assert fabric_config.environment is not None
+        assert fabric_config.environment.env[PLATFORM_IGW_API_KEY_ENV] == PLATFORM_IGW_API_KEY_PLACEHOLDER
+
+    def test_non_routed_secondary_model_is_left_uncredentialed(self) -> None:
+        payload = _example_yaml_config()
+        payload["default_harness"] = "codex"
+        payload["models"]["fast"] = {
+            "provider": "nvidia",
+            "model": "nvidia/nemotron-3-nano-30b-a3b",
+            "base_url": "https://integrate.api.nvidia.com/v1",
+        }
+        config = AgentConfig.model_validate(payload)
+
+        fabric_config = translate_agent_config(config)
+
+        assert fabric_config.models["fast"].api_key_env is None
+
+    def test_harness_only_model_still_translates_without_a_models_map(self) -> None:
+        payload = _example_yaml_config()
+        payload["models"] = {}
+        config = AgentConfig.model_validate(payload)
+
+        fabric_config = translate_agent_config(config)
+
+        assert set(fabric_config.models) == {"default"}
+        assert fabric_config.models["default"].model == "nvidia/nemotron-3-nano-30b-a3b"
+
     def test_unknown_selected_harness_rejected(self) -> None:
         config = AgentConfig.model_validate(_example_yaml_config())
 
@@ -319,6 +396,34 @@ class TestTranslateAgentConfig:
         config = AgentConfig.model_validate(payload)
 
         with pytest.raises(FabricTranslationError, match="Unsupported harness kind 'custom'"):
+            translate_agent_config(config)
+
+    @pytest.mark.parametrize(
+        "adapter_id",
+        [
+            "nvidia.fabric.insights-analyst",
+            "nvidia.fabric.some.future.adapter",
+        ],
+    )
+    def test_fully_qualified_adapter_id_passes_through(self, adapter_id: str) -> None:
+        """Plugin-owned adapters ship their own descriptor, so no short-name entry is needed."""
+        payload = _example_yaml_config()
+        payload["default_harness"] = "selected"
+        payload["harnesses"] = {"selected": {"kind": adapter_id}}
+        config = AgentConfig.model_validate(payload)
+
+        fabric_config = translate_agent_config(config)
+
+        assert fabric_config.harness is not None
+        assert fabric_config.harness.adapter_id == adapter_id
+
+    def test_adapter_id_passthrough_requires_the_nvidia_fabric_prefix(self) -> None:
+        payload = _example_yaml_config()
+        payload["default_harness"] = "selected"
+        payload["harnesses"] = {"selected": {"kind": "acme.fabric.custom"}}
+        config = AgentConfig.model_validate(payload)
+
+        with pytest.raises(FabricTranslationError, match="Unsupported harness kind 'acme.fabric.custom'"):
             translate_agent_config(config)
 
     def test_missing_model_rejected(self) -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
- Allow fully-qualified Fabric adapter ids to pass through without needing to be "pre-registered" in the agents service
- Support multiple models in the agent config, not just one


## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fully qualified Fabric adapter IDs.
  * Models configured for Fabric are now forwarded more consistently, including multiple models and selected-model defaults.
  * Gateway credentials are automatically applied to routed models.

* **Bug Fixes**
  * Improved model selection and fallback behavior.
  * Non-NVIDIA Fabric adapter IDs are rejected appropriately.
  * Models without routing requirements remain uncredentialed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->