### PR TITLE
fix(agents): allow no-auth session lifecycle access

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/session_access.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/session_access.py
@@ -49,11 +49,14 @@ async def get_owned_session_by_id(
     effective_principal_id: str,
 ) -> AgentSession:
     """Resolve a session ID owned by the request's effective principal."""
+    filter_obj = {"id": session_id}
+    if effective_principal_id:
+        filter_obj["created_by"] = effective_principal_id
     try:
         session = await entity_client.find_one(
             AgentSession,
             workspace=workspace,
-            filter_obj={"id": session_id, "created_by": effective_principal_id},
+            filter_obj=filter_obj,
         )
     except NemoEntityNotFoundError as exc:
         raise session_id_not_found(workspace, session_id) from exc
@@ -78,7 +81,12 @@ def _is_owned_session(
     effective_principal_id: str,
 ) -> bool:
     """Return whether a session belongs to the request workspace and principal."""
-    return session.workspace == workspace and session.created_by == effective_principal_id
+    if session.workspace != workspace:
+        return False
+    # No-auth mode has no request principal. Entity writes still use the
+    # platform service client and therefore carry a service ``created_by``;
+    # workspace scoping is the applicable boundary in that mode.
+    return not effective_principal_id or session.created_by == effective_principal_id
 
 
 def session_not_found(workspace: str, name: str) -> HTTPException:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/sessions.py
@@ -110,7 +110,8 @@ async def list_sessions(
 ) -> SessionPage:
     """List the current principal's sessions, optionally filtered by deployment ID."""
     filter_dict = dict(filter) if isinstance(filter, dict) else filter.model_dump(exclude_none=True)
-    filter_dict["created_by"] = effective_principal_id
+    if effective_principal_id:
+        filter_dict["created_by"] = effective_principal_id
     try:
         result = await entity_client.list(
             AgentSession,

--- a/plugins/nemo-agents/tests/unit/test_gateway.py
+++ b/plugins/nemo-agents/tests/unit/test_gateway.py
@@ -482,6 +482,38 @@ class TestSessionAwareRouting:
         assert stream_call.kwargs["url"] == "http://localhost:9002/v1/chat/completions"
         assert stream_call.kwargs["headers"][SESSION_ID_HEADER] == "session-2"
 
+    def test_noauth_route_resolves_service_owned_session_without_owner_filter(
+        self, client: TestClient, test_app: FastAPI, mock_entity_client: AsyncMock
+    ) -> None:
+        test_app.dependency_overrides[get_effective_principal_id] = lambda: ""
+        session = _make_session(
+            session_id="session-2",
+            deployment_id="deployment-2",
+            created_by="service:platform",
+        )
+        bound_deployment = _make_deployment(
+            name="calc-v2",
+            agent="calc",
+            endpoint="http://localhost:9002",
+            deployment_id="deployment-2",
+        )
+        mock_entity_client.find_one = AsyncMock(side_effect=[session, bound_deployment])
+        httpx_mock = _make_httpx_mock(200, b'{"ok": true}')
+
+        with patch("nemo_agents_plugin.api.v2.gateway.httpx.AsyncClient", return_value=httpx_mock):
+            response = client.post(
+                "/apis/agents/v2/workspaces/default/agents/calc/-/v1/chat/completions",
+                headers={SESSION_ID_HEADER: "session-2"},
+                json={"messages": []},
+            )
+
+        assert response.status_code == 200
+        assert mock_entity_client.find_one.await_args_list[0] == call(
+            AgentSession,
+            workspace="default",
+            filter_obj={"id": "session-2"},
+        )
+
     def test_direct_route_accepts_session_for_same_deployment(
         self, client: TestClient, mock_entity_client: AsyncMock
     ) -> None:

--- a/plugins/nemo-agents/tests/unit/test_sessions_api.py
+++ b/plugins/nemo-agents/tests/unit/test_sessions_api.py
@@ -348,6 +348,45 @@ class TestDeleteSession:
         assert response.status_code == 409
 
 
+class TestNoAuthSessionLifecycle:
+    def test_service_owned_session_remains_accessible_without_a_principal(
+        self, client: TestClient, mock_entity_client: AsyncMock
+    ) -> None:
+        client.app.dependency_overrides[get_effective_principal_id] = lambda: ""
+        deployment = _make_deployment()
+        session = _make_session(created_by="service:platform")
+        mock_entity_client.find_one.return_value = deployment
+        mock_entity_client.create.return_value = session
+
+        create_response = client.post(BASE, json={"deployment_id": "deployment-id", "name": "session-one"})
+
+        assert create_response.status_code == 201
+        assert create_response.json()["created_by"] == "service:platform"
+
+        mock_entity_client.list.return_value = _list_response(session)
+        list_response = client.get(BASE)
+
+        assert list_response.status_code == 200
+        assert [item["name"] for item in list_response.json()["data"]] == ["session-one"]
+        assert mock_entity_client.list.await_args.kwargs["filter_obj"] is None
+
+        mock_entity_client.get.return_value = session
+        get_response = client.get(f"{BASE}/session-one")
+
+        assert get_response.status_code == 200
+
+        mock_entity_client.update.side_effect = lambda updated: updated
+        close_response = client.post(f"{BASE}/session-one/close")
+
+        assert close_response.status_code == 200
+        assert close_response.json()["status"] == "closed"
+
+        delete_response = client.delete(f"{BASE}/session-one")
+
+        assert delete_response.status_code == 204
+        mock_entity_client.delete.assert_awaited_once()
+
+
 class TestFabricRuntimeCleanup:
     async def test_cleanup_calls_bound_deployment_session_endpoint(self, mock_entity_client: AsyncMock) -> None:
         deployment = _make_deployment()


### PR DESCRIPTION
## Summary

- use workspace scoping for session access when no effective principal exists in no-auth mode
- omit the created_by query predicate for no-auth list and session-ID lookup
- retain same-principal filtering and non-disclosing 404 behavior whenever auth supplies a principal

This makes service-owned sessions created in no-auth mode usable through list, read, invoke, close, and delete.

## Regression coverage

- service-owned no-auth CRUD lifecycle
- service-owned no-auth gateway invocation
- existing auth owner/cross-owner behavior remains covered
- session API and gateway suites: 116 passed
- ruff, ty, and pre-commit passed

NVBug: 6688509 (NPLAT-5)
DevTest: T6344819


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unauthenticated session access and lifecycle operations.
  * Service-owned sessions can now be listed, retrieved, closed, and deleted without an authenticated principal.
  * Unauthenticated gateway requests can correctly resolve service-owned sessions while maintaining workspace validation.

* **Tests**
  * Added coverage for unauthenticated session management and gateway requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->