### PR TITLE
fix(studio): allow running evaluation without a healthy deployment (ASTD-516)

### DIFF
--- a/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
+++ b/web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx
@@ -128,7 +128,7 @@ export const AgentDetailRoute: FC = () => {
   const modelNames = getAgentModelNames(agent?.config);
   const canDeploy = !!agent?.config;
 
-  const canRunEvaluation = !!agentName && canDeploy && healthyDeployments.length > 0;
+  const canRunEvaluation = !!agentName && canDeploy;
 
   const status = healthyDeployments.length > 0 ? 'running' : agentDeployments[0]?.status;
   const statusPillLabel =


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->

<img width="1750" height="1103" alt="Screenshot 2026-08-31 at 09 55 45" src="https://github.com/user-attachments/assets/ad34fd89-b6df-422a-8944-ade1eab9f9e5" />

## Summary

The page-level "Run evaluation" button on the Agent detail page was disabled whenever an agent had no healthy deployment, so `SubmitEvaluationModal` could never open. PR #1433 removed the equivalent deployment gate inside the modal, but this earlier gate made that fix unreachable. Now the button requires only a valid agent config, matching the modal's own gate — an agent without a running deployment can start an evaluation again.

## Related Issue

Fixes ASTD-516 (NVBugs 6683708). No GitHub issue.

## Changes

- Drop `healthyDeployments.length > 0` from `canRunEvaluation` in `web/packages/studio/src/routes/agents/AgentDetailRoute/index.tsx`, leaving `!!agentName && canDeploy`.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [x] Existing tests cover changed behavior — justification: `AgentDetailRoute/index.test.tsx` asserts the "Run evaluation" button renders; the change only widens when it is enabled, and behavior was verified manually in the running Studio dev server against an agent with no healthy deployment.
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing docs describe this button's enablement.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `npm run typecheck` (web/packages/studio) — passed.
- `vitest --run src/routes/agents/AgentDetailRoute/index.test.tsx` — 5 passed.
- Commit-stage pre-commit hooks (DCO sign-off, merge-conflict check) — passed. Full `uv run pre-commit run -a` not run for this single-line web change; relied on targeted typecheck + test above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation actions are now available when an agent has a name and deployable configuration, even if no healthy deployments are currently available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->