### PR TITLE
fix(plugin): handle unreadable spec and options files

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py
@@ -577,8 +577,8 @@ def _add_submit_command(
 
         try:
             merged_options = _merge_options_inputs(options, options_file)
-        except ValueError as exc:
-            typer.echo(f"Error: {exc}", err=True)
+        except (OSError, ValueError) as exc:
+            typer.echo(f"Error: invalid options — {exc}", err=True)
             raise typer.Exit(code=1) from exc
 
         renderer_cls: type[CLIRenderer] | None = None
@@ -804,7 +804,7 @@ def _load_spec(spec_str: str, spec_file: Path | None) -> dict:
             loaded = load_spec_file(spec_file)
         else:
             loaded = json.loads(spec_str)
-    except (json.JSONDecodeError, ValueError) as exc:
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
         typer.echo(f"Error: invalid spec — {exc}", err=True)
         raise typer.Exit(code=1) from exc
     if not isinstance(loaded, dict):

--- a/packages/nemo_platform_plugin/tests/test_commands.py
+++ b/packages/nemo_platform_plugin/tests/test_commands.py
@@ -475,6 +475,31 @@ class TestSpecFlagRename:
         assert result.exit_code == 0
         assert json.loads(result.output)["message"] == "Hello, FromYaml!"
 
+    def test_run_missing_spec_file_exits_cleanly(self, tmp_path: Path) -> None:
+        missing_file = tmp_path / "missing.yaml"
+        app = _app_with_jobs(_GreetJob)
+        result = runner.invoke(
+            app,
+            ["greet", "run", "--spec-file", str(missing_file)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1
+        combined = (result.output or "") + (result.stderr or "")
+        assert "invalid spec" in combined
+        assert str(missing_file) in combined
+
+    def test_run_directory_spec_file_exits_cleanly(self, tmp_path: Path) -> None:
+        app = _app_with_jobs(_GreetJob)
+        result = runner.invoke(
+            app,
+            ["greet", "run", "--spec-file", str(tmp_path)],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1
+        combined = (result.output or "") + (result.stderr or "")
+        assert "invalid spec" in combined
+        assert str(tmp_path) in combined
+
     def test_run_config_alias_still_works(self) -> None:
         """--config remains as a deprecated alias for --spec during the transition."""
         app = _app_with_jobs(_GreetJob)
@@ -547,6 +572,24 @@ class TestSubmitOptionsPassthrough:
         assert result.exit_code != 0
         combined = (result.output or "") + (result.stderr or "")
         assert "top-level mapping" in combined
+
+    def test_submit_missing_options_file_exits_cleanly(self, tmp_path: Path) -> None:
+        missing_file = tmp_path / "missing-options.yaml"
+        app = _app_with_jobs(_GreetJob)
+        result = runner.invoke(
+            app,
+            [
+                "greet",
+                "submit",
+                "--options-file",
+                str(missing_file),
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 1
+        combined = (result.output or "") + (result.stderr or "")
+        assert "invalid options" in combined
+        assert str(missing_file) in combined
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

Handle missing or unreadable job CLI `--spec-file` and `--options-file` paths as local input errors. These now exit with code 1 and a clean Typer error instead of allowing `OSError` subclasses to escape as tracebacks.

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

NVBug 6696357

## Changes
<!-- List the concrete changes included in this pull request. -->

- Catch `OSError` while loading job/function specs so bad `--spec-file` paths use the existing `invalid spec` error path.
- Catch `OSError` while merging job submit options so bad `--options-file` paths report `invalid options` and exit 1.
- Add CLI regression coverage for missing spec files, directory spec paths, and missing options files.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: CLI behavior now matches the existing documented malformed-input behavior; no user-facing command syntax changed.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->

- `flox activate -- uv run nemo safe-synthesizer generate --spec-file /tmp/definitely-not-here.json` — exited 1 with a clean `Error: invalid spec — ...` message and no traceback.
- `flox activate -- uv run --frozen pytest packages/nemo_platform_plugin/tests/test_commands.py -v` — passed (`78 passed`; pytest reported temp-directory cleanup warnings unrelated to the changed code).
- `uv run ruff check packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py packages/nemo_platform_plugin/tests/test_commands.py` — passed.
- `uv run ruff format --check packages/nemo_platform_plugin/src/nemo_platform_plugin/commands.py packages/nemo_platform_plugin/tests/test_commands.py` — passed.
- `flox activate -- uv run pre-commit run -a` — passed.
- DCO audit over `origin/release/0.5..HEAD` — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for inaccessible or invalid specification and options files.
  * Commands now provide clear “invalid” error messages, including the affected file path, instead of exposing raw file-access errors.

* **Tests**
  * Added coverage for missing files and directory paths supplied to specification and options file commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->