### PR TITLE
fix(safe-synthesizer): honor submitted job profile

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py
@@ -22,6 +22,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
     get_args,
     get_origin,
     overload,
@@ -127,6 +128,8 @@ class BaseJobRequest(BaseModel, Generic[JobConfigT]):
     description: str | None = None
     project: str | None = None
     spec: JobConfigT
+    profile: str | None = None
+    options: dict[str, Any] | None = None
     ownership: dict | None = None
     custom_fields: dict | None = None
     output_location: str | None = None
@@ -658,6 +661,8 @@ async def _compile_platform_spec(
     job_name: str | None,
     service_name: str,
     sdk: AsyncNeMoPlatform,
+    profile: str | None,
+    options: dict[str, Any] | None,
 ) -> PlatformJobSpec:
     """Compile input and output specs into a PlatformJobSpec for execution.
 
@@ -674,12 +679,30 @@ async def _compile_platform_spec(
         PermissionError: If the compiler raises a PermissionError.
     """
     try:
+        submit_control_kwargs = _submit_control_kwargs(compiler, profile=profile, options=options)
         if inspect.iscoroutinefunction(compiler):
-            platform_spec = await compiler(workspace, original_spec, transformed_spec, entity_client, job_name, sdk)
+            platform_spec = cast(
+                PlatformJobSpec,
+                await compiler(
+                    workspace, original_spec, transformed_spec, entity_client, job_name, sdk, **submit_control_kwargs
+                ),
+            )
         else:
             # Run sync compilers in a thread pool to avoid blocking the event loop.
-            platform_spec = await to_thread.run_sync(
-                partial(compiler, workspace, original_spec, transformed_spec, entity_client, job_name, sdk)
+            platform_spec = cast(
+                PlatformJobSpec,
+                await to_thread.run_sync(
+                    partial(
+                        compiler,
+                        workspace,
+                        original_spec,
+                        transformed_spec,
+                        entity_client,
+                        job_name,
+                        sdk,
+                        **submit_control_kwargs,
+                    )
+                ),
             )
 
         _validate_job_spec(platform_spec)
@@ -699,6 +722,41 @@ async def _compile_platform_spec(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=f"Failed to compile {service_name} job spec: {str(e)}",
         ) from e
+
+
+def _submit_control_kwargs(
+    compiler: Callable[..., object],
+    *,
+    profile: str | None,
+    options: dict[str, Any] | None,
+) -> dict[str, object]:
+    """Return profile/options kwargs accepted by *compiler*.
+
+    The low-level ``job_route_factory`` predates submitter controls and has
+    six-argument compiler call sites. Preserve those call sites while allowing
+    ``add_job_routes`` adapters and newer compilers to receive the body fields.
+    """
+    signature = inspect.signature(compiler)
+    parameters = signature.parameters
+    accepts_kwargs = any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters.values())
+    accepts_profile = accepts_kwargs or "profile" in parameters
+    accepts_options = accepts_kwargs or "options" in parameters
+
+    unsupported = []
+    if profile is not None and not accepts_profile:
+        unsupported.append("profile")
+    if options and not accepts_options:
+        unsupported.append("options")
+    if unsupported:
+        compiler_name = getattr(compiler, "__qualname__", getattr(compiler, "__name__", repr(compiler)))
+        raise PlatformJobCompilationError(f"{compiler_name} does not support submit field(s): {', '.join(unsupported)}")
+
+    kwargs: dict[str, object] = {}
+    if accepts_profile:
+        kwargs["profile"] = profile
+    if accepts_options:
+        kwargs["options"] = options
+    return kwargs
 
 
 def job_route_factory(
@@ -873,6 +931,8 @@ def job_route_factory(
                 job_name,
                 service_name,
                 sdk,
+                request.profile,
+                request.options,
             )
 
             # Create the job using the SDK pointed to the platform jobs microservice.

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py
@@ -20,9 +20,9 @@ from typing import (
     Generic,
     Literal,
     Type,
+    TypeGuard,
     TypeVar,
     Union,
-    cast,
     get_args,
     get_origin,
     overload,
@@ -287,6 +287,10 @@ def _validate_job_spec(job: PlatformJobSpec) -> None:
     validate_gpu_available_for_docker(job)
 
 
+def _is_platform_job_spec(job: object) -> TypeGuard[PlatformJobSpec]:
+    return isinstance(job, dict) and "steps" in job
+
+
 class BaseResultSerializer(BaseModel, ABC):
     def route_kwargs(self) -> dict:
         """
@@ -331,7 +335,7 @@ class JSONLResultSerializer(BaseResultSerializer):
         }
         return ret
 
-    async def _file_lines_iterator(self, file_path: str, limit: int | None = None):
+    async def _file_lines_iterator(self, file_path: Path, limit: int | None = None):
         async with await open_file(file_path, mode="r", encoding="utf-8") as f:
             lines = 0
             async for line in f:
@@ -340,7 +344,7 @@ class JSONLResultSerializer(BaseResultSerializer):
                 if limit and lines >= limit:
                     return
 
-    def serialize(self, output_path: Path, limit: int | None = None) -> StreamingResponse:
+    def serialize(self, output_path: Path, limit: int | None = None, **_kwargs: object) -> StreamingResponse:
         """
         Stream a DataFrame row by row as JSON objects
         """
@@ -395,7 +399,7 @@ class PydanticJSONLResultSerializer(BaseResultSerializer):
                 if limit and lines >= limit:
                     return
 
-    def serialize(self, output_path: Path, limit: int | None = None) -> StreamingResponse:
+    def serialize(self, output_path: Path, limit: int | None = None, **_kwargs: object) -> StreamingResponse:
         return StreamingResponse(
             self._validated_lines_iterator(str(output_path), limit), media_type="application/jsonl"
         )
@@ -680,31 +684,32 @@ async def _compile_platform_spec(
     """
     try:
         submit_control_kwargs = _submit_control_kwargs(compiler, profile=profile, options=options)
+        compile_result: PlatformJobSpec | Awaitable[PlatformJobSpec]
         if inspect.iscoroutinefunction(compiler):
-            platform_spec = cast(
-                PlatformJobSpec,
-                await compiler(
-                    workspace, original_spec, transformed_spec, entity_client, job_name, sdk, **submit_control_kwargs
-                ),
+            compile_result = compiler(
+                workspace, original_spec, transformed_spec, entity_client, job_name, sdk, **submit_control_kwargs
             )
         else:
             # Run sync compilers in a thread pool to avoid blocking the event loop.
-            platform_spec = cast(
-                PlatformJobSpec,
-                await to_thread.run_sync(
-                    partial(
-                        compiler,
-                        workspace,
-                        original_spec,
-                        transformed_spec,
-                        entity_client,
-                        job_name,
-                        sdk,
-                        **submit_control_kwargs,
-                    )
-                ),
+            compile_result = await to_thread.run_sync(
+                partial(
+                    compiler,
+                    workspace,
+                    original_spec,
+                    transformed_spec,
+                    entity_client,
+                    job_name,
+                    sdk,
+                    **submit_control_kwargs,
+                )
             )
+        if inspect.isawaitable(compile_result):
+            platform_spec = await compile_result
+        else:
+            platform_spec = compile_result
 
+        if not _is_platform_job_spec(platform_spec):
+            raise PlatformJobCompilationError("compiled job spec must be a mapping with steps")
         _validate_job_spec(platform_spec)
         return platform_spec
     except PermissionError as e:
@@ -871,12 +876,13 @@ def job_route_factory(
     # When job_output is not provided, they are the same type.
     # Type ignore is safe here because _validate_basemodel_or_union already validated these types
     # are either BaseModel subclasses or unions of BaseModel subclasses.
-    TypedJobRequest = type(f"{job_type}JobRequest", (BaseJobRequest[job_input],), {})
-    TypedJobResponse = type(f"{job_type}Job", (BaseJob[job_output],), {})
+    TypedJobRequest = type(f"{job_type}JobRequest", (BaseJobRequest[job_input],), {})  # ty: ignore[invalid-type-form]
+    TypedJobResponse = type(f"{job_type}Job", (BaseJob[job_output],), {})  # ty: ignore[invalid-type-form]
     TypedJobsListFilter = type(f"{job_type}JobsListFilter", (BaseJobsListFilter,), {})
 
     TypedJobsSortField = StrEnum(
-        f"{job_type}JobsSortField", {name: member.value for name, member in BaseJobsSortField.__members__.items()}
+        f"{job_type}JobsSortField",  # ty: ignore[mismatched-type-name]
+        {name: member.value for name, member in BaseJobsSortField.__members__.items()},
     )
 
     def from_response(job_resp: PlatformJob) -> TypedJobResponse:
@@ -890,7 +896,7 @@ def job_route_factory(
             created_at=job_resp.created_at,
             updated_at=job_resp.updated_at,
             spec=handle_job_spec_mismatch(job_output, job_resp.spec),
-            status=job_resp.status,  # type: ignore
+            status=job_resp.status,
             status_details=job_resp.status_details,
             error_details=job_resp.error_details,
             ownership=job_resp.ownership,
@@ -993,8 +999,8 @@ def job_route_factory(
             sdk: AsyncNeMoPlatform = Depends(get_sdk_client),
             page: int = Query(default=1, description="Page number.", gt=0),
             page_size: int = Query(default=10, description="Page size.", gt=0),
-            sort: TypedJobsSortField = Query(  # type: ignore[valid-type]
-                default=TypedJobsSortField.CREATED_AT_DESC,
+            sort: TypedJobsSortField = Query(  # ty: ignore[invalid-type-form]
+                default=TypedJobsSortField(BaseJobsSortField.CREATED_AT_DESC.value),
                 description="The field to sort by. To sort in decreasing order, use `-` in front of the field name.",
             ),
             parsed: ParsedFilter = Depends(make_filter_dep(TypedJobsListFilter)),

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/routes.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/routes.py
@@ -33,14 +33,10 @@ Compare to the legacy pattern this replaces::
         generate_job_name=my_name_generator,
     )
 
-``add_job_routes`` applies :func:`stamp_profile` to the compiled
-``PlatformJobSpec`` using ``default_profile``. It does *not* yet thread
-submitter-provided ``profile`` / ``options`` body fields through
-:class:`BaseJobRequest`; the wrapper passes ``profile=None`` /
-``options=None`` to ``NemoJob.compile`` until the request body shape is
-extended. (The submitter CLI flags ``--profile`` / ``-o`` reach
-``submit_remote`` and are POSTed in the body, where the server currently
-ignores them via Pydantic's ``extra="ignore"`` default.)
+``add_job_routes`` threads submitter-provided ``profile`` / ``options``
+body fields through to ``NemoJob.compile``. It then applies
+:func:`stamp_profile` to the compiled ``PlatformJobSpec`` using the submitted
+profile, or ``default_profile`` when the request did not choose one.
 """
 
 from __future__ import annotations
@@ -101,8 +97,8 @@ def add_job_routes(
             provide a ``name``. Passthrough to the factory.
         default_profile: Profile label stamped onto each step of the
             compiled ``PlatformJobSpec`` when the plugin's ``compile``
-            didn't set one explicitly. Submitter-chosen ``--profile``
-            plumbing is not yet wired through ``BaseJobRequest``.
+            didn't set one explicitly and the submitter did not provide
+            ``profile``.
 
     Returns:
         An :class:`APIRouter` with the standard job endpoints mounted.
@@ -267,11 +263,12 @@ def _adapt_compile(
     """Bridge ``NemoJob.compile`` to the factory's ``platform_job_config_compiler`` shape.
 
     The factory calls ``compiler(workspace, original_spec, transformed_spec,
-    entity_client, job_name, sdk)``. :meth:`NemoJob.compile` is an
-    ``async classmethod`` that uses kwargs and also accepts
-    ``profile`` / ``options``; both are passed as ``None`` until the
-    request body shape threads them through. After ``compile`` returns,
-    the adapter applies :func:`stamp_profile` with ``default_profile``.
+    entity_client, job_name, sdk)`` and forwards submitter-provided
+    ``profile`` / ``options`` to compilers that accept those kwargs.
+    :meth:`NemoJob.compile` is an ``async classmethod`` that uses kwargs and
+    accepts those submit controls. After ``compile`` returns, the adapter
+    applies :func:`stamp_profile` with the submitted profile or
+    ``default_profile``.
 
     Missing-override errors from the ``NemoJob.compile`` base marker
     become :class:`PlatformJobCompilationError` so the factory's
@@ -285,6 +282,8 @@ def _adapt_compile(
         entity_client: Any,
         job_name: str | None,
         sdk: Any,
+        profile: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> Any:
         del original_spec  # NemoJob.compile only needs the canonical (transformed) spec
         try:
@@ -294,13 +293,13 @@ def _adapt_compile(
                 entity_client=entity_client,
                 job_name=job_name,
                 async_sdk=sdk,
-                profile=None,
-                options=None,
+                profile=profile,
+                options=options,
             )
         except NotImplementedError as exc:
             raise PlatformJobCompilationError(str(exc)) from exc
 
-        stamp_profile(result, default_profile)
+        stamp_profile(result, profile or default_profile)
         return result
 
     return compile_adapter

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/routes.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/routes.py
@@ -50,6 +50,7 @@ from nemo_platform_plugin.job import job_collection_path_for
 from nemo_platform_plugin.jobs.api_factory import (
     JobRouteOption,
     PlatformJobResultRoute,
+    _submit_control_kwargs,
     job_route_factory,
 )
 from nemo_platform_plugin.jobs.exceptions import PlatformJobCompilationError
@@ -287,14 +288,14 @@ def _adapt_compile(
     ) -> Any:
         del original_spec  # NemoJob.compile only needs the canonical (transformed) spec
         try:
+            submit_control_kwargs = _submit_control_kwargs(job_cls.compile, profile=profile, options=options)
             result = await job_cls.compile(
                 workspace=workspace,
                 spec=transformed_spec,
                 entity_client=entity_client,
                 job_name=job_name,
                 async_sdk=sdk,
-                profile=profile,
-                options=options,
+                **submit_control_kwargs,
             )
         except NotImplementedError as exc:
             raise PlatformJobCompilationError(str(exc)) from exc

--- a/packages/nemo_platform_plugin/tests/test_jobs_create_spec_json.py
+++ b/packages/nemo_platform_plugin/tests/test_jobs_create_spec_json.py
@@ -133,3 +133,94 @@ def test_create_job_forwards_transformed_spec_in_json_mode() -> None:
     assert blob == base64.b64encode(_PICKLE_BYTES).decode("ascii")
     # Must be JSON-serializable for the typed jobs client (raw bytes would 500).
     json.dumps({"spec": spec})
+
+
+def test_create_job_forwards_profile_and_options_to_compiler() -> None:
+    """Submitter controls belong to the compiler, not Pydantic's ignored extras."""
+    seen: dict[str, object] = {}
+
+    async def _capturing_compiler(
+        workspace: str,
+        original_spec: _InputSpec,
+        transformed_spec: _InputSpec,
+        entity_client: object,
+        job_name: str | None,
+        sdk: object,
+        profile: str | None = None,
+        options: dict | None = None,
+    ) -> PlatformJobSpec:
+        del workspace, original_spec, transformed_spec, entity_client, job_name, sdk
+        seen.update(profile=profile, options=options)
+        return PlatformJobSpec(
+            steps=[
+                PlatformJobStep(
+                    name="step",
+                    executor=CPUExecutionProviderSpec(
+                        provider="cpu",
+                        profile=profile or "default",
+                        container=ContainerSpec(image="test"),
+                    ),
+                    config={},
+                )
+            ]
+        )
+
+    router = job_route_factory(
+        service_name="widgets",
+        job_type="Widget",
+        job_input=_InputSpec,
+        platform_job_config_compiler=_capturing_compiler,
+    )
+    app = FastAPI()
+    app.include_router(router, prefix="/apis/widgets/v2/workspaces/{workspace}")
+    app.dependency_overrides[get_sdk_client] = lambda: MagicMock()
+    app.dependency_overrides[get_entity_client] = lambda: MagicMock()
+
+    async def _create_job(*, workspace: str, body: object) -> MagicMock:
+        del workspace, body
+        return _mock_create_response({"label": "metric"})
+
+    mock_jobs = SimpleNamespace(create_job=_create_job)
+
+    client = TestClient(app)
+    with patch(
+        "nemo_platform_plugin.jobs.api_factory.client_from_platform",
+        return_value=mock_jobs,
+    ):
+        response = client.post(
+            "/apis/widgets/v2/workspaces/default/jobs",
+            json={
+                "spec": {"label": "metric"},
+                "profile": "research",
+                "options": {"slurm": {"nodes": 4}},
+            },
+        )
+
+    assert response.status_code == 201, response.text
+    assert seen == {"profile": "research", "options": {"slurm": {"nodes": 4}}}
+
+
+def test_create_job_rejects_unsupported_profile_and_options() -> None:
+    router = job_route_factory(
+        service_name="widgets",
+        job_type="Widget",
+        job_input=_InputSpec,
+        platform_job_config_compiler=_compiler,
+    )
+    app = FastAPI()
+    app.include_router(router, prefix="/apis/widgets/v2/workspaces/{workspace}")
+    app.dependency_overrides[get_sdk_client] = lambda: MagicMock()
+    app.dependency_overrides[get_entity_client] = lambda: MagicMock()
+
+    client = TestClient(app)
+    response = client.post(
+        "/apis/widgets/v2/workspaces/default/jobs",
+        json={
+            "spec": {"label": "metric"},
+            "profile": "research",
+            "options": {"slurm": {"nodes": 4}},
+        },
+    )
+
+    assert response.status_code == 422, response.text
+    assert "does not support submit field(s): profile, options" in response.json()["detail"]

--- a/packages/nemo_platform_plugin/tests/test_jobs_routes.py
+++ b/packages/nemo_platform_plugin/tests/test_jobs_routes.py
@@ -395,6 +395,89 @@ async def test_compile_adapter_forwards_submitted_profile_and_options() -> None:
 
 
 @pytest.mark.asyncio
+async def test_compile_adapter_omits_empty_controls_for_legacy_compile() -> None:
+    seen: dict[str, object] = {}
+
+    class LegacyCompile(NemoJob):
+        name = "legacy-compile"
+        spec_schema = _WidgetSpec
+
+        def run(self, config: dict) -> dict:
+            return config
+
+        @classmethod
+        async def compile(
+            cls,
+            *,
+            workspace: str,
+            spec: BaseModel,
+            entity_client,
+            job_name,
+            async_sdk,
+        ):
+            seen.update(workspace=workspace, spec=spec, entity_client=entity_client, job_name=job_name, sdk=async_sdk)
+            return _FakePlatformSpec(steps=[_FakeStep(profile=None)])
+
+    adapter = _adapt_compile(LegacyCompile, default_profile="default")
+    platform_spec = await adapter(
+        "ws",
+        None,
+        _WidgetSpec(name="x"),
+        "ec",
+        "job-1",
+        "sdk",
+        profile=None,
+        options={},
+    )
+
+    assert seen == {
+        "workspace": "ws",
+        "spec": _WidgetSpec(name="x"),
+        "entity_client": "ec",
+        "job_name": "job-1",
+        "sdk": "sdk",
+    }
+    assert platform_spec.steps[0].executor.profile == "default"
+
+
+@pytest.mark.asyncio
+async def test_compile_adapter_rejects_unsupported_submitted_controls_for_legacy_compile() -> None:
+    class LegacyCompile(NemoJob):
+        name = "legacy-compile"
+        spec_schema = _WidgetSpec
+
+        def run(self, config: dict) -> dict:
+            return config
+
+        @classmethod
+        async def compile(
+            cls,
+            *,
+            workspace: str,
+            spec: BaseModel,
+            entity_client,
+            job_name,
+            async_sdk,
+        ):
+            del workspace, spec, entity_client, job_name, async_sdk
+            return _FakePlatformSpec(steps=[_FakeStep(profile=None)])
+
+    adapter = _adapt_compile(LegacyCompile, default_profile="default")
+
+    with pytest.raises(PlatformJobCompilationError, match="does not support submit field\\(s\\): profile, options"):
+        await adapter(
+            "ws",
+            None,
+            _WidgetSpec(name="x"),
+            "ec",
+            None,
+            "sdk",
+            profile="research",
+            options={"slurm": {"nodes": 4}},
+        )
+
+
+@pytest.mark.asyncio
 async def test_compile_adapter_preserves_profile_set_by_plugin_compile() -> None:
     class CompileSetsProfile(NemoJob):
         name = "pre-stamped"

--- a/packages/nemo_platform_plugin/tests/test_jobs_routes.py
+++ b/packages/nemo_platform_plugin/tests/test_jobs_routes.py
@@ -353,6 +353,48 @@ async def test_compile_adapter_invokes_nemo_compile_and_stamps_default_profile()
 
 
 @pytest.mark.asyncio
+async def test_compile_adapter_forwards_submitted_profile_and_options() -> None:
+    seen: dict = {}
+
+    class CaptureSubmitControls(NemoJob):
+        name = "capture-submit-controls"
+        spec_schema = _WidgetSpec
+
+        def run(self, config: dict) -> dict:
+            return config
+
+        @classmethod
+        async def compile(
+            cls,
+            *,
+            workspace: str,
+            spec: BaseModel,
+            entity_client,
+            job_name,
+            async_sdk,
+            profile=None,
+            options=None,
+        ):
+            seen.update(profile=profile, options=options)
+            return _FakePlatformSpec(steps=[_FakeStep(profile=None)])
+
+    adapter = _adapt_compile(CaptureSubmitControls, default_profile="default")
+    platform_spec = await adapter(
+        "ws",
+        None,
+        _WidgetSpec(name="x"),
+        "ec",
+        None,
+        "sdk",
+        profile="research",
+        options={"slurm": {"nodes": 4}},
+    )
+
+    assert seen == {"profile": "research", "options": {"slurm": {"nodes": 4}}}
+    assert platform_spec.steps[0].executor.profile == "research"
+
+
+@pytest.mark.asyncio
 async def test_compile_adapter_preserves_profile_set_by_plugin_compile() -> None:
     class CompileSetsProfile(NemoJob):
         name = "pre-stamped"

--- a/packages/nmp_common/tests/api_factory/test_api_factory.py
+++ b/packages/nmp_common/tests/api_factory/test_api_factory.py
@@ -1715,7 +1715,9 @@ class TestCompilePlatformSpec:
         def compiler(workspace, input_spec, output_spec, entity_client, job_name, sdk):
             return expected
 
-        result = await _compile_platform_spec(compiler, "ws", spec, spec, MagicMock(), "name", "svc", MagicMock())
+        result = await _compile_platform_spec(
+            compiler, "ws", spec, spec, MagicMock(), "name", "svc", MagicMock(), None, None
+        )
         assert result is expected
 
     @pytest.mark.anyio
@@ -1727,7 +1729,9 @@ class TestCompilePlatformSpec:
         async def compiler(workspace, input_spec, output_spec, entity_client, job_name, sdk):
             return expected
 
-        result = await _compile_platform_spec(compiler, "ws", spec, spec, MagicMock(), "name", "svc", MagicMock())
+        result = await _compile_platform_spec(
+            compiler, "ws", spec, spec, MagicMock(), "name", "svc", MagicMock(), None, None
+        )
         assert result is expected
 
     @pytest.mark.anyio
@@ -1740,7 +1744,9 @@ class TestCompilePlatformSpec:
 
         spec = FooJobConfig(foo="a", bar=1)
         with pytest.raises(HTTPException) as exc_info:
-            await _compile_platform_spec(bad_compiler, "ws", spec, spec, MagicMock(), "name", "my_svc", MagicMock())
+            await _compile_platform_spec(
+                bad_compiler, "ws", spec, spec, MagicMock(), "name", "my_svc", MagicMock(), None, None
+            )
         assert exc_info.value.status_code == 422
         assert "my_svc" in exc_info.value.detail
         assert "missing field" in exc_info.value.detail
@@ -1766,6 +1772,8 @@ class TestCompilePlatformSpec:
                 "name",
                 "my_svc",
                 MagicMock(),
+                None,
+                None,
             )
         assert exc_info.value.status_code == 503
         assert "my_svc" in exc_info.value.detail
@@ -1795,7 +1803,9 @@ class TestCompilePlatformSpec:
 
         spec = FooJobConfig(foo="a", bar=1)
         with pytest.raises(HTTPException) as exc_info:
-            await _compile_platform_spec(compiler_bad_config, "ws", spec, spec, MagicMock(), "name", "svc", MagicMock())
+            await _compile_platform_spec(
+                compiler_bad_config, "ws", spec, spec, MagicMock(), "name", "svc", MagicMock(), None, None
+            )
         assert exc_info.value.status_code == 422
         assert "not json serializable" in exc_info.value.detail.lower()
 

--- a/plugins/nemo-agents/openapi/openapi.yaml
+++ b/plugins/nemo-agents/openapi/openapi.yaml
@@ -4458,6 +4458,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/AnalyzeBatchConfig'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -5075,6 +5082,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/EvaluateAgentSpec'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -5293,6 +5307,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/EvaluateSuiteSubmitConfig'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -5573,6 +5594,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/ExecuteAgentJobConfig'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -5958,6 +5986,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/OptimizeSpec'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -6177,6 +6212,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/OptimizeSkillsConfig'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -6424,6 +6466,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/PackageAgentInput'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true

--- a/plugins/nemo-anonymizer/openapi/openapi.yaml
+++ b/plugins/nemo-anonymizer/openapi/openapi.yaml
@@ -1455,6 +1455,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/AnonymizerRequest'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true

--- a/plugins/nemo-auditor/openapi/openapi.yaml
+++ b/plugins/nemo-auditor/openapi/openapi.yaml
@@ -1041,6 +1041,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/AuditInputSpec'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true

--- a/plugins/nemo-customizer/openapi/openapi.yaml
+++ b/plugins/nemo-customizer/openapi/openapi.yaml
@@ -1317,6 +1317,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/AutomodelJobInput'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -2782,6 +2789,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/RlJobInput'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -3374,6 +3388,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/UnslothJobInput'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true

--- a/plugins/nemo-data-designer/openapi/openapi.yaml
+++ b/plugins/nemo-data-designer/openapi/openapi.yaml
@@ -826,6 +826,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/DataDesignerJobConfig'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true

--- a/plugins/nemo-evaluator/openapi/openapi.yaml
+++ b/plugins/nemo-evaluator/openapi/openapi.yaml
@@ -2540,6 +2540,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/AgentEvalInputSpec'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -3185,6 +3192,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/EvaluateInputSpec'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true

--- a/plugins/nemo-iron-swarm/openapi/openapi.yaml
+++ b/plugins/nemo-iron-swarm/openapi/openapi.yaml
@@ -2683,6 +2683,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/SynthBenignSpec'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true
@@ -2929,6 +2936,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/WarGameSpec'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true

--- a/plugins/nemo-safe-synthesizer/openapi/openapi.yaml
+++ b/plugins/nemo-safe-synthesizer/openapi/openapi.yaml
@@ -847,6 +847,13 @@ components:
           type: string
         spec:
           $ref: '#/components/schemas/SafeSynthesizerJobConfig'
+        profile:
+          title: Profile
+          type: string
+        options:
+          title: Options
+          additionalProperties: true
+          type: object
         ownership:
           title: Ownership
           additionalProperties: true

--- a/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/jobs/generate.py
+++ b/plugins/nemo-safe-synthesizer/src/nemo_safe_synthesizer_plugin/jobs/generate.py
@@ -83,6 +83,9 @@ class GenerateJob(NemoJob):
         options: dict | None = None,
     ) -> PlatformJobSpec:
         assert isinstance(spec, SafeSynthesizerJobConfig)
+        if options:
+            raise PlatformJobCompilationError("Safe Synthesizer does not support submit options.")
+
         steps = []
 
         try:
@@ -154,7 +157,7 @@ class GenerateJob(NemoJob):
                 ) from e
 
         if spec.config:
-            steps.append(_create_job_step(spec, environment))
+            steps.append(_create_job_step(spec, environment, profile=profile))
 
         if not steps:
             raise PlatformJobCompilationError("No steps to run")
@@ -164,7 +167,12 @@ class GenerateJob(NemoJob):
         raise NotImplementedError("Safe Synthesizer does not support local execution.")
 
 
-def _create_job_step(spec: SafeSynthesizerJobConfig, environment: list[EnvironmentVariable]) -> PlatformJobStep:
+def _create_job_step(
+    spec: SafeSynthesizerJobConfig,
+    environment: list[EnvironmentVariable],
+    *,
+    profile: str | None = None,
+) -> PlatformJobStep:
     resources = ResourcesSpec(
         limits=ResourcesLimitsSpec(
             memory=plugin_config.default_job_resource_memory_limit,
@@ -179,7 +187,7 @@ def _create_job_step(spec: SafeSynthesizerJobConfig, environment: list[Environme
         name="safe-synthesizer",
         executor=GPUExecutionProviderSpec(
             provider="gpu",
-            profile=plugin_config.job_executor_profile,
+            profile=profile or plugin_config.job_executor_profile,
             container=ContainerSpec(
                 image=plugin_config.container_image_ref or get_qualified_image(plugin_config.container_image),
                 entrypoint=plugin_config.entrypoint,

--- a/plugins/nemo-safe-synthesizer/tests/unit/test_jobs.py
+++ b/plugins/nemo-safe-synthesizer/tests/unit/test_jobs.py
@@ -89,13 +89,15 @@ def _make_spec(data_source: str = DEFAULT_DATA_SOURCE, model_provider: str | Non
     )
 
 
-async def _compile(spec, mock_sdk):
+async def _compile(spec, mock_sdk, *, profile: str | None = None, options: dict | None = None):
     return await GenerateJob.compile(
         workspace=DEFAULT_WORKSPACE,
         spec=spec,
         entity_client=MagicMock(),
         job_name=None,
         async_sdk=mock_sdk,
+        profile=profile,
+        options=options,
     )
 
 
@@ -159,6 +161,22 @@ async def test_job_config_compiler_uses_safe_synthesizer_tasks_image(mock_sdk, m
         "-m",
         "nemo_safe_synthesizer_plugin.tasks.safe_synthesizer",
     ]
+
+
+@pytest.mark.asyncio
+async def test_job_config_compiler_uses_submitted_profile(mock_sdk, monkeypatch):
+    monkeypatch.setattr(generate.plugin_config, "job_executor_profile", "configured-default")
+
+    result = await _compile(_make_spec(), mock_sdk, profile="research")
+
+    step = next(iter(result["steps"]))
+    assert step["executor"]["profile"] == "research"
+
+
+@pytest.mark.asyncio
+async def test_job_config_compiler_rejects_submit_options(mock_sdk):
+    with pytest.raises(PlatformJobCompilationError, match="does not support submit options"):
+        await _compile(_make_spec(), mock_sdk, options={"slurm": {"nodes": 4}})
 
 
 @pytest.mark.asyncio

--- a/plugins/nemo-safe-synthesizer/tests/unit/test_service.py
+++ b/plugins/nemo-safe-synthesizer/tests/unit/test_service.py
@@ -28,6 +28,9 @@ def test_service_routes_include_safe_synthesizer_jobs_path():
     assert "/v2/workspaces/{workspace}/jobs" in spec["paths"]
     assert "/v2/workspaces/{workspace}/jobs/{job}/results/adapter/download" in spec["paths"]
     assert "GenerateJobRequest" in spec["components"]["schemas"]
+    request_properties = spec["components"]["schemas"]["GenerateJobRequest"]["properties"]
+    assert "profile" in request_properties
+    assert "options" in request_properties
 
 
 def test_service_authz_derives_from_job_routes():


### PR DESCRIPTION
## Summary

Threads submitted `profile` and `options` fields through generated plugin job routes instead of silently dropping them. Safe Synthesizer now honors `--profile` when compiling the job executor profile, and unsupported submit controls fail with clear validation errors instead of surfacing as internal errors.

## Related Issue

NVBug 6696527 / NPLAT-10

## Changes

- Added `profile` and `options` to generated job request bodies.
- Forwarded supported submit controls to platform job compilers while rejecting unsupported requested controls.
- Preserved legacy six-argument compile implementations by inspecting each concrete `job_cls.compile` before forwarding submit controls.
- Updated `add_job_routes` to pass submitted profile/options into `NemoJob.compile` and stamp the submitted profile as the fallback executor profile.
- Updated Safe Synthesizer `GenerateJob.compile` to use a submitted profile over plugin defaults and reject unsupported options.
- Removed the reviewer-noted `typing.cast` in `_compile_platform_spec`; the compiler result is now typed as `PlatformJobSpec | Awaitable[PlatformJobSpec]` and narrowed with `_is_platform_job_spec` before validation.
- Added focused coverage for route forwarding, legacy compile compatibility, unsupported controls, Safe Synthesizer profile handling, direct compiler helper calls, and generated request schemas.
- Regenerated plugin OpenAPI specs affected by the request-body schema change.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior - justification:
- [ ] Tests not applicable - justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable - justification: behavior now matches the existing submitted `--profile` CLI surface; generated OpenAPI was refreshed.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `make refresh-openapi` passed.
- `flox -q activate -- uv run --frozen ty check packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py` passed.
- `flox -q activate -- uv run ruff check packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py` passed.
- `flox -q activate -- uv run ruff format --check packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py` passed.
- `flox -q activate -- uv run --frozen pytest packages/nemo_platform_plugin/tests/test_jobs_routes.py packages/nemo_platform_plugin/tests/test_jobs_create_spec_json.py packages/nmp_common/tests/api_factory/test_api_factory.py::TestCompilePlatformSpec plugins/nemo-safe-synthesizer/tests/unit/test_jobs.py plugins/nemo-safe-synthesizer/tests/unit/test_service.py -v` passed: 52 tests.
- `flox -q activate -- uv run pre-commit run -a` ran through the repo hooks and then stopped in `studio-lint-staged` because `lint-staged` was not available in this local environment; earlier hooks in that run passed, including ruff, ruff format, ty, uv lock checks, license/header checks, plugin import guard, and merge-conflict check.
- Full repo `flox -q activate -- uv run --frozen ty check` still reports existing project-wide diagnostics unrelated to this reviewer comment; the changed `api_factory.py` file passes when checked directly.
- Local DCO audit over `merge-base(origin/release/0.5, HEAD)..HEAD` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Job requests now support optional execution profiles and custom options across supported job types.
  - Submitted profiles are applied during job execution, overriding configured defaults when provided.
  - API schemas now document the new request fields.

- **Bug Fixes**
  - Unsupported non-empty options are rejected with clear validation errors.
  - Compiler integrations now remain compatible with jobs that do not support the new controls.
  - Compiler results receive additional validation to improve error handling.

- **Tests**
  - Added coverage for profile and options forwarding, validation, default handling, and asynchronous compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->