### PR TITLE
feat(insights): Persist AnalysisRun entity, list/get endpoints

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -10546,6 +10546,7 @@ nemo insights analysis-runs list [OPTIONS]
 * `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
 * `--page <INTEGER>`: Page number (1-indexed). [default: 1]
 * `--page-size <INTEGER>`: Items per page. [default: 20]
+* `--sort`: Sort field; prefix with '-' for descending. [default: -created_at]
 
 **Help:**
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -10391,6 +10391,7 @@ nemo insights [OPTIONS] COMMAND [ARGS]...
 **Commands:**
 
 * `analysis`: Manage periodic agent analysis opt-in state.
+* `analysis-runs`: Submit and inspect on-demand analysis runs.
 
 *Jobs:*
 
@@ -10471,6 +10472,109 @@ nemo insights analysis status [OPTIONS]
 * `--agent`: Optional agent name. Omit to list all analysis configs.
 * `--workspace`: Workspace to inspect. [default: default]
 * `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+#### nemo insights analysis-runs
+
+Submit and inspect on-demand analysis runs.
+
+**Usage:**
+
+```shell
+nemo insights analysis-runs [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `create`: Submit an analysis run for an agent.
+* `list`: List analysis runs.
+* `get`: Get one analysis run, joined with the live state of its...
+
+##### nemo insights analysis-runs create
+
+Submit an analysis run for an agent.
+
+The run is backed by an agents.execute job that shares its name.
+With --wait, exits non-zero if that job does not complete.
+
+**Usage:**
+
+```shell
+nemo insights analysis-runs create [OPTIONS]
+```
+
+**Options:**
+
+* `--agent`: Name of the agent whose telemetry should be analyzed.
+* `--workspace`: Workspace the agent belongs to. [default: default]
+* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--default-model`: Model Entity ref for analysis work. Default: the configured default model.
+* `--fast-model`: Model Entity ref for context summarization. Default: the configured fast model.
+* `--since`: ISO-8601 lower bound enforced on the analyst's trace/span reads.
+* `--ethos <PATH>`: Path to the agent's Ethos Markdown. Its contents are sent with the run.
+* `--evaluation-id`: Restrict the run to spans from one evaluation.
+* `--timeout-seconds <FLOAT>`: Timeout applied to the backing execute-agent job.
+* `--wait`: Poll the run until its backing job reaches a terminal state.
+* `--poll-timeout <FLOAT>`: How long --wait polls before giving up. [default: 900.0]
+* `--poll-interval <FLOAT>`: Seconds between --wait polls. [default: 5.0]
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+##### nemo insights analysis-runs list
+
+List analysis runs. Job state is not joined — read one run to get it.
+
+**Usage:**
+
+```shell
+nemo insights analysis-runs list [OPTIONS]
+```
+
+**Options:**
+
+* `--agent`: Only list runs that analyzed this agent.
+* `--workspace`: Workspace to inspect. [default: default]
+* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--page <INTEGER>`: Page number (1-indexed). [default: 1]
+* `--page-size <INTEGER>`: Items per page. [default: 20]
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+##### nemo insights analysis-runs get
+
+Get one analysis run, joined with the live state of its backing job.
+
+A null job means submission never landed: no job exists under the
+run's name, and the run can be resubmitted.
+
+**Usage:**
+
+```shell
+nemo insights analysis-runs get [OPTIONS] NAME
+```
+
+**Arguments:**
+
+* `<NAME>`: Name of the analysis run.
+
+**Options:**
+
+* `--workspace`: Workspace the run belongs to. [default: default]
+* `--base-url`: Base URL of the running NMP instance. [default: http://localhost:8080] [env: NMP_BASE_URL=]
+* `--wait`: Poll until the run's backing job reaches a terminal state.
+* `--poll-timeout <FLOAT>`: How long --wait polls before giving up. [default: 900.0]
+* `--poll-interval <FLOAT>`: Seconds between --wait polls. [default: 5.0]
 
 **Help:**
 

--- a/e2e/test_insights_analysis_run.py
+++ b/e2e/test_insights_analysis_run.py
@@ -155,8 +155,15 @@ def _mock_analyst_models(sdk: NeMoPlatform, workspace: str) -> tuple[str, str]:
 
 
 def _job_diagnostics(sdk: NeMoPlatform, workspace: str, job_name: str, prefix: str) -> str:
-    """Explain a failed run with the backing job's own logs."""
+    """Explain a failed run with the backing job's own error details and logs."""
     parts = [prefix]
+    try:
+        job = sdk.agents.jobs.execute.get(job_name, workspace=workspace)
+        for field in ("error_details", "status_details"):
+            if detail := job.get(field):
+                parts.append(f"{field}: {json.dumps(detail, indent=2, default=str)}")
+    except Exception as error:
+        parts.append(f"Could not fetch the job: {error}")
     try:
         logs = client_from_platform(sdk, JobsClient).list_job_logs(workspace=workspace, name=job_name)
         for entry in logs.items():

--- a/e2e/test_insights_analysis_run.py
+++ b/e2e/test_insights_analysis_run.py
@@ -25,8 +25,11 @@ from typing import Any
 import pytest
 from nemo_platform import NeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.inference_middleware import BackendFormat
 from nemo_platform_plugin.jobs.client import JobsClient
-from nmp.testing import MockProviderResponse, add_mock_provider
+from nemo_platform_plugin.models.client import ModelsClient
+from nemo_platform_plugin.models.types import CreateModelEntityRequest
+from nmp.testing import MockProviderResponse, add_mock_provider, wait_for_model_entity
 
 from e2e.agents_deploy_helpers import unique_name
 
@@ -133,7 +136,7 @@ def _mock_analyst_models(sdk: NeMoPlatform, workspace: str) -> tuple[str, str]:
     default_model = unique_name("analyst-default")
     fast_model = unique_name("analyst-fast")
 
-    add_mock_provider(
+    provider = add_mock_provider(
         sdk,
         workspace=workspace,
         name=unique_name("analyst-provider"),
@@ -151,6 +154,25 @@ def _mock_analyst_models(sdk: NeMoPlatform, workspace: str) -> tuple[str, str]:
         },
         served_models={default_model: default_model, fast_model: fast_model},
     )
+
+    # Create the Model Entities rather than waiting on provider autodiscovery.
+    # The models controller reconciles a provider's served_models into entities
+    # asynchronously, so relying on it races the run we are about to submit --
+    # and the Analyst resolves Model Entities, not served-model ids. This is the
+    # same create-then-wait the evaluator e2e does for the same reason.
+    models = client_from_platform(sdk, ModelsClient)
+    for name in (default_model, fast_model):
+        models.create_model(
+            workspace=workspace,
+            body=CreateModelEntityRequest(
+                name=name,
+                backend_format=BackendFormat.OPENAI_CHAT,
+                model_providers=[f"{workspace}/{provider.name}"],
+            ),
+            exist_ok=True,
+        ).data()
+        wait_for_model_entity(sdk, workspace, name)
+
     return f"{workspace}/{default_model}", f"{workspace}/{fast_model}"
 
 

--- a/e2e/test_insights_analysis_run.py
+++ b/e2e/test_insights_analysis_run.py
@@ -1,0 +1,252 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""E2E tests for Insights analysis runs backed by ``agents.execute`` jobs.
+
+This is the platform-side replacement for running the Analyst from an
+operator's shell: everything here goes through the ``analysis-runs`` API, so
+passing it means the path works on a remotely-deployed platform, where nobody
+can run ``nemo agents analyst run`` locally.
+
+The Analyst's model is mocked, deliberately. What is under test is the wiring —
+run recorded, job submitted under the run's name, Fabric runs the inline
+Analyst, the ``insights.analysis`` extension persists the change-set and saves
+the report — not whether a real model reaches a good conclusion. The Analyst is
+a Nooa CodeAct agent, so one mocked ``execute_python`` tool call carrying a
+``return_result(...)`` cell drives a complete, deterministic run.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+from nemo_platform import NeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.jobs.client import JobsClient
+from nmp.testing import MockProviderResponse, add_mock_provider
+
+from e2e.agents_deploy_helpers import unique_name
+
+# Subprocess jobs, so the run needs no Docker: the Analyst executes in-process
+# inside a Fabric local environment, and the mock provider stands in for the
+# model, so nothing here needs a container or a real inference provider.
+pytestmark = [
+    pytest.mark.timeout(900),
+    pytest.mark.e2e_config(
+        "e2e/configs/local-subprocess.yaml",
+        harness={"backend": "subprocess"},
+    ),
+]
+
+REPORT_RESULT_NAME = "analysis-report"
+JOB_TIMEOUT_SECONDS = 600.0
+
+ANALYST_SUMMARY = "Filed one insight from the deterministic e2e change-set."
+INSIGHT_TITLE = "Knowledge search returns no documents and the agent answers anyway"
+INSIGHT_DESCRIPTION = (
+    "The retrieval tool returns an empty document set, and the agent produces a "
+    "confident answer instead of saying it could not find supporting context."
+)
+TRACE_REF = "trace-insights-analysis-run-e2e"
+# Sent inline on the run so the whole ethos chain — request, harness settings,
+# adapter, prompt — is exercised by a real job. We can't assert this makes it
+# in to the model prompt here, but we at least ensure it isn't rejected anywhere
+# along the way.
+ETHOS = "# Ethos\n\nAnswer only from retrieved context; say so when there is none."
+
+
+def _return_result_cell() -> str:
+    """The Python cell the mocked model 'writes' to end the CodeAct run.
+
+    ``return_result`` is the Analyst's single terminal call: Nooa validates the
+    value against ``AnalystResult`` and ends the run, so one cell is a whole
+    analysis.
+    """
+    return (
+        "return_result(result={"
+        f"'summary': {ANALYST_SUMMARY!r}, "
+        "'new_insights': [{"
+        f"'title': {INSIGHT_TITLE!r}, "
+        f"'description': {INSIGHT_DESCRIPTION!r}, "
+        "'status': 'open', "
+        f"'trace_refs': [{TRACE_REF!r}]"
+        "}], "
+        "'updated_insights': []})"
+    )
+
+
+def _execute_python_response(model: str, code: str) -> dict[str, Any]:
+    """A chat completion that calls the CodeAct ``execute_python`` tool."""
+    return {
+        "id": "chatcmpl-insights-analysis-run-e2e",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_analyst_execute",
+                            "type": "function",
+                            "function": {
+                                "name": "execute_python",
+                                "arguments": json.dumps({"code": code}),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _plain_response(model: str, content: str) -> dict[str, Any]:
+    return {
+        "id": "chatcmpl-insights-analysis-run-e2e-fast",
+        "object": "chat.completion",
+        "model": model,
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def _mock_analyst_models(sdk: NeMoPlatform, workspace: str) -> tuple[str, str]:
+    """Register the Analyst's default/fast Model Entity pair against a mock provider.
+
+    The pair must be workspace-qualified Model Entity refs — the Analyst
+    resolves them through the platform, not as raw provider model ids.
+    """
+    default_model = unique_name("analyst-default")
+    fast_model = unique_name("analyst-fast")
+
+    add_mock_provider(
+        sdk,
+        workspace=workspace,
+        name=unique_name("analyst-provider"),
+        mock_response_body_by_model={
+            # The default model drives the CodeAct loop and ends it on the
+            # first turn.
+            f"{workspace}/{default_model}": [
+                MockProviderResponse(response_body=_execute_python_response(default_model, _return_result_cell()))
+            ],
+            # The fast model is only used for context summarization, which a
+            # single-turn run never reaches. It still has to resolve.
+            f"{workspace}/{fast_model}": [
+                MockProviderResponse(response_body=_plain_response(fast_model, "unused summary"))
+            ],
+        },
+        served_models={default_model: default_model, fast_model: fast_model},
+    )
+    return f"{workspace}/{default_model}", f"{workspace}/{fast_model}"
+
+
+def _job_diagnostics(sdk: NeMoPlatform, workspace: str, job_name: str, prefix: str) -> str:
+    """Explain a failed run with the backing job's own logs."""
+    parts = [prefix]
+    try:
+        logs = client_from_platform(sdk, JobsClient).list_job_logs(workspace=workspace, name=job_name)
+        for entry in logs.items():
+            parts.append(f"  - {entry.message}")
+    except Exception as error:
+        parts.append(f"Could not fetch job logs: {error}")
+    return "\n".join(parts)
+
+
+def _list_job_results(sdk: NeMoPlatform, workspace: str, job_name: str) -> dict[str, Any]:
+    url = f"{str(sdk.base_url).rstrip('/')}/apis/agents/v2/workspaces/{workspace}/jobs/execute/{job_name}/results"
+    response = sdk._client.get(url)
+    assert response.status_code == 200, f"Failed to list results for {job_name}: {response.text}"
+    return response.json()
+
+
+def _download_job_result(sdk: NeMoPlatform, workspace: str, job_name: str, result_name: str) -> str:
+    url = (
+        f"{str(sdk.base_url).rstrip('/')}/apis/agents/v2/workspaces/{workspace}"
+        f"/jobs/execute/{job_name}/results/{result_name}/download"
+    )
+    response = sdk._client.get(url)
+    assert response.status_code == 200, f"Failed to download {result_name!r} for {job_name}: {response.text}"
+    return response.text
+
+
+def _created_insight_id(report: str) -> str:
+    """Pull the stored insight id out of the report's change log.
+
+    The Insight is read back by id rather than through ``list_insights``,
+    which additionally enriches each row from Intake and so needs ClickHouse
+    running. Reading by id keeps this test to the services the analysis-run
+    path itself depends on.
+    """
+    match = re.search(r"- created: .*\[(?P<insight_id>[^\]]+)\]", report)
+    assert match is not None, f"No created-insight line in report:\n{report}"
+    return match.group("insight_id")
+
+
+def test_analysis_run_persists_insights_and_saves_its_report(sdk: NeMoPlatform, workspace: str) -> None:
+    """One analysis run, end to end, through the supported API surface."""
+    target_agent = unique_name("analyzed-agent")
+    default_model, fast_model = _mock_analyst_models(sdk, workspace)
+
+    created = sdk.insights.analysis_runs.create(
+        workspace=workspace,
+        agent=target_agent,
+        default_model=default_model,
+        fast_model=fast_model,
+        ethos=ETHOS,
+        timeout_seconds=JOB_TIMEOUT_SECONDS,
+    )
+    run_name = created.run.name
+
+    # The run is recorded before the job is submitted, and the job takes the
+    # run's name — that shared name is the only link between them.
+    assert created.run.agent == target_agent
+    assert created.job is not None
+    assert created.job["name"] == run_name
+
+    final = sdk.insights.analysis_runs.wait(
+        workspace=workspace,
+        name=run_name,
+        timeout=JOB_TIMEOUT_SECONDS,
+        poll_interval=2.0,
+    )
+    assert final.job_status == "completed", _job_diagnostics(
+        sdk, workspace, run_name, f"Analysis run {run_name} finished with job status {final.job_status!r}"
+    )
+
+    # The run survives as a queryable record, not just as a job.
+    listed = sdk.insights.analysis_runs.list_runs(workspace=workspace, agent=target_agent)
+    assert run_name in {run.name for run in listed.data}
+    assert final.run.default_model == default_model
+    assert final.run.fast_model == fast_model
+
+    # The report is the durable record of what the run did — the same result
+    # name AnalyzeJob saves, so the two paths stay comparable.
+    result_names = {str(result["name"]) for result in _list_job_results(sdk, workspace, run_name)["data"]}
+    assert REPORT_RESULT_NAME in result_names, f"Saved results: {sorted(result_names)}"
+    report = _download_job_result(sdk, workspace, run_name, REPORT_RESULT_NAME)
+    assert ANALYST_SUMMARY in report
+    assert INSIGHT_TITLE in report
+
+    # The extension persisted the change-set as a real Insight. The report's
+    # change log is what says which one: it is written from what the Insights
+    # API returned, so its id only exists if the write landed.
+    insight_id = _created_insight_id(report)
+    filed = sdk.insights.insights.get(workspace=workspace, insight_id=insight_id)
+    assert filed.title == INSIGHT_TITLE
+    assert filed.description == INSIGHT_DESCRIPTION
+    assert filed.agent == target_agent
+    assert filed.trace_refs == [TRACE_REF]

--- a/e2e/test_insights_analysis_run.py
+++ b/e2e/test_insights_analysis_run.py
@@ -45,6 +45,9 @@ pytestmark = [
 ]
 
 REPORT_RESULT_NAME = "analysis-report"
+# Written by the execute-agent job; the only place an adapter failure is recorded.
+FABRIC_RUN_RESULT_NAME = "fabric_run_result"
+FABRIC_ERROR_RESULT_NAME = "fabric_error"
 JOB_TIMEOUT_SECONDS = 600.0
 
 ANALYST_SUMMARY = "Filed one insight from the deterministic e2e change-set."
@@ -179,6 +182,14 @@ def _mock_analyst_models(sdk: NeMoPlatform, workspace: str) -> tuple[str, str]:
 def _job_diagnostics(sdk: NeMoPlatform, workspace: str, job_name: str, prefix: str) -> str:
     """Explain a failed run with the backing job's own error details and logs."""
     parts = [prefix]
+    # Fabric reports an adapter failure as a failed *result*, not an exception,
+    # so the task exits non-zero with nothing in its stdout and the Analyst's
+    # own error lives only in these results.
+    for result_name in (FABRIC_ERROR_RESULT_NAME, FABRIC_RUN_RESULT_NAME):
+        try:
+            parts.append(f"{result_name}: {_download_job_result(sdk, workspace, job_name, result_name)}")
+        except Exception as error:
+            parts.append(f"Could not fetch {result_name}: {error}")
     try:
         job = sdk.agents.jobs.execute.get(job_name, workspace=workspace)
         for field in ("error_details", "status_details"):

--- a/plugins/nemo-insights/README.md
+++ b/plugins/nemo-insights/README.md
@@ -86,6 +86,21 @@ uv run nemo insights analysis status
 uv run nemo insights analysis disable --agent research-agent
 ```
 
+`nemo agents analyst run` runs the Analyst locally, in your shell. To have the
+platform run it as a job instead, submit an *analysis run*:
+
+```bash
+uv run nemo insights analysis-runs create --agent research-agent --wait
+uv run nemo insights analysis-runs list --agent research-agent
+uv run nemo insights analysis-runs get <run-name>
+```
+
+A run and the `agents.execute` job backing it share one name, so `get` returns
+both together. `--wait` polls to a terminal job state and exits non-zero unless
+the job completed. `create` fills the default/fast model pair from your CLI
+config unless you pass `--default-model` / `--fast-model`; the request must
+carry it because the Platform process cannot read that file.
+
 `analysis enable` stores the effective default/fast pair in the server-side
 analysis config so scheduled jobs do not depend on the operator's local CLI
 file. Re-run `enable` after changing the pair with `nemo setup`. Existing
@@ -105,6 +120,8 @@ The plugin SDK is available as `client.insights`, including:
 
 - `client.insights.insights`
 - `client.insights.analysis_configs`
+- `client.insights.analysis_runs` — `create`, `list_runs`, `get`, and `wait`
+  (polls a run until its backing job is terminal)
 - `client.insights.analysis_run_statuses`
 
 ## Configuration

--- a/plugins/nemo-insights/examples/execute-agent-job/README.md
+++ b/plugins/nemo-insights/examples/execute-agent-job/README.md
@@ -13,8 +13,10 @@ continues to run side-by-side.
   with relative time offsets so it never ages out of Intake's retention window.
 - `seed_intake.py`: expands the spec into spans and annotations, posts them to
   Intake, then reads them back.
-- `submit_analysis_run.py`: submits the run through the Insights analysis-runs
-  API and optionally waits for the job's `analysis-report` result.
+- `submit_analysis_run.py`: submits the run through the analysis-runs SDK
+  (`client.insights.analysis_runs`) and optionally waits for the job's
+  `analysis-report` result. `nemo insights analysis-runs create|list|get` is
+  the same surface from the CLI.
 
 The high-level Insights service route lives in
 `nemo_insights_plugin.analysis_runs.router`. It accepts an Insights-shaped
@@ -127,20 +129,44 @@ entity — the Analyst only matches it against each span's normalized
      --wait
    ```
 
-   The model pair is **required**. It lives only in the operator's local CLI
-   config (`~/.config/nmp/config.yaml`), which the Platform process cannot read,
-   so the request has to carry it.
-
-3. Inspect the created Job's saved results directly if you did not use
-   `--wait`. The durable comparison point is the `analysis-report` result saved
-   by the Insights execute extension:
+   The model pair is **required** on the request. It lives only in the
+   operator's local CLI config (`~/.config/nmp/config.yaml`), which the
+   Platform process cannot read, so the request has to carry it. The CLI fills
+   it in from that config, which is why the equivalent one-liner needs no model
+   flags:
 
    ```bash
-   curl "$NMP_BASE_URL/apis/agents/v2/workspaces/default/jobs/execute/<job-name>/results"
-   curl "$NMP_BASE_URL/apis/agents/v2/workspaces/default/jobs/execute/<job-name>/results/analysis-report/download"
+   nemo insights analysis-runs create --agent demo-agent --wait
    ```
 
-   The Insights the run persisted show up under
+   The script and the CLI both go through `client.insights.analysis_runs`;
+   neither speaks raw HTTP.
+
+3. Inspect the run if you did not use `--wait`:
+
+   ```bash
+   nemo insights analysis-runs list --agent demo-agent
+   nemo insights analysis-runs get <run-name>          # joined with its job
+   nemo insights analysis-runs get <run-name> --wait   # poll to a terminal state
+   ```
+
+   A run and its backing job share one name, and `get` returns them together.
+   A `job` of `null` means submission never landed and the run can be
+   resubmitted.
+
+   The durable comparison point is the `analysis-report` result saved by the
+   Insights execute extension. Job results are an Agents/Jobs surface, so they
+   are still fetched from there:
+
+   ```bash
+   curl "$NMP_BASE_URL/apis/agents/v2/workspaces/default/jobs/execute/<run-name>/results"
+   curl "$NMP_BASE_URL/apis/agents/v2/workspaces/default/jobs/execute/<run-name>/results/analysis-report/download"
+   ```
+
+   The report is what tells you which Insights the run created or updated:
+   insights carry no per-run provenance, by either path. The agent's current
+   insights are read with `client.insights.insights.list_insights(...)`, or
+   from a shell with
    `GET /apis/insights/v2/workspaces/default/insights?agent=demo-agent`.
 
 ## Notes

--- a/plugins/nemo-insights/examples/execute-agent-job/submit_analysis_run.py
+++ b/plugins/nemo-insights/examples/execute-agent-job/submit_analysis_run.py
@@ -1,98 +1,104 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Submit an Insights Analyst demo run through the Insights analysis-runs API.
+"""Submit an Insights Analyst demo run through the analysis-runs SDK.
 
-This script is intentionally REST-shaped so the demo is easy to show with curl
-or a local platform server. The Insights API translates this request into the
-generic ``agents.execute`` job. The route
-composes the Analyst config from the supplied model pair and submits it as an
-inline agent definition, so there is no Analyst Agent entity to provision.
+Everything here is the supported surface — ``client.insights.analysis_runs``,
+mirrored by ``nemo insights analysis-runs`` — rather than hand-rolled HTTP, so
+the demo shows what an end user would actually write. The SDK translates the
+request into the generic ``agents.execute`` job: the route composes the Analyst
+config from the supplied model pair and submits it as an inline agent
+definition, so there is no Analyst Agent entity to provision.
 
-With ``--wait`` it polls the backing job to a terminal state and prints the
+With ``--wait`` it polls the run to a terminal state and prints the
 ``analysis-report`` result the ``insights.analysis`` execute extension saved —
-the durable comparison point against the existing ``AnalyzeJob``.
+the durable comparison point against the existing ``AnalyzeJob``, which saves
+the same report under the same result name.
+
+The equivalent one-liner, with the model pair taken from your CLI config::
+
+    nemo insights analysis-runs create --agent demo-agent --wait
 """
 
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
-import time
 from typing import Any
 
 import httpx
+from nemo_insights_plugin.client import make_client
+from nemo_platform import AsyncNeMoPlatform
 
-TERMINAL_STATUSES = {"completed", "error", "cancelled"}
 REPORT_RESULT_NAME = "analysis-report"
 
 
-def main() -> None:
+async def main() -> None:
     args = _parse_args()
-    payload: dict[str, Any] = {
+    if args.dry_run:
+        print(json.dumps(_request_preview(args), indent=2))
+        return
+
+    client = make_client(args.base_url)
+    try:
+        response = await client.insights.analysis_runs.create(
+            workspace=args.workspace,
+            agent=args.target_agent,
+            default_model=args.default_model,
+            fast_model=args.fast_model,
+            timeout_seconds=args.timeout_seconds,
+        )
+        run_name = response.run.name
+        print(f"Created analysis run '{run_name}' (job status: {response.job_status}).")
+        if not args.wait:
+            print(f"Poll it with: nemo insights analysis-runs get {run_name} --workspace {args.workspace}")
+            return
+
+        final = await client.insights.analysis_runs.wait(
+            workspace=args.workspace,
+            name=run_name,
+            timeout=args.poll_timeout,
+            poll_interval=args.poll_interval,
+            on_status=lambda status: print(f"  status: {status}"),
+        )
+        print(f"Run '{run_name}' finished with job status '{final.job_status}'.")
+        await _print_report(client, args.base_url, args.workspace, run_name)
+        if final.job_status != "completed":
+            raise SystemExit(1)
+    finally:
+        await client.close()
+
+
+def _request_preview(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "workspace": args.workspace,
         "agent": args.target_agent,
         "default_model": args.default_model,
         "fast_model": args.fast_model,
         "timeout_seconds": args.timeout_seconds,
     }
-    base_url = args.base_url.rstrip("/")
-    url = f"{base_url}/apis/insights/v2/workspaces/{args.workspace}/analysis-runs"
-    if args.dry_run:
-        print(json.dumps(payload, indent=2))
-        return
-
-    with httpx.Client(timeout=args.request_timeout) as client:
-        response = client.post(url, json=payload)
-        if response.status_code >= 400:
-            raise SystemExit(f"Failed to create analysis run ({response.status_code}): {response.text}")
-        job = response.json()["job"]
-        job_name = job["name"]
-        print(f"Created execute-agent job '{job_name}' (status: {job.get('status')}).")
-        if not args.wait:
-            print(f"Poll it with: GET {base_url}/apis/agents/v2/workspaces/{args.workspace}/jobs/execute/{job_name}")
-            return
-        status = _wait_for_terminal(client, base_url, args.workspace, job_name, args.poll_timeout, args.poll_interval)
-        print(f"Job '{job_name}' finished with status '{status}'.")
-        _print_report(client, base_url, args.workspace, job_name)
-        if status != "completed":
-            raise SystemExit(1)
 
 
-def _wait_for_terminal(
-    client: httpx.Client,
-    base_url: str,
-    workspace: str,
-    job_name: str,
-    poll_timeout: float,
-    poll_interval: float,
-) -> str:
-    job_url = f"{base_url}/apis/agents/v2/workspaces/{workspace}/jobs/execute/{job_name}"
-    deadline = time.monotonic() + poll_timeout
-    last_status = ""
-    while time.monotonic() < deadline:
-        response = client.get(job_url)
-        response.raise_for_status()
-        status = str(response.json().get("status") or "")
-        if status != last_status:
-            print(f"  status: {status}")
-            last_status = status
-        if status in TERMINAL_STATUSES:
-            return status
-        time.sleep(poll_interval)
-    raise SystemExit(f"Timed out after {poll_timeout}s waiting for job '{job_name}' (last status: {last_status!r}).")
+async def _print_report(client: AsyncNeMoPlatform, base_url: str, workspace: str, job_name: str) -> None:
+    """Print the saved analysis report, or explain why it is absent.
 
-
-def _print_report(client: httpx.Client, base_url: str, workspace: str, job_name: str) -> None:
-    """Print the saved analysis report, or explain why it is absent."""
-    results_url = f"{base_url}/apis/agents/v2/workspaces/{workspace}/jobs/execute/{job_name}/results"
-    response = client.get(results_url)
-    response.raise_for_status()
-    names = [result["name"] for result in response.json()["data"]]
+    Job results are an Agents/Jobs concern, so this reads them through
+    ``client.agents.jobs.execute``. Only the byte download still needs raw
+    HTTP: the jobs SDK exposes the result listing but not the file itself.
+    """
+    listing = await client.agents.jobs.execute.list_results(job_name, workspace=workspace)
+    names = [result["name"] for result in listing["data"]]
     if REPORT_RESULT_NAME not in names:
         print(f"No '{REPORT_RESULT_NAME}' result was saved. Available results: {', '.join(names) or '(none)'}")
         return
 
-    download = client.get(f"{results_url}/{REPORT_RESULT_NAME}/download", follow_redirects=True)
+    url = (
+        f"{base_url.rstrip('/')}/apis/agents/v2/workspaces/{workspace}"
+        f"/jobs/execute/{job_name}/results/{REPORT_RESULT_NAME}/download"
+    )
+    async with httpx.AsyncClient(timeout=60.0) as http:
+        download = await http.get(url, follow_redirects=True)
     download.raise_for_status()
     print(f"\n--- {REPORT_RESULT_NAME} ---")
     print(download.text)
@@ -110,8 +116,7 @@ def _parse_args() -> argparse.Namespace:
         "--fast-model", required=True, help="Model Entity ref, e.g. default/nvidia-nemotron-3-nano-30b-a3b."
     )
     parser.add_argument("--timeout-seconds", type=float, default=3600.0, help="Execute-job Fabric timeout.")
-    parser.add_argument("--request-timeout", type=float, default=30.0)
-    parser.add_argument("--wait", action="store_true", help="Poll the job and print its analysis report.")
+    parser.add_argument("--wait", action="store_true", help="Poll the run and print its analysis report.")
     parser.add_argument("--poll-timeout", type=float, default=900.0)
     parser.add_argument("--poll-interval", type=float, default=5.0)
     parser.add_argument("--dry-run", action="store_true")
@@ -119,4 +124,4 @@ def _parse_args() -> argparse.Namespace:
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/plugins/nemo-insights/pyproject.toml
+++ b/plugins/nemo-insights/pyproject.toml
@@ -58,5 +58,8 @@ packages = ["src/nemo_insights_plugin"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "integration: service integration tests",
+]
 pythonpath = ["src", "."]
 testpaths = ["tests"]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/_perms.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/_perms.py
@@ -24,6 +24,8 @@ class AnalysisConfigPerms(PermissionSet, namespace="insights.analysis-configs"):
 
 class AnalysisRunPerms(PermissionSet, namespace="insights.analysis-runs"):
     CREATE = perm("Submit an insights analysis run")
+    LIST = perm("List insights analysis runs")
+    READ = perm("Read an insights analysis run")
 
 
 class AnalysisRunStatusPerms(PermissionSet, namespace="insights.analysis-run-statuses"):

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
@@ -30,7 +30,7 @@ from nemo_insights_plugin.analyst.agent_config import AGENT_CONFIG_FORMAT, build
 from nemo_insights_plugin.authz import scope
 from nemo_insights_plugin.entities import AnalysisRun
 from nemo_insights_plugin.schema import AnalysisRunPage, AnalysisRunResponse, CreateAnalysisRunRequest
-from nemo_platform import APIStatusError, AsyncNeMoPlatform
+from nemo_platform import APIConnectionError, APIStatusError, AsyncNeMoPlatform
 from nemo_platform_plugin.authz import CallerKind, path_rule
 from nemo_platform_plugin.dependencies import get_sdk_client
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError, get_entity_client
@@ -93,6 +93,21 @@ async def create_analysis_run(
         # new name and no resubmit-under-an-existing-name route exists yet.
         logger.warning("Analysis run %r recorded but its job was not created: %s", saved.name, exc)
         raise HTTPException(status_code=exc.status_code, detail=_error_detail(exc)) from exc
+    except APIConnectionError as exc:
+        # Same stranded run, but a sibling of APIStatusError rather than a
+        # subclass, so it needs its own arm — and it is the case most likely to
+        # be worth retrying, since the request may never have reached Jobs.
+        # Log the run name: without it the orphan cannot be found afterwards.
+        logger.warning("Analysis run %r recorded but the Jobs service was unreachable: %s", saved.name, exc)
+        raise HTTPException(
+            status_code=503,
+            # Name the run: it exists, and this is the caller's only chance to
+            # learn what was persisted before the response is all they have.
+            detail={
+                "message": "Could not reach the Jobs service to submit the analysis run.",
+                "run": saved.name,
+            },
+        ) from exc
     return AnalysisRunResponse(run=saved, job=job)
 
 

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
@@ -92,7 +92,13 @@ async def create_analysis_run(
         # submitted"; recovering one is a read today, since every create mints a
         # new name and no resubmit-under-an-existing-name route exists yet.
         logger.warning("Analysis run %r recorded but its job was not created: %s", saved.name, exc)
-        raise HTTPException(status_code=exc.status_code, detail=_error_detail(exc)) from exc
+        raise HTTPException(
+            status_code=exc.status_code,
+            # ``error`` keeps the Agents service's own detail — a missing entity
+            # or invalid config reads better from the service that rejected it —
+            # while ``run`` names the record this call stranded.
+            detail={"error": _error_detail(exc), "run": saved.name},
+        ) from exc
     except APIConnectionError as exc:
         # Same stranded run, but a sibling of APIStatusError rather than a
         # subclass, so it needs its own arm — and it is the case most likely to
@@ -101,10 +107,11 @@ async def create_analysis_run(
         logger.warning("Analysis run %r recorded but the Jobs service was unreachable: %s", saved.name, exc)
         raise HTTPException(
             status_code=503,
-            # Name the run: it exists, and this is the caller's only chance to
-            # learn what was persisted before the response is all they have.
+            # Same shape as the status arm above: ``run`` names the record this
+            # call stranded, which is the caller's only chance to learn what was
+            # persisted before the response is all they have.
             detail={
-                "message": "Could not reach the Jobs service to submit the analysis run.",
+                "error": "Could not reach the Jobs service to submit the analysis run.",
                 "run": saved.name,
             },
         ) from exc

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
@@ -279,6 +279,13 @@ def _inline_analyst(request: CreateAnalysisRunRequest, *, workspace: str) -> dic
             ethos=request.ethos,
             since=request.since,
             evaluation_id=request.evaluation_id,
+            # The Analyst's self-observability builds its own OTLP exporter from
+            # the operator's local CLI config, which does not exist in a task
+            # pod, so on a cluster it exports unauthenticated at best. Telemetry
+            # for these runs belongs in the agent config's relay endpoints,
+            # where the agents layer already carries auth; until that is wired,
+            # a run must not depend on it.
+            enable_observability=False,
         ),
     }
 

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
@@ -3,100 +3,162 @@
 
 """High-level Insights analysis-run request helpers.
 
-This module is intentionally a thin facade over the generic ``agents.execute``
-job. The current ``AnalyzeJob`` can continue to run side-by-side while this
-path exercises the Analyst-as-Agent implementation.
+This module is a thin facade over the generic ``agents.execute`` job. The
+current ``AnalyzeJob`` can continue to run side-by-side while this path
+exercises the Analyst-as-Agent implementation.
+
+Insights persists one :class:`~nemo_insights_plugin.entities.AnalysisRun` per
+run, holding only what the Jobs layer cannot know: that a job was an analysis
+run, and over which agent and scope. Execution state is *not* copied — it is
+read back from the job on demand.
+
+The run is named before the job is submitted and the job takes that same name,
+so the two are linked by construction rather than by a write-back. That is what
+makes the failure modes distinguishable: a run whose job 404s never landed, and
+a resubmission that conflicts is proof the original did.
 """
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import Annotated, Any
+import logging
+import uuid
+from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from nemo_insights_plugin._perms import AnalysisRunPerms
 from nemo_insights_plugin.analyst.agent_config import AGENT_CONFIG_FORMAT, build_analyst_agent_config
 from nemo_insights_plugin.authz import scope
+from nemo_insights_plugin.entities import AnalysisRun
+from nemo_insights_plugin.schema import AnalysisRunPage, AnalysisRunResponse, CreateAnalysisRunRequest
 from nemo_platform import APIStatusError, AsyncNeMoPlatform
 from nemo_platform_plugin.authz import CallerKind, path_rule
 from nemo_platform_plugin.dependencies import get_sdk_client
-from pydantic import BaseModel, Field, StringConstraints
+from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError, get_entity_client
+from nemo_platform_plugin.schema import PaginationData
+
+logger = logging.getLogger(__name__)
 
 INSIGHTS_ANALYSIS_EXTENSION_KIND = "insights.analysis"
+ANALYSIS_RUN_NAME_PREFIX = "insights-run-"
 
 router = APIRouter(tags=["Insights Analysis Runs"])
 
-NonBlankString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+def mint_analysis_run_name() -> str:
+    """Mint the name shared by an analysis run and its backing job.
+
+    Minted by Insights rather than assigned by the Jobs service so the run can
+    be persisted *before* the job is submitted. Uniqueness comes from the uuid,
+    not from the agent — an earlier version derived the name from the agent and
+    collided on the second run.
+    """
+    return f"{ANALYSIS_RUN_NAME_PREFIX}{uuid.uuid4().hex}"
 
 
-class CreateAnalysisRunRequest(BaseModel):
-    """Client-facing request to run the Insights Analyst through ``agents.execute``."""
-
-    agent: NonBlankString = Field(description="Agent whose telemetry should be analyzed.")
-    default_model: str = Field(
-        description=(
-            "Workspace-qualified Model Entity ref ('<workspace>/<name>') the Analyst uses for "
-            "analysis work. Required: the model pair is the operator's choice and is not "
-            "persisted anywhere the Platform process can read it."
-        ),
-    )
-    fast_model: str = Field(
-        description=(
-            "Workspace-qualified Model Entity ref used for context summarization. Required for "
-            "the same reason as default_model."
-        ),
-    )
-    ethos: NonBlankString | None = Field(
-        default=None,
-        description=(
-            "Optional Ethos Markdown for the agent under test. Sent inline rather than as a "
-            "reference: the execute job's Fabric adapter has no Files access."
-        ),
-    )
-    since: datetime | None = Field(
-        default=None,
-        description="Optional lower bound enforced on the Analyst's trace/span reads.",
-    )
-    evaluation_id: NonBlankString | None = Field(
-        default=None,
-        description="Optional run scope AND-pinned onto every span read.",
-    )
-    name: str | None = Field(
-        default=None,
-        description="Optional job name. Omit to let the Jobs service generate a unique one.",
-    )
-    timeout_seconds: float | None = Field(default=None, gt=0, description="Optional execute job timeout.")
-
-
-class CreateAnalysisRunResponse(BaseModel):
-    """Response returned after creating the backing execute-agent job."""
-
-    job: dict[str, Any]
-
-
-@router.post("/analysis-runs", response_model=CreateAnalysisRunResponse)
+@router.post("/analysis-runs", response_model=AnalysisRunResponse, status_code=201)
 @scope.write
 @path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisRunPerms.CREATE])
 async def create_analysis_run(
     workspace: str,
     request: CreateAnalysisRunRequest,
     sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
-) -> CreateAnalysisRunResponse:
+    entity_client: NemoEntitiesClient = Depends(get_entity_client),
+) -> AnalysisRunResponse:
     """Create an Insights analysis run backed by the generic ``agents.execute`` job."""
-    spec = build_execute_agent_job_config(request, workspace=workspace)
+    run = AnalysisRun(
+        name=mint_analysis_run_name(),
+        workspace=workspace,
+        agent=request.agent,
+        since=request.since,
+        evaluation_id=request.evaluation_id or "",
+        default_model=request.default_model,
+        fast_model=request.fast_model,
+    )
     try:
-        # A ``None`` name is omitted from the request body so the Jobs service
-        # generates a unique one; a fixed name would collide on the second run
-        # for the same agent.
-        job = await sdk.agents.jobs.execute.create(spec=spec, name=request.name, workspace=workspace)
+        saved = await entity_client.create(run)
+    except Exception as exc:
+        safe_agent = request.agent.replace("\r", "").replace("\n", "")
+        logger.exception("Failed to record analysis run for agent '%s'", safe_agent)
+        raise HTTPException(status_code=500, detail="Failed to record the analysis run.") from exc
+
+    spec = build_execute_agent_job_config(request, workspace=workspace, run_name=saved.name)
+    try:
+        job = await sdk.agents.jobs.execute.create(spec=spec, name=saved.name, workspace=workspace)
     except APIStatusError as exc:
-        # Surface the Agents service's own error rather than a bare 500 — a
-        # missing Analyst Agent entity or an invalid config shows up here.
+        # The run record is deliberately left in place. Deleting it here could
+        # remove the only pointer to a job that was in fact created (a create
+        # that timed out client-side still lands), which is the untracked-job
+        # case this design exists to prevent. A run with no job reads as "never
+        # submitted" and can be resubmitted under the same name.
+        logger.warning("Analysis run %r recorded but its job was not created: %s", saved.name, exc)
         raise HTTPException(status_code=exc.status_code, detail=_error_detail(exc)) from exc
-    return CreateAnalysisRunResponse(job=job)
+    return AnalysisRunResponse(run=saved, job=job)
 
 
-def build_execute_agent_job_config(request: CreateAnalysisRunRequest, *, workspace: str) -> dict[str, Any]:
+@router.get("/analysis-runs", response_model=AnalysisRunPage)
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisRunPerms.LIST])
+async def list_analysis_runs(
+    workspace: str,
+    page: int = Query(default=1, ge=1, description="Page number (1-indexed)."),
+    page_size: int = Query(default=20, ge=1, le=100, description="Items per page."),
+    sort: str = Query(default="-created_at", description="Sort field."),
+    agent: str | None = Query(default=None, description="Filter by the agent that was analyzed."),
+    entity_client: NemoEntitiesClient = Depends(get_entity_client),
+) -> AnalysisRunPage:
+    """List analysis runs. Job state is not joined here — read a run to get it."""
+    filter_obj: dict[str, object] = {}
+    if agent is not None:
+        filter_obj["agent"] = agent
+    try:
+        result = await entity_client.list(
+            AnalysisRun,
+            workspace=workspace,
+            page=page,
+            page_size=page_size,
+            sort=sort,
+            filter_obj=filter_obj or None,
+        )
+    except Exception as exc:
+        logger.exception("Failed to list analysis runs")
+        raise HTTPException(status_code=500, detail="Failed to list analysis runs.") from exc
+
+    pagination = PaginationData.model_validate(result.pagination.model_dump()) if result.pagination else None
+    return AnalysisRunPage(data=result.data, pagination=pagination, sort=sort, filter=filter_obj or None)
+
+
+@router.get("/analysis-runs/{name}", response_model=AnalysisRunResponse)
+@scope.read
+@path_rule(callers=[CallerKind.PRINCIPAL], permissions=[AnalysisRunPerms.READ])
+async def get_analysis_run(
+    workspace: str,
+    name: str,
+    sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
+    entity_client: NemoEntitiesClient = Depends(get_entity_client),
+) -> AnalysisRunResponse:
+    """Get one analysis run, joined with the live state of its backing job."""
+    try:
+        run = await entity_client.get(AnalysisRun, name=name, workspace=workspace)
+    except NemoEntityNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail=f"Analysis run '{name}' not found in workspace '{workspace}'."
+        ) from exc
+    return AnalysisRunResponse(run=run, job=await _backing_job(sdk, workspace=workspace, name=name))
+
+
+async def _backing_job(sdk: AsyncNeMoPlatform, *, workspace: str, name: str) -> dict[str, Any] | None:
+    """Read the job sharing this run's name, or None when submission never landed."""
+    try:
+        return await sdk.agents.jobs.execute.get(name, workspace=workspace)
+    except APIStatusError as exc:
+        if exc.status_code == 404:
+            return None
+        raise
+
+
+def build_execute_agent_job_config(
+    request: CreateAnalysisRunRequest, *, workspace: str, run_name: str
+) -> dict[str, Any]:
     """Translate a high-level Insights request into a generic execute-agent job config."""
     extension_config: dict[str, Any] = {
         "agent": request.agent,

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
@@ -89,7 +89,8 @@ async def create_analysis_run(
         # remove the only pointer to a job that was in fact created (a create
         # that timed out client-side still lands), which is the untracked-job
         # case this design exists to prevent. A run with no job reads as "never
-        # submitted" and can be resubmitted under the same name.
+        # submitted"; recovering one is a read today, since every create mints a
+        # new name and no resubmit-under-an-existing-name route exists yet.
         logger.warning("Analysis run %r recorded but its job was not created: %s", saved.name, exc)
         raise HTTPException(status_code=exc.status_code, detail=_error_detail(exc)) from exc
     return AnalysisRunResponse(run=saved, job=job)

--- a/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/analysis_runs.py
@@ -65,6 +65,10 @@ async def create_analysis_run(
     entity_client: NemoEntitiesClient = Depends(get_entity_client),
 ) -> AnalysisRunResponse:
     """Create an Insights analysis run backed by the generic ``agents.execute`` job."""
+    # Resolve before recording anything: a bogus ref would otherwise persist a
+    # run and submit a job that cannot start, and the request carries the only
+    # copy of the operator's intent.
+    request = await _resolve_model_refs(sdk, request, workspace=workspace)
     run = AnalysisRun(
         name=mint_analysis_run_name(),
         workspace=workspace,
@@ -177,6 +181,60 @@ async def _backing_job(sdk: AsyncNeMoPlatform, *, workspace: str, name: str) -> 
         if exc.status_code == 404:
             return None
         raise
+
+
+async def _resolve_model_refs(
+    sdk: AsyncNeMoPlatform,
+    request: CreateAnalysisRunRequest,
+    *,
+    workspace: str,
+) -> CreateAnalysisRunRequest:
+    """Normalize the model pair to ``workspace/name`` and confirm both exist.
+
+    A bare name resolves against the run's own workspace. A qualified ref is
+    looked up in the workspace it names, so a run may use a model from another
+    workspace the caller can read; the entity store's own authorization decides
+    that, and a denial surfaces with the status it returned. The normalized form
+    is what gets stored and put in the job spec, because the Analyst only accepts
+    qualified refs.
+    """
+    resolved = {
+        field: await _resolve_model_ref(sdk, getattr(request, field), field=field, workspace=workspace)
+        for field in ("default_model", "fast_model")
+    }
+    return request.model_copy(update=resolved)
+
+
+async def _resolve_model_ref(sdk: AsyncNeMoPlatform, ref: str, *, field: str, workspace: str) -> str:
+    """Return ``<workspace>/<name>`` for an existing Model Entity, or raise 422."""
+    match ref.split("/"):
+        case [name]:
+            model_workspace = workspace
+        case [model_workspace, name] if model_workspace and name:
+            pass
+        case _:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{field} must be a Model Entity name or '<workspace>/<name>' ref, got {ref!r}.",
+            )
+
+    try:
+        await sdk.models.retrieve(name, workspace=model_workspace)
+    except APIStatusError as exc:
+        if exc.status_code == 404:
+            raise HTTPException(
+                status_code=422,
+                detail=f"{field} '{model_workspace}/{name}' is not a known Model Entity.",
+            ) from exc
+        raise HTTPException(status_code=exc.status_code, detail=_error_detail(exc)) from exc
+    except APIConnectionError as exc:
+        # Same reasoning as the submit path: an unreachable dependency is not
+        # the caller's bad request, and nothing has been recorded yet.
+        logger.warning("Could not reach the Models service to validate %s %r: %s", field, ref, exc)
+        raise HTTPException(
+            status_code=503, detail="Could not reach the Models service to validate the model refs."
+        ) from exc
+    return f"{model_workspace}/{name}"
 
 
 def build_execute_agent_job_config(

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -50,6 +50,7 @@ from nemo_insights_plugin.sdk_resources.analysis_runs import (
 )
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatformError
 from nemo_platform_plugin.cli import NemoCLI
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nemo_platform_plugin.nooa_model_client import configured_model_refs
 from nooa import GenerationError
 
@@ -866,7 +867,7 @@ async def _wait_for_run(
         poll_interval=poll_interval,
         on_status=_status_reporter(),
     )
-    return _json(response.model_dump(mode="json")), response.job_status == "completed"
+    return _json(response.model_dump(mode="json")), response.job_status == PlatformJobStatus.COMPLETED.value
 
 
 def _json(payload: object) -> str:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -12,10 +12,13 @@ The module-level :func:`analyze` and :func:`doctor` callbacks are the verb bodie
 import asyncio
 import json
 import os
+from collections.abc import AsyncIterator, Callable, Coroutine
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime
 from importlib.metadata import entry_points
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar, TypeVar
 
 import httpx
 import typer
@@ -39,7 +42,13 @@ from nemo_insights_plugin.preflight import (
     read_ethos,
 )
 from nemo_insights_plugin.profile import AnalysisProfile, load_profile, pick_ethos
-from nemo_platform import NeMoPlatformError
+from nemo_insights_plugin.sdk_resources.analysis_runs import (
+    DEFAULT_POLL_INTERVAL,
+    DEFAULT_WAIT_TIMEOUT,
+    AnalysisRunNotSubmittedError,
+    AnalysisRunTimeoutError,
+)
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatformError
 from nemo_platform_plugin.cli import NemoCLI
 from nemo_platform_plugin.nooa_model_client import configured_model_refs
 from nooa import GenerationError
@@ -93,7 +102,32 @@ def _preflight_or_exit(checks: list[CheckResult]) -> None:
 
 def _one_line_error(exc: BaseException) -> str:
     """Collapse expected CLI failures to one readable terminal line."""
-    return " ".join(str(exc).splitlines()).strip() or type(exc).__name__
+    message = " ".join(str(exc).splitlines()).strip() or type(exc).__name__
+    if isinstance(exc, httpx.HTTPStatusError):
+        # The default message names the status and URL but not the reason the
+        # service gave, which is the only part a caller can act on.
+        detail = " ".join(exc.response.text.splitlines()).strip()
+        if detail:
+            message = f"{message}: {detail}"
+    return message
+
+
+_T = TypeVar("_T")
+
+
+def _run_command(coro: Coroutine[Any, Any, _T]) -> _T:
+    """Run one analysis-run command, turning expected failures into exit 1."""
+    try:
+        return asyncio.run(coro)
+    except (
+        ValueError,
+        AnalysisRunNotSubmittedError,
+        AnalysisRunTimeoutError,
+        NeMoPlatformError,
+        httpx.HTTPError,
+    ) as exc:
+        typer.echo(f"Error: {_one_line_error(exc)}", err=True)
+        raise typer.Exit(1) from None
 
 
 def _resolve_analysis(
@@ -446,6 +480,184 @@ class InsightsCLI(NemoCLI):
                 )
             )
 
+        runs_app = typer.Typer(
+            help="Submit and inspect on-demand analysis runs.",
+            no_args_is_help=True,
+        )
+        app.add_typer(runs_app, name="analysis-runs")
+
+        @runs_app.command("create")
+        def create_analysis_run(
+            agent: str = typer.Option(
+                ...,
+                "--agent",
+                help="Name of the agent whose telemetry should be analyzed.",
+            ),
+            workspace: str = typer.Option(
+                DEFAULT_WORKSPACE,
+                "--workspace",
+                help="Workspace the agent belongs to.",
+            ),
+            base_url: str = typer.Option(
+                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
+                "--base-url",
+                help="Base URL of the running NMP instance.",
+                envvar="NMP_BASE_URL",
+            ),
+            default_model: str | None = typer.Option(
+                None,
+                "--default-model",
+                help="Model Entity ref for analysis work. Default: the configured default model.",
+            ),
+            fast_model: str | None = typer.Option(
+                None,
+                "--fast-model",
+                help="Model Entity ref for context summarization. Default: the configured fast model.",
+            ),
+            since: str | None = typer.Option(
+                None,
+                "--since",
+                help="ISO-8601 lower bound enforced on the analyst's trace/span reads.",
+            ),
+            ethos: Path | None = typer.Option(
+                None,
+                "--ethos",
+                help="Path to the agent's Ethos Markdown. Its contents are sent with the run.",
+            ),
+            evaluation_id: str | None = typer.Option(
+                None,
+                "--evaluation-id",
+                help="Restrict the run to spans from one evaluation.",
+            ),
+            timeout_seconds: float | None = typer.Option(
+                None,
+                "--timeout-seconds",
+                help="Timeout applied to the backing execute-agent job.",
+            ),
+            wait: bool = typer.Option(
+                False,
+                "--wait",
+                help="Poll the run until its backing job reaches a terminal state.",
+            ),
+            poll_timeout: float = typer.Option(
+                DEFAULT_WAIT_TIMEOUT,
+                "--poll-timeout",
+                help="How long --wait polls before giving up.",
+            ),
+            poll_interval: float = typer.Option(
+                DEFAULT_POLL_INTERVAL,
+                "--poll-interval",
+                help="Seconds between --wait polls.",
+            ),
+        ) -> None:
+            """Submit an analysis run for an agent.
+
+            The run is backed by an agents.execute job that shares its name.
+            With --wait, exits non-zero if that job does not complete.
+            """
+            payload, completed = _run_command(
+                _create_analysis_run(
+                    agent=agent,
+                    workspace=workspace,
+                    base_url=base_url,
+                    default_model=default_model,
+                    fast_model=fast_model,
+                    ethos=ethos,
+                    since=since,
+                    evaluation_id=evaluation_id,
+                    timeout_seconds=timeout_seconds,
+                    wait=wait,
+                    poll_timeout=poll_timeout,
+                    poll_interval=poll_interval,
+                )
+            )
+            typer.echo(payload)
+            if not completed:
+                raise typer.Exit(1)
+
+        @runs_app.command("list")
+        def list_analysis_runs(
+            agent: str | None = typer.Option(
+                None,
+                "--agent",
+                help="Only list runs that analyzed this agent.",
+            ),
+            workspace: str = typer.Option(
+                DEFAULT_WORKSPACE,
+                "--workspace",
+                help="Workspace to inspect.",
+            ),
+            base_url: str = typer.Option(
+                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
+                "--base-url",
+                help="Base URL of the running NMP instance.",
+                envvar="NMP_BASE_URL",
+            ),
+            page: int = typer.Option(1, "--page", help="Page number (1-indexed)."),
+            page_size: int = typer.Option(20, "--page-size", help="Items per page."),
+        ) -> None:
+            """List analysis runs. Job state is not joined — read one run to get it."""
+            typer.echo(
+                _run_command(
+                    _list_analysis_runs(
+                        agent=agent,
+                        workspace=workspace,
+                        base_url=base_url,
+                        page=page,
+                        page_size=page_size,
+                    )
+                )
+            )
+
+        @runs_app.command("get")
+        def get_analysis_run(
+            name: str = typer.Argument(..., help="Name of the analysis run."),
+            workspace: str = typer.Option(
+                DEFAULT_WORKSPACE,
+                "--workspace",
+                help="Workspace the run belongs to.",
+            ),
+            base_url: str = typer.Option(
+                os.environ.get("NMP_BASE_URL", DEFAULT_BASE_URL),
+                "--base-url",
+                help="Base URL of the running NMP instance.",
+                envvar="NMP_BASE_URL",
+            ),
+            wait: bool = typer.Option(
+                False,
+                "--wait",
+                help="Poll until the run's backing job reaches a terminal state.",
+            ),
+            poll_timeout: float = typer.Option(
+                DEFAULT_WAIT_TIMEOUT,
+                "--poll-timeout",
+                help="How long --wait polls before giving up.",
+            ),
+            poll_interval: float = typer.Option(
+                DEFAULT_POLL_INTERVAL,
+                "--poll-interval",
+                help="Seconds between --wait polls.",
+            ),
+        ) -> None:
+            """Get one analysis run, joined with the live state of its backing job.
+
+            A null job means submission never landed: no job exists under the
+            run's name, and the run can be resubmitted.
+            """
+            payload, completed = _run_command(
+                _get_analysis_run(
+                    name=name,
+                    workspace=workspace,
+                    base_url=base_url,
+                    wait=wait,
+                    poll_timeout=poll_timeout,
+                    poll_interval=poll_interval,
+                )
+            )
+            typer.echo(payload)
+            if not completed:
+                raise typer.Exit(1)
+
         for entry_point in sorted(entry_points(group="nemo.insights.commands"), key=lambda item: item.name):
             app.add_typer(entry_point.load()(), name=entry_point.name)
         return app
@@ -491,6 +703,170 @@ async def _analysis_config_command(
         raise ValueError(f"Unknown analysis config action: {action}")
     finally:
         await client.close()
+
+
+@asynccontextmanager
+async def _client(base_url: str) -> AsyncIterator[AsyncNeMoPlatform]:
+    """Open a platform client for one CLI command and always close it."""
+    client = make_client(base_url)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+def _parse_since(since: str | None) -> datetime | None:
+    """Parse ``--since`` here so a bad value fails before anything is submitted."""
+    if since is None:
+        return None
+    try:
+        return datetime.fromisoformat(since)
+    except ValueError:
+        raise ValueError(f"--since must be an ISO-8601 timestamp, got {since!r}") from None
+
+
+def _read_ethos_file(ethos: Path | None) -> str | None:
+    """Inline the Ethos here: the job's Fabric adapter has no Files access.
+
+    Unlike preflight's tolerant read, an explicit ``--ethos`` that cannot be
+    read is fatal — submitting the run without it would silently analyze the
+    agent against no contract at all.
+    """
+    if ethos is None:
+        return None
+    try:
+        content = ethos.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"--ethos could not be read: {exc}") from None
+    if not content.strip():
+        raise ValueError(f"--ethos is empty: {ethos}")
+    return content
+
+
+def _resolve_model_refs(default_model: str | None, fast_model: str | None) -> tuple[str, str]:
+    """Fill either model ref from the operator's CLI config when not given.
+
+    The Platform process cannot read that config, so the request has to carry
+    the pair; the CLI is where it is known.
+    """
+    if default_model and fast_model:
+        return default_model, fast_model
+    configured = configured_model_refs()
+    return default_model or configured.default, fast_model or configured.fast
+
+
+def _status_reporter() -> Callable[[str | None], None]:
+    """Report each job-status change on stderr, keeping stdout pure JSON."""
+
+    def report(status: str | None) -> None:
+        typer.echo(f"  status: {status}", err=True)
+
+    return report
+
+
+async def _create_analysis_run(
+    *,
+    agent: str,
+    workspace: str,
+    base_url: str,
+    default_model: str | None,
+    fast_model: str | None,
+    ethos: Path | None,
+    since: str | None,
+    evaluation_id: str | None,
+    timeout_seconds: float | None,
+    wait: bool,
+    poll_timeout: float,
+    poll_interval: float,
+) -> tuple[str, bool]:
+    """Submit a run and return its JSON plus whether it completed.
+
+    Without ``--wait`` there is nothing to have failed yet, so the run counts
+    as completed for exit-code purposes.
+    """
+    parsed_since = _parse_since(since)
+    ethos_content = _read_ethos_file(ethos)
+    resolved_default, resolved_fast = _resolve_model_refs(default_model, fast_model)
+    async with _client(base_url) as client:
+        response = await client.insights.analysis_runs.create(
+            workspace=workspace,
+            agent=agent,
+            default_model=resolved_default,
+            fast_model=resolved_fast,
+            ethos=ethos_content,
+            since=parsed_since,
+            evaluation_id=evaluation_id,
+            timeout_seconds=timeout_seconds,
+        )
+        if not wait:
+            return _json(response.model_dump(mode="json")), True
+        typer.echo(f"Created analysis run '{response.run.name}'.", err=True)
+        return await _wait_for_run(
+            client,
+            workspace=workspace,
+            name=response.run.name,
+            poll_timeout=poll_timeout,
+            poll_interval=poll_interval,
+        )
+
+
+async def _list_analysis_runs(
+    *,
+    agent: str | None,
+    workspace: str,
+    base_url: str,
+    page: int,
+    page_size: int,
+) -> str:
+    async with _client(base_url) as client:
+        result = await client.insights.analysis_runs.list_runs(
+            workspace=workspace,
+            agent=agent,
+            page=page,
+            page_size=page_size,
+        )
+    return _json(result.model_dump(mode="json"))
+
+
+async def _get_analysis_run(
+    *,
+    name: str,
+    workspace: str,
+    base_url: str,
+    wait: bool,
+    poll_timeout: float,
+    poll_interval: float,
+) -> tuple[str, bool]:
+    async with _client(base_url) as client:
+        if wait:
+            return await _wait_for_run(
+                client,
+                workspace=workspace,
+                name=name,
+                poll_timeout=poll_timeout,
+                poll_interval=poll_interval,
+            )
+        response = await client.insights.analysis_runs.get(workspace=workspace, name=name)
+    return _json(response.model_dump(mode="json")), True
+
+
+async def _wait_for_run(
+    client: AsyncNeMoPlatform,
+    *,
+    workspace: str,
+    name: str,
+    poll_timeout: float,
+    poll_interval: float,
+) -> tuple[str, bool]:
+    """Poll one run to a terminal job state, reporting status changes on stderr."""
+    response = await client.insights.analysis_runs.wait(
+        workspace=workspace,
+        name=name,
+        timeout=poll_timeout,
+        poll_interval=poll_interval,
+        on_status=_status_reporter(),
+    )
+    return _json(response.model_dump(mode="json")), response.job_status == "completed"
 
 
 def _json(payload: object) -> str:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/cli.py
@@ -596,6 +596,11 @@ class InsightsCLI(NemoCLI):
             ),
             page: int = typer.Option(1, "--page", help="Page number (1-indexed)."),
             page_size: int = typer.Option(20, "--page-size", help="Items per page."),
+            sort: str = typer.Option(
+                "-created_at",
+                "--sort",
+                help="Sort field; prefix with '-' for descending.",
+            ),
         ) -> None:
             """List analysis runs. Job state is not joined — read one run to get it."""
             typer.echo(
@@ -606,6 +611,7 @@ class InsightsCLI(NemoCLI):
                         base_url=base_url,
                         page=page,
                         page_size=page_size,
+                        sort=sort,
                     )
                 )
             )
@@ -818,6 +824,7 @@ async def _list_analysis_runs(
     base_url: str,
     page: int,
     page_size: int,
+    sort: str,
 ) -> str:
     async with _client(base_url) as client:
         result = await client.insights.analysis_runs.list_runs(
@@ -825,6 +832,7 @@ async def _list_analysis_runs(
             agent=agent,
             page=page,
             page_size=page_size,
+            sort=sort,
         )
     return _json(result.model_dump(mode="json"))
 

--- a/plugins/nemo-insights/src/nemo_insights_plugin/entities.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/entities.py
@@ -69,6 +69,42 @@ class Insight(NemoEntity, entity_type="insights_insight"):
     )
 
 
+class AnalysisRun(NemoEntity, entity_type="insights_analysis_run"):
+    """One on-demand Insights analysis run — what was asked for, not how it went.
+
+    The record's ``name`` is also the name of the backing ``agents.execute``
+    job. Insights mints that name before submitting, so the link between a run
+    and its job is *derivable* rather than written back after the fact. That
+    removes the dual write, and with it the failure mode where a job exists
+    that no run points at: a run whose job name 404s simply never landed and
+    can be resubmitted under the same name, and a resubmission that collides is
+    proof the original landed.
+
+    Progress is deliberately absent. Status, logs, and results belong to the
+    Job and are read from it; mirroring them here would go stale immediately.
+    Insights owns only what no lower layer knows: that this job was an analysis
+    run, over which agent and scope.
+    """
+
+    agent: str = Field(description="Agent whose telemetry this run analyzed.")
+    since: datetime | None = Field(
+        default=None,
+        description="Lower bound the run enforced on trace/span reads.",
+    )
+    evaluation_id: str = Field(
+        default="",
+        description="Run scope AND-pinned onto every span read, when one was requested.",
+    )
+    default_model: str = Field(
+        default="",
+        description="Workspace-qualified Model Entity the run used for analysis work.",
+    )
+    fast_model: str = Field(
+        default="",
+        description="Workspace-qualified Model Entity the run used for context summarization.",
+    )
+
+
 class AnalysisConfig(NemoEntity, entity_type="insights_analysis_config"):
     """Per-agent opt-in state for framework-managed periodic analysis.
 

--- a/plugins/nemo-insights/src/nemo_insights_plugin/entities.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/entities.py
@@ -76,9 +76,9 @@ class AnalysisRun(NemoEntity, entity_type="insights_analysis_run"):
     job. Insights mints that name before submitting, so the link between a run
     and its job is *derivable* rather than written back after the fact. That
     removes the dual write, and with it the failure mode where a job exists
-    that no run points at: a run whose job name 404s simply never landed and
-    can be resubmitted under the same name, and a resubmission that collides is
-    proof the original landed.
+    that no run points at: a run whose job name 404s simply never landed. There
+    is no resubmit-under-an-existing-name route yet, so such a run is a read
+    today, not something a caller can drive back to completion.
 
     Progress is deliberately absent. Status, logs, and results belong to the
     Job and are read from it; mirroring them here would go stale immediately.

--- a/plugins/nemo-insights/src/nemo_insights_plugin/schema.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/schema.py
@@ -1,19 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Request/response schemas for the insights plugin HTTP API."""
+"""Request/response schemas for the insights plugin HTTP API.
+
+These live here rather than beside their routes so the SDK resources can share
+them: importing :mod:`nemo_insights_plugin.analysis_runs` from an SDK client
+would drag FastAPI and the whole Analyst agent stack in with it.
+"""
 
 from datetime import datetime
+from typing import Annotated, Any
 
 from nemo_insights_plugin.entities import (
     AnalysisConfig,
     AnalysisConfigStatus,
+    AnalysisRun,
     AnalysisRunStatus,
     Insight,
     InsightStatus,
 )
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nemo_platform_plugin.schema import NemoListResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StringConstraints
 
 
 class CreateInsightRequest(BaseModel):
@@ -79,6 +87,76 @@ class UpdateAnalysisConfigRequest(BaseModel):
     enabled: bool | None = None
 
 
+NonBlankString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class CreateAnalysisRunRequest(BaseModel):
+    """Client-facing request to run the Insights Analyst through ``agents.execute``."""
+
+    agent: NonBlankString = Field(description="Agent whose telemetry should be analyzed.")
+    default_model: str = Field(
+        description=(
+            "Workspace-qualified Model Entity ref ('<workspace>/<name>') the Analyst uses for "
+            "analysis work. Required: the model pair is the operator's choice and is not "
+            "persisted anywhere the Platform process can read it."
+        ),
+    )
+    fast_model: str = Field(
+        description=(
+            "Workspace-qualified Model Entity ref used for context summarization. Required for "
+            "the same reason as default_model."
+        ),
+    )
+    ethos: NonBlankString | None = Field(
+        default=None,
+        description=(
+            "Optional Ethos Markdown for the agent under test. Sent inline rather than as a "
+            "reference: the execute job's Fabric adapter has no Files access."
+        ),
+    )
+    since: datetime | None = Field(
+        default=None,
+        description="Optional lower bound enforced on the Analyst's trace/span reads.",
+    )
+    evaluation_id: NonBlankString | None = Field(
+        default=None,
+        description="Optional run scope AND-pinned onto every span read.",
+    )
+    timeout_seconds: float | None = Field(default=None, gt=0, description="Optional execute job timeout.")
+
+
+class AnalysisRunResponse(BaseModel):
+    """An analysis run plus the live state of the job backing it."""
+
+    run: AnalysisRun
+    job: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "The backing execute-agent job, or null when no job exists under the run's name — "
+            "meaning submission never landed and the run can be resubmitted."
+        ),
+    )
+
+    @property
+    def job_status(self) -> str | None:
+        """Status of the backing job, or None when no job exists under the run's name."""
+        if self.job is None:
+            return None
+        status = self.job.get("status")
+        return str(status) if status else None
+
+    @property
+    def job_is_terminal(self) -> bool:
+        """Whether the backing job has finished, successfully or not.
+
+        A run with no job is *not* terminal: it never landed and can be
+        resubmitted, which is a different outcome from a job that ran and
+        failed.
+        """
+        status = self.job_status
+        return status in {terminal.value for terminal in PlatformJobStatus.terminals()}
+
+
 class UpdateAnalysisRunStatusRequest(BaseModel):
     """Body for ``PATCH /analysis-run-statuses/{agent}``."""
 
@@ -91,4 +169,5 @@ class UpdateAnalysisRunStatusRequest(BaseModel):
 
 
 AnalysisConfigPage = NemoListResponse[AnalysisConfig]
+AnalysisRunPage = NemoListResponse[AnalysisRun]
 AnalysisRunStatusPage = NemoListResponse[AnalysisRunStatus]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/schema.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/schema.py
@@ -94,17 +94,18 @@ class CreateAnalysisRunRequest(BaseModel):
     """Client-facing request to run the Insights Analyst through ``agents.execute``."""
 
     agent: NonBlankString = Field(description="Agent whose telemetry should be analyzed.")
-    default_model: str = Field(
+    default_model: NonBlankString = Field(
         description=(
-            "Workspace-qualified Model Entity ref ('<workspace>/<name>') the Analyst uses for "
-            "analysis work. Required: the model pair is the operator's choice and is not "
+            "Model Entity the Analyst uses for analysis work, as a name or a "
+            "'<workspace>/<name>' ref; a bare name resolves in the run's workspace and is "
+            "stored qualified. Required: the model pair is the operator's choice and is not "
             "persisted anywhere the Platform process can read it."
         ),
     )
-    fast_model: str = Field(
+    fast_model: NonBlankString = Field(
         description=(
-            "Workspace-qualified Model Entity ref used for context summarization. Required for "
-            "the same reason as default_model."
+            "Model Entity used for context summarization, in the same form as default_model. "
+            "Required for the same reason."
         ),
     )
     ethos: NonBlankString | None = Field(

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk.py
@@ -9,6 +9,9 @@ the ``nemo.sdk`` entry-point in :file:`pyproject.toml`. Exposes:
 - ``client.insights.analysis_configs.{enable,disable,list_configs,get,update}``
   — :class:`~nemo_insights_plugin.entities.AnalysisConfig` CRUD/control for
   periodic analysis opt-in state.
+- ``client.insights.analysis_runs.{create,list_runs,get,wait}`` —
+  :class:`~nemo_insights_plugin.entities.AnalysisRun` submission and read-back
+  for on-demand Analyst runs, each backed by an ``agents.execute`` job.
 - ``client.insights.analysis_run_statuses.{list_statuses,get,update}``
   — :class:`~nemo_insights_plugin.entities.AnalysisRunStatus` state written by
   analyzer jobs.
@@ -26,6 +29,10 @@ from nemo_insights_plugin.sdk_resources.analysis_configs import (
     _AsyncAnalysisConfigResource,
     _AsyncAnalysisRunStatusResource,
 )
+from nemo_insights_plugin.sdk_resources.analysis_runs import (
+    _AnalysisRunResource,
+    _AsyncAnalysisRunResource,
+)
 from nemo_insights_plugin.sdk_resources.insights import (
     _AsyncInsightResource,
     _InsightResource,
@@ -42,6 +49,7 @@ class InsightsPluginResource:
         self._http_client = platform._client
         self._insights: _InsightResource | None = None
         self._analysis_configs: _AnalysisConfigResource | None = None
+        self._analysis_runs: _AnalysisRunResource | None = None
         self._analysis_run_statuses: _AnalysisRunStatusResource | None = None
 
     @property
@@ -55,6 +63,12 @@ class InsightsPluginResource:
         if self._analysis_configs is None:
             self._analysis_configs = _AnalysisConfigResource(self)
         return self._analysis_configs
+
+    @property
+    def analysis_runs(self) -> _AnalysisRunResource:
+        if self._analysis_runs is None:
+            self._analysis_runs = _AnalysisRunResource(self)
+        return self._analysis_runs
 
     @property
     def analysis_run_statuses(self) -> _AnalysisRunStatusResource:
@@ -74,6 +88,7 @@ class AsyncInsightsPluginResource:
         self._http_client = platform._client
         self._insights: _AsyncInsightResource | None = None
         self._analysis_configs: _AsyncAnalysisConfigResource | None = None
+        self._analysis_runs: _AsyncAnalysisRunResource | None = None
         self._analysis_run_statuses: _AsyncAnalysisRunStatusResource | None = None
 
     @property
@@ -87,6 +102,12 @@ class AsyncInsightsPluginResource:
         if self._analysis_configs is None:
             self._analysis_configs = _AsyncAnalysisConfigResource(self)
         return self._analysis_configs
+
+    @property
+    def analysis_runs(self) -> _AsyncAnalysisRunResource:
+        if self._analysis_runs is None:
+            self._analysis_runs = _AsyncAnalysisRunResource(self)
+        return self._analysis_runs
 
     @property
     def analysis_run_statuses(self) -> _AsyncAnalysisRunStatusResource:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_runs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_runs.py
@@ -1,0 +1,307 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK sub-resources for on-demand Insights analysis runs.
+
+Mounted as ``client.insights.analysis_runs``. Each method maps 1:1 onto the
+FastAPI routes in :mod:`nemo_insights_plugin.analysis_runs`, plus one
+convenience verb — :meth:`_AnalysisRunResource.wait` — that polls ``get``
+until the backing job reaches a terminal state. Waiting belongs here rather
+than in each caller because the run/job link is derived from the shared name:
+a caller polling on its own would have to know that rule.
+"""
+
+import asyncio
+import time
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any, Protocol
+
+from nemo_insights_plugin.entities import AnalysisRun
+from nemo_insights_plugin.schema import (
+    AnalysisRunPage,
+    AnalysisRunResponse,
+    CreateAnalysisRunRequest,
+)
+from nemo_insights_plugin.sdk_resources._entity import entity_from_response, hydrate_page
+
+DEFAULT_WAIT_TIMEOUT = 900.0
+DEFAULT_POLL_INTERVAL = 5.0
+
+
+class AnalysisRunNotSubmittedError(RuntimeError):
+    """No job exists under the run's name, so waiting on it would never end.
+
+    Insights names a run before submitting its job and the job takes that same
+    name, so a missing job is proof the submission never landed — a resubmit
+    case, not a slow one.
+    """
+
+
+class AnalysisRunTimeoutError(TimeoutError):
+    """The backing job did not reach a terminal state within the wait budget."""
+
+
+class _ResourceParent(Protocol):
+    """The slice of the insights SDK namespace this sub-resource needs."""
+
+    _http_client: Any
+
+    def _url(self, path: str) -> str: ...
+
+
+def _build_create_body(
+    *,
+    agent: str,
+    default_model: str,
+    fast_model: str,
+    ethos: str | None,
+    since: datetime | None,
+    evaluation_id: str | None,
+    timeout_seconds: float | None,
+) -> dict[str, Any]:
+    body = CreateAnalysisRunRequest(
+        agent=agent,
+        default_model=default_model,
+        fast_model=fast_model,
+        ethos=ethos,
+        since=since,
+        evaluation_id=evaluation_id,
+        timeout_seconds=timeout_seconds,
+    )
+    return body.model_dump(mode="json", exclude_none=True)
+
+
+def _list_params(
+    *,
+    page: int,
+    page_size: int,
+    sort: str,
+    agent: str | None,
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"page": page, "page_size": page_size, "sort": sort}
+    if agent is not None:
+        params["agent"] = agent
+    return params
+
+
+def _run_response_from_response(data: dict[str, Any]) -> AnalysisRunResponse:
+    """Parse a run-plus-job body, preserving the run's store-assigned metadata."""
+    response = AnalysisRunResponse.model_validate(data)
+    raw_run = data.get("run")
+    if isinstance(raw_run, dict):
+        response.run = entity_from_response(AnalysisRun, raw_run)
+    return response
+
+
+def _page_from_response(data: dict[str, Any]) -> AnalysisRunPage:
+    page = AnalysisRunPage.model_validate(data)
+    hydrate_page(page.data, data.get("data"))
+    return page
+
+
+def _wait_deadline(timeout: float) -> float:
+    return time.monotonic() + timeout
+
+
+def _timed_out(deadline: float) -> bool:
+    return time.monotonic() >= deadline
+
+
+def _check_waitable(response: AnalysisRunResponse) -> None:
+    if response.job is None:
+        raise AnalysisRunNotSubmittedError(
+            f"Analysis run '{response.run.name}' has no backing job — its submission never "
+            "landed, so it will never reach a terminal state. Resubmit it."
+        )
+
+
+def _wait_timeout_error(response: AnalysisRunResponse, timeout: float) -> AnalysisRunTimeoutError:
+    return AnalysisRunTimeoutError(
+        f"Analysis run '{response.run.name}' did not finish within {timeout}s "
+        f"(last job status: {response.job_status!r})."
+    )
+
+
+class _AnalysisRunResource:
+    """Sync ``analysis_runs`` sub-resource."""
+
+    def __init__(self, parent: _ResourceParent) -> None:
+        self._parent = parent
+
+    def create(
+        self,
+        *,
+        workspace: str,
+        agent: str,
+        default_model: str,
+        fast_model: str,
+        ethos: str | None = None,
+        since: datetime | None = None,
+        evaluation_id: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> AnalysisRunResponse:
+        """Submit an analysis run. The model pair is required — see the route."""
+        response = self._parent._http_client.post(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs"),
+            json=_build_create_body(
+                agent=agent,
+                default_model=default_model,
+                fast_model=fast_model,
+                ethos=ethos,
+                since=since,
+                evaluation_id=evaluation_id,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+        response.raise_for_status()
+        return _run_response_from_response(response.json())
+
+    def list_runs(
+        self,
+        *,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str = "-created_at",
+        agent: str | None = None,
+    ) -> AnalysisRunPage:
+        """List analysis runs. Job state is not joined — read one run to get it."""
+        response = self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs"),
+            params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
+        )
+        response.raise_for_status()
+        return _page_from_response(response.json())
+
+    def get(self, *, workspace: str, name: str) -> AnalysisRunResponse:
+        """Get one analysis run joined with the live state of its backing job."""
+        response = self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs/{name}"),
+        )
+        response.raise_for_status()
+        return _run_response_from_response(response.json())
+
+    def wait(
+        self,
+        *,
+        workspace: str,
+        name: str,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+        on_status: Callable[[str | None], None] | None = None,
+    ) -> AnalysisRunResponse:
+        """Poll a run until its job finishes, then return the final state.
+
+        Raises :class:`AnalysisRunNotSubmittedError` if the run has no job and
+        :class:`AnalysisRunTimeoutError` if *timeout* elapses first.
+        """
+        deadline = _wait_deadline(timeout)
+        last_status: str | None = ""
+        while True:
+            response = self.get(workspace=workspace, name=name)
+            _check_waitable(response)
+            if on_status is not None and response.job_status != last_status:
+                on_status(response.job_status)
+            last_status = response.job_status
+            if response.job_is_terminal:
+                return response
+            if _timed_out(deadline):
+                raise _wait_timeout_error(response, timeout)
+            time.sleep(poll_interval)
+
+
+class _AsyncAnalysisRunResource:
+    """Async ``analysis_runs`` sub-resource — mirrors :class:`_AnalysisRunResource`."""
+
+    def __init__(self, parent: _ResourceParent) -> None:
+        self._parent = parent
+
+    async def create(
+        self,
+        *,
+        workspace: str,
+        agent: str,
+        default_model: str,
+        fast_model: str,
+        ethos: str | None = None,
+        since: datetime | None = None,
+        evaluation_id: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> AnalysisRunResponse:
+        """Submit an analysis run. The model pair is required — see the route."""
+        response = await self._parent._http_client.post(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs"),
+            json=_build_create_body(
+                agent=agent,
+                default_model=default_model,
+                fast_model=fast_model,
+                ethos=ethos,
+                since=since,
+                evaluation_id=evaluation_id,
+                timeout_seconds=timeout_seconds,
+            ),
+        )
+        response.raise_for_status()
+        return _run_response_from_response(response.json())
+
+    async def list_runs(
+        self,
+        *,
+        workspace: str,
+        page: int = 1,
+        page_size: int = 20,
+        sort: str = "-created_at",
+        agent: str | None = None,
+    ) -> AnalysisRunPage:
+        """List analysis runs. Job state is not joined — read one run to get it."""
+        response = await self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs"),
+            params=_list_params(page=page, page_size=page_size, sort=sort, agent=agent),
+        )
+        response.raise_for_status()
+        return _page_from_response(response.json())
+
+    async def get(self, *, workspace: str, name: str) -> AnalysisRunResponse:
+        """Get one analysis run joined with the live state of its backing job."""
+        response = await self._parent._http_client.get(
+            self._parent._url(f"/v2/workspaces/{workspace}/analysis-runs/{name}"),
+        )
+        response.raise_for_status()
+        return _run_response_from_response(response.json())
+
+    async def wait(
+        self,
+        *,
+        workspace: str,
+        name: str,
+        timeout: float = DEFAULT_WAIT_TIMEOUT,
+        poll_interval: float = DEFAULT_POLL_INTERVAL,
+        on_status: Callable[[str | None], None] | None = None,
+    ) -> AnalysisRunResponse:
+        """Poll a run until its job finishes, then return the final state.
+
+        Raises :class:`AnalysisRunNotSubmittedError` if the run has no job and
+        :class:`AnalysisRunTimeoutError` if *timeout* elapses first.
+        """
+        deadline = _wait_deadline(timeout)
+        last_status: str | None = ""
+        while True:
+            response = await self.get(workspace=workspace, name=name)
+            _check_waitable(response)
+            if on_status is not None and response.job_status != last_status:
+                on_status(response.job_status)
+            last_status = response.job_status
+            if response.job_is_terminal:
+                return response
+            if _timed_out(deadline):
+                raise _wait_timeout_error(response, timeout)
+            await asyncio.sleep(poll_interval)
+
+
+__all__ = [
+    "AnalysisRunNotSubmittedError",
+    "AnalysisRunTimeoutError",
+    "_AnalysisRunResource",
+    "_AsyncAnalysisRunResource",
+]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/service.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/service.py
@@ -69,7 +69,7 @@ class InsightsService(NemoService):
     """
 
     name: ClassVar[str] = "insights"
-    dependencies: ClassVar[list[str]] = ["entities", "jobs", "intake"]
+    dependencies: ClassVar[list[str]] = ["entities", "jobs", "intake", "models"]
 
     def get_routers(self) -> list[RouterSpec]:
         config = get_nemo_config(InsightsConfig)

--- a/plugins/nemo-insights/tests/integration/test_analysis_runs_integration.py
+++ b/plugins/nemo-insights/tests/integration/test_analysis_runs_integration.py
@@ -31,6 +31,7 @@ from nemo_insights_plugin.service import InsightsService
 from nmp.core.entities.service import EntitiesService
 from nmp.core.files.service import FilesService
 from nmp.core.jobs.service import JobsService
+from nmp.core.models.service import ModelsService
 from nmp.platform_runner.plugin_adapter import NemoServiceAdapter
 from nmp.testing import ClientContext, create_test_client, subprocess_job_executor_patch
 from pydantic import ValidationError
@@ -55,8 +56,8 @@ class _TestAgentsService(NemoServiceAdapter):
 
 
 @contextmanager
-def _platform() -> Iterator[ClientContext]:
-    """Insights in front of the Agents and Jobs services it actually calls."""
+def _platform(*, workspaces: list[str] | None = None, workspace: str = WORKSPACE) -> Iterator[ClientContext]:
+    """Insights in front of the Agents, Jobs and Models services it actually calls."""
     with (
         subprocess_job_executor_patch(),
         create_test_client(
@@ -65,10 +66,17 @@ def _platform() -> Iterator[ClientContext]:
             EntitiesService,
             JobsService,
             FilesService,
+            ModelsService,
             client_type=ClientContext,
-            workspace=WORKSPACE,
+            workspaces=workspaces or [workspace],
+            workspace=workspace,
         ) as ctx,
     ):
+        # The create path resolves the model pair before recording a run, so
+        # the referenced entities have to exist.
+        if workspace == WORKSPACE:
+            for ref in (DEFAULT_MODEL, FAST_MODEL):
+                ctx.sdk.models.create(workspace=WORKSPACE, name=ref.split("/", 1)[1], backend_format="OPENAI_CHAT")
         yield ctx
 
 
@@ -77,8 +85,8 @@ def _create(ctx: ClientContext, **overrides: Any) -> Any:
     return ctx.sdk.insights.analysis_runs.create(
         workspace=WORKSPACE,
         agent=overrides.pop("agent", "demo-agent"),
-        default_model=DEFAULT_MODEL,
-        fast_model=FAST_MODEL,
+        default_model=overrides.pop("default_model", DEFAULT_MODEL),
+        fast_model=overrides.pop("fast_model", FAST_MODEL),
         **overrides,
     )
 
@@ -128,6 +136,55 @@ def test_the_sdk_serializes_a_since_bound_the_route_accepts() -> None:
         assert spec["agent"]["config"]["harnesses"]["insights"]["settings"]["since"] == "2026-08-01T00:00:00+00:00"
         # The step config preserves the original request alongside the resolved agent.
         assert spec["request"]["timeout_seconds"] == 30.0
+
+
+def test_a_bare_model_name_resolves_in_the_run_workspace_and_is_stored_qualified() -> None:
+    """The Analyst only accepts qualified refs, so normalization has to happen before storage."""
+    with _platform() as ctx:
+        created = _create(ctx, default_model="analyst-default", fast_model="analyst-fast")
+
+        assert created.run.default_model == DEFAULT_MODEL
+        assert created.run.fast_model == FAST_MODEL
+        models = _backing_job(ctx, created.run.name)["spec"]["agent"]["config"]["models"]
+        assert models["default"]["model"] == DEFAULT_MODEL
+        assert models["fast"]["model"] == FAST_MODEL
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "does-not-exist",
+        f"{WORKSPACE}/does-not-exist",
+        "too/many/slashes",
+    ],
+)
+def test_a_model_ref_that_does_not_resolve_is_rejected_before_anything_is_recorded(ref: str) -> None:
+    """A bogus ref used to 201, persisting a run behind a job that could never start."""
+    with _platform() as ctx:
+        with pytest.raises(httpx.HTTPStatusError) as excinfo:
+            _create(ctx, default_model=ref)
+
+        assert excinfo.value.response.status_code == 422, excinfo.value.response.text
+        assert ctx.sdk.insights.analysis_runs.list_runs(workspace=WORKSPACE).data == []
+
+
+def test_a_qualified_ref_may_name_a_model_in_another_workspace() -> None:
+    """A run is not confined to its own workspace's models, only to what the caller can read."""
+    with _platform(workspaces=["workspace-a", "workspace-b"], workspace="workspace-a") as ctx:
+        for name in ("foo", "bar"):
+            ctx.sdk.models.create(workspace="workspace-b", name=name, backend_format="OPENAI_CHAT")
+
+        created = ctx.sdk.insights.analysis_runs.create(
+            workspace="workspace-a",
+            agent="borrowing-agent",
+            default_model="workspace-b/foo",
+            fast_model="workspace-b/bar",
+        )
+
+        assert created.run.workspace == "workspace-a"
+        assert created.run.default_model == "workspace-b/foo"
+        job = ctx.sdk.agents.jobs.execute.get(created.run.name, workspace="workspace-a")
+        assert job["spec"]["agent"]["config"]["models"]["default"]["model"] == "workspace-b/foo"
 
 
 # ---------------------------------------------------------------------------
@@ -195,7 +252,7 @@ def test_getting_an_unknown_run_is_a_404() -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("field", ["agent", "evaluation_id", "ethos"])
+@pytest.mark.parametrize("field", ["agent", "evaluation_id", "ethos", "default_model", "fast_model"])
 def test_the_sdk_rejects_a_blank_setting_without_a_round_trip(field: str) -> None:
     """``_build_create_body`` builds the request model, so the SDK fails before sending."""
     with _platform() as ctx:
@@ -203,7 +260,7 @@ def test_the_sdk_rejects_a_blank_setting_without_a_round_trip(field: str) -> Non
             _create(ctx, **{field: "   "})
 
 
-@pytest.mark.parametrize("field", ["agent", "evaluation_id", "ethos"])
+@pytest.mark.parametrize("field", ["agent", "evaluation_id", "ethos", "default_model", "fast_model"])
 def test_the_route_rejects_a_blank_setting_on_the_wire(field: str) -> None:
     """A caller that is not the SDK still gets a 422 rather than a run that fails later."""
     with _platform() as ctx:

--- a/plugins/nemo-insights/tests/integration/test_analysis_runs_integration.py
+++ b/plugins/nemo-insights/tests/integration/test_analysis_runs_integration.py
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Analysis runs through the SDK against real Insights, Agents and Jobs services.
+
+The unit tests stub every seam in this path: the route tests stub the entity
+client and the execute-agent SDK, the SDK tests stub the HTTP client, and the
+CLI tests stub the SDK. So nothing shows that the SDK's request shape actually
+satisfies the route, that its response parsing handles real bodies, or that
+submitting a run produces a real ``agents.execute`` job the read path can join.
+
+These drive the SDK — the interface a user actually holds — against the real
+services in-process. The job *body* is deliberately not run: Fabric executes the
+Analyst in a subprocess against a live platform, and standing that up here would
+mean faking the transport, model reconciliation and SDK wiring that the e2e
+suite exists to prove. Inference belongs to e2e; this tier covers the platform
+plumbing around it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import pytest
+from nemo_agents_plugin.service import AgentsService
+from nemo_insights_plugin.service import InsightsService
+from nmp.core.entities.service import EntitiesService
+from nmp.core.files.service import FilesService
+from nmp.core.jobs.service import JobsService
+from nmp.platform_runner.plugin_adapter import NemoServiceAdapter
+from nmp.testing import ClientContext, create_test_client, subprocess_job_executor_patch
+from pydantic import ValidationError
+
+pytestmark = pytest.mark.integration
+
+WORKSPACE = "default"
+ANALYSIS_RUNS_URL = f"/apis/insights/v2/workspaces/{WORKSPACE}/analysis-runs"
+DEFAULT_MODEL = f"{WORKSPACE}/analyst-default"
+FAST_MODEL = f"{WORKSPACE}/analyst-fast"
+ETHOS = "# Ethos\n\nAnswer only from retrieved context."
+
+
+class _TestInsightsService(NemoServiceAdapter):
+    def __init__(self) -> None:
+        super().__init__(InsightsService())
+
+
+class _TestAgentsService(NemoServiceAdapter):
+    def __init__(self) -> None:
+        super().__init__(AgentsService())
+
+
+@contextmanager
+def _platform() -> Iterator[ClientContext]:
+    """Insights in front of the Agents and Jobs services it actually calls."""
+    with (
+        subprocess_job_executor_patch(),
+        create_test_client(
+            _TestInsightsService,
+            _TestAgentsService,
+            EntitiesService,
+            JobsService,
+            FilesService,
+            client_type=ClientContext,
+            workspace=WORKSPACE,
+        ) as ctx,
+    ):
+        yield ctx
+
+
+def _create(ctx: ClientContext, **overrides: Any) -> Any:
+    """Submit a run the way a user does, which submits a real job."""
+    return ctx.sdk.insights.analysis_runs.create(
+        workspace=WORKSPACE,
+        agent=overrides.pop("agent", "demo-agent"),
+        default_model=DEFAULT_MODEL,
+        fast_model=FAST_MODEL,
+        **overrides,
+    )
+
+
+def _backing_job(ctx: ClientContext, run_name: str) -> dict[str, Any]:
+    return ctx.sdk.agents.jobs.execute.get(run_name, workspace=WORKSPACE)
+
+
+# ---------------------------------------------------------------------------
+# Create: the run is recorded and a job is submitted under its name
+# ---------------------------------------------------------------------------
+
+
+def test_creating_a_run_submits_a_job_under_its_name() -> None:
+    """The shared name is the only link between run and job, so prove it holds."""
+    with _platform() as ctx:
+        created = _create(ctx)
+
+        assert created.job is not None
+        assert created.job["name"] == created.run.name
+        # The job is real: the Jobs service answers for it independently.
+        assert _backing_job(ctx, created.run.name)["name"] == created.run.name
+
+
+def test_the_submitted_job_carries_the_analyst_config_the_facade_built() -> None:
+    """The request's scope has to survive into the job spec, or the run analyzes the wrong thing."""
+    with _platform() as ctx:
+        created = _create(ctx, agent="scoped-agent", ethos=ETHOS, evaluation_id="eval-123")
+
+        spec = _backing_job(ctx, created.run.name)["spec"]
+
+        assert spec["extension"]["kind"] == "insights.analysis"
+        assert spec["extension"]["config"]["agent"] == "scoped-agent"
+        settings = spec["agent"]["config"]["harnesses"]["insights"]["settings"]
+        assert settings["agent"] == "scoped-agent"
+        assert settings["ethos"] == ETHOS
+        assert settings["evaluation_id"] == "eval-123"
+
+
+def test_the_sdk_serializes_a_since_bound_the_route_accepts() -> None:
+    """``since`` crosses the wire as JSON, so the SDK's encoding has to survive the round trip."""
+    with _platform() as ctx:
+        created = _create(ctx, since=datetime(2026, 8, 1, tzinfo=timezone.utc), timeout_seconds=30.0)
+
+        assert created.run.since == datetime(2026, 8, 1, tzinfo=timezone.utc)
+        spec = _backing_job(ctx, created.run.name)["spec"]
+        assert spec["agent"]["config"]["harnesses"]["insights"]["settings"]["since"] == "2026-08-01T00:00:00+00:00"
+        # The step config preserves the original request alongside the resolved agent.
+        assert spec["request"]["timeout_seconds"] == 30.0
+
+
+# ---------------------------------------------------------------------------
+# Read: join the run with its job, and list from the store
+# ---------------------------------------------------------------------------
+
+
+def test_reading_a_run_joins_it_with_its_backing_job() -> None:
+    with _platform() as ctx:
+        created = _create(ctx, agent="joined-agent")
+
+        read = ctx.sdk.insights.analysis_runs.get(workspace=WORKSPACE, name=created.run.name)
+
+        assert read.run.agent == "joined-agent"
+        assert read.job is not None, "a submitted run must read back with its job"
+        assert read.job_status is not None
+
+
+def test_runs_are_listed_from_the_store_and_filtered_by_agent() -> None:
+    with _platform() as ctx:
+        alpha = {_create(ctx, agent="alpha").run.name for _ in range(2)}
+        beta = _create(ctx, agent="beta").run.name
+
+        filtered = ctx.sdk.insights.analysis_runs.list_runs(workspace=WORKSPACE, agent="alpha")
+        unfiltered = ctx.sdk.insights.analysis_runs.list_runs(workspace=WORKSPACE)
+
+        assert {run.name for run in filtered.data} == alpha
+        assert beta in {run.name for run in unfiltered.data}
+
+
+def test_the_sort_the_sdk_sends_is_accepted_and_echoed() -> None:
+    """The route's sort field is only reachable through the SDK's kwarg."""
+    with _platform() as ctx:
+        _create(ctx, agent="sorted-agent")
+
+        page = ctx.sdk.insights.analysis_runs.list_runs(workspace=WORKSPACE, agent="sorted-agent", sort="created_at")
+
+        assert page.sort == "created_at"
+
+
+def test_pagination_reaches_the_store_and_is_reported_back() -> None:
+    with _platform() as ctx:
+        for _ in range(3):
+            _create(ctx, agent="paged-agent")
+
+        page = ctx.sdk.insights.analysis_runs.list_runs(workspace=WORKSPACE, agent="paged-agent", page=1, page_size=2)
+
+        assert len(page.data) == 2
+        assert page.pagination is not None
+        assert page.pagination.page_size == 2
+        assert page.pagination.total_results == 3
+
+
+def test_getting_an_unknown_run_is_a_404() -> None:
+    """Needs no job, Fabric or model, so it belongs here rather than in e2e."""
+    with _platform() as ctx:
+        with pytest.raises(httpx.HTTPStatusError) as excinfo:
+            ctx.sdk.insights.analysis_runs.get(workspace=WORKSPACE, name="insights-run-does-not-exist")
+
+        assert excinfo.value.response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Validation: the SDK and the wire reject blanks at different points
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("field", ["agent", "evaluation_id", "ethos"])
+def test_the_sdk_rejects_a_blank_setting_without_a_round_trip(field: str) -> None:
+    """``_build_create_body`` builds the request model, so the SDK fails before sending."""
+    with _platform() as ctx:
+        with pytest.raises(ValidationError):
+            _create(ctx, **{field: "   "})
+
+
+@pytest.mark.parametrize("field", ["agent", "evaluation_id", "ethos"])
+def test_the_route_rejects_a_blank_setting_on_the_wire(field: str) -> None:
+    """A caller that is not the SDK still gets a 422 rather than a run that fails later."""
+    with _platform() as ctx:
+        response = ctx.test_client.post(
+            ANALYSIS_RUNS_URL,
+            json={
+                "agent": "demo-agent",
+                "default_model": DEFAULT_MODEL,
+                "fast_model": FAST_MODEL,
+                field: "   ",
+            },
+        )
+
+        assert response.status_code == 422, response.text

--- a/plugins/nemo-insights/tests/test_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_analysis_runs.py
@@ -344,7 +344,7 @@ async def test_a_failed_submission_leaves_the_run_record_in_place() -> None:
         await create_analysis_run("default", _request(), _sdk(jobs), _entities(entities))
 
     assert excinfo.value.status_code == 422
-    assert excinfo.value.detail == "bad model ref"
+    assert excinfo.value.detail == {"error": "bad model ref", "run": entities.created[0].name}
     assert len(entities.created) == 1
 
 
@@ -376,7 +376,7 @@ async def test_a_failed_submission_falls_back_to_the_raw_error_body() -> None:
         await create_analysis_run("default", _request(), _sdk(jobs), _entities(entities))
 
     assert excinfo.value.status_code == 500
-    assert excinfo.value.detail == {"message": "upstream exploded"}
+    assert excinfo.value.detail == {"error": {"message": "upstream exploded"}, "run": entities.created[0].name}
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-insights/tests/test_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_analysis_runs.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import inspect
 from datetime import datetime, timezone
 from typing import Any, cast
 
@@ -19,10 +20,13 @@ from nemo_insights_plugin.analysis_runs import (
     build_execute_agent_job_config,
     create_analysis_run,
     get_analysis_run,
+    list_analysis_runs,
     mint_analysis_run_name,
 )
 from nemo_insights_plugin.entities import AnalysisRun
+from nemo_insights_plugin.schema import AnalysisRunPage
 from nemo_platform import APIStatusError, AsyncNeMoPlatform
+from nemo_platform_plugin.entities.base import ListResponse, PaginationInfo
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
 from nemo_platform_plugin.entity_naming import NAME_MAX_LENGTH, NAME_PATTERN
 from pydantic import ValidationError
@@ -30,6 +34,7 @@ from pydantic import ValidationError
 DEFAULT_MODEL = "default/big"
 FAST_MODEL = "default/small"
 RUN_NAME = "insights-run-0123456789abcdef0123456789abcdef"
+DECLARED_SORT_DEFAULT = "-created_at"
 
 
 def _request(**overrides: Any) -> CreateAnalysisRunRequest:
@@ -80,6 +85,7 @@ class _StubEntities:
 
     def __init__(self, existing: AnalysisRun | None = None, create_error: Exception | None = None) -> None:
         self.created: list[AnalysisRun] = []
+        self.list_queries: list[dict[str, Any]] = []
         self._existing = existing
         self._create_error = create_error
 
@@ -94,6 +100,19 @@ class _StubEntities:
             raise NemoEntityNotFoundError(f"{workspace}/{name}")
         return self._existing
 
+    async def list(self, _type: type, **query: Any) -> ListResponse[AnalysisRun]:
+        self.list_queries.append(query)
+        return ListResponse(
+            data=[self._existing] if self._existing is not None else [],
+            pagination=PaginationInfo(
+                page=query["page"],
+                page_size=query["page_size"],
+                current_page_size=1 if self._existing is not None else 0,
+                total_pages=1,
+                total_results=1 if self._existing is not None else 0,
+            ),
+        )
+
 
 def _sdk(jobs: _StubExecuteJobs) -> AsyncNeMoPlatform:
     """The route only touches ``sdk.agents.jobs.execute``; cast past the concrete type."""
@@ -102,6 +121,15 @@ def _sdk(jobs: _StubExecuteJobs) -> AsyncNeMoPlatform:
 
 def _entities(stub: _StubEntities) -> NemoEntitiesClient:
     return cast(NemoEntitiesClient, stub)
+
+
+def _raise(error: Exception) -> Any:
+    """Replace a stub method with one that fails, for the error-path tests."""
+
+    async def _fail(*_args: Any, **_kwargs: Any) -> Any:
+        raise error
+
+    return _fail
 
 
 def _api_status_error(status_code: int, body: Any) -> APIStatusError:
@@ -374,3 +402,68 @@ async def test_get_returns_404_for_an_unknown_run() -> None:
         await get_analysis_run("default", RUN_NAME, _sdk(_StubExecuteJobs()), _entities(entities))
 
     assert excinfo.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# List: filter, sort and pagination assembly
+# ---------------------------------------------------------------------------
+
+
+async def _list(entities: _StubEntities, **overrides: Any) -> AnalysisRunPage:
+    """Call the handler directly, supplying what FastAPI would otherwise resolve.
+
+    A direct call bypasses dependency resolution, so the ``Query`` defaults
+    arrive as ``Query`` objects rather than values; pass them explicitly.
+    """
+    return await list_analysis_runs(
+        overrides.pop("workspace", "default"),
+        page=overrides.pop("page", 1),
+        page_size=overrides.pop("page_size", 20),
+        sort=overrides.pop("sort", DECLARED_SORT_DEFAULT),
+        agent=overrides.pop("agent", None),
+        entity_client=_entities(entities),
+        **overrides,
+    )
+
+
+def test_the_route_declares_the_expected_sort_default() -> None:
+    """Direct handler calls cannot observe it, so pin the declaration itself."""
+    assert inspect.signature(list_analysis_runs).parameters["sort"].default.default == "-created_at"
+
+
+async def test_list_passes_the_page_and_sort_through_to_the_entity_query() -> None:
+    entities = _StubEntities(existing=_run())
+
+    page = await list_analysis_runs(
+        "team-a", page=2, page_size=5, sort="created_at", agent=None, entity_client=_entities(entities)
+    )
+
+    query = entities.list_queries[0]
+    assert (query["workspace"], query["page"], query["page_size"], query["sort"]) == ("team-a", 2, 5, "created_at")
+    assert page.sort == "created_at"
+    assert page.pagination is not None
+    assert (page.pagination.page, page.pagination.total_results) == (2, 1)
+
+
+async def test_list_builds_an_agent_filter_only_when_one_is_asked_for() -> None:
+    """An empty filter must go down as None, not as an empty dict the store would apply."""
+    with_agent = _StubEntities(existing=_run())
+    without_agent = _StubEntities(existing=_run())
+
+    filtered = await _list(with_agent, agent="demo-agent")
+    unfiltered = await _list(without_agent, agent=None)
+
+    assert with_agent.list_queries[0]["filter_obj"] == {"agent": "demo-agent"}
+    assert filtered.filter == {"agent": "demo-agent"}
+    assert without_agent.list_queries[0]["filter_obj"] is None
+    assert unfiltered.filter is None
+
+
+async def test_list_surfaces_a_store_failure_as_a_500() -> None:
+    entities = _StubEntities()
+    entities.list = _raise(RuntimeError("entity store down"))  # type: ignore[method-assign]
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _list(entities)
+
+    assert excinfo.value.status_code == 500

--- a/plugins/nemo-insights/tests/test_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_analysis_runs.py
@@ -14,15 +14,22 @@ from fastapi import HTTPException
 from nemo_agents_plugin.entities import AgentInline
 from nemo_agents_plugin.jobs.execute import ExecuteAgentJobConfig
 from nemo_insights_plugin.analysis_runs import (
+    ANALYSIS_RUN_NAME_PREFIX,
     CreateAnalysisRunRequest,
     build_execute_agent_job_config,
     create_analysis_run,
+    get_analysis_run,
+    mint_analysis_run_name,
 )
+from nemo_insights_plugin.entities import AnalysisRun
 from nemo_platform import APIStatusError, AsyncNeMoPlatform
+from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
+from nemo_platform_plugin.entity_naming import NAME_MAX_LENGTH, NAME_PATTERN
 from pydantic import ValidationError
 
 DEFAULT_MODEL = "default/big"
 FAST_MODEL = "default/small"
+RUN_NAME = "insights-run-0123456789abcdef0123456789abcdef"
 
 
 def _request(**overrides: Any) -> CreateAnalysisRunRequest:
@@ -36,15 +43,28 @@ def _request(**overrides: Any) -> CreateAnalysisRunRequest:
 
 
 class _StubExecuteJobs:
-    def __init__(self, response: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+    def __init__(
+        self,
+        response: dict[str, Any] | None = None,
+        error: Exception | None = None,
+        get_error: Exception | None = None,
+    ) -> None:
         self.calls: list[dict[str, Any]] = []
-        self._response = response or {"name": "execute-a1b2", "status": "created"}
+        self.gets: list[str] = []
+        self._response = response or {"name": RUN_NAME, "status": "created"}
         self._error = error
+        self._get_error = get_error
 
     async def create(self, *, spec: dict[str, Any], name: str | None = None, workspace: str) -> dict[str, Any]:
         self.calls.append({"spec": spec, "name": name, "workspace": workspace})
         if self._error is not None:
             raise self._error
+        return self._response
+
+    async def get(self, name: str, *, workspace: str) -> dict[str, Any]:
+        self.gets.append(name)
+        if self._get_error is not None:
+            raise self._get_error
         return self._response
 
 
@@ -55,9 +75,33 @@ class _StubSdk:
         self.agents = type("_Agents", (), {"jobs": type("_Jobs", (), {"execute": jobs})()})()
 
 
+class _StubEntities:
+    """Records entity writes so the ordering against job creation is observable."""
+
+    def __init__(self, existing: AnalysisRun | None = None, create_error: Exception | None = None) -> None:
+        self.created: list[AnalysisRun] = []
+        self._existing = existing
+        self._create_error = create_error
+
+    async def create(self, entity: AnalysisRun) -> AnalysisRun:
+        if self._create_error is not None:
+            raise self._create_error
+        self.created.append(entity)
+        return entity
+
+    async def get(self, _type: type, *, name: str, workspace: str) -> AnalysisRun:
+        if self._existing is None:
+            raise NemoEntityNotFoundError(f"{workspace}/{name}")
+        return self._existing
+
+
 def _sdk(jobs: _StubExecuteJobs) -> AsyncNeMoPlatform:
     """The route only touches ``sdk.agents.jobs.execute``; cast past the concrete type."""
     return cast(AsyncNeMoPlatform, _StubSdk(jobs))
+
+
+def _entities(stub: _StubEntities) -> NemoEntitiesClient:
+    return cast(NemoEntitiesClient, stub)
 
 
 def _api_status_error(status_code: int, body: Any) -> APIStatusError:
@@ -66,34 +110,81 @@ def _api_status_error(status_code: int, body: Any) -> APIStatusError:
     return APIStatusError("boom", response=response, body=body)
 
 
+def _run(**overrides: Any) -> AnalysisRun:
+    return AnalysisRun(
+        name=overrides.pop("name", RUN_NAME),
+        workspace=overrides.pop("workspace", "default"),
+        agent=overrides.pop("agent", "demo-agent"),
+        **overrides,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Run naming — the link between a run and its job
+# ---------------------------------------------------------------------------
+
+
+def test_minted_run_name_is_a_valid_entity_name() -> None:
+    """The name doubles as the job name, so it must satisfy the platform pattern."""
+    import re
+
+    name = mint_analysis_run_name()
+
+    assert name.startswith(ANALYSIS_RUN_NAME_PREFIX)
+    assert len(name) <= NAME_MAX_LENGTH
+    assert re.match(NAME_PATTERN, name)
+
+
+def test_minted_run_names_are_unique() -> None:
+    """Uniqueness comes from the uuid, not the agent — an agent-derived name collided."""
+    assert len({mint_analysis_run_name() for _ in range(100)}) == 100
+
+
+# ---------------------------------------------------------------------------
+# Job spec construction
+# ---------------------------------------------------------------------------
+
+
 def test_execute_job_config_validates_against_the_real_job_schema() -> None:
-    spec = build_execute_agent_job_config(_request(agent="demo-agent"), workspace="team-a")
+    spec = build_execute_agent_job_config(_request(), workspace="team-a", run_name=RUN_NAME)
 
     config = ExecuteAgentJobConfig.model_validate(spec)
 
     assert config.extension is not None
     assert config.extension.kind == "insights.analysis"
-    assert config.extension.config == {"agent": "demo-agent", "workspace": "team-a"}
+
+
+def test_the_extension_is_scoped_to_the_agent_and_workspace() -> None:
+    """The extension needs no run identity: nothing it writes is stamped with one."""
+    spec = build_execute_agent_job_config(_request(), workspace="team-a", run_name=RUN_NAME)
+
+    config = ExecuteAgentJobConfig.model_validate(spec)
+
+    assert config.extension is not None
+    assert config.extension.config == {
+        "agent": "demo-agent",
+        "workspace": "team-a",
+    }
 
 
 def test_analyst_is_submitted_inline_with_the_requested_models() -> None:
     """There is no Analyst Agent entity; the request composes one per run."""
-    spec = build_execute_agent_job_config(_request(agent="demo-agent"), workspace="team-a")
+    spec = build_execute_agent_job_config(_request(), workspace="team-a", run_name=RUN_NAME)
 
     config = ExecuteAgentJobConfig.model_validate(spec)
 
     assert isinstance(config.agent, AgentInline)
-    assert config.agent.config["name"] == "insights-analyst"
-    assert config.agent.config["models"]["default"]["model"] == "default/big"
-    assert config.agent.config["models"]["fast"]["model"] == "default/small"
+    assert config.agent.config["models"]["default"]["model"] == DEFAULT_MODEL
+    assert config.agent.config["models"]["fast"]["model"] == FAST_MODEL
     assert config.agent.config["harnesses"]["insights"]["settings"]["agent"] == "demo-agent"
-    assert config.agent.config["harnesses"]["insights"]["settings"]["workspace"] == "team-a"
 
 
 def test_read_scope_reaches_the_inline_analyst_settings() -> None:
     request = _request(since=datetime(2026, 8, 1, tzinfo=timezone.utc), evaluation_id="eval-123")
 
-    config = ExecuteAgentJobConfig.model_validate(build_execute_agent_job_config(request, workspace="default"))
+    config = ExecuteAgentJobConfig.model_validate(
+        build_execute_agent_job_config(request, workspace="default", run_name=RUN_NAME)
+    )
 
     assert isinstance(config.agent, AgentInline)
     settings = config.agent.config["harnesses"]["insights"]["settings"]
@@ -105,14 +196,18 @@ def test_ethos_is_inlined_into_the_analyst_harness_settings() -> None:
     """Parity with AnalyzeSpec.ethos: the Fabric adapter has no Files access to resolve a ref."""
     request = _request(ethos="# Ethos\n\nBe careful.")
 
-    config = ExecuteAgentJobConfig.model_validate(build_execute_agent_job_config(request, workspace="default"))
+    config = ExecuteAgentJobConfig.model_validate(
+        build_execute_agent_job_config(request, workspace="default", run_name=RUN_NAME)
+    )
 
     assert isinstance(config.agent, AgentInline)
     assert config.agent.config["harnesses"]["insights"]["settings"]["ethos"] == "# Ethos\n\nBe careful."
 
 
 def test_ethos_is_omitted_when_unset() -> None:
-    config = ExecuteAgentJobConfig.model_validate(build_execute_agent_job_config(_request(), workspace="default"))
+    config = ExecuteAgentJobConfig.model_validate(
+        build_execute_agent_job_config(_request(), workspace="default", run_name=RUN_NAME)
+    )
 
     assert isinstance(config.agent, AgentInline)
     assert "ethos" not in config.agent.config["harnesses"]["insights"]["settings"]
@@ -131,7 +226,9 @@ def test_blank_settings_are_rejected(field: str, blank: str) -> None:
 def test_surrounding_whitespace_is_trimmed_before_it_reaches_the_inline_analyst() -> None:
     request = _request(agent="  demo-agent  ", evaluation_id="  eval-123\n", ethos="\n# Ethos\n")
 
-    config = ExecuteAgentJobConfig.model_validate(build_execute_agent_job_config(request, workspace="team-a"))
+    config = ExecuteAgentJobConfig.model_validate(
+        build_execute_agent_job_config(request, workspace="team-a", run_name=RUN_NAME)
+    )
 
     assert isinstance(config.agent, AgentInline)
     settings = config.agent.config["harnesses"]["insights"]["settings"]
@@ -142,70 +239,138 @@ def test_surrounding_whitespace_is_trimmed_before_it_reaches_the_inline_analyst(
     assert config.extension.config["agent"] == "demo-agent"
 
 
+def test_execute_job_config_omits_timeout_when_unset() -> None:
+    spec = build_execute_agent_job_config(_request(), workspace="default", run_name=RUN_NAME)
+
+    assert "timeout_seconds" not in spec
+
+
+def test_execute_job_config_carries_timeout_when_set() -> None:
+    spec = build_execute_agent_job_config(_request(timeout_seconds=120.0), workspace="default", run_name=RUN_NAME)
+
+    assert ExecuteAgentJobConfig.model_validate(spec).timeout_seconds == 120.0
+
+
 def test_model_refs_are_required() -> None:
     """The pair lives only in the operator's CLI config, so the request must carry it."""
     with pytest.raises(ValidationError):
         CreateAnalysisRunRequest.model_validate({"agent": "demo-agent"})
 
 
-def test_execute_job_config_omits_timeout_when_unset() -> None:
-    spec = build_execute_agent_job_config(_request(agent="demo-agent"), workspace="default")
-
-    assert "timeout_seconds" not in spec
-
-
-def test_execute_job_config_carries_timeout_when_set() -> None:
-    request = _request(timeout_seconds=120.0)
-
-    spec = build_execute_agent_job_config(request, workspace="default")
-
-    assert ExecuteAgentJobConfig.model_validate(spec).timeout_seconds == 120.0
+# ---------------------------------------------------------------------------
+# Create: record first, then submit under the same name
+# ---------------------------------------------------------------------------
 
 
-async def test_create_analysis_run_submits_through_the_agents_sdk() -> None:
+async def test_create_records_the_run_before_submitting_the_job() -> None:
     jobs = _StubExecuteJobs()
+    entities = _StubEntities()
 
-    response = await create_analysis_run("team-a", _request(agent="demo-agent"), _sdk(jobs))
+    response = await create_analysis_run("team-a", _request(), _sdk(jobs), _entities(entities))
 
-    assert response.job == {"name": "execute-a1b2", "status": "created"}
-    assert jobs.calls[0]["workspace"] == "team-a"
-    assert jobs.calls[0]["spec"]["agent"]["config"]["name"] == "insights-analyst"
+    assert len(entities.created) == 1
+    assert response.run.agent == "demo-agent"
+    assert response.run.workspace == "team-a"
+    assert response.job == {"name": RUN_NAME, "status": "created"}
 
 
-async def test_create_analysis_run_leaves_job_name_to_the_jobs_service() -> None:
-    """A fixed name would collide on the second run for the same agent."""
+async def test_the_job_takes_the_run_name_so_the_link_needs_no_write_back() -> None:
     jobs = _StubExecuteJobs()
+    entities = _StubEntities()
 
-    await create_analysis_run("default", _request(agent="demo-agent"), _sdk(jobs))
+    response = await create_analysis_run("default", _request(), _sdk(jobs), _entities(entities))
 
-    assert jobs.calls[0]["name"] is None
+    assert jobs.calls[0]["name"] == response.run.name
+    assert response.run.name.startswith(ANALYSIS_RUN_NAME_PREFIX)
 
 
-async def test_create_analysis_run_forwards_an_explicit_job_name() -> None:
+async def test_the_run_captures_the_request_scope() -> None:
+    entities = _StubEntities()
+    request = _request(since=datetime(2026, 8, 1, tzinfo=timezone.utc), evaluation_id="eval-123")
+
+    response = await create_analysis_run("default", request, _sdk(_StubExecuteJobs()), _entities(entities))
+
+    assert response.run.since == datetime(2026, 8, 1, tzinfo=timezone.utc)
+    assert response.run.evaluation_id == "eval-123"
+    assert response.run.default_model == DEFAULT_MODEL
+    assert response.run.fast_model == FAST_MODEL
+
+
+async def test_nothing_is_submitted_when_the_run_cannot_be_recorded() -> None:
     jobs = _StubExecuteJobs()
-    request = _request(name="nightly-demo-agent")
-
-    await create_analysis_run("default", request, _sdk(jobs))
-
-    assert jobs.calls[0]["name"] == "nightly-demo-agent"
-
-
-async def test_create_analysis_run_surfaces_the_agents_service_error() -> None:
-    error = _api_status_error(422, {"detail": "Agent 'insights-analyst' not found."})
-    jobs = _StubExecuteJobs(error=error)
+    entities = _StubEntities(create_error=RuntimeError("store down"))
 
     with pytest.raises(HTTPException) as excinfo:
-        await create_analysis_run("default", _request(agent="demo-agent"), _sdk(jobs))
+        await create_analysis_run("default", _request(), _sdk(jobs), _entities(entities))
+
+    assert excinfo.value.status_code == 500
+    assert jobs.calls == []
+
+
+async def test_a_failed_submission_leaves_the_run_record_in_place() -> None:
+    """Deleting it could orphan a job that a timed-out create actually landed."""
+    jobs = _StubExecuteJobs(error=_api_status_error(422, {"detail": "bad model ref"}))
+    entities = _StubEntities()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_analysis_run("default", _request(), _sdk(jobs), _entities(entities))
 
     assert excinfo.value.status_code == 422
-    assert excinfo.value.detail == "Agent 'insights-analyst' not found."
+    assert excinfo.value.detail == "bad model ref"
+    assert len(entities.created) == 1
 
 
-async def test_create_analysis_run_falls_back_to_the_raw_error_body() -> None:
+async def test_a_failed_submission_falls_back_to_the_raw_error_body() -> None:
+    """A body with no ``detail`` key is surfaced whole rather than dropped."""
     jobs = _StubExecuteJobs(error=_api_status_error(500, {"message": "upstream exploded"}))
+    entities = _StubEntities()
 
     with pytest.raises(HTTPException) as excinfo:
-        await create_analysis_run("default", _request(agent="demo-agent"), _sdk(jobs))
+        await create_analysis_run("default", _request(), _sdk(jobs), _entities(entities))
 
     assert excinfo.value.status_code == 500
     assert excinfo.value.detail == {"message": "upstream exploded"}
+
+
+# ---------------------------------------------------------------------------
+# Read: join the run with its job by derived name
+# ---------------------------------------------------------------------------
+
+
+async def test_get_joins_the_run_with_its_backing_job() -> None:
+    jobs = _StubExecuteJobs()
+    entities = _StubEntities(existing=_run())
+
+    response = await get_analysis_run("default", RUN_NAME, _sdk(jobs), _entities(entities))
+
+    assert jobs.gets == [RUN_NAME]
+    assert response.job is not None
+    assert response.run.name == RUN_NAME
+
+
+async def test_a_run_whose_job_is_missing_reads_as_never_submitted() -> None:
+    """This is the disambiguation: no job under the run's name means it never landed."""
+    jobs = _StubExecuteJobs(get_error=_api_status_error(404, {"detail": "not found"}))
+    entities = _StubEntities(existing=_run())
+
+    response = await get_analysis_run("default", RUN_NAME, _sdk(jobs), _entities(entities))
+
+    assert response.job is None
+    assert response.run.name == RUN_NAME
+
+
+async def test_a_non_404_job_lookup_failure_is_not_swallowed() -> None:
+    jobs = _StubExecuteJobs(get_error=_api_status_error(503, {"detail": "jobs down"}))
+    entities = _StubEntities(existing=_run())
+
+    with pytest.raises(APIStatusError):
+        await get_analysis_run("default", RUN_NAME, _sdk(jobs), _entities(entities))
+
+
+async def test_get_returns_404_for_an_unknown_run() -> None:
+    entities = _StubEntities()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await get_analysis_run("default", RUN_NAME, _sdk(_StubExecuteJobs()), _entities(entities))
+
+    assert excinfo.value.status_code == 404

--- a/plugins/nemo-insights/tests/test_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_analysis_runs.py
@@ -73,11 +73,26 @@ class _StubExecuteJobs:
         return self._response
 
 
+class _StubModels:
+    """Model Entity lookups the create path makes before recording a run."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self.retrieved: list[tuple[str, str]] = []
+        self._error = error
+
+    async def retrieve(self, name: str, *, workspace: str) -> object:
+        self.retrieved.append((workspace, name))
+        if self._error is not None:
+            raise self._error
+        return object()
+
+
 class _StubSdk:
     """Minimal stand-in for the request-scoped ``AsyncNeMoPlatform``."""
 
-    def __init__(self, jobs: _StubExecuteJobs) -> None:
+    def __init__(self, jobs: _StubExecuteJobs, models: _StubModels | None = None) -> None:
         self.agents = type("_Agents", (), {"jobs": type("_Jobs", (), {"execute": jobs})()})()
+        self.models = models or _StubModels()
 
 
 class _StubEntities:
@@ -114,9 +129,9 @@ class _StubEntities:
         )
 
 
-def _sdk(jobs: _StubExecuteJobs) -> AsyncNeMoPlatform:
-    """The route only touches ``sdk.agents.jobs.execute``; cast past the concrete type."""
-    return cast(AsyncNeMoPlatform, _StubSdk(jobs))
+def _sdk(jobs: _StubExecuteJobs, models: _StubModels | None = None) -> AsyncNeMoPlatform:
+    """The route touches ``sdk.agents.jobs.execute`` and ``sdk.models``; cast past the concrete type."""
+    return cast(AsyncNeMoPlatform, _StubSdk(jobs, models))
 
 
 def _entities(stub: _StubEntities) -> NemoEntitiesClient:
@@ -241,7 +256,7 @@ def test_ethos_is_omitted_when_unset() -> None:
     assert "ethos" not in config.agent.config["harnesses"]["insights"]["settings"]
 
 
-@pytest.mark.parametrize("field", ["agent", "evaluation_id", "ethos"])
+@pytest.mark.parametrize("field", ["agent", "evaluation_id", "ethos", "default_model", "fast_model"])
 @pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
 def test_blank_settings_are_rejected(field: str, blank: str) -> None:
     """These reach the adapter verbatim, which rejects a blank only once the job is running."""
@@ -322,6 +337,51 @@ async def test_the_run_captures_the_request_scope() -> None:
     assert response.run.evaluation_id == "eval-123"
     assert response.run.default_model == DEFAULT_MODEL
     assert response.run.fast_model == FAST_MODEL
+
+
+async def test_a_bare_model_name_is_looked_up_in_the_run_workspace() -> None:
+    models = _StubModels()
+
+    await create_analysis_run(
+        "team-a",
+        _request(default_model="big", fast_model="small"),
+        _sdk(_StubExecuteJobs(), models),
+        _entities(_StubEntities()),
+    )
+
+    assert models.retrieved == [("team-a", "big"), ("team-a", "small")]
+
+
+async def test_a_denied_model_lookup_keeps_the_status_the_store_returned() -> None:
+    """A cross-workspace ref the caller cannot read is a 403, not a malformed request."""
+    denied = _api_status_error(403, {"detail": "no access to workspace-b"})
+    entities = _StubEntities()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_analysis_run(
+            "workspace-a",
+            _request(default_model="workspace-b/foo"),
+            _sdk(_StubExecuteJobs(), _StubModels(error=denied)),
+            _entities(entities),
+        )
+
+    assert excinfo.value.status_code == 403
+    assert excinfo.value.detail == "no access to workspace-b"
+    assert entities.created == []
+
+
+async def test_an_unreachable_models_service_is_not_reported_as_a_bad_request() -> None:
+    """Nothing is recorded yet, so this is a 503 rather than a 422 blaming the caller."""
+    unreachable = APIConnectionError(request=httpx.Request("GET", "http://platform/models"))
+    entities = _StubEntities()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_analysis_run(
+            "default", _request(), _sdk(_StubExecuteJobs(), _StubModels(error=unreachable)), _entities(entities)
+        )
+
+    assert excinfo.value.status_code == 503
+    assert entities.created == []
 
 
 async def test_nothing_is_submitted_when_the_run_cannot_be_recorded() -> None:

--- a/plugins/nemo-insights/tests/test_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_analysis_runs.py
@@ -25,7 +25,7 @@ from nemo_insights_plugin.analysis_runs import (
 )
 from nemo_insights_plugin.entities import AnalysisRun
 from nemo_insights_plugin.schema import AnalysisRunPage
-from nemo_platform import APIStatusError, AsyncNeMoPlatform
+from nemo_platform import APIConnectionError, APIStatusError, AsyncNeMoPlatform
 from nemo_platform_plugin.entities.base import ListResponse, PaginationInfo
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
 from nemo_platform_plugin.entity_naming import NAME_MAX_LENGTH, NAME_PATTERN
@@ -346,6 +346,25 @@ async def test_a_failed_submission_leaves_the_run_record_in_place() -> None:
     assert excinfo.value.status_code == 422
     assert excinfo.value.detail == "bad model ref"
     assert len(entities.created) == 1
+
+
+async def test_an_unreachable_jobs_service_leaves_a_findable_run_record() -> None:
+    """APIConnectionError is a sibling of APIStatusError, so it needs its own arm.
+
+    This is the case a retry could plausibly fix, so the orphan has to be
+    findable afterwards rather than vanishing into an unhandled 500.
+    """
+    unreachable = APIConnectionError(request=httpx.Request("POST", "http://platform/jobs/execute"))
+    jobs = _StubExecuteJobs(error=unreachable)
+    entities = _StubEntities()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_analysis_run("default", _request(), _sdk(jobs), _entities(entities))
+
+    assert excinfo.value.status_code == 503
+    assert len(entities.created) == 1
+    # The caller cannot recover a run it was never told the name of.
+    assert excinfo.value.detail["run"] == entities.created[0].name
 
 
 async def test_a_failed_submission_falls_back_to_the_raw_error_body() -> None:

--- a/plugins/nemo-insights/tests/test_analyst_fabric_descriptor.py
+++ b/plugins/nemo-insights/tests/test_analyst_fabric_descriptor.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Any
 
 import nemo_fabric as fabric
-import pytest
 from nemo_agents_plugin.agent_config import AgentConfig
 from nemo_agents_plugin.fabric.translator import translate_agent_config
 from nemo_fabric_adapter_contract import models as contract
@@ -27,10 +26,30 @@ _PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 DESCRIPTOR = _PLUGIN_ROOT / "insights-analyst.fabric-adapter.json"
 
 
+_REINSTALL_HINT = "Refresh it with: uv sync --reinstall-package nemo-insights-plugin"
+
+
 def _installed_descriptor() -> Path:
+    """Where Fabric's default InstalledPackage discovery looks for the descriptor.
+
+    The wheel ships it as shared-data (see ``pyproject.toml``), so this is the
+    path Fabric names in its own ``FabricConfigError`` when a setting is missing
+    from the schema.
+    """
     import sys
 
     return Path(sys.prefix) / "share" / "nemo-fabric" / "adapters" / "insights-analyst" / DESCRIPTOR.name
+
+
+def _require_installed_descriptor() -> Path:
+    """Fail rather than skip: a skipped plan check is a green CI that proved nothing.
+
+    A fresh venv always has the descriptor, so absence means a stale local
+    install, not an unsupported environment.
+    """
+    installed = _installed_descriptor()
+    assert installed.exists(), f"Adapter descriptor is not installed at {installed}. {_REINSTALL_HINT}"
+    return installed
 
 
 def _built_config(**overrides: Any) -> dict[str, Any]:
@@ -59,12 +78,10 @@ def test_installed_descriptor_matches_the_source() -> None:
     ``uv sync`` alone will not refresh it for an unchanged editable package;
     the descriptor only reaches Fabric after a reinstall.
     """
-    installed = _installed_descriptor()
-    if not installed.exists():
-        pytest.skip(f"Adapter descriptor is not installed at {installed}")
+    installed = _require_installed_descriptor()
 
     assert json.loads(installed.read_text(encoding="utf-8")) == json.loads(DESCRIPTOR.read_text(encoding="utf-8")), (
-        "Stale installed descriptor. Refresh it with: uv sync --reinstall-package nemo-insights-plugin"
+        f"Stale installed descriptor. {_REINSTALL_HINT}"
     )
 
 
@@ -125,10 +142,19 @@ def test_optional_read_settings_are_carried_when_set() -> None:
     assert settings["enable_observability"] is False
 
 
+def test_descriptor_declares_the_ethos_setting() -> None:
+    """The adapter reads ``ethos``; an undeclared key is rejected by the closed schema."""
+    settings_schema = json.loads(DESCRIPTOR.read_text(encoding="utf-8"))["settings_schema"]
+
+    assert "ethos" in settings_schema["properties"]
+    assert settings_schema["additionalProperties"] is False
+    # The pre-rename name of the same field; nothing reads it any more.
+    assert "agent_spec" not in settings_schema["properties"]
+
+
 def test_fabric_plans_a_config_carrying_an_ethos(tmp_path: Path) -> None:
     """Planning is where a setting the descriptor omits actually blows up."""
-    if not _installed_descriptor().exists():
-        pytest.skip("Adapter descriptor is not installed; Fabric cannot resolve it.")
+    _require_installed_descriptor()
 
     config = _analyst_config(ethos="# Ethos\n\nBe careful.")
     assert config.harnesses["insights"].settings["ethos"] == "# Ethos\n\nBe careful."
@@ -138,8 +164,7 @@ def test_fabric_plans_a_config_carrying_an_ethos(tmp_path: Path) -> None:
 
 def test_fabric_plans_the_built_config(tmp_path: Path) -> None:
     """Fabric validates the adapter descriptor while planning; this is the real check."""
-    if not _installed_descriptor().exists():
-        pytest.skip("Adapter descriptor is not installed; Fabric cannot resolve it.")
+    _require_installed_descriptor()
 
     plan = fabric.Fabric().plan(translate_agent_config(_analyst_config()), base_dir=tmp_path)
 

--- a/plugins/nemo-insights/tests/test_cli_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_cli_analysis_runs.py
@@ -317,6 +317,27 @@ def test_list_prints_a_page_of_runs(app: typer.Typer, monkeypatch: pytest.Monkey
     assert json.loads(result.stdout)["data"][0]["name"] == RUN_NAME
 
 
+def test_list_defaults_to_newest_first(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "list"])
+
+    assert result.exit_code == 0, result.output
+    assert runs.list_calls[0]["sort"] == "-created_at"
+
+
+def test_list_forwards_an_explicit_sort(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The route accepts a sort, so the CLI has to be able to reach it."""
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "list", "--sort", "created_at"])
+
+    assert result.exit_code == 0, result.output
+    assert runs.list_calls[0]["sort"] == "created_at"
+
+
 def test_get_prints_the_run_and_its_job(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
     runs = _StubAnalysisRuns()
     _install_client(monkeypatch, runs)

--- a/plugins/nemo-insights/tests/test_cli_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_cli_analysis_runs.py
@@ -1,0 +1,349 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``nemo insights analysis-runs`` — submit and inspect analysis runs."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import typer
+from nemo_insights_plugin import cli
+from nemo_insights_plugin.entities import AnalysisRun
+from nemo_insights_plugin.schema import AnalysisRunPage, AnalysisRunResponse
+from nemo_insights_plugin.sdk_resources.analysis_runs import AnalysisRunTimeoutError
+from nemo_platform_plugin.nooa_model_client import ConfiguredModelRefs
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+RUN_NAME = "insights-run-0123456789abcdef0123456789abcdef"
+CONFIGURED_DEFAULT = "default/configured-big"
+CONFIGURED_FAST = "default/configured-small"
+
+
+def _run(**overrides: Any) -> AnalysisRun:
+    return AnalysisRun(
+        name=overrides.pop("name", RUN_NAME),
+        workspace=overrides.pop("workspace", "default"),
+        agent=overrides.pop("agent", "demo-agent"),
+        **overrides,
+    )
+
+
+def _response(status: str | None = "created", **overrides: Any) -> AnalysisRunResponse:
+    job = None if status is None else {"name": RUN_NAME, "status": status}
+    return AnalysisRunResponse(run=_run(**overrides), job=job)
+
+
+class _StubAnalysisRuns:
+    """Stands in for ``client.insights.analysis_runs``, recording each call."""
+
+    def __init__(
+        self,
+        *,
+        create_response: AnalysisRunResponse | None = None,
+        get_response: AnalysisRunResponse | None = None,
+        wait_response: AnalysisRunResponse | None = None,
+        wait_error: Exception | None = None,
+    ) -> None:
+        self.create_calls: list[dict[str, Any]] = []
+        self.list_calls: list[dict[str, Any]] = []
+        self.get_calls: list[dict[str, Any]] = []
+        self.wait_calls: list[dict[str, Any]] = []
+        self._create_response = create_response or _response()
+        self._get_response = get_response or _response(status="completed")
+        self._wait_response = wait_response or _response(status="completed")
+        self._wait_error = wait_error
+
+    async def create(self, **kwargs: Any) -> AnalysisRunResponse:
+        self.create_calls.append(kwargs)
+        return self._create_response
+
+    async def list_runs(self, **kwargs: Any) -> AnalysisRunPage:
+        self.list_calls.append(kwargs)
+        return AnalysisRunPage(data=[_run()], pagination=None, sort="-created_at", filter=None)
+
+    async def get(self, **kwargs: Any) -> AnalysisRunResponse:
+        self.get_calls.append(kwargs)
+        return self._get_response
+
+    async def wait(self, **kwargs: Any) -> AnalysisRunResponse:
+        self.wait_calls.append(kwargs)
+        if self._wait_error is not None:
+            raise self._wait_error
+        on_status = kwargs.get("on_status")
+        if on_status is not None:
+            on_status(self._wait_response.job_status)
+        return self._wait_response
+
+
+class _StubClient:
+    def __init__(self, runs: _StubAnalysisRuns) -> None:
+        self.insights = SimpleNamespace(analysis_runs=runs)
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def app() -> typer.Typer:
+    return cli.InsightsCLI().get_cli()
+
+
+@pytest.fixture(autouse=True)
+def configured_models(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        cli,
+        "configured_model_refs",
+        lambda: ConfiguredModelRefs(default=CONFIGURED_DEFAULT, fast=CONFIGURED_FAST),
+    )
+
+
+def _install_client(monkeypatch: pytest.MonkeyPatch, runs: _StubAnalysisRuns) -> _StubClient:
+    client = _StubClient(runs)
+    monkeypatch.setattr(cli, "make_client", lambda base_url: client)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+def test_create_submits_a_run_and_prints_it_as_json(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    client = _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["run"]["name"] == RUN_NAME
+    assert runs.create_calls[0]["agent"] == "demo-agent"
+    assert runs.create_calls[0]["workspace"] == "default"
+    assert client.closed is True
+
+
+def test_create_falls_back_to_the_configured_model_pair(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The Platform process cannot read the operator's config, so the CLI supplies it."""
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert runs.create_calls[0]["default_model"] == CONFIGURED_DEFAULT
+    assert runs.create_calls[0]["fast_model"] == CONFIGURED_FAST
+
+
+def test_explicit_model_refs_win_over_the_configured_pair(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(
+        app,
+        [
+            "analysis-runs",
+            "create",
+            "--agent",
+            "demo-agent",
+            "--default-model",
+            "default/big",
+            "--fast-model",
+            "default/small",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert runs.create_calls[0]["default_model"] == "default/big"
+    assert runs.create_calls[0]["fast_model"] == "default/small"
+
+
+def test_create_passes_the_requested_read_scope(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(
+        app,
+        [
+            "analysis-runs",
+            "create",
+            "--agent",
+            "demo-agent",
+            "--since",
+            "2026-08-01T00:00:00+00:00",
+            "--evaluation-id",
+            "eval-123",
+            "--timeout-seconds",
+            "60",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert runs.create_calls[0]["since"] == datetime(2026, 8, 1, tzinfo=timezone.utc)
+    assert runs.create_calls[0]["evaluation_id"] == "eval-123"
+    assert runs.create_calls[0]["timeout_seconds"] == 60.0
+
+
+def test_create_reads_the_ethos_file_and_sends_its_contents(
+    app: typer.Typer, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``--ethos`` takes a path like ``nemo insights analyze``; the API wants the Markdown."""
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+    ethos = tmp_path / "ETHOS.md"
+    ethos.write_text("# Ethos\n\nBe careful.\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent", "--ethos", str(ethos)])
+
+    assert result.exit_code == 0, result.output
+    assert runs.create_calls[0]["ethos"] == "# Ethos\n\nBe careful.\n"
+
+
+def test_create_without_an_ethos_sends_none(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert runs.create_calls[0]["ethos"] is None
+
+
+def test_an_unreadable_ethos_fails_before_anything_is_submitted(
+    app: typer.Typer, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Submitting without it would analyze the agent against no contract at all."""
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(
+        app, ["analysis-runs", "create", "--agent", "demo-agent", "--ethos", str(tmp_path / "missing.md")]
+    )
+
+    assert result.exit_code == 1
+    assert "--ethos" in result.output
+    assert runs.create_calls == []
+
+
+def test_an_empty_ethos_file_fails_before_anything_is_submitted(
+    app: typer.Typer, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+    ethos = tmp_path / "ETHOS.md"
+    ethos.write_text("   \n", encoding="utf-8")
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent", "--ethos", str(ethos)])
+
+    assert result.exit_code == 1
+    assert runs.create_calls == []
+
+
+def test_a_malformed_since_fails_before_anything_is_submitted(
+    app: typer.Typer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent", "--since", "last tuesday"])
+
+    assert result.exit_code == 1
+    assert "ISO-8601" in result.output
+    assert runs.create_calls == []
+
+
+def test_create_without_wait_does_not_poll(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert runs.wait_calls == []
+
+
+def test_create_with_wait_polls_the_run_it_just_created(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent", "--wait", "--poll-interval", "0"])
+
+    assert result.exit_code == 0, result.output
+    assert runs.wait_calls[0]["name"] == RUN_NAME
+    assert json.loads(result.stdout)["job"]["status"] == "completed"
+
+
+def test_wait_exits_non_zero_when_the_job_fails(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A finished-but-failed job still prints; only the exit code carries the verdict."""
+    runs = _StubAnalysisRuns(wait_response=_response(status="error"))
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent", "--wait"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["job"]["status"] == "error"
+
+
+def test_wait_timeout_is_reported_as_an_error(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns(wait_error=AnalysisRunTimeoutError("did not finish within 1.0s"))
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "create", "--agent", "demo-agent", "--wait"])
+
+    assert result.exit_code == 1
+    assert "did not finish" in result.output
+
+
+# ---------------------------------------------------------------------------
+# list and get
+# ---------------------------------------------------------------------------
+
+
+def test_list_prints_a_page_of_runs(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "list", "--agent", "demo-agent"])
+
+    assert result.exit_code == 0, result.output
+    assert runs.list_calls[0]["agent"] == "demo-agent"
+    assert json.loads(result.stdout)["data"][0]["name"] == RUN_NAME
+
+
+def test_get_prints_the_run_and_its_job(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "get", RUN_NAME])
+
+    assert result.exit_code == 0, result.output
+    assert runs.get_calls[0]["name"] == RUN_NAME
+    assert json.loads(result.stdout)["job"]["status"] == "completed"
+
+
+def test_get_reports_a_run_whose_job_never_landed(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns(get_response=_response(status=None))
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "get", RUN_NAME])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["job"] is None
+
+
+def test_get_with_wait_polls_instead_of_reading_once(app: typer.Typer, monkeypatch: pytest.MonkeyPatch) -> None:
+    runs = _StubAnalysisRuns()
+    _install_client(monkeypatch, runs)
+
+    result = runner.invoke(app, ["analysis-runs", "get", RUN_NAME, "--wait"])
+
+    assert result.exit_code == 0, result.output
+    assert runs.wait_calls[0]["name"] == RUN_NAME
+    assert runs.get_calls == []

--- a/plugins/nemo-insights/tests/test_sdk_analysis_runs.py
+++ b/plugins/nemo-insights/tests/test_sdk_analysis_runs.py
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The ``client.insights.analysis_runs`` SDK sub-resource."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+from nemo_insights_plugin.sdk_resources.analysis_runs import (
+    AnalysisRunNotSubmittedError,
+    AnalysisRunTimeoutError,
+    _AnalysisRunResource,
+    _AsyncAnalysisRunResource,
+    _ResourceParent,
+)
+
+RUN_NAME = "insights-run-0123456789abcdef0123456789abcdef"
+DEFAULT_MODEL = "default/big"
+FAST_MODEL = "default/small"
+
+
+def _run_body(**overrides: Any) -> dict[str, Any]:
+    return {
+        "id": "entity-123",
+        "name": RUN_NAME,
+        "workspace": "default",
+        "agent": "demo-agent",
+        "since": None,
+        "evaluation_id": "",
+        "default_model": DEFAULT_MODEL,
+        "fast_model": FAST_MODEL,
+        **overrides,
+    }
+
+
+def _response_body(status: str | None = "created", **run_overrides: Any) -> dict[str, Any]:
+    job = None if status is None else {"name": RUN_NAME, "status": status}
+    return {"run": _run_body(**run_overrides), "job": job}
+
+
+class _StubResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        """Every stubbed response is a success; failures are exercised elsewhere."""
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class _StubHttpClient:
+    """Records requests and replays a queued sequence of response bodies.
+
+    The last body repeats, so a polling test only has to queue the states it
+    cares about.
+    """
+
+    def __init__(self, *bodies: dict[str, Any]) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._bodies = list(bodies) or [_response_body()]
+
+    def _next(self) -> _StubResponse:
+        body = self._bodies[0] if len(self._bodies) == 1 else self._bodies.pop(0)
+        return _StubResponse(body)
+
+    def post(self, url: str, json: dict[str, Any] | None = None) -> _StubResponse:
+        self.calls.append({"method": "POST", "url": url, "json": json})
+        return self._next()
+
+    def get(self, url: str, params: dict[str, Any] | None = None) -> _StubResponse:
+        self.calls.append({"method": "GET", "url": url, "params": params})
+        return self._next()
+
+
+class _AsyncStubHttpClient:
+    """Async mirror of :class:`_StubHttpClient`, delegating to one for recording."""
+
+    def __init__(self, *bodies: dict[str, Any]) -> None:
+        self._sync = _StubHttpClient(*bodies)
+
+    @property
+    def calls(self) -> list[dict[str, Any]]:
+        return self._sync.calls
+
+    async def post(self, url: str, json: dict[str, Any] | None = None) -> _StubResponse:
+        return self._sync.post(url, json)
+
+    async def get(self, url: str, params: dict[str, Any] | None = None) -> _StubResponse:
+        return self._sync.get(url, params)
+
+
+class _StubParent:
+    def __init__(self, http_client: _StubHttpClient) -> None:
+        self._http_client = http_client
+
+    def _url(self, path: str) -> str:
+        return f"http://platform/apis/insights{path}"
+
+
+def _resource(http_client: _StubHttpClient) -> _AnalysisRunResource:
+    return _AnalysisRunResource(cast(_ResourceParent, _StubParent(http_client)))
+
+
+def _async_resource(http_client: _AsyncStubHttpClient) -> _AsyncAnalysisRunResource:
+    return _AsyncAnalysisRunResource(cast(_ResourceParent, _StubParent(cast(_StubHttpClient, http_client))))
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+
+def test_create_posts_the_request_to_the_analysis_runs_route() -> None:
+    http = _StubHttpClient()
+
+    _resource(http).create(
+        workspace="team-a",
+        agent="demo-agent",
+        default_model=DEFAULT_MODEL,
+        fast_model=FAST_MODEL,
+    )
+
+    assert http.calls[0]["url"] == "http://platform/apis/insights/v2/workspaces/team-a/analysis-runs"
+    assert http.calls[0]["json"] == {
+        "agent": "demo-agent",
+        "default_model": DEFAULT_MODEL,
+        "fast_model": FAST_MODEL,
+    }
+
+
+def test_create_sends_optional_read_scope_when_given() -> None:
+    """Unset optionals stay off the wire so the server's defaults apply."""
+    http = _StubHttpClient()
+
+    _resource(http).create(
+        workspace="default",
+        agent="demo-agent",
+        default_model=DEFAULT_MODEL,
+        fast_model=FAST_MODEL,
+        since=datetime(2026, 8, 1, tzinfo=timezone.utc),
+        evaluation_id="eval-123",
+        timeout_seconds=60.0,
+    )
+
+    assert http.calls[0]["json"] == {
+        "agent": "demo-agent",
+        "default_model": DEFAULT_MODEL,
+        "fast_model": FAST_MODEL,
+        "since": "2026-08-01T00:00:00Z",
+        "evaluation_id": "eval-123",
+        "timeout_seconds": 60.0,
+    }
+
+
+def test_create_sends_the_ethos_inline() -> None:
+    """The Fabric adapter has no Files access, so the Markdown travels in the body."""
+    http = _StubHttpClient()
+
+    _resource(http).create(
+        workspace="default",
+        agent="demo-agent",
+        default_model=DEFAULT_MODEL,
+        fast_model=FAST_MODEL,
+        ethos="# Ethos\n\nBe careful.",
+    )
+
+    assert http.calls[0]["json"]["ethos"] == "# Ethos\n\nBe careful."
+
+
+def test_create_omits_the_ethos_when_unset() -> None:
+    http = _StubHttpClient()
+
+    _resource(http).create(workspace="default", agent="demo-agent", default_model=DEFAULT_MODEL, fast_model=FAST_MODEL)
+
+    assert "ethos" not in http.calls[0]["json"]
+
+
+async def test_async_create_sends_the_ethos_inline() -> None:
+    http = _AsyncStubHttpClient()
+
+    await _async_resource(http).create(
+        workspace="default",
+        agent="demo-agent",
+        default_model=DEFAULT_MODEL,
+        fast_model=FAST_MODEL,
+        ethos="# Ethos",
+    )
+
+    assert http.calls[0]["json"]["ethos"] == "# Ethos"
+
+
+def test_create_returns_the_run_with_its_store_assigned_id() -> None:
+    response = _resource(_StubHttpClient()).create(
+        workspace="default",
+        agent="demo-agent",
+        default_model=DEFAULT_MODEL,
+        fast_model=FAST_MODEL,
+    )
+
+    assert response.run.name == RUN_NAME
+    assert response.run.id == "entity-123"
+    assert response.job == {"name": RUN_NAME, "status": "created"}
+
+
+# ---------------------------------------------------------------------------
+# List and get
+# ---------------------------------------------------------------------------
+
+
+def test_list_runs_omits_the_agent_filter_when_not_given() -> None:
+    http = _StubHttpClient({"data": [], "pagination": None, "sort": "-created_at", "filter": None})
+
+    _resource(http).list_runs(workspace="default")
+
+    assert http.calls[0]["params"] == {"page": 1, "page_size": 20, "sort": "-created_at"}
+
+
+def test_list_runs_filters_by_agent_and_hydrates_items() -> None:
+    http = _StubHttpClient(
+        {
+            "data": [_run_body()],
+            "pagination": {
+                "page": 1,
+                "page_size": 20,
+                "current_page_size": 1,
+                "total_pages": 1,
+                "total_results": 1,
+            },
+            "sort": "-created_at",
+            "filter": {"agent": "demo-agent"},
+        }
+    )
+
+    page = _resource(http).list_runs(workspace="default", agent="demo-agent")
+
+    assert http.calls[0]["params"]["agent"] == "demo-agent"
+    assert page.data[0].id == "entity-123"
+
+
+def test_get_reads_one_run_joined_with_its_job() -> None:
+    http = _StubHttpClient(_response_body(status="active"))
+
+    response = _resource(http).get(workspace="default", name=RUN_NAME)
+
+    assert http.calls[0]["url"].endswith(f"/analysis-runs/{RUN_NAME}")
+    assert response.job_status == "active"
+    assert response.job_is_terminal is False
+
+
+def test_a_run_with_no_job_has_no_status_and_is_not_terminal() -> None:
+    """A missing job means submission never landed — not that the run finished."""
+    response = _resource(_StubHttpClient(_response_body(status=None))).get(workspace="default", name=RUN_NAME)
+
+    assert response.job is None
+    assert response.job_status is None
+    assert response.job_is_terminal is False
+
+
+@pytest.mark.parametrize(
+    ("status", "terminal"),
+    [("completed", True), ("error", True), ("cancelled", True), ("pending", False), ("active", False)],
+)
+def test_job_terminality_follows_the_platform_job_states(status: str, terminal: bool) -> None:
+    response = _resource(_StubHttpClient(_response_body(status=status))).get(workspace="default", name=RUN_NAME)
+
+    assert response.job_is_terminal is terminal
+
+
+# ---------------------------------------------------------------------------
+# Wait
+# ---------------------------------------------------------------------------
+
+
+def test_wait_polls_until_the_job_is_terminal() -> None:
+    http = _StubHttpClient(
+        _response_body(status="created"),
+        _response_body(status="active"),
+        _response_body(status="completed"),
+    )
+    seen: list[str | None] = []
+
+    response = _resource(http).wait(
+        workspace="default",
+        name=RUN_NAME,
+        poll_interval=0,
+        on_status=seen.append,
+    )
+
+    assert response.job_status == "completed"
+    assert seen == ["created", "active", "completed"]
+    assert len(http.calls) == 3
+
+
+def test_wait_returns_a_failed_job_rather_than_raising() -> None:
+    """A job that ran and failed is an answer; the caller decides what it means."""
+    response = _resource(_StubHttpClient(_response_body(status="error"))).wait(
+        workspace="default", name=RUN_NAME, poll_interval=0
+    )
+
+    assert response.job_status == "error"
+    assert response.job_is_terminal is True
+
+
+def test_wait_refuses_to_poll_a_run_that_was_never_submitted() -> None:
+    """Its job will never appear, so polling would only burn the timeout."""
+    http = _StubHttpClient(_response_body(status=None))
+
+    with pytest.raises(AnalysisRunNotSubmittedError) as excinfo:
+        _resource(http).wait(workspace="default", name=RUN_NAME, poll_interval=0)
+
+    assert RUN_NAME in str(excinfo.value)
+    assert len(http.calls) == 1
+
+
+def test_wait_times_out_with_the_last_status_it_saw() -> None:
+    http = _StubHttpClient(_response_body(status="active"))
+
+    with pytest.raises(AnalysisRunTimeoutError) as excinfo:
+        _resource(http).wait(workspace="default", name=RUN_NAME, timeout=0, poll_interval=0)
+
+    assert "'active'" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Async parity
+# ---------------------------------------------------------------------------
+
+
+async def test_async_create_matches_the_sync_request() -> None:
+    http = _AsyncStubHttpClient()
+
+    response = await _async_resource(http).create(
+        workspace="team-a",
+        agent="demo-agent",
+        default_model=DEFAULT_MODEL,
+        fast_model=FAST_MODEL,
+    )
+
+    assert http.calls[0]["url"] == "http://platform/apis/insights/v2/workspaces/team-a/analysis-runs"
+    assert response.run.id == "entity-123"
+
+
+async def test_async_wait_polls_until_terminal() -> None:
+    http = _AsyncStubHttpClient(
+        _response_body(status="active"),
+        _response_body(status="completed"),
+    )
+
+    response = await _async_resource(http).wait(workspace="default", name=RUN_NAME, poll_interval=0)
+
+    assert response.job_status == "completed"
+    assert len(http.calls) == 2
+
+
+async def test_async_get_reads_one_run() -> None:
+    http = _AsyncStubHttpClient(_response_body(status="active"))
+
+    response = await _async_resource(http).get(workspace="default", name=RUN_NAME)
+
+    assert response.job_status == "active"


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Adds an `AnalysisRun` entity, with list and get endpoints, so that users can view analysis jobs separate from other agent execution jobs. The `AnalysisRun.name` is used as the job name to link the two.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added on-demand Insights analysis runs for submitting, monitoring, listing, and retrieving agent analyses.
  - Added CLI options for model selection, time and evaluation filters, Ethos input, timeouts, sorting, pagination, JSON output, and polling.
  - Added synchronous and asynchronous SDK support with wait helpers and clear timeout or missing-job errors.
  - Analysis runs retain status and backing-job linkage for later retrieval, including runs without a backing job.

- **Documentation**
  - Added CLI reference, SDK guidance, and updated examples for creating and managing analysis runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->