### PR TITLE
test(eval-author): cover rho agent audit demo flow

### DIFF
--- a/plugins/nemo-eval-author/tests/integration/test_discover_real_repos.py
+++ b/plugins/nemo-eval-author/tests/integration/test_discover_real_repos.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration coverage for real-shaped Eval Author fixture repositories."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+_DISCOVER = _PLUGIN_ROOT / "skills" / "eval-author-discover" / "scripts" / "discover.py"
+_AUDIT_SPEC = _PLUGIN_ROOT / "skills" / "eval-author-audit" / "scripts" / "audit_spec"
+_AUDIT_GENERATE = _AUDIT_SPEC / "generate.py"
+_AUDIT_VALIDATE = _AUDIT_SPEC / "validate.py"
+_AUDIT_MEASURE = _AUDIT_SPEC / "measure.py"
+_AUDIT_REPORT = _AUDIT_SPEC / "report.py"
+
+
+def _fixtures_root() -> Path:
+    value = os.environ.get("EVAL_AUTHOR_FIXTURES_ROOT")
+    if not value:
+        pytest.skip("set EVAL_AUTHOR_FIXTURES_ROOT to the nemo-eval-author-fixtures checkout")
+    root = Path(value)
+    if not root.is_dir():
+        pytest.skip(f"EVAL_AUTHOR_FIXTURES_ROOT is not a directory: {root}")
+    return root
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(["docker", "info"], capture_output=True, check=False).returncode == 0
+
+
+def _load_cases(root: Path) -> list[dict[str, Any]]:
+    manifest = root / "cases.yaml"
+    if not manifest.is_file():
+        pytest.skip(f"fixture manifest does not exist: {manifest}")
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    return payload["cases"]
+
+
+def _run_discover(repo: Path, *, pythonpath_repo: bool) -> tuple[int, dict[str, Any]]:
+    env = os.environ.copy()
+    if pythonpath_repo:
+        env["PYTHONPATH"] = str(repo) if not env.get("PYTHONPATH") else f"{repo}{os.pathsep}{env['PYTHONPATH']}"
+    result = subprocess.run(
+        [sys.executable, str(_DISCOVER), "--repo", str(repo), "--compact"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.stdout, f"discover.py printed nothing for {repo}; stderr:\n{result.stderr}"
+    return result.returncode, json.loads(result.stdout)
+
+
+def _run_json_script(script: Path, *args: str) -> tuple[int, dict[str, Any], str]:
+    result = subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.stdout, f"{script.name} printed nothing; stderr:\n{result.stderr}"
+    return result.returncode, json.loads(result.stdout), result.stderr
+
+
+def _case_by_name(root: Path, name: str) -> dict[str, Any]:
+    for case in _load_cases(root):
+        if case["name"] == name:
+            return case
+    pytest.fail(f"fixture case is missing from cases.yaml: {name}")
+
+
+def _copy_case_repo(root: Path, name: str, destination: Path) -> Path:
+    repo = destination / name
+    shutil.copytree(root / "cases" / name / "repo", repo)
+    return repo
+
+
+def _checks_by_name(report: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {check["name"]: check for check in report["checks"]}
+
+
+def _measure_frozen_trials_and_report(
+    *,
+    audit: Path,
+    trial_root: Path,
+    measurement_dir: Path,
+    report_path: Path,
+) -> dict[str, Any]:
+    trial_dirs = sorted(path for path in trial_root.iterdir() if path.is_dir())
+    assert trial_dirs, f"no frozen Harbor trial directories under {trial_root}"
+    for trial_dir in trial_dirs:
+        measure_code, measure_summary, measure_stderr = _run_json_script(
+            _AUDIT_MEASURE,
+            "--audit",
+            str(audit),
+            "--trial-dir",
+            str(trial_dir),
+            "--out-dir",
+            str(measurement_dir),
+        )
+        assert measure_code == 0, measure_stderr or measure_summary
+
+    report_code, report_summary, report_stderr = _run_json_script(
+        _AUDIT_REPORT,
+        "--audit",
+        str(audit),
+        "--coverage-dir",
+        str(measurement_dir),
+        "--out",
+        str(report_path),
+    )
+
+    assert report_code == 0, report_stderr or report_summary
+    return report_summary
+
+
+def test_discover_fixture_corpus_matches_manifest_expectations(tmp_path: Path) -> None:
+    if find_spec("harbor") is None:
+        pytest.skip("Harbor is not installed")
+    if not _docker_available():
+        pytest.skip("Docker daemon is required for fixture backend validation")
+
+    root = _fixtures_root()
+    for case in _load_cases(root):
+        expected = case["expected"]
+        repo = _copy_case_repo(root, case["name"], tmp_path / "discover")
+
+        code, report = _run_discover(repo, pythonpath_repo=bool(expected.get("pythonpath_repo")))
+
+        assert code == expected["exit_code"], case["name"]
+        assert report["proven"] is True, case["name"]
+        assert report["runnable"] is expected["runnable"], case["name"]
+        assert sorted(report["dataset_paths"]) == sorted(expected["dataset_paths"]), case["name"]
+
+        checks = _checks_by_name(report)
+        for check_name in expected["required_check_names_pass"]:
+            assert checks[check_name]["status"] == "pass", f"{case['name']}:{check_name}"
+
+        configs_by_path = {config["path"]: config for config in report["configs"]}
+        for expected_config in expected["configs"]:
+            config = configs_by_path[expected_config["path"]]
+            assert config["name"] == expected_config["name"], case["name"]
+            assert config["runnable"] is expected_config["runnable"], case["name"]
+            assert expected_config["run_command_contains"] in report["run_command"], case["name"]
+
+
+def test_rho_agent_frozen_audit_measurement_matches_manifest_expectations(tmp_path: Path) -> None:
+    if find_spec("harbor") is None:
+        pytest.skip("Harbor is not installed")
+
+    root = _fixtures_root()
+    case = _case_by_name(root, "rho-agent")
+    expected = case["expected"]["audit_measurement"]
+    case_root = _copy_case_repo(root, "rho-agent", tmp_path / "audit")
+    audit = case_root / ".eval-author" / "audit.md"
+    trial_root = case_root / expected["frozen_trial_dir"]
+    assert trial_root.is_dir()
+
+    validate_code, validate_summary, validate_stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+    assert validate_code == 0, validate_stderr or validate_summary
+    assert validate_summary["valid"] is True
+
+    report_summary = _measure_frozen_trials_and_report(
+        audit=audit,
+        trial_root=trial_root,
+        measurement_dir=tmp_path / "audit-measurements",
+        report_path=tmp_path / "audit-coverage-report.json",
+    )
+
+    assert report_summary["measured_kinds"] == [expected["measured_kind"]]
+    assert report_summary["covered_count"] == expected["covered_count"]
+    assert report_summary["uncovered_count"] == expected["uncovered_count"]
+
+
+def test_rho_agent_demo_ready_generates_audit_and_coverage_from_frozen_traces(tmp_path: Path) -> None:
+    if find_spec("harbor") is None:
+        pytest.skip("Harbor is not installed")
+
+    root = _fixtures_root()
+    case = _case_by_name(root, "rho-agent-demo-ready")
+    expected = case["expected"]["audit_bootstrap"]
+    case_root = _copy_case_repo(root, "rho-agent-demo-ready", tmp_path / "demo")
+    audit_dir = case_root / ".eval-author"
+    audit = case_root / expected["audit_path"]
+    items = audit_dir / "audit-items.yaml"
+    trial_root = case_root / expected["frozen_trial_dir"]
+    report_path = tmp_path / "demo-audit-coverage-report.json"
+
+    assert (case_root / expected["ethos_path"]).is_file()
+    assert trial_root.is_dir()
+    assert not audit.exists()
+    assert not items.exists()
+
+    shutil.copyfile(root / expected["reference_items_path"], items)
+
+    generate_code, generate_summary, generate_stderr = _run_json_script(
+        _AUDIT_GENERATE,
+        "--ethos",
+        str(case_root / expected["ethos_path"]),
+        "--items",
+        str(items),
+        "--items-mode",
+        "full",
+        "--out",
+        str(audit),
+    )
+    assert generate_code == 0, generate_stderr or generate_summary
+    assert generate_summary["written"] is True
+    assert generate_summary["action"] == "create"
+    assert audit.is_file()
+
+    validate_code, validate_summary, validate_stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+    assert validate_code == 0, validate_stderr or validate_summary
+    assert validate_summary["valid"] is True
+
+    report_summary = _measure_frozen_trials_and_report(
+        audit=audit,
+        trial_root=trial_root,
+        measurement_dir=tmp_path / "demo-audit-measurements",
+        report_path=report_path,
+    )
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report_summary["measured_kinds"] == [expected["measured_kind"]]
+    assert report_summary["covered_count"] == expected["covered_count"]
+    assert report_summary["uncovered_count"] == expected["uncovered_count"]
+    assert report["uncovered_items"]
+    assert all(gap["generation"]["focus"] for gap in report["uncovered_items"])
+    assert all("needed_tools" in gap["generation"] for gap in report["uncovered_items"])
+    assert all("evidence_required" in gap["generation"] for gap in report["uncovered_items"])

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -1383,6 +1383,97 @@ def test_audit_generate_replace_mode_overwrites_existing_audit(tmp_path: Path) -
 
 
 @_needs_harbor
+def test_audit_flow_generates_validates_measures_and_reports_tool_coverage(tmp_path: Path) -> None:
+    ethos = tmp_path / "ETHOS.md"
+    ethos.write_text(
+        "---\nname: support-agent\n---\n"
+        "# Ethos\n\n"
+        "Use customer.lookup before account recovery and ticket.create for human escalation.\n",
+        encoding="utf-8",
+    )
+    audit_dir = tmp_path / ".eval-author"
+    items = audit_dir / "audit-items.yaml"
+    audit = audit_dir / "audit.md"
+    measurements = audit_dir / "audit-measurements"
+    coverage_report = audit_dir / "audit-coverage-report.json"
+    audit_items = [*_template_payload()["items"], _ticket_tool_item()]
+    audit_dir.mkdir()
+    _write_audit_items(items, audit_items)
+
+    generate = _run_script(
+        _AUDIT_GENERATE,
+        "--ethos",
+        str(ethos),
+        "--items",
+        str(items),
+        "--out",
+        str(audit),
+    )
+    assert generate.returncode == 0, generate.stderr
+    generate_summary = json.loads(generate.stdout)
+    assert generate_summary["written"] is True
+    assert generate_summary["action"] == "create"
+
+    validate_code, validate_summary, validate_stderr = _run_json_script(_AUDIT_VALIDATE, "--audit", str(audit))
+    assert validate_code == 0, validate_stderr or validate_summary
+    assert validate_summary["valid"] is True
+
+    trial_specs = [
+        ("support-account-recovery__lookup", "support/account-recovery", "lookup-run", ["customer.lookup"]),
+        ("support-account-recovery__ticket", "support/account-recovery", "ticket-run", ["ticket.create"]),
+    ]
+    coverage_paths: list[Path] = []
+    for trial_dir_name, task_name, run_name, tool_names in trial_specs:
+        trial_dir = tmp_path / "harbor-job" / trial_dir_name
+        _write_atif_trace(trial_dir / "agent" / "trajectory.json", tool_calls=tool_names)
+        (trial_dir / "result.json").write_text(
+            json.dumps({"task_name": task_name, "trial_name": run_name}),
+            encoding="utf-8",
+        )
+
+        measure_code, measure_summary, measure_stderr = _run_json_script(
+            _AUDIT_MEASURE,
+            "--audit",
+            str(audit),
+            "--trial-dir",
+            str(trial_dir),
+            "--out-dir",
+            str(measurements),
+        )
+
+        assert measure_code == 0, measure_stderr or measure_summary
+        assert measure_summary["task_id"] == task_name
+        assert measure_summary["run_id"] == run_name
+        coverage_paths.append(Path(measure_summary["measurements"][0]["coverage"]))
+
+    report_code, report_summary, report_stderr = _run_json_script(
+        _AUDIT_REPORT,
+        "--audit",
+        str(audit),
+        "--coverage-dir",
+        str(measurements),
+        "--out",
+        str(coverage_report),
+    )
+
+    report = json.loads(coverage_report.read_text(encoding="utf-8"))
+    gaps_by_name = {item["name"]: item for item in report["uncovered_items"]}
+
+    assert report_code == 0, report_stderr or report_summary
+    assert report_summary["coverage_input_count"] == 2
+    assert report_summary["measured_kinds"] == ["tool"]
+    assert report_summary["covered_count"] == 2
+    assert report_summary["uncovered"] == ["account_recovery", "account_recovery_unverified_identity"]
+    assert report["covered"] == ["customer.lookup", "ticket.create"]
+    assert report["coverage"]["by_kind"]["tool"] == {"item_count": 2, "covered_count": 2, "uncovered_count": 0}
+    assert report["coverage"]["by_kind"]["capability"]["uncovered_count"] == 1
+    assert report["coverage"]["by_kind"]["failure_case"]["uncovered_count"] == 1
+    assert {Path(input_report["path"]) for input_report in report["input_reports"]} == set(coverage_paths)
+    assert gaps_by_name["account_recovery"]["reason"] == "not_measured_by_any_method"
+    assert gaps_by_name["account_recovery_unverified_identity"]["reason"] == "not_measured_by_any_method"
+
+
+@_needs_harbor
 def test_audit_measure_reports_tool_call_coverage_from_atif_trace(tmp_path: Path) -> None:
     audit = _write_audit(tmp_path)
     trace = tmp_path / "trajectory.json"


### PR DESCRIPTION
## Summary

Adds regression coverage for the rho-agent Eval Author audit demo flow. The new integration test consumes the fixture corpus from NVIDIA-dev/nemo-eval-author-fixtures#4 and proves a demo-ready repo can start without `audit.md`, generate the audit spec, validate it, measure frozen Harbor-style traces, and aggregate coverage.

## Changes

- Add a fixture-backed integration test for the real-shaped `rho-agent` and `rho-agent-demo-ready` cases.
- Add a shared integration helper for measuring all frozen trials and aggregating coverage.
- Add a synthetic contract test that exercises generate -> validate -> measure -> report for tool-call coverage.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: this PR adds tests only; demo run documentation lives in the fixture PR.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `EVAL_AUTHOR_FIXTURES_ROOT=/Users/mstaats/git-repos/nemo-eval-author-fixtures/nemo-eval-author-fixtures uv run --project plugins/nemo-eval-author --with pytest --with pyyaml --with jsonschema --with 'harbor==0.20.0' --with 'litellm==1.83.14' pytest plugins/nemo-eval-author/tests/integration/test_discover_real_repos.py -q` -> `2 passed, 1 skipped`
- `EVAL_AUTHOR_FIXTURES_ROOT=/Users/mstaats/git-repos/nemo-eval-author-fixtures/nemo-eval-author-fixtures uv run --project plugins/nemo-eval-author --with pytest --with pyyaml --with jsonschema --with 'harbor==0.20.0' --with 'litellm==1.83.14' pytest plugins/nemo-eval-author/tests -q` -> `106 passed, 2 skipped`
- `uv run --project plugins/nemo-eval-author --with pytest --with pyyaml --with jsonschema pytest plugins/nemo-eval-author/tests -q` -> `91 passed, 17 skipped`
- `uv run --project plugins/nemo-eval-author --with ruff ruff check plugins/nemo-eval-author/tests/integration/test_discover_real_repos.py plugins/nemo-eval-author/tests/test_skill_contract.py` -> passed
- `uv run --project plugins/nemo-eval-author --with ruff ruff format --check plugins/nemo-eval-author/tests/integration/test_discover_real_repos.py plugins/nemo-eval-author/tests/test_skill_contract.py` -> passed
- Manual temp rehearsal against `rho-agent-demo-ready` generated `audit.md`, measured 4 frozen traces, and aggregated `covered_count: 14`, `uncovered_count: 14`.
- `uv run pre-commit run -a` -> blocked before hooks ran: root dependency setup failed building `litellm==1.95.0` via maturin/cargo because this host has `rustc 1.93.1` and transitive AWS Rust crates require `rustc 1.94.1`.

Notes:

- The skipped fixture integration check is Docker-backed Harbor discover validation; Docker daemon is unavailable on the local host used for validation.
- This PR depends on the fixture data in NVIDIA-dev/nemo-eval-author-fixtures#4.
