### PR TITLE
test(evaluator): pin the symlink-loop premise only where it holds

### DIFF
--- a/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
+++ b/packages/nemo_evaluator_sdk/tests/agent_eval/test_harbor_runtime.py
@@ -879,8 +879,10 @@ def test_symlink_loop_degrades_the_stamp_instead_of_killing_the_run(tmp_path: Pa
     loop.symlink_to(loop)
 
     # Pin the premise: if this stops raising, the guard below is no longer load-bearing.
-    with pytest.raises(RuntimeError):
-        loop.resolve()
+    # From 3.13 `resolve()` returns the path for a loop instead of raising.
+    if sys.version_info < (3, 13):
+        with pytest.raises(RuntimeError):
+            loop.resolve()
     assert _safe_resolve(loop) == loop.absolute(), "_safe_resolve must swallow the loop, not just OSError"
 
     task = AgentEvalTask(


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

`test_symlink_loop_degrades_the_stamp_instead_of_killing_the_run` asserts that `Path.resolve()` raises `RuntimeError` on a symlink loop, to keep the `RuntimeError` arm of `_safe_resolve` honest. CPython changed that in 3.13: non-strict `resolve()` returns the unresolved path and raises nothing, so the test fails there. The premise is now pinned only below 3.13.

No production change. `_safe_resolve` already returns the unresolved absolute path on either interpreter, so the assertion the test exists for passes on both.

```
3.12.11  resolve() -> RuntimeError
3.13.12  resolve() -> /private/var/.../loop
```

## Changes

- Guard the premise assertion on `sys.version_info < (3, 13)`. The following assertion, `_safe_resolve(loop) == loop.absolute()`, is unchanged and covers both interpreters.

## Type of Change

- [x] CI, build, or test infrastructure

## Quality Gates

- [x] Existing tests cover changed behavior — justification: this fixes a test's own premise; the assertion under test is unchanged and now runs on both supported interpreters.
- [x] Documentation not applicable — justification: no user-visible behavior changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

```
uv run --frozen -p 3.12 pytest packages/nemo_evaluator_sdk/tests/agent_eval -q
  764 passed, 18 skipped

uv run --frozen -p 3.13 pytest packages/nemo_evaluator_sdk/tests/agent_eval -q
  764 passed, 18 skipped   (fails without this change)

uv run --frozen ruff check packages/nemo_evaluator_sdk          All checks passed
tools/lint/lint-python-types.sh                                 All checks passed
```

Blocked pre-commit hooks, both environmental and unrelated to this change:

- `Helm Docs` — `helm-docs` is not installed locally. No Helm chart is touched here.
- `Run uv lock with platform uv` — the hook requires exactly uv 0.9.14 and this machine has 0.9.30. No `pyproject.toml` or `uv.lock` is touched here, and `Check for uv.lock drift` passed.

Every other hook passed.

## Note for reviewers

This never failed CI, and still will not: the `Python unit tests` job pins `python-version: "3.12"` and the Flox toolchain sets `UV_PYTHON=3.12`, so 3.13 is never exercised by the unit suite even though `requires-python = ">=3.12, <3.14"` and py3.13 wheels are built. It only shows up under a bare `uv run`, which resolves the newest allowed interpreter.

The rest of the `agent_eval` suite is clean on 3.13, so this was the only instance. Whether the unit-test job should gain a 3.13 leg is a separate question and deliberately not decided here.

Separately: `_safe_resolve`'s docstring says 3.14 is the version that stops raising on a loop. It is 3.13, so the `RuntimeError` arm is already dead code on 3.13. Left untouched here to keep this diff to the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of symlink-loop handling across Python versions.
  * Ensured looped paths continue to resolve safely without causing unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->