### PR TITLE
feat(eval-author): add task closure skill

### DIFF
--- a/plugins/nemo-eval-author/README.md
+++ b/plugins/nemo-eval-author/README.md
@@ -20,8 +20,8 @@ runs on whatever Python the customer already has. Audit validation needs PyYAML
 to read the marked YAML block and jsonschema to enforce
 `schemas/audit.schema.json`. Trace inspection requires the supported `nemo` CLI,
 an explicit workspace, and read access to a configured local or remote NeMo
-Platform instance. Closing a generated task draft requires Harbor and may
-require Docker plus model provider credentials.
+Platform instance. Closing a generated task draft requires Python 3.11 or
+later, Harbor, and may require Docker plus model provider credentials.
 
 `tests/test_skill_contract.py` holds to the same boundary and imports nothing
 from the platform, so `pytest`, `pyyaml`, and `jsonschema` are enough to run it.

--- a/plugins/nemo-eval-author/README.md
+++ b/plugins/nemo-eval-author/README.md
@@ -3,10 +3,10 @@
 
 # NeMo Eval Author
 
-Four skills that an agent reads to work on the evaluation suites in a user's own
-repository and to understand traces from NeMo Intake. This directory provides no
-installed public package or service, so a customer points their agent at
-`skills/` and nothing gets installed.
+Skills that an agent reads to work on evaluation suites in a user's own
+repository, close generated eval gaps, and understand traces from NeMo Intake.
+This directory provides no installed public package or service, so a customer
+points their agent at `skills/` and nothing gets installed.
 
 The audit sub-flow also ships a bundled validator CLI at
 [`skills/eval-author-audit/scripts/audit_spec/validate.py`](skills/eval-author-audit/scripts/audit_spec/validate.py)
@@ -20,7 +20,8 @@ runs on whatever Python the customer already has. Audit validation needs PyYAML
 to read the marked YAML block and jsonschema to enforce
 `schemas/audit.schema.json`. Trace inspection requires the supported `nemo` CLI,
 an explicit workspace, and read access to a configured local or remote NeMo
-Platform instance.
+Platform instance. Closing a generated task draft requires Harbor and may
+require Docker plus model provider credentials.
 
 `tests/test_skill_contract.py` holds to the same boundary and imports nothing
 from the platform, so `pytest`, `pyyaml`, and `jsonschema` are enough to run it.
@@ -32,7 +33,9 @@ group.
 | --- | --- |
 | [`eval-author`](skills/eval-author/SKILL.md) | Core. Owns the standard every sub-flow follows and routes to one. |
 | [`eval-author-discover`](skills/eval-author-discover/SKILL.md) | Sub-flow. Records whether a repository's Harbor evals are ready to run. |
-| [`eval-author-audit`](skills/eval-author-audit/SKILL.md) | Sub-flow. Validates an existing finite `audit.md` coverage denominator. |
+| [`eval-author-audit`](skills/eval-author-audit/SKILL.md) | Sub-flow. Generates, validates, measures, and aggregates an `audit.md` coverage denominator. |
+| [`eval-author-task-create`](skills/eval-author-task-create/SKILL.md) | Sub-flow. Turns one actionable uncovered tool into a Harbor-native task draft. |
+| [`eval-author-task-close`](skills/eval-author-task-close/SKILL.md) | Sub-flow. Repairs and proves one generated task draft, then classifies coverage closure from measured ATIF repeats. |
 | [`eval-author-inspect-trace`](skills/eval-author-inspect-trace/SKILL.md) | Sub-flow. Not user-invocable. Explains one Intake trace after `eval-author` selects it. |
 
 ## Where findings go
@@ -41,13 +44,20 @@ group.
 JSON as front matter so a later model reads the verdict without Harbor. It is
 visible and worth committing: a teammate who reads it skips the discovery pass.
 
+`eval-author-task-create` writes proposals and generated Harbor task drafts under
+`.eval-author/`.
+
+`eval-author-task-close` writes task runs, measurements, and closure reports
+under `.eval-author/`. It may repair only the generated task draft it is closing.
+It does not promote accepted drafts into the repository's canonical eval suite.
+
 `eval-author-inspect-trace` leaves one report per trace under
 `.eval-author/traces/`. The front matter carries Intake source metadata and the
 exact read commands. Findings use `behavior`, `issue`, `recovery`, and
 `uncertainty` categories.
 
-The bundled scripts write no files. They report to stdout, and the skill tells
-the agent where to save. Trace inspection contains instructions only.
+Bundled scripts print JSON verdicts to stdout and write only the explicit output
+paths named by the skill. Trace inspection contains instructions only.
 
 ## Why skills instead of an agent
 
@@ -77,6 +87,10 @@ contexts, authentication, transport, filters, pagination, and errors.
   whether a Harbor suite can run.
 - Use [`eval-author-audit`](skills/eval-author-audit/SKILL.md) to validate an
   existing finite `audit.md` coverage denominator.
+- Use [`eval-author-task-create`](skills/eval-author-task-create/SKILL.md) to
+  scaffold one task draft from an actionable uncovered tool.
+- Use [`eval-author-task-close`](skills/eval-author-task-close/SKILL.md) to
+  prove or reject that generated task draft.
 - After `eval-author` selects it, follow
   [`eval-author-inspect-trace`](skills/eval-author-inspect-trace/SKILL.md) to
   explain one Intake trace.

--- a/plugins/nemo-eval-author/pyproject.toml
+++ b/plugins/nemo-eval-author/pyproject.toml
@@ -4,11 +4,11 @@
 [project]
 name = "nemo-eval-author-plugin"
 version = "0.1.0"
-description = "Eval Author skills for Harbor suite discovery, audit-spec validation, and Intake trace understanding."
+description = "Eval Author skills for Harbor suite discovery, audit coverage, task authoring, task closure, and Intake trace understanding."
 requires-python = ">=3.12,<3.14"
 
 [tool.uv]
-# Nothing here installs as a package. The directory holds four skills, their
+# Nothing here installs as a package. The directory holds Eval Author skills, their
 # bundled scripts, and contract tests. The skills stay at the top level
 # because this plugin doesn't use the `nemo.skills` entry point.
 package = false

--- a/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-audit/SKILL.md
@@ -317,5 +317,8 @@ Treat that list as the input for a later task-generation step.
 - When aggregate `uncovered_items` includes actionable tools
   (`reason: not_covered_by_any_input_report`), hand off to
   [`eval-author-task-create`](../eval-author-task-create/SKILL.md) to scaffold
-  and prove one gap at a time. Capability or failure-case items with
+  one gap at a time, then to
+  [`eval-author-task-close`](../eval-author-task-close/SKILL.md) when the user
+  wants to prove the generated draft with Oracle, real-agent ATIF, and closure
+  classification. Capability or failure-case items with
   `reason: not_measured_by_any_method` stay audit findings only in v1.

--- a/plugins/nemo-eval-author/skills/eval-author-task-close/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-task-close/SKILL.md
@@ -214,6 +214,9 @@ uv run <skill_dir>/scripts/task_close.py report \
   --out .eval-author/task-closures/<task-slug>/closure-report.json
 ```
 
+The classifier uses `--draft` to verify each after-report belongs to
+`<task-slug>`. If you classify without `--draft`, pass `--task-id <task-slug>`.
+
 Report the JSON verdict. Treat these distinctions carefully:
 
 - `closed`: Oracle passed and both measured real-agent repeats covered the target tool.

--- a/plugins/nemo-eval-author/skills/eval-author-task-close/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-task-close/SKILL.md
@@ -1,0 +1,231 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: eval-author-task-close
+description: >-
+  Close one generated Eval Author Harbor task draft by repairing only the draft,
+  proving task/verifier quality with Harbor Oracle, running the real agent when
+  authorized, measuring the resulting ATIF traces, and reporting whether the
+  selected audit coverage gap closed. Use when the user asks to finish, verify,
+  close, or prove a generated task draft. Writes only under `.eval-author/`.
+triggers:
+  - close a generated Harbor task
+  - verify a generated eval task closes coverage
+  - finish the Eval Author task draft
+  - prove the generated task works
+  - turn the generated task into coverage closure
+not-for:
+  - eval-author (use for the shared standard and routing)
+  - eval-author-audit (use to create the denominator and coverage report)
+  - eval-author-task-create (use to select a gap and scaffold the initial draft)
+  - eval-author-discover (use to prove an existing suite is runnable)
+  - nemo-evaluator (use to run an existing benchmark without authoring tasks)
+compatibility: >-
+  Python 3.11 or later for the helper script. Harbor is required for Oracle and
+  real-agent trials. Docker is required for Docker-backed tasks. Real-agent runs
+  may require provider credentials and explicit user approval.
+maturity: alpha
+license: Apache-2.0
+user-invocable: true
+allowed-tools: [Bash, Read, Write, Grep, Glob]
+---
+
+# Eval Author: close task
+
+Read `eval-author` for the shared evidence standard and boundaries. Read
+`eval-author-task-create` for the draft's selected target and canonical paths.
+Read `eval-author-audit` before measuring any new trajectory.
+
+This sub-flow owns the evidence loop after `eval-author-task-create` has already
+created a candidate under `.eval-author/task-drafts/<task-slug>`:
+
+```text
+generated Harbor draft
+  -> runnable task with a meaningful verifier
+  -> Oracle reward 1
+  -> real-agent ATIF repeats
+  -> measured coverage closure or precise failure
+```
+
+Do not optimize for a green real-agent score. A real-agent verifier failure can
+be a successful eval-authoring result when the task is runnable, the verifier is
+meaningful, and the measured trace closes the target tool gap.
+
+## Script
+
+`scripts/task_close.py` provides deterministic checks and reports:
+
+| Command | Verdict |
+|---|---|
+| `preflight` | Checks whether the local Harbor CLI is compatible and, when requested, Docker is reachable |
+| `inspect` | Checks the draft layout, obvious placeholders, verifier reward writer, failure path, task metadata, and optional before-report target |
+| `report` | Combines the before report, after coverage reports, Oracle reward, and real-agent rewards into one fine-grained closure verdict |
+
+The script prints one JSON object. For `report`, exit code 0 means coverage
+closure was accepted, not that the real agent necessarily passed the task.
+
+## Status Updates
+
+Give the user short status updates before each material step:
+
+- draft inspection
+- verifier/environment repair attempt
+- Harbor Oracle run
+- real-agent run request
+- ATIF measurement
+- closure classification
+
+When stopping, name the specific status and human next step. Failure is a valid
+outcome; asking for human task design, credentials, environment help, or verifier
+review is expected when evidence is insufficient.
+
+## Inputs
+
+Start from the generated draft and the coverage artifacts that motivated it:
+
+```text
+.eval-author/audit.md
+.eval-author/audit-coverage-report.json
+.eval-author/task-drafts/<task-slug>/
+target tool name
+```
+
+Use the existing Harbor config or agent invocation only when it is already proven
+for this repository or the user supplies it. Real-agent runs spend credentials,
+so ask before starting them unless the user already approved the run.
+
+## Step 1: preflight local executors
+
+```bash
+uv run <skill_dir>/scripts/task_close.py preflight --require-docker \
+  --out .eval-author/task-closures/<task-slug>/preflight.json
+```
+
+If this returns `blocked_no_harbor`, `blocked_incompatible_harbor`, or
+`blocked_no_docker`, stop and report the status unless the user wants to change
+the local environment. Do not skip Oracle proof and call the task accepted.
+
+## Step 2: inspect the draft
+
+```bash
+uv run <skill_dir>/scripts/task_close.py inspect \
+  --draft .eval-author/task-drafts/<task-slug> \
+  --target <tool-name> \
+  --before .eval-author/audit-coverage-report.json \
+  --out .eval-author/task-closures/<task-slug>/inspection.json
+```
+
+Repair required failures before Oracle. Edit only files inside
+`.eval-author/task-drafts/<task-slug>/`. Do not edit customer source, existing
+evals, or frozen input traces.
+
+## Step 3: repair for runnability and verifier sanity
+
+Use at most three repair attempts for each category before asking for human help:
+
+- environment/Dockerfile or task metadata repair
+- verifier repair
+- Oracle solution repair
+
+The verifier grades the task outcome, not tool calls. ATIF measurement proves
+tool coverage separately. Do not weaken the verifier merely to get reward 1.
+
+Before Oracle, reason through these controls and implement them when practical:
+
+- empty or missing answer fails
+- wrong answer fails
+- canonical solution passes
+- verifier does not inspect trajectory/tool-call logs
+- verifier does not award unconditional reward 1
+
+If a generated verifier cannot be made meaningful, stop with
+`needs_human_verifier_review`.
+
+## Step 4: prove with Oracle
+
+Run Harbor's Oracle before spending model credentials:
+
+```bash
+harbor trial start \
+  --path .eval-author/task-drafts/<task-slug> \
+  --agent oracle \
+  --trial-name oracle \
+  --trials-dir .eval-author/task-runs/<task-slug>/oracle
+```
+
+Continue only when Harbor reports no exception and reward 1.0. If Oracle fails,
+repair the task, solution, or verifier without weakening the verifier. Stop with
+`oracle_failed` after the repair budget is exhausted.
+
+## Step 5: run the real agent without aiming for green
+
+Run two real-agent repeats only after approval:
+
+```bash
+harbor trial start \
+  --path .eval-author/task-drafts/<task-slug> \
+  --agent <agent-name> \
+  --trial-name repeat-1 \
+  --trials-dir .eval-author/task-runs/<task-slug>/repeat-1
+```
+
+Repeat for `repeat-2`. Record each reward and trial directory. A reward 0 can be
+a valid result if the task is sane and the target tool is covered.
+
+Require each trial to emit an `agent/trajectory.json` that
+`eval-author-audit` can parse. A missing or invalid ATIF file is
+`trajectory_invalid`, not coverage evidence.
+
+## Step 6: measure each new trajectory
+
+Measure repeats separately so one successful run cannot hide another:
+
+```bash
+uv run --with-requirements <audit_skill_dir>/requirements.txt \
+  <audit_skill_dir>/scripts/audit_spec/measure.py \
+  --audit .eval-author/audit.md \
+  --trial-dir .eval-author/task-runs/<task-slug>/repeat-1 \
+  --task-id <task-slug> \
+  --run-id repeat-1 \
+  --out-dir .eval-author/task-measurements/<task-slug>/repeat-1
+
+uv run --with-requirements <audit_skill_dir>/requirements.txt \
+  <audit_skill_dir>/scripts/audit_spec/report.py \
+  --audit .eval-author/audit.md \
+  --coverage-dir .eval-author/task-measurements/<task-slug>/repeat-1 \
+  --out .eval-author/task-measurements/<task-slug>/repeat-1-report.json
+```
+
+Repeat for `repeat-2`.
+
+## Step 7: classify closure
+
+```bash
+uv run <skill_dir>/scripts/task_close.py report \
+  --before .eval-author/audit-coverage-report.json \
+  --after .eval-author/task-measurements/<task-slug>/repeat-1-report.json \
+  --after .eval-author/task-measurements/<task-slug>/repeat-2-report.json \
+  --target <tool-name> \
+  --draft .eval-author/task-drafts/<task-slug> \
+  --oracle-reward <oracle-reward> \
+  --agent-reward <repeat-1-reward> \
+  --agent-reward <repeat-2-reward> \
+  --out .eval-author/task-closures/<task-slug>/closure-report.json
+```
+
+Report the JSON verdict. Treat these distinctions carefully:
+
+- `closed`: Oracle passed and both measured real-agent repeats covered the target tool.
+- `agent_solved_without_target_tool`: the real agent got reward but coverage did not close.
+- `coverage_unproven`: fewer than two distinct measured real-agent repeats were supplied.
+- `coverage_not_closed`: the target tool was not covered in every repeat.
+- `trajectory_invalid`: a new run did not produce measurable ATIF.
+- `oracle_failed`: Harbor did not prove the task/verifier/solution combination.
+- `task_draft_needs_repair`: static draft inspection found required gaps.
+- `oracle_unproven`: Oracle was not run or the reward was not supplied.
+- `blocked_no_docker`: local Docker is unavailable for Docker-backed proof.
+
+When `status: closed` and `real_agent.passed_task: false`, the generated eval is
+valid and found an agent failure. Promotion into the repository's canonical eval
+suite is a separate explicit step after the user accepts the draft.

--- a/plugins/nemo-eval-author/skills/eval-author-task-close/scripts/task_close.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-close/scripts/task_close.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inspect generated Harbor task drafts and classify coverage closure evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+from typing import Any
+
+_ACTIONABLE_REASON = "not_covered_by_any_input_report"
+_DRAFT_PARTS = (".eval-author", "task-drafts")
+_CLOSURE_PARTS = (".eval-author", "task-closures")
+_REQUIRED_TASK_FILES = (
+    "instruction.md",
+    "task.toml",
+    "environment/Dockerfile",
+    "tests/test.sh",
+    "solution/solve.sh",
+)
+_MIN_AFTER_REPORTS = 2
+_REWARD_THRESHOLD = 1.0
+
+
+class CloseError(ValueError):
+    """A user-correctable task-close input error."""
+
+
+def _read_text(path: Path) -> str:
+    """Read UTF-8 text from ``path`` or raise ``CloseError``."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CloseError(f"cannot read {path}: {exc}") from exc
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    """Load one JSON object from ``path`` or raise ``CloseError``."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise CloseError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CloseError(f"expected a JSON object: {path}")
+    return payload
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write ``payload`` to ``path`` under the task-closure work area."""
+    _require_parts(path, _CLOSURE_PARTS, "output must be under .eval-author/task-closures/")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _require_parts(path: Path, parts: tuple[str, str], message: str) -> None:
+    """Require ``path`` to live under a named ``.eval-author`` subdirectory."""
+    resolved_parts = path.resolve().parts
+    for index in range(len(resolved_parts) - 1):
+        if resolved_parts[index : index + 2] == parts:
+            return
+    raise CloseError(message)
+
+
+def _check(name: str, passed: bool, message: str, *, severity: str = "required") -> dict[str, Any]:
+    """Build one draft inspection check."""
+    return {
+        "name": name,
+        "passed": passed,
+        "severity": severity,
+        "message": message,
+    }
+
+
+def _preflight(*, require_docker: bool) -> tuple[int, dict[str, Any]]:
+    """Check local tools needed for task closure without starting a task."""
+    checks: list[dict[str, Any]] = []
+    harbor = shutil.which("harbor")
+    checks.append(_check("harbor:available", harbor is not None, "harbor executable is available"))
+    harbor_compatible = False
+    if harbor is not None:
+        result = subprocess.run(
+            [harbor, "trial", "start", "--help"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        harbor_compatible = result.returncode == 0
+        checks.append(
+            _check(
+                "harbor:trial_start",
+                harbor_compatible,
+                "harbor exposes `trial start` for single-task Oracle and real-agent runs",
+            )
+        )
+
+    docker_ready = None
+    if require_docker:
+        docker = shutil.which("docker")
+        checks.append(_check("docker:available", docker is not None, "docker executable is available"))
+        if docker is not None:
+            result = subprocess.run(
+                [docker, "info", "--format", "{{.ServerVersion}}"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            docker_ready = result.returncode == 0
+            checks.append(_check("docker:daemon", docker_ready, "docker daemon is reachable"))
+
+    required_failed = [check for check in checks if check["severity"] == "required" and not check["passed"]]
+    if harbor is None:
+        status = "blocked_no_harbor"
+        next_step = "Install or expose a Harbor CLI compatible with `harbor trial start`."
+    elif not harbor_compatible:
+        status = "blocked_incompatible_harbor"
+        next_step = "Use a Harbor CLI version that exposes `harbor trial start`."
+    elif docker_ready is False or (require_docker and docker_ready is None):
+        status = "blocked_no_docker"
+        next_step = "Start Docker or use a supported non-Docker Harbor environment before Oracle proof."
+    else:
+        status = "ready"
+        next_step = "Run draft inspection or Harbor Oracle."
+
+    payload = {
+        "schema": "nemo.eval_author.task_close_preflight.v1",
+        "status": status,
+        "valid": not required_failed,
+        "checks": checks,
+        "next_step": next_step,
+    }
+    return (0 if payload["valid"] else 1), payload
+
+
+def _contains_placeholder(text: str) -> bool:
+    """Return whether ``text`` still looks like unfilled scaffold content."""
+    return bool(re.search(r"\b(TODO|FIXME|TBD|placeholder|replace me|your solution)\b", text, re.IGNORECASE))
+
+
+def _looks_like_unconditional_reward(text: str) -> bool:
+    """Return whether a verifier appears to award reward 1 without a failure path."""
+    writes_reward_one = bool(
+        re.search(r"\breward\s*=\s*1\b", text) or re.search(r"\b(?:echo|printf)\b[^\n]*\b1\b[^\n]*reward\.txt", text)
+    )
+    has_failure_path = bool(
+        re.search(r"\breward\s*=\s*0\b", text)
+        or re.search(r"\b(?:echo|printf)\b[^\n]*\b0\b[^\n]*reward\.txt", text)
+        or re.search(r"\bif\b|\bcase\b", text)
+    )
+    return writes_reward_one and not has_failure_path
+
+
+def _load_task_toml(path: Path) -> dict[str, Any]:
+    """Load ``task.toml`` as TOML or raise ``CloseError``."""
+    try:
+        with path.open("rb") as stream:
+            payload = tomllib.load(stream)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise CloseError(f"cannot parse {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CloseError(f"expected TOML table in {path}")
+    return payload
+
+
+def _target_is_actionable(before: dict[str, Any], target: str) -> bool:
+    """Return whether ``target`` is an actionable uncovered tool in a before report."""
+    for item in before.get("uncovered_items") or []:
+        if not isinstance(item, dict):
+            continue
+        if item.get("name") == target and item.get("kind") == "tool" and item.get("reason") == _ACTIONABLE_REASON:
+            return True
+    return False
+
+
+def _inspect_draft(draft: Path, *, target: str, before_report: Path | None = None) -> dict[str, Any]:
+    """Inspect one generated Harbor task draft without running it."""
+    checks: list[dict[str, Any]] = []
+    checks.append(
+        _check(
+            "draft_under_eval_author",
+            _path_has_parts(draft, _DRAFT_PARTS),
+            "draft path must live under .eval-author/task-drafts/",
+        )
+    )
+    checks.append(_check("draft_exists", draft.is_dir(), "draft directory exists"))
+
+    for relative in _REQUIRED_TASK_FILES:
+        path = draft / relative
+        exists = path.is_file()
+        checks.append(_check(f"{relative}:exists", exists, f"{relative} exists"))
+        if exists:
+            text = _read_text(path)
+            checks.append(_check(f"{relative}:nonempty", bool(text.strip()), f"{relative} is not empty"))
+            checks.append(
+                _check(
+                    f"{relative}:no_placeholder",
+                    not _contains_placeholder(text),
+                    f"{relative} has no obvious scaffold placeholders",
+                )
+            )
+
+    task_toml = draft / "task.toml"
+    if task_toml.is_file():
+        try:
+            task_config = _load_task_toml(task_toml)
+        except CloseError as exc:
+            checks.append(_check("task_toml:parse", False, str(exc)))
+        else:
+            task = task_config.get("task")
+            keywords = task.get("keywords") if isinstance(task, dict) else None
+            if keywords is None:
+                keywords = task_config.get("metadata", {}).get("keywords")
+            checks.append(_check("task_toml:task_name", bool(task and task.get("name")), "task.toml names the task"))
+            checks.append(
+                _check(
+                    "task_toml:keywords",
+                    isinstance(keywords, list) and bool(keywords),
+                    "task.toml carries nonempty keywords or metadata keywords",
+                )
+            )
+
+    dockerfile = draft / "environment" / "Dockerfile"
+    if dockerfile.is_file():
+        text = _read_text(dockerfile)
+        checks.append(
+            _check(
+                "dockerfile:from", bool(re.search(r"^\s*FROM\s+\S+", text, re.MULTILINE)), "Dockerfile has a base image"
+            )
+        )
+
+    verifier = draft / "tests" / "test.sh"
+    if verifier.is_file():
+        text = _read_text(verifier)
+        checks.append(
+            _check(
+                "verifier:writes_reward",
+                "/logs/verifier/reward.txt" in text,
+                "verifier writes /logs/verifier/reward.txt",
+            )
+        )
+        checks.append(
+            _check(
+                "verifier:has_failure_path",
+                bool(re.search(r"\breward\s*=\s*0\b", text) or re.search(r"\bif\b|\bcase\b", text)),
+                "verifier has an observable failure path",
+            )
+        )
+        checks.append(
+            _check(
+                "verifier:not_unconditional_reward",
+                not _looks_like_unconditional_reward(text),
+                "verifier does not appear to award reward 1 unconditionally",
+            )
+        )
+
+    solution = draft / "solution" / "solve.sh"
+    if solution.is_file():
+        text = _read_text(solution)
+        checks.append(
+            _check(
+                "solution:executable_hint",
+                text.startswith("#!") or "python" in text or "bash" in text,
+                "solution is executable or names an executable interpreter",
+                severity="advisory",
+            )
+        )
+
+    if before_report is not None:
+        before = _read_json(before_report)
+        checks.append(
+            _check(
+                "before_report:target_actionable",
+                _target_is_actionable(before, target),
+                f"{target!r} is an actionable uncovered tool in the before report",
+            )
+        )
+
+    required = [check for check in checks if check["severity"] == "required"]
+    required_failed = [check for check in required if not check["passed"]]
+    status = "ready_for_oracle" if not required_failed else "needs_repair"
+    return {
+        "schema": "nemo.eval_author.task_close_inspection.v1",
+        "draft": str(draft),
+        "target_tool": target,
+        "status": status,
+        "valid": not required_failed,
+        "checks": checks,
+        "summary": {
+            "required_passed": len(required) - len(required_failed),
+            "required_failed": len(required_failed),
+            "advisory_failed": sum(1 for check in checks if check["severity"] == "advisory" and not check["passed"]),
+        },
+    }
+
+
+def _path_has_parts(path: Path, parts: tuple[str, str]) -> bool:
+    """Return whether ``path`` is under a named ``.eval-author`` subdirectory."""
+    resolved_parts = path.resolve().parts
+    return any(resolved_parts[index : index + 2] == parts for index in range(len(resolved_parts) - 1))
+
+
+def _run_ids_from_report(report: dict[str, Any], *, report_path: Path) -> list[str]:
+    """Return ATIF ``subject.run_id`` values recorded in one aggregate coverage report."""
+    input_reports = report.get("input_reports")
+    if not isinstance(input_reports, list) or not input_reports:
+        raise CloseError(f"after report must include input_reports with subject.run_id: {report_path}")
+    run_ids: list[str] = []
+    for index, entry in enumerate(input_reports):
+        if not isinstance(entry, dict):
+            raise CloseError(f"after report input_reports[{index}] must be an object: {report_path}")
+        subject = entry.get("subject")
+        if not isinstance(subject, dict):
+            raise CloseError(f"after report input_reports[{index}] must include subject: {report_path}")
+        run_id = subject.get("run_id")
+        if not isinstance(run_id, str) or not run_id.strip():
+            raise CloseError(
+                f"after report input_reports[{index}].subject.run_id must be a non-empty string: {report_path}"
+            )
+        run_ids.append(run_id)
+    return run_ids
+
+
+def _coverage_runs(after_paths: list[Path], target: str) -> tuple[list[dict[str, Any]], bool]:
+    """Return per-repeat coverage verdicts and whether all repeats cover ``target``."""
+    if len(after_paths) < _MIN_AFTER_REPORTS:
+        raise CloseError(f"at least {_MIN_AFTER_REPORTS} --after reports are required")
+    resolved_paths = [path.resolve() for path in after_paths]
+    if len(set(resolved_paths)) != len(resolved_paths):
+        raise CloseError("--after reports must be distinct")
+
+    runs: list[dict[str, Any]] = []
+    run_ids: list[str] = []
+    all_covered = True
+    for path in after_paths:
+        report = _read_json(path)
+        report_run_ids = _run_ids_from_report(report, report_path=path)
+        run_ids.extend(report_run_ids)
+        covered = target in set(report.get("covered") or [])
+        still_uncovered = target in set(report.get("uncovered") or [])
+        passed = covered and not still_uncovered
+        all_covered = all_covered and passed
+        runs.append({"report": str(path), "run_ids": report_run_ids, "covered": covered, "passed": passed})
+
+    if len(set(run_ids)) != len(run_ids):
+        raise CloseError("--after reports must come from distinct ATIF subject.run_id values")
+    return runs, all_covered
+
+
+def _rewards_pass(rewards: list[float] | None, threshold: float) -> bool | None:
+    """Return whether every provided reward meets ``threshold``; ``None`` means unproven."""
+    if rewards is None or not rewards:
+        return None
+    return all(reward >= threshold for reward in rewards)
+
+
+def _closure_report(
+    *,
+    before_path: Path,
+    after_paths: list[Path],
+    target: str,
+    oracle_reward: float | None,
+    agent_rewards: list[float] | None,
+    reward_threshold: float,
+    draft: Path | None = None,
+) -> tuple[int, dict[str, Any]]:
+    """Classify one generated task draft from task, reward, and coverage evidence."""
+    before = _read_json(before_path)
+    target_actionable = _target_is_actionable(before, target)
+    runs: list[dict[str, Any]] = []
+    coverage_closed = False
+    coverage_error = None
+    if target_actionable:
+        try:
+            runs, coverage_closed = _coverage_runs(after_paths, target)
+        except CloseError as exc:
+            coverage_error = str(exc)
+
+    oracle_passed = None if oracle_reward is None else oracle_reward >= reward_threshold
+    agent_passed = _rewards_pass(agent_rewards, reward_threshold)
+
+    inspection = _inspect_draft(draft, target=target, before_report=before_path) if draft is not None else None
+    draft_ready = None if inspection is None else bool(inspection["valid"])
+
+    if not target_actionable:
+        status = "target_not_actionable"
+        next_step = "Regenerate or inspect the before report; the target is not an actionable uncovered tool."
+    elif draft_ready is False:
+        status = "task_draft_needs_repair"
+        next_step = "Repair the generated draft under .eval-author/task-drafts/ and rerun inspection."
+    elif oracle_passed is None:
+        status = "oracle_unproven"
+        next_step = "Run Harbor Oracle and pass --oracle-reward from the observed result."
+    elif not oracle_passed:
+        status = "oracle_failed"
+        next_step = "Repair the task environment, canonical solution, or verifier without weakening the verifier."
+    elif coverage_error is not None:
+        if coverage_error.startswith("at least"):
+            status = "coverage_unproven"
+            next_step = "Run and measure at least two distinct real-agent repeats before classifying closure."
+        else:
+            status = "trajectory_invalid"
+            next_step = (
+                "Fix the real-agent run or measurement artifact so each after report has a distinct ATIF run_id."
+            )
+    elif not coverage_closed and agent_passed is True:
+        status = "agent_solved_without_target_tool"
+        next_step = "Revise the task so success naturally requires the target tool, then rerun both real-agent trials."
+    elif not coverage_closed:
+        status = "coverage_not_closed"
+        next_step = "Inspect trajectories and task design; the target tool was not covered in every repeat."
+    else:
+        status = "closed"
+        next_step = "The generated task draft has evidence-backed coverage closure; promotion is a separate step."
+
+    accepted = status == "closed"
+    payload = {
+        "schema": "nemo.eval_author.task_close_report.v1",
+        "target_tool": target,
+        "before": str(before_path),
+        "after": [str(path) for path in after_paths],
+        "status": status,
+        "accepted": accepted,
+        "valid": True,
+        "failure_reason": None if accepted else status,
+        "task_runnable": oracle_passed,
+        "draft_ready": draft_ready,
+        "oracle": {
+            "reward": oracle_reward,
+            "threshold": reward_threshold,
+            "passed": oracle_passed,
+        },
+        "real_agent": {
+            "rewards": agent_rewards or [],
+            "threshold": reward_threshold,
+            "passed_task": agent_passed,
+        },
+        "coverage": {
+            "closed": coverage_closed,
+            "error": coverage_error,
+            "runs": runs,
+        },
+        "next_step": next_step,
+    }
+    if inspection is not None:
+        payload["inspection"] = inspection
+    return (0 if accepted else 1), payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inspect = subparsers.add_parser("inspect", help="inspect a generated Harbor task draft")
+    inspect.add_argument("--draft", type=Path, required=True)
+    inspect.add_argument("--target", required=True)
+    inspect.add_argument("--before", type=Path)
+    inspect.add_argument("--out", type=Path)
+
+    preflight = subparsers.add_parser("preflight", help="check local Harbor and optional Docker availability")
+    preflight.add_argument("--require-docker", action="store_true")
+    preflight.add_argument("--out", type=Path)
+
+    report = subparsers.add_parser("report", help="classify closure from before/after coverage and reward evidence")
+    report.add_argument("--before", type=Path, required=True)
+    report.add_argument("--after", type=Path, action="append", required=True)
+    report.add_argument("--target", required=True)
+    report.add_argument("--draft", type=Path)
+    report.add_argument("--oracle-reward", type=float)
+    report.add_argument("--agent-reward", type=float, action="append")
+    report.add_argument("--reward-threshold", type=float, default=_REWARD_THRESHOLD)
+    report.add_argument("--out", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one task-close command and print a JSON verdict on stdout."""
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "inspect":
+            payload = _inspect_draft(args.draft, target=args.target, before_report=args.before)
+            exit_code = 0 if payload["valid"] else 1
+        elif args.command == "preflight":
+            exit_code, payload = _preflight(require_docker=args.require_docker)
+        else:
+            exit_code, payload = _closure_report(
+                before_path=args.before,
+                after_paths=args.after,
+                target=args.target,
+                oracle_reward=args.oracle_reward,
+                agent_rewards=args.agent_reward,
+                reward_threshold=args.reward_threshold,
+                draft=args.draft,
+            )
+        if args.out is not None:
+            _write_json(args.out, payload)
+    except CloseError as exc:
+        payload = {"valid": False, "error": str(exc)}
+        exit_code = 1
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/nemo-eval-author/skills/eval-author-task-close/scripts/task_close.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-close/scripts/task_close.py
@@ -168,6 +168,15 @@ def _load_task_toml(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _optional_mapping(value: Any, *, table: str, path: Path) -> dict[str, Any]:
+    """Return a TOML table mapping or raise ``CloseError`` for scalar values."""
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise CloseError(f"{path}: [{table}] must be a TOML table when present")
+    return value
+
+
 def _target_is_actionable(before: dict[str, Any], target: str) -> bool:
     """Return whether ``target`` is an actionable uncovered tool in a before report."""
     for item in before.get("uncovered_items") or []:
@@ -212,18 +221,30 @@ def _inspect_draft(draft: Path, *, target: str, before_report: Path | None = Non
         except CloseError as exc:
             checks.append(_check("task_toml:parse", False, str(exc)))
         else:
-            task = task_config.get("task")
-            keywords = task.get("keywords") if isinstance(task, dict) else None
-            if keywords is None:
-                keywords = task_config.get("metadata", {}).get("keywords")
-            checks.append(_check("task_toml:task_name", bool(task and task.get("name")), "task.toml names the task"))
-            checks.append(
-                _check(
-                    "task_toml:keywords",
-                    isinstance(keywords, list) and bool(keywords),
-                    "task.toml carries nonempty keywords or metadata keywords",
+            try:
+                task = _optional_mapping(task_config.get("task"), table="task", path=task_toml)
+                metadata = _optional_mapping(task_config.get("metadata"), table="metadata", path=task_toml)
+            except CloseError as exc:
+                checks.append(_check("task_toml:structure", False, str(exc)))
+            else:
+                keywords = task.get("keywords")
+                if keywords is None:
+                    keywords = metadata.get("keywords")
+                task_name = task.get("name")
+                checks.append(
+                    _check(
+                        "task_toml:task_name",
+                        isinstance(task_name, str) and bool(task_name.strip()),
+                        "task.toml names the task",
+                    )
                 )
-            )
+                checks.append(
+                    _check(
+                        "task_toml:keywords",
+                        isinstance(keywords, list) and bool(keywords),
+                        "task.toml carries nonempty keywords or metadata keywords",
+                    )
+                )
 
     dockerfile = draft / "environment" / "Dockerfile"
     if dockerfile.is_file():
@@ -305,31 +326,41 @@ def _path_has_parts(path: Path, parts: tuple[str, str]) -> bool:
     return any(resolved_parts[index : index + 2] == parts for index in range(len(resolved_parts) - 1))
 
 
-def _run_ids_from_report(report: dict[str, Any], *, report_path: Path) -> list[str]:
-    """Return ATIF ``subject.run_id`` values recorded in one aggregate coverage report."""
+def _run_from_report(report: dict[str, Any], *, report_path: Path, expected_task_id: str) -> dict[str, str]:
+    """Return the single ATIF ``subject`` identity recorded in one coverage report."""
     input_reports = report.get("input_reports")
     if not isinstance(input_reports, list) or not input_reports:
         raise CloseError(f"after report must include input_reports with subject.run_id: {report_path}")
-    run_ids: list[str] = []
-    for index, entry in enumerate(input_reports):
-        if not isinstance(entry, dict):
-            raise CloseError(f"after report input_reports[{index}] must be an object: {report_path}")
-        subject = entry.get("subject")
-        if not isinstance(subject, dict):
-            raise CloseError(f"after report input_reports[{index}] must include subject: {report_path}")
-        run_id = subject.get("run_id")
-        if not isinstance(run_id, str) or not run_id.strip():
-            raise CloseError(
-                f"after report input_reports[{index}].subject.run_id must be a non-empty string: {report_path}"
-            )
-        run_ids.append(run_id)
-    return run_ids
+    if len(input_reports) != 1:
+        raise CloseError(f"after report must contain exactly one input report: {report_path}")
+    entry = input_reports[0]
+    if not isinstance(entry, dict):
+        raise CloseError(f"after report input_reports[0] must be an object: {report_path}")
+    subject = entry.get("subject")
+    if not isinstance(subject, dict):
+        raise CloseError(f"after report input_reports[0] must include subject: {report_path}")
+    task_id = subject.get("task_id")
+    if not isinstance(task_id, str) or not task_id.strip():
+        raise CloseError(f"after report input_reports[0].subject.task_id must be a non-empty string: {report_path}")
+    if task_id != expected_task_id:
+        raise CloseError(
+            f"after report input_reports[0].subject.task_id must be {expected_task_id!r}, got {task_id!r}: "
+            f"{report_path}"
+        )
+    run_id = subject.get("run_id")
+    if not isinstance(run_id, str) or not run_id.strip():
+        raise CloseError(f"after report input_reports[0].subject.run_id must be a non-empty string: {report_path}")
+    return {"task_id": task_id, "run_id": run_id}
 
 
-def _coverage_runs(after_paths: list[Path], target: str) -> tuple[list[dict[str, Any]], bool]:
+def _coverage_runs(
+    after_paths: list[Path], target: str, *, expected_task_id: str | None
+) -> tuple[list[dict[str, Any]], bool]:
     """Return per-repeat coverage verdicts and whether all repeats cover ``target``."""
     if len(after_paths) < _MIN_AFTER_REPORTS:
         raise CloseError(f"at least {_MIN_AFTER_REPORTS} --after reports are required")
+    if expected_task_id is None:
+        raise CloseError("expected task id is required; pass --task-id or --draft")
     resolved_paths = [path.resolve() for path in after_paths]
     if len(set(resolved_paths)) != len(resolved_paths):
         raise CloseError("--after reports must be distinct")
@@ -339,13 +370,21 @@ def _coverage_runs(after_paths: list[Path], target: str) -> tuple[list[dict[str,
     all_covered = True
     for path in after_paths:
         report = _read_json(path)
-        report_run_ids = _run_ids_from_report(report, report_path=path)
-        run_ids.extend(report_run_ids)
+        report_run = _run_from_report(report, report_path=path, expected_task_id=expected_task_id)
+        run_ids.append(report_run["run_id"])
         covered = target in set(report.get("covered") or [])
         still_uncovered = target in set(report.get("uncovered") or [])
         passed = covered and not still_uncovered
         all_covered = all_covered and passed
-        runs.append({"report": str(path), "run_ids": report_run_ids, "covered": covered, "passed": passed})
+        runs.append(
+            {
+                "report": str(path),
+                "task_id": report_run["task_id"],
+                "run_id": report_run["run_id"],
+                "covered": covered,
+                "passed": passed,
+            }
+        )
 
     if len(set(run_ids)) != len(run_ids):
         raise CloseError("--after reports must come from distinct ATIF subject.run_id values")
@@ -368,16 +407,18 @@ def _closure_report(
     agent_rewards: list[float] | None,
     reward_threshold: float,
     draft: Path | None = None,
+    task_id: str | None = None,
 ) -> tuple[int, dict[str, Any]]:
     """Classify one generated task draft from task, reward, and coverage evidence."""
     before = _read_json(before_path)
     target_actionable = _target_is_actionable(before, target)
+    expected_task_id = task_id or (draft.name if draft is not None else None)
     runs: list[dict[str, Any]] = []
     coverage_closed = False
     coverage_error = None
     if target_actionable:
         try:
-            runs, coverage_closed = _coverage_runs(after_paths, target)
+            runs, coverage_closed = _coverage_runs(after_paths, target, expected_task_id=expected_task_id)
         except CloseError as exc:
             coverage_error = str(exc)
 
@@ -422,6 +463,7 @@ def _closure_report(
     payload = {
         "schema": "nemo.eval_author.task_close_report.v1",
         "target_tool": target,
+        "task_id": expected_task_id,
         "before": str(before_path),
         "after": [str(path) for path in after_paths],
         "status": status,
@@ -472,6 +514,7 @@ def _parser() -> argparse.ArgumentParser:
     report.add_argument("--after", type=Path, action="append", required=True)
     report.add_argument("--target", required=True)
     report.add_argument("--draft", type=Path)
+    report.add_argument("--task-id")
     report.add_argument("--oracle-reward", type=float)
     report.add_argument("--agent-reward", type=float, action="append")
     report.add_argument("--reward-threshold", type=float, default=_REWARD_THRESHOLD)
@@ -497,6 +540,7 @@ def main(argv: list[str] | None = None) -> int:
                 agent_rewards=args.agent_reward,
                 reward_threshold=args.reward_threshold,
                 draft=args.draft,
+                task_id=args.task_id,
             )
         if args.out is not None:
             _write_json(args.out, payload)

--- a/plugins/nemo-eval-author/skills/eval-author-task-close/scripts/task_close.py
+++ b/plugins/nemo-eval-author/skills/eval-author-task-close/scripts/task_close.py
@@ -326,7 +326,7 @@ def _path_has_parts(path: Path, parts: tuple[str, str]) -> bool:
     return any(resolved_parts[index : index + 2] == parts for index in range(len(resolved_parts) - 1))
 
 
-def _run_from_report(report: dict[str, Any], *, report_path: Path, expected_task_id: str) -> dict[str, str]:
+def _run_from_report(report: dict[str, Any], *, report_path: Path, expected_task_id: str) -> dict[str, Any]:
     """Return the single ATIF ``subject`` identity recorded in one coverage report."""
     input_reports = report.get("input_reports")
     if not isinstance(input_reports, list) or not input_reports:
@@ -350,7 +350,26 @@ def _run_from_report(report: dict[str, Any], *, report_path: Path, expected_task
     run_id = subject.get("run_id")
     if not isinstance(run_id, str) or not run_id.strip():
         raise CloseError(f"after report input_reports[0].subject.run_id must be a non-empty string: {report_path}")
-    return {"task_id": task_id, "run_id": run_id}
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "covered": _strings_from_report_field(entry.get("covered"), field="covered", report_path=report_path),
+        "uncovered": _strings_from_report_field(entry.get("uncovered"), field="uncovered", report_path=report_path),
+    }
+
+
+def _strings_from_report_field(value: Any, *, field: str, report_path: Path) -> set[str]:
+    """Return string members from an optional coverage report field."""
+    if value is None:
+        return set()
+    if not isinstance(value, list):
+        raise CloseError(f"after report input_reports[0].{field} must be a list when present: {report_path}")
+    strings: set[str] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, str):
+            raise CloseError(f"after report input_reports[0].{field}[{index}] must be a string: {report_path}")
+        strings.add(item)
+    return strings
 
 
 def _coverage_runs(
@@ -372,8 +391,8 @@ def _coverage_runs(
         report = _read_json(path)
         report_run = _run_from_report(report, report_path=path, expected_task_id=expected_task_id)
         run_ids.append(report_run["run_id"])
-        covered = target in set(report.get("covered") or [])
-        still_uncovered = target in set(report.get("uncovered") or [])
+        covered = target in report_run["covered"]
+        still_uncovered = target in report_run["uncovered"]
         passed = covered and not still_uncovered
         all_covered = all_covered and passed
         runs.append(
@@ -412,7 +431,9 @@ def _closure_report(
     """Classify one generated task draft from task, reward, and coverage evidence."""
     before = _read_json(before_path)
     target_actionable = _target_is_actionable(before, target)
-    expected_task_id = task_id or (draft.name if draft is not None else None)
+    expected_task_id = draft.name if draft is not None else task_id
+    if expected_task_id is not None and not expected_task_id.strip():
+        expected_task_id = None
     runs: list[dict[str, Any]] = []
     coverage_closed = False
     coverage_error = None

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
@@ -23,9 +23,9 @@ not-for:
   - eval-author-discover (use to prove an existing suite is runnable)
   - nemo-evaluator (use to run an existing benchmark without authoring tasks)
 compatibility: >-
-  Python 3.11 or later and a Harbor CLI compatible with `harbor task init`.
-  Closing the generated draft requires `eval-author-task-close`, Harbor, and
-  often Docker plus provider credentials.
+  Python 3.11 or later for the copied helper scripts and a Harbor CLI compatible
+  with `harbor task init`. Closing the generated draft requires
+  `eval-author-task-close`, Harbor, and often Docker plus provider credentials.
 maturity: alpha
 license: Apache-2.0
 user-invocable: true

--- a/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md
@@ -5,11 +5,11 @@
 name: eval-author-task-create
 description: >-
   Create one Harbor task from one actionable uncovered tool in an Eval Author
-  audit coverage report, prove the task with Harbor's Oracle, run it repeatedly
-  with the repository's real agent when authorized, and accept it only when
-  measured ATIF closes the selected gap every time. Use when the user asks to
-  fill an eval gap, turn audit uncovered_items into a Harbor task, or add missing
-  tool coverage. Writes drafts and measurements only under `.eval-author/`.
+  audit coverage report. Use when the user asks to fill an eval gap, turn audit
+  uncovered_items into a Harbor task draft, or add missing tool coverage. Hand
+  the generated draft to `eval-author-task-close` for Oracle proof, real-agent
+  runs, measured ATIF, and closure classification. Writes drafts and proposals
+  only under `.eval-author/`.
 triggers:
   - create a Harbor task from an audit gap
   - fill an uncovered eval tool
@@ -19,12 +19,13 @@ triggers:
 not-for:
   - eval-author (use for the shared standard and routing)
   - eval-author-audit (use to create the denominator and coverage report)
+  - eval-author-task-close (use to prove or reject an existing generated task draft)
   - eval-author-discover (use to prove an existing suite is runnable)
   - nemo-evaluator (use to run an existing benchmark without authoring tasks)
 compatibility: >-
   Python 3.11 or later and a Harbor CLI compatible with `harbor task init`.
-  Docker is required for Oracle and Docker-backed real-agent runs. Real-agent
-  runs may require provider credentials and explicit user approval.
+  Closing the generated draft requires `eval-author-task-close`, Harbor, and
+  often Docker plus provider credentials.
 maturity: alpha
 license: Apache-2.0
 user-invocable: true
@@ -34,14 +35,12 @@ allowed-tools: [Bash, Read, Write, Grep, Glob]
 # Eval Author: create task
 
 Read `eval-author` for the shared evidence standard and boundaries. Read
-`eval-author-audit` for measurement and aggregation. This sub-flow owns only:
+`eval-author-audit` for the coverage report that provides actionable gaps. This
+sub-flow owns only:
 
 ```text
 actionable uncovered tool
   → Harbor-native draft
-  → Oracle reward 1
-  → repeated real-agent ATIF
-  → target tool covered in every report
 ```
 
 Work on one tool gap at a time. Keep every generated artifact under
@@ -55,7 +54,7 @@ Work on one tool gap at a time. Keep every generated artifact under
 |---|---|
 | `select` | Lists only tool items with `reason: not_covered_by_any_input_report` and emits a deterministic `task_slug` plus artifact paths |
 | `scaffold` | Calls Harbor's own `harbor task init`, requires matching draft/proposal names for that slug, and installs the supplied instruction |
-| `verify` | Exits 0 only when the selected tool was uncovered before and covered in two distinct repeated after-reports with distinct ATIF `subject.run_id` values |
+| `verify` | Deterministic primitive used by task-close-style workflows; exits 0 only when the selected tool was uncovered before and covered in two distinct repeated after-reports with distinct ATIF `subject.run_id` values |
 
 The script prints one JSON object. Exit code 0 is success; do not replace its
 verdict with model judgment.
@@ -119,58 +118,14 @@ Then complete Harbor's generated files:
 Do not leave generated placeholders, `pass`, unconditional reward 1, or empty
 keywords.
 
-## Step 4: prove task correctness with Oracle
+## Step 4: hand off to task-close
 
-Run Harbor's Oracle before spending model credentials:
+After the draft exists and the generated files are filled in, use
+`eval-author-task-close` to repair it, prove it with Oracle, run the real agent
+when authorized, measure new ATIF, and classify closure.
 
-```bash
-harbor run -p .eval-author/task-drafts/<task-slug> -a oracle
-```
-
-Continue only when Harbor reports no exception and reward 1.0. Fix the task,
-solution, or verifier when Oracle fails; do not weaken the verifier merely to
-make it pass.
-
-## Step 5: run the real agent twice
-
-Running a model spends credentials. Do it only when the user asked for the run
-or approved it. Use the repository's proven agent configuration, point it at the
-draft, and set `n_attempts: 2`. Keep the resulting job under `.eval-author/`.
-
-Require both trials to:
-
-1. finish without an exception,
-2. receive the intended verifier reward, and
-3. contain `agent/trajectory.json` accepted as ATIF by the audit `measure.py`.
-
-`SUPPORTS_ATIF = true` is not evidence that the emitted JSON matches Harbor's
-current schema. A `measure.py` parse failure is an agent-adapter defect, not a
-coverage result.
-
-## Step 6: measure and aggregate each trial
-
-Run `eval-author-audit`'s `measure.py` and `report.py` separately for each
-trial. Keep repeat outputs separate so one successful run cannot hide another:
-
-```bash
-uv run --with-requirements <audit_skill_dir>/requirements.txt \
-  <audit_skill_dir>/scripts/audit_spec/measure.py \
-  --audit .eval-author/audit.md \
-  --trial-dir <job-dir>/<trial-1> \
-  --task-id <task-slug> \
-  --run-id repeat-1 \
-  --out-dir .eval-author/task-measurements/<task-slug>/repeat-1
-
-uv run --with-requirements <audit_skill_dir>/requirements.txt \
-  <audit_skill_dir>/scripts/audit_spec/report.py \
-  --audit .eval-author/audit.md \
-  --coverage-dir .eval-author/task-measurements/<task-slug>/repeat-1 \
-  --out .eval-author/task-measurements/<task-slug>/repeat-1-report.json
-```
-
-Repeat for trial 2.
-
-## Step 7: accept only deterministic closure
+The legacy `verify` command remains available as a deterministic coverage-only
+primitive:
 
 ```bash
 uv run <skill_dir>/scripts/task_pipeline.py verify \
@@ -179,7 +134,3 @@ uv run <skill_dir>/scripts/task_pipeline.py verify \
   --after .eval-author/task-measurements/<task-slug>/repeat-2-report.json \
   --target <tool-name>
 ```
-
-Accept the draft only when `accepted` is `true`. Report Oracle reward, both
-real-agent rewards, both trial paths, and the verify JSON. If either repeat
-misses the tool, revise the task and rerun both attempts.

--- a/plugins/nemo-eval-author/skills/eval-author/SKILL.md
+++ b/plugins/nemo-eval-author/skills/eval-author/SKILL.md
@@ -21,16 +21,17 @@ triggers:
 not-for:
   - eval-author-discover (use to run the discovery pass and get a runnable verdict)
   - eval-author-audit (use to generate, validate, measure, or aggregate audit.md coverage)
-  - eval-author-task-create (use to create and prove one Harbor task from an actionable audit gap)
+  - eval-author-task-create (use to create one Harbor task draft from an actionable audit gap)
+  - eval-author-task-close (use to prove or reject a generated Harbor task draft)
   - eval-author-inspect-trace (use after this skill selects the trace sub-flow)
   - nemo-intake (use to instrument agents, ingest telemetry, or query Intake outside Eval Author)
   - nemo-experimentalist (use to run insight-driven optimization end to end, which drives the Eval Author agent itself)
   - nemo-evaluator (use to run an existing benchmark rather than work on a repository's own suite)
 compatibility: >-
-  The router is read-only. Discovery, audit, and task creation use the local
-  checkout. Task execution requires Harbor and may require Docker and provider
-  credentials. Trace inspection requires the nemo CLI, an explicit workspace,
-  and read access to configured Intake.
+  The router is read-only. Discovery, audit, task creation, and task closure use
+  the local checkout. Task execution requires Harbor and may require Docker and
+  provider credentials. Trace inspection requires the nemo CLI, an explicit
+  workspace, and read access to configured Intake.
 maturity: alpha
 license: Apache-2.0
 user-invocable: true
@@ -55,7 +56,7 @@ The authority depends on the sub-flow:
   doesn't prove that Harbor accepts it.
 - For audit-spec validation, the bundled schema and validator judge the finite
   `audit.md` coverage denominator.
-- For task creation, Harbor's Oracle judges task solvability and verifier
+- For task closure, Harbor's Oracle judges task solvability and verifier
   correctness; measured ATIF proves whether repeated runs close the selected gap.
 - For trace inspection, Intake establishes what happened. Local source code can
   explain behavior, but it can't replace recorded trace evidence.
@@ -87,14 +88,16 @@ and the boundaries; the sub-flow carries the steps.
 |---|---|
 | `eval-author-discover` | Establish whether a repository's evaluations run, name the rung that fails, and get the exact command to run them |
 | `eval-author-audit` | Generate and validate a finite `audit.md` coverage denominator, write per-method coverage/details files for one ATIF trace, then aggregate coverage reports |
-| `eval-author-task-create` | Create one Harbor-native task from one actionable uncovered tool, prove it with Oracle, and accept it only when repeated measured runs close the gap |
+| `eval-author-task-create` | Create one Harbor-native task draft from one actionable uncovered tool |
+| `eval-author-task-close` | Repair one generated task draft, prove it with Oracle, run the real agent when authorized, and report whether measured repeats close the gap |
 | `eval-author-inspect-trace` | Understand one Intake trace without presuming that the trace contains a failure. Not user-invocable; this skill selects it |
 
 `eval-author-audit` works one level above tasks: it generates and validates the
 coverage denominator, measures traces against it, and aggregates deterministic
 coverage reports. `eval-author-task-create` consumes only actionable tool gaps
 from that report and uses Harbor's native task scaffolder rather than guessing a
-task layout.
+task layout. `eval-author-task-close` handles the separate execution and
+evidence loop for generated task drafts.
 
 ## Boundaries
 
@@ -106,13 +109,14 @@ user, not to you.
   only files you add belong under `.eval-author/`, which is theirs to commit or
   ignore.
   `eval-author-discover` scripts write nothing; `eval-author-audit` writes only
-  requested audit artifacts; `eval-author-task-create` writes only drafts,
-  proposals, job outputs, and measurements there.
+  requested audit artifacts; `eval-author-task-create` writes only drafts and
+  proposals; `eval-author-task-close` writes only draft repairs, job outputs,
+  measurements, and closure reports there.
 - **A missing tool is a finding, not a task.** When the provider is not installed,
   say so and stop short of proving anything. Report what you found regardless, and
   do not install the provider into the user's environment.
 - **Do not run without approval.** Discovery proves an existing suite can run and
-  hands over the command. Task creation may run Oracle locally, then starts
+  hands over the command. Task closure may run Oracle locally, then starts
   real-agent jobs only when the user explicitly asked for or approved that spend.
 - **Trusted repositories only.** Validating a config can execute repository code,
   because an agent named by import path gets imported. If the repository is not

--- a/plugins/nemo-eval-author/tests/test_skill_contract.py
+++ b/plugins/nemo-eval-author/tests/test_skill_contract.py
@@ -5,8 +5,9 @@
 
 ``eval-author`` is the core skill: it owns the standard, the vocabulary, the
 boundaries, and the routing. ``eval-author-discover``, ``eval-author-audit``,
-and ``eval-author-task-create`` bundle scripts. ``eval-author-inspect-trace``
-uses the provider's supported commands. Sub-flows defer the standard to the core.
+``eval-author-task-create``, and ``eval-author-task-close`` bundle scripts.
+``eval-author-inspect-trace`` uses the provider's supported commands. Sub-flows
+defer the standard to the core.
 
 These tests are that enforcement:
 
@@ -58,13 +59,15 @@ _CORE_DIR = _SKILLS_DIR / "eval-author"
 _DISCOVER_DIR = _SKILLS_DIR / "eval-author-discover"
 _AUDIT_DIR = _SKILLS_DIR / "eval-author-audit"
 _TASK_CREATE_DIR = _SKILLS_DIR / "eval-author-task-create"
+_TASK_CLOSE_DIR = _SKILLS_DIR / "eval-author-task-close"
 _INSPECT_DIR = _SKILLS_DIR / "eval-author-inspect-trace"
-_SKILL_DIRS = (_CORE_DIR, _DISCOVER_DIR, _AUDIT_DIR, _TASK_CREATE_DIR, _INSPECT_DIR)
-_SUB_FLOW_DIRS = (_DISCOVER_DIR, _AUDIT_DIR, _TASK_CREATE_DIR, _INSPECT_DIR)
+_SKILL_DIRS = (_CORE_DIR, _DISCOVER_DIR, _AUDIT_DIR, _TASK_CREATE_DIR, _TASK_CLOSE_DIR, _INSPECT_DIR)
+_SUB_FLOW_DIRS = (_DISCOVER_DIR, _AUDIT_DIR, _TASK_CREATE_DIR, _TASK_CLOSE_DIR, _INSPECT_DIR)
 _DISCOVER_SCRIPTS_DIR = _DISCOVER_DIR / "scripts"
 _AUDIT_SPEC_DIR = _AUDIT_DIR / "scripts" / "audit_spec"
 _TASK_CREATE_SCRIPTS_DIR = _TASK_CREATE_DIR / "scripts"
-_SCRIPT_DIRS = (_DISCOVER_SCRIPTS_DIR, _AUDIT_SPEC_DIR, _TASK_CREATE_SCRIPTS_DIR)
+_TASK_CLOSE_SCRIPTS_DIR = _TASK_CLOSE_DIR / "scripts"
+_SCRIPT_DIRS = (_DISCOVER_SCRIPTS_DIR, _AUDIT_SPEC_DIR, _TASK_CREATE_SCRIPTS_DIR, _TASK_CLOSE_SCRIPTS_DIR)
 _DISCOVER = _DISCOVER_SCRIPTS_DIR / "discover.py"
 _LADDER = _DISCOVER_SCRIPTS_DIR / "providers" / "harbor" / "_ladder.py"
 _AUDIT_VALIDATE = _AUDIT_SPEC_DIR / "validate.py"
@@ -450,6 +453,7 @@ def test_the_core_routes_and_the_sub_flow_executes() -> None:
     discover_tools = set(_frontmatter_and_body(_DISCOVER_DIR)[0]["allowed-tools"])
     audit_tools = set(_frontmatter_and_body(_AUDIT_DIR)[0]["allowed-tools"])
     task_create_tools = set(_frontmatter_and_body(_TASK_CREATE_DIR)[0]["allowed-tools"])
+    task_close_tools = set(_frontmatter_and_body(_TASK_CLOSE_DIR)[0]["allowed-tools"])
     inspect_tools = set(_frontmatter_and_body(_INSPECT_DIR)[0]["allowed-tools"])
 
     assert not {"Bash", "Write"} & core_tools, f"the core routes and explains; {sorted(core_tools)} is too broad"
@@ -460,7 +464,10 @@ def test_the_core_routes_and_the_sub_flow_executes() -> None:
         f"{_AUDIT_DIR.name} generates and validates audit files; it has {sorted(audit_tools)}"
     )
     assert {"Bash", "Write"} <= task_create_tools, (
-        f"{_TASK_CREATE_DIR.name} generates and proves task drafts; it has {sorted(task_create_tools)}"
+        f"{_TASK_CREATE_DIR.name} generates task drafts; it has {sorted(task_create_tools)}"
+    )
+    assert {"Bash", "Write"} <= task_close_tools, (
+        f"{_TASK_CLOSE_DIR.name} closes generated task drafts; it has {sorted(task_close_tools)}"
     )
     assert {"Bash", "Write"} <= inspect_tools, (
         f"{_INSPECT_DIR.name} runs provider commands and saves a report; it has {sorted(inspect_tools)}"
@@ -573,6 +580,13 @@ def test_task_create_script_the_skill_names_exists() -> None:
     relative = "scripts/task_pipeline.py"
     assert relative in body
     assert (_TASK_CREATE_DIR / relative).is_file()
+
+
+def test_task_close_script_the_skill_names_exists() -> None:
+    _, body = _frontmatter_and_body(_TASK_CLOSE_DIR)
+    relative = "scripts/task_close.py"
+    assert relative in body
+    assert (_TASK_CLOSE_DIR / relative).is_file()
 
 
 def test_every_audit_spec_path_the_skill_names_exists() -> None:

--- a/plugins/nemo-eval-author/tests/test_task_close.py
+++ b/plugins/nemo-eval-author/tests/test_task_close.py
@@ -346,6 +346,68 @@ def test_report_rejects_after_report_for_different_task(tmp_path: Path) -> None:
     assert "subject.task_id must be 'cover-read'" in payload["coverage"]["error"]
 
 
+def test_report_uses_draft_slug_before_task_id_flag(tmp_path: Path) -> None:
+    """When both are supplied, the draft being closed defines the expected task id."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    draft = tmp_path / ".eval-author" / "task-drafts" / "cover-read"
+    _write_before_report(before)
+    _write_after_report(first, covered=["read"], uncovered=[], run_id="repeat-1")
+    _write_after_report(second, covered=["read"], uncovered=[], run_id="repeat-2")
+    _write_ready_draft(draft)
+
+    result = _run(
+        "report",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        "read",
+        "--task-id",
+        "other-task",
+        "--draft",
+        str(draft),
+        "--oracle-reward",
+        "1.0",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["task_id"] == "cover-read"
+    assert payload["status"] == "closed"
+
+
+def test_report_reads_coverage_from_validated_input_report(tmp_path: Path) -> None:
+    """Outer aggregate coverage cannot make an uncovered selected input report pass."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_before_report(before)
+    first.write_text(
+        json.dumps(
+            {
+                "covered": ["read"],
+                "uncovered": [],
+                "uncovered_items": [],
+                "input_reports": [_input_report(run_id="repeat-1", covered=[])],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_after_report(second, covered=["read"], uncovered=[], run_id="repeat-2")
+
+    result = _run(*_report_args(before, first, second), "--oracle-reward", "1.0")
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "coverage_not_closed"
+    assert payload["coverage"]["runs"][0]["covered"] is False
+
+
 def test_report_classifies_missing_second_repeat_as_coverage_unproven(tmp_path: Path) -> None:
     """A single measured repeat is not enough evidence to accept or reject closure."""
     before = tmp_path / "before.json"

--- a/plugins/nemo-eval-author/tests/test_task_close.py
+++ b/plugins/nemo-eval-author/tests/test_task_close.py
@@ -27,6 +27,11 @@ def _run(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedP
 
 def _input_report(*, run_id: str, covered: list[str]) -> dict[str, Any]:
     """Build one aggregate ``input_reports`` entry for task-close tests."""
+    return _input_report_for_task(task_id="cover-read", run_id=run_id, covered=covered)
+
+
+def _input_report_for_task(*, task_id: str, run_id: str, covered: list[str]) -> dict[str, Any]:
+    """Build one aggregate ``input_reports`` entry for a named task."""
     return {
         "path": f".eval-author/task-measurements/run={run_id}/tool_calls/coverage.json",
         "method": "tool_calls",
@@ -34,7 +39,7 @@ def _input_report(*, run_id: str, covered: list[str]) -> dict[str, Any]:
         "subject": {
             "trace": f".eval-author/task-runs/cover-read/{run_id}/agent/trajectory.json",
             "trace_format": "atif",
-            "task_id": "cover-read",
+            "task_id": task_id,
             "run_id": run_id,
         },
         "covered": covered,
@@ -73,6 +78,23 @@ def _write_after_report(path: Path, *, covered: list[str], uncovered: list[str],
         "input_reports": [_input_report(run_id=run_id, covered=covered)],
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _report_args(before: Path, first: Path, second: Path, *, target: str = "read") -> list[str]:
+    """Return common closure report CLI arguments for task-close tests."""
+    return [
+        "report",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        target,
+        "--task-id",
+        "cover-read",
+    ]
 
 
 def _write_ready_draft(path: Path, *, verifier: str | None = None) -> None:
@@ -176,6 +198,22 @@ def test_inspect_rejects_unconditional_reward_verifier(tmp_path: Path) -> None:
     assert "verifier:not_unconditional_reward" in failed
 
 
+def test_inspect_rejects_scalar_task_toml_table_without_traceback(tmp_path: Path) -> None:
+    """Scalar TOML tables produce inspection failures, not AttributeError tracebacks."""
+    draft = tmp_path / ".eval-author" / "task-drafts" / "cover-read"
+    _write_ready_draft(draft)
+    (draft / "task.toml").write_text('task = "not-a-table"\nmetadata = "not-a-table"\n', encoding="utf-8")
+
+    result = _run("inspect", "--draft", str(draft), "--target", "read")
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "needs_repair"
+    failed = {check["name"] for check in payload["checks"] if not check["passed"]}
+    assert "task_toml:structure" in failed
+
+
 def test_report_accepts_coverage_closure_even_when_agent_failed_reward(tmp_path: Path) -> None:
     """A generated eval can be accepted and still expose a real-agent task failure."""
     before = tmp_path / "before.json"
@@ -186,15 +224,7 @@ def test_report_accepts_coverage_closure_even_when_agent_failed_reward(tmp_path:
     _write_after_report(second, covered=["read"], uncovered=[], run_id="repeat-2")
 
     result = _run(
-        "report",
-        "--before",
-        str(before),
-        "--after",
-        str(first),
-        "--after",
-        str(second),
-        "--target",
-        "read",
+        *_report_args(before, first, second),
         "--oracle-reward",
         "1.0",
         "--agent-reward",
@@ -221,15 +251,7 @@ def test_report_classifies_agent_solved_without_target_tool(tmp_path: Path) -> N
     _write_after_report(second, covered=[], uncovered=["read"], run_id="repeat-2")
 
     result = _run(
-        "report",
-        "--before",
-        str(before),
-        "--after",
-        str(first),
-        "--after",
-        str(second),
-        "--target",
-        "read",
+        *_report_args(before, first, second),
         "--oracle-reward",
         "1.0",
         "--agent-reward",
@@ -256,15 +278,7 @@ def test_report_requires_distinct_after_run_ids(tmp_path: Path) -> None:
     _write_after_report(second, covered=["read"], uncovered=[], run_id="repeat-1")
 
     result = _run(
-        "report",
-        "--before",
-        str(before),
-        "--after",
-        str(first),
-        "--after",
-        str(second),
-        "--target",
-        "read",
+        *_report_args(before, first, second),
         "--oracle-reward",
         "1.0",
     )
@@ -273,6 +287,63 @@ def test_report_requires_distinct_after_run_ids(tmp_path: Path) -> None:
     payload = json.loads(result.stdout)
     assert payload["status"] == "trajectory_invalid"
     assert "distinct ATIF subject.run_id" in payload["coverage"]["error"]
+
+
+def test_report_rejects_aggregate_after_report_with_multiple_inputs(tmp_path: Path) -> None:
+    """One aggregate coverage report cannot stand in for repeated task measurements."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_before_report(before)
+    first.write_text(
+        json.dumps(
+            {
+                "covered": ["read"],
+                "uncovered": [],
+                "uncovered_items": [],
+                "input_reports": [
+                    _input_report(run_id="repeat-1", covered=["read"]),
+                    _input_report(run_id="repeat-2", covered=["read"]),
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_after_report(second, covered=["read"], uncovered=[], run_id="repeat-3")
+
+    result = _run(*_report_args(before, first, second), "--oracle-reward", "1.0")
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "trajectory_invalid"
+    assert "exactly one input report" in payload["coverage"]["error"]
+
+
+def test_report_rejects_after_report_for_different_task(tmp_path: Path) -> None:
+    """After-reports from another generated task do not prove this task closed coverage."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_before_report(before)
+    first.write_text(
+        json.dumps(
+            {
+                "covered": ["read"],
+                "uncovered": [],
+                "uncovered_items": [],
+                "input_reports": [_input_report_for_task(task_id="other-task", run_id="repeat-1", covered=["read"])],
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_after_report(second, covered=["read"], uncovered=[], run_id="repeat-2")
+
+    result = _run(*_report_args(before, first, second), "--oracle-reward", "1.0")
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "trajectory_invalid"
+    assert "subject.task_id must be 'cover-read'" in payload["coverage"]["error"]
 
 
 def test_report_classifies_missing_second_repeat_as_coverage_unproven(tmp_path: Path) -> None:
@@ -290,6 +361,8 @@ def test_report_classifies_missing_second_repeat_as_coverage_unproven(tmp_path: 
         str(first),
         "--target",
         "read",
+        "--task-id",
+        "cover-read",
         "--oracle-reward",
         "1.0",
     )

--- a/plugins/nemo-eval-author/tests/test_task_close.py
+++ b/plugins/nemo-eval-author/tests/test_task_close.py
@@ -1,0 +1,300 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+_PLUGIN = Path(__file__).resolve().parents[1]
+_SCRIPT = _PLUGIN / "skills" / "eval-author-task-close" / "scripts" / "task_close.py"
+
+
+def _run(*args: str, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    """Invoke ``task_close.py`` with ``args`` and return the completed process."""
+    return subprocess.run(
+        [sys.executable, str(_SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def _input_report(*, run_id: str, covered: list[str]) -> dict[str, Any]:
+    """Build one aggregate ``input_reports`` entry for task-close tests."""
+    return {
+        "path": f".eval-author/task-measurements/run={run_id}/tool_calls/coverage.json",
+        "method": "tool_calls",
+        "item_kind": "tool",
+        "subject": {
+            "trace": f".eval-author/task-runs/cover-read/{run_id}/agent/trajectory.json",
+            "trace_format": "atif",
+            "task_id": "cover-read",
+            "run_id": run_id,
+        },
+        "covered": covered,
+        "covered_count": len(covered),
+    }
+
+
+def _write_before_report(path: Path, *, target: str = "read") -> None:
+    """Write a minimal before report with one actionable uncovered tool."""
+    payload = {
+        "covered": ["write"],
+        "uncovered": [target],
+        "uncovered_items": [
+            {
+                "name": target,
+                "kind": "tool",
+                "reason": "not_covered_by_any_input_report",
+                "description": f"Use {target}.",
+                "generation": {
+                    "focus": f"Exercise {target}.",
+                    "needed_tools": [target],
+                    "evidence_required": [{"kind": "tool_call", "tool": target}],
+                },
+            }
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_after_report(path: Path, *, covered: list[str], uncovered: list[str], run_id: str) -> None:
+    """Write a minimal aggregate after report."""
+    payload = {
+        "covered": covered,
+        "uncovered": uncovered,
+        "uncovered_items": [],
+        "input_reports": [_input_report(run_id=run_id, covered=covered)],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_ready_draft(path: Path, *, verifier: str | None = None) -> None:
+    """Write a generated Harbor task draft with substantive files."""
+    (path / "environment").mkdir(parents=True)
+    (path / "tests").mkdir()
+    (path / "solution").mkdir()
+    (path / "instruction.md").write_text("Read /app/data/input.txt and write the answer.\n", encoding="utf-8")
+    (path / "task.toml").write_text(
+        'version = "1.0"\n'
+        "\n[task]\n"
+        'name = "example/cover-read"\n'
+        'authors = ["NVIDIA"]\n'
+        'keywords = ["read", "file"]\n'
+        "\n[verifier]\n"
+        "timeout_sec = 60.0\n"
+        "\n[agent]\n"
+        "timeout_sec = 120.0\n"
+        "\n[environment]\n"
+        "cpus = 1\n"
+        "memory_mb = 1024\n",
+        encoding="utf-8",
+    )
+    (path / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\nRUN mkdir -p /app/data\n", encoding="utf-8")
+    (path / "tests" / "test.sh").write_text(
+        verifier
+        or "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "reward=0\n"
+        "if [ -f /app/answer.txt ]; then\n"
+        "  if grep -qx expected /app/answer.txt; then reward=1; fi\n"
+        "fi\n"
+        "mkdir -p /logs/verifier\n"
+        "printf '%s\\n' \"$reward\" > /logs/verifier/reward.txt\n",
+        encoding="utf-8",
+    )
+    (path / "solution" / "solve.sh").write_text(
+        "#!/usr/bin/env bash\nset -euo pipefail\nprintf 'expected\\n' > /app/answer.txt\n",
+        encoding="utf-8",
+    )
+
+
+def _write_executable(path: Path, text: str) -> None:
+    """Write an executable script used by preflight tests."""
+    path.write_text(text, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def test_preflight_reports_blocked_no_docker(tmp_path: Path) -> None:
+    """Preflight distinguishes Docker daemon problems from task or verifier failures."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_executable(
+        bin_dir / "harbor",
+        '#!/usr/bin/env bash\nif [ "$1" = trial ] && [ "$2" = start ] && [ "$3" = --help ]; then exit 0; fi\nexit 2\n',
+    )
+    _write_executable(bin_dir / "docker", "#!/usr/bin/env bash\nexit 1\n")
+    env = {**os.environ, "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}"}
+
+    result = _run("preflight", "--require-docker", env=env)
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "blocked_no_docker"
+    assert payload["valid"] is False
+
+
+def test_inspect_accepts_substantive_generated_draft(tmp_path: Path) -> None:
+    """A filled generated draft is ready for Oracle, not accepted as closed."""
+    draft = tmp_path / ".eval-author" / "task-drafts" / "cover-read"
+    before = tmp_path / ".eval-author" / "audit-coverage-report.json"
+    before.parent.mkdir()
+    _write_ready_draft(draft)
+    _write_before_report(before)
+    out = tmp_path / ".eval-author" / "task-closures" / "cover-read" / "inspection.json"
+
+    result = _run("inspect", "--draft", str(draft), "--target", "read", "--before", str(before), "--out", str(out))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "ready_for_oracle"
+    assert payload["valid"] is True
+    assert out.is_file()
+
+
+def test_inspect_rejects_unconditional_reward_verifier(tmp_path: Path) -> None:
+    """A verifier that only writes reward 1 still needs repair."""
+    draft = tmp_path / ".eval-author" / "task-drafts" / "cover-read"
+    _write_ready_draft(
+        draft,
+        verifier="#!/usr/bin/env bash\nmkdir -p /logs/verifier\necho 1 > /logs/verifier/reward.txt\n",
+    )
+
+    result = _run("inspect", "--draft", str(draft), "--target", "read")
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "needs_repair"
+    failed = {check["name"] for check in payload["checks"] if not check["passed"]}
+    assert "verifier:has_failure_path" in failed
+    assert "verifier:not_unconditional_reward" in failed
+
+
+def test_report_accepts_coverage_closure_even_when_agent_failed_reward(tmp_path: Path) -> None:
+    """A generated eval can be accepted and still expose a real-agent task failure."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_before_report(before)
+    _write_after_report(first, covered=["read"], uncovered=[], run_id="repeat-1")
+    _write_after_report(second, covered=["read"], uncovered=[], run_id="repeat-2")
+
+    result = _run(
+        "report",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        "read",
+        "--oracle-reward",
+        "1.0",
+        "--agent-reward",
+        "0.0",
+        "--agent-reward",
+        "0.0",
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "closed"
+    assert payload["accepted"] is True
+    assert payload["coverage"]["closed"] is True
+    assert payload["real_agent"]["passed_task"] is False
+
+
+def test_report_classifies_agent_solved_without_target_tool(tmp_path: Path) -> None:
+    """A passing task reward is not coverage closure if the target tool is absent."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_before_report(before)
+    _write_after_report(first, covered=[], uncovered=["read"], run_id="repeat-1")
+    _write_after_report(second, covered=[], uncovered=["read"], run_id="repeat-2")
+
+    result = _run(
+        "report",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        "read",
+        "--oracle-reward",
+        "1.0",
+        "--agent-reward",
+        "1.0",
+        "--agent-reward",
+        "1.0",
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "agent_solved_without_target_tool"
+    assert payload["accepted"] is False
+    assert payload["coverage"]["closed"] is False
+    assert payload["real_agent"]["passed_task"] is True
+
+
+def test_report_requires_distinct_after_run_ids(tmp_path: Path) -> None:
+    """Copied after reports do not count as independent closure evidence."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    _write_before_report(before)
+    _write_after_report(first, covered=["read"], uncovered=[], run_id="repeat-1")
+    _write_after_report(second, covered=["read"], uncovered=[], run_id="repeat-1")
+
+    result = _run(
+        "report",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--after",
+        str(second),
+        "--target",
+        "read",
+        "--oracle-reward",
+        "1.0",
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "trajectory_invalid"
+    assert "distinct ATIF subject.run_id" in payload["coverage"]["error"]
+
+
+def test_report_classifies_missing_second_repeat_as_coverage_unproven(tmp_path: Path) -> None:
+    """A single measured repeat is not enough evidence to accept or reject closure."""
+    before = tmp_path / "before.json"
+    first = tmp_path / "first.json"
+    _write_before_report(before)
+    _write_after_report(first, covered=["read"], uncovered=[], run_id="repeat-1")
+
+    result = _run(
+        "report",
+        "--before",
+        str(before),
+        "--after",
+        str(first),
+        "--target",
+        "read",
+        "--oracle-reward",
+        "1.0",
+    )
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "coverage_unproven"
+    assert payload["failure_reason"] == "coverage_unproven"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Add an `eval-author-task-close` skill for taking a generated Harbor task draft through inspection, Oracle proof guidance, real-agent measurement guidance, and fine-grained coverage closure classification. This splits task generation from task closure so Eval Author can report precise failure modes instead of treating generation as proof.

## Related Issue
None.

## Changes
- Add `eval-author-task-close/SKILL.md` with the draft repair, Oracle, real-agent, measurement, and closure workflow.
- Add `scripts/task_close.py` with `preflight`, `inspect`, and `report` JSON verdict commands.
- Add tests for blocked Docker preflight, generated-draft inspection, weak verifier detection, TOML structure failures, coverage closure with agent reward failure, agent-solved-without-tool, duplicate run IDs, cross-task after-reports, aggregate after-reports, draft/task-id precedence, input-report-scoped coverage, and missing repeat evidence.
- Update Eval Author routing/docs so `eval-author-audit -> eval-author-task-create -> eval-author-task-close` is the documented path.
- Address CodeRabbit review comments: document the Python 3.11 task-close prerequisite, validate `task.toml` table shapes before nested lookups, require each after-report to contain exactly one input report for the expected task id, make `--draft` own task identity when supplied, and classify coverage from the validated input-report entry.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- Rebased onto `origin/main` on 2026-08-29; current head `c063075b0f6dfb26764da2a21c47db36506e9794`.
- DCO audit over `origin/main..HEAD` -> `DCO OK` for all three PR commits.
- `uv run --no-project --with pytest pytest plugins/nemo-eval-author/tests/test_task_close.py -q` -> 12 passed
- `uv run --no-project --with pytest --with PyYAML --with jsonschema pytest plugins/nemo-eval-author/tests/test_skill_contract.py -q` -> 101 passed, 13 skipped
- `uv run --no-project --with pytest --with 'harbor==0.20.0' pytest plugins/nemo-eval-author/tests/test_task_pipeline.py -q` -> 10 passed
- `uv run --no-project --with ruff ruff check plugins/nemo-eval-author/README.md plugins/nemo-eval-author/skills/eval-author-task-create/SKILL.md plugins/nemo-eval-author/skills/eval-author-task-close/SKILL.md plugins/nemo-eval-author/skills/eval-author-task-close/scripts/task_close.py plugins/nemo-eval-author/tests/test_task_close.py` -> passed
- `uv run --no-project --with ruff ruff format --check plugins/nemo-eval-author/skills/eval-author-task-close/scripts/task_close.py plugins/nemo-eval-author/tests/test_task_close.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `uv run pre-commit run -a` -> blocked before hooks run because `litellm==1.95.0` invokes `maturin`; resolved AWS Rust crates require rustc `1.94.1`, while this host has rustc `1.93.1`.
- `uvx pre-commit run -a` -> ruff, ruff format, ty, uv-lock-check, UI lint-staged, plugin import guard, merge-conflict check, and Flox lock check passed; blocked checks were host-tooling issues: Rust `1.93.1` too old for `litellm`/AWS crates, missing `helm-docs`, uv `0.9.24` instead of required `0.9.14`, and missing `yq` for version-consistency hooks.
- Rho demo smoke: `task_close.py preflight --require-docker` with Harbor `0.20.0` -> `status: ready`.
- Rho demo smoke: `task_close.py inspect --draft <rho post-Harbor cover-read-excel draft> --target read_excel --before <before report>` -> `status: ready_for_oracle`, 24 required checks passed.
- Rho demo smoke: `task_close.py report --before <before report> --after <source-repeat-1 report> --after <source-repeat-2 report> --target read_excel --draft <rho post-Harbor cover-read-excel draft> --oracle-reward 1.0 --agent-reward 1.0 --agent-reward 1.0` -> `status: closed`, `accepted: true`, `coverage.closed: true`.

## Overlap Check

Compared against Brian Cleary's open PR #1624, `feat(eval-author): add rho-agent walkthrough demo and quick-start CLI`, on 2026-08-29. There is no direct changed-file overlap: #1624 adds walkthrough docs, a quick-start CLI/TUI, sandbox helpers, bundled rho-agent Harbor assets, and walkthrough tests; #1625 adds the reusable `eval-author-task-close` skill, `task_close.py`, task-close tests, and skill routing docs. The conceptual overlap is gap-closing workflow coverage, but the layers are different: #1624 is an end-to-end demo driver, while #1625 is the reusable closure/proof primitive that a walkthrough can call after task generation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated workflow for closing and validating generated evaluation task drafts.
  - Closure checks cover task structure, verifier behavior, Oracle results, authorized agent runs, repeat evidence, and target-tool coverage.
  - Added structured closure reports with success, failure, incomplete, and blocked statuses.
  - Separated task creation from task closure for clearer evaluation workflows.

- **Documentation**
  - Expanded guidance for evaluation sub-flows, prerequisites, audit follow-up, closure classifications, validation requirements, and generated outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->