### PR TITLE
fix(studio): append new guardrail test cases to the end of the list

### DIFF
--- a/web/packages/studio/src/mocks/handlers/guardrails.ts
+++ b/web/packages/studio/src/mocks/handlers/guardrails.ts
@@ -147,6 +147,22 @@ export const seedMockGuardrailCheck = (
   return entity;
 };
 
+/**
+ * Apply the entity-store `sort` param (`field` / `-field`), defaulting to the service's own
+ * `-created_at`. Without this the stub would hand back insertion order and hide any bug in
+ * what the client actually asks for.
+ */
+const sortEntities = <T extends object>(data: T[], sort: string | null): T[] => {
+  const spec = sort ?? '-created_at';
+  const descending = spec.startsWith('-');
+  const field = descending ? spec.slice(1) : spec;
+  return [...data].sort((a, b) => {
+    const left = String((a as Record<string, unknown>)[field] ?? '');
+    const right = String((b as Record<string, unknown>)[field] ?? '');
+    return descending ? right.localeCompare(left) : left.localeCompare(right);
+  });
+};
+
 const page = <T>(data: T[]) => ({
   data,
   pagination: {
@@ -170,11 +186,13 @@ export const guardrailsHandlers = [
   http.get(
     `${PLATFORM_BASE_URL}/apis/entities/v2/workspaces/:workspace/entities/${GUARDRAIL_CHECKS_ENTITY_TYPE}`,
     ({ request }) => {
-      const filter = new URL(request.url).searchParams.get('filter');
+      const params = new URL(request.url).searchParams;
+      const filter = params.get('filter');
       const parent = filter ? (JSON.parse(filter) as { parent?: string }).parent : undefined;
-      return HttpResponse.json(
-        page(parent ? guardrailChecks.filter((check) => check.parent === parent) : guardrailChecks)
-      );
+      const matched = parent
+        ? guardrailChecks.filter((check) => check.parent === parent)
+        : [...guardrailChecks];
+      return HttpResponse.json(page(sortEntities(matched, params.get('sort'))));
     }
   ),
 

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCard.test.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCard.test.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { GuardrailCheckEntity } from '@studio/api/guardrail-checks/types';
+import { mockGuardrailChecks } from '@studio/mocks/handlers/guardrails';
+import { GuardrailTestCard } from '@studio/routes/guardrails/GuardrailChecksTab/GuardrailTestCard';
+import { render, screen } from '@studio/tests/util/render';
+
+const [seedCheck] = mockGuardrailChecks;
+
+const renderCard = (autoFocus: boolean, check: GuardrailCheckEntity = seedCheck!) =>
+  render(
+    <GuardrailTestCard
+      check={check}
+      index={0}
+      workspace="default"
+      registerFlush={() => {}}
+      autoFocus={autoFocus}
+    />
+  );
+
+describe('GuardrailTestCard', () => {
+  // "Add Another Test" appends below the fold; the card it produced has to come to the user.
+  it('focuses the first message body when it is the just-created card', () => {
+    renderCard(true);
+
+    expect(screen.getByTestId('guardrail-check-message-content')).toHaveFocus();
+  });
+
+  it('leaves focus alone for an existing card', () => {
+    renderCard(false);
+
+    expect(screen.getByTestId('guardrail-check-message-content')).not.toHaveFocus();
+  });
+});

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCard.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCard.tsx
@@ -24,6 +24,8 @@ interface GuardrailTestCardProps {
   workspace: string;
   /** Registers this card's flusher with the editor; called with `null` on unmount. */
   registerFlush: (name: string, flush: (() => Promise<GuardrailCheckEntity>) | null) => void;
+  /** Set on a just-created card: scrolls it into view and focuses its first message body. */
+  autoFocus?: boolean;
 }
 
 type ViewMode = 'chat' | 'json';
@@ -56,6 +58,7 @@ export const GuardrailTestCard: FC<GuardrailTestCardProps> = ({
   index,
   workspace,
   registerFlush,
+  autoFocus = false,
 }) => {
   const toast = useToast();
   const [viewMode, setViewMode] = useState<ViewMode>('chat');
@@ -170,6 +173,17 @@ export const GuardrailTestCard: FC<GuardrailTestCardProps> = ({
 
   const watchedMessages = useWatch({ control: form.control, name: 'messages' });
 
+  // A newly added test lands at the end of a list that is usually taller than the viewport,
+  // so reveal it rather than leaving the user to hunt for the card their click produced.
+  const messagesRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!autoFocus) return;
+    const body = messagesRef.current?.querySelector('textarea');
+    body?.focus();
+    // Not implemented in jsdom; focus() alone already scrolls in a real browser.
+    body?.scrollIntoView?.({ block: 'nearest' });
+  }, [autoFocus]);
+
   return (
     <Panel elevation="high">
       <Stack gap="density-md">
@@ -189,7 +203,7 @@ export const GuardrailTestCard: FC<GuardrailTestCardProps> = ({
 
         {/* Chat view */}
         {viewMode === 'chat' ? (
-          <div onBlur={handleContainerBlur}>
+          <div ref={messagesRef} onBlur={handleContainerBlur}>
             <Stack gap="density-md">
               {fields.map((field, i) => (
                 <GuardrailMessageRow

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCasesEditor.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCasesEditor.tsx
@@ -80,7 +80,12 @@ export const GuardrailTestCasesEditor: FC<GuardrailTestCasesEditorProps> = ({
     },
   });
 
+  // The card to reveal once the created check lands in the refetched list. Without it the new
+  // card renders below the fold, under the button that was just clicked.
+  const [newCheckId, setNewCheckId] = useState<string | null>(null);
+
   const createMutation = useCreateGuardrailCheck({
+    onSuccess: (entity) => setNewCheckId(entity.id),
     onError: (error) => {
       toast.error(getErrorMessage(error, 'Failed to create test'));
     },
@@ -209,6 +214,7 @@ export const GuardrailTestCasesEditor: FC<GuardrailTestCasesEditorProps> = ({
               index={i}
               workspace={workspace}
               registerFlush={registerFlush}
+              autoFocus={check.id === newCheckId}
             />
           ))}
           <LoadingButton

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.test.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.test.tsx
@@ -86,6 +86,24 @@ describe('GuardrailChecksTab', () => {
     expect(screen.getByRole('button', { name: /Run 2 Tests/ })).toBeInTheDocument();
   });
 
+  // The entity-store sorts `-created_at` by default, which put every newly created test at the
+  // top of the list while the "Add Another Test" button that produced it sits at the bottom.
+  // Seeded rather than clicked: invalidateGuardrailChecksCaches targets the module-singleton
+  // queryClient, not the one TestProviders renders, so a created entity never reaches the list.
+  it('lists tests oldest-first, so the newest lands at the end', async () => {
+    seedMockGuardrailCheck('newest-check', {
+      data: { messages: [{ role: 'user', content: 'Added last' }], runs: [] },
+    });
+    renderChecks('pii-filter');
+
+    await screen.findByText('Guardrail Test Cases', undefined, { timeout: XL_SELECTOR_TIMEOUT });
+    expect(
+      screen
+        .getAllByTestId('guardrail-check-message-content')
+        .map((body) => (body as HTMLTextAreaElement).value)
+    ).toEqual(['My SSN is 123-45-6789', 'Hello there', 'Added last']);
+  });
+
   it('redirects the bare checks URL onto the default sub-tab', async () => {
     renderChecks('pii-filter');
 

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.tsx
@@ -40,7 +40,9 @@ export const GuardrailChecksTab: FC = () => {
   } = useGuardrailChecksForConfig(
     workspace,
     config?.id ?? '',
-    { page_size: 1000 },
+    // Oldest-first: the entity-store defaults to `-created_at`, which would drop each newly
+    // created check at the top of the list while "Add Another Test" sits at the bottom.
+    { page_size: 1000, sort: 'created_at' },
     { enabled: isValidSubTab && Boolean(config?.id) }
   );
 


### PR DESCRIPTION
## Summary

In the guardrails **Test and Validate** tab, "Add Another Test" sits at the bottom of the card list but the new card appeared at the **top**, off-screen above the button that had just been clicked. The list is rendered in API order and the entity store defaults to `sort=-created_at`, so the newest check sorted first. Checks are now requested oldest-first, so a new test is appended at the end — directly below the button — and the new card is scrolled into view with its first message body focused.

## Changes

- `GuardrailChecksTab/index.tsx`: request checks with `sort: 'created_at'` instead of relying on the entity store's `-created_at` default.
- `GuardrailTestCasesEditor.tsx`: remember the created check's id and pass `autoFocus` to the matching card once it lands in the refetched list.
- `GuardrailTestCard.tsx`: new optional `autoFocus` prop — on mount it focuses the card's first message body and calls `scrollIntoView({ block: 'nearest' })` (optional-chained; jsdom does not implement it).
- `mocks/handlers/guardrails.ts`: the checks-list MSW handler now honors the `sort` param, defaulting to the service's own `-created_at`, instead of replaying insertion order — which had hidden list ordering from tests entirely.
- Tests: new ordering test in `GuardrailChecksTab/index.test.tsx`; new `GuardrailTestCard.test.tsx` covering focus-on-new-card and no-focus for existing cards.

Nothing depended on the previous newest-first order: `runGuardrailChecks` maps results back to checks by name, and the Results sub-tab derives its index from the same `checks` array the Tests tab renders. A side effect is that the "Test N" labels are now stable across reloads instead of renumbering whenever a test is added.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal Studio UI behavior, no documented interface changes

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm vitest --run src/routes/guardrails src/components/dataViews/GuardrailChecksDataView src/components/sidePanels/GuardrailCheckDetailSidePanel src/tests` — 21 files, 232 tests passed.
- Reverting only the `sort` param fails the new ordering test **and** the pre-existing "runs a freshly created, still-empty test on the first click" test, confirming the assertion is not trivially satisfied by the mock.
- `pnpm exec eslint <changed files> --max-warnings 0` — clean.
- `pnpm exec prettier --check <changed files>` — clean.
- `pnpm exec tsc -p packages/studio --noEmit` — one error in `packages/common/src/components/FilesetSearchableSelect/index.tsx`, verified present on the unmodified tree as well; no new type errors from this change.
- `uv run pre-commit run -a` was not run over the whole repo; the pre-commit and pre-push hooks ran on commit (copyright headers, UI lint-staged, DCO, merge-conflict checks) and passed. The Python hooks are no-ops here — this change touches only `web/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Guardrail checks now appear in oldest-first order, making newly added tests easier to locate.
  * Creating a new guardrail test automatically scrolls to and focuses its message field for faster entry.
  * Guardrail check lists now apply sorting consistently when filtered.

* **Bug Fixes**
  * Prevented list sorting from changing stored test data unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->