### PR TITLE
fix(models): parse string /v1/models responses during provider discovery

### DIFF
--- a/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
+++ b/services/core/models/src/nmp/core/models/controllers/provider_reconciler.py
@@ -3,6 +3,7 @@
 
 """Model provider reconciliation logic for Models Controller."""
 
+import json
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -679,6 +680,15 @@ class ModelProviderReconciler:
                 name=provider.name,
                 timeout=self._controller_config.provider_discovery_timeout_seconds,
             )
+
+            if isinstance(models_response, str):
+                # Attempt to parse JSON, in case the value is valid JSON but the
+                # content-type header was not sent.
+                try:
+                    models_response = json.loads(models_response)
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning(f"Non-OpenAI compliant response format from {provider_id}")
+                    return DiscoveryNonCompliant()
 
             if not isinstance(models_response, dict) or "data" not in models_response:
                 logger.warning(f"Non-OpenAI compliant response format from {provider_id}")

--- a/services/core/models/tests/unit/controllers/test_provider_reconciler.py
+++ b/services/core/models/tests/unit/controllers/test_provider_reconciler.py
@@ -3,6 +3,7 @@
 
 """Unit tests for ModelProviderReconciler."""
 
+import json
 import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -291,6 +292,50 @@ async def test_get_available_models_from_provider_non_compliant_missing_data(rec
     mock_models_sdk.inference.gateway.provider.get = AsyncMock(
         return_value={"object": "list"}  # Missing 'data'
     )
+
+    model_provider = ModelProvider(
+        name="test-provider",
+        workspace="test-ns",
+        host_url="https://test-provider.com",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    result = await reconciler._discover_models(model_provider)
+
+    assert isinstance(result, DiscoveryNonCompliant)
+
+
+@pytest.mark.asyncio
+async def test_get_available_models_from_provider_parses_json_string_response(reconciler, mock_models_sdk):
+    """A valid JSON body served without an application/json Content-Type (e.g. some
+    Ollama versions) arrives as a raw string from the SDK. Discovery should still
+    parse it instead of treating it as non-compliant."""
+    mock_models_sdk.inference.gateway.provider.get = AsyncMock(
+        return_value=json.dumps(
+            {
+                "object": "list",
+                "data": [{"id": "llama3:latest", "object": "model", "created": 1715357716, "owned_by": "library"}],
+            }
+        )
+    )
+
+    model_provider = ModelProvider(
+        name="test-provider",
+        workspace="test-ns",
+        host_url="http://localhost:11434/v1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    result = await reconciler._discover_models(model_provider)
+
+    assert isinstance(result, DiscoverySuccess)
+    assert result.models == [{"id": "llama3:latest", "root": None, "parent": None}]
+
+
+@pytest.mark.asyncio
+async def test_get_available_models_from_provider_non_compliant_unparsable_string(reconciler, mock_models_sdk):
+    """A non-JSON string response (genuinely non-compliant) is still rejected."""
+    mock_models_sdk.inference.gateway.provider.get = AsyncMock(return_value="<html>not json</html>")
 
     model_provider = ModelProvider(
         name="test-provider",


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
`nemo setup`'s model-discovery step failed for local Ollama providers with "returned a non-OpenAI compliant response from GET /v1/models," even though Ollama's `/v1/models` body is valid OpenAI-compatible JSON — it's just served without an `application/json` Content-Type header, so the SDK hands discovery a raw string instead of a parsed dict. Discovery now tries `json.loads()` on a string response before falling back to non-compliant, so Ollama (and similar servers) discover correctly while genuinely non-JSON responses still fail as before.

## Related Issue
Fixes [NMP-19](https://linear.app/nvidia/issue/NMP-19/nemo-setup-fails-to-discover-local-models)

## Changes
- `services/core/models/src/nmp/core/models/controllers/provider_reconciler.py`: attempt `json.loads()` on string `/v1/models` responses before treating them as `DiscoveryNonCompliant`.
- `services/core/models/tests/unit/controllers/test_provider_reconciler.py`: add regression tests for a string-JSON response (now discovers successfully) and a non-JSON string response (still correctly rejected).

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal reconciler bug fix, no user-facing CLI/API/docs surface changed.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `uv run pre-commit run --files services/core/models/src/nmp/core/models/controllers/provider_reconciler.py services/core/models/tests/unit/controllers/test_provider_reconciler.py` — passed (ruff, ruff format, ty, copyright headers, merge-conflict check; other hooks skipped, no matching files).
- `uv run --frozen pytest services/core/models/tests/unit/controllers/test_provider_reconciler.py -v` — 127 passed, including the two new regression tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved provider discovery when model lists are returned as JSON-formatted text.
  - Valid responses are now parsed and processed correctly.
  - Invalid JSON responses are correctly identified as non-compliant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->