### PR TITLE
fix(evaluator): align source and task Python runtimes

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -84,7 +84,7 @@
       "PNPM_VERSION": "10.34.5",
       "UV_CACHE_DIR": "${FLOX_ENV_CACHE}/uv-cache",
       "UV_MANAGED_PYTHON": "1",
-      "UV_PYTHON": "3.12",
+      "UV_PYTHON": "3.13",
       "UV_PYTHON_INSTALL_DIR": "${FLOX_ENV_CACHE}/python",
       "UV_VENV_SEED": "1",
       "WIDTH": "50"
@@ -825,96 +825,6 @@
       "priority": 5
     },
     {
-      "attr_path": "uv",
-      "broken": false,
-      "derivation": "/nix/store/5xdn711qjgkkady64ywrxq6mhbi9nz9h-uv-0.9.14.drv",
-      "description": "Extremely fast Python package installer and resolver, written in Rust",
-      "install_id": "uv",
-      "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=418468ac9527e799809c900eda37cbff999199b6",
-      "name": "uv-0.9.14",
-      "pname": "uv",
-      "rev": "418468ac9527e799809c900eda37cbff999199b6",
-      "rev_count": 905402,
-      "rev_date": "2025-12-02T09:27:49Z",
-      "scrape_date": "2025-12-04T02:56:01.692648Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.9.14",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/zbg4ksfcdcmqbw8x0f0xlla16g2lhxgy-uv-0.9.14"
-      },
-      "system": "aarch64-darwin",
-      "group": "uv",
-      "priority": 5
-    },
-    {
-      "attr_path": "uv",
-      "broken": false,
-      "derivation": "/nix/store/8z6dv3xfq2mc9hw87w37sw2hs1jlchyg-uv-0.9.14.drv",
-      "description": "Extremely fast Python package installer and resolver, written in Rust",
-      "install_id": "uv",
-      "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=418468ac9527e799809c900eda37cbff999199b6",
-      "name": "uv-0.9.14",
-      "pname": "uv",
-      "rev": "418468ac9527e799809c900eda37cbff999199b6",
-      "rev_count": 905402,
-      "rev_date": "2025-12-02T09:27:49Z",
-      "scrape_date": "2025-12-04T03:05:28.971221Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.9.14",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/2k74mawzpjihb1jpyxlmbhaz7wflbhyb-uv-0.9.14"
-      },
-      "system": "aarch64-linux",
-      "group": "uv",
-      "priority": 5
-    },
-    {
-      "attr_path": "uv",
-      "broken": false,
-      "derivation": "/nix/store/16j8ajlaksqd7pv1pnp12v22bb79wsl8-uv-0.9.14.drv",
-      "description": "Extremely fast Python package installer and resolver, written in Rust",
-      "install_id": "uv",
-      "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=418468ac9527e799809c900eda37cbff999199b6",
-      "name": "uv-0.9.14",
-      "pname": "uv",
-      "rev": "418468ac9527e799809c900eda37cbff999199b6",
-      "rev_count": 905402,
-      "rev_date": "2025-12-02T09:27:49Z",
-      "scrape_date": "2025-12-04T03:23:20.097970Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.9.14",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/483pf97g9l0l3rh0988ghffcppm4001a-uv-0.9.14"
-      },
-      "system": "x86_64-linux",
-      "group": "uv",
-      "priority": 5
-    },
-    {
       "attr_path": "diffutils",
       "broken": false,
       "derivation": "/nix/store/7lxvn9pyy7nz2s8qj0bdzqjj31nph3mw-diffutils-3.12.drv",
@@ -1548,6 +1458,96 @@
       "system": "x86_64-linux",
       "group": "toplevel",
       "priority": 5
+    },
+    {
+      "attr_path": "uv",
+      "broken": false,
+      "derivation": "/nix/store/5xdn711qjgkkady64ywrxq6mhbi9nz9h-uv-0.9.14.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=418468ac9527e799809c900eda37cbff999199b6",
+      "name": "uv-0.9.14",
+      "pname": "uv",
+      "rev": "418468ac9527e799809c900eda37cbff999199b6",
+      "rev_count": 905402,
+      "rev_date": "2025-12-02T09:27:49Z",
+      "scrape_date": "2025-12-04T02:56:01.692648Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.9.14",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/zbg4ksfcdcmqbw8x0f0xlla16g2lhxgy-uv-0.9.14"
+      },
+      "system": "aarch64-darwin",
+      "group": "uv",
+      "priority": 5
+    },
+    {
+      "attr_path": "uv",
+      "broken": false,
+      "derivation": "/nix/store/8z6dv3xfq2mc9hw87w37sw2hs1jlchyg-uv-0.9.14.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=418468ac9527e799809c900eda37cbff999199b6",
+      "name": "uv-0.9.14",
+      "pname": "uv",
+      "rev": "418468ac9527e799809c900eda37cbff999199b6",
+      "rev_count": 905402,
+      "rev_date": "2025-12-02T09:27:49Z",
+      "scrape_date": "2025-12-04T03:05:28.971221Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.9.14",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/2k74mawzpjihb1jpyxlmbhaz7wflbhyb-uv-0.9.14"
+      },
+      "system": "aarch64-linux",
+      "group": "uv",
+      "priority": 5
+    },
+    {
+      "attr_path": "uv",
+      "broken": false,
+      "derivation": "/nix/store/16j8ajlaksqd7pv1pnp12v22bb79wsl8-uv-0.9.14.drv",
+      "description": "Extremely fast Python package installer and resolver, written in Rust",
+      "install_id": "uv",
+      "license": "[ Apache-2.0, MIT ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=418468ac9527e799809c900eda37cbff999199b6",
+      "name": "uv-0.9.14",
+      "pname": "uv",
+      "rev": "418468ac9527e799809c900eda37cbff999199b6",
+      "rev_count": 905402,
+      "rev_date": "2025-12-02T09:27:49Z",
+      "scrape_date": "2025-12-04T03:23:20.097970Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.9.14",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/483pf97g9l0l3rh0988ghffcppm4001a-uv-0.9.14"
+      },
+      "system": "x86_64-linux",
+      "group": "uv",
+      "priority": 5
     }
   ],
   "compose": {
@@ -1701,7 +1701,7 @@
           "vars": {
             "UV_CACHE_DIR": "${FLOX_ENV_CACHE}/uv-cache",
             "UV_MANAGED_PYTHON": "1",
-            "UV_PYTHON": "3.12",
+            "UV_PYTHON": "3.13",
             "UV_PYTHON_INSTALL_DIR": "${FLOX_ENV_CACHE}/python",
             "UV_VENV_SEED": "1"
           },

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 PYTEST_EXTRA ?=
 # Default development toolchain versions. Keep these aligned with Flox; the
 # version-consistency checks validate them in pre-commit and CI.
-PYTHON_VERSION ?= 3.12
+PYTHON_VERSION ?= 3.13
 UV_VERSION := 0.9.14
 NODE_VERSION := 22.23.2
 PNPM_VERSION := 10.34.5

--- a/tests/unit/test_python_runtime_contract.py
+++ b/tests/unit/test_python_runtime_contract.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Contracts shared by source and container Python runtimes."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_source_bootstrap_matches_container_python_minor() -> None:
+    """Cloudpickle payloads require the source and task runtimes to share a minor version."""
+    makefile = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    docker_bake = (REPO_ROOT / "docker-bake.hcl").read_text(encoding="utf-8")
+    flox_manifest = (REPO_ROOT / "tools/python/.flox/env/manifest.toml").read_text(encoding="utf-8")
+
+    source_match = re.search(r"^PYTHON_VERSION \?= (\d+\.\d+)$", makefile, re.MULTILINE)
+    flox_match = re.search(r'^UV_PYTHON="(\d+\.\d+)"$', flox_manifest, re.MULTILINE)
+    image_match = re.search(
+        r'variable "NMP_PYTHON_IMAGE"\s*\{\s*default = "python:(\d+\.\d+)(?:\.\d+)?[^\"]*"',
+        docker_bake,
+        re.MULTILINE,
+    )
+
+    assert source_match is not None, "Makefile must declare the default source Python version"
+    assert flox_match is not None, "Flox must declare the default source Python version"
+    assert image_match is not None, "docker-bake.hcl must declare the default task Python image"
+    assert source_match.group(1) == flox_match.group(1)
+    assert source_match.group(1) == image_match.group(1)

--- a/tools/python/.flox/env/manifest.lock
+++ b/tools/python/.flox/env/manifest.lock
@@ -12,7 +12,7 @@
     "vars": {
       "UV_CACHE_DIR": "${FLOX_ENV_CACHE}/uv-cache",
       "UV_MANAGED_PYTHON": "1",
-      "UV_PYTHON": "3.12",
+      "UV_PYTHON": "3.13",
       "UV_PYTHON_INSTALL_DIR": "${FLOX_ENV_CACHE}/python",
       "UV_VENV_SEED": "1"
     },
@@ -79,36 +79,6 @@
         "out": "/nix/store/2k74mawzpjihb1jpyxlmbhaz7wflbhyb-uv-0.9.14"
       },
       "system": "aarch64-linux",
-      "group": "uv",
-      "priority": 5
-    },
-    {
-      "attr_path": "uv",
-      "broken": false,
-      "derivation": "/nix/store/v9j7x0id9jkqg88fydksrddjy2pxcgib-uv-0.9.14.drv",
-      "description": "Extremely fast Python package installer and resolver, written in Rust",
-      "install_id": "uv",
-      "license": "[ Apache-2.0, MIT ]",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=418468ac9527e799809c900eda37cbff999199b6",
-      "name": "uv-0.9.14",
-      "pname": "uv",
-      "rev": "418468ac9527e799809c900eda37cbff999199b6",
-      "rev_count": 905402,
-      "rev_date": "2025-12-02T09:27:49Z",
-      "scrape_date": "2025-12-04T03:13:57.183996Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.9.14",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/msq3vg45z01w0bl7q0k57yyczjh10hv8-uv-0.9.14"
-      },
-      "system": "x86_64-darwin",
       "group": "uv",
       "priority": 5
     },

--- a/tools/python/.flox/env/manifest.toml
+++ b/tools/python/.flox/env/manifest.toml
@@ -9,7 +9,7 @@ uv = { pkg-path = "uv", version = "0.9.14", pkg-group = "uv" }
 [vars]
 UV_VENV_SEED="1"
 UV_MANAGED_PYTHON="1"
-UV_PYTHON="3.12"
+UV_PYTHON="3.13"
 UV_CACHE_DIR="${FLOX_ENV_CACHE}/uv-cache"
 UV_PYTHON_INSTALL_DIR="${FLOX_ENV_CACHE}/python"
 


### PR DESCRIPTION
## Summary

- move the default source bootstrap and Flox interpreter from Python 3.12 to Python 3.13
- align the source SDK/API minor version with the official Python 3.13.14 task image
- retain Cloudpickle's cross-minor safety rejection
- add a regression contract requiring Makefile, Flox, and Docker task Python minors to stay aligned

Python 3.12 remains within the supported matrix and can still be selected explicitly; remote Cloudpickle code must run on the matching task-runtime minor.

## Regression coverage

- Flox bootstrap completed with Python 3.13.9 and 510 locked packages
- Python runtime/Cloudpickle suite: 34 passed
- a payload serialized by the source Python 3.13.9 environment deserialized successfully in the official Python 3.13.14 CPU task image
- ruff, ty, Flox lock checks, version-consistency checks, and pre-commit passed

NVBug: 6688474 (NPLAT-4)
DevTest: T6220627, T6220630, T6220636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Python runtime to version 3.13 across the project’s development and container environments.
  * Improved consistency between local setup, automated builds, and runtime configuration.

* **Tests**
  * Added automated validation to ensure all configured Python runtime versions remain aligned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->