### PR TITLE
chore: sync cli reference docs

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -5972,6 +5972,7 @@ nemo agents deploy [OPTIONS]
 * `--name, -n`: Deployment name (auto-generated if omitted).
 * `--mode`: Runtime backend: subprocess (default), docker, or k8s. [default: subprocess]
 * `--image, -i`: Container image for docker/k8s modes (falls back to deployments.default_image).
+* `--use-image-entrypoint`: For docker/k8s modes, preserve the image ENTRYPOINT/CMD instead of injecting the platform-owned agent server command.
 * `--environment, -e`: AgentEnvironment to deploy under, as a 'workspace/name' ref (e.g. 'default/repo-research-ben'). Its EnvironmentSpec is merged into the agent config and its ComputeSpec/secret refs are snapshotted onto the deployment at create time.
 * `--wait, --no-wait`: Wait for the deployment to reach a terminal status (running or failed) before returning.  Exits 0 only on running; exits 1 with the failure reason if runtime startup fails or readiness times out. Pass --no-wait for fire-and-forget behaviour (the original default — returns the pending deployment immediately as JSON).
 * `--timeout, -t <INTEGER>`: Maximum seconds to wait for a terminal status (only with --wait). [default: 300]


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
`make lint-fix` to sync the CLI reference docs



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `--use-image-entrypoint` option to `nemo agents deploy`, allowing deployments to preserve the container image’s configured startup command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->