### PR TITLE
chore: remove jobs stainless SDK dependency

### DIFF
--- a/e2e/test_evaluator_plugin.py
+++ b/e2e/test_evaluator_plugin.py
@@ -830,9 +830,10 @@ def test_gym_agent_evaluate_job_completes(
 
         # Download the results archive to a tmp path.
         archive_path = tmp_path / "agent-eval-results.tar.gz"
-        evaluator_sdk.jobs.results.download(
-            "agent-eval-results", job=job_name, workspace=evaluator_workspace
-        ).write_to_file(archive_path)
+        archive = client_from_platform(evaluator_sdk, JobsClient).download_job_result(
+            name="agent-eval-results", job=job_name, workspace=evaluator_workspace
+        )
+        archive_path.write_bytes(archive.read())
 
         # Extract the trials.jsonl file from the archive.
         extract_dir = tmp_path / "agent-eval-results"

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -16687,6 +16687,25 @@ components:
       - artifact_url
       - artifact_storage_type
       title: PlatformJobResultResponse
+    PlatformJobSecret:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: The name of the secret
+        value:
+          title: Value
+          description: The secret value submitted with the job
+          type: string
+        ref_id:
+          title: Ref Id
+          description: Reference id for the stored secret value
+          type: string
+      type: object
+      required:
+      - name
+      title: PlatformJobSecret
+      description: Inline secret material submitted with a job spec.
     PlatformJobSecretEnvironmentVariableRef:
       properties:
         name:
@@ -16715,6 +16734,12 @@ components:
           type: array
           title: Steps
           description: List of steps to be executed in the job
+        secrets:
+          title: Secrets
+          description: Secrets referenced by the job
+          items:
+            $ref: '#/components/schemas/PlatformJobSecret'
+          type: array
       type: object
       required:
       - steps

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -16687,6 +16687,25 @@ components:
       - artifact_url
       - artifact_storage_type
       title: PlatformJobResultResponse
+    PlatformJobSecret:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: The name of the secret
+        value:
+          title: Value
+          description: The secret value submitted with the job
+          type: string
+        ref_id:
+          title: Ref Id
+          description: Reference id for the stored secret value
+          type: string
+      type: object
+      required:
+      - name
+      title: PlatformJobSecret
+      description: Inline secret material submitted with a job spec.
     PlatformJobSecretEnvironmentVariableRef:
       properties:
         name:
@@ -16715,6 +16734,12 @@ components:
           type: array
           title: Steps
           description: List of steps to be executed in the job
+        secrets:
+          title: Secrets
+          description: Secrets referenced by the job
+          items:
+            $ref: '#/components/schemas/PlatformJobSecret'
+          type: array
       type: object
       required:
       - steps

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -16687,6 +16687,25 @@ components:
       - artifact_url
       - artifact_storage_type
       title: PlatformJobResultResponse
+    PlatformJobSecret:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: The name of the secret
+        value:
+          title: Value
+          description: The secret value submitted with the job
+          type: string
+        ref_id:
+          title: Ref Id
+          description: Reference id for the stored secret value
+          type: string
+      type: object
+      required:
+      - name
+      title: PlatformJobSecret
+      description: Inline secret material submitted with a job spec.
     PlatformJobSecretEnvironmentVariableRef:
       properties:
         name:
@@ -16715,6 +16734,12 @@ components:
           type: array
           title: Steps
           description: List of steps to be executed in the job
+        secrets:
+          title: Secrets
+          description: Secrets referenced by the job
+          items:
+            $ref: '#/components/schemas/PlatformJobSecret'
+          type: array
       type: object
       required:
       - steps

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/job_results.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/job_results.py
@@ -19,7 +19,7 @@ Concrete impls living in this codebase:
 The API is deliberately narrow: a single ``save(name, local_path, *,
 ignore_patterns=None) -> ResultRef``. Read paths (``get`` / ``list``)
 are not on the Protocol — task code that needs to enumerate results
-goes through the platform SDK directly (e.g. ``sdk.jobs.results.list``).
+goes through the typed Jobs client.
 """
 
 from __future__ import annotations
@@ -157,7 +157,7 @@ class PlatformJobResults(JobResults):
         sdk: :class:`NeMoPlatform` handle used for both file uploads and
             the jobs-results registration.
         attempt_id: Optional override for the job attempt id; when
-            omitted, looked up lazily via ``sdk.jobs.retrieve(...)``.
+            omitted, looked up lazily via the typed Jobs client.
     """
 
     def __init__(

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/_mapping_access.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/_mapping_access.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mapping-style access helpers for job spec models.
+
+Job spec request shapes are often built and adjusted as nested data objects.
+Supporting both attribute access (``step.executor.profile``) and mapping-style
+access (``step["executor"]["profile"]``) keeps plugin compilers, API handlers,
+and tests ergonomic without requiring callers to care whether a nested shape is
+a plain dict or a Pydantic model.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MappingAccessMixin:
+    """Support a small mapping-style access surface on Pydantic models."""
+
+    def __getitem__(self: BaseModel, key: str) -> Any:
+        return getattr(self, key)
+
+    def __setitem__(self: BaseModel, key: str, value: Any) -> None:
+        setattr(self, key, value)
+
+    def __contains__(self: BaseModel, key: object) -> bool:
+        return isinstance(key, str) and key in self.model_fields_set
+
+    def get(self: BaseModel, key: str, default: Any = None) -> Any:
+        return getattr(self, key, default)
+
+    def __eq__(self: BaseModel, other: object) -> bool:
+        if isinstance(other, Mapping):
+            full = self.model_dump(mode="json", exclude_none=True)
+            compact = self.model_dump(mode="json", exclude_none=True, exclude_defaults=True)
+            return other == full or other == compact
+        return BaseModel.__eq__(self, other)
+
+
+class JobSpecModel(MappingAccessMixin, BaseModel):
+    """Base model for job spec request shapes."""
+
+    model_config = ConfigDict(validate_assignment=True)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py
@@ -7,6 +7,7 @@ import logging
 import os
 import tarfile
 from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Mapping
 from datetime import datetime
 from enum import StrEnum, auto
 from functools import partial
@@ -15,12 +16,10 @@ from types import UnionType
 from typing import (
     Annotated,
     Any,
-    Awaitable,
     Callable,
     Generic,
     Literal,
     Type,
-    TypeGuard,
     TypeVar,
     Union,
     get_args,
@@ -32,21 +31,6 @@ from anyio import open_file, to_thread
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from nemo_platform import AsyncNeMoPlatform
-from nemo_platform.types.jobs import (
-    ComputeResourcesParam,
-    ComputeResourceSpecParam,
-    ContainerSpecParam,
-    CPUExecutionProviderParam,
-    DistributedGPUExecutionProviderParam,
-    GPUExecutionProviderParam,
-    PlatformJobEnvironmentVariableParam,
-    PlatformJobSecretEnvironmentVariableRefParam,
-    PlatformJobSpecParam,
-    PlatformJobStepSpecParam,
-    StepLifecycleParam,
-    SubprocessExecutionProviderParam,
-)
-from nemo_platform.types.jobs.platform_job_step_spec_param import Executor
 from nemo_platform_plugin.api.filter import ComparisonOperation, FilterOperation, FilterOperator, LogicalOperation
 from nemo_platform_plugin.api.parsed_filter import ParsedFilter, make_filter_dep
 from nemo_platform_plugin.authz import AuthzScope, CallerKind, path_rule
@@ -57,6 +41,18 @@ from nemo_platform_plugin.jobs.client import AsyncJobsClient
 from nemo_platform_plugin.jobs.docker import validate_gpu_available_for_docker
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError, PlatformJobDependencyUnavailableError
 from nemo_platform_plugin.jobs.openapi_utils import generate_openapi_extra_params
+from nemo_platform_plugin.jobs.providers import (
+    ComputeResources,
+    ComputeResourceSpec,
+    CPUExecutionProvider,
+    DistributedGPUExecutionProvider,
+    GPUExecutionProvider,
+    Provider,
+    SubprocessExecutionProvider,
+)
+from nemo_platform_plugin.jobs.providers import (
+    ContainerSpec as ProviderContainerSpec,
+)
 from nemo_platform_plugin.jobs.result_manager import download_from_result_info
 from nemo_platform_plugin.jobs.schemas import (
     PlatformJobListResultResponse,
@@ -64,6 +60,16 @@ from nemo_platform_plugin.jobs.schemas import (
     PlatformJobResultResponse,
     PlatformJobStatus,
     PlatformJobStatusResponse,
+)
+from nemo_platform_plugin.jobs.spec import (
+    PlatformJobEnvironmentVariable,
+    PlatformJobSecret,
+    PlatformJobSecretEnvironmentVariableRef,
+    PlatformJobSpec,
+    PlatformJobStepSpec,
+)
+from nemo_platform_plugin.jobs.spec import (
+    StepLifecycle as PlatformJobStepLifecycle,
 )
 from nemo_platform_plugin.jobs.types import (
     CreatePlatformJobRequest,
@@ -79,27 +85,24 @@ from pydantic import BaseModel, Field, TypeAdapter, field_validator
 
 logger = logging.getLogger(__name__)
 
-# This type is aliased to ensure we don't expose internal stainless
-# type paths to services integrating the job service.
-#
-# TODO(AIRCORE-922): remove these Stainless-generated ``*Param`` TypedDict aliases.
-# The plugin now owns pydantic equivalents in ``jobs/spec.py`` and ``jobs/providers.py``,
-# but ~10 consuming plugins construct these as dict literals (TypedDict), so repointing
-# them to the pydantic models is a cross-cutting change tracked by AIRCORE-922.
-PlatformJobSpec = PlatformJobSpecParam
-PlatformJobStep = PlatformJobStepSpecParam
-StepLifecycle = StepLifecycleParam
-ExecutorSpec = Executor
-CPUExecutionProviderSpec = CPUExecutionProviderParam
-GPUExecutionProviderSpec = GPUExecutionProviderParam
-DistributedGPUExecutionProviderSpec = DistributedGPUExecutionProviderParam
-SubprocessExecutionProviderSpec = SubprocessExecutionProviderParam
-ResourcesSpec = ComputeResourcesParam
-ResourcesLimitsSpec = ComputeResourceSpecParam
-ResourcesRequestsSpec = ComputeResourceSpecParam
-ContainerSpec = ContainerSpecParam
-EnvironmentVariable = PlatformJobEnvironmentVariableParam
-EnvironmentVariableFromSecret = PlatformJobSecretEnvironmentVariableRefParam
+# Public compatibility aliases for services that build Jobs specs through the
+# route factory. These now point at plugin-owned Pydantic models, not Stainless
+# generated SDK TypedDicts.
+PlatformJobStep = PlatformJobStepSpec
+ExecutorSpec = Provider
+ContainerSpec = ProviderContainerSpec
+CPUExecutionProviderSpec = CPUExecutionProvider
+GPUExecutionProviderSpec = GPUExecutionProvider
+DistributedGPUExecutionProviderSpec = DistributedGPUExecutionProvider
+SubprocessExecutionProviderSpec = SubprocessExecutionProvider
+ResourcesSpec = ComputeResources
+ResourcesLimitsSpec = ComputeResourceSpec
+ResourcesRequestsSpec = ComputeResourceSpec
+StepLifecycle = PlatformJobStepLifecycle
+EnvironmentVariable = PlatformJobEnvironmentVariable
+EnvironmentVariableFromSecret = PlatformJobSecretEnvironmentVariableRef
+JobSecret = PlatformJobSecret
+PlatformJobSpecLike = PlatformJobSpec | Mapping[str, Any]
 
 # Descriptions stamped onto the standard job permissions, keyed by verb. The catalog is
 # derived from the routes, so these descriptions are the source of truth for the generated
@@ -171,6 +174,13 @@ class BaseJobsSortField(StrEnum):
     CREATED_AT_DESC = "-created_at"
     UPDATED_AT_ASC = "updated_at"
     UPDATED_AT_DESC = "-updated_at"
+
+
+def _make_jobs_sort_field(job_type: str) -> type[StrEnum]:
+    return StrEnum(
+        f"{job_type}JobsSortField",
+        {name: member.value for name, member in BaseJobsSortField.__members__.items()},
+    )
 
 
 # Field-name allowlists for value-side validation in list_jobs. ``make_filter_dep``
@@ -273,22 +283,22 @@ def handle_job_spec_mismatch(job_input: Type[JobConfigT] | JobSchemaLike, spec: 
     return job_spec
 
 
-def _validate_job_spec(job: PlatformJobSpec) -> None:
+def _validate_job_spec(job: object) -> PlatformJobSpec:
     """Validate the job spec for common misconfigurations."""
+    try:
+        platform_job = PlatformJobSpec.model_validate(job)
+    except Exception as e:
+        raise PlatformJobCompilationError(f"platform job spec is invalid: {str(e)}") from e
 
     # Validate that any config's provided are serializeable to json
     try:
-        for step in job["steps"]:
-            if "config" in step:
-                json.dumps(step["config"])
+        for step in platform_job.steps:
+            json.dumps(step.config)
     except Exception as e:
         raise PlatformJobCompilationError(f"step config is not json serializable: {str(e)}")
 
-    validate_gpu_available_for_docker(job)
-
-
-def _is_platform_job_spec(job: object) -> TypeGuard[PlatformJobSpec]:
-    return isinstance(job, dict) and "steps" in job
+    validate_gpu_available_for_docker(platform_job)
+    return platform_job
 
 
 class BaseResultSerializer(BaseModel, ABC):
@@ -306,7 +316,7 @@ class BaseResultSerializer(BaseModel, ABC):
         }
 
     @abstractmethod
-    def serialize(self, output_path: Path, **kwargs) -> Response:
+    def serialize(self, output_path: Path, limit: int | None = None) -> Response:
         """
         Convert a file/dir into an appropriate fastapi output format.
         """
@@ -316,7 +326,8 @@ class BaseResultSerializer(BaseModel, ABC):
 class JSONResultSerializer(BaseResultSerializer):
     serializer_type: Literal["json"] = "json"
 
-    def serialize(self, output_path: Path, **kwargs) -> JSONResponse:
+    def serialize(self, output_path: Path, limit: int | None = None) -> JSONResponse:
+        del limit
         with output_path.open() as f:
             return JSONResponse(json.load(f))
 
@@ -364,7 +375,7 @@ class PydanticJSONLResultSerializer(BaseResultSerializer):
         }
         return ret
 
-    async def _validated_lines_iterator(self, file_path: str, limit: int | None = None):
+    async def _validated_lines_iterator(self, file_path: Path, limit: int | None = None):
         lines = 0
         line_number = 0
         async with await open_file(file_path, mode="r", encoding="utf-8") as f:
@@ -399,10 +410,8 @@ class PydanticJSONLResultSerializer(BaseResultSerializer):
                 if limit and lines >= limit:
                     return
 
-    def serialize(self, output_path: Path, limit: int | None = None, **_kwargs: object) -> StreamingResponse:
-        return StreamingResponse(
-            self._validated_lines_iterator(str(output_path), limit), media_type="application/jsonl"
-        )
+    def serialize(self, output_path: Path, limit: int | None = None) -> StreamingResponse:
+        return StreamingResponse(self._validated_lines_iterator(output_path, limit), media_type="application/jsonl")
 
 
 class PydanticResultSerializer(BaseResultSerializer):
@@ -415,7 +424,8 @@ class PydanticResultSerializer(BaseResultSerializer):
         # to use when generating the schema.
         return super().route_kwargs() | {"response_model": self.model}
 
-    def serialize(self, output_path: Path, **kwargs) -> JSONResponse:
+    def serialize(self, output_path: Path, limit: int | None = None) -> JSONResponse:
+        del limit
         with output_path.open() as f:
             json_in = json.load(f)
 
@@ -442,7 +452,8 @@ class FileResultSerializer(BaseResultSerializer):
         }
         return ret
 
-    def serialize(self, output_path: Path, **kwargs) -> FileResponse:
+    def serialize(self, output_path: Path, limit: int | None = None) -> FileResponse:
+        del limit
         if output_path.is_dir():
             filename = f"{output_path.name}.tar.gz"
             tar_path = output_path.parent / filename
@@ -479,12 +490,17 @@ class PlatformJobResultRoute(BaseModel):
 # Signature: (workspace, original_spec, transformed_spec, entity_client, job_name, sdk) -> PlatformJobSpec
 # job_name is the resolved name (user-provided or auto-generated), None when no name is available
 # sdk is always provided for accessing secrets, files, and models with user context
+# A compiler may be implemented synchronously or asynchronously. Model that in
+# the callable's return type instead of narrowing the callable itself with
+# runtime-only typing helpers.
 PlatformJobSpecCompiler = Callable[
-    [str, JobInputT, JobOutputT, EntityClient, str | None, AsyncNeMoPlatform], PlatformJobSpec
+    [str, JobInputT, JobOutputT, EntityClient, str | None, AsyncNeMoPlatform],
+    PlatformJobSpecLike | Awaitable[PlatformJobSpecLike],
 ]
 PlatformJobSpecCompilerAsync = Callable[
-    [str, JobInputT, JobOutputT, EntityClient, str | None, AsyncNeMoPlatform], Awaitable[PlatformJobSpec]
+    [str, JobInputT, JobOutputT, EntityClient, str | None, AsyncNeMoPlatform], Awaitable[PlatformJobSpecLike]
 ]
+
 
 # Input-to-output transformer types: receives job_name to use for related fields (e.g., output)
 # Signature: (original_spec, workspace, entity_client, job_name, sdk) -> transformed_spec
@@ -657,7 +673,7 @@ async def _transform_input_to_output(
 
 
 async def _compile_platform_spec(
-    compiler: PlatformJobSpecCompiler | PlatformJobSpecCompilerAsync,
+    compiler: PlatformJobSpecCompiler,
     workspace: str,
     original_spec: JobSchemaLike,
     transformed_spec: JobSchemaLike,
@@ -684,7 +700,7 @@ async def _compile_platform_spec(
     """
     try:
         submit_control_kwargs = _submit_control_kwargs(compiler, profile=profile, options=options)
-        compile_result: PlatformJobSpec | Awaitable[PlatformJobSpec]
+        compile_result: PlatformJobSpecLike | Awaitable[PlatformJobSpecLike]
         if inspect.iscoroutinefunction(compiler):
             compile_result = compiler(
                 workspace, original_spec, transformed_spec, entity_client, job_name, sdk, **submit_control_kwargs
@@ -708,10 +724,7 @@ async def _compile_platform_spec(
         else:
             platform_spec = compile_result
 
-        if not _is_platform_job_spec(platform_spec):
-            raise PlatformJobCompilationError("compiled job spec must be a mapping with steps")
-        _validate_job_spec(platform_spec)
-        return platform_spec
+        return _validate_job_spec(platform_spec)
     except PermissionError as e:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -768,8 +781,7 @@ def job_route_factory(
     service_name: str,
     job_type: str,
     job_input: JobSchemaLike,
-    platform_job_config_compiler: PlatformJobSpecCompiler[JobInputT, JobOutputT]
-    | PlatformJobSpecCompilerAsync[JobInputT, JobOutputT],
+    platform_job_config_compiler: PlatformJobSpecCompiler[JobInputT, JobOutputT],
     route_options: list[JobRouteOption] | None = None,
     job_result_routes: list[PlatformJobResultRoute] | None = None,
     job_output: JobSchemaLike | None = None,
@@ -870,20 +882,28 @@ def job_route_factory(
     # with `job_type` as a prefix, so that the correct name is used in the openapi spec, instead of
     # multiple duplicative `TypedJob` and `TypedJobRequest` definitions (one for each factory client).
     # The first arg is the type/class name, the second arg is a tuple of base classes to inherit,
-    # and the third arg is a dict of definitions for the class body (unused in our case).
+    # and the third arg defines the runtime ``spec`` annotation used by Pydantic.
     #
     # Request uses job_input (input schema), Response uses job_output (output schema)
     # When job_output is not provided, they are the same type.
-    # Type ignore is safe here because _validate_basemodel_or_union already validated these types
-    # are either BaseModel subclasses or unions of BaseModel subclasses.
-    TypedJobRequest = type(f"{job_type}JobRequest", (BaseJobRequest[job_input],), {})  # ty: ignore[invalid-type-form]
-    TypedJobResponse = type(f"{job_type}Job", (BaseJob[job_output],), {})  # ty: ignore[invalid-type-form]
-    TypedJobsListFilter = type(f"{job_type}JobsListFilter", (BaseJobsListFilter,), {})
-
-    TypedJobsSortField = StrEnum(
-        f"{job_type}JobsSortField",  # ty: ignore[mismatched-type-name]
-        {name: member.value for name, member in BaseJobsSortField.__members__.items()},
+    # _validate_basemodel_or_union already validated these types are either
+    # BaseModel subclasses or unions of BaseModel subclasses.
+    TypedJobRequest = type(
+        f"{job_type}JobRequest",
+        (BaseJobRequest[BaseModel],),
+        {"__annotations__": {"spec": job_input}},
     )
+    TypedJobResponse = type(
+        f"{job_type}Job",
+        (BaseJob[BaseModel],),
+        {"__annotations__": {"spec": job_output}},
+    )
+    TypedJobsListFilter = type(f"{job_type}JobsListFilter", (BaseJobsListFilter,), {})
+    # Keep the OpenAPI schema names stable for generated SDK consumers.  The
+    # values are shared across job factories, but Studio imports the generated
+    # per-job symbols (for example ``EvaluateJobsSortField``), so the route
+    # annotation must expose a concrete enum named for this job type.
+    TypedJobsSortField = _make_jobs_sort_field(job_type)
 
     def from_response(job_resp: PlatformJob) -> TypedJobResponse:
         # Use job_output for deserialization (what's stored and returned)
@@ -985,22 +1005,13 @@ def job_route_factory(
             ).data()
             return from_response(job_resp)
 
-        @router.get(
-            "/jobs",
-            response_model=Page[TypedJobResponse],
-            response_model_exclude_none=True,
-            openapi_extra=generate_openapi_extra_params(
-                filter_schema=TypedJobsListFilter,
-                filter_description="Filter jobs on various criteria.",
-            ),
-        )
         async def list_jobs(
             workspace: str,
             sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
             page: int = Query(default=1, description="Page number.", gt=0),
             page_size: int = Query(default=10, description="Page size.", gt=0),
-            sort: TypedJobsSortField = Query(  # ty: ignore[invalid-type-form]
-                default=TypedJobsSortField(BaseJobsSortField.CREATED_AT_DESC.value),
+            sort: BaseJobsSortField = Query(
+                default=BaseJobsSortField.CREATED_AT_DESC,
                 description="The field to sort by. To sort in decreasing order, use `-` in front of the field name.",
             ),
             parsed: ParsedFilter = Depends(make_filter_dep(TypedJobsListFilter)),
@@ -1051,6 +1062,19 @@ def job_route_factory(
                 sort=sort,
                 filter=user_filter or None,
             )
+
+        list_jobs.__annotations__["sort"] = TypedJobsSortField
+        router.add_api_route(
+            "/jobs",
+            list_jobs,
+            methods=["GET"],
+            response_model=Page[TypedJobResponse],
+            response_model_exclude_none=True,
+            openapi_extra=generate_openapi_extra_params(
+                filter_schema=TypedJobsListFilter,
+                filter_description="Filter jobs on various criteria.",
+            ),
+        )
 
         @router.get(
             "/jobs/{name}",

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/docker.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/docker.py
@@ -4,14 +4,18 @@
 """Docker-specific job validation (e.g. GPU availability for Docker backends)."""
 
 import logging
+from collections.abc import Mapping
+from typing import Any
 
-from nemo_platform.types.jobs import PlatformJobSpecParam
 from nemo_platform_plugin.capabilities import probe_docker
 from nemo_platform_plugin.config import Configuration, NemoPlatformConfig, Runtime
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
+from nemo_platform_plugin.jobs.spec import PlatformJobSpec
 from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
+
+PlatformJobSpecLike = PlatformJobSpec | Mapping[str, Any]
 
 
 def get_platform_config() -> NemoPlatformConfig:
@@ -24,15 +28,11 @@ _GPU_UNAVAILABLE_MSG = (
 )
 
 
-def spec_has_gpu_step(job: PlatformJobSpecParam) -> bool:
+def spec_has_gpu_step(job: PlatformJobSpecLike) -> bool:
     """Return True if the job spec has at least one step requiring a GPU."""
-    steps = job.get("steps") or ()
-    for step in steps:
-        executor = step.get("executor")
-        if executor is None:
-            continue
-        provider = executor.get("provider")
-        if provider in ("gpu", "gpu_distributed"):
+    platform_job = PlatformJobSpec.model_validate(job)
+    for step in platform_job.steps:
+        if step.executor.provider in ("gpu", "gpu_distributed"):
             return True
     return False
 
@@ -51,7 +51,7 @@ def _docker_gpu_validation_applies(runtime: Runtime) -> bool:
     return False
 
 
-def validate_gpu_available_for_docker(job: PlatformJobSpecParam) -> None:
+def validate_gpu_available_for_docker(job: PlatformJobSpecLike) -> None:
     """Fail fast when job requires GPU but platform Docker has no GPUs configured.
 
     platform_config.docker.get_reserved_gpu_ids() returns:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/profile.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/profile.py
@@ -22,11 +22,9 @@ The helper mutates *spec* in place and also returns it for chaining.
 
 Why it lives in ``nemo_platform_plugin`` and not in the Jobs service:
 
-Each step's ``executor`` is a discriminated union
-(``CPUExecutionProviderParam`` / ``GPUExecutionProviderParam`` /
-``DistributedGPUExecutionProviderParam``) from the generated
-``nemo_platform`` SDK. All three carry a ``profile: str`` field — that's the
-only attribute the stamper touches. Keeping the helper in ``nemo_platform_plugin``
+Each step's ``executor`` is a plugin-owned discriminated union. All provider
+models carry a ``profile: str`` field — that's the only attribute the stamper
+touches. Keeping the helper in ``nemo_platform_plugin``
 alongside the factory avoids dragging plugin-service code through the Jobs
 service's internals and matches where ``add_job_routes()`` already lives.
 """

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/providers.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/providers.py
@@ -18,14 +18,15 @@ from __future__ import annotations
 import re
 from typing import Annotated, Literal, Self, Union
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from nemo_platform_plugin.jobs._mapping_access import JobSpecModel
+from pydantic import Field, field_validator, model_validator
 
 # SHM: megabyte/gigabyte scale only — Mi, Gi (binary) or M, G (decimal SI).
 # Ki / Ti / Pi / Ei and other suffixes are not accepted for /dev/shm.
 _SHM_QUANTITY_RE = re.compile(r"^([+-]?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?)(Mi|Gi|M|G)$")
 
 
-class ContainerSpec(BaseModel):
+class ContainerSpec(JobSpecModel):
     """
     Specification for a container configuration.
 
@@ -42,14 +43,14 @@ class ContainerSpec(BaseModel):
     """The command to execute as a list of strings (e.g., ['python', 'script.py']). This overrides a container's default commands (e.g. CMD in Docker) if provided."""
 
 
-class ComputeResourceSpec(BaseModel):
+class ComputeResourceSpec(JobSpecModel):
     """Resource specification."""
 
     cpu: str | None = Field(default=None, description="CPU specification (e.g., '250m', '1', '2.5').")
     memory: str | None = Field(default=None, description="Memory specification (e.g., '128Mi', '1Gi', '512M').")
 
 
-class ComputeResources(BaseModel):
+class ComputeResources(JobSpecModel):
     """Resource requirements matching k8s ResourceRequirements format."""
 
     requests: ComputeResourceSpec = Field(
@@ -85,7 +86,7 @@ class ComputeResources(BaseModel):
         return s
 
 
-class TaskSpec(BaseModel):
+class TaskSpec(JobSpecModel):
     """
     Specification for a task to be executed.
 
@@ -99,7 +100,7 @@ class TaskSpec(BaseModel):
     """Arguments to pass to the command. Can be a list of strings or a single string."""
 
 
-class CPUExecutionProvider(BaseModel):
+class CPUExecutionProvider(JobSpecModel):
     """
     CPU-based execution provider.
 
@@ -121,7 +122,7 @@ class CPUExecutionProvider(BaseModel):
     )
 
 
-class GPUExecutionProvider(BaseModel):
+class GPUExecutionProvider(JobSpecModel):
     """
     GPU-based execution provider.
 
@@ -143,7 +144,7 @@ class GPUExecutionProvider(BaseModel):
     )
 
 
-class DistributedGPUExecutionProvider(BaseModel):
+class DistributedGPUExecutionProvider(JobSpecModel):
     """
     GPU-based execution provider.
 
@@ -165,7 +166,7 @@ class DistributedGPUExecutionProvider(BaseModel):
     )
 
 
-class SubprocessExecutionProvider(BaseModel):
+class SubprocessExecutionProvider(JobSpecModel):
     """Host subprocess execution provider."""
 
     provider: Literal["subprocess"] = "subprocess"

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/spec.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/spec.py
@@ -15,21 +15,30 @@ server and the typed HTTP client share one definition.
 
 from __future__ import annotations
 
-from typing import Optional, Self
+from typing import Any, Optional, Self
 
 from nemo_platform_plugin.entity_naming import NAME_PATTERN, NAME_PATTERN_DESCRIPTION
+from nemo_platform_plugin.jobs._mapping_access import JobSpecModel
 from nemo_platform_plugin.jobs.constants import PERSISTENT_JOB_STORAGE_PATH_ENVVAR
 from nemo_platform_plugin.jobs.providers import Provider
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 
-class PlatformJobSecretEnvironmentVariableRef(BaseModel):
+class PlatformJobSecretEnvironmentVariableRef(JobSpecModel):
     """Reference to a secret to populate an environment variable for a job step."""
 
     name: str = Field(description="The name of the secret to reference")
 
 
-class PlatformJobEnvironmentVariable(BaseModel):
+class PlatformJobSecret(JobSpecModel):
+    """Inline secret material submitted with a job spec."""
+
+    name: str = Field(description="The name of the secret")
+    value: Optional[str] = Field(default=None, description="The secret value submitted with the job")
+    ref_id: Optional[str] = Field(default=None, description="Reference id for the stored secret value")
+
+
+class PlatformJobEnvironmentVariable(JobSpecModel):
     """Environment variable for a job step"""
 
     name: str = Field(description="The environment variable name")
@@ -51,7 +60,7 @@ class PlatformJobEnvironmentVariable(BaseModel):
         return self
 
 
-class StepLifecycle(BaseModel):
+class StepLifecycle(JobSpecModel):
     """Controller-level lifecycle configuration for a job step.
 
     These settings control how the jobs controller manages the step,
@@ -66,7 +75,7 @@ class StepLifecycle(BaseModel):
     )
 
 
-class PlatformJobStepSpec(BaseModel):
+class PlatformJobStepSpec(JobSpecModel):
     """Specification for a single step in a platform job."""
 
     name: str = Field(
@@ -82,6 +91,13 @@ class PlatformJobStepSpec(BaseModel):
     lifecycle: StepLifecycle = Field(
         default_factory=StepLifecycle, description="Lifecycle configuration settings for the step"
     )
+
+    @field_validator("environment", mode="before")
+    @classmethod
+    def _coerce_empty_mapping_environment(cls, value: Any) -> Any:
+        if value == {}:
+            return []
+        return value
 
     @property
     def requires_persistent_storage(self) -> bool:
@@ -99,10 +115,11 @@ class PlatformJobStepSpec(BaseModel):
     model_config = ConfigDict(regex_engine="python-re")
 
 
-class PlatformJobSpec(BaseModel):
+class PlatformJobSpec(JobSpecModel):
     """Specification for a platform job, containing steps and secrets."""
 
     steps: list[PlatformJobStepSpec] = Field(description="List of steps to be executed in the job")
+    secrets: Optional[list[PlatformJobSecret]] = Field(default=None, description="Secrets referenced by the job")
 
     @model_validator(mode="after")
     def validate_steps(self) -> Self:
@@ -123,7 +140,7 @@ ProfileRef = str
 BackendRef = str
 
 
-class BaseExecutionProfile(BaseModel):
+class BaseExecutionProfile(JobSpecModel):
     """Execution configuration for a job.
 
     Base class for the concrete execution profiles in

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/dispatcher.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/tasks/dispatcher.py
@@ -197,7 +197,7 @@ def _build_ctx_from_env(sdk: Any) -> JobContext:
 
     ``PlatformJobResults.job_name`` is the *submitted* platform job name, not
     the job class name — :class:`~nemo_platform_plugin.jobs.result_manager.ResultManager`
-    uses it to look up the job via ``jobs_sdk.jobs.retrieve`` so each
+    uses it to look up the job via the typed Jobs client so each
     ``ctx.results.save()`` registers against the correct job record. The
     backends inject this as ``NEMO_JOB_ID = step.job``; the NemoJob class
     identifier (e.g. ``"evaluate"``) would point at a non-existent job and

--- a/packages/nemo_platform_plugin/tests/test_dispatcher.py
+++ b/packages/nemo_platform_plugin/tests/test_dispatcher.py
@@ -156,7 +156,9 @@ class TestExitCodes:
             name = "non-dict"
 
             def run(self, config: dict) -> dict:
-                return "hello"  # type: ignore[return-value]
+                # Intentionally violate the typed contract to pin the dispatcher
+                # behavior for bad runtime returns without hiding it behind a cast.
+                return "hello"  # ty: ignore[invalid-return-type]
 
         rc = run_task(_Job, sdk=_DEFAULT_SDK)
 
@@ -355,7 +357,7 @@ class TestExitCodes:
         class _Job(NemoJob):
             name = "needs-sdk"
 
-            def run(self, config: dict, *, sdk) -> dict:  # ty: ignore[invalid-method-override]
+            def run(self, config: dict, *, sdk) -> dict:
                 return {"status": "completed"}
 
         with pytest.raises(LocalRunError, match="sdk"):
@@ -385,7 +387,7 @@ class TestExitCodes:
         class _Job(NemoJob):
             name = "weird-required-param"
 
-            def run(self, config: dict, *, foo) -> dict:  # ty: ignore[invalid-method-override]
+            def run(self, config: dict, *, foo) -> dict:
                 return {"status": "completed", "foo": foo}
 
         with pytest.raises(LocalRunError, match="foo"):
@@ -400,7 +402,7 @@ class TestSignatureDI:
         class _Job(NemoJob):
             name = "ctx-job"
 
-            def run(self, config: dict, *, ctx: JobContext) -> dict:  # ty: ignore[invalid-method-override]
+            def run(self, config: dict, *, ctx: JobContext) -> dict:
                 captured["ctx"] = ctx
                 return {"status": "completed"}
 
@@ -419,7 +421,7 @@ class TestSignatureDI:
         class _Job(NemoJob):
             name = "sdk-job"
 
-            def run(self, config: dict, *, sdk) -> dict:  # ty: ignore[invalid-method-override]
+            def run(self, config: dict, *, sdk) -> dict:
                 captured["sdk"] = sdk
                 return {"status": "completed"}
 
@@ -471,7 +473,7 @@ class TestStepConfigPlumbing:
         class _Job(NemoJob):
             name = "echo"
 
-            def run(self, config: dict, *, ctx: JobContext) -> dict:  # ty: ignore[invalid-method-override]
+            def run(self, config: dict, *, ctx: JobContext) -> dict:
                 captured["config"] = config
                 return {"status": "completed"}
 
@@ -505,7 +507,7 @@ class TestCtxOverride:
         class _Job(NemoJob):
             name = "ctx-override"
 
-            def run(self, config: dict, *, ctx: JobContext) -> dict:  # ty: ignore[invalid-method-override]
+            def run(self, config: dict, *, ctx: JobContext) -> dict:
                 captured["ctx"] = ctx
                 return {"status": "completed"}
 
@@ -555,7 +557,7 @@ class TestCtxOverride:
         class _Job(NemoJob):
             name = "results-sink"
 
-            def run(self, config: dict, *, ctx: JobContext) -> dict:  # ty: ignore[invalid-method-override]
+            def run(self, config: dict, *, ctx: JobContext) -> dict:
                 captured["results"] = ctx.results
                 return {"status": "completed"}
 
@@ -609,7 +611,7 @@ class TestBuildCtxFromEnv:
     def test_results_use_submitted_job_id_not_class_name(self, tmp_path: Path, monkeypatch) -> None:
         # Regression: ``PlatformJobResults`` must be keyed off the *submitted*
         # platform job name (``NEMO_JOB_ID``) so ``ResultManager.create_result``
-        # can ``jobs_sdk.jobs.retrieve(name=...)`` it. Earlier versions passed
+        # can retrieve it via the typed Jobs client. Earlier versions passed
         # ``job_cls.name`` (the NemoJob class identifier like ``"evaluate"``)
         # which points at a non-existent job record.
         captured: dict[str, str] = {}

--- a/packages/nemo_platform_plugin/tests/test_jobs_create_spec_json.py
+++ b/packages/nemo_platform_plugin/tests/test_jobs_create_spec_json.py
@@ -11,16 +11,22 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from nemo_platform_plugin.dependencies import get_entity_client, get_sdk_client
 from nemo_platform_plugin.jobs.api_factory import (
     ContainerSpec,
     CPUExecutionProviderSpec,
+    EnvironmentVariable,
+    GPUExecutionProviderSpec,
+    JobSecret,
     PlatformJobSpec,
     PlatformJobStep,
     job_route_factory,
 )
-from pydantic import BaseModel, ConfigDict
+from nemo_platform_plugin.jobs.docker import spec_has_gpu_step
+from nemo_platform_plugin.jobs.types import CreatePlatformJobRequest
+from pydantic import BaseModel, ConfigDict, ValidationError
 from starlette.testclient import TestClient
 
 # Non-UTF-8 bytes like a cloudpickle metric bundle blob.
@@ -92,6 +98,83 @@ def _mock_create_response(spec: dict[str, object]) -> MagicMock:
     return response
 
 
+class _RecordingJobsClient:
+    def __init__(self) -> None:
+        self.created_body: CreatePlatformJobRequest | None = None
+
+    async def create_job(self, *, workspace: str, body: CreatePlatformJobRequest) -> MagicMock:
+        del workspace
+        self.created_body = body
+        expected_spec = {"blob": base64.b64encode(_PICKLE_BYTES).decode("ascii")}
+        return _mock_create_response(expected_spec)
+
+
+def test_job_spec_models_support_mapping_style_access() -> None:
+    env = EnvironmentVariable(name="ENV_VAR", value="value")
+    executor = CPUExecutionProviderSpec(
+        provider="cpu",
+        profile="default",
+        container=ContainerSpec(image="test"),
+    )
+    step = PlatformJobStep(
+        name="step",
+        executor=executor,
+        config={},
+        environment=[env],
+    )
+
+    assert "executor" in step
+    assert "resources" not in executor
+    assert step["environment"] == [{"name": "ENV_VAR", "value": "value"}]
+    step["executor"]["profile"] = "custom"
+    assert step.executor.profile == "custom"
+
+
+def test_job_spec_mapping_assignment_validates_executor_models() -> None:
+    step = PlatformJobStep(
+        name="step",
+        executor=CPUExecutionProviderSpec(
+            provider="cpu",
+            profile="default",
+            container=ContainerSpec(image="test"),
+        ),
+        config={},
+    )
+
+    with pytest.raises(ValidationError):
+        step["executor"] = {}
+
+    step["executor"] = {
+        "provider": "gpu",
+        "profile": "default",
+        "container": {"image": "gpu-image"},
+    }
+
+    assert isinstance(step.executor, GPUExecutionProviderSpec)
+    assert spec_has_gpu_step(PlatformJobSpec(steps=[step])) is True
+
+
+def test_job_spec_includes_inline_secrets() -> None:
+    spec = PlatformJobSpec(
+        steps=[
+            PlatformJobStep(
+                name="step",
+                executor=CPUExecutionProviderSpec(
+                    provider="cpu",
+                    profile="default",
+                    container=ContainerSpec(image="test"),
+                ),
+            )
+        ],
+        secrets=[JobSecret(name="secret-name", value="secret-value")],
+    )
+
+    assert spec["secrets"] == [{"name": "secret-name", "value": "secret-value"}]
+    assert spec.model_dump(mode="json", exclude_none=True)["secrets"] == [
+        {"name": "secret-name", "value": "secret-value"}
+    ]
+
+
 def test_create_job_forwards_transformed_spec_in_json_mode() -> None:
     """Binary fields in transformed specs must be base64 strings, not raw bytes."""
     router = job_route_factory(
@@ -107,15 +190,7 @@ def test_create_job_forwards_transformed_spec_in_json_mode() -> None:
     app.dependency_overrides[get_sdk_client] = lambda: MagicMock()
     app.dependency_overrides[get_entity_client] = lambda: MagicMock()
 
-    captured_body: dict[str, object] = {}
-
-    async def _create_job(*, workspace: str, body: object) -> MagicMock:
-        del workspace
-        captured_body["body"] = body
-        expected_spec = {"blob": base64.b64encode(_PICKLE_BYTES).decode("ascii")}
-        return _mock_create_response(expected_spec)
-
-    mock_jobs = SimpleNamespace(create_job=_create_job)
+    mock_jobs = _RecordingJobsClient()
 
     client = TestClient(app)
     with patch(
@@ -125,9 +200,9 @@ def test_create_job_forwards_transformed_spec_in_json_mode() -> None:
         response = client.post("/apis/widgets/v2/workspaces/default/jobs", json={"spec": {"label": "metric"}})
 
     assert response.status_code == 201, response.text
-    body = captured_body["body"]
+    body = mock_jobs.created_body
     assert body is not None
-    spec = body.spec if hasattr(body, "spec") else body["spec"]  # type: ignore[index]
+    spec = body.spec
     blob = spec["blob"] if isinstance(spec, dict) else spec.blob
     assert isinstance(blob, str), f"expected base64 string, got {type(blob)}"
     assert blob == base64.b64encode(_PICKLE_BYTES).decode("ascii")

--- a/packages/nemo_platform_plugin/tests/test_jobs_filter.py
+++ b/packages/nemo_platform_plugin/tests/test_jobs_filter.py
@@ -343,7 +343,7 @@ class TestPluginJobsFilterValueValidation:
 
 class TestForwardedFilterSurvivesSdkSerialization:
     """Codex adversarial-review concern: the kwargs-capturing tests above prove
-    *what* the factory hands to ``sdk.jobs.list``, but not whether the SDK's
+    *what* the factory hands to the typed Jobs client, but not whether the old SDK's
     querystring serializer can encode it onto the wire without mangling.
 
     The typed client forwards ``filter`` as a single JSON-string query param

--- a/packages/nmp_common/src/nmp/common/jobs/docker.py
+++ b/packages/nmp_common/src/nmp/common/jobs/docker.py
@@ -3,12 +3,17 @@
 
 """Docker-specific job validation compatibility wrapper."""
 
-from nemo_platform.types.jobs import PlatformJobSpecParam
+from collections.abc import Mapping
+from typing import Any
+
 from nemo_platform_plugin.jobs.docker import spec_has_gpu_step as spec_has_gpu_step
 from nemo_platform_plugin.jobs.docker import validate_gpu_available_for_docker as _plugin_validate
+from nemo_platform_plugin.jobs.spec import PlatformJobSpec
+
+PlatformJobSpecLike = PlatformJobSpec | Mapping[str, Any]
 
 
-def validate_gpu_available_for_docker(job: PlatformJobSpecParam) -> None:
+def validate_gpu_available_for_docker(job: PlatformJobSpecLike) -> None:
     """Fail fast when job requires GPU but platform Docker has no GPUs configured.
 
     Delegates to :func:`nemo_platform_plugin.jobs.docker.validate_gpu_available_for_docker`

--- a/packages/nmp_common/tests/api_factory/test_api_factory.py
+++ b/packages/nmp_common/tests/api_factory/test_api_factory.py
@@ -14,8 +14,6 @@ from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
-from nemo_platform.types.jobs import PlatformJobResponse as PlatformJob
-from nemo_platform.types.shared.platform_job_status import PlatformJobStatus
 from nemo_platform_plugin.client.errors import (
     ConflictError as ClientConflictError,
 )
@@ -45,6 +43,8 @@ from nemo_platform_plugin.jobs.api_factory import (
     job_route_factory,
 )
 from nemo_platform_plugin.jobs.exceptions import PlatformJobDependencyUnavailableError
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
+from nemo_platform_plugin.jobs.types import PlatformJobResponse as PlatformJob
 from nmp.common.errors.sdk_exception_handlers import register_sdk_exception_handlers
 from nmp.common.jobs.exceptions import PlatformJobCompilationError
 from nmp.common.jobs.schemas import (
@@ -138,7 +138,7 @@ def test_validate_job_spec():
             )
         ]
     )
-    assert _validate_job_spec(valid_job) is None
+    assert _validate_job_spec(valid_job) == valid_job
 
     # Invalid job spec, because the config provided into the step's config is not json serializeable
     invalid_job = PlatformJobSpec(
@@ -385,7 +385,7 @@ def mock_service_with_job_routes():
 
 def create_mock_platform_job(
     job_id: str,
-    status: PlatformJobStatus = "completed",
+    status: PlatformJobStatus | str = PlatformJobStatus.COMPLETED,
     created_at: str = "2023-01-01T10:00:00Z",
 ) -> PlatformJob:
     """Helper function to create a mock PlatformJob for testing."""
@@ -395,11 +395,23 @@ def create_mock_platform_job(
         name=f"Job {job_id}",
         source="test_service",
         project="test-project",
-        status=status,
+        status=PlatformJobStatus(status),
         created_at=created_at,  # ty: ignore[invalid-argument-type] # type is coerced
         updated_at=created_at,  # ty: ignore[invalid-argument-type] # type is coerced
         spec={"foo": "test", "bar": 1},
-        platform_spec={"steps": []},  # ty: ignore[invalid-argument-type] # type is coerced
+        platform_spec=PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="foo_step",
+                    executor=CPUExecutionProviderSpec(
+                        provider="cpu",
+                        profile="default",
+                        container=ContainerSpec(image="foo_image"),
+                    ),
+                    config={},
+                )
+            ]
+        ),
         ownership={},
         attempt_id=f"attempt-{job_id}",
         fileset=f"fileset-{job_id}",

--- a/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/jobs/execute.py
@@ -537,19 +537,19 @@ def _compute_to_resources(compute: ComputeSpecInline | None) -> ResourcesSpec | 
     _reject_unsupported_resource_keys(resources.limits, "limits")
     _reject_unsupported_resource_keys(resources.requests, "requests")
 
-    spec: ResourcesSpec = {}
+    spec: dict[str, Any] = {}
     limits = _cpu_memory_spec(resources.limits)
-    if limits:
+    if limits is not None:
         spec["limits"] = limits
     requests = _cpu_memory_spec(resources.requests)
-    if requests:
+    if requests is not None:
         spec["requests"] = requests
 
     num_gpus = _gpu_count(resources.limits, resources.requests)
     if num_gpus is not None:
         spec["num_gpus"] = num_gpus
 
-    return spec or None
+    return ResourcesSpec(**spec) if spec else None
 
 
 def _reject_unsupported_resource_keys(resource_map: dict[str, str], where: str) -> None:
@@ -561,15 +561,15 @@ def _reject_unsupported_resource_keys(resource_map: dict[str, str], where: str) 
         )
 
 
-def _cpu_memory_spec(resource_map: dict[str, str]) -> ResourcesLimitsSpec:
-    # ``ResourcesLimitsSpec`` and ``ResourcesRequestsSpec`` are the same TypedDict
-    # (``ComputeResourceSpecParam``); one builder covers both sides.
-    spec: ResourcesLimitsSpec = {}
+def _cpu_memory_spec(resource_map: dict[str, str]) -> ResourcesLimitsSpec | None:
+    # ``ResourcesLimitsSpec`` and ``ResourcesRequestsSpec`` are the same
+    # plugin-owned compute resource spec; one builder covers both sides.
+    spec: dict[str, str] = {}
     if "cpu" in resource_map:
         spec["cpu"] = resource_map["cpu"]
     if "memory" in resource_map:
         spec["memory"] = resource_map["memory"]
-    return spec
+    return ResourcesLimitsSpec(**spec) if spec else None
 
 
 def _gpu_count(limits: dict[str, str], requests: dict[str, str]) -> int | None:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/tasks/evaluate_suite/__main__.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/tasks/evaluate_suite/__main__.py
@@ -11,7 +11,7 @@ framework.
 
 This module is invoked by the platform's host-subprocess executor when a
 caller submits an evaluate-suite job (``POST /apis/agents/.../jobs`` →
-``sdk.jobs.create`` → controller dispatches ``python -m
+typed Jobs client create → controller dispatches ``python -m
 nemo_agents_plugin.tasks.evaluate_suite``).
 """
 

--- a/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-anonymizer/src/nemo_anonymizer_plugin/sdk/job_resources.py
@@ -20,8 +20,8 @@ from nemo_anonymizer_plugin.sdk.errors import AnonymizerJobError
 from nemo_anonymizer_plugin.sdk.job_results import AnonymizerJobResults
 from nemo_anonymizer_plugin.sdk.logging import with_logging
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform.types import PlatformJobStatus
 from nemo_platform_plugin.jobs.archive import safe_extract_tar
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/job_resources.py
+++ b/plugins/nemo-auditor/src/nemo_auditor/sdk_resources/job_resources.py
@@ -16,8 +16,8 @@ from pathlib import Path
 from typing import Awaitable, Callable, TypeVar
 
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform.types import PlatformJobStatus
 from nemo_platform_plugin.jobs.archive import safe_extract_tar
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from typing_extensions import Self
 
 logger = logging.getLogger(__name__)

--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
@@ -20,8 +20,8 @@ from nemo_data_designer_plugin.sdk.errors import DataDesignerJobError, extract_h
 from nemo_data_designer_plugin.sdk.job_results import DataDesignerJobResults
 from nemo_data_designer_plugin.sdk.logging import with_logging
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform.types import PlatformJobStatus
 from nemo_platform_plugin.jobs.archive import safe_extract_tar
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from typing_extensions import Self
 
 logger = logging.getLogger(__name__)

--- a/plugins/nemo-data-designer/tests/integration/test_job_task.py
+++ b/plugins/nemo-data-designer/tests/integration/test_job_task.py
@@ -34,6 +34,8 @@ from nemo_data_designer_plugin.jobs.spec import DataDesignerJobConfig
 from nemo_data_designer_plugin.jobs.task_results import ANALYSIS_RESULT_NAME, ARTIFACTS_RESULT_NAME
 from nemo_data_designer_plugin.sdk.job_results import DataDesignerJobResults
 from nemo_data_designer_plugin.sdk.resources import DataDesignerResource
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.jobs.client import JobsClient
 
 pytestmark = pytest.mark.integration
 
@@ -57,6 +59,10 @@ def _get_dataset(ctx: u.CreateJobTestContext, job_name: str, tmp_path: Path) -> 
 
 def _get_analysis(ctx: u.CreateJobTestContext, job_name: str, tmp_path: Path) -> DatasetProfilerResults:
     return _load_results(ctx, job_name, tmp_path).load_analysis()
+
+
+def _list_job_results(ctx: u.CreateJobTestContext, job_name: str):
+    return client_from_platform(ctx.sdk, JobsClient).list_job_results(name=job_name).data()
 
 
 @pytest.fixture
@@ -84,7 +90,7 @@ async def test_task(tmp_path: Path) -> None:
         result = ctx.run_task()
         assert result.exit_code == 0
 
-        results = ctx.sdk.jobs.results.list(job_name)
+        results = _list_job_results(ctx, job_name)
         assert len(results.data) == 2
         result_names = [r.name for r in results.data]
         assert ANALYSIS_RESULT_NAME in result_names
@@ -122,7 +128,7 @@ async def test_save_partial_dataset_on_failure(_failing_result_manager: None, tm
         result = ctx.run_task()
         assert result.exit_code == 1
 
-        results = ctx.sdk.jobs.results.list(job_name)
+        results = _list_job_results(ctx, job_name)
         assert len(results.data) == 1
         result_names = [r.name for r in results.data]
         assert ANALYSIS_RESULT_NAME not in result_names

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -52,8 +52,6 @@ from nemo_evaluator_sdk.enums import AgentFormat
 from nemo_evaluator_sdk.metrics.exact_match import ExactMatchMetric
 from nemo_evaluator_sdk.values import Agent, GenericAgent, Model, RunConfigOnline, RunConfigOnlineModel, SecretRef
 from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
-from nemo_platform.types.jobs import SubprocessExecutionProvider
-from nemo_platform.types.jobs.platform_job_spec import PlatformJobSpec
 from nemo_platform_plugin.client.errors import InternalServerError, NemoResponseValidationError, NemoTransportError
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import LocalJobResults
@@ -68,7 +66,8 @@ from nemo_platform_plugin.jobs.execution_profiles import (
     VolcanoJobExecutionProfile,
     VolcanoJobExecutionProfileConfig,
 )
-from nemo_platform_plugin.jobs.spec import BaseExecutionProfile
+from nemo_platform_plugin.jobs.providers import SubprocessExecutionProvider
+from nemo_platform_plugin.jobs.spec import BaseExecutionProfile, PlatformJobSpec
 from nemo_platform_plugin.scheduler import NemoJobScheduler
 from pytest_mock import MockerFixture
 
@@ -81,6 +80,10 @@ def _inline_metric() -> MetricInline:
     return MetricInline.model_validate(bundle.model_dump(mode="json"))
 
 
+def _task_inputs(**values: Any) -> TaskInputs:
+    return TaskInputs.model_validate(values)
+
+
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
@@ -89,7 +92,7 @@ def _task_spec() -> AgentEvalTaskSpec:
     return AgentEvalTaskSpec(
         id="task-1",
         intent="Answer the question.",
-        inputs={"instruction": "What is 2+2?"},
+        inputs=_task_inputs(instruction="What is 2+2?"),
         metrics=[_inline_metric()],
     )
 
@@ -165,7 +168,7 @@ async def test_reference_round_trips_from_input_spec_to_runtime_task() -> None:
             AgentEvalTaskInput(
                 id="fix-bug",
                 intent="Fix the bug.",
-                inputs={"instruction": "Fix calculator.py."},
+                inputs=_task_inputs(instruction="Fix calculator.py."),
                 reference=reference,
                 metrics=[_inline_metric()],
             )
@@ -444,9 +447,12 @@ def test_build_evaluator_without_platform_forwards_no_headers() -> None:
 
 def test_input_spec_accepts_stored_metric_reference() -> None:
     spec = AgentEvalInputSpec(
-        tasks=[AgentEvalTaskInput(id="task-1", intent="Answer.", inputs={}, metrics=[MetricRef("stored-metric")])],
+        tasks=[
+            AgentEvalTaskInput(id="task-1", intent="Answer.", inputs=TaskInputs(), metrics=[MetricRef("stored-metric")])
+        ],
         target=_runner_target("openai/gpt-5.4"),
     )
+    assert not isinstance(spec.tasks, TasksetRef)
     assert isinstance(spec.tasks[0].metrics[0], MetricRef)
 
 
@@ -470,7 +476,7 @@ async def test_to_spec_resolves_inline_task_metrics_without_a_platform() -> None
             AgentEvalTaskInput(
                 id="task-1",
                 intent="Answer the question.",
-                inputs={"instruction": "What is 2+2?"},
+                inputs=_task_inputs(instruction="What is 2+2?"),
                 metrics=[_inline_metric()],
             )
         ],
@@ -490,7 +496,9 @@ async def test_to_spec_requires_platform_to_resolve_a_metric_reference() -> None
     # A stored MetricRef can only be loaded with an entity store + SDK; without one, to_spec must
     # fail loudly rather than silently drop the metric.
     input_spec = AgentEvalInputSpec(
-        tasks=[AgentEvalTaskInput(id="task-1", intent="Answer.", inputs={}, metrics=[MetricRef("stored-metric")])],
+        tasks=[
+            AgentEvalTaskInput(id="task-1", intent="Answer.", inputs=TaskInputs(), metrics=[MetricRef("stored-metric")])
+        ],
         target=_runner_target("openai/gpt-5.4"),
     )
     with pytest.raises(ValueError, match="platform connection"):
@@ -864,7 +872,10 @@ def test_run_local_executes_each_target_type(target: Target, mocker: MockerFixtu
     input_spec = AgentEvalInputSpec(
         tasks=[
             AgentEvalTaskInput(
-                id="task-1", intent="Answer.", inputs={"instruction": "What is 2+2?"}, metrics=[_inline_metric()]
+                id="task-1",
+                intent="Answer.",
+                inputs=_task_inputs(instruction="What is 2+2?"),
+                metrics=[_inline_metric()],
             )
         ],
         target=target,
@@ -898,7 +909,7 @@ def test_run_local_scores_precomputed_trials_offline(mocker: MockerFixture) -> N
         )
     ]
     input_spec = AgentEvalInputSpec(
-        tasks=[AgentEvalTaskInput(id="task-1", intent="Answer.", inputs={}, metrics=[_inline_metric()])],
+        tasks=[AgentEvalTaskInput(id="task-1", intent="Answer.", inputs=TaskInputs(), metrics=[_inline_metric()])],
         trials=precomputed,
     )
 

--- a/plugins/nemo-evaluator/tests/test_evaluate_job.py
+++ b/plugins/nemo-evaluator/tests/test_evaluate_job.py
@@ -57,11 +57,11 @@ from nemo_evaluator_sdk.values import (
 )
 from nemo_evaluator_sdk.values.models import ModelRef
 from nemo_evaluator_sdk.values.scores import JSONScoreParser, RangeScore
-from nemo_platform.types.jobs.platform_job_spec import PlatformJobSpec
 from nemo_platform_plugin.commands import add_job_commands
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
 from nemo_platform_plugin.job_results import LocalJobResults
 from nemo_platform_plugin.jobs.constants import PERSISTENT_JOB_STORAGE_PATH_ENVVAR
+from nemo_platform_plugin.jobs.spec import PlatformJobSpec
 from nemo_platform_plugin.scheduler import NemoJobScheduler
 from pydantic import BaseModel, ConfigDict
 from pytest_mock import MockerFixture

--- a/plugins/nemo-insights/src/nemo_insights_plugin/controller.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/controller.py
@@ -5,17 +5,24 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from datetime import datetime, timezone
-from typing import Any, ClassVar, TypeVar, cast
+from typing import ClassVar, TypeVar
 from zoneinfo import ZoneInfo
 
 from nemo_insights_plugin.analyst.analyst_backend import make_analyst_backend
 from nemo_insights_plugin.config import InsightsConfig
 from nemo_insights_plugin.entities import AnalysisConfig, AnalysisRunStatus
-from nemo_insights_plugin.jobs.analyze import AnalyzeJob, AnalyzeSpec
+from nemo_insights_plugin.jobs.analyze import AnalyzeSpec
 from nemo_insights_plugin.schedule import is_due
+from nemo_insights_plugin.sdk_resources.analysis_jobs import (
+    AnalysisJob,
+    AsyncAnalysisJobsClient,
+    CreateAnalysisJobRequest,
+    ListAnalysisJobsQueryParams,
+)
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.config import get_nemo_config
@@ -26,8 +33,6 @@ from nemo_platform_plugin.entity_client import (
     NemoEntityConflictError,
     NemoEntityNotFoundError,
 )
-from nemo_platform_plugin.jobs.client import AsyncJobsClient
-from nemo_platform_plugin.jobs.types import CreatePlatformJobRequest, ListJobsQueryParams, PlatformJobSpec
 from nemo_platform_plugin.sdk_provider import get_async_platform_sdk
 
 logger = logging.getLogger(__name__)
@@ -67,7 +72,7 @@ class InsightsAnalysisController(NemoController):
     def __init__(self) -> None:
         self._sdk: AsyncNeMoPlatform | None = None
         self._entities: NemoEntitiesClient | None = None
-        self._jobs: AsyncJobsClient | None = None
+        self._jobs: AsyncAnalysisJobsClient | None = None
         self._config: InsightsConfig | None = None
 
     @property
@@ -79,7 +84,7 @@ class InsightsAnalysisController(NemoController):
         return _require(self._entities, "entities")
 
     @property
-    def jobs(self) -> AsyncJobsClient:
+    def jobs(self) -> AsyncAnalysisJobsClient:
         return _require(self._jobs, "jobs")
 
     @property
@@ -93,11 +98,11 @@ class InsightsAnalysisController(NemoController):
         return 60.0
 
     async def on_startup(self) -> None:
-        """Initialise service-principal SDK and entity client."""
+        """Initialise service-principal SDK and typed clients."""
         self._config = get_nemo_config(InsightsConfig)
         self._sdk = get_async_platform_sdk(as_service="insights", internal=True)
         self._entities = NemoEntitiesClient(client_from_platform(self._sdk, AsyncEntitiesClient))
-        self._jobs = client_from_platform(self._sdk, AsyncJobsClient)
+        self._jobs = client_from_platform(self._sdk, AsyncAnalysisJobsClient)
         logger.info("InsightsAnalysisController started.")
 
     async def on_shutdown(self) -> None:
@@ -119,7 +124,7 @@ class InsightsAnalysisController(NemoController):
             return []
 
     async def reconcile_one(self, obj: object) -> None:
-        config = cast(AnalysisConfig, obj)
+        config = obj if isinstance(obj, AnalysisConfig) else AnalysisConfig.model_validate(obj)
         try:
             await self._reconcile_config(config)
         except NemoEntityConflictError:
@@ -200,13 +205,14 @@ class InsightsAnalysisController(NemoController):
 
     async def _has_active_job(self, config: AnalysisConfig) -> bool:
         try:
-            jobs = await self.jobs.list_jobs(
+            query_params: ListAnalysisJobsQueryParams = {
+                "filter": json.dumps({"status": {"$in": _ACTIVE_JOB_STATUSES}}),
+                "page_size": 100,
+                "sort": "-created_at",
+            }
+            jobs = await self.jobs.list_analysis_jobs(
                 workspace=config.workspace,
-                query_params=ListJobsQueryParams(
-                    filter=cast(Any, {"source": "insights", "status": _ACTIVE_JOB_STATUSES}),
-                    page_size=100,
-                    sort="-created_at",
-                ),
+                query_params=query_params,
             )
         except Exception:
             logger.debug(
@@ -255,19 +261,12 @@ class InsightsAnalysisController(NemoController):
             fast_model=config.fast_model or config.default_model,
         )
         job_name = _job_name(config, submitted_at)
-        platform_spec = await self._compile_job_spec(
-            workspace=config.workspace,
-            spec=spec,
-            job_name=job_name,
-        )
         (
-            await self.jobs.create_job(
+            await self.jobs.create_analysis_job(
                 workspace=config.workspace,
-                body=CreatePlatformJobRequest(
-                    source="insights",
+                body=CreateAnalysisJobRequest(
                     name=job_name,
-                    spec=spec.model_dump(mode="json"),
-                    platform_spec=platform_spec,
+                    spec=spec,
                     custom_fields={"insights_analysis_agent": config.agent},
                 ),
             )
@@ -279,25 +278,9 @@ class InsightsAnalysisController(NemoController):
             config.workspace,
         )
 
-    async def _compile_job_spec(self, *, workspace: str, spec: AnalyzeSpec, job_name: str) -> PlatformJobSpec:
-        return cast(
-            PlatformJobSpec,
-            await AnalyzeJob.compile(
-                workspace=workspace,
-                spec=spec,
-                entity_client=self.entities,
-                job_name=job_name,
-                async_sdk=self.sdk,
-                profile=self.insights_config.analyst.job_profile,
-            ),
-        )
 
-
-def _job_targets_agent(job: object, agent: str) -> bool:
-    custom_fields = getattr(job, "custom_fields", None)
-    if isinstance(custom_fields, dict):
-        return custom_fields.get("insights_analysis_agent") == agent
-    return False
+def _job_targets_agent(job: AnalysisJob, agent: str) -> bool:
+    return (job.custom_fields or {}).get("insights_analysis_agent") == agent
 
 
 def _job_name(config: AnalysisConfig, submitted_at: datetime) -> str:

--- a/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_jobs.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/sdk_resources/analysis_jobs.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed client for Insights analysis jobs."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from datetime import datetime
+
+from nemo_insights_plugin.jobs.analyze import AnalyzeJob, AnalyzeSpec
+from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
+from nemo_platform_plugin.client.endpoint import get, post
+from nemo_platform_plugin.client.method import method
+from nemo_platform_plugin.client.types import Paginated
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
+from pydantic import BaseModel
+from typing_extensions import NotRequired, TypedDict
+
+
+class CreateAnalysisJobRequest(BaseModel):
+    """Body accepted by the Insights analysis job route."""
+
+    name: str | None = None
+    description: str | None = None
+    project: str | None = None
+    spec: AnalyzeSpec
+    ownership: dict[str, object] | None = None
+    custom_fields: dict[str, object] | None = None
+    output_location: str | None = None
+
+
+class AnalysisJob(BaseModel):
+    """Insights analysis job response from the plugin-owned job route."""
+
+    id: str | None = None
+    name: str
+    description: str | None = None
+    project: str | None = None
+    workspace: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    spec: AnalyzeSpec
+    status: PlatformJobStatus | None = None
+    status_details: dict[str, object] | None = None
+    error_details: dict[str, object] | None = None
+    ownership: dict[str, object] | None = None
+    custom_fields: dict[str, object] | None = None
+
+
+_COLLECTION = f"/jobs/{AnalyzeJob.name}"
+
+
+class ListAnalysisJobsQueryParams(TypedDict, total=False):
+    page: NotRequired[int]
+    page_size: NotRequired[int]
+    sort: NotRequired[str]
+    filter: NotRequired[str]
+
+
+@post(f"/apis/insights/v2/workspaces/{{workspace}}{_COLLECTION}")
+@abstractmethod
+def create_analysis_job(*, workspace: str | None = None, body: CreateAnalysisJobRequest) -> AnalysisJob: ...
+
+
+@get(f"/apis/insights/v2/workspaces/{{workspace}}{_COLLECTION}")
+@abstractmethod
+def list_analysis_jobs(
+    *, workspace: str | None = None, query_params: ListAnalysisJobsQueryParams | None = None
+) -> Paginated[AnalysisJob]: ...
+
+
+@get(f"/apis/insights/v2/workspaces/{{workspace}}{_COLLECTION}/{{name}}")
+@abstractmethod
+def get_analysis_job(*, workspace: str | None = None, name: str) -> AnalysisJob: ...
+
+
+class _AnalysisJobsMethods:
+    create_analysis_job = method(create_analysis_job)
+    list_analysis_jobs = method(list_analysis_jobs)
+    get_analysis_job = method(get_analysis_job)
+
+
+class AnalysisJobsClient(_AnalysisJobsMethods, NemoClient):
+    """Sync client for the Insights analysis job API."""
+
+
+class AsyncAnalysisJobsClient(_AnalysisJobsMethods, AsyncNemoClient):
+    """Async client for the Insights analysis job API."""
+
+
+__all__ = [
+    "AnalysisJob",
+    "AnalysisJobsClient",
+    "AsyncAnalysisJobsClient",
+    "CreateAnalysisJobRequest",
+    "ListAnalysisJobsQueryParams",
+]

--- a/plugins/nemo-insights/src/nemo_insights_plugin/service.py
+++ b/plugins/nemo-insights/src/nemo_insights_plugin/service.py
@@ -13,6 +13,7 @@ from typing import ClassVar
 from fastapi import APIRouter, Depends, HTTPException, Query
 from nemo_insights_plugin._perms import AnalysisConfigPerms, AnalysisRunStatusPerms, InsightPerms
 from nemo_insights_plugin.authz import scope
+from nemo_insights_plugin.config import InsightsConfig
 from nemo_insights_plugin.entities import (
     AnalysisConfig,
     AnalysisRunStatus,
@@ -32,6 +33,7 @@ from nemo_insights_plugin.schema import (
     UpdateInsightRequest,
 )
 from nemo_platform_plugin.authz import CallerKind, path_rule
+from nemo_platform_plugin.config import get_nemo_config
 from nemo_platform_plugin.entities import (
     EntityValidationError as NemoEntityValidationError,
 )
@@ -69,6 +71,7 @@ class InsightsService(NemoService):
     dependencies: ClassVar[list[str]] = ["entities", "jobs", "intake"]
 
     def get_routers(self) -> list[RouterSpec]:
+        config = get_nemo_config(InsightsConfig)
         return [
             RouterSpec(
                 _build_insights_router(),
@@ -89,7 +92,12 @@ class InsightsService(NemoService):
                 prefix="/v2/workspaces/{workspace}",
             ),
             RouterSpec(
-                add_job_routes(AnalyzeJob, authz=scope),
+                add_job_routes(
+                    AnalyzeJob,
+                    service_name="insights",
+                    default_profile=config.analyst.job_profile,
+                    authz=scope,
+                ),
                 tag="Insights Analysis Jobs",
                 description="Submit and track one-shot insights analyst jobs.",
                 prefix="/v2/workspaces/{workspace}",

--- a/plugins/nemo-insights/tests/test_client.py
+++ b/plugins/nemo-insights/tests/test_client.py
@@ -1,9 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from unittest.mock import MagicMock, patch
 
+import httpx
+import pytest
 from nemo_insights_plugin.client import make_client
+from nemo_insights_plugin.jobs.analyze import AnalyzeSpec
+from nemo_insights_plugin.sdk_resources.analysis_jobs import AsyncAnalysisJobsClient, CreateAnalysisJobRequest
 from nemo_platform_ext.auth.helpers import NMPOIDCConfig
 
 REMOTE_URL = "https://nemo-platform.example.com"
@@ -47,3 +52,117 @@ def test_remote_auth_uses_local_oauth_context() -> None:
 
     client_cls.assert_called_once_with(base_url=REMOTE_URL, config_path=config_path)
     assert client is client_cls.return_value
+
+
+def _analysis_spec() -> AnalyzeSpec:
+    return AnalyzeSpec(
+        agent="research-agent",
+        default_model="default/gpt-5",
+        fast_model="default/gpt-5-mini",
+        update_analysis_config=True,
+    )
+
+
+def _analysis_jobs_client(handler: httpx.AsyncBaseTransport) -> tuple[AsyncAnalysisJobsClient, httpx.AsyncClient]:
+    http_client = httpx.AsyncClient(transport=handler)
+    client = AsyncAnalysisJobsClient(base_url=REMOTE_URL, http_client=http_client)
+    return client, http_client
+
+
+@pytest.mark.asyncio
+async def test_async_analysis_jobs_client_posts_to_insights_job_route() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        body = json.loads(request.content)
+        assert body == {
+            "name": "analysis-job",
+            "spec": {
+                "agent": "research-agent",
+                "default_model": "default/gpt-5",
+                "fast_model": "default/gpt-5-mini",
+                "update_analysis_config": True,
+            },
+            "custom_fields": {"insights_analysis_agent": "research-agent"},
+        }
+        return httpx.Response(
+            201,
+            request=request,
+            json={
+                "name": "analysis-job",
+                "spec": body["spec"],
+                "custom_fields": body["custom_fields"],
+            },
+        )
+
+    client, http_client = _analysis_jobs_client(httpx.MockTransport(handler))
+    try:
+        job = (
+            await client.create_analysis_job(
+                workspace="default",
+                body=CreateAnalysisJobRequest(
+                    name="analysis-job",
+                    spec=_analysis_spec(),
+                    custom_fields={"insights_analysis_agent": "research-agent"},
+                ),
+            )
+        ).data()
+    finally:
+        await http_client.aclose()
+
+    assert requests[0].method == "POST"
+    assert requests[0].url.path == "/apis/insights/v2/workspaces/default/jobs/analyze-job"
+    assert job.name == "analysis-job"
+    assert job.spec.agent == "research-agent"
+
+
+@pytest.mark.asyncio
+async def test_async_analysis_jobs_client_lists_with_json_filter() -> None:
+    requests: list[httpx.Request] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        filter_param = request.url.params["filter"]
+        assert json.loads(filter_param) == {"status": {"$in": ["active"]}}
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "data": [
+                    {
+                        "name": "analysis-job",
+                        "spec": _analysis_spec().model_dump(mode="json"),
+                        "status": "active",
+                        "custom_fields": {"insights_analysis_agent": "research-agent"},
+                    }
+                ],
+                "pagination": {
+                    "page": 1,
+                    "page_size": 100,
+                    "current_page_size": 1,
+                    "total_pages": 1,
+                    "total_results": 1,
+                },
+                "sort": "-created_at",
+                "filter": {"status": {"$in": ["active"]}},
+            },
+        )
+
+    client, http_client = _analysis_jobs_client(httpx.MockTransport(handler))
+    try:
+        page = (
+            await client.list_analysis_jobs(
+                workspace="default",
+                query_params={
+                    "page_size": 100,
+                    "filter": json.dumps({"status": {"$in": ["active"]}}),
+                },
+            )
+        ).page()
+    finally:
+        await http_client.aclose()
+
+    assert requests[0].method == "GET"
+    assert requests[0].url.path == "/apis/insights/v2/workspaces/default/jobs/analyze-job"
+    assert page.items[0].spec.agent == "research-agent"

--- a/plugins/nemo-insights/tests/test_periodic_analysis.py
+++ b/plugins/nemo-insights/tests/test_periodic_analysis.py
@@ -3,10 +3,12 @@
 
 """Tests for periodic insights analysis plumbing."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Generic, TypeVar
 from zoneinfo import ZoneInfo
 
 import httpx
@@ -37,18 +39,60 @@ from nemo_insights_plugin.entities import (
 )
 from nemo_insights_plugin.jobs.analyze import AnalyzeJob, AnalyzeSpec
 from nemo_insights_plugin.schedule import is_due, previous_scheduled
-from nemo_platform import AsyncNeMoPlatform, NeMoPlatform
+from nemo_insights_plugin.schema import UpdateAnalysisRunStatusRequest
+from nemo_insights_plugin.sdk_resources.analysis_jobs import (
+    AnalysisJob,
+    AsyncAnalysisJobsClient,
+    CreateAnalysisJobRequest,
+    ListAnalysisJobsQueryParams,
+)
+from nemo_platform import AsyncNeMoPlatform, NeMoPlatform, Omit
+from nemo_platform.pagination import AsyncDefaultPagination, DefaultPaginationPagination
+from nemo_platform.types.intake.span_filter_param import SpanFilterParam
 from nemo_platform.types.intake.spans.span_group import SpanGroup
+from nemo_platform.types.intake.spans.span_group_sort_field import SpanGroupSortField
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.entities.client import AsyncEntitiesClient
 from nemo_platform_plugin.entity_client import NemoEntitiesClient, NemoEntityNotFoundError
 from nemo_platform_plugin.job_context import JobContext, StoragePaths
-from nemo_platform_plugin.job_results import JobResults
-from nemo_platform_plugin.jobs.client import AsyncJobsClient
+from nemo_platform_plugin.job_results import JobResults, ResultRef
 from nemo_platform_plugin.jobs.constants import (
     DEFAULT_JOB_STORAGE_PATH,
     PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
 )
+from nemo_platform_plugin.jobs.schemas import PlatformJobStatus
 from nemo_platform_plugin.nooa_model_client import ConfiguredModelRefs
 from pydantic import ValidationError
+
+_BASE_URL = "https://example.com"
+_T = TypeVar("_T")
+
+
+def _async_platform() -> AsyncNeMoPlatform:
+    return AsyncNeMoPlatform(base_url=_BASE_URL)
+
+
+def _http_not_found_error() -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", _BASE_URL)
+    response = httpx.Response(404, request=request)
+    return httpx.HTTPStatusError("not found", request=request, response=response)
+
+
+@dataclass
+class _TypedResponse(Generic[_T]):
+    body: _T
+
+    def data(self) -> _T:
+        return self.body
+
+
+class _AsyncItems(Generic[_T]):
+    def __init__(self, items: list[_T]) -> None:
+        self._items = items
+
+    async def items(self) -> AsyncIterator[_T]:
+        for item in self._items:
+            yield item
 
 
 def test_merge_since_filter_adds_lower_bound() -> None:
@@ -82,35 +126,10 @@ def test_merge_since_filter_compares_equivalent_iso_representations() -> None:
     assert result == {"started_at": {"gte": current}}
 
 
-class _MissingInsights:
-    async def get(self, **kwargs: object) -> None:
-        del kwargs
-        request = httpx.Request("GET", "https://example.com/insights/missing")
-        response = httpx.Response(404, request=request)
-        raise httpx.HTTPStatusError("not found", request=request, response=response)
-
-
-@pytest.mark.asyncio
-async def test_remote_persist_validates_updates_without_trace_refs() -> None:
-    client = SimpleNamespace(insights=SimpleNamespace(insights=_MissingInsights()))
-    backend = RemoteAnalystBackend(cast(AsyncNeMoPlatform, client))
-    result = AnalystResult(
-        summary="Nothing new.",
-        updated_insights=[InsightUpdate(id="missing-insight")],
-    )
-
-    report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
-
-    assert "- skipped (insight not found): missing-insight" in report
-    assert "- updated: missing-insight" not in report
-
-
 _STAMP = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
 
 
 class _RecordingInsights:
-    """Stand-in for the Insights SDK resource that assigns platform ids."""
-
     def __init__(self) -> None:
         self.rows: dict[str, Insight] = {}
 
@@ -121,8 +140,8 @@ class _RecordingInsights:
         title: str,
         agent: str,
         description: str,
-        status: InsightStatus,
-        trace_refs: list[str],
+        status: InsightStatus | str = InsightStatus.OPEN,
+        trace_refs: list[str] | None = None,
     ) -> Insight:
         insight_id = f"insight-remote-{len(self.rows) + 1}"
         row = Insight(
@@ -131,43 +150,91 @@ class _RecordingInsights:
             title=title,
             agent=agent,
             description=description,
-            status=status,
+            status=InsightStatus(status),
             trace_refs=list(trace_refs or []),
         )
         row._id = insight_id
         row._created_at = _STAMP
         row._updated_at = _STAMP
+        row._db_version = 1
         self.rows[insight_id] = row
         return row
 
     async def get(self, *, workspace: str, insight_id: str) -> Insight:
         del workspace
-        return self.rows[insight_id]
+        row = self.rows.get(insight_id)
+        if row is None:
+            raise _http_not_found_error()
+        return row
 
-    async def update(self, *, workspace: str, insight_id: str, trace_refs: list[str]) -> Insight:
+    async def update(
+        self,
+        *,
+        workspace: str,
+        insight_id: str,
+        agent: str | None = None,
+        description: str | None = None,
+        status: InsightStatus | str | None = None,
+        trace_refs: list[str] | None = None,
+    ) -> Insight:
         del workspace
-        row = self.rows[insight_id]
-        row.trace_refs = list(trace_refs)
+        row = self.rows.get(insight_id)
+        if row is None:
+            raise _http_not_found_error()
+        if agent is not None:
+            row.agent = agent
+        if description is not None:
+            row.description = description
+        if status is not None:
+            row.status = InsightStatus(status)
+        if trace_refs is not None:
+            row.trace_refs = list(trace_refs)
         return row
 
 
-def _remote_backend_with_mirror(path: Path) -> tuple[RemoteAnalystBackend, _RecordingInsights]:
-    insights = _RecordingInsights()
-    client = SimpleNamespace(insights=SimpleNamespace(insights=insights))
-    backend = RemoteAnalystBackend(cast(AsyncNeMoPlatform, client), mirror=InsightsFileStore(path))
-    return backend, insights
+@asynccontextmanager
+async def _remote_backend_with_mirror(
+    path: Path | None,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    insights: _RecordingInsights | None = None,
+) -> AsyncIterator[tuple[RemoteAnalystBackend, _RecordingInsights]]:
+    async with _async_platform() as sdk:
+        insights_resource = sdk.insights.insights
+        recording = insights or _RecordingInsights()
+        monkeypatch.setattr(insights_resource, "create", recording.create)
+        monkeypatch.setattr(insights_resource, "get", recording.get)
+        monkeypatch.setattr(insights_resource, "update", recording.update)
+        mirror = InsightsFileStore(path) if path is not None else None
+        yield RemoteAnalystBackend(sdk, mirror=mirror), recording
 
 
 @pytest.mark.asyncio
-async def test_remote_persist_mirrors_platform_records_to_the_file(tmp_path: Path) -> None:
+async def test_remote_persist_validates_updates_without_trace_refs(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = AnalystResult(
+        summary="Nothing new.",
+        updated_insights=[InsightUpdate(id="missing-insight")],
+    )
+
+    async with _remote_backend_with_mirror(None, monkeypatch) as (backend, _):
+        report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
+
+    assert "- skipped (insight not found): missing-insight" in report
+    assert "- updated: missing-insight" not in report
+
+
+@pytest.mark.asyncio
+async def test_remote_persist_mirrors_platform_records_to_the_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     path = tmp_path / "insights.yaml"
-    backend, _ = _remote_backend_with_mirror(path)
     result = AnalystResult(
         summary="Found one.",
         new_insights=[NewInsight(title="Retrieval drops context", description="Long inputs.", trace_refs=["t1"])],
     )
 
-    report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
+    async with _remote_backend_with_mirror(path, monkeypatch) as (backend, _):
+        report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
 
     records = yaml.safe_load(path.read_text(encoding="utf-8"))["insights"]
     assert [r["id"] for r in records] == ["insight-remote-1"]
@@ -177,26 +244,28 @@ async def test_remote_persist_mirrors_platform_records_to_the_file(tmp_path: Pat
 
 
 @pytest.mark.asyncio
-async def test_mirror_updates_match_platform_ids_across_runs(tmp_path: Path) -> None:
+async def test_mirror_updates_match_platform_ids_across_runs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     path = tmp_path / "insights.yaml"
-    backend, _ = _remote_backend_with_mirror(path)
-    await backend.persist_result(
-        workspace="default",
-        agent="research-agent",
-        result=AnalystResult(
-            summary="Found one.",
-            new_insights=[NewInsight(title="Retrieval drops context", description="Long inputs.", trace_refs=["t1"])],
-        ),
-    )
+    async with _remote_backend_with_mirror(path, monkeypatch) as (backend, _):
+        await backend.persist_result(
+            workspace="default",
+            agent="research-agent",
+            result=AnalystResult(
+                summary="Found one.",
+                new_insights=[
+                    NewInsight(title="Retrieval drops context", description="Long inputs.", trace_refs=["t1"])
+                ],
+            ),
+        )
 
-    await backend.persist_result(
-        workspace="default",
-        agent="research-agent",
-        result=AnalystResult(
-            summary="More evidence.",
-            updated_insights=[InsightUpdate(id="insight-remote-1", trace_refs=["t2"])],
-        ),
-    )
+        await backend.persist_result(
+            workspace="default",
+            agent="research-agent",
+            result=AnalystResult(
+                summary="More evidence.",
+                updated_insights=[InsightUpdate(id="insight-remote-1", trace_refs=["t2"])],
+            ),
+        )
 
     records = yaml.safe_load(path.read_text(encoding="utf-8"))["insights"]
     assert len(records) == 1, "the second run must update the mirrored record, not append a second one"
@@ -204,52 +273,53 @@ async def test_mirror_updates_match_platform_ids_across_runs(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
-async def test_mirror_write_failure_warns_without_failing_the_run(tmp_path: Path) -> None:
+async def test_mirror_write_failure_warns_without_failing_the_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     blocked = tmp_path / "blocked"
     blocked.write_text("not a directory", encoding="utf-8")
-    backend, insights = _remote_backend_with_mirror(blocked / "insights.yaml")
     result = AnalystResult(
         summary="Found one.",
         new_insights=[NewInsight(title="Retrieval drops context", description="Long inputs.")],
     )
 
-    report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
+    async with _remote_backend_with_mirror(blocked / "insights.yaml", monkeypatch) as (backend, insights):
+        report = await backend.persist_result(workspace="default", agent="research-agent", result=result)
 
     assert "- created: Retrieval drops context" in report
     assert "could not be written" in report
     assert list(insights.rows) == ["insight-remote-1"], "the platform write is the source of truth and must stand"
 
 
-def test_make_analyst_backend_always_writes_to_the_platform(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_make_analyst_backend_always_writes_to_the_platform(tmp_path: Path) -> None:
     """An output path adds a mirror; it never diverts writes off the platform."""
-    client = SimpleNamespace()
-
-    platform_client = cast(AsyncNeMoPlatform, client)
-    plain = make_analyst_backend(client=platform_client, insights_output=None)
-    mirrored = make_analyst_backend(client=platform_client, insights_output=str(tmp_path / "insights.yaml"))
+    async with _async_platform() as client:
+        plain = make_analyst_backend(client=client, insights_output=None)
+        mirrored = make_analyst_backend(client=client, insights_output=str(tmp_path / "insights.yaml"))
 
     assert isinstance(plain, RemoteAnalystBackend) and plain.mirror is None
     assert isinstance(mirrored, RemoteAnalystBackend)
     assert mirrored.mirror is not None and mirrored.mirror.path == tmp_path / "insights.yaml"
 
 
-def test_local_only_is_evaluation_plumbing_and_requires_a_path(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_local_only_is_evaluation_plumbing_and_requires_a_path(tmp_path: Path) -> None:
     """``local_only`` stays reachable for the evaluation, which no CLI flag sets."""
-    client = SimpleNamespace()
+    async with _async_platform() as client:
+        local = make_analyst_backend(
+            client=client,
+            insights_output=str(tmp_path / "insights.yaml"),
+            local_only=True,
+        )
+        assert isinstance(local, LocalAnalystBackend)
 
-    platform_client = cast(AsyncNeMoPlatform, client)
-    local = make_analyst_backend(
-        client=platform_client,
-        insights_output=str(tmp_path / "insights.yaml"),
-        local_only=True,
-    )
-    assert isinstance(local, LocalAnalystBackend)
-
-    with pytest.raises(ValueError, match="requires an insights output path"):
-        make_analyst_backend(client=platform_client, insights_output=None, local_only=True)
+        with pytest.raises(ValueError, match="requires an insights output path"):
+            make_analyst_backend(client=client, insights_output=None, local_only=True)
 
 
-def test_local_backend_reads_and_writes_insights_file_with_explicit_utf8(
+@pytest.mark.asyncio
+async def test_local_backend_reads_and_writes_insights_file_with_explicit_utf8(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     read_calls: list[dict[str, object]] = []
@@ -274,23 +344,23 @@ def test_local_backend_reads_and_writes_insights_file_with_explicit_utf8(
     monkeypatch.setattr(Path, "read_text", spy_read_text)
     monkeypatch.setattr(Path, "write_text", spy_write_text)
 
-    backend = LocalAnalystBackend(
-        client=cast(AsyncNeMoPlatform, SimpleNamespace()),
-        path=tmp_path / "insights.yaml",
-    )
-    backend.store.write_records([])
-    backend.store.read_records()
+    async with _async_platform() as client:
+        backend = LocalAnalystBackend(client=client, path=tmp_path / "insights.yaml")
+        backend.store.write_records([])
+        backend.store.read_records()
 
     assert write_calls[-1].get("encoding") == "utf-8"
     assert read_calls[-1].get("encoding") == "utf-8"
 
 
-def test_local_backend_write_preserves_other_top_level_keys(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_local_backend_write_preserves_other_top_level_keys(tmp_path: Path) -> None:
     path = tmp_path / "insights.yaml"
     path.write_text("metadata: retained\ninsights:\n- id: stale\n", encoding="utf-8")
-    backend = LocalAnalystBackend(client=cast(AsyncNeMoPlatform, SimpleNamespace()), path=path)
 
-    backend.store.write_records([{"id": "insight-1"}])
+    async with _async_platform() as client:
+        backend = LocalAnalystBackend(client=client, path=path)
+        backend.store.write_records([{"id": "insight-1"}])
 
     assert yaml.safe_load(path.read_text(encoding="utf-8")) == {
         "metadata": "retained",
@@ -300,33 +370,30 @@ def test_local_backend_write_preserves_other_top_level_keys(tmp_path: Path) -> N
 
 @pytest.mark.asyncio
 async def test_local_backend_list_preserves_entity_metadata(tmp_path: Path) -> None:
-    backend = LocalAnalystBackend(
-        client=cast(AsyncNeMoPlatform, SimpleNamespace()),
-        path=tmp_path / "insights.yaml",
-    )
-    backend.store.write_records(
-        [
-            {
-                "id": "insight-local-1",
-                "workspace": "default",
-                "title": "Repeated failure",
-                "description": "The agent repeats the same failure.",
-                "agent": "research-agent",
-                "status": "open",
-                "trace_refs": ["trace-1"],
-                "created_at": _STAMP.isoformat(),
-                "updated_at": _STAMP.isoformat(),
-            }
-        ]
-    )
-
-    page = await backend.list_insights(
-        workspace="default",
-        page=1,
-        page_size=10,
-        agent=None,
-        status=None,
-    )
+    async with _async_platform() as client:
+        backend = LocalAnalystBackend(client=client, path=tmp_path / "insights.yaml")
+        backend.store.write_records(
+            [
+                {
+                    "id": "insight-local-1",
+                    "workspace": "default",
+                    "title": "Repeated failure",
+                    "description": "The agent repeats the same failure.",
+                    "agent": "research-agent",
+                    "status": "open",
+                    "trace_refs": ["trace-1"],
+                    "created_at": _STAMP.isoformat(),
+                    "updated_at": _STAMP.isoformat(),
+                }
+            ]
+        )
+        page = await backend.list_insights(
+            workspace="default",
+            page=1,
+            page_size=10,
+            agent=None,
+            status=None,
+        )
 
     assert page.data[0].id == "insight-local-1"
     assert page.data[0].created_at == _STAMP
@@ -351,87 +418,106 @@ def test_merge_eval_filter_overwrites_model_supplied_scope() -> None:
     }
 
 
+@dataclass
+class _SpanGroupsCall:
+    workspace: str | None
+    by: str
+    filter: SpanFilterParam | Omit
+    page: int | Omit
+    page_size: int | Omit
+    sort: SpanGroupSortField | Omit
+
+
 class _SpanGroups:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, object]] = []
+    def __init__(self, *, data: list[SpanGroup], total: int) -> None:
+        self.data = data
+        self.total = total
+        self.calls: list[_SpanGroupsCall] = []
 
-    async def list(self, **kwargs: object) -> SimpleNamespace:
-        self.calls.append(kwargs)
-        return SimpleNamespace(
-            data=[SpanGroup(group={"session_id": "session-1"}, span_count=3, started_at=_STAMP)],
-            pagination=SimpleNamespace(total_results=7),
+    async def list(
+        self,
+        *,
+        workspace: str | None = None,
+        by: str,
+        filter: SpanFilterParam | Omit,
+        page: int | Omit,
+        page_size: int | Omit,
+        sort: SpanGroupSortField | Omit,
+    ) -> AsyncDefaultPagination[SpanGroup]:
+        self.calls.append(
+            _SpanGroupsCall(
+                workspace=workspace,
+                by=by,
+                filter=filter,
+                page=page,
+                page_size=page_size,
+                sort=sort,
+            )
         )
-
-
-class _SpanGroupClient:
-    def __init__(self) -> None:
-        self.groups = _SpanGroups()
-        self.intake = SimpleNamespace(
-            spans=SimpleNamespace(groups=self.groups),
+        size = page_size if isinstance(page_size, int) else len(self.data)
+        return AsyncDefaultPagination[SpanGroup](
+            data=self.data,
+            pagination=DefaultPaginationPagination(
+                page=1,
+                page_size=size,
+                current_page_size=len(self.data),
+                total_pages=1,
+                total_results=self.total,
+            ),
         )
 
 
 @pytest.mark.asyncio
-async def test_count_agent_sessions_uses_server_side_session_groups() -> None:
+async def test_count_agent_sessions_uses_server_side_session_groups(monkeypatch: pytest.MonkeyPatch) -> None:
     since = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
-    client = _SpanGroupClient()
-    backend = RemoteAnalystBackend(cast(AsyncNeMoPlatform, client))
+    groups = _SpanGroups(data=[SpanGroup(group={"session_id": "session-1"}, span_count=3, started_at=_STAMP)], total=7)
 
-    count = await backend.count_agent_sessions(
-        agent="research-agent",
-        workspace="default",
-        since=since,
-    )
+    async with _async_platform() as client:
+        monkeypatch.setattr(client.intake.spans.groups, "list", groups.list)
+        backend = RemoteAnalystBackend(client)
+        count = await backend.count_agent_sessions(
+            agent="research-agent",
+            workspace="default",
+            since=since,
+        )
 
     assert count == 7
-    assert client.groups.calls == [
-        {
-            "workspace": "default",
-            "by": "session_id",
-            "page": 1,
-            "page_size": 1,
-            "filter": {
+    assert groups.calls == [
+        _SpanGroupsCall(
+            workspace="default",
+            by="session_id",
+            filter={
                 "agent_name": "research-agent",
                 "started_at": {"gte": "2026-06-04T12:00:00+00:00"},
             },
-            "sort": "-span_count",
-        }
+            page=1,
+            page_size=1,
+            sort="-span_count",
+        )
     ]
 
 
-class _SpanGroupsPaged:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, object]] = []
-
-    async def list(self, **kwargs: object) -> SimpleNamespace:
-        self.calls.append(kwargs)
-        return SimpleNamespace(
-            data=[
-                SpanGroup(group={"session_id": "session-1"}, span_count=12, started_at=_STAMP),
-                SpanGroup(group={"session_id": "session-2"}, span_count=5, started_at=_STAMP),
-            ],
-            pagination=SimpleNamespace(total_results=37),
-        )
-
-
-class _GroupsBackendClient:
-    def __init__(self, groups: _SpanGroupsPaged) -> None:
-        self.intake = SimpleNamespace(spans=SimpleNamespace(groups=groups))
-
-
 @pytest.mark.asyncio
-async def test_list_span_groups_fans_out_over_sessions() -> None:
+async def test_list_span_groups_fans_out_over_sessions(monkeypatch: pytest.MonkeyPatch) -> None:
     since = datetime(2026, 6, 4, 12, tzinfo=timezone.utc)
-    groups = _SpanGroupsPaged()
-    backend = RemoteAnalystBackend(cast(AsyncNeMoPlatform, _GroupsBackendClient(groups)))
-
-    result = await backend.list_span_groups(
-        workspace="default",
-        filter={"agent_name": "research-agent"},
-        group_by="session_id",
-        limit=100,
-        since=since,
+    groups = _SpanGroups(
+        data=[
+            SpanGroup(group={"session_id": "session-1"}, span_count=12, started_at=_STAMP),
+            SpanGroup(group={"session_id": "session-2"}, span_count=5, started_at=_STAMP),
+        ],
+        total=37,
     )
+
+    async with _async_platform() as client:
+        monkeypatch.setattr(client.intake.spans.groups, "list", groups.list)
+        backend = RemoteAnalystBackend(client)
+        result = await backend.list_span_groups(
+            workspace="default",
+            filter={"agent_name": "research-agent"},
+            group_by="session_id",
+            limit=100,
+            since=since,
+        )
 
     stamp = _STAMP.isoformat().replace("+00:00", "Z")
     assert result == {
@@ -445,57 +531,64 @@ async def test_list_span_groups_fans_out_over_sessions() -> None:
         "truncated": True,
     }
     assert groups.calls == [
-        {
-            "workspace": "default",
-            "by": "session_id",
-            "page": 1,
-            "page_size": 100,
-            "filter": {
+        _SpanGroupsCall(
+            workspace="default",
+            by="session_id",
+            filter={
                 "agent_name": "research-agent",
                 "started_at": {"gte": "2026-06-04T12:00:00+00:00"},
             },
-            "sort": "-span_count",
-        }
+            page=1,
+            page_size=100,
+            sort="-span_count",
+        )
     ]
 
 
 @pytest.mark.asyncio
-async def test_count_agent_sessions_pins_evaluation_id() -> None:
-    client = _SpanGroupClient()
-    backend = RemoteAnalystBackend(cast(AsyncNeMoPlatform, client))
+async def test_count_agent_sessions_pins_evaluation_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    groups = _SpanGroups(data=[SpanGroup(group={"session_id": "session-1"}, span_count=3, started_at=_STAMP)], total=7)
 
-    await backend.count_agent_sessions(
-        agent="research-agent",
-        workspace="default",
-        evaluation_id="run-1",
-    )
+    async with _async_platform() as client:
+        monkeypatch.setattr(client.intake.spans.groups, "list", groups.list)
+        backend = RemoteAnalystBackend(client)
+        await backend.count_agent_sessions(
+            agent="research-agent",
+            workspace="default",
+            evaluation_id="run-1",
+        )
 
-    assert client.groups.calls == [
-        {
-            "workspace": "default",
-            "by": "session_id",
-            "page": 1,
-            "page_size": 1,
-            "filter": {"agent_name": "research-agent", "evaluation_id": "run-1"},
-            "sort": "-span_count",
-        }
+    assert groups.calls == [
+        _SpanGroupsCall(
+            workspace="default",
+            by="session_id",
+            filter={"agent_name": "research-agent", "evaluation_id": "run-1"},
+            page=1,
+            page_size=1,
+            sort="-span_count",
+        )
     ]
 
 
 @pytest.mark.asyncio
-async def test_list_span_groups_pins_evaluation_id() -> None:
-    groups = _SpanGroupsPaged()
-    backend = RemoteAnalystBackend(cast(AsyncNeMoPlatform, _GroupsBackendClient(groups)))
-
-    await backend.list_span_groups(
-        workspace="default",
-        filter={"agent_name": "research-agent"},
-        group_by="session_id",
-        limit=100,
-        evaluation_id="run-1",
+async def test_list_span_groups_pins_evaluation_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    groups = _SpanGroups(
+        data=[SpanGroup(group={"session_id": "session-1"}, span_count=3, started_at=_STAMP)],
+        total=7,
     )
 
-    assert groups.calls[0]["filter"] == {
+    async with _async_platform() as client:
+        monkeypatch.setattr(client.intake.spans.groups, "list", groups.list)
+        backend = RemoteAnalystBackend(client)
+        await backend.list_span_groups(
+            workspace="default",
+            filter={"agent_name": "research-agent"},
+            group_by="session_id",
+            limit=100,
+            evaluation_id="run-1",
+        )
+
+    assert groups.calls[0].filter == {
         "agent_name": "research-agent",
         "evaluation_id": "run-1",
     }
@@ -633,40 +726,65 @@ def test_config_rejects_unknown_timezone() -> None:
         AnalystSchedulerConfig(timezone="Mars/Olympus_Mons")
 
 
-class _Artifact:
-    def __init__(self, name: str, path: Path) -> None:
-        self.name = name
-        self.path = path
-
-    def model_dump(self) -> dict[str, str]:
-        return {"name": self.name, "path": str(self.path)}
-
-
-class _Results:
+class _Results(JobResults):
     def __init__(self) -> None:
         self.saved: list[tuple[str, Path]] = []
 
-    def save(self, name: str, path: Path, **_: object) -> _Artifact:
+    def save(
+        self,
+        name: str,
+        local_path: str | Path,
+        *,
+        ignore_patterns: list[str] | str | None = None,
+    ) -> ResultRef:
+        del ignore_patterns
+        path = Path(local_path)
         self.saved.append((name, path))
-        return _Artifact(name, path)
+        return ResultRef(name=name, artifact_url=f"file://{path}")
 
 
-class _SyncAnalysisRunStatuses:
+class _RecordingAnalysisRunStatuses:
     def __init__(self) -> None:
-        self.updates: list[dict[str, object]] = []
+        self.updates: list[UpdateAnalysisRunStatusRequest] = []
 
-    def update(self, **kwargs: object) -> AnalysisRunStatus:
-        self.updates.append(kwargs)
-        return AnalysisRunStatus(
-            name=str(kwargs["agent"]),
-            workspace=str(kwargs["workspace"]),
-            agent=str(kwargs["agent"]),
+    def update(
+        self,
+        *,
+        workspace: str,
+        agent: str,
+        status: AnalysisConfigStatus | str | None = None,
+        last_successful_run_at: datetime | None = None,
+        last_attempted_at: datetime | None = None,
+        last_completed_at: datetime | None = None,
+        last_submitted_job: str | None = None,
+        last_error: str | None = None,
+    ) -> AnalysisRunStatus:
+        resolved_status = AnalysisConfigStatus(status) if isinstance(status, str) else status
+        update = UpdateAnalysisRunStatusRequest(
+            status=resolved_status,
+            last_successful_run_at=last_successful_run_at,
+            last_attempted_at=last_attempted_at,
+            last_completed_at=last_completed_at,
+            last_submitted_job=last_submitted_job,
+            last_error=last_error,
         )
-
-
-class _SyncSdk:
-    def __init__(self) -> None:
-        self.insights = SimpleNamespace(analysis_run_statuses=_SyncAnalysisRunStatuses())
+        self.updates.append(update)
+        row = AnalysisRunStatus(
+            name=agent,
+            workspace=workspace,
+            agent=agent,
+            status=update.status or AnalysisConfigStatus.IDLE,
+            last_successful_run_at=update.last_successful_run_at,
+            last_attempted_at=update.last_attempted_at,
+            last_completed_at=update.last_completed_at,
+            last_submitted_job=update.last_submitted_job or "",
+            last_error=update.last_error or "",
+        )
+        row._id = "analysis-run-status-1"
+        row._created_at = _STAMP
+        row._updated_at = _STAMP
+        row._db_version = 1
+        return row
 
 
 def _ctx(tmp_path: Path) -> JobContext:
@@ -677,7 +795,7 @@ def _ctx(tmp_path: Path) -> JobContext:
     return JobContext(
         workspace="default",
         storage=StoragePaths(ephemeral=ephemeral, persistent=persistent),
-        results=cast(JobResults, _Results()),
+        results=_Results(),
         job_id="insights-job-1",
     )
 
@@ -703,25 +821,26 @@ def test_analyze_job_records_success(monkeypatch: pytest.MonkeyPatch, tmp_path: 
         "nemo_insights_plugin.jobs.analyze.get_async_task_sdk",
         lambda plugin: async_client,
     )
-    sdk = _SyncSdk()
-
-    result = AnalyzeJob().run(
-        _analyze_spec().model_dump(mode="json"),
-        ctx=_ctx(tmp_path),
-        sdk=cast(NeMoPlatform, sdk),
-    )
+    statuses = _RecordingAnalysisRunStatuses()
+    with NeMoPlatform(base_url=_BASE_URL) as sdk:
+        monkeypatch.setattr(sdk.insights.analysis_run_statuses, "update", statuses.update)
+        result = AnalyzeJob().run(
+            _analyze_spec().model_dump(mode="json"),
+            ctx=_ctx(tmp_path),
+            sdk=sdk,
+        )
 
     assert result["status"] == "completed"
     assert result["artifact"] == {
         "name": "analysis-report",
-        "path": str(tmp_path / "persistent" / "analysis-report.txt"),
+        "artifact_url": f"file://{tmp_path / 'persistent' / 'analysis-report.txt'}",
     }
-    updates = sdk.insights.analysis_run_statuses.updates
-    assert [u["status"] for u in updates] == [
+    updates = statuses.updates
+    assert [u.status for u in updates] == [
         AnalysisConfigStatus.RUNNING,
         AnalysisConfigStatus.IDLE,
     ]
-    assert updates[-1]["last_submitted_job"] == "insights-job-1"
+    assert updates[-1].last_submitted_job == "insights-job-1"
     assert (tmp_path / "persistent" / "analysis-report.txt").read_text() == "analysis report"
     assert calls[0]["client"] is async_client
     assert calls[0]["model_refs"] == ConfiguredModelRefs(
@@ -744,7 +863,7 @@ async def test_analyze_job_compile_requests_storage_without_provider_credentials
     )
 
     step = next(iter(platform_spec["steps"]))
-    assert step["environment"] == [
+    assert [env.model_dump(exclude_none=True) for env in step["environment"]] == [
         {
             "name": PERSISTENT_JOB_STORAGE_PATH_ENVVAR,
             "value": DEFAULT_JOB_STORAGE_PATH,
@@ -752,58 +871,67 @@ async def test_analyze_job_compile_requests_storage_without_provider_credentials
     ]
 
 
-class _AsyncJobList:
-    def __init__(self, jobs: list[SimpleNamespace]) -> None:
-        self._jobs = jobs
+class _RecordingAnalysisJobs:
+    def __init__(
+        self,
+        *,
+        jobs: list[AnalysisJob] | None = None,
+    ) -> None:
+        self.created: list[CreateAnalysisJobRequest] = []
+        self.query_params: list[ListAnalysisJobsQueryParams | None] = []
+        self._listed_jobs = list(jobs or [])
 
-    async def items(self):
-        for job in self._jobs:
-            yield job
+    async def list_analysis_jobs(
+        self,
+        *,
+        workspace: str | None = None,
+        query_params: ListAnalysisJobsQueryParams | None = None,
+    ) -> _AsyncItems[AnalysisJob]:
+        del workspace
+        self.query_params.append(query_params)
+        return _AsyncItems(self._listed_jobs)
 
-
-class _AsyncJobs:
-    """Duck-typed AsyncJobsClient: records created jobs, serves list_jobs items."""
-
-    def __init__(self, jobs: list[SimpleNamespace] | None = None) -> None:
-        self.created: list[Any] = []
-        self.jobs = list(jobs or [])
-
-    async def create_job(self, *, workspace: str, body: Any) -> SimpleNamespace:
+    async def create_analysis_job(
+        self,
+        *,
+        workspace: str | None = None,
+        body: CreateAnalysisJobRequest,
+    ) -> _TypedResponse[AnalysisJob]:
         del workspace
         self.created.append(body)
-        return SimpleNamespace(data=lambda: SimpleNamespace(name=body.name))
-
-    async def list_jobs(self, *, workspace: str, query_params: Any = None) -> _AsyncJobList:
-        del workspace, query_params
-        return _AsyncJobList(self.jobs)
-
-
-class _AsyncSdk:
-    def __init__(self, jobs: list[SimpleNamespace] | None = None) -> None:
-        self.jobs = _AsyncJobs(jobs=jobs)
+        job = AnalysisJob(
+            name=body.name or "analysis-job",
+            spec=body.spec,
+            custom_fields=body.custom_fields,
+        )
+        return _TypedResponse(job)
 
 
-class _Entities:
-    def __init__(self, run_status: AnalysisRunStatus | None = None) -> None:
-        self.updated: list[AnalysisConfig] = []
-        self.run_status = run_status
+class _RunStatusLookup:
+    def __init__(self, run_status: AnalysisRunStatus | None) -> None:
+        self._run_status = run_status
 
-    async def get(self, entity_type: type, *, name: str, workspace: str) -> AnalysisRunStatus:
-        del name, workspace
-        if entity_type is AnalysisRunStatus and self.run_status is not None:
-            return self.run_status
-        raise NemoEntityNotFoundError("missing")
+    async def get(
+        self,
+        entity_type: type[AnalysisRunStatus],
+        name: str,
+        *,
+        workspace: str | None = None,
+        parent: str | None = None,
+    ) -> AnalysisRunStatus:
+        del entity_type, name, workspace, parent
+        if self._run_status is None:
+            raise NemoEntityNotFoundError("missing")
+        return self._run_status
 
-    async def update(self, config: AnalysisConfig) -> AnalysisConfig:
-        self.updated.append(config)
-        return config
 
-
-def _controller(
+@asynccontextmanager
+async def _controller(
+    monkeypatch: pytest.MonkeyPatch,
     *,
-    jobs: list[SimpleNamespace] | None = None,
+    jobs: list[AnalysisJob] | None = None,
     run_status: AnalysisRunStatus | None = None,
-) -> tuple[InsightsAnalysisController, _AsyncSdk, _Entities]:
+) -> AsyncIterator[tuple[InsightsAnalysisController, _RecordingAnalysisJobs]]:
     controller = InsightsAnalysisController()
     controller._config = InsightsConfig(
         analyst=AnalystSchedulerConfig(
@@ -812,12 +940,17 @@ def _controller(
             job_profile="test-profile",
         )
     )
-    sdk = _AsyncSdk(jobs=jobs)
-    entities = _Entities(run_status=run_status)
-    controller._sdk = cast(AsyncNeMoPlatform, sdk)
-    controller._jobs = cast(AsyncJobsClient, sdk.jobs)
-    controller._entities = cast(NemoEntitiesClient, entities)
-    return controller, sdk, entities
+    async with _async_platform() as sdk:
+        jobs_client = client_from_platform(sdk, AsyncAnalysisJobsClient)
+        recording_jobs = _RecordingAnalysisJobs(jobs=jobs)
+        entities = NemoEntitiesClient(client_from_platform(sdk, AsyncEntitiesClient))
+        monkeypatch.setattr(jobs_client, "list_analysis_jobs", recording_jobs.list_analysis_jobs)
+        monkeypatch.setattr(jobs_client, "create_analysis_job", recording_jobs.create_analysis_job)
+        monkeypatch.setattr(entities, "get", _RunStatusLookup(run_status).get)
+        controller._sdk = sdk
+        controller._jobs = jobs_client
+        controller._entities = entities
+        yield controller, recording_jobs
 
 
 def test_generated_job_name_fits_derived_fileset_name_limit() -> None:
@@ -836,7 +969,6 @@ def test_generated_job_name_fits_derived_fileset_name_limit() -> None:
 
 @pytest.mark.asyncio
 async def test_controller_submits_due_job(monkeypatch: pytest.MonkeyPatch) -> None:
-    controller, sdk, entities = _controller()
     config = AnalysisConfig(
         name="research-agent",
         workspace="default",
@@ -845,58 +977,58 @@ async def test_controller_submits_due_job(monkeypatch: pytest.MonkeyPatch) -> No
         fast_model="default/gpt-5-mini",
     )
 
-    async def fake_compile_job_spec(**_: object) -> dict[str, list[object]]:
-        return {"steps": [{"name": "step-one", "executor": {"provider": "cpu", "container": {"image": "x"}}}]}
+    async with _controller(monkeypatch) as (controller, jobs):
+        await controller._reconcile_config(config)
 
-    monkeypatch.setattr(controller, "_compile_job_spec", fake_compile_job_spec)
-    await controller._reconcile_config(config)
-
-    assert len(sdk.jobs.created) == 1
-    created = sdk.jobs.created[0]
-    created_spec = cast(dict[str, object], created.spec)
-    assert created.source == "insights"
-    assert created_spec["agent"] == "research-agent"
-    assert created_spec["since"] is None
-    assert created_spec["default_model"] == "default/gpt-5"
-    assert created_spec["fast_model"] == "default/gpt-5-mini"
-    assert entities.updated == []
+    assert len(jobs.created) == 1
+    created = jobs.created[0]
+    created_spec = created.spec
+    assert created.name is not None
+    assert created.name.startswith("opt-analyze-default-research-agent-")
+    assert created.custom_fields == {"insights_analysis_agent": "research-agent"}
+    assert created_spec.agent == "research-agent"
+    assert created_spec.since is None
+    assert created_spec.default_model == "default/gpt-5"
+    assert created_spec.fast_model == "default/gpt-5-mini"
 
 
 @pytest.mark.asyncio
 async def test_controller_defers_legacy_config_without_persisted_models(
+    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    controller, sdk, _ = _controller()
     config = AnalysisConfig(name="research-agent", workspace="default", agent="research-agent")
 
-    with caplog.at_level("ERROR", logger="nemo_insights_plugin.controller"):
-        await controller._reconcile_config(config)
+    async with _controller(monkeypatch) as (controller, jobs):
+        with caplog.at_level("ERROR", logger="nemo_insights_plugin.controller"):
+            await controller._reconcile_config(config)
 
-    assert sdk.jobs.created == []
+    assert jobs.created == []
     assert "has no model selection" in caplog.text
     assert "nemo insights analysis enable" in caplog.text
 
 
 @pytest.mark.asyncio
 async def test_controller_skips_active_job(monkeypatch: pytest.MonkeyPatch) -> None:
-    controller, sdk, _ = _controller(
-        jobs=[
-            SimpleNamespace(
-                status="active",
-                custom_fields={"insights_analysis_agent": "research-agent"},
-            )
-        ]
-    )
     config = AnalysisConfig(
         name="research-agent",
         workspace="default",
         agent="research-agent",
+        default_model="default/gpt-5",
+        fast_model="default/gpt-5-mini",
     )
 
-    async def fake_compile_job_spec(**_: object) -> dict[str, list[object]]:
-        return {"steps": [{"name": "step-one", "executor": {"provider": "cpu", "container": {"image": "x"}}}]}
+    async with _controller(
+        monkeypatch,
+        jobs=[
+            AnalysisJob(
+                name="existing-analysis-job",
+                spec=_analyze_spec(),
+                status=PlatformJobStatus.ACTIVE,
+                custom_fields={"insights_analysis_agent": "research-agent"},
+            )
+        ],
+    ) as (controller, jobs):
+        await controller._reconcile_config(config)
 
-    monkeypatch.setattr(controller, "_compile_job_spec", fake_compile_job_spec)
-    await controller._reconcile_config(config)
-
-    assert sdk.jobs.created == []
+    assert jobs.created == []

--- a/plugins/nemo-iron-swarm/src/nemo_iron_swarm_plugin/jobs/hitl.py
+++ b/plugins/nemo-iron-swarm/src/nemo_iron_swarm_plugin/jobs/hitl.py
@@ -6,7 +6,7 @@
 The war-game job drives the synth service (interview rounds, then benign-suite review) and relays each
 checkpoint to the operator via the job's ``status_details`` — Studio renders it and PATCHes a response.
 :func:`drive_synth_hitl` is the transport-agnostic loop (``publish``/``await_response`` injected so it is
-unit-testable); :class:`StatusDetailsChannel` implements those over ``sdk.jobs`` for the real job.
+unit-testable); :class:`StatusDetailsChannel` implements those over the typed Jobs client for the real job.
 """
 
 from __future__ import annotations

--- a/plugins/nemo-optimization/src/nemo_optimization/jobs/optimize.py
+++ b/plugins/nemo-optimization/src/nemo_optimization/jobs/optimize.py
@@ -364,7 +364,7 @@ def _publish_results(
     The backends write everything under ``ctx.storage.persistent / "results"``
     and register it via ``ctx.results.save``, which on the platform lands in the
     job's own fileset under ``results/<attempt_id>/``.  That is addressable only
-    through ``sdk.jobs.results``, so a remote client that wants to read the
+    through the typed Jobs results client, so a remote client that wants to read the
     optimized config back — or hand it to a follow-up job — needs a stable
     location it names up front.  Publishing the whole ``results`` tree keeps
     this backend-agnostic: no ``RESULT_NAME`` coupling, and the ``ga`` backend

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -16690,6 +16690,25 @@ components:
       - artifact_url
       - artifact_storage_type
       title: PlatformJobResultResponse
+    PlatformJobSecret:
+      properties:
+        name:
+          type: string
+          title: Name
+          description: The name of the secret
+        value:
+          title: Value
+          description: The secret value submitted with the job
+          type: string
+        ref_id:
+          title: Ref Id
+          description: Reference id for the stored secret value
+          type: string
+      type: object
+      required:
+      - name
+      title: PlatformJobSecret
+      description: Inline secret material submitted with a job spec.
     PlatformJobSecretEnvironmentVariableRef:
       properties:
         name:
@@ -16718,6 +16737,12 @@ components:
           type: array
           title: Steps
           description: List of steps to be executed in the job
+        secrets:
+          title: Secrets
+          description: Secrets referenced by the job
+          items:
+            $ref: '#/components/schemas/PlatformJobSecret'
+          type: array
       type: object
       required:
       - steps

--- a/sdk/python/nemo-platform/.nmpcontext/stainless.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/stainless.yaml
@@ -552,6 +552,7 @@ resources:
       platform_job_list_sort_field: PlatformJobListSortField
       platform_job_response: PlatformJobResponse
       platform_job_responses_page: PlatformJobResponsesPage
+      platform_job_secret: PlatformJobSecret
       platform_job_secret_environment_variable_ref: PlatformJobSecretEnvironmentVariableRef
       platform_job_sort_field: PlatformJobSortField
       platform_job_spec: PlatformJobSpec

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/jobs/api.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/jobs/api.md
@@ -38,6 +38,7 @@ from nemo_platform.types.jobs import (
     PlatformJobListSortField,
     PlatformJobResponse,
     PlatformJobResponsesPage,
+    PlatformJobSecret,
     PlatformJobSecretEnvironmentVariableRef,
     PlatformJobSortField,
     PlatformJobSpec,

--- a/sdk/python/nemo-platform/src/nemo_platform/types/jobs/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/jobs/__init__.py
@@ -31,6 +31,7 @@ from .platform_job_task import PlatformJobTask as PlatformJobTask
 from .result_list_params import ResultListParams as ResultListParams
 from .docker_volume_mount import DockerVolumeMount as DockerVolumeMount
 from .job_get_logs_params import JobGetLogsParams as JobGetLogsParams
+from .platform_job_secret import PlatformJobSecret as PlatformJobSecret
 from .container_spec_param import ContainerSpecParam as ContainerSpecParam
 from .result_create_params import ResultCreateParams as ResultCreateParams
 from .step_lifecycle_param import StepLifecycleParam as StepLifecycleParam
@@ -48,6 +49,7 @@ from .kubernetes_secret_volume import KubernetesSecretVolume as KubernetesSecret
 from .docker_job_network_config import DockerJobNetworkConfig as DockerJobNetworkConfig
 from .docker_job_storage_config import DockerJobStorageConfig as DockerJobStorageConfig
 from .e2e_job_execution_profile import E2EJobExecutionProfile as E2EJobExecutionProfile
+from .platform_job_secret_param import PlatformJobSecretParam as PlatformJobSecretParam
 from .step_update_status_params import StepUpdateStatusParams as StepUpdateStatusParams
 from .kubernetes_object_metadata import KubernetesObjectMetadata as KubernetesObjectMetadata
 from .compute_resource_spec_param import ComputeResourceSpecParam as ComputeResourceSpecParam

--- a/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_secret.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_secret.py
@@ -15,22 +15,21 @@
 
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from __future__ import annotations
+from typing import Optional
 
-from typing import Iterable
-from typing_extensions import Required, TypedDict
+from ..._models import BaseModel
 
-from .platform_job_secret_param import PlatformJobSecretParam
-from .platform_job_step_spec_param import PlatformJobStepSpecParam
-
-__all__ = ["PlatformJobSpecParam"]
+__all__ = ["PlatformJobSecret"]
 
 
-class PlatformJobSpecParam(TypedDict, total=False):
-    """Specification for a platform job, containing steps and secrets."""
+class PlatformJobSecret(BaseModel):
+    """Inline secret material submitted with a job spec."""
 
-    steps: Required[Iterable[PlatformJobStepSpecParam]]
-    """List of steps to be executed in the job"""
+    name: str
+    """The name of the secret"""
 
-    secrets: Iterable[PlatformJobSecretParam]
-    """Secrets referenced by the job"""
+    ref_id: Optional[str] = None
+    """Reference id for the stored secret value"""
+
+    value: Optional[str] = None
+    """The secret value submitted with the job"""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_secret_param.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_secret_param.py
@@ -17,20 +17,19 @@
 
 from __future__ import annotations
 
-from typing import Iterable
 from typing_extensions import Required, TypedDict
 
-from .platform_job_secret_param import PlatformJobSecretParam
-from .platform_job_step_spec_param import PlatformJobStepSpecParam
-
-__all__ = ["PlatformJobSpecParam"]
+__all__ = ["PlatformJobSecretParam"]
 
 
-class PlatformJobSpecParam(TypedDict, total=False):
-    """Specification for a platform job, containing steps and secrets."""
+class PlatformJobSecretParam(TypedDict, total=False):
+    """Inline secret material submitted with a job spec."""
 
-    steps: Required[Iterable[PlatformJobStepSpecParam]]
-    """List of steps to be executed in the job"""
+    name: Required[str]
+    """The name of the secret"""
 
-    secrets: Iterable[PlatformJobSecretParam]
-    """Secrets referenced by the job"""
+    ref_id: str
+    """Reference id for the stored secret value"""
+
+    value: str
+    """The secret value submitted with the job"""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_spec.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/jobs/platform_job_spec.py
@@ -15,9 +15,10 @@
 
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List
+from typing import List, Optional
 
 from ..._models import BaseModel
+from .platform_job_secret import PlatformJobSecret
 from .platform_job_step_spec import PlatformJobStepSpec
 
 __all__ = ["PlatformJobSpec"]
@@ -28,3 +29,6 @@ class PlatformJobSpec(BaseModel):
 
     steps: List[PlatformJobStepSpec]
     """List of steps to be executed in the job"""
+
+    secrets: Optional[List[PlatformJobSecret]] = None
+    """Secrets referenced by the job"""

--- a/sdk/python/nemo-platform/tests/api_resources/test_jobs.py
+++ b/sdk/python/nemo-platform/tests/api_resources/test_jobs.py
@@ -105,7 +105,14 @@ class TestJobs:
                         ],
                         "lifecycle": {"staleness_timeout_seconds": 0},
                     }
-                ]
+                ],
+                "secrets": [
+                    {
+                        "name": "name",
+                        "ref_id": "ref_id",
+                        "value": "value",
+                    }
+                ],
             },
             source="source",
             spec={"foo": "bar"},
@@ -800,7 +807,14 @@ class TestAsyncJobs:
                         ],
                         "lifecycle": {"staleness_timeout_seconds": 0},
                     }
-                ]
+                ],
+                "secrets": [
+                    {
+                        "name": "name",
+                        "ref_id": "ref_id",
+                        "value": "value",
+                    }
+                ],
             },
             source="source",
             spec={"foo": "bar"},

--- a/sdk/stainless.yaml
+++ b/sdk/stainless.yaml
@@ -552,6 +552,7 @@ resources:
       platform_job_list_sort_field: PlatformJobListSortField
       platform_job_response: PlatformJobResponse
       platform_job_responses_page: PlatformJobResponsesPage
+      platform_job_secret: PlatformJobSecret
       platform_job_secret_environment_variable_ref: PlatformJobSecretEnvironmentVariableRef
       platform_job_sort_field: PlatformJobSortField
       platform_job_spec: PlatformJobSpec

--- a/services/automodel/tests/test_integrations_compiler.py
+++ b/services/automodel/tests/test_integrations_compiler.py
@@ -13,6 +13,7 @@ from nmp.automodel.api.v2.jobs.schemas import (
     SFTTraining,
 )
 from nmp.automodel.app.jobs.training.compiler import compile_training_step
+from nmp.automodel.entities.values import OutputNameType
 from nmp.common.entities.utils import get_random_id
 
 
@@ -40,7 +41,7 @@ def _job_spec_with_integrations() -> CustomizationJobOutput:
             micro_batch_size=1,
             max_seq_length=2048,
         ),
-        output=OutputResponse(name="out", type="adapter", fileset="out-fs"),
+        output=OutputResponse(name="out", type=OutputNameType.ADAPTER, fileset="out-fs"),
         integrations=IntegrationsSpec.model_validate(
             {
                 "wandb": {
@@ -56,6 +57,7 @@ def test_compile_training_step_injects_wandb_secret() -> None:
     step = compile_training_step(_job_spec_with_integrations(), base_env=[], me=_make_model_entity())
 
     env = step["environment"] if isinstance(step, dict) else step.environment
+    assert env is not None
     assert {"name": "WANDB_API_KEY", "from_secret": {"name": "default/wandb-key"}} in env
 
 
@@ -64,6 +66,7 @@ def test_compile_training_step_no_integrations() -> None:
     step = compile_training_step(spec, base_env=[], me=_make_model_entity())
 
     env = step["environment"] if isinstance(step, dict) else step.environment
+    assert env is not None
     secret_envs = [item for item in env if item.get("name") == "WANDB_API_KEY"]
     assert secret_envs == []
 

--- a/services/core/jobs/src/nmp/core/jobs/app/schemas.py
+++ b/services/core/jobs/src/nmp/core/jobs/app/schemas.py
@@ -14,6 +14,7 @@ from nemo_platform_plugin.jobs import spec as _spec
 BackendRef = _spec.BackendRef
 BaseExecutionProfile = _spec.BaseExecutionProfile
 PlatformJobEnvironmentVariable = _spec.PlatformJobEnvironmentVariable
+PlatformJobSecret = _spec.PlatformJobSecret
 PlatformJobSecretEnvironmentVariableRef = _spec.PlatformJobSecretEnvironmentVariableRef
 PlatformJobSpec = _spec.PlatformJobSpec
 PlatformJobStepSpec = _spec.PlatformJobStepSpec

--- a/services/core/jobs/tests/conftest.py
+++ b/services/core/jobs/tests/conftest.py
@@ -17,9 +17,10 @@ from nemo_platform import AsyncNeMoPlatform
 from nemo_platform_plugin.capabilities import reset_capability_cache
 from nemo_platform_plugin.jobs.api_factory import ContainerSpec as FactoryContainerSpec
 from nemo_platform_plugin.jobs.api_factory import CPUExecutionProviderSpec as FactoryCPUExecutionProviderSpec
-from nemo_platform_plugin.jobs.api_factory import PlatformJobEnvironmentVariableParam, job_route_factory
+from nemo_platform_plugin.jobs.api_factory import EnvironmentVariable as FactoryEnvironmentVariable
 from nemo_platform_plugin.jobs.api_factory import PlatformJobSpec as FactoryPlatformJobSpec
 from nemo_platform_plugin.jobs.api_factory import PlatformJobStep as FactoryPlatformJobStep
+from nemo_platform_plugin.jobs.api_factory import job_route_factory
 from nmp.common.config import Configuration, ImagePullSecret, PlatformConfig
 from nmp.common.entities.client import EntityClient
 from nmp.common.jobs.constants import (
@@ -318,7 +319,6 @@ def mock_nmp_client(_mock_files_client, mock_jobs_client):
     """
     mock_client = MagicMock()
     mock_client.beta = MagicMock()
-    mock_client.jobs = MagicMock()
 
     from nemo_platform_plugin.jobs.client import JobsClient
 
@@ -572,7 +572,7 @@ def hello_world_job_config(
                     ),
                 ),
                 config=output_spec.model_dump(),
-                environment=[PlatformJobEnvironmentVariableParam(name="ENV_VAR", value="test_value")],
+                environment=[FactoryEnvironmentVariable(name="ENV_VAR", value="test_value")],
             ),
         ]
     )

--- a/services/core/jobs/tests/controllers/test_base.py
+++ b/services/core/jobs/tests/controllers/test_base.py
@@ -578,7 +578,9 @@ class TestCheckTaskStaleness:
     def test_disabled_when_lifecycle_is_none(self):
         backend = _make_backend()
         step = _make_step()
-        step.step_spec.lifecycle = None
+        step_spec = step.step_spec
+        assert step_spec is not None
+        step.step_spec = step_spec.model_copy(update={"lifecycle": None})
 
         assert backend.check_step_is_stale(step) is False
 

--- a/services/core/jobs/tests/controllers/test_subprocess_backend.py
+++ b/services/core/jobs/tests/controllers/test_subprocess_backend.py
@@ -44,8 +44,14 @@ def _step_with_command(step, command: list[str]):
 
 def _step_with_unvalidated_command(step, command: list[str]):
     updated_step = step.model_copy(deep=True)
-    updated_step.step_spec.executor = SubprocessExecutionProvider.model_construct(
-        provider="subprocess", profile="default", command=command
+    step_spec = updated_step.step_spec
+    assert step_spec is not None
+    updated_step.step_spec = step_spec.model_copy(
+        update={
+            "executor": SubprocessExecutionProvider.model_construct(
+                provider="subprocess", profile="default", command=command
+            )
+        }
     )
     return updated_step
 

--- a/services/core/jobs/tests/test_job_search.py
+++ b/services/core/jobs/tests/test_job_search.py
@@ -1,122 +1,136 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+
 import pytest
 from httpx import AsyncClient
 from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.jobs.client import AsyncJobsClient
+from nemo_platform_plugin.jobs.spec import PlatformJobSpec
+from nemo_platform_plugin.jobs.types import CreatePlatformJobRequest, ListJobsQueryParams
 from nmp.common.entities import DEFAULT_WORKSPACE
 
 # Skip all substring search tests until entity store supports LIKE queries (nmp-oq7)
 SUBSTRING_SEARCH_SKIP = pytest.mark.skip(reason="Requires substring search support in entity store (nmp-oq7)")
 
 
+TEST_PLATFORM_SPEC = PlatformJobSpec.model_validate(
+    {
+        "steps": [
+            {
+                "name": "step1",
+                "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}},
+            }
+        ]
+    }
+)
+
+
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_jobs_by_name(test_sdk: AsyncNeMoPlatform):
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="training-job-v1",
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="evaluation-job",
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="training-job-v1",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="evaluation-job",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
-    response = await test_sdk.jobs.list(extra_query={"filter[name]": ["training"]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1
-    assert "training" in response.data[0].name.lower()
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": "training"}})),
+        )
+    ).page()
+    assert len(response.items) == 1
+    assert "training" in response.items[0].name.lower()
 
 
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_jobs_by_project(test_sdk: AsyncNeMoPlatform):
-    # TODO: Once SDK is regenerated, pass project= directly instead of extra_body
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="job1",
-        source="testing",
-        extra_body={"project": "nlp-project"},
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="job2",
-        source="testing",
-        extra_body={"project": "vision-project"},
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="job1",
+                source="testing",
+                project="nlp-project",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="job2",
+                source="testing",
+                project="vision-project",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
-    response = await test_sdk.jobs.list(extra_query={"filter[project]": ["nlp"]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1
-    assert response.data[0].project == "nlp-project"
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"project": {"$like": "nlp"}})),
+        )
+    ).page()
+    assert len(response.items) == 1
+    assert response.items[0].project == "nlp-project"
 
 
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_jobs_multiple_values_or_logic(test_sdk: AsyncNeMoPlatform):
-    await test_sdk.jobs.create(
-        name="training-job",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="evaluation-job",
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="inference-job",
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    for name in ["training-job", "evaluation-job", "inference-job"]:
+        (
+            await jobs.create_job(
+                workspace=DEFAULT_WORKSPACE,
+                body=CreatePlatformJobRequest(
+                    name=name,
+                    source="testing",
+                    spec={},
+                    platform_spec=TEST_PLATFORM_SPEC,
+                ),
+            )
+        ).data()
 
-    response = await test_sdk.jobs.list(
-        extra_query={"filter[name]": ["training", "evaluation"]}, workspace=DEFAULT_WORKSPACE
-    )
-    assert len(response.data) == 2
-    names = [job.name for job in response.data]
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(
+                filter=json.dumps({"$or": [{"name": {"$like": "training"}}, {"name": {"$like": "evaluation"}}]})
+            ),
+        )
+    ).page()
+    assert len(response.items) == 2
+    names = [job.name for job in response.items]
     assert "training-job" in names
     assert "evaluation-job" in names
 
@@ -124,178 +138,179 @@ async def test_search_jobs_multiple_values_or_logic(test_sdk: AsyncNeMoPlatform)
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_jobs_multiple_fields_and_logic(test_sdk: AsyncNeMoPlatform):
-    # TODO: Once SDK is regenerated, pass project= directly instead of extra_body
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="training-job-nlp",
-        source="testing",
-        extra_body={"project": "nlp-project"},
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="training-job-vision",
-        source="testing",
-        extra_body={"project": "vision-project"},
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="evaluation-job-nlp",
-        source="testing",
-        extra_body={"project": "nlp-project"},
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    for name, project in [
+        ("training-job-nlp", "nlp-project"),
+        ("training-job-vision", "vision-project"),
+        ("evaluation-job-nlp", "nlp-project"),
+    ]:
+        (
+            await jobs.create_job(
+                workspace=DEFAULT_WORKSPACE,
+                body=CreatePlatformJobRequest(
+                    name=name,
+                    source="testing",
+                    project=project,
+                    spec={},
+                    platform_spec=TEST_PLATFORM_SPEC,
+                ),
+            )
+        ).data()
 
     # Search for training jobs in nlp project - should only match training-job-nlp
-    response = await test_sdk.jobs.list(
-        extra_query={"filter[name]": ["training"], "filter[project]": ["nlp"]}, workspace=DEFAULT_WORKSPACE
-    )
-    assert len(response.data) == 1
-    assert response.data[0].name == "training-job-nlp"
-    assert response.data[0].project == "nlp-project"
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(
+                filter=json.dumps({"$and": [{"name": {"$like": "training"}}, {"project": {"$like": "nlp"}}]})
+            ),
+        )
+    ).page()
+    assert len(response.items) == 1
+    assert response.items[0].name == "training-job-nlp"
+    assert response.items[0].project == "nlp-project"
 
 
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_jobs_case_insensitive(test_sdk: AsyncNeMoPlatform):
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="Training-Job-V1",
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="Training-Job-V1",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
-    response = await test_sdk.jobs.list(
-        extra_query={"filter[name]": ["training"]},
-        workspace=DEFAULT_WORKSPACE,
-    )
-    assert len(response.data) == 1
-    assert response.data[0].name == "Training-Job-V1"
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": "training"}})),
+        )
+    ).page()
+    assert len(response.items) == 1
+    assert response.items[0].name == "Training-Job-V1"
 
 
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_jobs_partial_match(test_sdk: AsyncNeMoPlatform):
-    await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="my-training-job-v1",
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="my-training-job-v1",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
-    response = await test_sdk.jobs.list(extra_query={"filter[name]": ["train"]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1
-    assert "train" in response.data[0].name.lower()
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": "train"}})),
+        )
+    ).page()
+    assert len(response.items) == 1
+    assert "train" in response.items[0].name.lower()
 
 
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_combined_with_filter(test_sdk: AsyncNeMoPlatform):
-    job1 = await test_sdk.jobs.create(
-        name="training-job-1",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        name="training-job-2",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    job1 = (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="training-job-1",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="training-job-2",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
-    await test_sdk.jobs.cancel(job1.id, workspace=DEFAULT_WORKSPACE)
+    (await jobs.cancel_job(workspace=DEFAULT_WORKSPACE, name=job1.name)).data()
 
-    response = await test_sdk.jobs.list(
-        filter={"source": "testing", "name": "training-job-1"}, workspace=DEFAULT_WORKSPACE
-    )
-    assert len(response.data) == 1
-    assert response.data[0].id == job1.id
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"source": "testing", "name": "training-job-1"})),
+        )
+    ).page()
+    assert len(response.items) == 1
+    assert response.items[0].id == job1.id
 
 
 @pytest.mark.asyncio
 @SUBSTRING_SEARCH_SKIP
 async def test_search_no_results(test_sdk: AsyncNeMoPlatform):
-    await test_sdk.jobs.create(
-        name="training-job",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="training-job",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
-    response = await test_sdk.jobs.list(extra_query={"filter[name]": ["nonexistent"]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 0
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": "nonexistent"}})),
+        )
+    ).page()
+    assert len(response.items) == 0
 
 
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_empty_string(test_sdk: AsyncNeMoPlatform):
-    await test_sdk.jobs.create(
-        name="job1",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        name="job2",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    for name in ["job1", "job2"]:
+        (
+            await jobs.create_job(
+                workspace=DEFAULT_WORKSPACE,
+                body=CreatePlatformJobRequest(
+                    name=name,
+                    source="testing",
+                    spec={},
+                    platform_spec=TEST_PLATFORM_SPEC,
+                ),
+            )
+        ).data()
 
-    response = await test_sdk.jobs.list(extra_query={"filter[name]": [""]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 2
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": ""}})),
+        )
+    ).page()
+    assert len(response.items) == 2
 
 
 @SUBSTRING_SEARCH_SKIP
@@ -320,82 +335,95 @@ async def test_search_via_http_client(test_client: AsyncClient):
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_pagination(test_sdk: AsyncNeMoPlatform):
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
     for i in range(15):
-        await test_sdk.jobs.create(
-            name=f"training-job-{i}",
+        (
+            await jobs.create_job(
+                workspace=DEFAULT_WORKSPACE,
+                body=CreatePlatformJobRequest(
+                    name=f"training-job-{i}",
+                    source="testing",
+                    spec={},
+                    platform_spec=TEST_PLATFORM_SPEC,
+                ),
+            )
+        ).data()
+
+    response = (
+        await jobs.list_jobs(
             workspace=DEFAULT_WORKSPACE,
-            source="testing",
-            spec={},
-            platform_spec={
-                "steps": [
-                    {
-                        "name": "step1",
-                        "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}},
-                    }
-                ]
-            },
+            query_params=ListJobsQueryParams(
+                page=1,
+                page_size=10,
+                filter=json.dumps({"name": {"$like": "training"}}),
+            ),
         )
+    ).page()
+    assert len(response.items) == 10
+    assert response.metadata["total_results"] == 15
 
-    response = await test_sdk.jobs.list(
-        page=1, page_size=10, extra_query={"filter[name]": ["training"]}, workspace=DEFAULT_WORKSPACE
-    )
-    assert len(response.data) == 10
-    assert response.pagination.total_results == 15
-
-    response_page2 = await test_sdk.jobs.list(
-        page=2, page_size=10, extra_query={"filter[name]": ["training"]}, workspace=DEFAULT_WORKSPACE
-    )
-    assert len(response_page2.data) == 5
+    response_page2 = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(
+                page=2,
+                page_size=10,
+                filter=json.dumps({"name": {"$like": "training"}}),
+            ),
+        )
+    ).page()
+    assert len(response_page2.items) == 5
 
 
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_underscore_behavior(test_sdk: AsyncNeMoPlatform):
     """Test that underscore is treated as a literal character in search (substring matching)."""
-    await test_sdk.jobs.create(
-        name="test_job_with_underscore",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
-    await test_sdk.jobs.create(
-        name="test-job-with-dash",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    for name in ["test_job_with_underscore", "test-job-with-dash"]:
+        (
+            await jobs.create_job(
+                workspace=DEFAULT_WORKSPACE,
+                body=CreatePlatformJobRequest(
+                    name=name,
+                    source="testing",
+                    spec={},
+                    platform_spec=TEST_PLATFORM_SPEC,
+                ),
+            )
+        ).data()
 
     # Underscore is treated as a literal character - only matches jobs containing "_"
-    response = await test_sdk.jobs.list(extra_query={"filter[name]": ["_"]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1  # Only the job with underscore matches
-    assert response.data[0].name == "test_job_with_underscore"
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": "_"}})),
+        )
+    ).page()
+    assert len(response.items) == 1  # Only the job with underscore matches
+    assert response.items[0].name == "test_job_with_underscore"
 
     # Create a job with a valid name containing special allowed characters
-    await test_sdk.jobs.create(
-        name="job-100-complete",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="job-100-complete",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
     # Search for the job using a substring
-    response = await test_sdk.jobs.list(extra_query={"filter[name]": ["100"]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1  # Only the job-100-complete job matches
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": "100"}})),
+        )
+    ).page()
+    assert len(response.items) == 1  # Only the job-100-complete job matches
 
 
 @SUBSTRING_SEARCH_SKIP
@@ -403,48 +431,59 @@ async def test_search_underscore_behavior(test_sdk: AsyncNeMoPlatform):
 async def test_search_long_string(test_sdk: AsyncNeMoPlatform):
     # Use a name within the 255 character limit
     long_name = "job-" + "a" * 200  # Total 204 chars, within 255 limit
-    await test_sdk.jobs.create(
-        name=long_name,
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name=long_name,
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
     long_search = "a" * 200
-    response = await test_sdk.jobs.list(extra_query={"filter[name]": [long_search]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1
-    assert long_search in response.data[0].name
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": long_search}})),
+        )
+    ).page()
+    assert len(response.items) == 1
+    assert long_search in response.items[0].name
 
 
 @SUBSTRING_SEARCH_SKIP
 @pytest.mark.asyncio
 async def test_search_result_limit(test_sdk: AsyncNeMoPlatform):
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
     for i in range(150):
-        await test_sdk.jobs.create(
-            name=f"batch-job-{i:03d}",
-            workspace=DEFAULT_WORKSPACE,
-            source="testing",
-            spec={},
-            platform_spec={
-                "steps": [
-                    {
-                        "name": "step1",
-                        "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}},
-                    }
-                ]
-            },
-        )
+        (
+            await jobs.create_job(
+                workspace=DEFAULT_WORKSPACE,
+                body=CreatePlatformJobRequest(
+                    name=f"batch-job-{i:03d}",
+                    source="testing",
+                    spec={},
+                    platform_spec=TEST_PLATFORM_SPEC,
+                ),
+            )
+        ).data()
 
-    response = await test_sdk.jobs.list(
-        page=1, page_size=100, extra_query={"filter[name]": ["batch"]}, workspace=DEFAULT_WORKSPACE
-    )
-    assert len(response.data) == 100
-    assert response.pagination.total_results == 150
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(
+                page=1,
+                page_size=100,
+                filter=json.dumps({"name": {"$like": "batch"}}),
+            ),
+        )
+    ).page()
+    assert len(response.items) == 100
+    assert response.metadata["total_results"] == 150
 
 
 @SUBSTRING_SEARCH_SKIP
@@ -466,18 +505,24 @@ async def test_search_invalid_field(test_client: AsyncClient):
 @pytest.mark.asyncio
 async def test_search_special_characters(test_sdk: AsyncNeMoPlatform):
     # Use only valid special characters per the pattern ^[\w\-\+.@:]*$
-    await test_sdk.jobs.create(
-        name="job-with-special-chars@example.com:8080",
-        workspace=DEFAULT_WORKSPACE,
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {"name": "step1", "executor": {"provider": "cpu", "profile": "default", "container": {"image": "test"}}}
-            ]
-        },
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="job-with-special-chars@example.com:8080",
+                source="testing",
+                spec={},
+                platform_spec=TEST_PLATFORM_SPEC,
+            ),
+        )
+    ).data()
 
-    response = await test_sdk.jobs.list(extra_query={"filter[name]": ["@example"]}, workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1
-    assert "@example" in response.data[0].name
+    response = (
+        await jobs.list_jobs(
+            workspace=DEFAULT_WORKSPACE,
+            query_params=ListJobsQueryParams(filter=json.dumps({"name": {"$like": "@example"}})),
+        )
+    ).page()
+    assert len(response.items) == 1
+    assert "@example" in response.items[0].name

--- a/services/core/jobs/tests/test_jobs_api.py
+++ b/services/core/jobs/tests/test_jobs_api.py
@@ -14,6 +14,10 @@ import pytest
 from fastapi import HTTPException
 from httpx import AsyncClient
 from nemo_platform import AsyncNeMoPlatform
+from nemo_platform_plugin.client.adapter import client_from_platform
+from nemo_platform_plugin.jobs.client import AsyncJobsClient
+from nemo_platform_plugin.jobs.schemas import FileStorageType, PlatformJobResultCreateRequest
+from nemo_platform_plugin.jobs.types import PlatformJobTaskUpdate
 from nmp.common.entities import ALL_WORKSPACES, DEFAULT_WORKSPACE
 from nmp.common.entities.client import EntityValidationError
 from nmp.common.jobs.schemas import PlatformJobStatus
@@ -37,31 +41,13 @@ from nmp.core.jobs.app.dispatcher import (
 )
 from nmp.core.jobs.app.providers import ContainerSpec, GPUExecutionProvider, SubprocessExecutionProvider
 from nmp.core.jobs.app.schemas import (
+    PlatformJobSecret,
     PlatformJobSpec,
     PlatformJobStepSpec,
 )
 from nmp.core.jobs.app.test_helpers import TestConstants
 from pydantic import ValidationError
 from starlette.datastructures import QueryParams
-
-
-def to_sdk_create_params(request: CreatePlatformJobRequest) -> Dict[str, Any]:
-    """
-    Convert CreatePlatformJobRequest to SDK-compatible params.
-
-    TODO: Once SDK is regenerated, remove this helper and pass project=/output_location= directly.
-    """
-    data = request.model_dump(mode="json")  # JSON mode serializes nested objects properly
-    extra_body: Dict[str, Any] = {}
-    project = data.pop("project", None)
-    if project:
-        extra_body["project"] = project
-    output_location = data.pop("output_location", None)
-    if output_location:
-        extra_body["output_location"] = output_location
-    if extra_body:
-        data["extra_body"] = extra_body
-    return data
 
 
 def expected_translated_executor_dump() -> Dict[str, Any]:
@@ -85,38 +71,45 @@ def expected_translated_executor_dump() -> Dict[str, Any]:
 
 @pytest.mark.asyncio
 async def test_create_job_using_sdk(test_sdk: AsyncNeMoPlatform):
-    job = await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
-        name="test-job",
-        source="testing",
-        spec={},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "basic",
-                    "executor": {
-                        "provider": "cpu",
-                        "profile": "default",
-                        # entrypoint+command are required so the cpu→subprocess
-                        # translation hop in the Jobs API (see
-                        # `translate_cpu_container_steps_to_subprocess`) can
-                        # produce a non-empty subprocess command. Real plugin
-                        # compilers always set both; mirroring that here keeps
-                        # the SDK round-trip path realistic.
-                        "container": {
-                            "image": "test-image",
-                            "entrypoint": ["python", "-m"],
-                            "command": ["nmp.testing.fake_task"],
-                        },
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    job = (
+        await jobs.create_job(
+            workspace=DEFAULT_WORKSPACE,
+            body=CreatePlatformJobRequest(
+                name="test-job",
+                source="testing",
+                spec={},
+                platform_spec=PlatformJobSpec.model_validate(
+                    {
+                        "steps": [
+                            {
+                                "name": "basic",
+                                "executor": {
+                                    "provider": "cpu",
+                                    "profile": "default",
+                                    # entrypoint+command are required so the cpu->subprocess
+                                    # translation hop in the Jobs API (see
+                                    # `translate_cpu_container_steps_to_subprocess`) can
+                                    # produce a non-empty subprocess command. Real plugin
+                                    # compilers always set both; mirroring that here keeps
+                                    # the SDK round-trip path realistic.
+                                    "container": {
+                                        "image": "test-image",
+                                        "entrypoint": ["python", "-m"],
+                                        "command": ["nmp.testing.fake_task"],
+                                    },
+                                },
+                            }
+                        ]
                     },
-                }
-            ]
-        },
-    )
+                ),
+            ),
+        )
+    ).data()
     assert job.id
-    response = await test_sdk.jobs.list(workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1
-    job_item = response.data[0]
+    response = (await jobs.list_jobs(workspace=DEFAULT_WORKSPACE)).page()
+    assert len(response.items) == 1
+    job_item = response.items[0]
     assert job_item.name == "test-job"
     assert len(job_item.platform_spec.steps) == 1
 
@@ -186,44 +179,53 @@ def test_step_name_validation(step_name: str, should_pass: bool):
 @pytest.mark.asyncio
 @pytest.mark.skip("This is an integration test that requires secrets service.")
 async def test_create_job_with_secrets(test_sdk: AsyncNeMoPlatform):
-    job = await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE,
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    request = CreatePlatformJobRequest(
         name="test-job",
         source="testing",
         spec={},
-        platform_spec={
-            "steps": [
-                {
-                    "name": "basic",
-                    "executor": {
-                        "provider": "cpu",
-                        "profile": "default",
-                        "container": {"image": "test-image"},
-                    },
-                    "environment": [
-                        {"name": "MY_SECRET_ENV", "from_secret": {"name": "secret_name_1"}},
-                    ],
-                }
-            ],
-            "secrets": [{"name": "secret_name_1", "value": "secret_value_1"}],
-        },
+        platform_spec=PlatformJobSpec.model_validate(
+            {
+                "steps": [
+                    {
+                        "name": "basic",
+                        "executor": {
+                            "provider": "cpu",
+                            "profile": "default",
+                            "container": {
+                                "image": "test-image",
+                                "entrypoint": ["python", "-m"],
+                                "command": ["nmp.testing.fake_task"],
+                            },
+                        },
+                        "environment": [
+                            {"name": "MY_SECRET_ENV", "from_secret": {"name": "secret_name_1"}},
+                        ],
+                    }
+                ],
+                "secrets": [PlatformJobSecret(name="secret_name_1", value="secret_value_1")],
+            }
+        ),
     )
+    job = (await jobs.create_job(workspace=DEFAULT_WORKSPACE, body=request)).data()
     assert job.id
-    response = await test_sdk.jobs.list(workspace=DEFAULT_WORKSPACE)
-    assert len(response.data) == 1
-    job_item = response.data[0]
+    response = await jobs.list_jobs(workspace=DEFAULT_WORKSPACE)
+    page = response.page()
+    assert len(page.items) == 1
+    job_item = page.items[0]
     assert job_item.name == "test-job"
     assert len(job_item.platform_spec.steps) == 1
 
     # Assert that when created, we still got a secret reference back
-    assert job_item.platform_spec.secrets is not None
-    assert len(job_item.platform_spec.secrets) == 1
-    assert job_item.platform_spec.secrets[0].name == "secret_name_1"
+    secrets = job_item.platform_spec.secrets
+    assert secrets is not None
+    assert len(secrets) == 1
+    assert secrets[0].name == "secret_name_1"
     # We should not be returning the actual secret value in the job spec
-    assert job_item.platform_spec.secrets[0].value is None
+    assert secrets[0].value is None
     # The secret should have a ref_id (used for in-memory secret storage)
-    assert job_item.platform_spec.secrets[0].ref_id is not None
-    assert job_item.platform_spec.secrets[0].ref_id.startswith("job-")
+    assert secrets[0].ref_id is not None
+    assert secrets[0].ref_id.startswith("job-")
 
 
 @pytest.mark.asyncio
@@ -1014,35 +1016,42 @@ async def test_job_paging(test_client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_job_result_crud(test_sdk: AsyncNeMoPlatform, sample_platform_job_request: CreatePlatformJobRequest):
-    sdk_job_resp = await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE, **to_sdk_create_params(sample_platform_job_request)
-    )  # type: ignore
-    resp = await test_sdk.jobs.results.create(
-        name="result-name1",
-        workspace=DEFAULT_WORKSPACE,
-        job=sdk_job_resp.name,
-        artifact_url="default/test-fileset#myartifact",
-        artifact_storage_type="fileset",
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    sdk_job_resp = (await jobs.create_job(workspace=DEFAULT_WORKSPACE, body=sample_platform_job_request)).data()
+    resp = (
+        await jobs.create_job_result(
+            name="result-name1",
+            workspace=DEFAULT_WORKSPACE,
+            job=sdk_job_resp.name,
+            body=PlatformJobResultCreateRequest(
+                artifact_url="default/test-fileset#myartifact",
+                artifact_storage_type=FileStorageType.FILESET,
+            ),
+        )
+    ).data()
     assert resp.name == "result-name1"
     assert resp.job == sdk_job_resp.id
-    resp2 = await test_sdk.jobs.results.create(
-        name="result-name2",
-        workspace=DEFAULT_WORKSPACE,
-        job=sdk_job_resp.name,
-        artifact_url="default/test-fileset#myartifact",
-        artifact_storage_type="fileset",
-    )
+    resp2 = (
+        await jobs.create_job_result(
+            name="result-name2",
+            workspace=DEFAULT_WORKSPACE,
+            job=sdk_job_resp.name,
+            body=PlatformJobResultCreateRequest(
+                artifact_url="default/test-fileset#myartifact",
+                artifact_storage_type=FileStorageType.FILESET,
+            ),
+        )
+    ).data()
     assert resp2.name == "result-name2"
     assert resp2.job == sdk_job_resp.id
 
-    results = await test_sdk.jobs.results.list(sdk_job_resp.name, workspace=DEFAULT_WORKSPACE)
+    results = (await jobs.list_job_results(name=sdk_job_resp.name, workspace=DEFAULT_WORKSPACE)).data()
     assert len(results.data) == 2
     result2 = next(r for r in results.data if "result-name2" == r.name)
 
-    another_result_2 = await test_sdk.jobs.results.retrieve(
-        result2.name, workspace=DEFAULT_WORKSPACE, job=sdk_job_resp.name
-    )
+    another_result_2 = (
+        await jobs.get_job_result(name=result2.name, workspace=DEFAULT_WORKSPACE, job=sdk_job_resp.name)
+    ).data()
     assert result2 == another_result_2
     # The result's namespace is inherited from the parent job, not from the create request
     # Since the job uses the default namespace, the result should too
@@ -1065,24 +1074,28 @@ async def test_job_result_download(
     mock_result_manager._tmp_dir = tmp_dir
     mock_result_manager._path = tmp_file
 
-    sdk_job_resp = await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE, **to_sdk_create_params(sample_platform_job_request)
-    )  # type: ignore
-    result = await test_sdk.jobs.results.create(
-        name="result-name1",
-        workspace=DEFAULT_WORKSPACE,
-        job=sdk_job_resp.name,
-        artifact_url="default/test-fileset#result_name1",
-        artifact_storage_type="fileset",
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    sdk_job_resp = (await jobs.create_job(workspace=DEFAULT_WORKSPACE, body=sample_platform_job_request)).data()
+    result = (
+        await jobs.create_job_result(
+            name="result-name1",
+            workspace=DEFAULT_WORKSPACE,
+            job=sdk_job_resp.name,
+            body=PlatformJobResultCreateRequest(
+                artifact_url="default/test-fileset#result_name1",
+                artifact_storage_type=FileStorageType.FILESET,
+            ),
+        )
+    ).data()
 
     with patch("nmp.common.jobs.result_manager.result_manager_factory", return_value=mock_result_manager):
-        download = await test_sdk.jobs.results.download(result.name, workspace=DEFAULT_WORKSPACE, job=sdk_job_resp.name)
+        download = await jobs.download_job_result(name=result.name, workspace=DEFAULT_WORKSPACE, job=sdk_job_resp.name)
+        download_bytes = await download.read()
 
     # make sure we deleted the temp files on the server
     assert not tmp_dir.exists()
     assert not tmp_file.exists()
-    assert await download.text() == testdata
+    assert download_bytes.decode() == testdata
 
     # make the artifact a folder this time
     tmp_dir.mkdir()
@@ -1091,15 +1104,16 @@ async def test_job_result_download(
     mock_result_manager._path = tmp_dir
 
     with patch("nmp.common.jobs.result_manager.result_manager_factory", return_value=mock_result_manager):
-        download = await test_sdk.jobs.results.download(result.name, workspace=DEFAULT_WORKSPACE, job=sdk_job_resp.name)
+        download = await jobs.download_job_result(name=result.name, workspace=DEFAULT_WORKSPACE, job=sdk_job_resp.name)
+        tar_content = await download.read()
 
     # ensure we're returning the appropriate tar file
-    assert "result-name1.tar.gz" in download.headers["content-disposition"]
+    assert "result-name1.tar.gz" in download.http_response.headers["content-disposition"]
     assert not tmp_dir.exists()
     assert not tmp_file.exists()
 
     # ensure the content of the tar includes the tmp_file
-    tar_bytes = BytesIO(await download.read())
+    tar_bytes = BytesIO(tar_content)
     with tarfile.open(fileobj=tar_bytes, mode="r:gz") as tar:
         extracted_file = tar.extractfile(tar.getmember("testdir/testfile.txt"))
         assert extracted_file
@@ -1118,9 +1132,8 @@ async def test_job_status_details_crud(
     patch = {"progress": 75}
 
     # Create a job
-    sdk_job_resp = await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE, **to_sdk_create_params(sample_platform_job_request)
-    )  # type: ignore
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    sdk_job_resp = (await jobs.create_job(workspace=DEFAULT_WORKSPACE, body=sample_platform_job_request)).data()
     job_name = sdk_job_resp.name  # API URLs use job name, not ID
 
     ### Test patching a job status details
@@ -1164,14 +1177,18 @@ async def test_job_status_details_crud(
     assert step_status_details == {"message": "Step is now active"}
 
     # Now lets create a task associated with the step, and then update it's status
-    task_resp = await test_sdk.jobs.tasks.create_or_update(
-        "task-1",
-        workspace=DEFAULT_WORKSPACE,
-        job=job_name,
-        step="basic",
-        status="active",
-        status_details={"message": "Task is now active"},
-    )
+    task_resp = (
+        await jobs.update_job_step_task(
+            name="task-1",
+            workspace=DEFAULT_WORKSPACE,
+            job=job_name,
+            step="basic",
+            body=PlatformJobTaskUpdate(
+                status=PlatformJobStatus.ACTIVE,
+                status_details={"message": "Task is now active"},
+            ),
+        )
+    ).data()
     assert task_resp is not None
 
     # Now get the task and inspect it's status details (URL uses task name, not ID)
@@ -1310,7 +1327,7 @@ class MockRequest:
 async def test_get_platform_jobs_steps_list_filter(query_string, expected_checks):
     """Test the get_platform_jobs_steps_list_filter function with various filter parameters."""
     request = MockRequest(query_string)
-    result = get_platform_jobs_steps_list_filter(request)  # type: ignore[arg-type]
+    result = get_platform_jobs_steps_list_filter(request)  # ty: ignore[invalid-argument-type]
     assert expected_checks(result)
 
 
@@ -1319,7 +1336,7 @@ async def test_get_platform_jobs_steps_list_filter_invalid():
     """Test that invalid status raises an error."""
     request = MockRequest("filter[status]=INVALID_STATUS")
     with pytest.raises(HTTPException) as exc_info:
-        get_platform_jobs_steps_list_filter(request)  # type: ignore[arg-type]
+        get_platform_jobs_steps_list_filter(request)  # ty: ignore[invalid-argument-type]
     assert exc_info.value.detail is not None
     assert "filter.status" in str(exc_info.value.detail)
     assert "Expected one or more of" in str(exc_info.value.detail)
@@ -1535,9 +1552,8 @@ async def test_job_status_timestamps(
     sample_platform_job_request: CreatePlatformJobRequest,
 ):
     """Test that created_at and updated_at are present at job, step, and task levels in status response."""
-    sdk_job_resp = await test_sdk.jobs.create(
-        workspace=DEFAULT_WORKSPACE, **to_sdk_create_params(sample_platform_job_request)
-    )
+    jobs = client_from_platform(test_sdk, AsyncJobsClient)
+    sdk_job_resp = (await jobs.create_job(workspace=DEFAULT_WORKSPACE, body=sample_platform_job_request)).data()
     job_name = sdk_job_resp.name
 
     # Activate the step so the job is in a meaningful state
@@ -1548,13 +1564,15 @@ async def test_job_status_timestamps(
     assert response.status_code == 200
 
     # Create a task for the step
-    task_resp = await test_sdk.jobs.tasks.create_or_update(
-        "task-1",
-        workspace=DEFAULT_WORKSPACE,
-        job=job_name,
-        step="basic",
-        status="active",
-    )
+    task_resp = (
+        await jobs.update_job_step_task(
+            name="task-1",
+            workspace=DEFAULT_WORKSPACE,
+            job=job_name,
+            step="basic",
+            body=PlatformJobTaskUpdate(status=PlatformJobStatus.ACTIVE),
+        )
+    ).data()
     assert task_resp is not None
 
     # Fetch the status and verify timestamps are present at all levels

--- a/services/core/jobs/tests/test_timestamp_contracts.py
+++ b/services/core/jobs/tests/test_timestamp_contracts.py
@@ -4,7 +4,7 @@
 from datetime import datetime
 from typing import assert_type
 
-from nemo_platform.types.jobs import PlatformJobStepWithContext
+from nemo_platform_plugin.jobs.types import PlatformJobStepWithContext
 
 
 def test_platform_job_step_with_context_parses_wire_timestamps_to_datetime() -> None:
@@ -21,7 +21,7 @@ def test_platform_job_step_with_context_parses_wire_timestamps_to_datetime() -> 
         }
     )
 
-    assert_type(step.created_at, datetime | None)
-    assert_type(step.updated_at, datetime | None)
+    assert_type(step.created_at, datetime)
+    assert_type(step.updated_at, datetime)
     assert isinstance(step.created_at, datetime)
     assert isinstance(step.updated_at, datetime)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->
This PR removes the Jobs surface's remaining dependency on Stainless-generated SDK job resources. CLI commands, job route factories, and plugin/job tests now use the platform plugin's typed Jobs client and plugin-owned job models while preserving the existing job spec shape. No user-facing CLI or API behavior change is intended.

## Changes
<!-- List the concrete changes included in this pull request. -->
- Route generated Jobs CLI commands for jobs, results, steps, and tasks through `nemo_platform_plugin.jobs.client.JobsClient`, including request bodies, pagination, wait/watch paths, and binary result downloads.
- Replace public job spec, provider, resource, environment, and status aliases that pointed at Stainless types with plugin-owned Pydantic models and schemas.
- Add mapping-style compatibility for job spec models so existing plugin code can continue to read, compare, and mutate specs like dictionaries.
- Update core service, plugin, CLI, and SDK-tool tests/fixtures to avoid generated Jobs SDK resources and cover typed pagination, job creation, result/status/task operations, and spec compatibility.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: Internal Jobs SDK/client dependency refactor with no intended user-facing docs or CLI contract changes.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->
- `git diff --check origin/main...HEAD` - passed.
- DCO audit against `origin/main..HEAD` - passed for `80c07a1e821fa054e7b86ffe2ed64f5175c15a49`.
- `git diff origin/main...HEAD -G'(AKIA|BEGIN [A-Z ]*PRIVATE KEY|ghp_|github_pat_|NVIDIA_API_KEY=|OPENAI_API_KEY=)' --name-only` - no matches.
- Not run in this metadata refresh: `uv run pre-commit run -a`; targeted pytest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validated job specification models that retain mapping-style access and assignment compatibility.
  * Added support for accepting and normalizing job specifications provided as mappings or typed models.
  * Improved Docker GPU-step validation for both input formats.
  * Job result downloads and enumeration now use the typed Jobs client.

* **Bug Fixes**
  * Empty environment mappings are normalized correctly.
  * Log processing now tolerates missing name and severity fields.
  * Resource specifications omit empty CPU and memory settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->