### PR TITLE
fix(evaluator): validate agent evaluation task IDs

### DIFF
--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/agent_spec.py
@@ -27,7 +27,7 @@ from nemo_evaluator_sdk.agent_eval.tasks import SemanticView
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
 from nemo_evaluator_sdk.values import Agent, Model, RunConfigOnline, RunConfigOnlineModel
 from nemo_evaluator_sdk.values.agents import AgentBase
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class ModelTarget(BaseModel):
@@ -262,6 +262,13 @@ class _AgentEvalTaskCommon(BaseModel):
     )
     metadata: TaskMetadataList = Field(default_factory=list, description="Key/value annotations for the task.")
 
+    @field_validator("id")
+    @classmethod
+    def _id_must_not_be_blank(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("task id must not be empty")
+        return value
+
 
 class AgentEvalTaskInput(_AgentEvalTaskCommon):
     """Submitter-facing task DTO: metrics may be inline bundles or stored-metric references."""
@@ -372,6 +379,11 @@ class AgentEvalInputSpec(_AgentEvalSpecCommon):
         # inline list must carry at least one task, mirroring the canonical spec's ``min_length=1``.
         if isinstance(self.tasks, list) and not self.tasks:
             raise ValueError("provide at least one task, or a `tasks` taskset reference")
+        if isinstance(self.tasks, list):
+            ids = [task.id for task in self.tasks]
+            duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+            if duplicates:
+                raise ValueError(f"duplicate inline task ids: {duplicates}")
         return self
 
 
@@ -379,6 +391,14 @@ class AgentEvalSpec(_AgentEvalSpecCommon):
     """Canonical agent-evaluation spec: tasks with all metric references resolved to inline."""
 
     tasks: list[AgentEvalTaskSpec] = Field(min_length=1, description="Tasks to evaluate; at least one is required.")
+
+    @model_validator(mode="after")
+    def _reject_duplicate_task_ids(self) -> Self:
+        ids = [task.id for task in self.tasks]
+        duplicates = sorted({task_id for task_id in ids if ids.count(task_id) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate agent-eval task ids: {duplicates}")
+        return self
 
     @model_validator(mode="after")
     def _reject_unresolved_metric_model_refs(self) -> Self:

--- a/plugins/nemo-evaluator/tests/test_agent_evaluate.py
+++ b/plugins/nemo-evaluator/tests/test_agent_evaluate.py
@@ -463,6 +463,26 @@ def test_input_spec_rejects_empty_inline_task_list() -> None:
         AgentEvalInputSpec(tasks=[], target=_runner_target("openai/gpt-5.4"))
 
 
+@pytest.mark.parametrize("task_id", ["", "  \t"])
+def test_input_spec_rejects_blank_inline_task_id(task_id: str) -> None:
+    with pytest.raises(ValueError, match="task id must not be empty"):
+        AgentEvalInputSpec(
+            tasks=[AgentEvalTaskInput(id=task_id, intent="Answer.", inputs={})],
+            target=_runner_target("openai/gpt-5.4"),
+        )
+
+
+def test_input_spec_rejects_duplicate_inline_task_ids() -> None:
+    with pytest.raises(ValueError, match=r"duplicate inline task ids: \['task-1'\]"):
+        AgentEvalInputSpec(
+            tasks=[
+                AgentEvalTaskInput(id="task-1", intent="Answer first.", inputs={}),
+                AgentEvalTaskInput(id="task-1", intent="Answer second.", inputs={}),
+            ],
+            target=_runner_target("openai/gpt-5.4"),
+        )
+
+
 async def test_to_spec_resolves_inline_task_metrics_without_a_platform() -> None:
     # Inline metrics need no entity client/SDK; refs would, but none are used here.
     input_spec = AgentEvalInputSpec(


### PR DESCRIPTION
## Summary

- reject empty and whitespace-only inline agent-evaluation task IDs at the submit DTO boundary
- reject duplicate inline IDs before a job is created
- preserve the same uniqueness invariant after stored tasksets resolve to the canonical spec

Invalid CLI/API submissions now fail Pydantic validation instead of creating durable jobs.

## Regression coverage

- blank and whitespace-only task IDs
- duplicate inline task IDs
- evaluator agent-evaluate/task-ref suites: 79 passed
- ruff, ty, and pre-commit passed

NVBug: 6688347 (NPLAT-3)
DevTest: T6344842, T6344843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task configuration now rejects blank task IDs.
  * Duplicate task IDs are detected and reported clearly across inline and resolved task configurations.

* **Tests**
  * Added coverage for invalid blank IDs and duplicate identifiers, including validation error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->