### PR TITLE
chore(data-designer): Eliminate possibility of KeyError in log parsing

### DIFF
--- a/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
+++ b/plugins/nemo-data-designer/src/nemo_data_designer_plugin/sdk/job_resources.py
@@ -78,9 +78,9 @@ class _WaitLogCollector:
     def accept_logs(self, current_logs: list[dict[str, str]]) -> None:
         for log in current_logs[len(self.seen_logs) :]:
             self.seen_logs.append(log)
-            if not log["name"].startswith("data_designer"):
+            if not log.get("name", "").startswith("data_designer"):
                 continue
-            level = log["levelname"].lower()
+            level = log.get("levelname", "").lower()
             if level == "info":
                 logger.info(log["message"])
             elif level in {"warning", "warn"}:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Uses `.get` with fallback instead of indexing by key to avoid the (unlikely) chance of a `KeyError` while parsing logs in the SDK



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log handling when entries are missing a name or severity level.
  * Prevented errors caused by incomplete log metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->