### PR TITLE
fix(jobs): release docker GPUs on delete

### DIFF
--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -556,10 +556,12 @@ class DockerJobBackend(JobBackend[ProviderT, DockerJobExecutionProfileConfig], G
         }
 
     def _release_step_resources(self, step: PlatformJobStepWithContext, *, reason: str) -> None:
+        """No-op resource hook for Docker backends without per-step resources."""
         del step, reason
         return
 
     def _release_container_resources(self, container: Container, *, reason: str) -> None:
+        """No-op resource hook for Docker backends without per-container resources."""
         del container, reason
         return
 
@@ -1266,12 +1268,69 @@ chmod -R 777 {job_vol}/{storage_subpath}
                     )
                 except Exception:
                     logger.exception("Failed to persist scheduling error for job step")
-                self._release_step_resources(step, reason="scheduling_error")
+                if self._remove_container_after_failed_schedule(step, reason="scheduling_error"):
+                    self._release_step_resources(step, reason="scheduling_error")
             except Exception:
                 logger.exception("Unexpected error while scheduling container for job step")
-                self._release_step_resources(step, reason="unexpected_scheduling_error")
+                if self._remove_container_after_failed_schedule(step, reason="unexpected_scheduling_error"):
+                    self._release_step_resources(step, reason="unexpected_scheduling_error")
             finally:
                 self._container_start_admission.release()
+
+    def _remove_container_after_failed_schedule(self, step: PlatformJobStepWithContext, *, reason: str) -> bool:
+        container = self.get_container(step)
+        if container is None:
+            return True
+
+        if not self._is_container_owned_by_this_controller(container):
+            logger.warning(
+                "Skipping Docker scheduling-error cleanup for unowned container",
+                extra={
+                    "job": step.job,
+                    "step": step.name,
+                    "container_name": getattr(container, "name", None),
+                    "owner_label": (getattr(container, "labels", None) or {}).get(JOB_CONTROLLER_INSTANCE_ID_LABEL),
+                    "reason": reason,
+                },
+            )
+            return False
+
+        logger.info(
+            "Removing Docker container after scheduling failure",
+            extra={
+                "job": step.job,
+                "step": step.name,
+                "container_name": container.name,
+                "reason": reason,
+            },
+        )
+        self._stop_workload_identity_refresher(container.name)
+        try:
+            container.remove(force=True)
+        except NotFound:
+            logger.info(
+                "Container disappeared during Docker scheduling-error cleanup",
+                extra={"job": step.job, "step": step.name, "container_name": container.name, "reason": reason},
+            )
+        except Exception:
+            logger.exception(
+                "Failed to remove container after Docker scheduling error",
+                extra={"job": step.job, "step": step.name, "container_name": container.name, "reason": reason},
+            )
+            return False
+
+        labels = getattr(container, "labels", None) or {}
+        workspace = labels.get(JOB_WORKSPACE_ID_LABEL)
+        job = labels.get(JOB_ID_LABEL)
+        task = labels.get(JOB_TASK_ID_LABEL)
+        if workspace and job and task:
+            self.cleanup_task_storage_volumes(workspace, job, task)
+        else:
+            logger.debug(
+                "Skipping task storage cleanup after Docker scheduling error because labels are incomplete",
+                extra={"job": step.job, "step": step.name, "container_name": container.name, "reason": reason},
+            )
+        return True
 
     def _run_container_in_thread(self, step: PlatformJobStepWithContext, container_args: dict):
         status_details = {}
@@ -2026,6 +2085,8 @@ chmod -R 777 {job_vol}/{storage_subpath}
                             extra=cleanup_log_extra,
                         )
                         continue
+
+                    self._release_container_resources(container, reason="terminal_container_cleanup")
 
                     # Always disconnect the container from its network first if not already done.
                     # We do this to avoid dangling containers being connected to user-defined networks.

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -1171,7 +1171,23 @@ chmod -R 777 {job_vol}/{storage_subpath}
         container_args["network"] = self._execution_profile_config.networking.job_container_network
         return self.configure_container(container_args, executor_config)
 
-    def cancel_scheduling(self, step: PlatformJobStepWithContext) -> bool:
+    def _release_step_resources_after_scheduling_stop(
+        self,
+        step: PlatformJobStepWithContext,
+        *,
+        reason: str,
+        created_container: Container | None = None,
+    ) -> None:
+        """Release step resources once any already-created container is gone."""
+        if created_container is not None and not self._remove_container_before_resource_release(
+            step, created_container, reason=reason
+        ):
+            return
+        self._release_step_resources(step, reason=reason)
+
+    def cancel_scheduling(
+        self, step: PlatformJobStepWithContext, *, created_container: Container | None = None
+    ) -> bool:
         """Check if the job step is cancelling or pausing, and update status accordingly."""
         updated_step = self.get_step_safe(step_name=step.name, job=step.job, workspace=step.workspace)
         if updated_step is None:
@@ -1179,7 +1195,9 @@ chmod -R 777 {job_vol}/{storage_subpath}
                 "Job step disappeared before Docker container start; cancelling scheduling",
                 extra={"workspace": step.workspace, "job": step.job, "step": step.name},
             )
-            self._release_step_resources(step, reason="step_missing_before_start")
+            self._release_step_resources_after_scheduling_stop(
+                step, reason="step_missing_before_start", created_container=created_container
+            )
             return True
 
         is_cancelling_or_pausing = updated_step.status in (
@@ -1197,7 +1215,9 @@ chmod -R 777 {job_vol}/{storage_subpath}
                 logger.info(
                     "Job step is already in terminal state, no update required", extra={"status": updated_step.status}
                 )
-                self._release_step_resources(step, reason="step_terminal_before_start")
+                self._release_step_resources_after_scheduling_stop(
+                    step, reason="step_terminal_before_start", created_container=created_container
+                )
                 return True  # Already in terminal state, no step updates needed
 
             status_details = {}
@@ -1220,7 +1240,9 @@ chmod -R 777 {job_vol}/{storage_subpath}
                     "Job step disappeared while Docker scheduling was stopping",
                     extra={"workspace": step.workspace, "job": step.job, "step": step.name},
                 )
-            self._release_step_resources(step, reason="step_stopped_before_start")
+            self._release_step_resources_after_scheduling_stop(
+                step, reason="step_stopped_before_start", created_container=created_container
+            )
         return is_cancelling_or_pausing
 
     def get_jobs_launcher_binary(self) -> io.BytesIO | None:
@@ -1277,14 +1299,13 @@ chmod -R 777 {job_vol}/{storage_subpath}
             finally:
                 self._container_start_admission.release()
 
-    def _remove_container_after_failed_schedule(self, step: PlatformJobStepWithContext, *, reason: str) -> bool:
-        container = self.get_container(step)
-        if container is None:
-            return True
-
+    def _remove_container_before_resource_release(
+        self, step: PlatformJobStepWithContext, container: Container, *, reason: str
+    ) -> bool:
+        """Remove an owned created container before releasing resources tied to it."""
         if not self._is_container_owned_by_this_controller(container):
             logger.warning(
-                "Skipping Docker scheduling-error cleanup for unowned container",
+                "Skipping Docker resource-release cleanup for unowned container",
                 extra={
                     "job": step.job,
                     "step": step.name,
@@ -1296,7 +1317,7 @@ chmod -R 777 {job_vol}/{storage_subpath}
             return False
 
         logger.info(
-            "Removing Docker container after scheduling failure",
+            "Removing Docker container before releasing scheduling resources",
             extra={
                 "job": step.job,
                 "step": step.name,
@@ -1309,12 +1330,12 @@ chmod -R 777 {job_vol}/{storage_subpath}
             container.remove(force=True)
         except NotFound:
             logger.info(
-                "Container disappeared during Docker scheduling-error cleanup",
+                "Container disappeared during Docker resource-release cleanup",
                 extra={"job": step.job, "step": step.name, "container_name": container.name, "reason": reason},
             )
         except Exception:
             logger.exception(
-                "Failed to remove container after Docker scheduling error",
+                "Failed to remove container before Docker resource release",
                 extra={"job": step.job, "step": step.name, "container_name": container.name, "reason": reason},
             )
             return False
@@ -1327,10 +1348,16 @@ chmod -R 777 {job_vol}/{storage_subpath}
             self.cleanup_task_storage_volumes(workspace, job, task)
         else:
             logger.debug(
-                "Skipping task storage cleanup after Docker scheduling error because labels are incomplete",
+                "Skipping task storage cleanup before Docker resource release because labels are incomplete",
                 extra={"job": step.job, "step": step.name, "container_name": container.name, "reason": reason},
             )
         return True
+
+    def _remove_container_after_failed_schedule(self, step: PlatformJobStepWithContext, *, reason: str) -> bool:
+        container = self.get_container(step)
+        if container is None:
+            return True
+        return self._remove_container_before_resource_release(step, container, reason=reason)
 
     def _run_container_in_thread(self, step: PlatformJobStepWithContext, container_args: dict):
         status_details = {}
@@ -1518,7 +1545,7 @@ chmod -R 777 {job_vol}/{storage_subpath}
         # cancel scheduling the container
         logger.debug("Checking for cancellation or pausing before starting container")
         pre_start_cancel_check_started_at = time.monotonic()
-        if self.cancel_scheduling(step):
+        if self.cancel_scheduling(step, created_container=container):
             logger.debug(
                 "Docker pre-start cancellation check stopped scheduling",
                 extra={

--- a/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
+++ b/services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py
@@ -21,6 +21,7 @@ from docker.errors import APIError, ImageNotFound, NotFound
 from docker.models.containers import Container
 from docker.types import LogConfig, Mount
 from nemo_platform_plugin.capabilities import CapabilityUnavailableError, probe_docker
+from nemo_platform_plugin.client.errors import NotFoundError as ClientNotFoundError
 from nemo_platform_plugin.jobs.execution_profiles import (
     DockerJobExecutionProfile as PluginDockerJobExecutionProfile,
 )
@@ -554,6 +555,14 @@ class DockerJobBackend(JobBackend[ProviderT, DockerJobExecutionProfileConfig], G
             ]
         }
 
+    def _release_step_resources(self, step: PlatformJobStepWithContext, *, reason: str) -> None:
+        del step, reason
+        return
+
+    def _release_container_resources(self, container: Container, *, reason: str) -> None:
+        del container, reason
+        return
+
     def job_storage_subpath(self, workspace: str, job: str) -> str:
         return f"jobs/{workspace}/{job}"
 
@@ -1035,6 +1044,7 @@ chmod -R 777 {job_vol}/{storage_subpath}
             submitted_to_threadpool_at = time.monotonic()
             self._container_run_threadpool.submit(self.run_container, step, container_args, submitted_to_threadpool_at)
         except Exception:
+            self._release_step_resources(step, reason="schedule_failed_before_start")
             self._container_start_admission.release()
             raise
         logger.debug(
@@ -1161,7 +1171,15 @@ chmod -R 777 {job_vol}/{storage_subpath}
 
     def cancel_scheduling(self, step: PlatformJobStepWithContext) -> bool:
         """Check if the job step is cancelling or pausing, and update status accordingly."""
-        updated_step = self.get_step(step_name=step.name, job=step.job, workspace=step.workspace)
+        updated_step = self.get_step_safe(step_name=step.name, job=step.job, workspace=step.workspace)
+        if updated_step is None:
+            logger.info(
+                "Job step disappeared before Docker container start; cancelling scheduling",
+                extra={"workspace": step.workspace, "job": step.job, "step": step.name},
+            )
+            self._release_step_resources(step, reason="step_missing_before_start")
+            return True
+
         is_cancelling_or_pausing = updated_step.status in (
             PlatformJobStatus.CANCELLING,
             PlatformJobStatus.CANCELLED,
@@ -1177,6 +1195,7 @@ chmod -R 777 {job_vol}/{storage_subpath}
                 logger.info(
                     "Job step is already in terminal state, no update required", extra={"status": updated_step.status}
                 )
+                self._release_step_resources(step, reason="step_terminal_before_start")
                 return True  # Already in terminal state, no step updates needed
 
             status_details = {}
@@ -1187,12 +1206,19 @@ chmod -R 777 {job_vol}/{storage_subpath}
                 status = PlatformJobStatus.CANCELLED
                 status_details["message"] = "Job is cancelled, not creating container"
             logger.info("Job step is not scheduling container", extra={"status": updated_step.status})
-            self._jobs.update_job_step_status(
-                name=step.name,
-                workspace=step.workspace,
-                job=step.job,
-                body=PlatformJobStatusUpdateRequest(status=status, status_details=status_details),
-            )
+            try:
+                self._jobs.update_job_step_status(
+                    name=step.name,
+                    workspace=step.workspace,
+                    job=step.job,
+                    body=PlatformJobStatusUpdateRequest(status=status, status_details=status_details),
+                )
+            except ClientNotFoundError:
+                logger.info(
+                    "Job step disappeared while Docker scheduling was stopping",
+                    extra={"workspace": step.workspace, "job": step.job, "step": step.name},
+                )
+            self._release_step_resources(step, reason="step_stopped_before_start")
         return is_cancelling_or_pausing
 
     def get_jobs_launcher_binary(self) -> io.BytesIO | None:
@@ -1240,8 +1266,10 @@ chmod -R 777 {job_vol}/{storage_subpath}
                     )
                 except Exception:
                     logger.exception("Failed to persist scheduling error for job step")
+                self._release_step_resources(step, reason="scheduling_error")
             except Exception:
                 logger.exception("Unexpected error while scheduling container for job step")
+                self._release_step_resources(step, reason="unexpected_scheduling_error")
             finally:
                 self._container_start_admission.release()
 
@@ -2069,6 +2097,9 @@ chmod -R 777 {job_vol}/{storage_subpath}
         self.cleanup_task_storage_volumes(workspace, job, task)
         logger.debug("Cleaned up task storage volume", extra={"workspace": workspace, "job": job, "task": task})
 
+        if self._is_container_owned_by_this_controller(container):
+            self._release_container_resources(container, reason="container_cleanup")
+
         # Clean up persistent storage for successful jobs that used it
         # Only clean up if the job itself is in a terminal state to prevent premature cleanup
         if JOB_USES_PERSISTENT_STORAGE_LABEL in container.labels:
@@ -2162,8 +2193,28 @@ class GPUDockerJobBackend(DockerJobBackend[GPUExecutionProvider]):
             job_update.status.value if isinstance(job_update.status, PlatformJobStatus) else job_update.status
         )
         if self.gpu_pool is not None and status_value in terminal_states:
-            self.gpu_pool.release_gpu(step.id)
+            self._release_gpu_for_step_id(step.id, reason="terminal_sync")
         return job_update
+
+    def _release_gpu_for_step_id(self, step_id: str, *, reason: str) -> list[int]:
+        if self.gpu_pool is None:
+            return []
+        released = self.gpu_pool.release_gpu(step_id)
+        if released:
+            logger.info(
+                "Released Docker GPU allocation for job step",
+                extra={"step_id": step_id, "gpu_ids": released, "reason": reason},
+            )
+        return released
+
+    def _release_step_resources(self, step: PlatformJobStepWithContext, *, reason: str) -> None:
+        self._release_gpu_for_step_id(step.id, reason=reason)
+
+    def _release_container_resources(self, container: Container, *, reason: str) -> None:
+        labels = getattr(container, "labels", None) or {}
+        step_id = labels.get(JOB_STEP_ID_LABEL)
+        if step_id:
+            self._release_gpu_for_step_id(step_id, reason=reason)
 
     def configure_container(self, container_args: dict, executor_config: GPUExecutionProvider) -> dict:
         """Customize container arguments for GPU execution."""

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -1655,6 +1655,46 @@ def test_gpu_pool_released_when_cancel_scheduling_sees_terminal_step(
     executor._jobs.update_job_step_status.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "refreshed_status,expected_update_status",
+    [
+        (PlatformJobStatus.CANCELLED, None),
+        (PlatformJobStatus.PAUSED, None),
+        (PlatformJobStatus.CANCELLING, PlatformJobStatus.CANCELLED),
+        (PlatformJobStatus.PAUSING, PlatformJobStatus.PAUSED),
+    ],
+)
+def test_gpu_pool_released_when_cancel_scheduling_removes_created_container_before_release(
+    mock_nmp_client, docker_client_mock, refreshed_status, expected_update_status
+):
+    step = _gpu_step(step_id=f"{refreshed_status.value}-created-container-step-id")
+    executor = _gpu_backend(mock_nmp_client, docker_client_mock)
+    container_mock = _gpu_container(step, status="created", task_id="task-pre-start-stop")
+    refreshed_step = MagicMock()
+    refreshed_step.status = refreshed_status
+
+    executor.gpu_pool.allocate_gpu(step.id)
+    assert executor.gpu_pool.gpu_to_workload_id[0] == step.id
+
+    def assert_remove_before_release(*, force: bool) -> None:
+        assert force is True
+        assert executor.gpu_pool.gpu_to_workload_id[0] == step.id
+
+    container_mock.remove.side_effect = assert_remove_before_release
+    executor.get_step_safe = MagicMock(return_value=refreshed_step)
+
+    assert executor.cancel_scheduling(step, created_container=container_mock) is True
+
+    container_mock.remove.assert_called_once_with(force=True)
+    assert executor.gpu_pool.gpu_to_workload_id[0] is None
+    assert executor.gpu_pool.allocate_gpu("next-step-id") == [0]
+    if expected_update_status is None:
+        executor._jobs.update_job_step_status.assert_not_called()
+    else:
+        executor._jobs.update_job_step_status.assert_called_once()
+        assert executor._jobs.update_job_step_status.call_args.kwargs["body"].status == expected_update_status
+
+
 def test_gpu_pool_released_when_cancel_scheduling_status_update_loses_step(mock_nmp_client, docker_client_mock):
     step = _gpu_step(step_id="cancelling-lost-step-id")
     executor = _gpu_backend(mock_nmp_client, docker_client_mock)

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -1528,6 +1528,113 @@ def test_gpu_cleanup_on_job_error(mock_nmp_client, docker_client_mock):
     assert executor.gpu_pool.gpu_to_workload_id[0] is None
 
 
+def test_gpu_pool_released_when_deleted_step_stops_scheduling(mock_nmp_client, docker_client_mock):
+    """A deleted step before container start must not leave its GPU allocation orphaned."""
+    gpu_executor_config = GPUExecutionProvider.model_validate(
+        {
+            "provider": "gpu",
+            "profile": "default",
+            "container": {
+                "image": "test-gpu-image:latest",
+            },
+            "resources": {
+                "num_gpus": 1,
+            },
+            "config": {},
+        }
+    )
+    step = PlatformJobStepWithContext.model_validate(
+        {
+            "id": "deleted-step-id",
+            "job": "job-deleted-before-start",
+            "attempt_id": "test-job-attempt-id",
+            "name": "gpu-deleted-step",
+            "fileset": "test-logs-fileset",
+            "workspace": "default",
+            "step_spec": {
+                "name": "gpu-deleted-step",
+                "executor": gpu_executor_config.model_dump(),
+                "config": {},
+                "environment": [],
+            },
+            "status": "created",
+        }
+    )
+
+    with patch("nmp.core.jobs.controllers.backends.docker.SharedResourceManager") as mock_srm:
+        mock_pool = DockerGPUPool(reserved_gpu_device_ids=[0])
+        mock_srm.get_instance.return_value.get_gpu_pool.return_value = mock_pool
+
+        executor = GPUDockerJobBackend(
+            nmp_sdk=mock_nmp_client,
+            execution_profile_config=DockerJobExecutionProfileConfig(
+                storage=DockerJobStorageConfig(volume_name="test_jobs_storage"),
+            ),
+            profile_name="default",
+        )
+        executor._client = docker_client_mock
+
+    executor.gpu_pool.allocate_gpu(step.id)
+    assert executor.gpu_pool.gpu_to_workload_id[0] == step.id
+
+    executor.get_step_safe = MagicMock(return_value=None)
+
+    assert executor.cancel_scheduling(step) is True
+    assert executor.gpu_pool.gpu_to_workload_id[0] is None
+    executor._jobs.update_job_step_status.assert_not_called()
+
+
+def test_gpu_cleanup_releases_deleted_step_container_without_terminal_sync(mock_nmp_client, docker_client_mock):
+    """Cleanup after job deletion releases GPUs even when terminal sync never saw the step."""
+    step_id = "deleted-terminal-step-id"
+
+    with patch("nmp.core.jobs.controllers.backends.docker.SharedResourceManager") as mock_srm:
+        mock_pool = DockerGPUPool(reserved_gpu_device_ids=[0])
+        mock_srm.get_instance.return_value.get_gpu_pool.return_value = mock_pool
+
+        executor = GPUDockerJobBackend(
+            nmp_sdk=mock_nmp_client,
+            execution_profile_config=DockerJobExecutionProfileConfig(
+                storage=DockerJobStorageConfig(volume_name="test_jobs_storage"),
+            ),
+            profile_name="default",
+        )
+        executor._client = docker_client_mock
+
+    executor.gpu_pool.allocate_gpu(step_id)
+    assert executor.gpu_pool.gpu_to_workload_id[0] == step_id
+    executor._execution_profile_config.cleanup_completed_jobs_immediately = True
+
+    container_mock = MagicMock()
+    container_mock.name = "job-deleted-before-sync-gpu-step"
+    container_mock.id = "deleted-terminal-container-id"
+    container_mock.status = "exited"
+    container_mock.attrs = {
+        "State": {"ExitCode": 0, "FinishedAt": datetime.datetime.now(datetime.UTC).isoformat()},
+        "NetworkSettings": {"Networks": {"host": {}}},
+    }
+    container_mock.labels = {
+        JOB_WORKSPACE_ID_LABEL: "default",
+        JOB_ID_LABEL: "job-deleted-before-sync",
+        JOB_STEP_NAME_LABEL: "gpu-step",
+        JOB_STEP_ID_LABEL: step_id,
+        JOB_TASK_ID_LABEL: "task-deleted-step",
+        JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
+        JOB_EXECUTION_BACKEND_LABEL: "docker",
+        JOB_EXECUTION_PROFILE_LABEL: "default",
+        JOB_TYPE_LABEL: JOB_TYPE_JOB,
+    }
+
+    docker_client_mock.containers.list.return_value = [container_mock]
+    executor.check_step_is_terminal = MagicMock(return_value=True)
+
+    executor.cleanup_steps()
+
+    assert executor.gpu_pool.gpu_to_workload_id[0] is None
+    container_mock.remove.assert_called_once_with(force=True)
+
+
 def test_ensure_volume_creates_when_test_missing(docker_job: CPUDockerJobBackend, docker_client_mock, test_job_step):
     """Test that _ensure_job_storage creates a volume when one doesn't exist."""
 

--- a/services/core/jobs/tests/controllers/test_docker_backend.py
+++ b/services/core/jobs/tests/controllers/test_docker_backend.py
@@ -9,9 +9,11 @@ from types import SimpleNamespace
 from typing import Iterator
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from docker.errors import APIError, NotFound
 from nemo_platform.types.shared import AuthContext as SdkAuthContext
+from nemo_platform_plugin.client.errors import NotFoundError as ClientNotFoundError
 from nmp.common.auth import NMP_PRINCIPAL_ENVVAR, AuthContext, Principal
 from nmp.common.config import PlatformConfig
 from nmp.common.docker.gpu_pool import DockerGPUPool
@@ -1528,9 +1530,8 @@ def test_gpu_cleanup_on_job_error(mock_nmp_client, docker_client_mock):
     assert executor.gpu_pool.gpu_to_workload_id[0] is None
 
 
-def test_gpu_pool_released_when_deleted_step_stops_scheduling(mock_nmp_client, docker_client_mock):
-    """A deleted step before container start must not leave its GPU allocation orphaned."""
-    gpu_executor_config = GPUExecutionProvider.model_validate(
+def _gpu_executor_config(num_gpus: int = 1) -> GPUExecutionProvider:
+    return GPUExecutionProvider.model_validate(
         {
             "provider": "gpu",
             "profile": "default",
@@ -1538,29 +1539,41 @@ def test_gpu_pool_released_when_deleted_step_stops_scheduling(mock_nmp_client, d
                 "image": "test-gpu-image:latest",
             },
             "resources": {
-                "num_gpus": 1,
+                "num_gpus": num_gpus,
             },
             "config": {},
         }
     )
-    step = PlatformJobStepWithContext.model_validate(
+
+
+def _gpu_step(
+    *,
+    step_id: str = "test-gpu-step-id",
+    job: str = "test-gpu-job",
+    name: str = "gpu-step",
+    status: PlatformJobStatus | str = PlatformJobStatus.CREATED,
+) -> PlatformJobStepWithContext:
+    gpu_executor_config = _gpu_executor_config()
+    return PlatformJobStepWithContext.model_validate(
         {
-            "id": "deleted-step-id",
-            "job": "job-deleted-before-start",
+            "id": step_id,
+            "job": job,
             "attempt_id": "test-job-attempt-id",
-            "name": "gpu-deleted-step",
+            "name": name,
             "fileset": "test-logs-fileset",
             "workspace": "default",
             "step_spec": {
-                "name": "gpu-deleted-step",
+                "name": name,
                 "executor": gpu_executor_config.model_dump(),
                 "config": {},
                 "environment": [],
             },
-            "status": "created",
+            "status": status,
         }
     )
 
+
+def _gpu_backend(mock_nmp_client, docker_client_mock) -> GPUDockerJobBackend:
     with patch("nmp.core.jobs.controllers.backends.docker.SharedResourceManager") as mock_srm:
         mock_pool = DockerGPUPool(reserved_gpu_device_ids=[0])
         mock_srm.get_instance.return_value.get_gpu_pool.return_value = mock_pool
@@ -1573,6 +1586,47 @@ def test_gpu_pool_released_when_deleted_step_stops_scheduling(mock_nmp_client, d
             profile_name="default",
         )
         executor._client = docker_client_mock
+        return executor
+
+
+def _gpu_container(
+    step: PlatformJobStepWithContext,
+    *,
+    status: str = "exited",
+    exit_code: int = 0,
+    finished_at: str | None = None,
+    task_id: str = "task-gpu-step",
+) -> MagicMock:
+    container = MagicMock()
+    container.name = f"{step.job}-{step.name}"
+    container.id = f"container-{step.id}"
+    container.status = status
+    container.attrs = {
+        "State": {
+            "ExitCode": exit_code,
+            "FinishedAt": finished_at or datetime.datetime.now(datetime.UTC).isoformat(),
+        },
+        "NetworkSettings": {"Networks": {"host": {}}},
+    }
+    container.labels = {
+        JOB_WORKSPACE_ID_LABEL: step.workspace,
+        JOB_ID_LABEL: step.job,
+        JOB_STEP_NAME_LABEL: step.name,
+        JOB_STEP_ID_LABEL: step.id,
+        JOB_TASK_ID_LABEL: task_id,
+        JOB_MANAGED_BY_LABEL: JOB_MANAGED_BY_JOBS_CONTROLLER,
+        JOB_CONTROLLER_INSTANCE_ID_LABEL: TEST_JOBS_CONTROLLER_INSTANCE_ID,
+        JOB_EXECUTION_BACKEND_LABEL: "docker",
+        JOB_EXECUTION_PROFILE_LABEL: "default",
+        JOB_TYPE_LABEL: JOB_TYPE_JOB,
+    }
+    return container
+
+
+def test_gpu_pool_released_when_deleted_step_stops_scheduling(mock_nmp_client, docker_client_mock):
+    """A deleted step before container start must not leave its GPU allocation orphaned."""
+    step = _gpu_step(step_id="deleted-step-id", job="job-deleted-before-start", name="gpu-deleted-step")
+    executor = _gpu_backend(mock_nmp_client, docker_client_mock)
 
     executor.gpu_pool.allocate_gpu(step.id)
     assert executor.gpu_pool.gpu_to_workload_id[0] == step.id
@@ -1582,6 +1636,38 @@ def test_gpu_pool_released_when_deleted_step_stops_scheduling(mock_nmp_client, d
     assert executor.cancel_scheduling(step) is True
     assert executor.gpu_pool.gpu_to_workload_id[0] is None
     executor._jobs.update_job_step_status.assert_not_called()
+
+
+@pytest.mark.parametrize("terminal_status", [PlatformJobStatus.CANCELLED, PlatformJobStatus.PAUSED])
+def test_gpu_pool_released_when_cancel_scheduling_sees_terminal_step(
+    mock_nmp_client, docker_client_mock, terminal_status
+):
+    step = _gpu_step(step_id=f"{terminal_status.value}-step-id")
+    executor = _gpu_backend(mock_nmp_client, docker_client_mock)
+    refreshed_step = MagicMock()
+    refreshed_step.status = terminal_status
+
+    executor.gpu_pool.allocate_gpu(step.id)
+    executor.get_step_safe = MagicMock(return_value=refreshed_step)
+
+    assert executor.cancel_scheduling(step) is True
+    assert executor.gpu_pool.gpu_to_workload_id[0] is None
+    executor._jobs.update_job_step_status.assert_not_called()
+
+
+def test_gpu_pool_released_when_cancel_scheduling_status_update_loses_step(mock_nmp_client, docker_client_mock):
+    step = _gpu_step(step_id="cancelling-lost-step-id")
+    executor = _gpu_backend(mock_nmp_client, docker_client_mock)
+    refreshed_step = MagicMock()
+    refreshed_step.status = PlatformJobStatus.CANCELLING
+
+    executor.gpu_pool.allocate_gpu(step.id)
+    executor.get_step_safe = MagicMock(return_value=refreshed_step)
+    executor._jobs.update_job_step_status.side_effect = ClientNotFoundError(httpx.Response(404, text="missing"))
+
+    assert executor.cancel_scheduling(step) is True
+    assert executor.gpu_pool.gpu_to_workload_id[0] is None
+    executor._jobs.update_job_step_status.assert_called_once()
 
 
 def test_gpu_cleanup_releases_deleted_step_container_without_terminal_sync(mock_nmp_client, docker_client_mock):
@@ -1633,6 +1719,93 @@ def test_gpu_cleanup_releases_deleted_step_container_without_terminal_sync(mock_
 
     assert executor.gpu_pool.gpu_to_workload_id[0] is None
     container_mock.remove.assert_called_once_with(force=True)
+
+
+def test_gpu_cleanup_releases_retained_deleted_step_container_without_terminal_sync(
+    mock_nmp_client, docker_client_mock
+):
+    """Retained terminal containers must free GPUs before the cleanup TTL expires."""
+    step = _gpu_step(
+        step_id="retained-deleted-terminal-step-id",
+        job="job-retained-deleted-before-sync",
+        name="gpu-step",
+    )
+    executor = _gpu_backend(mock_nmp_client, docker_client_mock)
+    executor._execution_profile_config.cleanup_completed_jobs_immediately = False
+    executor._execution_profile_config.ttl_seconds_after_finished = 300
+
+    executor.gpu_pool.allocate_gpu(step.id)
+    assert executor.gpu_pool.gpu_to_workload_id[0] == step.id
+
+    recent_finished_at = (datetime.datetime.now(datetime.UTC) - datetime.timedelta(seconds=10)).isoformat()
+    container_mock = _gpu_container(step, finished_at=recent_finished_at, task_id="task-retained-deleted-step")
+    docker_client_mock.containers.list.return_value = [container_mock]
+    executor.check_step_is_terminal = MagicMock(return_value=True)
+
+    executor.cleanup_steps()
+
+    assert executor.gpu_pool.gpu_to_workload_id[0] is None
+    container_mock.remove.assert_not_called()
+
+
+def test_gpu_pool_released_when_failed_schedule_after_configure_container(
+    mock_nmp_client, docker_client_mock, mock_platform_config
+):
+    step = _gpu_step(step_id="submit-failed-step-id", job="job-submit-failed")
+    executor = _gpu_backend(mock_nmp_client, docker_client_mock)
+    executor._container_run_threadpool = MagicMock()
+    executor._container_run_threadpool.submit.side_effect = RuntimeError("threadpool unavailable")
+
+    acquired = 0
+    final_acquired = False
+    try:
+        for _ in range(DOCKER_CONTAINER_START_WORKERS - 1):
+            assert executor._container_start_admission.acquire(blocking=False)
+            acquired += 1
+
+        with (
+            patch("nmp.core.jobs.controllers.backends.docker.get_platform_config", return_value=mock_platform_config),
+            pytest.raises(RuntimeError, match="threadpool unavailable"),
+        ):
+            executor.schedule_single_container(_gpu_executor_config(), step)
+
+        assert executor.gpu_pool.gpu_to_workload_id[0] is None
+        final_acquired = executor._container_start_admission.acquire(blocking=False)
+        assert final_acquired
+    finally:
+        if final_acquired:
+            executor._container_start_admission.release()
+        for _ in range(acquired):
+            executor._container_start_admission.release()
+
+
+def test_gpu_failed_schedule_removes_created_container_before_releasing_pool(mock_nmp_client, docker_client_mock):
+    step = _gpu_step(step_id="run-failed-created-container-step-id", job="job-run-failed")
+    executor = _gpu_backend(mock_nmp_client, docker_client_mock)
+    container_mock = _gpu_container(step, status="created", task_id="task-run-failed")
+
+    executor.gpu_pool.allocate_gpu(step.id)
+    assert executor.gpu_pool.gpu_to_workload_id[0] == step.id
+
+    def assert_remove_before_release(*, force: bool) -> None:
+        assert force is True
+        assert executor.gpu_pool.gpu_to_workload_id[0] == step.id
+
+    container_mock.remove.side_effect = assert_remove_before_release
+
+    assert executor._container_start_admission.acquire(blocking=False)
+    executor._run_container_in_thread = MagicMock(
+        side_effect=FailedToScheduleError("container failed", error_details={"message": "container failed"})
+    )
+    docker_client_mock.containers.get.side_effect = None
+    docker_client_mock.containers.get.return_value = container_mock
+
+    executor.run_container(step, {})
+
+    container_mock.remove.assert_called_once_with(force=True)
+    assert executor.gpu_pool.gpu_to_workload_id[0] is None
+    assert executor._container_start_admission.acquire(blocking=False)
+    executor._container_start_admission.release()
 
 
 def test_ensure_volume_creates_when_test_missing(docker_job: CPUDockerJobBackend, docker_client_mock, test_job_step):


### PR DESCRIPTION
## Summary
Fix Docker GPU job cleanup so GPU pool allocations are released when a terminal owned container is classified for cleanup, even when the container is retained for logs until TTL. Also remove any created Docker container before releasing GPU resources after scheduling errors or pre-start cancel/pause, so the pool cannot be reused while a container still exists.

## Related Issue
NVBug 6696332

## Changes
- Add Docker backend resource-release hooks and clarify that the base CPU hooks are no-ops.
- Release GPU allocations at terminal-container inspection time before immediate-vs-TTL cleanup decisions.
- Remove owned containers created during failed scheduling or pre-start cancel/pause before releasing that step's GPU allocation.
- Add focused GPU Docker backend tests for retained terminal containers, cancelled/paused pre-start steps, lost-step updates, failed submit after GPU allocation, failed run cleanup with a created container, and pre-start created-container pause/cancel cleanup.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: backend resource cleanup fix with no user-facing API or workflow documentation changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox -q activate -- uv run --frozen pytest services/core/jobs/tests/controllers/test_docker_backend.py -k 'gpu_pool_released or gpu_cleanup or cancel_scheduling or failed_schedule' -v` — 23 passed, 63 deselected.
- `flox -q activate -- uv run --frozen pytest services/core/jobs/tests/controllers/test_docker_backend.py -v` — 86 passed.
- `flox -q activate -- uv run ruff check services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py services/core/jobs/tests/controllers/test_docker_backend.py` — passed.
- `flox -q activate -- uv run ruff format --check services/core/jobs/src/nmp/core/jobs/controllers/backends/docker.py services/core/jobs/tests/controllers/test_docker_backend.py` — passed.
- `flox -q activate -- uv run pre-commit run -a` — passed.
- DCO audit against `origin/release/0.5` — passed for 3 commits.
- `git diff --check` and `git diff --cached --check` — passed before commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU resource cleanup when jobs are cancelled, fail to schedule, or finish.
  * Prevented GPU allocations from remaining reserved after deleted, cancelled, or terminal job steps.
  * Ensured containers created during scheduling are removed when jobs are cancelled before starting.
  * Improved cleanup of failed or terminated job containers and associated resources.
  * Improved handling of missing job steps and unavailable status updates during cancellation and cleanup.
  * Preserved retained terminal containers while releasing their GPU allocations before final cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->