### PR TITLE
feat(anonymizer): make execution remote only

### DIFF
--- a/docs/anonymizer/cli.mdx
+++ b/docs/anonymizer/cli.mdx
@@ -11,14 +11,11 @@ This reference covers the `nemo anonymizer` commands exposed by the Anonymizer p
 
 ## Command Surface
 
-| Command                          | Source                          | Description                                                  |
-|----------------------------------|---------------------------------|--------------------------------------------------------------|
-| `nemo anonymizer validate`       | Manual Typer command            | Validate an `AnonymizerConfig` (and optional `model_configs`).|
-| `nemo anonymizer preview run`    | Generated from `NemoFunction`   | Local streaming preview.                                     |
-| `nemo anonymizer preview submit` | Generated from `NemoFunction`   | Remote streaming preview against the plugin service.         |
-| `nemo anonymizer run run`        | Generated from `NemoJob`        | Local job execution in the CLI process.                      |
-| `nemo anonymizer run submit`     | Generated from `NemoJob`        | Submit an `anonymizer.run` job to the NeMo Platform Jobs worker. |
-| `nemo anonymizer run explain`    | Generated from `NemoJob`        | Print the job key, submit endpoint, and JSON schemas.        |
+| Command                          | Description                                                  |
+|----------------------------------|--------------------------------------------------------------|
+| `nemo anonymizer validate`       | Validate an `AnonymizerConfig` (and optional `model_configs`).|
+| `nemo anonymizer preview`        | Run a streaming preview through the Anonymizer plugin service. |
+| `nemo anonymizer run`            | Submit an `anonymizer.run` job to the NeMo Platform Jobs worker. |
 
 ## `nemo anonymizer validate`
 
@@ -35,60 +32,33 @@ nemo anonymizer validate \
 | `--config`        | yes      | Path to the `AnonymizerConfig` YAML.                                                              |
 | `--model-configs` | no       | Optional path to a model-configs YAML to validate alongside the config (same shape the library expects). |
 
-The command does not accept `data.source`. Input-source validation happens during `preview` or `run`.
+The command does not accept `data.source`. Input-source validation happens during preview or run execution.
 
 ## `nemo anonymizer preview`
 
-Both `preview run` and `preview submit` take a spec file matching `PreviewRequest`.
-
 ```bash
-nemo anonymizer preview run \
-  --spec-file /tmp/anonymizer-preview.yaml \
-  --workspace "${NMP_WORKSPACE:-default}"
-
-nemo anonymizer preview submit \
+nemo anonymizer preview \
   --spec-file /tmp/anonymizer-preview.yaml \
   --workspace "${NMP_WORKSPACE:-default}" \
   --base-url "${NMP_BASE_URL:-http://localhost:8080}"
 ```
 
-| Flag             | Description                                                                                       |
-|------------------|---------------------------------------------------------------------------------------------------|
-| `--spec-file`    | Path to the `PreviewRequest` YAML.                                                                |
-| `--workspace`    | NeMo Platform workspace. Used to resolve fileset references and Inference Gateway providers.   |
-| `--base-url`     | Override the platform base URL (typically auto-populated from the CLI config).                    |
+| Flag             | Description                                                                            |
+|------------------|----------------------------------------------------------------------------------------|
+| `--spec-file`    | Path to the `PreviewRequest` YAML or JSON.                                             |
+| `--workspace`    | Workspace used for fileset resolution and Inference Gateway providers.                 |
+| `--base-url`     | Plugin-service base URL.                                                              |
+| `--request-id`   | Optional `X-Request-ID` header value for tracing the request.                         |
 
-### Preview source kinds
-
-| Form                                  | `preview run` | `preview submit` |
-|---------------------------------------|---------------|------------------|
-| Local path (`/tmp/input.csv`)         | yes           | no               |
-| HTTP(S) URL (`https://.../input.csv`) | yes           | yes              |
-| Fileset reference (`fs#path`)         | yes           | yes              |
-
-### Preview output
-
-`preview` streams newline-delimited JSON frames to stdout. Filter with `jq`:
-
-```bash
-nemo anonymizer preview run --spec-file /tmp/anonymizer-preview.yaml > /tmp/preview.ndjson
-
-jq -R 'fromjson? | select(.kind == "preview_dataset") | .records' /tmp/preview.ndjson
-```
-
-Frame kinds: `log`, `preview_dataset`, `trace_dataset`, `failed_records`, `heartbeat`, `done`, `error`. See the [preview tutorial](/documentation/anonymize-data/tutorials/preview-a-config) for details.
+`preview` calls the plugin service and streams NDJSON frames to stdout. It rejects local file paths in `data.source` (use a fileset reference or `http(s)` URL) and requires explicit `model_configs`.
 
 ## `nemo anonymizer run`
 
 ```bash
-nemo anonymizer run run --spec-file /tmp/anonymizer-run.yaml
-
-nemo anonymizer run submit \
+nemo anonymizer run \
   --spec-file /tmp/anonymizer-run.yaml \
   --workspace "${NMP_WORKSPACE:-default}" \
   --base-url "${NMP_BASE_URL:-http://localhost:8080}"
-
-nemo anonymizer run explain
 ```
 
 | Flag             | Description                                                                                       |
@@ -98,30 +68,14 @@ nemo anonymizer run explain
 
 ### Run source kinds
 
-| Form                                  | `run run` | `run submit` |
-|---------------------------------------|-----------|--------------|
-| Local path (`/tmp/input.csv`)         | yes       | no           |
-| HTTP(S) URL (`https://.../input.csv`) | yes       | yes          |
-| Fileset reference (`fs#path`)         | yes       | yes          |
+| Form                                  | `run` |
+|---------------------------------------|-------|
+| HTTP(S) URL (`https://.../input.csv`) | yes   |
+| Fileset reference (`fs#path`)         | yes   |
 
 ### Run output
 
-`run run` prints `{"exit_code": 0}` on success. The local job results manager logs the artifact directory to stderr:
-
-```text
-Saved result 'artifacts' to file:///.../persistent/results/artifacts
-```
-
-The artifact directory contains:
-
-| File                  | Description                                                  |
-|-----------------------|--------------------------------------------------------------|
-| `dataset.parquet`     | Anonymized output.                                           |
-| `trace.parquet`       | Detection trace.                                             |
-| `metadata.json`       | Run metadata (includes original text column).                |
-| `failed_records.json` | Per-record failures. Only written when records failed.       |
-
-`run submit` submits an `anonymizer.run` job to the Jobs service and prints the assigned job name and submit endpoint:
+`run` submits an `anonymizer.run` job to the Jobs service and prints the assigned job name and submit endpoint:
 
 ```text
   |-- job name: anonymizer-run-2026-05-12-abc123
@@ -145,27 +99,21 @@ dataset = results.load_dataset()
 
 See [SDK Resources](/documentation/anonymize-data/sdk-resources) for the full `AnonymizerJobResource` / `AnonymizerJobResults` surface.
 
-Compared to `run run`, `run submit` rejects local file paths in `data.source` (use a fileset reference or `http(s)` URL) and requires explicit `model_configs` because the job runs outside the CLI process.
+`run` rejects local file paths in `data.source` (use a fileset reference or `http(s)` URL) and requires explicit `model_configs` because the job runs outside the CLI process.
 
 ## Spec File Reference
 
-Both preview and run specs use the shared `AnonymizerRequest` shape:
+Run specs use the `AnonymizerRequest` shape. Preview specs use the same fields plus `num_records`:
 
 | Field             | Type                                            | Required | Notes                                                                  |
 |-------------------|-------------------------------------------------|----------|------------------------------------------------------------------------|
 | `config`          | `AnonymizerConfig`                              | yes      | Library config. See the [library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs). |
-| `data.source`     | string                                          | yes      | Local path, `http(s)` URL, or fileset reference.                       |
+| `data.source`     | string                                          | yes      | `http(s)` URL or fileset reference.                                    |
 | `data.text_column`| string                                          | no       | Defaults to `text`.                                                    |
 | `data.id_column`  | string                                          | no       | Optional record identifier column.                                     |
 | `data.data_summary` | string                                        | no       | Optional short description of the data.                                |
-| `model_configs`   | list of Data Designer `ModelConfig`             | depends  | Required for `preview submit` and `run submit`; optional for `preview run` and `run run`. |
+| `model_configs`   | list of Data Designer `ModelConfig`             | yes      | Required so execution routes through NeMo Platform Inference Gateway.  |
 | `selected_models` | object with `detection` / `replace` / `rewrite` | no       | Role overrides on top of bundled defaults. Requires `model_configs`.   |
-
-Preview-only:
-
-| Field         | Type    | Required | Notes                                                                  |
-|---------------|---------|----------|------------------------------------------------------------------------|
-| `num_records` | int ≥ 1 | no       | Defaults to 10. Capped by the service's `preview_num_records.max`.     |
 
 ## Fileset Reference Forms
 

--- a/docs/anonymizer/index.mdx
+++ b/docs/anonymizer/index.mdx
@@ -11,7 +11,7 @@ The Anonymizer service detects personally identifiable information (PII) in text
 
 ## Overview
 
-The service wraps the open-source [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer) and exposes it through the NeMo Platform's Python SDK and CLI. The library still owns PII detection, replacement, rewrite, and config validation. The platform adds inference routing through the Inference Gateway, fileset-backed inputs, plugin-service execution for streaming preview, and a Jobs-worker path for full anonymization runs.
+The service wraps the open-source [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer) and exposes it through the NeMo Platform's Python SDK and CLI. The library still owns PII detection, replacement, rewrite, and config validation. The platform adds inference routing through the Inference Gateway, fileset-backed inputs, SDK/service execution for streaming preview, and a Jobs-worker path for full anonymization runs.
 
 ## How It Works: Library + Platform
 
@@ -62,14 +62,19 @@ preview_result.trace_dataset     # detection trace
 preview_result.display_record(0) # render a record with entity highlights
 ```
 
-For a full anonymization run, execute the job locally or submit it to the Jobs worker:
+The basic CLI equivalent streams NDJSON frames:
 
 ```bash
-nemo anonymizer run run --spec-file /path/to/run-spec.yaml      # in-process
-nemo anonymizer run submit --spec-file /path/to/run-spec.yaml   # NeMo Services job
+nemo anonymizer preview --spec-file /path/to/preview-spec.yaml
 ```
 
-The SDK equivalent of `run submit` is `sdk.anonymizer.run(request)`, which returns an `AnonymizerJobResource` you can poll with `wait_until_done()` and pull artifacts from with `download_artifacts()`.
+For a full anonymization run, submit the job to the Jobs worker:
+
+```bash
+nemo anonymizer run --spec-file /path/to/run-spec.yaml
+```
+
+The SDK equivalent is `sdk.anonymizer.run(request)`, which returns an `AnonymizerJobResource` you can poll with `wait_until_done()` and pull artifacts from with `download_artifacts()`.
 
 **The platform handles:** Inference routing through the Inference Gateway, fileset-backed inputs, and authentication.
 
@@ -80,9 +85,9 @@ When using Anonymizer as a NeMo Platform service:
 | Feature           | Standalone Library                                  | NeMo Platform Service                                                                                       |
 |-------------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
 | **Inference**     | Direct calls to NVIDIA Build defaults               | Routes through the Inference Gateway via `model_configs`                                                        |
-| **Execution**     | Local Python process                                | Streaming preview runs in the plugin service; full runs execute either in the local CLI (`run run`) or on the Jobs worker (`run submit`) |
-| **Input sources** | Local file, `http(s)` URL                           | Local file (`run run` only), `http(s)` URL, or NeMo Platform Fileset                                        |
-| **Artifacts**     | Local filesystem                                    | Local artifact directory (`persistent/results/artifacts`) for `run run`; NeMo Platform job artifact storage for `run submit` |
+| **Execution**     | Local Python process                                | Streaming preview runs through the SDK/service; full runs execute on the Jobs worker |
+| **Input sources** | Local file, `http(s)` URL                           | `http(s)` URL or NeMo Platform Fileset                                        |
+| **Artifacts**     | Local filesystem                                    | NeMo Platform job artifact storage for `run` |
 | **Authentication**| Direct API keys                                     | NeMo Platform Secrets service                                                                               |
 
 ## Replacement Strategies
@@ -103,10 +108,10 @@ See the [library documentation](https://github.com/NVIDIA-NeMo/Anonymizer/tree/m
 
 This package is a thin wrapper around the [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer). It does **not** re-document detection, replacement, or rewrite semantics. It adds:
 
-- A `nemo anonymizer` CLI with `validate`, `preview`, and `run` command groups.
+- A `nemo anonymizer` CLI with `validate`, `preview`, and `run` commands.
 - An `sdk.anonymizer` SDK accessor (`AnonymizerResource`, `AsyncAnonymizerResource`).
 - A streaming `anonymizer.preview` function that emits `preview_dataset`, `trace_dataset`, and `failed_records` frames from the plugin service.
-- An `anonymizer.run` job that writes `dataset.parquet`, `trace.parquet`, `metadata.json`, and optional `failed_records.json`. The job can execute in the local CLI process (`nemo anonymizer run run`) or on the NeMo Platform Jobs worker (`nemo anonymizer run submit` / `sdk.anonymizer.run`).
+- An `anonymizer.run` job that writes `dataset.parquet`, `trace.parquet`, `metadata.json`, and optional `failed_records.json`. The job executes on the NeMo Platform Jobs worker (`nemo anonymizer run` / `sdk.anonymizer.run`).
 - Fileset input handling (`fileset://<workspace>/<fileset>#<path>`).
 - Inference Gateway routing for model providers referenced from `model_configs`.
 

--- a/docs/anonymizer/sdk-resources.mdx
+++ b/docs/anonymizer/sdk-resources.mdx
@@ -78,13 +78,11 @@ The async variant (`AsyncAnonymizerJobResource`) exposes the same surface with `
 
 ## AnonymizerJobResults
 
-`download_artifacts` returns an `AnonymizerJobResults` object that loads parquet / JSON artifacts into memory. The same class also works for the local `run run` flow — point it at the artifact directory the local job results manager logs:
+`download_artifacts` returns an `AnonymizerJobResults` object that loads parquet / JSON artifacts into memory:
 
 ```python
-from pathlib import Path
-from nemo_anonymizer_plugin.sdk.job_results import AnonymizerJobResults
-
-results = AnonymizerJobResults(Path("/path/to/persistent/results/artifacts"))
+job = sdk.anonymizer.get_job_resource("anonymizer-run-2026-05-12-abc123")
+results = job.download_artifacts()
 dataset = results.load_dataset()
 ```
 
@@ -141,7 +139,7 @@ The plugin-owned API-boundary input spec:
 
 | Field          | Type           | Description                                                                              |
 |----------------|----------------|------------------------------------------------------------------------------------------|
-| `source`       | `str`          | Local path, `http(s)` URL, or fileset reference for a CSV / Parquet file.                |
+| `source`       | `str`          | `http(s)` URL or fileset reference for a CSV / Parquet file.                            |
 | `text_column`  | `str` (default `"text"`) | Column containing text to anonymize.                                          |
 | `id_column`    | `str \\| None`  | Optional record identifier column.                                                       |
 | `data_summary` | `str \\| None`  | Optional short description of the data passed to Anonymizer library prompts.             |

--- a/docs/anonymizer/tutorials/index.mdx
+++ b/docs/anonymizer/tutorials/index.mdx
@@ -79,8 +79,8 @@ When using Anonymizer as a NeMo Platform service:
 | Feature        | Difference                                              | Details                                                                                |
 |----------------|---------------------------------------------------------|----------------------------------------------------------------------------------------|
 | **Inference**  | Routes through the Inference Gateway                    | Configure providers once and reference them by name from `model_configs`.              |
-| **Input data** | Filesets and HTTP(S) URLs (local paths only in local CLI execution) | Use `sdk.files.filesets.create` / `sdk.files.upload`, then reference with `#<path>`. |
-| **Artifacts**  | Local or platform-managed                               | `run run` writes to `persistent/results/artifacts` locally; `run submit` stores artifacts in NeMo Platform job storage. |
+| **Input data** | Filesets and HTTP(S) URLs                               | Use `sdk.files.filesets.create` / `sdk.files.upload`, then reference with `#<path>`. |
+| **Artifacts**  | Platform-managed                                        | `run` stores artifacts in NeMo Platform job storage. |
 
 ## Prerequisites
 
@@ -92,7 +92,7 @@ The root workspace includes the Anonymizer plugin, so `nemo services run` discov
 nemo anonymizer --help
 ```
 
-You should see `validate`, `preview`, and `run` command groups.
+You should see `validate`, `preview`, and `run` commands.
 
 These tutorials route inference through an [Inference Gateway](/documentation/models-and-inference) provider, so a NeMo Platform cluster must be running before you preview or run a job. The examples reference the default NVIDIA Build provider created during setup.
 
@@ -100,7 +100,7 @@ These tutorials route inference through an [Inference Gateway](/documentation/mo
 
 ### Upload an Input Fileset
 
-`sdk.anonymizer.preview`, `preview submit`, and `run submit` reject local file paths, so the tutorials read from a fileset. Create a small CSV containing PII and upload it to a fileset named `anonymizer-inputs`:
+`sdk.anonymizer.preview`, `nemo anonymizer preview`, and `nemo anonymizer run` reject local file paths, so the tutorials read from a fileset. Create a small CSV containing PII and upload it to a fileset named `anonymizer-inputs`:
 
 ```python
 import os
@@ -152,14 +152,14 @@ The tutorials reference this file with `fileset://{WORKSPACE}/anonymizer-inputs#
 
 <Card title="Preview a Config" href="/documentation/anonymize-data/tutorials/preview-a-config">
 
-Stream a small anonymized sample to iterate on `AnonymizerConfig` and `model_configs`. Covers `sdk.anonymizer.preview`, `nemo anonymizer preview run` / `preview submit`, and the NDJSON frame stream.
+Stream a small anonymized sample to iterate on `AnonymizerConfig` and `model_configs` with the SDK or `nemo anonymizer preview`.
 
 <small><span class="md-tag">beginner</span> <span class="md-tag">anonymizer</span></small>
 
 </Card>
 <Card title="Run an Anonymizer Job" href="/documentation/anonymize-data/tutorials/run-an-anonymizer-job">
 
-Run the full pipeline locally with `nemo anonymizer run run` or submit it to the Jobs worker with `nemo anonymizer run submit`. Load `dataset.parquet`, `trace.parquet`, and `failed_records.json` artifacts.
+Submit the full pipeline to the Jobs worker with `nemo anonymizer run`. Load `dataset.parquet`, `trace.parquet`, and `failed_records.json` artifacts.
 
 <small><span class="md-tag">intermediate</span> <span class="md-tag">anonymizer</span></small>
 

--- a/docs/anonymizer/tutorials/preview.mdx
+++ b/docs/anonymizer/tutorials/preview.mdx
@@ -21,7 +21,7 @@ Complete the [tutorials prerequisites](/documentation/anonymize-data/tutorials#p
 
 ## What `preview` Does
 
-`preview` runs the Anonymizer pipeline on a small number of records and streams results back from the plugin service. Both surfaces (Python SDK and CLI) produce the same data; the SDK collects it into a `pandas` DataFrame while the CLI prints newline-delimited JSON frames.
+`preview` runs the Anonymizer pipeline on a small number of records and streams results back from the plugin service. The Python SDK collects the stream into a `pandas` DataFrame; the basic CLI streams NDJSON frames to stdout.
 
 The plugin emits four frame kinds:
 
@@ -38,12 +38,11 @@ Available preview surfaces:
 | Surface                          | Where it runs                       | Local paths | `model_configs` required |
 |----------------------------------|--------------------------------------|-------------|--------------------------|
 | `sdk.anonymizer.preview(...)`    | Anonymizer plugin service (remote)  | Rejected    | Required                 |
-| `nemo anonymizer preview run`    | Local CLI process                   | Allowed     | Optional                 |
-| `nemo anonymizer preview submit` | Anonymizer plugin service (remote)  | Rejected    | Required                 |
+| `nemo anonymizer preview`        | Anonymizer plugin service (remote)  | Rejected    | Required                 |
 
 ## Step 1: Build a `PreviewRequest`
 
-A preview request bundles the `AnonymizerConfig`, the input spec, and optional `model_configs` / `selected_models`.
+A preview request bundles the `AnonymizerConfig`, the input spec, and `model_configs` / `selected_models`.
 
 ```python
 import os
@@ -83,11 +82,11 @@ Field reference:
 | Field             | Type                                  | Notes                                                                                                                  |
 |-------------------|---------------------------------------|------------------------------------------------------------------------------------------------------------------------|
 | `config`          | [`AnonymizerConfig`](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) | The library config. The example uses `Redact`; the plugin also supports `substitute`, `annotate`, `hash`, and `rewrite`. |
-| `data.source`     | string                                | Local path, `http(s)` URL, or fileset reference. See [input source forms](#input-source-forms).                        |
+| `data.source`     | string                                | `http(s)` URL or fileset reference. See [input source forms](#input-source-forms).                                    |
 | `data.text_column`| string                                | Column containing text to anonymize. Defaults to `text`.                                                               |
 | `data.id_column`  | string                                | Optional record identifier column.                                                                                     |
 | `data.data_summary`| string                               | Optional short description passed to Anonymizer library prompts.                                                       |
-| `model_configs`   | list                                  | Data Designer `ModelConfig` entries. `provider` must reference an Inference Gateway provider name (or `workspace/provider`). Omit to use Anonymizer library defaults (CLI local execution only). |
+| `model_configs`   | list                                  | Required Data Designer `ModelConfig` entries. `provider` must reference an Inference Gateway provider name (or `workspace/provider`). |
 | `selected_models` | object                                | Optional `detection` / `replace` / `rewrite` overrides on top of the bundled defaults. Requires `model_configs`.       |
 | `num_records`     | int (≥ 1)                             | Number of records to preview. Defaults to 10.                                                                          |
 
@@ -109,7 +108,16 @@ preview.failed_records     # list[dict] of per-record failures (usually empty)
 preview.display_record(0)  # render record 0 with entity highlights in a notebook
 ```
 
-`AnonymizerResource.preview` calls the plugin service, so the same constraints as `preview submit` apply: use a fileset or `http(s)` source, and include `model_configs`.
+`AnonymizerResource.preview` calls the plugin service: use a fileset or `http(s)` source, and include `model_configs`.
+
+The CLI accepts the same request as a YAML or JSON spec file and streams NDJSON frames:
+
+```bash
+nemo anonymizer preview \
+  --spec-file /tmp/anonymizer-preview.yaml \
+  --workspace "${NMP_WORKSPACE:-default}" \
+  --base-url "${NMP_BASE_URL:-http://localhost:8080}"
+```
 
 <Accordion title="Async client">
 
@@ -127,6 +135,7 @@ preview = await async_sdk.anonymizer.preview(request)
 ```
 
 </Accordion>
+
 ## Step 3: Persist Preview Records
 
 `AnonymizerPreviewResult.dataset` and `trace_dataset` are pandas DataFrames, so save them with standard pandas methods:
@@ -141,60 +150,15 @@ preview.dataset.to_parquet("anonymized-preview.parquet", index=False)
 `AnonymizerPreviewResult` stores everything in memory; nothing is persisted to disk by default. The `dataset` field is a regular pandas DataFrame and can be saved with `to_csv` or `to_parquet`.
 
 </Accordion>
-## Step 4: Run from the CLI (Alternative)
-
-The CLI accepts the same request shape as a YAML spec file. Use `preview run` for local execution (allows local paths, model configs optional) or `preview submit` for the plugin service path (same as `sdk.anonymizer.preview`).
-
-Write the spec to YAML:
-
-```python
-import yaml
-from pathlib import Path
-
-spec_path = Path("/tmp/anonymizer-preview.yaml")
-spec_path.write_text(yaml.safe_dump(request.model_dump(mode="json", exclude_none=True)))
-```
-
-Run preview locally:
-
-```bash
-nemo anonymizer preview run \
-  --spec-file /tmp/anonymizer-preview.yaml \
-  --workspace "${NMP_WORKSPACE:-default}"
-```
-
-Or submit to the plugin service:
-
-```bash
-nemo anonymizer preview submit \
-  --spec-file /tmp/anonymizer-preview.yaml \
-  --workspace "${NMP_WORKSPACE:-default}" \
-  --base-url "${NMP_BASE_URL:-http://localhost:8080}"
-```
-
-Both commands stream NDJSON frames to stdout. Filter with `jq`:
-
-```bash
-nemo anonymizer preview run \
-  --spec-file /tmp/anonymizer-preview.yaml \
-  --workspace "${NMP_WORKSPACE:-default}" \
-  > /tmp/anonymizer-preview.ndjson
-
-jq -R 'fromjson? | select(.kind == "preview_dataset") | .records' \
-  /tmp/anonymizer-preview.ndjson
-```
-
-If `preview submit` returns 404 against the gateway, the plugin service isn't mounted. Restart `nemo services run` so the plugin is discovered and remounts `/apis/anonymizer/...`; see [Setup](/documentation/get-started).
 
 ## Input Source Forms
 
-The plugin accepts three forms for `data.source`:
+The plugin accepts two forms for `data.source`:
 
-| Form                                  | `sdk.anonymizer.preview` / `preview submit` | `preview run` |
-|---------------------------------------|-----------------------------------|---------------|
-| Local path (`/tmp/input.csv`)         | No                                | Yes           |
-| HTTP(S) URL (`https://.../input.csv`) | Yes                               | Yes           |
-| Fileset reference                     | Yes                               | Yes           |
+| Form                                  | `sdk.anonymizer.preview` | `nemo anonymizer preview` |
+|---------------------------------------|--------------------------|---------------------------|
+| HTTP(S) URL (`https://.../input.csv`) | Yes                      | Yes                       |
+| Fileset reference                     | Yes                      | Yes                       |
 
 Fileset references take any of these forms; the workspace and fileset must already exist:
 

--- a/docs/anonymizer/tutorials/run.mdx
+++ b/docs/anonymizer/tutorials/run.mdx
@@ -7,7 +7,7 @@ description: ""
 ---
 <a id="anonymizer-tutorials-run"></a>
 
-This tutorial walks through the `anonymizer.run` job: defining a run spec, executing it locally or on the NeMo Platform Jobs worker, and loading the parquet artifacts it produces.
+This tutorial walks through the `anonymizer.run` job: defining a run spec, submitting it to the NeMo Platform Jobs worker, and loading the parquet artifacts it produces.
 
 For detection, rewrite, and replacement strategy details, see the [open-source library documentation](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs).
 
@@ -23,13 +23,11 @@ Complete the [tutorials prerequisites](/documentation/anonymize-data/tutorials#p
 
 `anonymizer.run` executes the full Anonymizer pipeline on every record of an input file and writes the output as job artifacts.
 
-There are three run commands:
+The CLI exposes one run command:
 
-| Command                       | Where it runs                                | Local paths | `model_configs` required | Artifacts                                              |
-|-------------------------------|----------------------------------------------|-------------|--------------------------|--------------------------------------------------------|
-| `nemo anonymizer run run`     | Local CLI process via generated `is_local` path | Allowed     | Optional                 | Written under `persistent/results/artifacts` locally   |
-| `nemo anonymizer run submit`  | NeMo Platform Jobs worker                | Rejected    | Required                 | Stored in NeMo Platform job artifact storage; pull with `download_artifacts()` |
-| `nemo anonymizer run explain` | Local schema introspection                   | n/a         | n/a                      | Prints job key, submit endpoint, and input/spec schemas |
+| Command                 | Where it runs                 | Local paths | `model_configs` required | Artifacts                                              |
+|-------------------------|-------------------------------|-------------|--------------------------|--------------------------------------------------------|
+| `nemo anonymizer run`   | NeMo Platform Jobs worker     | Rejected    | Required                 | Stored in NeMo Platform job artifact storage; pull with `download_artifacts()` |
 
 Job artifacts (under the `artifacts/` directory):
 
@@ -78,7 +76,7 @@ request = AnonymizerRequest(
 
 ## Step 2: Write the Spec to YAML
 
-The CLI run commands read a YAML spec file. Serialize the `AnonymizerRequest` directly:
+The CLI run command reads a YAML spec file. Serialize the `AnonymizerRequest` directly:
 
 ```python
 import yaml
@@ -90,36 +88,10 @@ spec_path.write_text(yaml.safe_dump(request.model_dump(mode="json", exclude_none
 
 ## Step 3: Run the Job
 
-Choose one execution path. Option A runs in the local CLI process. Option B submits the same request to the NeMo Platform Jobs worker.
-
-### Option A: Run Locally
+Submit the spec to the NeMo Platform Jobs worker:
 
 ```bash
-nemo anonymizer run run --spec-file /tmp/anonymizer-run.yaml
-```
-
-The local job context runs the Anonymizer library `Anonymizer.run(...)` in-process, then writes artifacts through the generated local job results manager.
-
-Expected output:
-
-```json
-{"exit_code": 0}
-```
-
-`run run` does not echo the artifact path on stdout. The local job results manager logs the path to stderr in the form:
-
-```text
-Saved result 'artifacts' to file:///.../persistent/results/artifacts
-```
-
-Use that path in the next step.
-
-### Option B: Submit to the Jobs Worker
-
-To execute the same spec on the NeMo Platform Jobs worker instead of in the CLI process, use `run submit`:
-
-```bash
-nemo anonymizer run submit \
+nemo anonymizer run \
   --spec-file /tmp/anonymizer-run.yaml \
   --workspace "${NMP_WORKSPACE:-default}" \
   --base-url "${NMP_BASE_URL:-http://localhost:8080}"
@@ -140,58 +112,14 @@ sdk = NeMoPlatform(
 job = sdk.anonymizer.run(request)
 ```
 
-Compared to `run run`, the submit path:
-
-- Rejects local file paths in `data.source` — use a fileset reference (`<fileset>#<path>`) or `http(s)` URL.
-- Requires explicit `model_configs` referencing Inference Gateway providers, because the job runs outside the CLI process and cannot inherit Data Designer's locally-defined providers.
+The run path rejects local file paths in `data.source` — use a fileset reference (`<fileset>#<path>`) or `http(s)` URL. It also requires explicit `model_configs` referencing Inference Gateway providers.
 
 ## Step 4: Get Results
 
-### Option A Results: Local Run
-
-For `run run`, the result already exists on the local filesystem. Use the artifact directory printed in stderr:
+Track the platform job first. The job is ready for artifact download when its status is `completed`:
 
 ```bash
-ARTIFACTS_DIR=/path/to/persistent/results/artifacts
-ls "$ARTIFACTS_DIR"
-```
-
-Then load the parquet artifacts from that directory:
-
-```python
-import json
-from pathlib import Path
-
-import pandas as pd
-
-artifacts_dir = Path("/path/to/persistent/results/artifacts")  # from the stderr log
-
-metadata = json.loads((artifacts_dir / "metadata.json").read_text())
-dataset = pd.read_parquet(artifacts_dir / "dataset.parquet", dtype_backend="pyarrow")
-trace = pd.read_parquet(artifacts_dir / "trace.parquet", dtype_backend="pyarrow")
-
-failed_path = artifacts_dir / "failed_records.json"
-failed_records = json.loads(failed_path.read_text()) if failed_path.exists() else []
-
-print(dataset.head())
-print(f"records={len(dataset)} failures={len(failed_records)}")
-```
-
-The trace dataset (and the dataset itself for `annotate` / `substitute` strategies) contains pyarrow-backed `struct<entities: list<...>>` columns. If you need plain Python `dict`/`list` values for JSON output, use `pyarrow.parquet`:
-
-```python
-import pyarrow.parquet as pq
-
-table = pq.read_table(artifacts_dir / "dataset.parquet")
-records = table.slice(0, 5).to_pylist()
-```
-
-### Option B Results: Remote Run
-
-For `run submit`, track the platform job first. The job is ready for artifact download when its status is `completed`:
-
-```bash
-# Replace with the job name printed by `run submit`.
+# Replace with the job name printed by `nemo anonymizer run`.
 nemo jobs get-status <job-name> --workspace "${NMP_WORKSPACE:-default}"
 nemo jobs get-logs <job-name> --workspace "${NMP_WORKSPACE:-default}"
 ```
@@ -241,28 +169,18 @@ failed  = results.load_failed_records()
 
 `AnonymizerJobResults` exposes `load_dataset()`, `load_trace()`, `load_failed_records()`, and `display_record()` over the same underlying files. See [SDK Resources](/documentation/anonymize-data/sdk-resources#anonymizerjobresults).
 
-## Inspect the Schema Without Running
-
-`run explain` prints the job key, submit endpoint, and JSON schemas for `AnonymizerRequest` and the canonical `AnonymizerStepConfig`:
-
-```bash
-nemo anonymizer run explain
-```
-
-This is useful when authoring a spec programmatically or wiring the job into another tool.
-
 ## How the Job Compiles
 
 For each request, the plugin:
 
 1. Validates the Anonymizer library `AnonymizerConfig`.
-2. Validates the input source (rejects local paths on remote execution; checks fileset refs).
+2. Validates the input source (rejects local paths; checks fileset refs).
 3. Validates that `selected_models` overrides also have `model_configs`.
-4. Resolves `model_configs` providers — locally-defined Data Designer providers first, then Inference Gateway providers. Remote execution (`run submit`) resolves only through the Inference Gateway.
+4. Resolves `model_configs` providers through the Inference Gateway.
 5. Renders a unified `model_configs` YAML body for the library.
-6. Stores the resolved providers and YAML in the internal `AnonymizerStepConfig` consumed by the worker (in-process for `run run`, or on the Jobs worker for `run submit`).
+6. Stores the resolved providers and YAML in the internal `AnonymizerStepConfig` consumed by the Jobs worker.
 
-For `run submit`, provider endpoints are re-resolved at runtime so the job uses the in-cluster Inference Gateway address rather than the address captured at submission time.
+Provider endpoints are re-resolved at runtime so the job uses the in-cluster Inference Gateway address rather than the address captured at submission time.
 
 ## Next Steps
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -8582,11 +8582,11 @@ nemo anonymizer [OPTIONS] COMMAND [ARGS]...
 
 *Functions:*
 
-* `preview`: Streaming preview of an Anonymizer config.
+* `preview`: Submit preview over HTTP.
 
 *Jobs:*
 
-* `run`: Anonymize a dataset of records
+* `run`: Submit to a cluster.
 
 #### nemo anonymizer validate
 
@@ -8609,72 +8609,12 @@ nemo anonymizer validate [OPTIONS]
 
 #### nemo anonymizer preview
 
-Streaming preview of an Anonymizer config.
-
-**Usage:**
-
-```shell
-nemo anonymizer preview [OPTIONS] [COMMAND] [ARGS]...
-```
-
-**Help:**
-
-* `--help, -h`: Show this message and exit.
-
-**Commands:**
-
-* `run`: Run preview locally, in-process.
-* `submit`: Submit preview over HTTP.
-
-##### nemo anonymizer preview run
-
-Run preview locally, in-process.
-
-**Usage:**
-
-```shell
-nemo anonymizer preview run [OPTIONS]
-```
-
-**Function Spec:**
-
-* `--config.detect.gliner-threshold <FLOAT>`: GLiNER detection confidence threshold (0.0-1.0).
-* `--config.detect.validation-max-entities-per-call <INTEGER>`: Maximum number of candidate entities included in a single validator LLM call. When a row has more candidates than this, validation is split into chunks that are dispatched (round-robin) across the validator pool.
-* `--config.detect.validation-excerpt-window-chars <INTEGER>`: Number of characters to include before and after a chunk's entity span when building the text excerpt sent to the validator. Bounds the prompt context the validator sees per chunk; it is NOT the LLM's context window limit.
-* `--config.rewrite.privacy-goal.protect`: What to protect (e.g. direct identifiers, quasi-identifiers).
-* `--config.rewrite.privacy-goal.preserve`: What to preserve (e.g. utility, semantic meaning).
-* `--config.rewrite.instructions`: Additional instructions for the rewrite LLM.
-* `--config.rewrite.risk-tolerance`: Preset controlling repair thresholds and review flagging.
-* `--config.rewrite.max-repair-iterations <INTEGER>`: Maximum repair rounds. Set to 0 to disable repair.
-* `--config.rewrite.strict-entity-protection`: If True, requires every entity to receive a protective disposition during sensitivity analysis.
-* `--config.emit-telemetry`: Whether to emit anonymous Anonymizer telemetry events. See the Telemetry section in the README for what is collected and how to opt out at the environment or CLI level.
-* `--data.source`: Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet input file.
-* `--data.text-column`: Column containing text to anonymize.
-* `--data.id-column`: Optional column to use as record identifier.
-* `--data.data-summary`: Short description of the data.
-* `--num-records <INTEGER>`: Override `num_records` in the spec.
-
-**Help:**
-
-* `--help, -h`: Show this message and exit.
-
-**Spec Source:**
-
-* `--spec`: Spec as a JSON string. [default: \{}]
-* `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
-* `--workspace`: Workspace identity passed to the function as ctx.workspace. [default: default]
-
-Function Spec flags are generated from the PreviewRequest Pydantic schema. Precedence: --spec-file (base) → --spec JSON (overlay) → per-flag values (top).
-​
-
-##### nemo anonymizer preview submit
-
 Submit preview over HTTP.
 
 **Usage:**
 
 ```shell
-nemo anonymizer preview submit [OPTIONS]
+nemo anonymizer preview [OPTIONS]
 ```
 
 **Function Spec:**
@@ -8689,7 +8629,7 @@ nemo anonymizer preview submit [OPTIONS]
 * `--config.rewrite.max-repair-iterations <INTEGER>`: Maximum repair rounds. Set to 0 to disable repair.
 * `--config.rewrite.strict-entity-protection`: If True, requires every entity to receive a protective disposition during sensitivity analysis.
 * `--config.emit-telemetry`: Whether to emit anonymous Anonymizer telemetry events. See the Telemetry section in the README for what is collected and how to opt out at the environment or CLI level.
-* `--data.source`: Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet input file.
+* `--data.source`: HTTP(S) URL or fileset reference for a CSV/Parquet input file.
 * `--data.text-column`: Column containing text to anonymize.
 * `--data.id-column`: Optional column to use as record identifier.
 * `--data.data-summary`: Short description of the data.
@@ -8716,90 +8656,12 @@ Function Spec flags are generated from the PreviewRequest Pydantic schema. Prece
 
 #### nemo anonymizer run
 
-Anonymize a dataset of records
-
-**Usage:**
-
-```shell
-nemo anonymizer run [OPTIONS] [COMMAND] [ARGS]...
-```
-
-**Help:**
-
-* `--help, -h`: Show this message and exit.
-
-**Job Spec:**
-
-* `--config.detect.gliner-threshold <FLOAT>`: GLiNER detection confidence threshold (0.0-1.0).
-* `--config.detect.validation-max-entities-per-call <INTEGER>`: Maximum number of candidate entities included in a single validator LLM call. When a row has more candidates than this, validation is split into chunks that are dispatched (round-robin) across the validator pool.
-* `--config.detect.validation-excerpt-window-chars <INTEGER>`: Number of characters to include before and after a chunk's entity span when building the text excerpt sent to the validator. Bounds the prompt context the validator sees per chunk; it is NOT the LLM's context window limit.
-* `--config.rewrite.privacy-goal.protect`: What to protect (e.g. direct identifiers, quasi-identifiers).
-* `--config.rewrite.privacy-goal.preserve`: What to preserve (e.g. utility, semantic meaning).
-* `--config.rewrite.instructions`: Additional instructions for the rewrite LLM.
-* `--config.rewrite.risk-tolerance`: Preset controlling repair thresholds and review flagging.
-* `--config.rewrite.max-repair-iterations <INTEGER>`: Maximum repair rounds. Set to 0 to disable repair.
-* `--config.rewrite.strict-entity-protection`: If True, requires every entity to receive a protective disposition during sensitivity analysis.
-* `--config.emit-telemetry`: Whether to emit anonymous Anonymizer telemetry events. See the Telemetry section in the README for what is collected and how to opt out at the environment or CLI level.
-* `--data.source`: Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet input file.
-* `--data.text-column`: Column containing text to anonymize.
-* `--data.id-column`: Optional column to use as record identifier.
-* `--data.data-summary`: Short description of the data.
-
-**Spec Source:**
-
-* `--spec`: Spec as a JSON string. [default: \{}]
-* `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
-
-**Commands:**
-
-* `run`: Run locally, in-process.
-* `submit`: Submit to a cluster.
-* `explain`: Show input/output schemas.
-
-##### nemo anonymizer run run
-
-Run locally, in-process.
-
-**Usage:**
-
-```shell
-nemo anonymizer run run [OPTIONS]
-```
-
-**Help:**
-
-* `--help, -h`: Show this message and exit.
-
-**Job Spec:**
-
-* `--config.detect.gliner-threshold <FLOAT>`: GLiNER detection confidence threshold (0.0-1.0).
-* `--config.detect.validation-max-entities-per-call <INTEGER>`: Maximum number of candidate entities included in a single validator LLM call. When a row has more candidates than this, validation is split into chunks that are dispatched (round-robin) across the validator pool.
-* `--config.detect.validation-excerpt-window-chars <INTEGER>`: Number of characters to include before and after a chunk's entity span when building the text excerpt sent to the validator. Bounds the prompt context the validator sees per chunk; it is NOT the LLM's context window limit.
-* `--config.rewrite.privacy-goal.protect`: What to protect (e.g. direct identifiers, quasi-identifiers).
-* `--config.rewrite.privacy-goal.preserve`: What to preserve (e.g. utility, semantic meaning).
-* `--config.rewrite.instructions`: Additional instructions for the rewrite LLM.
-* `--config.rewrite.risk-tolerance`: Preset controlling repair thresholds and review flagging.
-* `--config.rewrite.max-repair-iterations <INTEGER>`: Maximum repair rounds. Set to 0 to disable repair.
-* `--config.rewrite.strict-entity-protection`: If True, requires every entity to receive a protective disposition during sensitivity analysis.
-* `--config.emit-telemetry`: Whether to emit anonymous Anonymizer telemetry events. See the Telemetry section in the README for what is collected and how to opt out at the environment or CLI level.
-* `--data.source`: Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet input file.
-* `--data.text-column`: Column containing text to anonymize.
-* `--data.id-column`: Optional column to use as record identifier.
-* `--data.data-summary`: Short description of the data.
-
-**Spec Source:**
-
-* `--spec`: Spec as a JSON string. [default: \{}]
-* `--spec-file <PATH>`: Path to a YAML or JSON spec file (used as base; per-flag values override).
-
-##### nemo anonymizer run submit
-
 Submit to a cluster.
 
 **Usage:**
 
 ```shell
-nemo anonymizer run submit [OPTIONS]
+nemo anonymizer run [OPTIONS]
 ```
 
 **Help:**
@@ -8818,7 +8680,7 @@ nemo anonymizer run submit [OPTIONS]
 * `--config.rewrite.max-repair-iterations <INTEGER>`: Maximum repair rounds. Set to 0 to disable repair.
 * `--config.rewrite.strict-entity-protection`: If True, requires every entity to receive a protective disposition during sensitivity analysis.
 * `--config.emit-telemetry`: Whether to emit anonymous Anonymizer telemetry events. See the Telemetry section in the README for what is collected and how to opt out at the environment or CLI level.
-* `--data.source`: Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet input file.
+* `--data.source`: HTTP(S) URL or fileset reference for a CSV/Parquet input file.
 * `--data.text-column`: Column containing text to anonymize.
 * `--data.id-column`: Optional column to use as record identifier.
 * `--data.data-summary`: Short description of the data.
@@ -8836,25 +8698,6 @@ nemo anonymizer run submit [OPTIONS]
 * `--cluster`: Configured cluster name to resolve via the NeMo CLI config.
 * `--base-url`: Explicit plugin-service base URL (overrides --cluster and all other submit host resolution).
 * `--workspace`: Workspace scope for the submission. [default: default]
-
-##### nemo anonymizer run explain
-
-Show input/output schemas.
-
-**Usage:**
-
-```shell
-nemo anonymizer run explain [OPTIONS]
-```
-
-**Options:**
-
-* `--profile`: Annotate the bundle with this profile. Profile metadata lands in MR 1.4b.
-* `--cluster`: Accepted for forward compatibility; unused in MR 1.4a.
-
-**Help:**
-
-* `--help, -h`: Show this message and exit.
 
 ### nemo evaluator
 

--- a/plugins/nemo-anonymizer/README.md
+++ b/plugins/nemo-anonymizer/README.md
@@ -9,8 +9,8 @@ to detect and replace/rewrite PII in tabular text data.
 
 The plugin exposes an `anonymizer` service, CLI commands under
 `nemo anonymizer`, an SDK accessor on `NeMoPlatform.anonymizer`, a streaming
-`anonymizer.preview` function, and an `anonymizer.run` job that executes
-on the `nmp-cpu-tasks` container image.
+preview API, and an `anonymizer.run` job that executes on the
+`nmp-cpu-tasks` container image.
 
 ## What it does
 
@@ -26,9 +26,8 @@ The plugin provides functional parity with the
 [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer):
 
 - All four replacement strategies + `Rewrite` mode.
-- Input sources: local file path, `http(s)://` URL, or NeMo Platform fileset reference.
-  Local paths are only supported by local execution (`run` verbs).
-- Remote execution requires `model_configs` so requests route through NeMo Platform
+- Input sources: `http(s)://` URL or NeMo Platform fileset reference.
+- Plugin execution requires `model_configs` so requests route through NeMo Platform
   Inference Gateway instead of the library's NVIDIA Build defaults.
 
 ## Installation (developer)
@@ -42,16 +41,12 @@ uv sync
 ## CLI quickstart
 
 ```bash
-nemo anonymizer preview run --spec-file ./preview_spec.yaml
-nemo anonymizer preview submit --spec-file ./preview_spec.yaml --workspace my-workspace
-
-nemo anonymizer run run --spec-file ./run_spec.yaml
-nemo anonymizer run submit --spec-file ./run_spec.yaml --workspace my-workspace
+nemo anonymizer preview --spec-file ./preview_spec.yaml --workspace my-workspace
+nemo anonymizer run --spec-file ./run_spec.yaml --workspace my-workspace
 ```
 
-Local execution can use local files, `http(s)` URLs, filesets, and locally
-defined Data Designer model providers. Remote execution supports `http(s)` URLs
-and filesets, and requires explicit `model_configs`.
+Preview and run specs support `http(s)` URLs and filesets, and require explicit
+`model_configs`.
 
 Fileset input references point at one CSV or Parquet file:
 

--- a/plugins/nemo-anonymizer/openapi/openapi.yaml
+++ b/plugins/nemo-anonymizer/openapi/openapi.yaml
@@ -509,8 +509,7 @@ components:
         source:
           type: string
           title: Source
-          description: Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet
-            input file.
+          description: HTTP(S) URL or fileset reference for a CSV/Parquet input file.
         text_column:
           type: string
           minLength: 1
@@ -532,13 +531,13 @@ components:
       description: 'Plugin boundary input spec.
 
 
-        The upstream ``AnonymizerInput`` validates local path existence at model
+        The upstream ``AnonymizerInput`` validates source locations at model
 
         construction time. The plugin keeps this looser shape at the API boundary
 
-        so fileset refs can be accepted and materialized before the upstream model
+        so HTTP(S) URLs and fileset refs can be accepted and materialized before
 
-        is constructed.'
+        the upstream model is constructed.'
     AnonymizerRequest:
       properties:
         config:
@@ -559,15 +558,15 @@ components:
       title: AnonymizerRequest
       description: "User-facing anonymizer execution request.\n\nFields:\n  config:\
         \           AnonymizerConfig \u2014 replace/rewrite mode + detection params.\n\
-        \  data:             AnonymizerInputSpec \u2014 source URL/path/fileset +\
-        \ text/id columns.\n  model_configs:    DD ``ModelConfig`` list. ``provider``\
+        \  data:             AnonymizerInputSpec \u2014 HTTP(S) URL or fileset source\
+        \ + text/id columns.\n  model_configs:    DD ``ModelConfig`` list. ``provider``\
         \ on each entry must\n                    reference a NeMo Platform inference\
         \ provider name (optionally\n                    ``workspace/provider``).\
-        \ When omitted, the upstream\n                    library defaults are used\
-        \ (which point at\n                    ``build.nvidia.com``); supplying this\
-        \ is the recommended\n                    path on NeMo Platform.\n  selected_models:\
-        \  Optional role->alias overrides. Omitted roles fall back\n             \
-        \       to the upstream library YAML defaults."
+        \ Optional on the request model for\n                    compatibility, but\
+        \ required by plugin preview/run execution\n                    so requests\
+        \ route through NeMo Platform Inference Gateway.\n  selected_models:  Optional\
+        \ role->alias overrides. Omitted roles fall back\n                    to the\
+        \ upstream library YAML defaults."
     AnonymizerStepConfig:
       properties:
         request:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/context.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/context.py
@@ -1,18 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Local/remote runtime context for the Anonymizer plugin."""
+"""Runtime context for the Anonymizer plugin."""
 
 from __future__ import annotations
 
-from typing import Protocol
-
 import data_designer.config as dd
 from data_designer.config.models import ModelProvider as DDModelProvider
-from data_designer_nemo.model_provider import (
-    make_local_first_model_provider_registry,
-    make_model_provider_registry,
-)
+from data_designer_nemo.model_provider import make_model_provider_registry
 from data_designer_nemo.sdk_translation import sync_to_async_sdk
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.input import (
@@ -24,73 +19,24 @@ from nemo_anonymizer_plugin.app.input import (
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
 
 
-class AnonymizerContext(Protocol):
-    async def make_model_providers(
-        self,
-        model_configs: list[dd.ModelConfig] | None,
-        *,
-        require_model_configs: bool,
-    ) -> list[DDModelProvider] | None: ...
-
-    async def prepare_input(self, data: AnonymizerInputSpec) -> PreparedAnonymizerInput: ...
-
-    def validate_input_reference(self, data: AnonymizerInputSpec) -> None: ...
+def require_model_configs_for_execution(model_configs: list[dd.ModelConfig] | None) -> list[dd.ModelConfig]:
+    if not model_configs:
+        raise AnonymizerInvalidConfigError(
+            "model_configs are required for anonymizer execution so requests route through NeMo Platform "
+            "Inference Gateway instead of Anonymizer library defaults."
+        )
+    return model_configs
 
 
-class LocalAnonymizerContext:
+class AnonymizerContext:
     def __init__(self, sdk: AsyncNeMoPlatform | NeMoPlatform, workspace: str):
         self._sdk = sdk
         self._workspace = workspace
 
     async def make_model_providers(
         self,
-        model_configs: list[dd.ModelConfig] | None,
-        *,
-        require_model_configs: bool,
+        model_configs: list[dd.ModelConfig],
     ) -> list[DDModelProvider] | None:
-        if not model_configs:
-            if require_model_configs:
-                raise AnonymizerInvalidConfigError("model_configs are required for this anonymizer execution path.")
-            return None
-        registry = await make_local_first_model_provider_registry(
-            model_configs,
-            sdk=self._sdk,
-            default_workspace=self._workspace,
-        )
-        if registry is None:
-            return None
-        return registry.providers
-
-    async def prepare_input(self, data: AnonymizerInputSpec) -> PreparedAnonymizerInput:
-        return await prepare_anonymizer_input_async(
-            data,
-            sdk=self._sdk,
-            workspace=self._workspace,
-            allow_local_paths=True,
-        )
-
-    def validate_input_reference(self, data: AnonymizerInputSpec) -> None:
-        validate_anonymizer_input_source(data, workspace=self._workspace, allow_local_paths=True)
-
-
-class RemoteAnonymizerContext:
-    def __init__(self, sdk: AsyncNeMoPlatform | NeMoPlatform, workspace: str):
-        self._sdk = sdk
-        self._workspace = workspace
-
-    async def make_model_providers(
-        self,
-        model_configs: list[dd.ModelConfig] | None,
-        *,
-        require_model_configs: bool,
-    ) -> list[DDModelProvider] | None:
-        if not model_configs:
-            if require_model_configs:
-                raise AnonymizerInvalidConfigError(
-                    "model_configs are required for remote anonymizer execution so requests route through NeMo Platform "
-                    "Inference Gateway instead of Anonymizer library defaults."
-                )
-            return None
         async_sdk = sync_to_async_sdk(self._sdk) if isinstance(self._sdk, NeMoPlatform) else self._sdk
         registry = await make_model_provider_registry(
             model_configs,
@@ -114,10 +60,7 @@ class RemoteAnonymizerContext:
 
 
 def create_anonymizer_context(
-    is_local: bool,
     sdk: AsyncNeMoPlatform | NeMoPlatform,
     workspace: str,
 ) -> AnonymizerContext:
-    if is_local:
-        return LocalAnonymizerContext(sdk, workspace)
-    return RemoteAnonymizerContext(sdk, workspace)
+    return AnonymizerContext(sdk, workspace)

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/input.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/input.py
@@ -12,8 +12,8 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-import anyio
 from anonymizer.config.anonymizer_config import AnonymizerInput
+from anyio import to_thread
 from filesets import FilesetPathError, build_fileset_ref, parse_fileset_ref
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
@@ -29,13 +29,13 @@ _SUPPORTED_FILE_SUFFIXES = {".csv", ".parquet"}
 class AnonymizerInputSpec(BaseModel):
     """Plugin boundary input spec.
 
-    The upstream ``AnonymizerInput`` validates local path existence at model
+    The upstream ``AnonymizerInput`` validates source locations at model
     construction time. The plugin keeps this looser shape at the API boundary
-    so fileset refs can be accepted and materialized before the upstream model
-    is constructed.
+    so HTTP(S) URLs and fileset refs can be accepted and materialized before
+    the upstream model is constructed.
     """
 
-    source: str = Field(description="Local path, HTTP(S) URL, or fileset reference for a CSV/Parquet input file.")
+    source: str = Field(description="HTTP(S) URL or fileset reference for a CSV/Parquet input file.")
     text_column: str = Field(default="text", min_length=1, description="Column containing text to anonymize.")
     id_column: str | None = Field(default=None, description="Optional column to use as record identifier.")
     data_summary: str | None = Field(default=None, description="Short description of the data.")
@@ -106,7 +106,7 @@ async def prepare_anonymizer_input_async(
         if sdk is None:
             raise AnonymizerInvalidConfigError("Fileset input requires a NeMo Platform SDK.")
         if isinstance(sdk, NeMoPlatform):
-            return await anyio.to_thread.run_sync(
+            return await to_thread.run_sync(
                 partial(
                     prepare_anonymizer_input,
                     data,
@@ -276,5 +276,5 @@ def _raise_for_unsupported_scheme(source: str) -> None:
     if parsed.scheme and "://" in source:
         raise AnonymizerInvalidConfigError(
             f"Input source {source!r} uses unsupported scheme {parsed.scheme!r}. "
-            "Use an http(s) URL, fileset reference, or local file path."
+            "Use an http(s) URL or fileset reference."
         )

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/model_configs.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/model_configs.py
@@ -4,8 +4,10 @@
 """Build and validate the ``model_configs`` YAML for the Anonymizer library.
 
 ``Anonymizer(model_configs=...)`` takes a unified YAML (string or file path)
-defining the model pool and optional ``selected_models`` overrides; ``None``
-uses bundled defaults. See ``anonymizer/config/default_model_configs/README.md``.
+defining the model aliases and optional ``selected_models`` overrides. The
+standalone library can use bundled defaults when this is omitted, but plugin
+preview/run execution requires explicit entries so providers resolve through
+NeMo Platform Inference Gateway.
 
 The plugin accepts overrides as a loose dict (``SelectedModelsOverrides``)
 because some roles take a scalar and others take a pool, then renders the
@@ -103,8 +105,8 @@ def validate_selected_models_have_model_configs(
 
     Upstream treats ``selected_models`` as a section in the same unified YAML
     document as ``model_configs``. If the plugin accepts overrides without a
-    model pool, the only choices are to silently ignore them or synthesize a
-    local default model pool that bypasses NeMo Platform provider resolution. Failing
+    model pool, the only choices are to silently ignore them or synthesize an
+    implicit default pool that bypasses NeMo Platform provider resolution. Failing
     fast keeps the user's intent explicit.
     """
     if has_selected_model_overrides(selected_models) and not model_configs:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/task_config.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/app/task_config.py
@@ -28,13 +28,12 @@ class AnonymizerRequest(BaseModel):
 
     Fields:
       config:           AnonymizerConfig — replace/rewrite mode + detection params.
-      data:             AnonymizerInputSpec — source URL/path/fileset + text/id columns.
+      data:             AnonymizerInputSpec — HTTP(S) URL or fileset source + text/id columns.
       model_configs:    DD ``ModelConfig`` list. ``provider`` on each entry must
                         reference a NeMo Platform inference provider name (optionally
-                        ``workspace/provider``). When omitted, the upstream
-                        library defaults are used (which point at
-                        ``build.nvidia.com``); supplying this is the recommended
-                        path on NeMo Platform.
+                        ``workspace/provider``). Optional on the request model for
+                        compatibility, but required by plugin preview/run execution
+                        so requests route through NeMo Platform Inference Gateway.
       selected_models:  Optional role->alias overrides. Omitted roles fall back
                         to the upstream library YAML defaults.
     """
@@ -70,7 +69,7 @@ class AnonymizerStepConfig(BaseModel):
 
     request: AnonymizerRequest
     # YAML body to hand to ``Anonymizer(model_configs=...)`` after the service
-    # resolved providers and roles. Empty string means "use library defaults".
+    # resolved providers and roles.
     model_configs_yaml: str
     # Provider definitions resolved against NeMo Platform. Each entry already points at
     # the Inference Gateway URL with the right auth headers. The task will pass

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/cli.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/cli.py
@@ -5,16 +5,14 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, ClassVar, Optional, cast
+from typing import Any, ClassVar, Optional
 
 import typer
 import yaml
 from anonymizer.config.anonymizer_config import AnonymizerConfig
 from nemo_anonymizer_plugin.app.upstream_logging import preserve_root_logging
 from nemo_platform_plugin.cli import NemoCLI
-from nemo_platform_plugin.job import NemoJob
 
 
 class AnonymizerCLI(NemoCLI):
@@ -34,27 +32,6 @@ class AnonymizerCLI(NemoCLI):
 
         app.command("validate")(validate_command)
         return app
-
-    def update_job_cli(self, job_cls: type[NemoJob], group: typer.Typer) -> None:
-        if job_cls.name != "run":
-            return
-
-        run_command = next((command for command in group.registered_commands if command.name == "run"), None)
-        if run_command is None or run_command.callback is None:
-            return
-
-        run_callback = cast(Callable[..., None], run_command.callback)
-        signature = getattr(run_callback, "__signature__", None)
-        if signature is None:
-            return
-
-        def _collapsed_run(typer_ctx: typer.Context, **kwargs: object) -> None:
-            if typer_ctx.invoked_subcommand is not None:
-                return
-            run_callback(typer_ctx, **kwargs)
-
-        setattr(_collapsed_run, "__signature__", signature)
-        group.callback(invoke_without_command=True)(_collapsed_run)
 
 
 def _load_yaml(path: Path) -> dict[str, Any]:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/_preview_worker.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/_preview_worker.py
@@ -66,9 +66,11 @@ def _make_anonymizer(
     model_configs_yaml: str,
     dd_providers: list[DDModelProvider] | None,
 ) -> Anonymizer:
+    if not model_configs_yaml:
+        raise RuntimeError("Anonymizer preview requires resolved model_configs.")
     with preserve_root_logging():
         return Anonymizer(
-            model_configs=model_configs_yaml or None,
+            model_configs=model_configs_yaml,
             model_providers=dd_providers,
         )
 
@@ -89,7 +91,10 @@ def _to_jsonable_records(df: pd.DataFrame) -> list[dict[str, Any]]:
             safe[col] = safe[col].apply(
                 lambda v: None if (v is None or (isinstance(v, float) and math.isnan(v))) else v
             )
-    return json.loads(safe.to_json(orient="records", date_format="iso", default_handler=str))
+    records_json = safe.to_json(orient="records", date_format="iso", default_handler=str)
+    if records_json is None:
+        return []
+    return json.loads(records_json)
 
 
 def _get_original_text_column(df: pd.DataFrame, *, fallback: str) -> str:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/preview.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/functions/preview.py
@@ -14,7 +14,11 @@ import anyio.from_thread
 import anyio.to_thread
 from anyio.lowlevel import current_token
 from fastapi import HTTPException, status
-from nemo_anonymizer_plugin.app.context import AnonymizerContext, create_anonymizer_context
+from nemo_anonymizer_plugin.app.context import (
+    AnonymizerContext,
+    create_anonymizer_context,
+    require_model_configs_for_execution,
+)
 from nemo_anonymizer_plugin.app.errors import AnonymizerInternalError, AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec, PreparedAnonymizerInput
 from nemo_anonymizer_plugin.app.model_configs import (
@@ -78,6 +82,7 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
     description: ClassVar[str] = "Streaming preview of an Anonymizer config."
     spec_schema: ClassVar[type[BaseModel]] = PreviewSpec
     frame_schema: ClassVar[Any] = PreviewFrame
+    generate_legacy_verbs: ClassVar[bool] = False
 
     async def run(
         self,
@@ -85,26 +90,20 @@ class PreviewFunction(NemoFunction[PreviewSpec]):
         *,
         ctx: FunctionContext,
         async_sdk: AsyncNeMoPlatform,
-        is_local: bool = False,
     ) -> AsyncIterator[BaseModel]:
         num_records = _validate_and_get_num_records(spec.num_records)
         validate_selected_models_have_model_configs(
             model_configs=spec.model_configs,
             selected_models=spec.selected_models,
         )
+        model_configs = require_model_configs_for_execution(spec.model_configs)
 
-        anon_ctx = create_anonymizer_context(is_local, async_sdk, ctx.workspace)
-        dd_providers = await anon_ctx.make_model_providers(
-            spec.model_configs,
-            require_model_configs=not is_local,
+        anon_ctx = create_anonymizer_context(async_sdk, ctx.workspace)
+        dd_providers = await anon_ctx.make_model_providers(model_configs)
+        model_configs_yaml = build_model_configs_yaml(
+            model_configs=model_configs,
+            selected_models=spec.selected_models,
         )
-        if spec.model_configs:
-            model_configs_yaml = build_model_configs_yaml(
-                model_configs=spec.model_configs,
-                selected_models=spec.selected_models,
-            )
-        else:
-            model_configs_yaml = ""
         async with _prepare_input(anon_ctx, spec.data) as prepared_input:
             send_stream, receive_stream = anyio.create_memory_object_stream[BaseModel]()
             token = current_token()

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/jobs/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/jobs/run.py
@@ -11,7 +11,7 @@ from anonymizer.config.anonymizer_config import AnonymizerConfig
 from anonymizer.interface.anonymizer import Anonymizer
 from anonymizer.interface.errors import InvalidConfigError
 from data_designer_nemo.errors import NDDInvalidConfigError
-from nemo_anonymizer_plugin.app.context import create_anonymizer_context
+from nemo_anonymizer_plugin.app.context import create_anonymizer_context, require_model_configs_for_execution
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.model_configs import (
     build_model_configs_yaml,
@@ -42,6 +42,7 @@ class RunJob(NemoJob):
     name: ClassVar[str] = "run"
     description: ClassVar[str] = "Anonymize a dataset of records"
     container: ClassVar[str] = "cpu-tasks"
+    generate_legacy_verbs: ClassVar[bool] = False
 
     input_spec_schema = AnonymizerRequest
     spec_schema = AnonymizerStepConfig
@@ -56,8 +57,9 @@ class RunJob(NemoJob):
         async_sdk: AsyncNeMoPlatform,
         is_local: bool,
     ) -> BaseModel:  # AnonymizerStepConfig
+        del entity_client, is_local
         input_spec = cast(AnonymizerRequest, input_spec)
-        anon_ctx = create_anonymizer_context(is_local, async_sdk, workspace)
+        anon_ctx = create_anonymizer_context(async_sdk, workspace)
 
         try:
             cls._validate_anonymizer_config(input_spec.config)
@@ -66,18 +68,13 @@ class RunJob(NemoJob):
                 model_configs=input_spec.model_configs,
                 selected_models=input_spec.selected_models,
             )
+            model_configs = require_model_configs_for_execution(input_spec.model_configs)
 
-            dd_providers = await anon_ctx.make_model_providers(
-                input_spec.model_configs,
-                require_model_configs=not is_local,
+            dd_providers = await anon_ctx.make_model_providers(model_configs)
+            yaml_body = build_model_configs_yaml(
+                model_configs=model_configs,
+                selected_models=input_spec.selected_models,
             )
-            if input_spec.model_configs:
-                yaml_body = build_model_configs_yaml(
-                    model_configs=input_spec.model_configs,
-                    selected_models=input_spec.selected_models,
-                )
-            else:
-                yaml_body = ""
         except (AnonymizerInvalidConfigError, NDDInvalidConfigError) as e:
             raise PlatformJobCompilationError(str(e)) from e
 
@@ -135,10 +132,9 @@ class RunJob(NemoJob):
         *,
         ctx: JobContext,
         sdk: NeMoPlatform,
-        is_local: bool = False,
     ) -> dict:
         step_config = AnonymizerStepConfig.model_validate(config)
-        return {"exit_code": run_step_config(step_config, ctx=ctx, sdk=sdk, is_local=is_local)}
+        return {"exit_code": run_step_config(step_config, ctx=ctx, sdk=sdk)}
 
 
 def _make_env_vars() -> list[EnvironmentVariable]:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/SKILL.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/SKILL.md
@@ -21,8 +21,8 @@ $ARGUMENTS
 
 The plugin wraps the [NVIDIA NeMo Anonymizer library](https://github.com/NVIDIA-NeMo/Anonymizer) and exposes:
 
-- An `anonymizer.preview` streaming function (small samples, fast iteration). Use `nemo anonymizer preview run` for local execution and `nemo anonymizer preview submit` for platform execution.
-- An `anonymizer.run` job for full-dataset execution. Use `nemo anonymizer run run` for local execution and `nemo anonymizer run submit` for Jobs-worker execution.
+- An `anonymizer.preview` streaming function (small samples, fast iteration) available through the NeMo Platform SDK/service and `nemo anonymizer preview`.
+- An `anonymizer.run` job for full-dataset execution. Use `nemo anonymizer run` for Jobs-worker execution.
 - A `nemo anonymizer validate` command (synchronous config validation).
 
 # Workflow
@@ -36,21 +36,20 @@ Read **only** the workflow file that matches the selected mode, then follow it:
 
 # Rules
 
-- Prefer CLI surfaces. Generate YAML specs and run `nemo anonymizer ...` commands unless the user explicitly asks for Python.
-- Always iterate via `nemo anonymizer preview run` or `nemo anonymizer preview submit` before running the full job. Previews are cheap and stream a small sample (default 10 records) with full detection traces.
+- Use the SDK or `nemo anonymizer preview` for preview, and `nemo anonymizer run` for full runs. Generate YAML specs unless the user explicitly asks for Python.
+- Always iterate via `sdk.anonymizer.preview(...)` or `nemo anonymizer preview` before running the full job. Previews are cheap and stream a small sample (default 10 records) with full detection traces.
 - When you include `config`, pick exactly one of `replace` (Annotate/Hash/Redact/Substitute) or `rewrite` on the `AnonymizerConfig`. Not both. Do not claim `config` is required for every flow; the Anonymizer library owns default config behavior and strategy semantics. See `references/replace-strategies.md` for plugin request formatting and the [library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) for semantics.
 - The input must be a single CSV or Parquet file. `text_column` defaults to `text`; set it explicitly when the free-text column has another name. If the dataset has a stable record id, also set `id_column`. See `references/inputs.md`.
-- `model_configs` is optional for local execution (`preview run` / `run run`); when omitted, the Anonymizer library defaults are used.
-- The current plugin-service / Jobs paths (`preview submit`, `run submit`) require `model_configs` so requests route through the NeMo Platform Inference Gateway. See `references/model-configs.md`.
+- Preview and run execution require `model_configs` so requests route through the NeMo Platform Inference Gateway. See `references/model-configs.md`.
 - `selected_models` overrides are only valid when `model_configs` is also supplied; aliases must resolve against that pool.
-- Local file paths only work for local execution. Plugin-service / Jobs execution requires an `http(s)` URL or a fileset reference (`<workspace>/<fileset>#<path>` or `fileset://...`).
+- Plugin-service / Jobs execution requires an `http(s)` URL or a fileset reference (`<workspace>/<fileset>#<path>` or `fileset://...`).
 - If a spec file matching the user's description already exists in the working directory, ask whether to edit it or create a new one.
 
 # Usage Tips and Common Pitfalls
 
 - **Replacement strategies need a discriminated payload.** Hand-written YAML specs must include `kind: redact` (or `annotate` / `hash` / `substitute`) inside the `replace` block.
 - **Substitute and rewrite need LLM-backed model aliases.** For plugin-service / Jobs execution they must be backed by providers declared in `model_configs`. For library-level details, refer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills.
-- **Spec files are YAML, not JSON.** `nemo anonymizer preview run --spec-file <path>` and `nemo anonymizer run run --spec-file <path>` both load YAML.
+- **Spec files may be YAML or JSON.** YAML is preferred for generated specs. `nemo anonymizer preview --spec-file <path>` and `nemo anonymizer run --spec-file <path>` load either format.
 - **Run results are artifacts.** The job writes an artifacts directory containing `dataset.parquet`, `trace.parquet`, `metadata.json`, and optional `failed_records.json`.
 - **Fileset refs use `#` to point at a file.** `<workspace>/<fileset>#<path>`, `<fileset>#<path>` (uses request workspace), or `fileset://<workspace>/<fileset>#<path>`. The `#` fragment must point at a `.csv` or `.parquet` file.
 - **Detection labels.** Keep the Anonymizer library default label set unless the user asks to restrict detection. Refer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills for supported label/config details.
@@ -59,13 +58,13 @@ Read **only** the workflow file that matches the selected mode, then follow it:
 # Troubleshooting
 
 - **`nemo anonymizer` CLI not found:** The plugin isn't installed in this environment. From the repo root, run `uv sync`; the root workspace includes the Anonymizer plugin. Confirm with `nemo anonymizer --help`. Do not install anything without the user's permission.
-- **`nemo anonymizer preview submit` returns 404:** The plugin service isn't mounted on the gateway. `nemo setup` does not auto-mount it. Re-run `nemo services run` (no `--services` flag) and verify the routes show up under `/apis/anonymizer/` in the OpenAPI listing. See `docs/anonymizer/tutorials/index.mdx` Prerequisites.
-- **`model_configs are required for remote execution`:** `preview submit` and `run submit` go through plugin-service / Jobs paths. Add `model_configs` referencing an Inference Gateway provider; use the inference/model-provider docs or skill for provider discovery.
-- **`Input source ... is a local path`:** Plugin-service execution rejects local paths. Either upload the file to a fileset, use an `http(s)` URL, or switch to `preview run` / `run run` (local execution).
+- **Preview returns 404:** The plugin service isn't mounted on the gateway. `nemo setup` does not auto-mount it. Re-run `nemo services run` (no `--services` flag) and verify `GET /apis/anonymizer/v2/workspaces/<workspace>/entity-labels` succeeds. See `docs/anonymizer/tutorials/index.mdx` Prerequisites.
+- **`model_configs are required for anonymizer execution`:** Preview and run go through plugin-service / Jobs paths. Add `model_configs` referencing an Inference Gateway provider; use the inference/model-provider docs or skill for provider discovery.
+- **`Input source ... is a local path`:** Plugin-service execution rejects local paths. Upload the file to a fileset or use an `http(s)` URL.
 - **`Fileset input ... must resolve to a .csv or .parquet file`:** The `#<path>` fragment points at a directory or a non-CSV/Parquet file. Point it at a single file.
 - **Config validation failed (HTTP 422):** Run `nemo anonymizer validate --config <yaml> [--model-configs <yaml>]` to surface the exact error synchronously. Common causes: mixing `replace` and `rewrite`, picking `Substitute` without a `replacement_generator` alias in `model_configs`, fileset path missing the `#<file>` fragment.
 - **`selected_models requires model_configs ...`:** The user passed `selected_models` overrides without an explicit model pool. Either drop the overrides or define `model_configs` with the aliases the overrides reference.
-- **User asks to run remotely:** Use `nemo anonymizer run submit`. Ensure `data.source` is an HTTP(S) URL or fileset reference and `model_configs` is present.
+- **User asks to run remotely:** Use `nemo anonymizer run`. Ensure `data.source` is an HTTP(S) URL or fileset reference and `model_configs` is present.
 - **Empty preview dataset / "No preview dataset received":** Check the log frames printed by the preview stream. Most commonly the detection model alias is wrong, or the dataset has zero rows after column resolution.
 
 # Output Template
@@ -75,19 +74,17 @@ Generate a YAML spec file in the current directory describing the request. Name 
 **Preview spec** — fast iteration over a small sample:
 
 ```yaml
-# Local:  nemo anonymizer preview run    --spec-file ./<this_file>.yaml --workspace <ws>
-# Remote: nemo anonymizer preview submit --spec-file ./<this_file>.yaml --workspace <ws>
+# Use with sdk.anonymizer.preview(...) or nemo anonymizer preview --spec-file ./<this_file>.yaml --workspace <ws>
 config:
   replace:
     kind: redact            # one of: redact, annotate, hash, substitute
     format_template: "[REDACTED_{label}]"
 data:
-  source: "anonymizer-inputs#anonymizer-input.csv"   # local path, http(s) URL, or fileset ref
+  source: "anonymizer-inputs#anonymizer-input.csv"   # http(s) URL or fileset ref
   text_column: biography
   id_column: id
 num_records: 5
-# Required for plugin-service execution (`preview submit`),
-# optional for local `preview run`:
+# Required for every plugin preview request:
 model_configs:
   - alias: gliner-pii-detector
     provider: nvidia-build
@@ -109,8 +106,7 @@ model_configs:
 **Run spec** — full-dataset job:
 
 ```yaml
-# Local:  nemo anonymizer run run    --spec-file ./<this_file>.yaml
-# Remote: nemo anonymizer run submit --spec-file ./<this_file>.yaml --workspace <ws>
+# Run with: nemo anonymizer run --spec-file ./<this_file>.yaml --workspace <ws>
 config:
   replace:
     kind: redact
@@ -119,7 +115,7 @@ data:
   source: "anonymizer-inputs#anonymizer-input.csv"
   text_column: biography
   id_column: id
-# Required for `run submit`, optional for `run run`:
+# Required for every plugin run request:
 model_configs:
   - alias: gliner-pii-detector
     provider: nvidia-build
@@ -132,4 +128,4 @@ model_configs:
     model: nvidia/nemotron-3-nano-30b-a3b
 ```
 
-Include only the bits the task requires — e.g., omit `model_configs` for purely local previews, omit `selected_models` unless overrides are needed, and use `Substitute` / `rewrite` only when the user wants LLM-generated replacements or holistic rewriting.
+Include only the bits the task requires — keep `model_configs` in every plugin preview and run request, omit `selected_models` unless overrides are needed, and use `Substitute` / `rewrite` only when the user wants LLM-generated replacements or holistic rewriting. Exceptions for omitted `model_configs` apply only to standalone Anonymizer library workflows outside this plugin skill.

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/inputs.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/inputs.md
@@ -7,7 +7,7 @@ The anonymizer reads a **single CSV or Parquet file**. Configure it via the `dat
 
 ```yaml
 data:
-  source: <local-path | http(s)-url | fileset-ref>
+  source: <http(s)-url | fileset-ref>
   text_column: text                # optional; defaults to "text"
   id_column: id                    # optional, stable record identifier
   data_summary: "Short free-text records; English."   # optional, helps LLMs
@@ -15,13 +15,12 @@ data:
 
 ## Source kinds
 
-| Kind     | Example                                          | Supported by                                                                              |
-|----------|--------------------------------------------------|-------------------------------------------------------------------------------------------|
-| Local    | `/tmp/input.csv` or `./data/input.parquet` | **Local execution only** (`preview run`, `run run`). |
-| HTTP(S)  | `https://example.com/input.csv`            | Local (`preview run`, `run run`) and plugin-service / Jobs execution (`preview submit`, `run submit`). |
-| Fileset  | `<workspace>/<fileset>#<path>`                   | Local (`preview run`, `run run`) and plugin-service / Jobs execution (`preview submit`, `run submit`). |
+| Kind     | Example                        | Supported by                       |
+|----------|--------------------------------|------------------------------------|
+| HTTP(S)  | `https://example.com/input.csv` | SDK preview, `nemo anonymizer preview`, and `nemo anonymizer run`. |
+| Fileset  | `<workspace>/<fileset>#<path>` | SDK preview, `nemo anonymizer preview`, and `nemo anonymizer run`. |
 
-Plugin-service / Jobs execution runs outside the caller's filesystem — use HTTP(S) URLs or fileset refs for those surfaces.
+Preview and run execution happen in the plugin service or Jobs worker, outside the caller's filesystem. Use HTTP(S) URLs or fileset refs.
 
 ## Fileset references
 
@@ -45,15 +44,7 @@ For upload commands, use the platform files CLI docs or `nemo-files` skill. Then
 
 Run jobs save a working artifacts directory; the anonymized dataset is one file inside that directory.
 
-### Where artifacts land for `run run`
-
-`nemo anonymizer run run` prints `{"exit_code": 0}` on success. The local job results manager logs the artifact directory to **stderr** in the form:
-
-```text
-Saved result 'artifacts' to file:///.../persistent/results/artifacts
-```
-
-Layout under that `artifacts/` directory:
+The job stores an `artifacts/` result with this layout:
 
 | File                  | Description                                                                |
 |-----------------------|----------------------------------------------------------------------------|
@@ -62,28 +53,11 @@ Layout under that `artifacts/` directory:
 | `metadata.json`       | Run metadata (includes the original text column name).                     |
 | `failed_records.json` | Per-record failures with reasons. Only written when at least one record failed. |
 
-### Loading the local artifacts
-
-Read the parquet files directly from the artifacts directory:
-
-```python
-import json
-from pathlib import Path
-import pandas as pd
-
-artifacts_dir = Path("/path/to/persistent/results/artifacts")
-metadata = json.loads((artifacts_dir / "metadata.json").read_text())
-dataset = pd.read_parquet(artifacts_dir / "dataset.parquet", dtype_backend="pyarrow")
-trace   = pd.read_parquet(artifacts_dir / "trace.parquet",   dtype_backend="pyarrow")
-failed_path = artifacts_dir / "failed_records.json"
-failed_records = json.loads(failed_path.read_text()) if failed_path.exists() else []
-```
-
 The trace dataset (and `dataset.parquet` for `annotate` / `substitute` strategies) contains pyarrow-backed `struct<entities: list<...>>` columns. If you need plain Python `dict`/`list` values for JSON output, read via `pyarrow.parquet.read_table(...).to_pylist()` instead of `pd.read_parquet`.
 
-### Remote CLI retrieval
+### CLI Retrieval
 
-For `run submit`, use the standard Jobs CLI after `nemo anonymizer run submit` prints the job name:
+Use the standard Jobs CLI after `nemo anonymizer run` prints the job name:
 
 ```bash
 nemo jobs get-status <job-name> --workspace <ws>

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/model-configs.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/model-configs.md
@@ -7,14 +7,13 @@
 
 ## When is `model_configs` required?
 
-| Surface                            | Status                  | `model_configs` required?                                                                                  |
-|------------------------------------|-------------------------|------------------------------------------------------------------------------------------------------------|
-| `nemo anonymizer preview run`      | Available (local)       | No — Anonymizer library defaults are used.                                                                 |
-| `nemo anonymizer run run`          | Available (local)       | No — Anonymizer library defaults are used.                                                                 |
-| `nemo anonymizer preview submit`   | Available (plugin svc)  | **Yes** — needed so requests route through the NeMo Platform Inference Gateway instead of build.nvidia.com directly. |
-| `nemo anonymizer run submit`       | Available (Jobs worker) | **Yes** — the job routes through the NeMo Platform Inference Gateway.                                                |
-| Strategy is `Substitute`           | n/a                     | Effectively yes for plugin-service / Jobs execution; provide a `replacement_generator`-capable alias.      |
-| Mode is `rewrite`                  | n/a                     | Effectively yes for plugin-service / Jobs execution; provide aliases for the Anonymizer library rewrite roles. |
+| Surface                  | Status                  | `model_configs` required?                                                                                  |
+|--------------------------|-------------------------|------------------------------------------------------------------------------------------------------------|
+| `sdk.anonymizer.preview` | Available (SDK/service) | **Yes** — needed so requests route through the NeMo Platform Inference Gateway instead of build.nvidia.com directly. |
+| `nemo anonymizer preview` | Available (plugin svc) | **Yes** — same service path as SDK preview.                                                                |
+| `nemo anonymizer run`    | Available (Jobs worker) | **Yes** — the job routes through the NeMo Platform Inference Gateway.                                      |
+| Strategy is `Substitute` | n/a                     | Provide a `replacement_generator`-capable alias.                                                           |
+| Mode is `rewrite`        | n/a                     | Provide aliases for the Anonymizer library rewrite roles.                                                  |
 
 `selected_models` is **only** legal alongside `model_configs` — passing overrides without a pool raises `selected_models requires model_configs so aliases can be resolved.`
 
@@ -54,9 +53,7 @@ Only emit a section if you actually want to override its defaults — overrides 
 
 ## Common patterns
 
-**Local default-everything preview** — no `model_configs`, no `selected_models`. Lets the Anonymizer library use its bundled defaults. Works for `preview run` and `run run`.
-
-**Plugin-service default model pool** (`preview submit`, `run submit`) — provide the aliases used by the Anonymizer library defaults:
+**Default model pool** (`sdk.anonymizer.preview`, `nemo anonymizer preview`, `nemo anonymizer run`) — provide the aliases used by the Anonymizer library defaults:
 
 ```yaml
 model_configs:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/preview-review.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/preview-review.md
@@ -5,11 +5,11 @@
 
 Use this when the user has run a preview and asked you to evaluate plugin results before committing to a full run.
 
-Reference docs: `docs/anonymizer/tutorials/preview.mdx` (frame schema, surfaces, CLI usage). For detection quality, strategy behavior, and rewrite tuning, defer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills.
+Reference docs: `docs/anonymizer/tutorials/preview.mdx` (frame schema, SDK usage, and basic CLI usage). For detection quality, strategy behavior, and rewrite tuning, defer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills.
 
 ## What you get back
 
-`nemo anonymizer preview run` and `nemo anonymizer preview submit` stream newline-delimited JSON frames with the same logical data:
+`sdk.anonymizer.preview` and `nemo anonymizer preview` stream frames with this logical data:
 
 - `preview_dataset` — public anonymized records.
 - `trace_dataset` — trace records with detection details.
@@ -19,11 +19,9 @@ Reference docs: `docs/anonymizer/tutorials/preview.mdx` (frame schema, surfaces,
 ## Plugin Review Checklist
 
 1. Surface any `failed_records` and the associated reasons.
-2. Confirm the preview used the intended execution surface:
-   - Local paths require `preview run`.
-   - `preview submit` requires HTTP(S) or fileset input and explicit `model_configs`.
+2. Confirm the preview used an HTTP(S) or fileset input and explicit `model_configs`.
 3. Confirm `model_configs` aliases line up with any `selected_models` overrides. For detection overrides, use Anonymizer library role names such as `entity_detector` and `entity_validator`.
-4. Ask the user to share CLI NDJSON frames for a specific record when you need to inspect exact spans and labels.
+4. Ask the user to share preview frames for a specific record when you need to inspect exact spans and labels.
 5. If quality needs tuning, refer to the Anonymizer library docs/skills for label selection, thresholds, replacement strategy parameters, and rewrite settings.
 
-When the preview is acceptable, derive the run spec by dropping `num_records`. Run writes artifacts. Use `nemo anonymizer run run` for local execution or `nemo anonymizer run submit` for platform execution.
+When the preview is acceptable, derive the run spec by dropping `num_records`. Run writes artifacts through `nemo anonymizer run`.

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/replace-strategies.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/replace-strategies.md
@@ -9,7 +9,7 @@ Plugin notes:
 
 - When specifying `config`, choose either `config.replace` or `config.rewrite`, not both.
 - Hand-written YAML specs must include a `kind` discriminator inside `replace`.
-- Plugin-service / Jobs execution requires `model_configs`; local `preview run` / `run run` can omit it and use Anonymizer library defaults.
+- Preview/run execution requires `model_configs` so provider calls route through NeMo Platform Inference Gateway.
 
 Minimal YAML shape:
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/rewrite-mode.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/references/rewrite-mode.md
@@ -5,10 +5,10 @@
 
 Use this reference only for plugin execution concerns. The [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) and library skills own rewrite semantics, privacy-goal fields, risk tuning, and recommended prompt wording.
 
-For plugin-service / Jobs execution (`preview submit`, `run submit`):
+For preview/run execution (`sdk.anonymizer.preview`, `nemo anonymizer run`):
 
 - Include `model_configs` so rewrite model calls route through NeMo Platform Inference Gateway providers.
-- Use HTTP(S) URLs or fileset references for `data.source`; local paths only work with `preview run` / `run run`.
+- Use HTTP(S) URLs or fileset references for `data.source`.
 - Only include `selected_models.rewrite` when you need to override library defaults, and use Anonymizer library role names exactly.
 
 Example role override shape:

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/autopilot.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/autopilot.md
@@ -8,6 +8,7 @@ The user has signaled they don't want to answer questions. Make defensible decis
 Source of truth for defaults: `docs/anonymizer/tutorials/index.mdx` and `docs/anonymizer/tutorials/{preview,run}.mdx`. If anything below conflicts with the docs, the docs win.
 
 1. **Resolve CLI command** — Run `command -v nemo 2>/dev/null || (test -x .venv/bin/nemo && realpath .venv/bin/nemo) || echo CLI_NOT_FOUND`.
+   - If the output is a path, make sure that directory is on `PATH`, then use plain `nemo ...` commands below.
    - If the output is `CLI_NOT_FOUND`, STOP and follow the Troubleshooting section in SKILL.md.
 2. **Decide defaults** without asking. Use these unless the user's prompt obviously requires otherwise:
    - **Strategy**: `Redact` with `format_template="[REDACTED_{label}]"`. Use `Substitute` only if the user explicitly says they want realistic synthetic replacements. Use `rewrite` only if the user explicitly mentions rewriting / a privacy goal / utility tradeoff.
@@ -15,27 +16,26 @@ Source of truth for defaults: `docs/anonymizer/tutorials/index.mdx` and `docs/an
    - **`text_column`**: pick the column most plausibly holding free text — `text`, `biography`, `body`, `message`, `content`, `description`, in that order. If you genuinely can't tell, ask one short question.
    - **`id_column`**: include an obvious id column (`id`, `record_id`) if present; otherwise omit.
    - **`num_records`**: 5 for preview.
-   - **Preview surface**: `nemo anonymizer preview run` (local) if the input is a local file path. Otherwise (HTTP(S) URL or fileset ref), `nemo anonymizer preview submit`.
-   - **Run surface**: `nemo anonymizer run run` for local paths. Use `nemo anonymizer run submit` only when the user explicitly asks for platform/cluster execution or provides a non-local input and model configs.
-   - **Model configs**: only set when using a plugin-service surface (`preview submit` / `run submit`) or when the strategy is `Substitute` / `rewrite`. When required, default to `nvidia-build` as the provider (or the provider the user named) with these aliases:
+   - **Preview surface**: `nemo anonymizer preview` through the plugin service, or `sdk.anonymizer.preview` if the user asked for Python.
+   - **Run surface**: `nemo anonymizer run`.
+   - **Input source**: use an HTTP(S) URL or fileset reference. If the user gave a local file path, ask them to upload it to a fileset or host it first.
+   - **Model configs**: always include them. Default to `nvidia-build` as the provider (or the provider the user named) with these aliases:
      - `gliner-pii-detector` → `nvidia/gliner-pii`
      - `gpt-oss-120b` → `openai/gpt-oss-120b`
      - `nemotron-30b-thinking` → `nvidia/nemotron-3-nano-30b-a3b`
-3. **(If using a plugin-service surface) Confirm the service is mounted.** Run `curl -s http://localhost:8080/openapi.json | jq -r '.paths | keys[]' | grep '^/apis/anonymizer/'`. If nothing prints, tell the user to run `nemo services run` (no `--services` flag) — `nemo setup` does not mount this plugin — then continue. Skip this step entirely for `preview run` / `run run`.
+3. **Confirm the plugin service is mounted.** Run `nmp_base_url="${NMP_BASE_URL:-http://localhost:8080}"; curl -sf "${nmp_base_url%/}/apis/anonymizer/v2/workspaces/${NMP_WORKSPACE:-default}/entity-labels" | jq -r '.data[0] // empty'`. If nothing prints, tell the user to run `nemo services run` (no `--services` flag) — `nemo setup` does not mount this plugin — then continue.
 4. **Build** — Write a YAML preview spec following the Output Template in SKILL.md. Default filename: `<text_column>_preview_spec.yaml` (e.g. `biography_preview_spec.yaml`).
-5. **Preview** — Run the surface chosen in step 2:
-   - Local: `nemo anonymizer preview run --spec-file <path> --workspace <ws>`
-   - Plugin service: `nemo anonymizer preview submit --spec-file <path> --workspace <ws>`
+5. **Preview** — Run `nemo anonymizer preview --spec-file <path> --workspace <ws>` with the preview spec.
 
    Briefly summarize the preview result — entities detected per label, any `failed_records`, and a one-record before/after example.
-6. **Generate run spec** — Without re-prompting, also produce a run YAML named `<text_column>_run_spec.yaml`. It mirrors the preview spec but drops `num_records`. Run writes artifacts, not a dataset entity. Keep `model_configs` only if it was needed for the preview or remote run.
+6. **Generate run spec** — Without re-prompting, also produce a run YAML named `<text_column>_run_spec.yaml`. It mirrors the preview spec but drops `num_records`. Run writes artifacts, not a dataset entity.
 7. **Finalize** — Tell the user the preview ran, briefly summarize what happens to PII under the chosen strategy, and give them the launch command:
 
    ```bash
-   nemo anonymizer run run --spec-file <run_spec>.yaml
+   nemo anonymizer run --spec-file <run_spec>.yaml --workspace <ws>
    ```
 
-   If the user asked for cluster execution, give `nemo anonymizer run submit --spec-file <run_spec>.yaml --workspace <ws>` instead. Mention that local artifacts are printed to stderr (`Saved result 'artifacts' to file://...`) and remote artifacts can be fetched with:
+   Mention that artifacts can be fetched with:
 
    ```bash
    nemo jobs get-status <job-name> --workspace <ws>

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/interactive.md
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/skills/anonymizer/workflows/interactive.md
@@ -8,44 +8,35 @@ This is an interactive, iterative anonymization design process. Do not disengage
 Source of truth for this workflow: `docs/anonymizer/tutorials/index.mdx`, `docs/anonymizer/tutorials/preview.mdx`, and `docs/anonymizer/tutorials/run.mdx`. Defer to them if the CLI flags or capabilities here look out of date.
 
 1. **Resolve CLI command** — Run `command -v nemo 2>/dev/null || (test -x .venv/bin/nemo && realpath .venv/bin/nemo) || echo CLI_NOT_FOUND`.
-   - If the output is a path, use `<path> anonymizer` as the command prefix for all `nemo anonymizer …` invocations in this workflow.
+   - If the output is a path, make sure that directory is on `PATH`, then use plain `nemo ...` commands below.
    - If the output is `CLI_NOT_FOUND`, STOP and follow the Troubleshooting section in SKILL.md. Do not continue.
-2. **Confirm the plugin service is mounted (only if the user wants `preview submit` or `run submit`).** Run `curl -s http://localhost:8080/openapi.json | jq -r '.paths | keys[]' | grep '^/apis/anonymizer/'`. If nothing prints, the plugin service isn't loaded — `nemo setup` does not auto-mount it. Tell the user to run `nemo services run` (no `--services` flag) and rerun the check. Local previews (`preview run`) and local runs (`run run`) do **not** need the plugin service mounted.
-3. **Confirm input source** — Decide which kind of input you're working with: a local CSV/Parquet file, an `http(s)://` URL, or a NeMo Platform fileset reference. If the user named a file but it's not yet on the platform and they want to use `preview submit`, ask whether to upload it to a fileset first (see `references/inputs.md`).
+2. **Confirm the plugin service is mounted before previewing or running.** Run `nmp_base_url="${NMP_BASE_URL:-http://localhost:8080}"; curl -sf "${nmp_base_url%/}/apis/anonymizer/v2/workspaces/${NMP_WORKSPACE:-default}/entity-labels" | jq -r '.data[0] // empty'`. If nothing prints, the plugin service isn't loaded — `nemo setup` does not auto-mount it. Tell the user to run `nemo services run` (no `--services` flag) and rerun the check.
+3. **Confirm input source** — Decide whether the input is an `http(s)://` URL or a NeMo Platform fileset reference. If the user named a local file, ask whether to upload it to a fileset or host it first (see `references/inputs.md`).
 4. **Clarify** — Ask the user clarifying questions to narrow down precisely what they want. Prefer a structured question tool if one is available, batch related questions together, keep the set short, and offer concrete options/defaults. Common things to make precise:
    - **Text column** to scan and (optional) **id column**.
    - **What to do with detected entities**: redact, annotate (tag inline), hash (deterministic token), substitute with realistic LLM-generated values, or fully rewrite the text under a privacy goal. See `references/replace-strategies.md` and `references/rewrite-mode.md`.
    - **Detection tuning** — keep Anonymizer library defaults unless the user explicitly asks for label/threshold changes; refer to the [Anonymizer library docs](https://github.com/NVIDIA-NeMo/Anonymizer/tree/main/docs) or library skills for those details.
-   - **Preview surface** — `preview run` (local, allows local paths) or `preview submit` (plugin service via CLI).
-   - **Run surface** — `nemo anonymizer run run` for local in-process execution or `nemo anonymizer run submit` for Jobs-worker execution. This is the Anonymizer equivalent of Data Designer's `create run` / `create submit` pattern.
-5. **Resolve model providers (only if needed)** — If the preview is going through the plugin service (`preview submit`), or the chosen replacement strategy is `Substitute` or `Rewrite`, ask which provider(s) and model aliases to use. For provider discovery or creation, refer to the platform inference/model-provider docs or the relevant inference/model skill. See `references/model-configs.md`.
+   - **Preview surface** — `nemo anonymizer preview` through the plugin service, or `sdk.anonymizer.preview` if the user wants Python.
+   - **Run surface** — `nemo anonymizer run` for Jobs-worker execution.
+5. **Resolve model providers** — Ask which provider(s) and model aliases to use, or default to the aliases in `references/model-configs.md`. For provider discovery or creation, refer to the platform inference/model-provider docs or the relevant inference/model skill.
 6. **Plan** — Summarize the planned config (replace vs rewrite strategy, detection tuning, model_configs, input source, num_records, preview surface) and ask the user to confirm before writing the spec.
 7. **Build** — Write a YAML spec file following the Output Template in SKILL.md. Use the **Preview** shape first.
 8. **Validate (optional)** — If you've also produced a stand-alone `AnonymizerConfig` YAML (e.g., the user wants `nemo anonymizer validate` to gate the run), invoke it now and address any errors before previewing.
-9. **Preview** — Pick the surface you agreed on in step 4:
-   - Local CLI: `nemo anonymizer preview run --spec-file <path> --workspace <ws>`
-   - Plugin service via CLI: `nemo anonymizer preview submit --spec-file <path> --workspace <ws>`
+9. **Preview** — Run `nemo anonymizer preview --spec-file <path> --workspace <ws>` with the preview spec, unless the user chose the SDK.
 
-   Inspect the resulting NDJSON frames: `log` lines, the `preview_dataset`, the `trace_dataset`, and any `failed_records`. Surface anything in `failed_records` to the user.
+   Inspect the resulting frames: `log` lines, the `preview_dataset`, the `trace_dataset`, and any `failed_records`. Surface anything in `failed_records` to the user.
 10. **Iterate**
     - Ask the user for feedback on the preview output. Offer to review the records yourself and suggest plugin-surface fixes (input source, model configs, selected model aliases) or refer to Anonymizer library docs/skills for library-level tuning. See `references/preview-review.md`.
     - Apply changes, re-preview. Repeat until the user is satisfied.
 11. **Finalize** — Once the user is happy with the preview:
     - Generate a run spec by dropping `num_records` from the preview request. Run writes artifacts, not a dataset entity.
-    - Tell the user they can run the full job locally with:
+    - Tell the user they can run the full job with:
 
       ```bash
-      nemo anonymizer run run --spec-file <run_spec>.yaml
+      nemo anonymizer run --spec-file <run_spec>.yaml --workspace <ws>
       ```
 
-    - If they want platform execution, tell them to use:
-
-      ```bash
-      nemo anonymizer run submit --spec-file <run_spec>.yaml --workspace <ws>
-      ```
-
-      The remote path requires `model_configs` and rejects local file paths.
-    - For remote jobs, show the CLI follow-up commands:
+    - For jobs, show the CLI follow-up commands:
 
       ```bash
       nemo jobs get-status <job-name> --workspace <ws>
@@ -53,6 +44,5 @@ Source of truth for this workflow: `docs/anonymizer/tutorials/index.mdx`, `docs/
       nemo jobs results list <job-name> --workspace <ws>
       nemo jobs results download artifacts --job <job-name> --workspace <ws> --output-file artifacts.tar.gz
       ```
-    - Note that local `run run` prints `{"exit_code": 0}` on success and logs the artifact directory to **stderr** in the form `Saved result 'artifacts' to file:///.../persistent/results/artifacts`. Walk through `references/inputs.md` if the user wants help loading those artifacts.
     - Caution that runtime depends on dataset size and the chosen strategy (LLM-backed strategies are slower).
     - Do not run the full job yourself — let the user decide when to launch it.

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/tasks/anonymizer/run.py
@@ -42,7 +42,7 @@ _TASK_LOG_HANDLER_MARKER = "_nemo_anonymizer_task_handler"
 def run(sdk: NeMoPlatform | None = None) -> int:
     try:
         service_sdk = sdk or get_platform_sdk(as_service="anonymizer")
-        return run_step_config(_load_step_config(), ctx=_get_ctx(service_sdk), sdk=service_sdk, is_local=False)
+        return run_step_config(_load_step_config(), ctx=_get_ctx(service_sdk), sdk=service_sdk)
     except Exception:
         logger.exception("Anonymizer task failed")
         return 1
@@ -53,10 +53,9 @@ def run_step_config(
     *,
     ctx: JobContext,
     sdk: NeMoPlatform | None = None,
-    is_local: bool = False,
 ) -> int:
     try:
-        return _run_with_step_config(sdk, step_config, ctx=ctx, is_local=is_local)
+        return _run_with_step_config(sdk, step_config, ctx=ctx)
     except Exception:
         logger.exception("Anonymizer task failed")
         return 1
@@ -67,28 +66,29 @@ def _run_with_step_config(
     step_config: AnonymizerStepConfig,
     *,
     ctx: JobContext,
-    is_local: bool,
 ) -> int:
     _configure_logging()
-    if service_sdk is None and not is_local:
+    if service_sdk is None:
         raise RuntimeError("Remote anonymizer task requires a NeMo Platform SDK.")
 
     storage_path = ctx.storage.persistent
     workspace = ctx.workspace
 
     request = step_config.request
-    dd_providers = _resolve_provider_endpoints(service_sdk, step_config, workspace, is_local=is_local)
+    if not step_config.model_configs_yaml:
+        raise RuntimeError("Remote anonymizer task requires resolved model_configs.")
+    dd_providers = _resolve_provider_endpoints(service_sdk, step_config, workspace)
     prepared_input = prepare_anonymizer_input(
         request.data,
         sdk=service_sdk,
         workspace=workspace,
-        allow_local_paths=is_local,
+        allow_local_paths=False,
     )
 
     try:
         with preserve_root_logging():
             anonymizer = Anonymizer(
-                model_configs=step_config.model_configs_yaml or None,
+                model_configs=step_config.model_configs_yaml,
                 model_providers=dd_providers,
                 artifact_path=storage_path / "anonymizer-artifacts",
             )
@@ -132,11 +132,9 @@ def _run_with_step_config(
 
 
 def _resolve_provider_endpoints(
-    sdk: NeMoPlatform | None,
+    sdk: NeMoPlatform,
     step_config: AnonymizerStepConfig,
     workspace: str,
-    *,
-    is_local: bool,
 ) -> list[DDModelProvider] | None:
     """Re-resolve provider endpoints in the task environment.
 
@@ -145,10 +143,6 @@ def _resolve_provider_endpoints(
     """
     if not step_config.dd_model_providers:
         return None
-    if is_local:
-        return [DDModelProvider.model_validate(raw) for raw in step_config.dd_model_providers]
-    if sdk is None:
-        raise RuntimeError("Remote anonymizer task requires a NeMo Platform SDK.")
     models = client_from_platform(sdk, ModelsClient)
     refreshed: list[DDModelProvider] = []
     for raw in step_config.dd_model_providers:

--- a/plugins/nemo-anonymizer/tests/unit/test_cli.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_cli.py
@@ -10,7 +10,8 @@ from typing import Any, ClassVar
 import yaml
 from nemo_anonymizer_plugin import cli as cli_module
 from nemo_anonymizer_plugin.cli import AnonymizerCLI
-from nemo_platform_plugin.commands import add_job_commands
+from nemo_anonymizer_plugin.functions.preview import PreviewFunction
+from nemo_platform_plugin.commands import add_function_commands, add_job_commands
 from nemo_platform_plugin.job import NemoJob
 from typer.testing import CliRunner
 
@@ -18,6 +19,7 @@ from typer.testing import CliRunner
 class _RunJob(NemoJob):
     name: ClassVar[str] = "run"
     description: ClassVar[str] = "Run test job."
+    generate_legacy_verbs: ClassVar[bool] = False
 
     def run(self, config: dict) -> dict:
         return {"config": config}
@@ -45,23 +47,111 @@ def test_cli_only_registers_manual_validate_command() -> None:
     assert "run-local" not in result.output
 
 
-def test_run_job_collapses_local_run_alias() -> None:
+def test_preview_function_uses_flat_remote_submit(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_post_function_submit(url, body, *, headers, renderer_cls=None, cli_kwargs=None):
+        captured["url"] = url
+        captured["body"] = body
+        captured["headers"] = headers
+        captured["renderer_cls"] = renderer_cls
+        captured["cli_kwargs"] = cli_kwargs
+
+    monkeypatch.setattr(
+        "nemo_platform_plugin.discovery.discover_functions",
+        lambda: {"anonymizer.preview": PreviewFunction},
+    )
+    monkeypatch.setattr("nemo_platform_plugin.commands._post_function_submit", fake_post_function_submit)
+    cli = AnonymizerCLI()
+    app = cli.get_cli()
+    runner = CliRunner()
+    add_function_commands(app, {"anonymizer.preview": PreviewFunction}, cli=cli)
+
+    help_result = runner.invoke(app, ["--help"])
+    preview_result = runner.invoke(
+        app,
+        [
+            "preview",
+            "--spec",
+            json.dumps(
+                {
+                    "config": {"replace": {"kind": "redact"}},
+                    "data": {"source": "https://example.com/input.csv", "text_column": "text"},
+                    "model_configs": [{"alias": "detector", "provider": "provider", "model": "test/model"}],
+                    "num_records": 2,
+                }
+            ),
+            "--workspace",
+            "team-a",
+            "--base-url",
+            "http://platform.example",
+        ],
+    )
+    nested_result = runner.invoke(app, ["preview", "submit", "--spec", "{}"])
+
+    assert help_result.exit_code == 0, help_result.output
+    assert "preview" in help_result.output
+    assert preview_result.exit_code == 0, preview_result.output
+    assert captured["url"] == "http://platform.example/apis/anonymizer/v2/workspaces/team-a/preview"
+    assert captured["body"] == {
+        "config": {"replace": {"kind": "redact"}},
+        "data": {"source": "https://example.com/input.csv", "text_column": "text"},
+        "model_configs": [{"alias": "detector", "provider": "provider", "model": "test/model"}],
+        "num_records": 2,
+    }
+    assert captured["headers"] == {}
+    assert captured["renderer_cls"] is None
+    assert nested_result.exit_code == 2
+    assert "unexpected extra argument" in nested_result.output
+
+
+def test_run_job_uses_flat_remote_submit(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_submit_remote(self, job_cls, spec, **kwargs):
+        captured["job_cls"] = job_cls
+        captured["spec"] = spec
+        captured["kwargs"] = kwargs
+        return {"name": "anon-job-1", "workspace": "team-a"}
+
+    monkeypatch.setattr("nemo_platform_plugin.scheduler.NemoJobScheduler.submit_remote", fake_submit_remote)
+
     cli = AnonymizerCLI()
     app = cli.get_cli()
     add_job_commands(app, {"anonymizer.run": _RunJob}, cli=cli)
     runner = CliRunner()
 
-    alias_result = runner.invoke(app, ["run", "--config", '{"name": "Alias"}'])
-    nested_result = runner.invoke(app, ["run", "run", "--config", '{"name": "Nested"}'])
+    run_result = runner.invoke(
+        app,
+        [
+            "run",
+            "--spec",
+            '{"name": "Remote"}',
+            "--workspace",
+            "team-a",
+            "--base-url",
+            "http://platform.example",
+        ],
+    )
+    nested_result = runner.invoke(app, ["run", "run", "--spec", '{"name": "Nested"}'])
     help_result = runner.invoke(app, ["run", "--help"])
 
-    assert alias_result.exit_code == 0, alias_result.output
-    assert json.loads(alias_result.output) == {"config": {"name": "Alias"}}
-    assert nested_result.exit_code == 0, nested_result.output
-    assert json.loads(nested_result.output) == {"config": {"name": "Nested"}}
+    assert run_result.exit_code == 0, run_result.output
+    assert json.loads(run_result.output) == {"name": "anon-job-1", "workspace": "team-a"}
+    assert captured["job_cls"] is _RunJob
+    assert captured["spec"] == {"name": "Remote"}
+    assert captured["kwargs"] == {
+        "base_url": "http://platform.example",
+        "workspace": "team-a",
+        "profile": None,
+        "options": None,
+        "headers": None,
+    }
+    assert nested_result.exit_code == 2
+    assert "unexpected extra argument" in nested_result.output
     assert help_result.exit_code == 0, help_result.output
-    assert "Run locally, in-process." in help_result.output
-    assert "Run run locally" not in help_result.output
+    assert "Submit to a cluster." in help_result.output
+    assert "Run locally, in-process." not in help_result.output
 
 
 def test_validate_command_runs_library_validation(tmp_path: Path, monkeypatch) -> None:

--- a/plugins/nemo-anonymizer/tests/unit/test_preview_function.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_preview_function.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from pathlib import Path
 from unittest.mock import AsyncMock
 
+import data_designer.config as dd
 import pandas as pd
 import pytest
-from anonymizer.config.anonymizer_config import AnonymizerConfig
+from anonymizer.config.anonymizer_config import AnonymizerConfig, AnonymizerInput
 from anonymizer.config.replace_strategies import Redact
+from nemo_anonymizer_plugin.app import context as context_module
 from nemo_anonymizer_plugin.app.errors import AnonymizerInvalidConfigError
 from nemo_anonymizer_plugin.app.input import AnonymizerInputSpec
 from nemo_anonymizer_plugin.app.model_configs import SelectedModelsOverrides
@@ -22,18 +23,16 @@ from nemo_platform_plugin.function_context import FunctionContext
 from pydantic import BaseModel
 
 
-def _preview_spec(tmp_path: Path) -> PreviewSpec:
-    csv = tmp_path / "input.csv"
-    csv.write_text("biography\nhello\n")
+def _preview_spec() -> PreviewSpec:
     return PreviewSpec(
         config=AnonymizerConfig(replace=Redact()),
-        data=AnonymizerInputSpec(source=str(csv), text_column="biography"),
+        data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="biography"),
+        model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
         num_records=1,
     )
 
 
 def test_preview_worker_sends_original_text_column_metadata(
-    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     frames: list[BaseModel] = []
@@ -55,9 +54,9 @@ def test_preview_worker_sends_original_text_column_metadata(
 
     worker_module._make_preview(
         frames.append,
-        _preview_spec(tmp_path),
-        data=object(),  # type: ignore[arg-type]
-        model_configs_yaml="",
+        _preview_spec(),
+        data=AnonymizerInput(source="https://example.com/input.csv", text_column="biography"),
+        model_configs_yaml="model_configs:\n- alias: detector\n  model: test/model\n  provider: provider\n",
         dd_providers=None,
         num_records=1,
     )
@@ -66,10 +65,14 @@ def test_preview_worker_sends_original_text_column_metadata(
     assert trace_frame.original_text_column == "biography"
 
 
+def test_preview_worker_requires_model_configs() -> None:
+    with pytest.raises(RuntimeError, match="requires resolved model_configs"):
+        worker_module._make_anonymizer(model_configs_yaml="", dd_providers=None)
+
+
 @pytest.mark.asyncio
 async def test_preview_function_resets_request_log_callback(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
     def fake_worker(
         send_frame: Callable[[BaseModel], None],
@@ -77,26 +80,34 @@ async def test_preview_function_resets_request_log_callback(
     ) -> None:
         send_frame(LogFrame(level="info", message="generated"))
 
+    igw_lookup = AsyncMock(return_value=None)
+    monkeypatch.setattr(context_module, "make_model_provider_registry", igw_lookup)
     monkeypatch.setattr(worker_module, "_make_preview", fake_worker)
+    async_sdk = AsyncMock(spec=AsyncNeMoPlatform)
 
     frames = [
         frame
         async for frame in PreviewFunction().run(
-            _preview_spec(tmp_path),
+            _preview_spec(),
             ctx=FunctionContext(workspace="team-a"),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=True,
+            async_sdk=async_sdk,
         )
     ]
 
+    igw_lookup.assert_awaited_once()
+    assert igw_lookup.await_args is not None
+    assert igw_lookup.await_args.kwargs["sdk"] is async_sdk
     assert [frame.model_dump()["kind"] for frame in frames] == ["log", "done"]
     assert request_callback_cvar.get() is None
 
 
 @pytest.mark.asyncio
-async def test_preview_function_rejects_selected_models_without_model_configs(tmp_path: Path) -> None:
-    spec = _preview_spec(tmp_path).model_copy(
-        update={"selected_models": SelectedModelsOverrides(detection={"entity_detector": "local"})}
+async def test_preview_function_rejects_selected_models_without_model_configs() -> None:
+    spec = _preview_spec().model_copy(
+        update={
+            "model_configs": None,
+            "selected_models": SelectedModelsOverrides(detection={"entity_detector": "detector"}),
+        }
     )
 
     with pytest.raises(AnonymizerInvalidConfigError, match="selected_models requires model_configs"):
@@ -106,22 +117,18 @@ async def test_preview_function_rejects_selected_models_without_model_configs(tm
                 spec,
                 ctx=FunctionContext(workspace="team-a"),
                 async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-                is_local=True,
             )
         ]
 
 
 @pytest.mark.asyncio
-async def test_preview_submit_requires_model_configs(tmp_path: Path) -> None:
+async def test_preview_submit_requires_model_configs() -> None:
     with pytest.raises(AnonymizerInvalidConfigError, match="model_configs are required"):
         [
             frame
             async for frame in PreviewFunction().run(
-                _preview_spec(tmp_path).model_copy(
-                    update={"data": AnonymizerInputSpec(source="https://example.com/input.csv")}
-                ),
+                _preview_spec().model_copy(update={"model_configs": None}),
                 ctx=FunctionContext(workspace="team-a"),
                 async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-                is_local=False,
             )
         ]

--- a/plugins/nemo-anonymizer/tests/unit/test_run_job.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_run_job.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import data_designer.config as dd
@@ -55,6 +56,24 @@ def _restore_task_loggers(snapshot: dict[str, tuple[list[logging.Handler], int, 
         logger.propagate = propagate
 
 
+async def _to_run_spec(
+    request: AnonymizerRequest,
+    *,
+    async_sdk: AsyncNeMoPlatform | None = None,
+) -> AnonymizerStepConfig:
+    resolved_async_sdk = (
+        async_sdk if async_sdk is not None else cast(AsyncNeMoPlatform, AsyncMock(spec=AsyncNeMoPlatform))
+    )
+    spec = await RunJob.to_spec(
+        request,
+        workspace="team-a",
+        entity_client=object(),
+        async_sdk=resolved_async_sdk,
+        is_local=False,
+    )
+    return cast(AnonymizerStepConfig, spec)
+
+
 @pytest.mark.asyncio
 async def test_run_job_rejects_selected_models_without_model_configs(
     monkeypatch: pytest.MonkeyPatch,
@@ -62,18 +81,12 @@ async def test_run_job_rejects_selected_models_without_model_configs(
     request = AnonymizerRequest(
         config=AnonymizerConfig(replace=Redact()),
         data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
-        selected_models=SelectedModelsOverrides(detection={"entity_detector": "local"}),
+        selected_models=SelectedModelsOverrides(detection={"entity_detector": "detector"}),
     )
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
 
     with pytest.raises(PlatformJobCompilationError, match="selected_models requires model_configs"):
-        await RunJob.to_spec(
-            request,
-            workspace="team-a",
-            entity_client=object(),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=False,
-        )
+        await _to_run_spec(request)
 
 
 @pytest.mark.asyncio
@@ -93,13 +106,7 @@ async def test_run_job_wraps_shared_provider_config_errors(
     )
 
     with pytest.raises(PlatformJobCompilationError, match="bad provider"):
-        await RunJob.to_spec(
-            request,
-            workspace="team-a",
-            entity_client=object(),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=False,
-        )
+        await _to_run_spec(request)
 
 
 @pytest.mark.asyncio
@@ -113,116 +120,64 @@ async def test_run_submit_requires_model_configs(
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
 
     with pytest.raises(PlatformJobCompilationError, match="model_configs are required"):
-        await RunJob.to_spec(
-            request,
-            workspace="team-a",
-            entity_client=object(),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=False,
-        )
+        await _to_run_spec(request)
 
 
 @pytest.mark.asyncio
-async def test_run_local_allows_missing_model_configs(
-    tmp_path: Path,
+async def test_run_job_uses_igw_provider_registry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
+    igw_registry = ModelProviderRegistry(
+        providers=[NDDModelProvider(name="provider", endpoint="http://platform.example/apis/models/provider")],
+    )
+    igw_lookup = AsyncMock(return_value=igw_registry)
     request = AnonymizerRequest(
         config=AnonymizerConfig(replace=Redact()),
-        data=AnonymizerInputSpec(source=str(csv), text_column="text"),
+        data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
+        model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
     )
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
-
-    step_config = await RunJob.to_spec(
-        request,
-        workspace="team-a",
-        entity_client=object(),
-        async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-        is_local=True,
-    )
-
-    assert isinstance(step_config, AnonymizerStepConfig)
-    assert step_config.model_configs_yaml == ""
-    assert step_config.dd_model_providers == []
-    round_tripped = AnonymizerStepConfig.model_validate(step_config.model_dump())
-    assert isinstance(round_tripped.request.config.replace, Redact)
-
-
-@pytest.mark.asyncio
-async def test_run_local_model_configs_uses_injected_async_sdk(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
-    local_first_registry = ModelProviderRegistry(
-        providers=[NDDModelProvider(name="local-provider", endpoint="http://localhost:8000")],
-    )
-    local_first_lookup = AsyncMock(return_value=local_first_registry)
-    request = AnonymizerRequest(
-        config=AnonymizerConfig(replace=Redact()),
-        data=AnonymizerInputSpec(source=str(csv), text_column="text"),
-        model_configs=[dd.ModelConfig(alias="detector", model="local/model", provider="local-provider")],
-    )
-    monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
-    monkeypatch.setattr(context_module, "make_local_first_model_provider_registry", local_first_lookup)
+    monkeypatch.setattr(context_module, "make_model_provider_registry", igw_lookup)
     async_sdk = AsyncMock(spec=AsyncNeMoPlatform)
 
-    step_config = await RunJob.to_spec(
-        request,
-        workspace="team-a",
-        entity_client=object(),
-        async_sdk=async_sdk,
-        is_local=True,
-    )
+    step_config = await _to_run_spec(request, async_sdk=async_sdk)
 
-    local_first_lookup.assert_awaited_once()
-    assert local_first_lookup.await_args is not None
-    assert local_first_lookup.await_args.kwargs["sdk"] is async_sdk
+    igw_lookup.assert_awaited_once()
+    assert igw_lookup.await_args is not None
+    assert igw_lookup.await_args.kwargs["sdk"] is async_sdk
     assert isinstance(step_config, AnonymizerStepConfig)
     assert len(step_config.dd_model_providers) == 1
-    assert step_config.dd_model_providers[0]["name"] == "local-provider"
+    assert step_config.dd_model_providers[0]["name"] == "provider"
 
 
 @pytest.mark.asyncio
-async def test_run_local_serialized_step_config_can_be_revalidated(
+async def test_run_serialized_step_config_can_be_revalidated(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
     request = AnonymizerRequest(
         config=AnonymizerConfig(replace=Redact()),
-        data=AnonymizerInputSpec(source=str(csv), text_column="text"),
+        data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
+        model_configs=[dd.ModelConfig(alias="detector", model="test/model", provider="provider")],
     )
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
+    monkeypatch.setattr(context_module, "make_model_provider_registry", AsyncMock(return_value=None))
     monkeypatch.setattr(run_module, "run_step_config", lambda *args, **kwargs: 0)
 
-    step_config = await RunJob.to_spec(
-        request,
-        workspace="team-a",
-        entity_client=object(),
-        async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-        is_local=True,
-    )
+    step_config = await _to_run_spec(request)
 
     ctx = _make_job_context(tmp_path)
     assert RunJob().run(
         step_config.model_dump(),
         ctx=ctx,
         sdk=Mock(spec=NeMoPlatform),
-        is_local=True,
     ) == {"exit_code": 0}
 
 
-def test_run_step_config_local_uses_ctx_results(
+def test_run_step_config_uses_ctx_results(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
     captured: dict[str, object] = {}
 
     class FakeFrame:
@@ -262,9 +217,9 @@ def test_run_step_config_local_uses_ctx_results(
     step_config = AnonymizerStepConfig(
         request=AnonymizerRequest(
             config=AnonymizerConfig(replace=Redact()),
-            data=AnonymizerInputSpec(source=str(csv), text_column="text"),
+            data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         ),
-        model_configs_yaml="",
+        model_configs_yaml="model_configs:\n- alias: detector\n  model: test/model\n  provider: provider\n",
         dd_model_providers=[],
     )
 
@@ -277,12 +232,13 @@ def test_run_step_config_local_uses_ctx_results(
             task_run_module.run_step_config(
                 step_config,
                 ctx=ctx,
-                is_local=True,
+                sdk=Mock(spec=NeMoPlatform),
             )
             == 0
         )
     finally:
         _restore_task_loggers(logging_snapshot)
+    assert captured["model_configs"] == "model_configs:\n- alias: detector\n  model: test/model\n  provider: provider\n"
     assert captured["artifact_path"] == ctx.storage.persistent / "anonymizer-artifacts"
     artifacts_dir = ctx.storage.persistent / "artifacts"
     assert (artifacts_dir / "dataset.parquet").read_text() == "dataset"
@@ -295,12 +251,10 @@ def test_run_step_config_local_uses_ctx_results(
 
 
 def test_run_step_config_remote_requires_sdk(tmp_path: Path) -> None:
-    csv = tmp_path / "input.csv"
-    csv.write_text("text\nhello\n")
     step_config = AnonymizerStepConfig(
         request=AnonymizerRequest(
             config=AnonymizerConfig(replace=Redact()),
-            data=AnonymizerInputSpec(source=str(csv), text_column="text"),
+            data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
         ),
         model_configs_yaml="",
         dd_model_providers=[],
@@ -309,9 +263,33 @@ def test_run_step_config_remote_requires_sdk(tmp_path: Path) -> None:
     logging_snapshot = _snapshot_task_loggers()
 
     try:
-        assert task_run_module.run_step_config(step_config, ctx=ctx, is_local=False) == 1
+        assert task_run_module.run_step_config(step_config, ctx=ctx) == 1
     finally:
         _restore_task_loggers(logging_snapshot)
+
+
+def test_run_step_config_requires_resolved_model_configs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    step_config = AnonymizerStepConfig(
+        request=AnonymizerRequest(
+            config=AnonymizerConfig(replace=Redact()),
+            data=AnonymizerInputSpec(source="https://example.com/input.csv", text_column="text"),
+        ),
+        model_configs_yaml="",
+        dd_model_providers=[],
+    )
+    anonymizer = Mock(side_effect=AssertionError("Anonymizer should not be constructed"))
+    monkeypatch.setattr(task_run_module, "Anonymizer", anonymizer)
+    ctx = _make_job_context(tmp_path)
+    logging_snapshot = _snapshot_task_loggers()
+
+    try:
+        assert task_run_module.run_step_config(step_config, ctx=ctx, sdk=Mock(spec=NeMoPlatform)) == 1
+    finally:
+        _restore_task_loggers(logging_snapshot)
+    anonymizer.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -329,10 +307,4 @@ async def test_run_submit_rejects_local_file(
     monkeypatch.setattr(RunJob, "_validate_anonymizer_config", classmethod(lambda cls, config: None))
 
     with pytest.raises(PlatformJobCompilationError, match="local path"):
-        await RunJob.to_spec(
-            request,
-            workspace="team-a",
-            entity_client=object(),
-            async_sdk=AsyncMock(spec=AsyncNeMoPlatform),
-            is_local=False,
-        )
+        await _to_run_spec(request)

--- a/plugins/nemo-anonymizer/tests/unit/test_upstream_logging.py
+++ b/plugins/nemo-anonymizer/tests/unit/test_upstream_logging.py
@@ -66,7 +66,7 @@ def test_make_anonymizer_preserves_root_logging_when_upstream_clobbers_it(monkey
         root.setLevel(logging.INFO)
         monkeypatch.setattr(worker_module, "Anonymizer", ClobberingAnonymizer)
 
-        anonymizer = worker_module._make_anonymizer(model_configs_yaml="", dd_providers=None)
+        anonymizer = worker_module._make_anonymizer(model_configs_yaml="model_configs: []", dd_providers=None)
 
         assert isinstance(anonymizer, ClobberingAnonymizer)
         assert root.handlers == [sentinel_handler]


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Simplifies Anonymizer platform execution to remote-only surfaces: SDK/service preview and a single `nemo anonymizer run` Jobs submission command. This removes local CLI preview/run paths so anonymizer requests consistently use fileset or HTTP(S) inputs and explicit `model_configs` resolved through NeMo Platform Inference Gateway.

## Changes

- Replaces generated legacy anonymizer CLI verbs with `nemo anonymizer run`; hides the preview CLI surface in favor of `sdk.anonymizer.preview`.
- Requires `model_configs` for preview and run execution and removes the local-first Data Designer provider fallback.
- Rejects local file paths for plugin execution; supported inputs are HTTP(S) URLs and NeMo Platform fileset references.
- Keeps full-run artifacts in platform job storage and refreshes provider endpoints inside the Jobs worker.
- Updates anonymizer docs, tutorials, README, and repo-local anonymizer skill guidance to match the remote-only workflow.
- Updates unit coverage for the flattened CLI, SDK preview path, required model configs, Inference Gateway provider resolution, and remote job task behavior.

## Breaking Changes / Migration

- Removed `nemo anonymizer preview run`, `nemo anonymizer preview submit`, `nemo anonymizer run run`, `nemo anonymizer run submit`, and `nemo anonymizer run explain`.
- Use `sdk.anonymizer.preview(...)` for previews.
- Use `nemo anonymizer run --spec-file <path> --workspace <ws>` for full anonymizer jobs.
- Upload local input files to a fileset or host them over HTTP(S), and include `model_configs` in preview/run specs.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior - justification:
- [ ] Tests not applicable - justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable - justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `git diff --check origin/main...HEAD` - passed
- `git diff --check` - passed
- `uv run --frozen pytest plugins/nemo-anonymizer/tests/unit/test_cli.py plugins/nemo-anonymizer/tests/unit/test_preview_function.py plugins/nemo-anonymizer/tests/unit/test_run_job.py plugins/nemo-anonymizer/tests/unit/test_upstream_logging.py -v` - passed, 20 tests
- DCO audit: the single PR commit includes a `Signed-off-by:` trailer matching the commit author email
- Not run locally: `uv run pre-commit run -a`
- Not run locally: `make docs-check`
- Not run locally: `make docs-broken-links`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct remote preview through `nemo anonymizer preview` and SDK workflows.
  * Simplified full-dataset execution with `nemo anonymizer run` and platform job retrieval.
* **Updates**
  * Inputs now support HTTP(S) URLs and fileset references only; local paths and execution are no longer supported.
  * Explicit `model_configs` are required for preview and run operations.
  * Removed nested local-run, submit, and explain commands.
  * Updated guides, examples, workflows, and references for remote execution, streaming previews, and artifact retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->