### PR TITLE
fix(cve): drop unreferenced mlflow-skinny cache metadata

### DIFF
--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -450,7 +450,7 @@ for py in /opt/ray_venvs/*/bin/python /opt/gym_venvs/*/bin/python; do
         uv pip install --python "${py}" --upgrade-package wandb "wandb>=0.29.0"
     fi
 done
-for dist_info_glob in mlflow-*.dist-info sqlparse-*.dist-info wandb-*.dist-info; do
+for dist_info_glob in mlflow-*.dist-info mlflow_skinny-*.dist-info sqlparse-*.dist-info wandb-*.dist-info; do
     for d in "${UV_CACHE_DIR}"/archive-v0/*/; do
         ls "${d}"${dist_info_glob} >/dev/null 2>&1 || continue
         find /opt/nemo_rl_venv /opt/ray_venvs /opt/gym_venvs -lname "*$(basename "${d}")*" -print -quit 2>/dev/null | grep -q . && continue

--- a/tests/unit/test_docker_workspace_slices.py
+++ b/tests/unit/test_docker_workspace_slices.py
@@ -154,12 +154,6 @@ def test_automodel_cve_layer_does_not_pin_full_mlflow_with_cryptography() -> Non
     assert not FULL_MLFLOW_SPEC_RE.search(text)
 
 
-def test_rl_uv_cache_cleanup_includes_mlflow_skinny_dist_info() -> None:
-    """Skinny metadata uses mlflow_skinny-*.dist-info, which mlflow-*.dist-info does not match."""
-    text = (ROOT / "docker/rl/Dockerfile.nmp-rl-base").read_text(encoding="utf-8")
-    assert "mlflow_skinny-*.dist-info" in text
-
-
 @pytest.mark.parametrize("slice_name", WORKSPACE_SLICES)
 def test_docker_workspace_slice_contains_all_workspace_sources(slice_name):
     """Every workspace source must name a package copied into the image slice."""

--- a/tests/unit/test_docker_workspace_slices.py
+++ b/tests/unit/test_docker_workspace_slices.py
@@ -154,6 +154,12 @@ def test_automodel_cve_layer_does_not_pin_full_mlflow_with_cryptography() -> Non
     assert not FULL_MLFLOW_SPEC_RE.search(text)
 
 
+def test_rl_uv_cache_cleanup_includes_mlflow_skinny_dist_info() -> None:
+    """Skinny metadata uses mlflow_skinny-*.dist-info, which mlflow-*.dist-info does not match."""
+    text = (ROOT / "docker/rl/Dockerfile.nmp-rl-base").read_text(encoding="utf-8")
+    assert "mlflow_skinny-*.dist-info" in text
+
+
 @pytest.mark.parametrize("slice_name", WORKSPACE_SLICES)
 def test_docker_workspace_slice_contains_all_workspace_sources(slice_name):
     """Every workspace source must name a package copied into the image slice."""


### PR DESCRIPTION
## Reviewer context

Trivial Dockerfile glob fix. `mlflow-skinny` wheels install `mlflow_skinny-<ver>.dist-info`; the RL uv-cache sweep only matched `mlflow-*.dist-info` and could leave scanner-visible archives. Please confirm the extra glob sits next to the existing mlflow/sqlparse/wandb loop.

## CVE / sheet

- Cluster: mlflow / mlflow-skinny leftover cache metadata (post-1609 skinny install)
- Change: add `mlflow_skinny-*.dist-info` to `dist_info_glob` in `docker/rl/Dockerfile.nmp-rl-base`
- Images: nmp-rl-base (and downstream RL GPU images)

## Non-changes

Does not bump mlflow, rebuild GPU images locally, or change 1615 / distroless.

## Verification

Cold `nmp-rl-training-smoke-test` is CI only.

Fixed in source; not re-scanned by Pulse.