### PR TITLE
feat(studio): delete guardrail test cases from the Test and Validate tab

### DIFF
--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCard.test.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCard.test.tsx
@@ -14,6 +14,7 @@ const renderCard = (autoFocus: boolean, check: GuardrailCheckEntity = seedCheck!
       check={check}
       index={0}
       workspace="default"
+      configId="cfg-1"
       registerFlush={() => {}}
       autoFocus={autoFocus}
     />

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCard.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCard.tsx
@@ -2,9 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getErrorMessage } from '@nemo/common/src/api/common/utils';
+import { DeleteConfirmationModal } from '@nemo/common/src/components/DeleteConfirmationModal';
 import { useToast } from '@nemo/common/src/providers/toast/useToast';
-import { Button, Flex, Panel, SegmentedControl, Stack, Text } from '@nvidia/foundations-react-core';
-import { useUpdateGuardrailCheck } from '@studio/api/guardrail-checks/hooks';
+import {
+  Button,
+  Flex,
+  Panel,
+  SegmentedControl,
+  Stack,
+  Text,
+  Tooltip,
+} from '@nvidia/foundations-react-core';
+import {
+  useDeleteGuardrailCheck,
+  useUpdateGuardrailCheck,
+} from '@studio/api/guardrail-checks/hooks';
 import type {
   GuardrailCheckEntity,
   GuardrailCheckMessage,
@@ -14,7 +26,7 @@ import {
   type GuardrailMessageFormRow,
   GuardrailMessageRow,
 } from '@studio/routes/guardrails/GuardrailChecksTab/GuardrailMessageRow';
-import { Plus } from 'lucide-react';
+import { Plus, Trash2 } from 'lucide-react';
 import { type FC, type FocusEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { useFieldArray, useForm, useWatch } from 'react-hook-form';
 
@@ -22,6 +34,8 @@ interface GuardrailTestCardProps {
   check: GuardrailCheckEntity;
   index: number;
   workspace: string;
+  /** Owning config entity id — required to address this check as a hard child on delete. */
+  configId: string;
   /** Registers this card's flusher with the editor; called with `null` on unmount. */
   registerFlush: (name: string, flush: (() => Promise<GuardrailCheckEntity>) | null) => void;
   /** Set on a just-created card: scrolls it into view and focuses its first message body. */
@@ -57,11 +71,13 @@ export const GuardrailTestCard: FC<GuardrailTestCardProps> = ({
   check,
   index,
   workspace,
+  configId,
   registerFlush,
   autoFocus = false,
 }) => {
   const toast = useToast();
   const [viewMode, setViewMode] = useState<ViewMode>('chat');
+  const [isConfirmingDelete, setIsConfirmingDelete] = useState(false);
 
   const form = useForm<GuardrailCheckFormValues>({
     defaultValues: { messages: toFormRows(check.data.messages) },
@@ -171,6 +187,19 @@ export const GuardrailTestCard: FC<GuardrailTestCardProps> = ({
     persist(form.getValues('messages'));
   };
 
+  // The modal reports the outcome itself, so the hook stays quiet — an onError toast here
+  // would double up on the modal's own error text.
+  const deleteMutation = useDeleteGuardrailCheck();
+
+  const handleDelete = useCallback(async (): Promise<boolean> => {
+    try {
+      await deleteMutation.mutateAsync({ workspace, name: check.name, parent: configId });
+      return true;
+    } catch {
+      return false;
+    }
+  }, [check.name, configId, deleteMutation, workspace]);
+
   const watchedMessages = useWatch({ control: form.control, name: 'messages' });
 
   // A newly added test lands at the end of a list that is usually taller than the viewport,
@@ -190,15 +219,28 @@ export const GuardrailTestCard: FC<GuardrailTestCardProps> = ({
         {/* Card header */}
         <Flex align="center" justify="between">
           <Text kind="label/bold/md">Test {index + 1}</Text>
-          <SegmentedControl
-            size="small"
-            value={viewMode}
-            onValueChange={(value) => setViewMode(value as ViewMode)}
-            items={[
-              { value: 'chat', children: 'Chat' },
-              { value: 'json', children: 'JSON' },
-            ]}
-          />
+          <Flex align="center" gap="density-sm">
+            <SegmentedControl
+              size="small"
+              value={viewMode}
+              onValueChange={(value) => setViewMode(value as ViewMode)}
+              items={[
+                { value: 'chat', children: 'Chat' },
+                { value: 'json', children: 'JSON' },
+              ]}
+            />
+            <Tooltip slotContent="Delete test" side="top">
+              <Button
+                type="button"
+                size="tiny"
+                kind="tertiary"
+                aria-label={`Delete test ${index + 1}`}
+                onClick={() => setIsConfirmingDelete(true)}
+              >
+                <Trash2 className="size-3.5" aria-hidden />
+              </Button>
+            </Tooltip>
+          </Flex>
         </Flex>
 
         {/* Chat view */}
@@ -237,6 +279,19 @@ export const GuardrailTestCard: FC<GuardrailTestCardProps> = ({
           </pre>
         )}
       </Stack>
+
+      {isConfirmingDelete ? (
+        <DeleteConfirmationModal
+          open
+          simpleConfirm
+          title={`Delete Test ${index + 1}`}
+          description={`Test ${index + 1} and its run history will be permanently deleted.`}
+          successText="Test deleted successfully."
+          errorText="Failed to delete the test. Please try again."
+          onDelete={handleDelete}
+          onClose={() => setIsConfirmingDelete(false)}
+        />
+      ) : null}
     </Panel>
   );
 };

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCasesEditor.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/GuardrailTestCasesEditor.tsx
@@ -213,6 +213,7 @@ export const GuardrailTestCasesEditor: FC<GuardrailTestCasesEditorProps> = ({
               check={check}
               index={i}
               workspace={workspace}
+              configId={configId}
               registerFlush={registerFlush}
               autoFocus={check.id === newCheckId}
             />

--- a/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.test.tsx
+++ b/web/packages/studio/src/routes/guardrails/GuardrailChecksTab/index.test.tsx
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { getGuardrailChecksQueryKey } from '@studio/api/guardrail-checks/guardrailChecks';
 import { GUARDRAIL_CHECKS_ENTITY_TYPE } from '@studio/api/guardrail-checks/types';
+import { queryClient } from '@studio/api/queryClient';
 import { PLATFORM_BASE_URL } from '@studio/constants/environment';
 import { ROUTES } from '@studio/constants/routes';
 import {
@@ -242,6 +244,65 @@ describe('GuardrailChecksTab', () => {
           }
         )
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('deleting a test', () => {
+    const openEditor = async () => {
+      const user = userEvent.setup();
+      renderChecks('pii-filter');
+      await screen.findByText('Guardrail Test Cases', undefined, { timeout: XL_SELECTOR_TIMEOUT });
+      return user;
+    };
+
+    it('asks for confirmation instead of deleting on the first click', async () => {
+      const user = await openEditor();
+
+      await user.click(screen.getByRole('button', { name: 'Delete test 1' }));
+
+      expect(await screen.findByText('Delete Test 1')).toBeInTheDocument();
+      expect(getMockGuardrailCheck('leaks-ssn')).toBeDefined();
+    });
+
+    it('deletes the confirmed check and leaves its siblings alone', async () => {
+      const user = await openEditor();
+
+      await user.click(screen.getByRole('button', { name: 'Delete test 1' }));
+      await user.click(await screen.findByRole('button', { name: 'Delete' }));
+
+      expect(
+        await screen.findByText('Test deleted successfully.', undefined, {
+          timeout: XL_SELECTOR_TIMEOUT,
+        })
+      ).toBeInTheDocument();
+      expect(getMockGuardrailCheck('leaks-ssn')).toBeUndefined();
+      expect(getMockGuardrailCheck('benign-greeting')).toBeDefined();
+    });
+
+    it('keeps the check when the user backs out of the modal', async () => {
+      const user = await openEditor();
+
+      await user.click(screen.getByRole('button', { name: 'Delete test 1' }));
+      await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+      expect(getMockGuardrailCheck('leaks-ssn')).toBeDefined();
+    });
+
+    // The card disappearing without a manual refresh rides on this invalidation; the app's
+    // singleton queryClient is not the one TestProviders renders, so assert the call itself.
+    it('invalidates the checks list so the card disappears on its own', async () => {
+      const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+      const user = await openEditor();
+
+      await user.click(screen.getByRole('button', { name: 'Delete test 1' }));
+      await user.click(await screen.findByRole('button', { name: 'Delete' }));
+
+      await screen.findByText('Test deleted successfully.', undefined, {
+        timeout: XL_SELECTOR_TIMEOUT,
+      });
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: getGuardrailChecksQueryKey(WORKSPACE),
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

A guardrail check could be created and edited in the **Test and Validate** tab but never removed, so a typo'd or obsolete test case stayed in the list forever and could only be cleaned up outside Studio. Individual messages *within* a check already had a delete action; the gap was at the check level. Each test card header now carries a delete action that confirms through the shared `DeleteConfirmationModal` before removing the check.

The plumbing already existed — `useDeleteGuardrailCheck` was implemented but referenced nowhere in the app — so this is the missing UI affordance plus tests.

## Changes

- `GuardrailTestCard.tsx`: a trash action in the card header (matching the icon-button idiom `GuardrailMessageRow` already uses), a `DeleteConfirmationModal` naming the test it would remove, and a `handleDelete` wired to `useDeleteGuardrailCheck`. The hook is used without an `onError` toast — the modal reports its own outcome, so adding one would double up.
- New required `configId` prop on the card: checks are hard children, so the delete call needs the owning config's entity id. `Entity.parent` is optional in the generated schema, whereas the editor already holds `configId` as a definite string.
- `GuardrailTestCasesEditor.tsx`: passes `configId` through.
- Tests in `GuardrailChecksTab/index.test.tsx` covering confirm-before-delete, delete-only-the-confirmed-check, cancel, and the cache invalidation that makes the card disappear.

The card disappears on its own because `useDeleteGuardrailCheck.onSuccess` calls `invalidateGuardrailChecksCaches`, refetching the config's check list. That invalidation targets the app's module-singleton `queryClient`, which is not the one `TestProviders` renders — so the test asserts the `invalidateQueries` call itself rather than pretending to observe the refetch.

**Results sub-tab:** no matching affordance is needed. Runs are stored on the check entity as `data.runs`, so a deleted check takes its run history with it and the Results table (a read view over the same `checks` array) updates from the same refetch. Bulk delete is left out as the issue marks it optional.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal Studio UI affordance, no documented interface changes

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm vitest --run src/routes/guardrails src/components/dataViews/GuardrailChecksDataView src/components/sidePanels/GuardrailCheckDetailSidePanel src/tests` — 21 files, 236 tests passed.
- `pnpm vitest --run src/api/guardrail-checks src/components/dataViews/GuardrailsDataView` — 3 files, 48 tests passed (the remaining suites touching the guardrails mock handlers).
- `pnpm exec eslint packages/studio/src/routes/guardrails/GuardrailChecksTab --max-warnings 0` — clean.
- `pnpm exec prettier --check packages/studio/src/routes/guardrails/GuardrailChecksTab` — clean.
- `pnpm exec tsc -p packages/studio --noEmit` — one error in `packages/common/src/components/FilesetSearchableSelect/index.tsx`, verified present on the unmodified tree as well; no new type errors from this change.
- `uv run pre-commit run -a` was not run over the whole repo; the commit hooks (copyright headers, UI lint-staged, DCO, merge-conflict checks) passed. The Python hooks are no-ops here — this change touches only `web/`.

## Stacked on

Builds on #1611 (`fix(studio): append new guardrail test cases to the end of the list`), which this branch's card and editor changes sit directly on top of. Review that one first.
