### PR TITLE
feat(eval-author): add audit coverage report viewer

### DIFF
--- a/plugins/nemo-eval-author/ui/README.md
+++ b/plugins/nemo-eval-author/ui/README.md
@@ -1,0 +1,19 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# Eval Author Coverage Report UI
+
+A small standalone viewer for `.eval-author/audit-coverage-report.json`.
+
+Open `index.html` directly in a browser, then paste or open an aggregate report
+with schema `nemo.eval_author.audit_coverage_report.v1`.
+
+The viewer shows:
+
+- overall and per-kind coverage
+- measured input reports and warnings
+- every uncovered audit item
+- actionable uncovered tool gaps for the task-creation flow proposed in
+  NVIDIA-NeMo/nemo-platform#1576
+
+The UI does not execute commands, edit files, or call NeMo services.

--- a/plugins/nemo-eval-author/ui/README.md
+++ b/plugins/nemo-eval-author/ui/README.md
@@ -11,7 +11,6 @@ with schema `nemo.eval_author.audit_coverage_report.v1`.
 The viewer shows:
 
 - overall and per-kind coverage
-- measured input reports and warnings
 - every uncovered audit item
 - actionable uncovered tool gaps for the task-creation flow proposed in
   NVIDIA-NeMo/nemo-platform#1576

--- a/plugins/nemo-eval-author/ui/app.js
+++ b/plugins/nemo-eval-author/ui/app.js
@@ -121,6 +121,7 @@ const els = {
   dashboard: document.querySelector("#dashboard"),
   agent: document.querySelector("#agent-name"),
   percent: document.querySelector("#coverage-percent"),
+  coverageDetail: document.querySelector("#coverage-detail"),
   actionableCount: document.querySelector("#actionable-count"),
   measuredKinds: document.querySelector("#measured-kinds"),
   kindBars: document.querySelector("#kind-bars"),
@@ -150,11 +151,25 @@ function parseReport(text) {
   return report;
 }
 
-function percent(summary) {
-  if (!summary?.item_count) {
+function coveragePercent(summary) {
+  const itemCount = Number(summary?.item_count || 0);
+  const coveredCount = Number(summary?.covered_count || 0);
+  if (!itemCount) {
     return 0;
   }
-  return Math.round((summary.covered_count / summary.item_count) * 100);
+  return Math.max(0, Math.min(100, Math.round((coveredCount / itemCount) * 100)));
+}
+
+function coverageLabel(summary) {
+  const itemCount = Number(summary?.item_count || 0);
+  const coveredCount = Number(summary?.covered_count || 0);
+  if (!itemCount) {
+    return { detail: "0 denominator items", percent: "n/a" };
+  }
+  return {
+    detail: `${coveredCount} of ${itemCount} audit items`,
+    percent: `${coveragePercent(summary)}%`,
+  };
 }
 
 function taskSlugForTool(toolName) {
@@ -224,7 +239,7 @@ function renderKindBars(report) {
   els.kindBars.innerHTML = kinds
     .map((kind) => {
       const summary = report.coverage?.by_kind?.[kind] || { item_count: 0, covered_count: 0, uncovered_count: 0 };
-      const value = percent(summary);
+      const value = coveragePercent(summary);
       return `
         <div class="kind-row">
           <strong>${escapeHtml(kind.replace("_", " "))}</strong>
@@ -305,6 +320,7 @@ function setInputCollapsed(collapsed) {
 
 function renderReport(report, { collapseInput = false } = {}) {
   const overall = report.coverage?.overall || { item_count: 0, covered_count: 0, uncovered_count: 0 };
+  const coverage = coverageLabel(overall);
   const gaps = actionableTools(report);
   els.dashboard.hidden = false;
   els.message.className = "message";
@@ -313,7 +329,8 @@ function renderReport(report, { collapseInput = false } = {}) {
     setInputCollapsed(true);
   }
   els.agent.textContent = report.audit?.agent || "unknown";
-  els.percent.textContent = `${percent(overall)}%`;
+  els.percent.textContent = coverage.percent;
+  els.coverageDetail.textContent = coverage.detail;
   els.actionableCount.textContent = gaps.length;
   els.measuredKinds.textContent = `measured: ${(report.measured_kinds || []).join(", ") || "none"}`;
   renderKindBars(report);

--- a/plugins/nemo-eval-author/ui/app.js
+++ b/plugins/nemo-eval-author/ui/app.js
@@ -121,14 +121,11 @@ const els = {
   agent: document.querySelector("#agent-name"),
   percent: document.querySelector("#coverage-percent"),
   actionableCount: document.querySelector("#actionable-count"),
-  inputCount: document.querySelector("#input-count"),
   measuredKinds: document.querySelector("#measured-kinds"),
   kindBars: document.querySelector("#kind-bars"),
   actionableGaps: document.querySelector("#actionable-gaps"),
   uncoveredCount: document.querySelector("#uncovered-count"),
   uncoveredItems: document.querySelector("#uncovered-items"),
-  inputsAndWarnings: document.querySelector("#inputs-and-warnings"),
-  copySelect: document.querySelector("#copy-select-command"),
 };
 
 let currentReport = null;
@@ -298,55 +295,26 @@ function renderUncoveredItems(report) {
     .join("");
 }
 
-function renderInputsAndWarnings(report) {
-  const inputs = report.input_reports || [];
-  const warnings = report.warnings || [];
-  const inputCards = inputs.length
-    ? inputs
-        .map(
-          (input) => `
-            <article class="info-card">
-              <p><strong>${escapeHtml(input.subject?.task_id || "unknown task")}</strong> / ${escapeHtml(
-                input.subject?.run_id || "unknown run",
-              )}</p>
-              <p>${escapeHtml(input.method)} covered ${escapeHtml(input.covered_count)} ${escapeHtml(
-                input.item_kind,
-              )} item(s).</p>
-              <pre>${escapeHtml(input.path)}</pre>
-            </article>
-          `,
-        )
-        .join("")
-    : '<article class="info-card"><p>No input reports recorded.</p></article>';
-  const warningCards = warnings.length
-    ? warnings.map((warning) => `<article class="info-card"><pre>${escapeHtml(JSON.stringify(warning, null, 2))}</pre></article>`).join("")
-    : '<article class="info-card"><p>No warnings.</p></article>';
-  els.inputsAndWarnings.innerHTML = `<div>${inputCards}</div><div>${warningCards}</div>`;
-}
-
 function renderReport(report) {
   currentReport = report;
   const overall = report.coverage?.overall || { item_count: 0, covered_count: 0, uncovered_count: 0 };
   const gaps = actionableTools(report);
   els.dashboard.hidden = false;
   els.message.className = "message";
-  els.message.textContent = `${report.audit?.path || "audit.md"} is ${report.audit?.status || "unknown"} for ${
-    report.audit?.agent || "unknown agent"
-  }.`;
+  els.message.hidden = true;
   els.agent.textContent = report.audit?.agent || "unknown";
   els.percent.textContent = `${percent(overall)}%`;
   els.actionableCount.textContent = gaps.length;
-  els.inputCount.textContent = report.input_reports?.length || 0;
   els.measuredKinds.textContent = `measured: ${(report.measured_kinds || []).join(", ") || "none"}`;
   renderKindBars(report);
   renderActionableGaps(gaps);
   renderUncoveredItems(report);
-  renderInputsAndWarnings(report);
 }
 
 function renderError(message) {
   currentReport = null;
   els.dashboard.hidden = true;
+  els.message.hidden = false;
   els.message.className = "message error";
   els.message.textContent = message;
 }
@@ -356,6 +324,7 @@ function renderFromInput() {
   if (!text) {
     currentReport = null;
     els.dashboard.hidden = true;
+    els.message.hidden = false;
     els.message.className = "message";
     els.message.textContent = `Paste or open a ${REPORT_SCHEMA} JSON report.`;
     return;
@@ -365,22 +334,6 @@ function renderFromInput() {
   } catch (error) {
     renderError(error instanceof Error ? error.message : "Could not parse report.");
   }
-}
-
-async function copySelectCommand() {
-  const gaps = currentReport ? actionableTools(currentReport) : [];
-  const command = [
-    "uv run skills/eval-author-task-create/scripts/task_pipeline.py select \\",
-    "  --report .eval-author/audit-coverage-report.json",
-  ].join("\n");
-  const text = gaps.length
-    ? `${command}\n\n# ${gaps.length} actionable tool gap(s): ${gaps.map((gap) => gap.name).join(", ")}`
-    : command;
-  await navigator.clipboard.writeText(text);
-  els.copySelect.textContent = "Copied";
-  window.setTimeout(() => {
-    els.copySelect.textContent = "Copy select command";
-  }, 1200);
 }
 
 els.input.addEventListener("input", renderFromInput);
@@ -396,6 +349,4 @@ els.file.addEventListener("change", async () => {
   els.input.value = await file.text();
   renderFromInput();
 });
-els.copySelect.addEventListener("click", copySelectCommand);
-
 renderFromInput();

--- a/plugins/nemo-eval-author/ui/app.js
+++ b/plugins/nemo-eval-author/ui/app.js
@@ -115,6 +115,7 @@ const sampleReport = {
 const els = {
   file: document.querySelector("#file-input"),
   input: document.querySelector("#report-input"),
+  toggleInput: document.querySelector("#toggle-input"),
   sample: document.querySelector("#sample-button"),
   message: document.querySelector("#message"),
   dashboard: document.querySelector("#dashboard"),
@@ -128,7 +129,7 @@ const els = {
   uncoveredItems: document.querySelector("#uncovered-items"),
 };
 
-let currentReport = null;
+let inputCollapsed = false;
 
 function escapeHtml(value) {
   return String(value ?? "")
@@ -295,13 +296,22 @@ function renderUncoveredItems(report) {
     .join("");
 }
 
-function renderReport(report) {
-  currentReport = report;
+function setInputCollapsed(collapsed) {
+  inputCollapsed = collapsed;
+  els.input.hidden = collapsed;
+  els.toggleInput.textContent = collapsed ? "Show JSON" : "Hide JSON";
+  els.toggleInput.setAttribute("aria-expanded", String(!collapsed));
+}
+
+function renderReport(report, { collapseInput = false } = {}) {
   const overall = report.coverage?.overall || { item_count: 0, covered_count: 0, uncovered_count: 0 };
   const gaps = actionableTools(report);
   els.dashboard.hidden = false;
   els.message.className = "message";
   els.message.hidden = true;
+  if (collapseInput) {
+    setInputCollapsed(true);
+  }
   els.agent.textContent = report.audit?.agent || "unknown";
   els.percent.textContent = `${percent(overall)}%`;
   els.actionableCount.textContent = gaps.length;
@@ -312,34 +322,37 @@ function renderReport(report) {
 }
 
 function renderError(message) {
-  currentReport = null;
   els.dashboard.hidden = true;
   els.message.hidden = false;
   els.message.className = "message error";
   els.message.textContent = message;
+  setInputCollapsed(false);
 }
 
-function renderFromInput() {
+function renderFromInput(options = {}) {
   const text = els.input.value.trim();
   if (!text) {
-    currentReport = null;
     els.dashboard.hidden = true;
     els.message.hidden = false;
     els.message.className = "message";
     els.message.textContent = `Paste or open a ${REPORT_SCHEMA} JSON report.`;
+    setInputCollapsed(false);
     return;
   }
   try {
-    renderReport(parseReport(text));
+    renderReport(parseReport(text), options);
   } catch (error) {
     renderError(error instanceof Error ? error.message : "Could not parse report.");
   }
 }
 
 els.input.addEventListener("input", renderFromInput);
+els.toggleInput.addEventListener("click", () => {
+  setInputCollapsed(!inputCollapsed);
+});
 els.sample.addEventListener("click", () => {
   els.input.value = JSON.stringify(sampleReport, null, 2);
-  renderFromInput();
+  renderFromInput({ collapseInput: true });
 });
 els.file.addEventListener("change", async () => {
   const [file] = els.file.files;
@@ -347,6 +360,6 @@ els.file.addEventListener("change", async () => {
     return;
   }
   els.input.value = await file.text();
-  renderFromInput();
+  renderFromInput({ collapseInput: true });
 });
 renderFromInput();

--- a/plugins/nemo-eval-author/ui/app.js
+++ b/plugins/nemo-eval-author/ui/app.js
@@ -1,0 +1,401 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const REPORT_SCHEMA = "nemo.eval_author.audit_coverage_report.v1";
+const ACTIONABLE_REASON = "not_covered_by_any_input_report";
+
+const sampleReport = {
+  schema: REPORT_SCHEMA,
+  audit: {
+    path: ".eval-author/audit.md",
+    schema: "nemo.eval_author.audit.v1",
+    agent: "support-agent",
+    status: "draft",
+    item_count: 5,
+    item_counts: { capability: 1, failure_case: 1, tool: 3 },
+  },
+  measured_kinds: ["tool"],
+  warnings: [],
+  input_reports: [
+    {
+      path: ".eval-author/audit-measurements/task=account-recovery/run=trial-001/tool_calls/coverage.json",
+      method: "tool_calls",
+      item_kind: "tool",
+      item_kind_count: 3,
+      subject: {
+        trace: ".harbor/runs/account-recovery/trials/trial-001/agent/trajectory.json",
+        trace_format: "atif",
+        task_id: "account-recovery",
+        run_id: "trial-001",
+      },
+      covered: ["customer.lookup"],
+      covered_count: 1,
+    },
+    {
+      path: ".eval-author/audit-measurements/task=escalation/run=trial-002/tool_calls/coverage.json",
+      method: "tool_calls",
+      item_kind: "tool",
+      item_kind_count: 3,
+      subject: {
+        trace: ".harbor/runs/escalation/trials/trial-002/agent/trajectory.json",
+        trace_format: "atif",
+        task_id: "escalation",
+        run_id: "trial-002",
+      },
+      covered: ["ticket.create"],
+      covered_count: 1,
+    },
+  ],
+  coverage: {
+    overall: { item_count: 5, covered_count: 2, uncovered_count: 3 },
+    by_kind: {
+      capability: { item_count: 1, covered_count: 0, uncovered_count: 1 },
+      failure_case: { item_count: 1, covered_count: 0, uncovered_count: 1 },
+      tool: { item_count: 3, covered_count: 2, uncovered_count: 1 },
+    },
+  },
+  covered: ["customer.lookup", "ticket.create"],
+  uncovered: ["password.reset", "account_recovery", "account_recovery_unverified_identity"],
+  uncovered_items: [
+    {
+      name: "password.reset",
+      kind: "tool",
+      reason: ACTIONABLE_REASON,
+      description: "Resets a verified customer's password.",
+      source_refs: ["ethos:Tools"],
+      generation: {
+        focus:
+          "Exercise a scenario where the agent should call password.reset: Used after identity is verified and the user requests password recovery.",
+        needed_tools: ["password.reset"],
+        evidence_required: [
+          {
+            kind: "tool_call",
+            tool: "password.reset",
+            description: "Trace shows a password.reset call after verification.",
+          },
+        ],
+      },
+      audit_item: {
+        kind: "tool",
+        name: "password.reset",
+        expected_use: "Used after identity is verified and the user requests password recovery.",
+      },
+    },
+    {
+      name: "account_recovery",
+      kind: "capability",
+      reason: "not_measured_by_any_method",
+      description: "Helps a verified user regain account access.",
+      source_refs: ["ethos:Behavior"],
+      generation: {
+        focus:
+          "Exercise capability account_recovery: Verify identity, inspect the account, reset access, and summarize the outcome.",
+        needed_tools: ["customer.lookup", "password.reset"],
+        evidence_required: [{ kind: "outcome", description: "Final response explains the account recovery result." }],
+      },
+      audit_item: { kind: "capability", name: "account_recovery" },
+    },
+    {
+      name: "account_recovery_unverified_identity",
+      kind: "failure_case",
+      reason: "not_measured_by_any_method",
+      description: "Refuses to reset access when identity verification is missing.",
+      source_refs: ["ethos:Success Criteria"],
+      generation: {
+        focus:
+          "Exercise failure case account_recovery_unverified_identity by triggering missing verification details.",
+        needed_tools: ["customer.lookup"],
+        evidence_required: [{ kind: "policy_boundary", description: "Agent refuses reset without verification." }],
+      },
+      audit_item: { kind: "failure_case", name: "account_recovery_unverified_identity" },
+    },
+  ],
+};
+
+const els = {
+  file: document.querySelector("#file-input"),
+  input: document.querySelector("#report-input"),
+  sample: document.querySelector("#sample-button"),
+  message: document.querySelector("#message"),
+  dashboard: document.querySelector("#dashboard"),
+  agent: document.querySelector("#agent-name"),
+  percent: document.querySelector("#coverage-percent"),
+  actionableCount: document.querySelector("#actionable-count"),
+  inputCount: document.querySelector("#input-count"),
+  measuredKinds: document.querySelector("#measured-kinds"),
+  kindBars: document.querySelector("#kind-bars"),
+  actionableGaps: document.querySelector("#actionable-gaps"),
+  uncoveredCount: document.querySelector("#uncovered-count"),
+  uncoveredItems: document.querySelector("#uncovered-items"),
+  inputsAndWarnings: document.querySelector("#inputs-and-warnings"),
+  copySelect: document.querySelector("#copy-select-command"),
+};
+
+let currentReport = null;
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+function parseReport(text) {
+  const report = JSON.parse(text);
+  if (!report || typeof report !== "object" || Array.isArray(report)) {
+    throw new Error("Expected one JSON object.");
+  }
+  if (report.schema !== REPORT_SCHEMA) {
+    throw new Error(`Expected schema ${REPORT_SCHEMA}.`);
+  }
+  return report;
+}
+
+function percent(summary) {
+  if (!summary?.item_count) {
+    return 0;
+  }
+  return Math.round((summary.covered_count / summary.item_count) * 100);
+}
+
+function taskSlugForTool(toolName) {
+  let slugBody = String(toolName || "")
+    .trim()
+    .replaceAll(".", "-")
+    .replaceAll(":", "-")
+    .replace(/[^A-Za-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .toLowerCase();
+  if (!slugBody) {
+    slugBody = "tool";
+  } else if (!/^[a-z]/.test(slugBody)) {
+    slugBody = `tool-${slugBody}`;
+  }
+  return `cover-${slugBody}`;
+}
+
+function artifactPaths(taskSlug) {
+  return {
+    proposal: `.eval-author/proposals/${taskSlug}-instruction.md`,
+    draft: `.eval-author/task-drafts/${taskSlug}`,
+    measurements: `.eval-author/task-measurements/${taskSlug}`,
+    taskId: taskSlug,
+  };
+}
+
+function actionableTools(report) {
+  const assigned = new Set();
+  return (report.uncovered_items || [])
+    .filter((item) => item.kind === "tool" && item.reason === ACTIONABLE_REASON)
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((item) => {
+      const base = taskSlugForTool(item.name);
+      let slug = base;
+      let suffix = 2;
+      while (assigned.has(slug)) {
+        slug = `${base}-${suffix}`;
+        suffix += 1;
+      }
+      assigned.add(slug);
+      return { ...item, task_slug: slug, paths: artifactPaths(slug) };
+    });
+}
+
+function renderList(items, empty = "None reported.") {
+  if (!items?.length) {
+    return `<p>${escapeHtml(empty)}</p>`;
+  }
+  return `<ul class="mini-list">${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+}
+
+function renderEvidence(items = []) {
+  if (!items.length) {
+    return "";
+  }
+  return renderList(
+    items.map((item) => {
+      const tool = item.tool ? ` ${item.tool}:` : "";
+      return `${item.kind || "evidence"}${tool} ${item.description || JSON.stringify(item)}`;
+    }),
+  );
+}
+
+function renderKindBars(report) {
+  const kinds = ["tool", "capability", "failure_case"];
+  els.kindBars.innerHTML = kinds
+    .map((kind) => {
+      const summary = report.coverage?.by_kind?.[kind] || { item_count: 0, covered_count: 0, uncovered_count: 0 };
+      const value = percent(summary);
+      return `
+        <div class="kind-row">
+          <strong>${escapeHtml(kind.replace("_", " "))}</strong>
+          <div class="bar-track" aria-label="${escapeHtml(kind)} ${value}% covered">
+            <div class="bar-fill" style="--coverage-width: ${value}%"></div>
+          </div>
+          <span>${summary.covered_count}/${summary.item_count} covered</span>
+        </div>
+      `;
+    })
+    .join("");
+}
+
+function renderActionableGaps(gaps) {
+  if (!gaps.length) {
+    els.actionableGaps.innerHTML =
+      '<article class="info-card"><p>No uncovered tool gaps are actionable for task creation.</p></article>';
+    return;
+  }
+  els.actionableGaps.innerHTML = gaps
+    .map((gap) => {
+      const neededTools = gap.generation?.needed_tools || [];
+      const evidence = gap.generation?.evidence_required || [];
+      return `
+        <article class="gap-card">
+          <div class="gap-heading">
+            <h3><code>${escapeHtml(gap.name)}</code></h3>
+            <span class="tag tool">${escapeHtml(gap.task_slug)}</span>
+          </div>
+          <p>${escapeHtml(gap.generation?.focus || gap.description)}</p>
+          <div class="gap-meta">
+            <span class="pill">reason: ${escapeHtml(gap.reason)}</span>
+            <span class="pill">needed: ${escapeHtml(neededTools.join(", ") || "none")}</span>
+          </div>
+          <div class="path-grid">
+            <div class="path-card"><span>proposal</span><code>${escapeHtml(gap.paths.proposal)}</code></div>
+            <div class="path-card"><span>draft</span><code>${escapeHtml(gap.paths.draft)}</code></div>
+            <div class="path-card"><span>measurements</span><code>${escapeHtml(gap.paths.measurements)}</code></div>
+            <div class="path-card"><span>task id</span><code>${escapeHtml(gap.paths.taskId)}</code></div>
+          </div>
+          ${evidence.length ? `<div>${renderEvidence(evidence)}</div>` : ""}
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderUncoveredItems(report) {
+  const items = report.uncovered_items || [];
+  els.uncoveredCount.textContent = `${items.length} gaps`;
+  if (!items.length) {
+    els.uncoveredItems.innerHTML = '<article class="info-card"><p>Everything in the denominator is covered.</p></article>';
+    return;
+  }
+  els.uncoveredItems.innerHTML = items
+    .map(
+      (item) => `
+        <article class="item-card">
+          <div class="gap-heading">
+            <h3><code>${escapeHtml(item.name)}</code></h3>
+            <span class="tag ${escapeHtml(item.kind)}">${escapeHtml(item.kind.replace("_", " "))}</span>
+          </div>
+          <p>${escapeHtml(item.description)}</p>
+          <p><strong>Reason:</strong> ${escapeHtml(item.reason)}</p>
+          <p><strong>Focus:</strong> ${escapeHtml(item.generation?.focus || "No generation focus supplied.")}</p>
+        </article>
+      `,
+    )
+    .join("");
+}
+
+function renderInputsAndWarnings(report) {
+  const inputs = report.input_reports || [];
+  const warnings = report.warnings || [];
+  const inputCards = inputs.length
+    ? inputs
+        .map(
+          (input) => `
+            <article class="info-card">
+              <p><strong>${escapeHtml(input.subject?.task_id || "unknown task")}</strong> / ${escapeHtml(
+                input.subject?.run_id || "unknown run",
+              )}</p>
+              <p>${escapeHtml(input.method)} covered ${escapeHtml(input.covered_count)} ${escapeHtml(
+                input.item_kind,
+              )} item(s).</p>
+              <pre>${escapeHtml(input.path)}</pre>
+            </article>
+          `,
+        )
+        .join("")
+    : '<article class="info-card"><p>No input reports recorded.</p></article>';
+  const warningCards = warnings.length
+    ? warnings.map((warning) => `<article class="info-card"><pre>${escapeHtml(JSON.stringify(warning, null, 2))}</pre></article>`).join("")
+    : '<article class="info-card"><p>No warnings.</p></article>';
+  els.inputsAndWarnings.innerHTML = `<div>${inputCards}</div><div>${warningCards}</div>`;
+}
+
+function renderReport(report) {
+  currentReport = report;
+  const overall = report.coverage?.overall || { item_count: 0, covered_count: 0, uncovered_count: 0 };
+  const gaps = actionableTools(report);
+  els.dashboard.hidden = false;
+  els.message.className = "message";
+  els.message.textContent = `${report.audit?.path || "audit.md"} is ${report.audit?.status || "unknown"} for ${
+    report.audit?.agent || "unknown agent"
+  }.`;
+  els.agent.textContent = report.audit?.agent || "unknown";
+  els.percent.textContent = `${percent(overall)}%`;
+  els.actionableCount.textContent = gaps.length;
+  els.inputCount.textContent = report.input_reports?.length || 0;
+  els.measuredKinds.textContent = `measured: ${(report.measured_kinds || []).join(", ") || "none"}`;
+  renderKindBars(report);
+  renderActionableGaps(gaps);
+  renderUncoveredItems(report);
+  renderInputsAndWarnings(report);
+}
+
+function renderError(message) {
+  currentReport = null;
+  els.dashboard.hidden = true;
+  els.message.className = "message error";
+  els.message.textContent = message;
+}
+
+function renderFromInput() {
+  const text = els.input.value.trim();
+  if (!text) {
+    currentReport = null;
+    els.dashboard.hidden = true;
+    els.message.className = "message";
+    els.message.textContent = `Paste or open a ${REPORT_SCHEMA} JSON report.`;
+    return;
+  }
+  try {
+    renderReport(parseReport(text));
+  } catch (error) {
+    renderError(error instanceof Error ? error.message : "Could not parse report.");
+  }
+}
+
+async function copySelectCommand() {
+  const gaps = currentReport ? actionableTools(currentReport) : [];
+  const command = [
+    "uv run skills/eval-author-task-create/scripts/task_pipeline.py select \\",
+    "  --report .eval-author/audit-coverage-report.json",
+  ].join("\n");
+  const text = gaps.length
+    ? `${command}\n\n# ${gaps.length} actionable tool gap(s): ${gaps.map((gap) => gap.name).join(", ")}`
+    : command;
+  await navigator.clipboard.writeText(text);
+  els.copySelect.textContent = "Copied";
+  window.setTimeout(() => {
+    els.copySelect.textContent = "Copy select command";
+  }, 1200);
+}
+
+els.input.addEventListener("input", renderFromInput);
+els.sample.addEventListener("click", () => {
+  els.input.value = JSON.stringify(sampleReport, null, 2);
+  renderFromInput();
+});
+els.file.addEventListener("change", async () => {
+  const [file] = els.file.files;
+  if (!file) {
+    return;
+  }
+  els.input.value = await file.text();
+  renderFromInput();
+});
+els.copySelect.addEventListener("click", copySelectCommand);
+
+renderFromInput();

--- a/plugins/nemo-eval-author/ui/index.html
+++ b/plugins/nemo-eval-author/ui/index.html
@@ -32,6 +32,10 @@
       </header>
 
       <section class="input-row" aria-label="Report JSON input">
+        <div class="input-heading">
+          <h2>Report JSON</h2>
+          <button id="toggle-input" type="button" aria-expanded="true">Hide JSON</button>
+        </div>
         <textarea
           id="report-input"
           spellcheck="false"

--- a/plugins/nemo-eval-author/ui/index.html
+++ b/plugins/nemo-eval-author/ui/index.html
@@ -1,0 +1,95 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Eval Author Coverage Report</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header class="masthead">
+        <div>
+          <p class="eyebrow">Eval Author</p>
+          <h1>Audit coverage report</h1>
+          <p class="lede">Open an aggregate coverage report and see the gaps that matter.</p>
+        </div>
+        <div class="actions">
+          <button id="sample-button" type="button">Load sample</button>
+          <label class="file-button">
+            <input id="file-input" type="file" accept=".json,application/json" />
+            Open report
+          </label>
+        </div>
+      </header>
+
+      <section class="input-row" aria-label="Report JSON input">
+        <textarea
+          id="report-input"
+          spellcheck="false"
+          placeholder="Paste .eval-author/audit-coverage-report.json here."
+        ></textarea>
+      </section>
+
+      <section id="message" class="message" role="status">
+        Paste or open a `nemo.eval_author.audit_coverage_report.v1` JSON report.
+      </section>
+
+      <section id="dashboard" class="dashboard" hidden>
+        <section class="summary-grid" aria-label="Coverage summary">
+          <article class="metric">
+            <span>Agent</span>
+            <strong id="agent-name"></strong>
+          </article>
+          <article class="metric">
+            <span>Coverage</span>
+            <strong id="coverage-percent"></strong>
+          </article>
+          <article class="metric">
+            <span>Actionable tools</span>
+            <strong id="actionable-count"></strong>
+          </article>
+          <article class="metric">
+            <span>Input reports</span>
+            <strong id="input-count"></strong>
+          </article>
+        </section>
+
+        <section class="panel" aria-label="Coverage by kind">
+          <div class="panel-title">
+            <h2>Coverage by kind</h2>
+            <span id="measured-kinds" class="pill"></span>
+          </div>
+          <div id="kind-bars" class="kind-bars"></div>
+        </section>
+
+        <section class="panel" aria-label="Actionable tool gaps">
+          <div class="panel-title">
+            <h2>Actionable tool gaps</h2>
+            <button id="copy-select-command" type="button">Copy select command</button>
+          </div>
+          <div id="actionable-gaps" class="gap-list"></div>
+        </section>
+
+        <section class="panel" aria-label="All uncovered items">
+          <div class="panel-title">
+            <h2>All uncovered items</h2>
+            <span id="uncovered-count" class="pill"></span>
+          </div>
+          <div id="uncovered-items" class="item-list"></div>
+        </section>
+
+        <section class="panel" aria-label="Measured reports and warnings">
+          <div class="panel-title">
+            <h2>Inputs and warnings</h2>
+          </div>
+          <div id="inputs-and-warnings" class="two-column"></div>
+        </section>
+      </section>
+    </main>
+
+    <script src="./app.js"></script>
+  </body>
+</html>

--- a/plugins/nemo-eval-author/ui/index.html
+++ b/plugins/nemo-eval-author/ui/index.html
@@ -57,10 +57,6 @@
             <span>Actionable tools</span>
             <strong id="actionable-count"></strong>
           </article>
-          <article class="metric">
-            <span>Input reports</span>
-            <strong id="input-count"></strong>
-          </article>
         </section>
 
         <section class="panel" aria-label="Coverage by kind">
@@ -74,7 +70,6 @@
         <section class="panel" aria-label="Actionable tool gaps">
           <div class="panel-title">
             <h2>Actionable tool gaps</h2>
-            <button id="copy-select-command" type="button">Copy select command</button>
           </div>
           <div id="actionable-gaps" class="gap-list"></div>
         </section>
@@ -85,13 +80,6 @@
             <span id="uncovered-count" class="pill"></span>
           </div>
           <div id="uncovered-items" class="item-list"></div>
-        </section>
-
-        <section class="panel" aria-label="Measured reports and warnings">
-          <div class="panel-title">
-            <h2>Inputs and warnings</h2>
-          </div>
-          <div id="inputs-and-warnings" class="two-column"></div>
         </section>
       </section>
     </main>

--- a/plugins/nemo-eval-author/ui/index.html
+++ b/plugins/nemo-eval-author/ui/index.html
@@ -6,13 +6,19 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Eval Author Coverage Report</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600&display=swap"
+    />
     <link rel="stylesheet" href="./styles.css" />
   </head>
-  <body>
+  <body class="np-page">
     <main class="shell">
       <header class="masthead">
         <div>
-          <p class="eyebrow">Eval Author</p>
+          <p class="eyebrow"><span class="dot" aria-hidden="true"></span>Eval Author</p>
           <h1>Audit coverage report</h1>
           <p class="lede">Open an aggregate coverage report and see the gaps that matter.</p>
         </div>

--- a/plugins/nemo-eval-author/ui/index.html
+++ b/plugins/nemo-eval-author/ui/index.html
@@ -56,6 +56,7 @@
           <article class="metric">
             <span>Coverage</span>
             <strong id="coverage-percent"></strong>
+            <small id="coverage-detail"></small>
           </article>
           <article class="metric">
             <span>Actionable tools</span>

--- a/plugins/nemo-eval-author/ui/styles.css
+++ b/plugins/nemo-eval-author/ui/styles.css
@@ -173,6 +173,17 @@ button,
   overflow: hidden;
 }
 
+.input-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 48px;
+  padding: 10px 12px 10px 16px;
+  border-bottom: 1px solid var(--line);
+  background: var(--surface);
+}
+
 textarea {
   display: block;
   width: 100%;

--- a/plugins/nemo-eval-author/ui/styles.css
+++ b/plugins/nemo-eval-author/ui/styles.css
@@ -21,6 +21,10 @@
   box-sizing: border-box;
 }
 
+[hidden] {
+  display: none !important;
+}
+
 body {
   margin: 0;
   min-width: 320px;
@@ -242,6 +246,14 @@ textarea {
   font-size: clamp(1.35rem, 2vw, 2rem);
   font-weight: 400;
   overflow-wrap: anywhere;
+}
+
+.metric small {
+  display: block;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 0.72rem;
+  line-height: 1.35;
 }
 
 .panel {

--- a/plugins/nemo-eval-author/ui/styles.css
+++ b/plugins/nemo-eval-author/ui/styles.css
@@ -2,19 +2,19 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 :root {
-  --bg: #f6f3ec;
-  --surface: #fffdf8;
-  --ink: #24272d;
-  --muted: #68717e;
-  --line: #ddd4c7;
-  --green: #3f7a4b;
-  --amber: #c59025;
-  --red: #b9574f;
-  --blue: #456f91;
-  --soft-green: #eaf3e8;
-  --soft-amber: #fff2cf;
-  --soft-blue: #eaf1f6;
-  --shadow: 0 14px 34px rgba(36, 39, 45, 0.1);
+  --bg: #fafaf6;
+  --surface: #f4f1e8;
+  --surface-raised: #ffffff;
+  --ink: #0f0f0f;
+  --muted: #5a5a5a;
+  --line: #d4d0c7;
+  --green: #76b900;
+  --green-dark: #33470f;
+  --green-soft: #f0f7e0;
+  --amber: #b78d00;
+  --red: #ba3f32;
+  --rail: #0f0f0f;
+  --shadow: 0 20px 60px rgba(15, 15, 15, 0.08);
 }
 
 * {
@@ -26,10 +26,13 @@ body {
   min-width: 320px;
   min-height: 100vh;
   color: var(--ink);
-  background: var(--bg);
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
+  background:
+    linear-gradient(90deg, rgba(212, 208, 199, 0.42) 1px, transparent 1px),
+    linear-gradient(rgba(212, 208, 199, 0.42) 1px, transparent 1px),
+    var(--bg);
+  background-size: 64px 64px;
+  font-family: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 14px;
 }
 
 button,
@@ -39,10 +42,10 @@ textarea {
 
 .shell {
   display: grid;
-  gap: 16px;
-  width: min(1180px, 100%);
+  gap: 18px;
+  width: min(1240px, 100%);
   margin: 0 auto;
-  padding: 24px;
+  padding: 22px;
 }
 
 .masthead,
@@ -51,8 +54,8 @@ textarea {
 .panel,
 .metric {
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: var(--surface);
+  border-radius: 0;
+  background: rgba(250, 250, 246, 0.94);
   box-shadow: var(--shadow);
 }
 
@@ -61,16 +64,34 @@ textarea {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 18px 20px;
+  min-height: 210px;
+  padding: 24px;
+  color: #fafaf6;
+  background:
+    radial-gradient(circle at 82% 20%, rgba(118, 185, 0, 0.22), transparent 28%),
+    linear-gradient(135deg, #0f0f0f 0%, #161913 58%, #263311 100%);
+  border-color: #0f0f0f;
 }
 
 .eyebrow {
-  margin: 0 0 4px;
-  color: var(--green);
-  font-size: 0.76rem;
-  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 16px;
+  color: #b8d680;
+  font-size: 0.72rem;
+  font-weight: 600;
   letter-spacing: 0;
   text-transform: uppercase;
+}
+
+.dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--green);
+  box-shadow: 0 0 0 5px rgba(118, 185, 0, 0.14);
 }
 
 h1,
@@ -88,7 +109,10 @@ h3 {
 }
 
 h1 {
-  font-size: clamp(1.8rem, 4vw, 3rem);
+  max-width: 780px;
+  font-size: clamp(2.25rem, 6vw, 5.6rem);
+  font-weight: 300;
+  letter-spacing: 0;
 }
 
 h2 {
@@ -100,8 +124,11 @@ h3 {
 }
 
 .lede {
-  margin: 8px 0 0;
-  color: var(--muted);
+  max-width: 680px;
+  margin: 18px 0 0;
+  color: #d4d0c7;
+  font-size: 1rem;
+  line-height: 1.7;
 }
 
 .actions {
@@ -116,19 +143,22 @@ button,
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 38px;
-  padding: 8px 12px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  color: var(--ink);
-  background: #ffffff;
-  font-weight: 750;
+  min-height: 40px;
+  padding: 9px 12px;
+  border: 1px solid #0f0f0f;
+  border-radius: 0;
+  color: #fafaf6;
+  background: #0f0f0f;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
   cursor: pointer;
 }
 
 .file-button {
-  border-color: #a87f1c;
-  background: #f0c85a;
+  color: #0f0f0f;
+  border-color: var(--green);
+  background: var(--green);
 }
 
 .file-button input {
@@ -146,26 +176,27 @@ button,
 textarea {
   display: block;
   width: 100%;
-  min-height: 160px;
+  min-height: 170px;
   resize: vertical;
-  padding: 14px;
+  padding: 16px;
   border: 0;
   outline: 0;
   color: var(--ink);
-  background: #fffaf1;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.88rem;
-  line-height: 1.45;
+  background: #fafaf6;
+  font-family: inherit;
+  font-size: 0.82rem;
+  line-height: 1.55;
 }
 
 .message {
   padding: 14px 16px;
   color: var(--muted);
+  background: var(--surface);
 }
 
 .message.error {
   color: var(--red);
-  background: #fff1ee;
+  background: #fff0ed;
 }
 
 .dashboard {
@@ -180,27 +211,31 @@ textarea {
 }
 
 .metric {
-  min-height: 96px;
-  padding: 14px;
+  min-height: 112px;
+  padding: 16px;
+  background: var(--surface-raised);
 }
 
 .metric span {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 18px;
   color: var(--muted);
-  font-size: 0.76rem;
-  font-weight: 800;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0;
   text-transform: uppercase;
 }
 
 .metric strong {
   display: block;
-  font-size: 1.55rem;
+  font-size: clamp(1.35rem, 2vw, 2rem);
+  font-weight: 400;
   overflow-wrap: anywhere;
 }
 
 .panel {
-  padding: 16px;
+  padding: 0;
+  background: var(--surface-raised);
 }
 
 .panel-title {
@@ -208,7 +243,10 @@ textarea {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 12px;
+  min-height: 58px;
+  margin: 0;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
 }
 
 .pill,
@@ -218,32 +256,34 @@ textarea {
   min-height: 26px;
   padding: 4px 8px;
   border: 1px solid var(--line);
-  border-radius: 999px;
+  border-radius: 0;
   color: var(--muted);
-  background: #ffffff;
-  font-size: 0.76rem;
-  font-weight: 800;
+  background: #fafaf6;
+  font-size: 0.68rem;
+  font-weight: 600;
   text-transform: uppercase;
 }
 
 .tag.tool {
-  color: var(--green);
-  background: var(--soft-green);
+  color: var(--green-dark);
+  border-color: var(--green);
+  background: var(--green-soft);
 }
 
 .tag.capability {
-  color: var(--blue);
-  background: var(--soft-blue);
+  color: #0f0f0f;
+  background: #e5e2d8;
 }
 
 .tag.failure_case {
   color: var(--amber);
-  background: var(--soft-amber);
+  background: #fff7db;
 }
 
 .kind-bars {
   display: grid;
   gap: 10px;
+  padding: 16px;
 }
 
 .kind-row {
@@ -254,16 +294,15 @@ textarea {
 }
 
 .bar-track {
-  height: 12px;
+  height: 8px;
   overflow: hidden;
-  border-radius: 999px;
-  background: #ece5db;
+  border-radius: 0;
+  background: #e5e2d8;
 }
 
 .bar-fill {
   width: var(--coverage-width);
   height: 100%;
-  border-radius: inherit;
   background: var(--green);
 }
 
@@ -278,14 +317,14 @@ textarea {
 .item-card,
 .info-card {
   border: 1px solid var(--line);
-  border-radius: 8px;
-  background: #ffffff;
+  border-radius: 0;
+  background: #fafaf6;
 }
 
 .gap-card {
   display: grid;
   gap: 10px;
-  padding: 14px;
+  padding: 16px;
 }
 
 .gap-heading {
@@ -297,7 +336,7 @@ textarea {
 
 .gap-heading code,
 .item-card code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-family: inherit;
   font-size: 0.92rem;
 }
 
@@ -330,16 +369,17 @@ textarea {
 .path-card {
   min-height: 64px;
   padding: 10px;
-  border-radius: 8px;
-  background: #f8f5ef;
+  border: 1px solid #e5e2d8;
+  border-radius: 0;
+  background: #ffffff;
 }
 
 .path-card span {
   display: block;
   margin-bottom: 5px;
   color: var(--muted);
-  font-size: 0.72rem;
-  font-weight: 800;
+  font-size: 0.68rem;
+  font-weight: 600;
   text-transform: uppercase;
 }
 
@@ -355,7 +395,7 @@ pre {
 
 .item-card,
 .info-card {
-  padding: 12px;
+  padding: 14px;
 }
 
 .item-card {
@@ -371,12 +411,19 @@ pre {
   margin: 0;
   padding: 10px;
   overflow: auto;
-  border-radius: 8px;
-  background: #f8f5ef;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.86rem;
+  border: 1px solid #e5e2d8;
+  border-radius: 0;
+  background: #ffffff;
+  font-family: inherit;
+  font-size: 0.78rem;
   line-height: 1.45;
   white-space: pre-wrap;
+}
+
+.gap-list,
+.item-list,
+.two-column {
+  padding: 16px;
 }
 
 @media (max-width: 860px) {

--- a/plugins/nemo-eval-author/ui/styles.css
+++ b/plugins/nemo-eval-author/ui/styles.css
@@ -206,7 +206,7 @@ textarea {
 
 .summary-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
 }
 
@@ -307,8 +307,7 @@ textarea {
 }
 
 .gap-list,
-.item-list,
-.two-column {
+.item-list {
   display: grid;
   gap: 10px;
 }
@@ -403,10 +402,6 @@ pre {
   gap: 8px;
 }
 
-.two-column {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-}
-
 pre {
   margin: 0;
   padding: 10px;
@@ -421,8 +416,7 @@ pre {
 }
 
 .gap-list,
-.item-list,
-.two-column {
+.item-list {
   padding: 16px;
 }
 
@@ -441,7 +435,6 @@ pre {
   }
 
   .summary-grid,
-  .two-column,
   .path-grid {
     grid-template-columns: 1fr;
   }

--- a/plugins/nemo-eval-author/ui/styles.css
+++ b/plugins/nemo-eval-author/ui/styles.css
@@ -1,0 +1,406 @@
+/* SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+:root {
+  --bg: #f6f3ec;
+  --surface: #fffdf8;
+  --ink: #24272d;
+  --muted: #68717e;
+  --line: #ddd4c7;
+  --green: #3f7a4b;
+  --amber: #c59025;
+  --red: #b9574f;
+  --blue: #456f91;
+  --soft-green: #eaf3e8;
+  --soft-amber: #fff2cf;
+  --soft-blue: #eaf1f6;
+  --shadow: 0 14px 34px rgba(36, 39, 45, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-width: 320px;
+  min-height: 100vh;
+  color: var(--ink);
+  background: var(--bg);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+}
+
+button,
+textarea {
+  font: inherit;
+}
+
+.shell {
+  display: grid;
+  gap: 16px;
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.masthead,
+.input-row,
+.message,
+.panel,
+.metric {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+}
+
+.masthead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px;
+}
+
+.eyebrow {
+  margin: 0 0 4px;
+  color: var(--green);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  overflow-wrap: anywhere;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  line-height: 1.12;
+}
+
+h1 {
+  font-size: clamp(1.8rem, 4vw, 3rem);
+}
+
+h2 {
+  font-size: 1rem;
+}
+
+h3 {
+  font-size: 0.98rem;
+}
+
+.lede {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+button,
+.file-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 8px 12px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--ink);
+  background: #ffffff;
+  font-weight: 750;
+  cursor: pointer;
+}
+
+.file-button {
+  border-color: #a87f1c;
+  background: #f0c85a;
+}
+
+.file-button input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.input-row {
+  overflow: hidden;
+}
+
+textarea {
+  display: block;
+  width: 100%;
+  min-height: 160px;
+  resize: vertical;
+  padding: 14px;
+  border: 0;
+  outline: 0;
+  color: var(--ink);
+  background: #fffaf1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.88rem;
+  line-height: 1.45;
+}
+
+.message {
+  padding: 14px 16px;
+  color: var(--muted);
+}
+
+.message.error {
+  color: var(--red);
+  background: #fff1ee;
+}
+
+.dashboard {
+  display: grid;
+  gap: 16px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.metric {
+  min-height: 96px;
+  padding: 14px;
+}
+
+.metric span {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.metric strong {
+  display: block;
+  font-size: 1.55rem;
+  overflow-wrap: anywhere;
+}
+
+.panel {
+  padding: 16px;
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.pill,
+.tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 4px 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  background: #ffffff;
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.tag.tool {
+  color: var(--green);
+  background: var(--soft-green);
+}
+
+.tag.capability {
+  color: var(--blue);
+  background: var(--soft-blue);
+}
+
+.tag.failure_case {
+  color: var(--amber);
+  background: var(--soft-amber);
+}
+
+.kind-bars {
+  display: grid;
+  gap: 10px;
+}
+
+.kind-row {
+  display: grid;
+  grid-template-columns: 130px minmax(0, 1fr) 110px;
+  gap: 12px;
+  align-items: center;
+}
+
+.bar-track {
+  height: 12px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #ece5db;
+}
+
+.bar-fill {
+  width: var(--coverage-width);
+  height: 100%;
+  border-radius: inherit;
+  background: var(--green);
+}
+
+.gap-list,
+.item-list,
+.two-column {
+  display: grid;
+  gap: 10px;
+}
+
+.gap-card,
+.item-card,
+.info-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.gap-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+}
+
+.gap-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.gap-heading code,
+.item-card code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.92rem;
+}
+
+.gap-card p,
+.item-card p,
+.info-card p,
+.mini-list li {
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.gap-card p,
+.item-card p,
+.info-card p {
+  margin: 0;
+}
+
+.gap-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.path-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.path-card {
+  min-height: 64px;
+  padding: 10px;
+  border-radius: 8px;
+  background: #f8f5ef;
+}
+
+.path-card span {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+code,
+pre {
+  overflow-wrap: anywhere;
+}
+
+.mini-list {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.item-card,
+.info-card {
+  padding: 12px;
+}
+
+.item-card {
+  display: grid;
+  gap: 8px;
+}
+
+.two-column {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+pre {
+  margin: 0;
+  padding: 10px;
+  overflow: auto;
+  border-radius: 8px;
+  background: #f8f5ef;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.86rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+@media (max-width: 860px) {
+  .shell {
+    padding: 12px;
+  }
+
+  .masthead {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .actions {
+    justify-content: flex-start;
+  }
+
+  .summary-grid,
+  .two-column,
+  .path-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .kind-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+  }
+}

--- a/plugins/nemo-eval-author/ui/styles.css
+++ b/plugins/nemo-eval-author/ui/styles.css
@@ -64,8 +64,8 @@ textarea {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  min-height: 210px;
-  padding: 24px;
+  min-height: 128px;
+  padding: 18px 20px;
   color: #fafaf6;
   background:
     radial-gradient(circle at 82% 20%, rgba(118, 185, 0, 0.22), transparent 28%),
@@ -77,7 +77,7 @@ textarea {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin: 0 0 16px;
+  margin: 0 0 10px;
   color: #b8d680;
   font-size: 0.72rem;
   font-weight: 600;
@@ -109,9 +109,9 @@ h3 {
 }
 
 h1 {
-  max-width: 780px;
-  font-size: clamp(2.25rem, 6vw, 5.6rem);
-  font-weight: 300;
+  max-width: 520px;
+  font-size: clamp(1.45rem, 3vw, 2.35rem);
+  font-weight: 400;
   letter-spacing: 0;
 }
 
@@ -125,10 +125,10 @@ h3 {
 
 .lede {
   max-width: 680px;
-  margin: 18px 0 0;
+  margin: 10px 0 0;
   color: #d4d0c7;
-  font-size: 1rem;
-  line-height: 1.7;
+  font-size: 0.86rem;
+  line-height: 1.55;
 }
 
 .actions {


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Adds a standalone Eval Author UI for viewing aggregate audit coverage reports. The viewer accepts `nemo.eval_author.audit_coverage_report.v1` JSON and highlights coverage totals, per-kind coverage, measured inputs, warnings, uncovered items, and the actionable tool gaps used by the task-creation flow. The styling follows the internal NeMo Platform preview aesthetic with IBM Plex Mono, off-white panels, dark hero treatment, thin dividers, and NVIDIA green accents.

## Related Issue
Related to #1576.

## Changes
- Add `plugins/nemo-eval-author/ui/index.html` as a standalone coverage report viewer.
- Add dependency-free JavaScript for parsing and rendering audit coverage reports.
- Add scoped CSS and README documentation for opening the viewer directly in a browser.
- Mirror the actionable gap rule from the task-creation flow: uncovered `tool` items with `reason: not_covered_by_any_input_report`.
- Align the visual treatment with the Agent Optimization / NeMo Platform preview site.

## Type of Change

- [x] Code change with documentation updates
- [ ] Code change (feature, bug fix, or refactor)
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: static dependency-free HTML/CSS/JS viewer with no package test harness yet; validated with JavaScript syntax and whitespace checks.
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `node --check ui/app.js` from `plugins/nemo-eval-author`: passed after the initial viewer implementation and after the visual restyle.
- `git diff --check`: passed after the initial viewer implementation and after the visual restyle.
- `uv run pre-commit run -a`: blocked by local environment/tooling. `ruff`, `ruff format`, `ty`, config reference, and several version checks passed before the run reported missing `helm-docs` and local `uv 0.12.6` instead of required `uv 0.9.14`.
