### PR TITLE
chore(coderabbit): review release branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,6 +17,8 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+      - "^release/.*$"
   path_filters:
     - "!sdk/**"
   path_instructions:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Allow CodeRabbit auto-reviews on pull requests targeting release branches.

## Changes

- Add `^release/.*$` to the CodeRabbit auto-review base branch filters.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [x] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This change only updates CodeRabbit configuration.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: This change has no user-visible product behavior.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `git diff --check origin/release/0.5...HEAD` passed.
- `yq -e '.' .coderabbit.yaml` parsed the configuration successfully.
- Asserted `.reviews.auto_review.base_branches` equals `["^release/.*$"]`.
- `uv run pre-commit run -a` was blocked because `uv` is not installed in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nvidia.slack.com/archives/C05PD5TSN06/p1787874030333849?thread_ts=1787874030.333849&cid=C05PD5TSN06)

<div><a href="https://cursor.com/agents/bc-ad9f58b5-753c-5acd-9691-04b9c4755259?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad9f58b5-753c-5acd-9691-04b9c4755259&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

