### PR TITLE
fix(jobs): preserve Docker cancellation intent

### DIFF
--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -1857,14 +1857,18 @@ chmod -R 777 {job_vol}/{storage_subpath}
             attrs = container.attrs or {}
             exit_code = attrs.get("State", {}).get("ExitCode", 0)
             status_details["exit_code"] = exit_code
+            if is_cancelling:
+                # Docker stop/kill exit codes vary with the container entrypoint and
+                # signal handling (for example 0, 1, 137, 143, or 255). Once the
+                # persisted step is cancelling, the user's cancellation intent is
+                # authoritative; the observed post-stop exit code remains diagnostic.
+                return (
+                    PlatformJobStatus.CANCELLED,
+                    {"message": f"Job was cancelled successfully with exit code {exit_code}"},
+                    error_stack,
+                )
             if exit_code == 0:
-                if is_cancelling:
-                    return (
-                        PlatformJobStatus.CANCELLED,
-                        {"message": f"Job was cancelled successfully with exit code {exit_code}"},
-                        error_stack,
-                    )
-                elif is_pausing:
+                if is_pausing:
                     return (
                         PlatformJobStatus.PAUSED,
                         {"message": f"Job paused successfully with exit code {exit_code}"},
@@ -1876,13 +1880,6 @@ chmod -R 777 {job_vol}/{storage_subpath}
                         {"message": f"Job completed successfully with exit code {exit_code}"},
                         error_stack,
                     )
-            elif exit_code == 137 and is_cancelling:
-                # 137 is SIGKILL, which is what Docker sends after the grace period expires
-                return (
-                    PlatformJobStatus.CANCELLED,
-                    {"message": f"Job was cancelled successfully with exit code {exit_code}"},
-                    error_stack,
-                )
             else:
                 # Get logs for error stack
                 try:

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -562,14 +562,17 @@ def test_docker_job_sync_cancelling_sigterm(docker_job, docker_client_mock, test
     container_mock.remove.assert_not_called()
 
 
-def test_docker_job_sync_cancelling_sigkill(docker_job, docker_client_mock, test_job_step):
-    """Test that the cancel method stops the container."""
+@pytest.mark.parametrize("exit_code", [1, 137, 143, 255])
+def test_docker_job_sync_cancelling_nonzero_exit(
+    docker_job, docker_client_mock, mock_jobs_client, test_job_step, exit_code
+):
+    """Cancellation intent wins over entrypoint-specific post-stop exit codes."""
 
     test_job_step.status = PlatformJobStatus.CANCELLING
     container_mock = MagicMock()
     container_mock.id = "16-character-uid"
     container_mock.status = "exited"
-    container_mock.attrs = {"State": {"ExitCode": 137}}  # SIGKILL will set exit code 137
+    container_mock.attrs = {"State": {"ExitCode": exit_code}}
     task_id = uuid.uuid4().hex
     container_mock.labels = owned_container_labels(
         {
@@ -586,7 +589,12 @@ def test_docker_job_sync_cancelling_sigkill(docker_job, docker_client_mock, test
     # Test sync with running container
     update = docker_job.sync(test_job_step)
     assert update.status == "cancelled"
+    assert update.status_details == {"message": f"Job was cancelled successfully with exit code {exit_code}"}
+    assert update.error_details == {}
     docker_client_mock.containers.get.assert_called_with("job-test-job-id-test-step")
+    task_update = mock_jobs_client.update_job_step_task.call_args.kwargs["body"]
+    assert task_update.status == PlatformJobStatus.CANCELLED
+    assert task_update.error_stack == ""
     # Container removed as part of cleanup_steps
     container_mock.remove.assert_not_called()
 


### PR DESCRIPTION
## Summary

- treat an exited/dead Docker container as cancelled whenever the persisted step is already cancelling
- retain the observed exit code in status details for diagnostics
- keep spontaneous non-zero exits on non-cancelling steps mapped to error

## Regression coverage

- verifies cancellation for exit codes 0, 1, 137, 143, and 255
- full Docker backend unit file: 77 passed
- ruff, ty, and pre-commit passed

NVBug: 6688317 (NPLAT-2)
DevTest: T6247915


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Docker jobs being cancelled are now consistently reported as **CANCELLED**, regardless of the container’s exit code.
  - Cancellation updates no longer include misleading error details or error stacks for nonzero exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->