### PR TITLE
fix(guardrails): Only include relevant messages when calling guardrails library

### DIFF
--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -127,6 +127,14 @@ def is_streaming_response_result(result: ResponseResult) -> TypeIs[AsyncIterator
     return not isinstance(result, dict)
 
 
+def _latest_user_message(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return the latest user message as the context for output rails."""
+    for message in reversed(messages):
+        if isinstance(message, dict) and message.get("role") == "user":
+            return [message]
+    return []
+
+
 def handle_streaming_output_check(
     llm_rails: LLMRails,
     response_result: AsyncIterator[dict[str, Any]],
@@ -366,11 +374,15 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
             return request
 
         user_log_options = extract_log_options_from_request(guardrails)
+        # Input rails evaluate the current request turn. Do not replay conversation
+        # history through LLMRails: historical tool-call events can be interpreted as
+        # pending actions and prevent the current turn from reaching the input rails.
+        current_messages = messages[-1:]
         generation_response = await self._run_rails(
             source,
             request.body,
             request.headers,
-            messages=messages,
+            messages=current_messages,
             rail_types=PROCESS_REQUEST_RAIL_TYPES,
             user_log_options=user_log_options,
             error_msg="Failed to run input rails",
@@ -518,12 +530,11 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
                 source, request_body, request_headers, "Failed to run streaming output rails"
             )
 
-            # Snapshot inputs so the streaming closure doesn't observe
-            # mutations after ``process_response`` returns. Deep copy
-            # ``messages`` — library walks nested dicts (and multimodal
-            # ``content`` arrays) async while streaming. Shallow copy
-            # ``request_body`` — only ``model`` (a string) is read.
-            captured_messages = copy.deepcopy(messages)
+            # Output rails need the latest user message for ``user_input``. Do not
+            # replay earlier conversation history: historical tool-call events can
+            # prevent the generated response from reaching the output rails.
+            # Deep copy because the library walks nested multimodal content async.
+            captured_messages = copy.deepcopy(_latest_user_message(messages))
             captured_request_body = dict(request_body)
 
             async def _streaming_with_lease() -> AsyncIterator[dict[str, Any]]:
@@ -574,11 +585,13 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
                 response_body_annotations=dict(response.response_body_annotations),
             )
 
+        output_messages = _latest_user_message(messages)
+        output_messages.append(build_assistant_message_from_response_result(response_result))
         generation_response = await self._run_rails(
             source,
             request_body,
             request_headers,
-            messages=messages + [build_assistant_message_from_response_result(response_result)],
+            messages=output_messages,
             rail_types=PROCESS_RESPONSE_RAIL_TYPES,
             user_log_options=user_log_options,
             error_msg="Failed to run output rails",

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -373,6 +373,10 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
             logger.warning("Request body is missing 'messages' key. Skipping input rails.")
             return request
 
+        if not messages or not isinstance(messages[-1], dict) or messages[-1].get("role") != "user":
+            logger.debug("Current request turn is not a user message. Skipping input rails.")
+            return request
+
         user_log_options = extract_log_options_from_request(guardrails)
         # Input rails evaluate the current request turn. Do not replay conversation
         # history through LLMRails: historical tool-call events can be interpreted as

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/responses.py
@@ -163,13 +163,11 @@ def extract_response_content(generation_response: GenerationResponse) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _index_of_last_user_message(messages: list[dict[str, Any]]) -> int | None:
-    """Return the index of the last ``role=user`` message, if any."""
-    last_user_index: int | None = None
-    for index, message in enumerate(messages):
-        if isinstance(message, dict) and message.get("role") == "user":
-            last_user_index = index
-    return last_user_index
+def _index_of_current_user_message(messages: list[dict[str, Any]]) -> int | None:
+    """Return the final message index when the current turn is a user message."""
+    if messages and isinstance(messages[-1], dict) and messages[-1].get("role") == "user":
+        return len(messages) - 1
+    return None
 
 
 def apply_input_rail_modifications(
@@ -184,7 +182,7 @@ def apply_input_rail_modifications(
     Returns the same list object when there is nothing to change; otherwise, returns a
     shallow copy that replaces only the last user message dict.
     """
-    last_user_index = _index_of_last_user_message(messages)
+    last_user_index = _index_of_current_user_message(messages)
     if last_user_index is None:
         return messages
 

--- a/plugins/nemo-guardrails/tests/integration/test_self_check_rails.py
+++ b/plugins/nemo-guardrails/tests/integration/test_self_check_rails.py
@@ -40,6 +40,32 @@ class TestSelfCheck:
     )
 
     @classmethod
+    def _messages_with_tool_history(cls) -> list[dict[str, Any]]:
+        return [
+            {"role": "user", "content": "Look up the weather in New York."},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"New York"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-1",
+                "content": "Sunny, 75 degrees Fahrenheit.",
+            },
+            {"role": "user", "content": cls.USER_INPUT},
+        ]
+
+    @classmethod
     def _build_self_check_input_prompt(cls) -> dict[str, Any]:
         return {
             "task": "self_check_input",
@@ -201,6 +227,51 @@ class TestSelfCheck:
             harness.assert_request_messages_contain(test_data_names.main_model_served_name, self.USER_INPUT)
             assert response["choices"][0]["message"]["content"] == self.BACKEND_RESPONSE
 
+    def test_input_rail_checks_current_user_after_tool_history(
+        self,
+        igw_plugin_harness: IGWPluginHarness,
+    ) -> None:
+        harness = igw_plugin_harness
+        test_data_names = make_guardrails_test_data_names(workspace=harness.workspace)
+        harness.mock_chat_completions(
+            test_data_names.main_model_entity_ref,
+            responses=[ChatCompletion(body=chat_completion(content=self._unsafe_input_self_check_response()))],
+        )
+        harness.add_provider(
+            workspace=harness.workspace,
+            name=test_data_names.model_provider_name,
+            served_models={test_data_names.main_model_served_name: test_data_names.main_model_served_name},
+        )
+        guardrail_config = make_guardrail_config(
+            harness.workspace,
+            test_data_names.guardrail_config_name,
+            data=self._config_data(rail_types=[RailType.INPUT], main_base_url=harness.nim_base_url),
+        )
+
+        with harness.load_plugin(GUARDRAILS_PLUGIN_NAME):
+            harness.add_virtual_model(
+                workspace=harness.workspace,
+                name=test_data_names.request_virtual_model_name,
+                default_model_entity=test_data_names.main_model_entity_ref,
+                request_middleware=[make_middleware_call(guardrail_config)],
+            )
+            response = harness.chat_completions(
+                workspace=harness.workspace,
+                body={
+                    "model": test_data_names.request_virtual_model_name,
+                    "messages": self._messages_with_tool_history(),
+                },
+            )
+
+        harness.assert_called_once(test_data_names.main_model_entity_ref)
+        harness.assert_no_calls_to(test_data_names.main_model_served_name)
+        harness.assert_request_messages_contain(
+            test_data_names.main_model_entity_ref,
+            self._expected_input_rail_prompt(self.USER_INPUT),
+        )
+        assert response["choices"][0]["finish_reason"] == "content_filter"
+        assert response["choices"][0]["message"]["content"] == self.BLOCKED_REFUSAL_TEXT
+
     @pytest.mark.parametrize(
         "expected_blocked_response",
         [
@@ -276,6 +347,54 @@ class TestSelfCheck:
             assert response["choices"][0]["message"]["content"] == self.BLOCKED_REFUSAL_TEXT
         else:
             assert response["choices"][0]["message"]["content"] == self.BACKEND_RESPONSE
+
+    def test_output_rail_checks_response_after_tool_history(
+        self,
+        igw_plugin_harness: IGWPluginHarness,
+    ) -> None:
+        harness = igw_plugin_harness
+        test_data_names = make_guardrails_test_data_names(workspace=harness.workspace)
+        harness.mock_chat_completions(
+            test_data_names.main_model_served_name,
+            responses=[ChatCompletion(body=chat_completion(content=self.BACKEND_RESPONSE))],
+        )
+        harness.mock_chat_completions(
+            test_data_names.main_model_entity_ref,
+            responses=[ChatCompletion(body=chat_completion(content=self._unsafe_output_self_check_response()))],
+        )
+        harness.add_provider(
+            workspace=harness.workspace,
+            name=test_data_names.model_provider_name,
+            served_models={test_data_names.main_model_served_name: test_data_names.main_model_served_name},
+        )
+        guardrail_config = make_guardrail_config(
+            harness.workspace,
+            test_data_names.guardrail_config_name,
+            data=self._config_data(rail_types=[RailType.OUTPUT], main_base_url=harness.nim_base_url),
+        )
+
+        with harness.load_plugin(GUARDRAILS_PLUGIN_NAME):
+            harness.add_virtual_model(
+                workspace=harness.workspace,
+                name=test_data_names.request_virtual_model_name,
+                default_model_entity=test_data_names.main_model_entity_ref,
+                response_middleware=[make_middleware_call(guardrail_config)],
+            )
+            response = harness.chat_completions(
+                workspace=harness.workspace,
+                body={
+                    "model": test_data_names.request_virtual_model_name,
+                    "messages": self._messages_with_tool_history(),
+                },
+            )
+
+        harness.assert_call_order([test_data_names.main_model_served_name, test_data_names.main_model_entity_ref])
+        harness.assert_request_messages_contain(
+            test_data_names.main_model_entity_ref,
+            self._expected_output_rail_prompt(self.BACKEND_RESPONSE),
+        )
+        assert response["choices"][0]["finish_reason"] == "content_filter"
+        assert response["choices"][0]["message"]["content"] == self.BLOCKED_REFUSAL_TEXT
 
     @pytest.mark.parametrize(
         "input_blocked,output_blocked,expected_blocked_response",

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -696,6 +696,33 @@ class TestProcessRequest:
         assert run_rails.call_args.kwargs["messages"] == [current_user]
         assert result["messages"] == request_body["messages"]
 
+    async def test_input_rails_skip_request_ending_with_tool_result(self, middleware: GuardrailsMiddleware) -> None:
+        request_body = {
+            "model": "ws/llama",
+            "messages": [
+                {"role": "user", "content": "Look up the weather"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "sunny"},
+            ],
+        }
+
+        with patch.object(middleware, "_run_rails") as run_rails:
+            result = await _process_request(middleware, request_body, {}, _entity_source())
+
+        assert result == request_body
+        assert result is not request_body
+        run_rails.assert_not_called()
+
     async def test_input_masking_skips_non_string_user_content(self, middleware: GuardrailsMiddleware) -> None:
         # Multimodal content is unsupported for PII write-back; leave the request alone
         # even when response.content looks like a redacted string (or a stringified list).

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -663,6 +663,39 @@ class TestProcessRequest:
         # Original request body must not be mutated (IGW aliases nested values).
         assert request_body["messages"][-1]["content"] == "Hi! I am Mr. John!"
 
+    async def test_input_rails_receive_only_current_turn_after_tool_history(
+        self, middleware: GuardrailsMiddleware
+    ) -> None:
+        current_user = {"role": "user", "content": "What about tomorrow?"}
+        request_body = {
+            "model": "ws/llama",
+            "messages": [
+                {"role": "user", "content": "Look up the weather"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "sunny"},
+                current_user,
+            ],
+        }
+        generation_response = _make_generation_response(is_blocked=False, content="What about tomorrow?")
+        run_rails = AsyncMock(return_value=generation_response)
+
+        with patch.object(middleware, "_run_rails", new=run_rails):
+            result = await _process_request(middleware, request_body, {}, _entity_source())
+
+        assert not isinstance(result, ImmediateResponse)
+        assert run_rails.call_args.kwargs["messages"] == [current_user]
+        assert result["messages"] == request_body["messages"]
+
     async def test_input_masking_skips_non_string_user_content(self, middleware: GuardrailsMiddleware) -> None:
         # Multimodal content is unsupported for PII write-back; leave the request alone
         # even when response.content looks like a redacted string (or a stringified list).
@@ -979,9 +1012,25 @@ class TestHandleStreamingOutputCheck:
 
 class TestProcessResponse:
     async def test_streaming_runs_output_rails(self, middleware: GuardrailsMiddleware) -> None:
+        latest_user = {"role": "user", "content": "What about tomorrow?"}
         request_body = {
             "model": "ws/llama",
-            "messages": [{"role": "user", "content": "Hello"}],
+            "messages": [
+                {"role": "user", "content": "Look up the weather"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "sunny"},
+                latest_user,
+            ],
             "stream": True,
         }
 
@@ -1008,7 +1057,7 @@ class TestProcessResponse:
             generator: AsyncIterator[str],
             messages: list[dict[str, Any]],
         ) -> AsyncIterator[str]:
-            assert messages == request_body["messages"]
+            assert messages == [latest_user]
             async for token in generator:
                 yield token.upper()
 
@@ -1466,6 +1515,49 @@ class TestProcessResponse:
 
         assert result == response_result
         mock_build.assert_called_once()
+
+    async def test_output_rails_receive_latest_user_and_response_without_tool_history(
+        self, middleware: GuardrailsMiddleware
+    ) -> None:
+        latest_user = {"role": "user", "content": "What about tomorrow?"}
+        assistant_response = {"role": "assistant", "content": "Tomorrow will be sunny."}
+        request_body = {
+            "model": "ws/llama",
+            "messages": [
+                {"role": "user", "content": "Look up the weather"},
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {"name": "weather", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call-1", "content": "sunny"},
+                latest_user,
+            ],
+        }
+        response_result = {
+            "id": "chatcmpl-123",
+            "choices": [{"index": 0, "message": assistant_response, "finish_reason": "stop"}],
+        }
+        passed_response = _make_generation_response(is_blocked=False, content=assistant_response["content"])
+        run_rails = AsyncMock(return_value=passed_response)
+
+        with patch.object(middleware, "_run_rails", new=run_rails):
+            await _process_response(
+                middleware,
+                response_result,
+                request_body,
+                {},
+                {},
+                _entity_source(output_flows=["self check output"]),
+            )
+
+        assert run_rails.call_args.kwargs["messages"] == [latest_user, assistant_response]
 
     @pytest.mark.parametrize("is_blocked", [True, False])
     async def test_input_generation_response_propagated(

--- a/plugins/nemo-guardrails/tests/unit/test_responses.py
+++ b/plugins/nemo-guardrails/tests/unit/test_responses.py
@@ -144,6 +144,27 @@ class TestApplyInputRailModifications:
 
         assert apply_input_rail_modifications(messages, generation_response) is messages
 
+    def test_does_not_rewrite_earlier_user_when_current_message_is_tool_result(self) -> None:
+        messages = [
+            {"role": "user", "content": "Look up the weather"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call-1",
+                        "type": "function",
+                        "function": {"name": "weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call-1", "content": "sunny"},
+        ]
+        generation_response = _make_generation_response(content="")
+
+        assert apply_input_rail_modifications(messages, generation_response) is messages
+        assert messages[0]["content"] == "Look up the weather"
+
 
 class TestApplyOutputRailModifications:
     def test_writes_back_from_response_content(self) -> None:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

### Upstream behavior

`LLMRails.generate_async` converts every supplied chat message into internal events and replays them to reconstruct the conversation state before running the configured rails.

This breaks when the history contains an assistant message with `tool_calls`. During replay, the library interprets that historical message as a new tool-call action rather than part of an already completed turn. It enters the tool-call state and stops processing the remaining messages. The expected behavior is that the library should evaluate the most recent user (for input rails) or assistant (for output rails) message.

For example, consider this message history:

1. User asks for the weather.
2. Assistant calls a weather tool.
3. Tool returns the weather.
4. User asks a follow-up question.

The plugin passes all four messages to `generate_async`. The library stops while internally replaying step 2 and never runs the input rail against step 4.

### Plugin fix

The plugin now avoids replaying unrelated conversation history:

- Input rails receive only the current user message.
- Output rails receive the latest user message and generated assistant response.
- Input-rail modifications cannot rewrite an earlier user message when the current turn is a tool result.

This supplies the context required by standard input and output rails. Previous conversation history isn't used by the library when running the rails, so there's no value in including it when calling the library.

## Changes
- Send only the current message to input rails.
- Send the latest user message and generated assistant response to output rails.
- Restrict input-rail write-back to a current user message.
- Add unit and integration coverage for input and output rails following tool-call history.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: This corrects internal message selection while preserving the documented Guardrails API and configuration behavior.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run ruff format <changed files>` — passed; all files already formatted.
- `uv run ruff check <changed files>` — passed.
- `uv run --frozen pytest plugins/nemo-guardrails/tests/unit/test_responses.py::TestApplyInputRailModifications plugins/nemo-guardrails/tests/unit/test_middleware.py::TestProcessRequest plugins/nemo-guardrails/tests/unit/test_middleware.py::TestProcessResponse -q` — 46 passed.
- `uv run --frozen pytest plugins/nemo-guardrails/tests/integration/test_self_check_rails.py::TestSelfCheck::test_input_rail_checks_current_user_after_tool_history plugins/nemo-guardrails/tests/integration/test_self_check_rails.py::TestSelfCheck::test_output_rail_checks_response_after_tool_history -q` — 2 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Guardrails now evaluate only the current user message, excluding earlier conversation and tool-call history.
  - Output checks focus on the current user request and assistant response.
  - Input-rail modifications no longer rewrite earlier user messages when the latest entry is a tool result.
  - Unsafe requests and responses continue to be blocked or replaced correctly after tool interactions.

- **Tests**
  - Added coverage for guardrail behavior across tool-call histories and current-turn message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->