### PR TITLE
feat(studio): show favorite as a star on the experiment title (ASTD-511)

### DIFF
--- a/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx
@@ -23,7 +23,7 @@ import { ExperimentMetrics } from '@studio/routes/ExperimentDetailRoute/Experime
 import { getExperimentRoute } from '@studio/routes/utils';
 import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
 import { useRequiredPathParams } from '@studio/util/hooks/useRequiredPathParams';
-import { ChartLine, ChartScatter, Pencil } from 'lucide-react';
+import { ChartLine, ChartScatter, Pencil, Star } from 'lucide-react';
 import { type FC, useEffect, useState } from 'react';
 
 export const ExperimentDetailRoute: FC = () => {
@@ -73,7 +73,21 @@ export const ExperimentDetailRoute: FC = () => {
       <Stack className="h-full overflow-auto" gap="density-2xl" padding="density-2xl">
         <PageHeader
           className="p-0"
-          slotHeading={experimentName}
+          slotHeading={
+            group?.is_favorite ? (
+              <Flex align="center" gap="density-sm">
+                <Star
+                  size={24}
+                  className="text-brand shrink-0"
+                  fill="currentColor"
+                  aria-label="Favorite"
+                />
+                {experimentName}
+              </Flex>
+            ) : (
+              experimentName
+            )
+          }
           slotDescription={group?.description || undefined}
           slotActions={
             <Button kind="secondary" disabled={!group} onClick={() => setEditOpen(true)}>

--- a/web/packages/studio/src/routes/ExperimentRoute/ExperimentCard.tsx
+++ b/web/packages/studio/src/routes/ExperimentRoute/ExperimentCard.tsx
@@ -4,7 +4,7 @@
 import { formatEvaluatorScore } from '@nemo/common/src/utils/formatters';
 import { useListEvaluations } from '@nemo/sdk/generated/platform/api';
 import type { ExperimentResponse } from '@nemo/sdk/generated/platform/schema';
-import { Anchor, Card, Tag, Text } from '@nvidia/foundations-react-core';
+import { Anchor, Card, Text } from '@nvidia/foundations-react-core';
 import { MetricTrend } from '@studio/components/charts/MetricTrend';
 import {
   DELTA_COMPARISON_LABEL,
@@ -15,6 +15,7 @@ import {
 import { Metric } from '@studio/routes/ExperimentRoute/Metric';
 import { UpdatedAt } from '@studio/routes/ExperimentRoute/UpdatedAt';
 import { getExperimentDetailRoute } from '@studio/routes/utils';
+import { Star } from 'lucide-react';
 import { type FC, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router';
 
@@ -60,16 +61,19 @@ export const ExperimentCard: FC<ExperimentCardProps> = ({ group, workspace }) =>
       {/* Main info */}
       <div className="flex flex-col items-start gap-2 flex-1">
         <div className="flex items-center gap-2">
+          {group.is_favorite && (
+            <Star
+              size={24}
+              className="text-brand shrink-0"
+              fill="currentColor"
+              aria-label="Favorite"
+            />
+          )}
           <Anchor asChild>
             <Link to={detailRoute} className="no-underline hover:underline">
               <Text kind="title/sm">{group.name}</Text>
             </Link>
           </Anchor>
-          {group.is_favorite && (
-            <Tag kind="outline" color="green" density="compact" readOnly>
-              Favorite
-            </Tag>
-          )}
         </div>
         {group.description && (
           <Text kind="body/regular/sm" className="text-secondary">


### PR DESCRIPTION

<img width="1750" height="1103" alt="Screenshot 2026-08-28 at 14 03 20" src="https://github.com/user-attachments/assets/70c5b1a0-ffab-4695-a2ee-5e9a98b43735" />


## Summary
On the Experiments list and the experiment view page, a favorited experiment was flagged with a green "Favorite" tag next to the title. This replaces that tag with a filled star (NVIDIA brand green) at the start of the title, rendered only when the experiment is a favorite — matching Rob's design review. Behavior is unchanged: the star is display-only; favoriting is still toggled through the existing `Favorite` switch in the Create/Edit experiment modals (`ExperimentFlagSwitch flag="is_favorite"`, saved via `createExperiment`/`updateExperiment`).

## Changes
- `web/packages/studio/src/routes/ExperimentRoute/ExperimentCard.tsx`: drop the `Favorite` `Tag`; render a lucide `Star` (size 24, `text-brand`, `fill="currentColor"`, `aria-label="Favorite"`) before the title when `is_favorite`. Remove the now-unused `Tag` import.
- `web/packages/studio/src/routes/ExperimentDetailRoute/index.tsx`: render the same star before `experimentName` in the `PageHeader` `slotHeading` when `is_favorite`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: presentational icon swap gated on the existing `is_favorite` flag; no new logic branch. Verified by running Studio against both surfaces.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no docs describe this cosmetic favorite indicator.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pnpm exec eslint packages/studio/src/routes/ExperimentRoute/ExperimentCard.tsx packages/studio/src/routes/ExperimentDetailRoute/index.tsx --max-warnings 0` → exit 0.
- `pnpm exec tsc --noEmit --noErrorTruncation` (packages/studio) → 0 errors.
- `pnpm exec prettier --check` on both files → "All matched files use Prettier code style!".
- Manual, against a running Studio dev server: on the Experiments list and the experiment view page, the favorite renders a green star at the start of the title and no "Favorite" tag; non-favorite experiments render no star.
- Full-repo `uv run pre-commit run -a` was not run (heavy; `uv` is unreliable under the macOS sandbox). Commit-stage hooks ran and passed: DCO sign-off, merge-conflict check, copyright headers, plugin-import guard.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Favorite experiments now display a filled star icon alongside their names in experiment headers and cards.
  * Replaced the text-based “Favorite” label with a clearer visual indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->