### PR TITLE
fix(rl): copy CPython 3.13.15 from slim-bookworm, not slim-trixie

### DIFF
--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -32,12 +32,14 @@ ARG NEMO_RL_REPO=https://github.com/soluwalana/RL.git
 ARG NEMO_RL_REF=nmp/customizer
 
 # uv 0.11.18 bundles a vulnerable quinn-proto (0.12 has breaking changes, so stay on 0.11.x).
-# Official CPython 3.13.15 is copied from python:3.13.15-slim-trixie. uv's catalog has no
+# Official CPython 3.13.15 is copied from python:3.13.15-slim-bookworm. uv's catalog has no
 # cpython-3.13.15-linux-*-gnu download; do not use `uv python install` for this patch.
+# Donor must be bookworm (OpenSSL 3.0), not trixie: cuda-dl-base is Ubuntu 24.04
+# (OpenSSL 3.0.13). Trixie-built _ssl needs OPENSSL_3.3.0 and fails to import.
 # UV_PYTHON must still point at the copied binary so RL's `.python-version` cannot pin 3.13.14.
 ARG UV_VERSION=0.11.33
 ARG PYTHON_VERSION=3.13.15
-ARG CPYTHON_IMAGE=python:${PYTHON_VERSION}-slim-trixie
+ARG CPYTHON_IMAGE=python:${PYTHON_VERSION}-slim-bookworm
 ARG CMAKE_VERSION=4.0.3
 
 FROM ${CPYTHON_IMAGE} AS cpython

--- a/docker/rl/README.md
+++ b/docker/rl/README.md
@@ -431,9 +431,10 @@ the uv cache + venv prefetch rather than via wheel images:
 - **Transformer-Engine** is the longest compile. It comes in with the `automodel` extra,
   which the GRPO policy worker needs, so it is built from source here.
   RL uses `.python-version` to pin an exact patch release. CPython 3.13.15 is copied from
-  `python:3.13.15-slim-trixie` into `/opt/cpython` (uv's catalog has no linux-gnu 3.13.15
-  build). `UV_PYTHON=/opt/cpython/bin/python3.13` overrides `.python-version` so worker
-  venvs cannot silently stay on 3.13.14.
+  `python:3.13.15-slim-bookworm` into `/opt/cpython` (uv's catalog has no linux-gnu 3.13.15
+  build; bookworm's OpenSSL 3.0 matches Ubuntu 24.04 on cuda-dl-base — trixie _ssl
+  needs OPENSSL_3.3.0 and does not import). `UV_PYTHON=/opt/cpython/bin/python3.13`
+  overrides `.python-version` so worker venvs cannot silently stay on 3.13.14.
 
 ## Layering for fast CI rebuilds
 


### PR DESCRIPTION
## Summary

- `COPY` official CPython 3.13.15 from `python:3.13.15-slim-bookworm` into `/opt/cpython` on `cuda-dl-base` (Ubuntu 24.04), instead of `slim-trixie`.
- Trixie-built `_ssl` needs `OPENSSL_3.3.0`; NGC `cuda-dl-base:26.07-cuda13.3-devel-ubuntu24.04` ships OpenSSL **3.0.13**, so `import ssl` fails. Bookworm is OpenSSL 3.0 / glibc 2.36 onto Noble 2.39 (safe direction).
- Does **not** change bake `NMP_PYTHON_IMAGE` or other images that `FROM` Trixie (those rootfs already have Trixie OpenSSL).

Follow-up to #1623. Same donor change will be cherry-picked onto #1641 (`release/0.5`).

## Test plan

- [x] `COPY --from=python:3.13.15-slim-trixie` onto amd64 `cuda-dl-base`: `python -V` ok; `import ssl` → `OPENSSL_3.3.0` not found
- [x] Same COPY from `python:3.13.15-slim-bookworm`: `python -V` and `bz2,lzma,sqlite3,ctypes,readline,ssl,hashlib` all import
- [ ] CI on this PR
- [ ] Nightly / RL bake when available (catalog image is `nmp-rl-training`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Python runtime base image to improve compatibility with the CUDA environment.
  * Resolved an issue preventing the Python SSL module from importing correctly.

* **Documentation**
  * Documented the required Python image and OpenSSL compatibility details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->