### PR TITLE
fix(rl): restore Python HTTPS support

### DIFF
--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -32,12 +32,12 @@ ARG NEMO_RL_REPO=https://github.com/soluwalana/RL.git
 ARG NEMO_RL_REF=nmp/customizer
 
 # uv 0.11.18 bundles a vulnerable quinn-proto (0.12 has breaking changes, so stay on 0.11.x).
-# Official CPython 3.13.15 is copied from python:3.13.15-slim-trixie. uv's catalog has no
+# Official CPython 3.13.15 is copied from python:3.13.15-slim-bookworm. uv's catalog has no
 # cpython-3.13.15-linux-*-gnu download; do not use `uv python install` for this patch.
 # UV_PYTHON must still point at the copied binary so RL's `.python-version` cannot pin 3.13.14.
 ARG UV_VERSION=0.11.33
 ARG PYTHON_VERSION=3.13.15
-ARG CPYTHON_IMAGE=python:${PYTHON_VERSION}-slim-trixie
+ARG CPYTHON_IMAGE=python:${PYTHON_VERSION}-slim-bookworm
 ARG CMAKE_VERSION=4.0.3
 
 FROM ${CPYTHON_IMAGE} AS cpython
@@ -86,6 +86,7 @@ RUN ARCH="$(uname -m)" && \
 # Official CPython (not uv-managed). libpython is $ORIGIN/../lib relative to the binary.
 COPY --from=cpython /usr/local /opt/cpython
 RUN chmod -R a+rX /opt/cpython
+RUN /opt/cpython/bin/python3.13 -c "import ssl; print(ssl.OPENSSL_VERSION)"
 
 # uv is the installer/sync tool only. CPython lives at /opt/cpython (world-readable) so the
 # runtime UID can follow venv symlinks. Copy the uv binary to /usr/local/bin for node env installs.

--- a/docker/rl/README.md
+++ b/docker/rl/README.md
@@ -431,7 +431,7 @@ the uv cache + venv prefetch rather than via wheel images:
 - **Transformer-Engine** is the longest compile. It comes in with the `automodel` extra,
   which the GRPO policy worker needs, so it is built from source here.
   RL uses `.python-version` to pin an exact patch release. CPython 3.13.15 is copied from
-  `python:3.13.15-slim-trixie` into `/opt/cpython` (uv's catalog has no linux-gnu 3.13.15
+  `python:3.13.15-slim-bookworm` into `/opt/cpython` (uv's catalog has no linux-gnu 3.13.15
   build). `UV_PYTHON=/opt/cpython/bin/python3.13` overrides `.python-version` so worker
   venvs cannot silently stay on 3.13.14.
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

[PR #1623](https://github.com/NVIDIA-NeMo/nemo-platform/pull/1623) copied CPython 3.13.15 from Debian Trixie into the Ubuntu 24.04 RL base, and the resulting interpreter cannot open HTTPS URLs. That breaks `causal-conv1d`'s prebuilt-wheel fetch with `unknown url type: https`, causing `nmp-rl-training` to fail.

This keeps Python 3.13.15 but sources it from Bookworm, which uses the same OpenSSL 3.0 generation as the CUDA base, and adds an early `import ssl` assertion so this incompatibility fails before the expensive RL dependency build.

## Changes

- Switch the RL CPython source image from `slim-trixie` to `slim-bookworm`.
- Assert that the copied interpreter can load SSL immediately after installation.
- Keep the RL image documentation aligned with the source image.

### Human attention needed

- **Decision:** approve Bookworm as the compatibility boundary for copied CPython 3.13.15.
- **Proof:** the image tag resolves for amd64 and arm64, and the multi-arch Bake graph renders successfully.
- **Biggest risk:** the full `nmp-rl-training` build and security scan are CI-only and remain pending.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: build-environment-only change; the internal RL README is updated for maintainers.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `git diff --check` — passed.
- `docker buildx imagetools inspect python:3.13.15-slim-bookworm` — resolved linux/amd64 and linux/arm64 manifests.
- `docker buildx bake --print nmp-rl-training` — passed; the target renders for linux/amd64 and linux/arm64.
- Full multi-arch `nmp-rl-training` build, RL smoke test, and security scan — pending CI; the repository explicitly keeps this cold GPU build out of local validation.
