### PR TITLE
fix: correct ssl handing so the RL docker build works again

### DIFF
--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -255,8 +255,14 @@ grep -Fq \
 
 uv sync ${UV_SYNC_MODE} --extra vllm      --no-install-project   # GRPO generation (vllm 0.20 cu130 + flashinfer + deep_gemm/deep_ep)
 uv sync ${UV_SYNC_MODE} --extra fsdp      --no-install-project   # DPO policy training (flash-attn, mamba-ssm, causal-conv1d)
+
+# Transformer Engine invokes Ninja with all detected CPUs by default. On the arm64 BuildKit worker,
+# eight simultaneous ptxas processes exhaust available memory. Limit only the two extras that
+# can build Transformer Engine; the remaining dependency syncs retain their normal parallelism.
+export NVTE_BUILD_MAX_JOBS=2
 uv sync ${UV_SYNC_MODE} --extra automodel --no-install-project   # GRPO policy training, DTensor V2 (+ LoRA); builds Transformer-Engine
 uv sync ${UV_SYNC_MODE} --extra mcore     --no-install-project   # Megatron training + Megatron-native generation; reuses automodel's TE
+unset NVTE_BUILD_MAX_JOBS
 uv sync ${UV_SYNC_MODE} --extra modelopt  --no-install-project   # quantization / model-opt
 uv sync ${UV_SYNC_MODE} --extra nemo_gym  --no-install-project   # NeMo-Gym (uv workspace member)
 uv sync ${UV_SYNC_MODE} --all-groups      --no-install-project   # build/test/etc groups

--- a/docker/rl/Dockerfile.nmp-rl-base
+++ b/docker/rl/Dockerfile.nmp-rl-base
@@ -86,6 +86,8 @@ RUN ARCH="$(uname -m)" && \
     rm -rf "${F}" "${F}.tar.gz"
 
 # Official CPython (not uv-managed). libpython is $ORIGIN/../lib relative to the binary.
+# The extension modules also link against OpenSSL from this copied prefix, so expose its libdir to
+# the dynamic loader before Python imports urllib's HTTPS support.
 COPY --from=cpython /usr/local /opt/cpython
 RUN chmod -R a+rX /opt/cpython
 
@@ -98,13 +100,15 @@ ARG UV_VERSION
 # Raise uv's HTTP retry budget and cap concurrent downloads for large GitHub-hosted wheels like vLLM,
 # which can hit transient HTTP/2 refused-stream failures under BuildKit.
 ENV UV_PYTHON=/opt/cpython/bin/python3.13 \
+    LD_LIBRARY_PATH=/opt/cpython/lib \
     UV_HTTP_TIMEOUT=120 \
     UV_HTTP_RETRIES=8 \
     UV_CONCURRENT_DOWNLOADS=4 \
     PATH="/opt/cpython/bin:/usr/local/bin:/root/.local/bin:${PATH}"
 RUN umask 022 && \
     curl -LsSf "https://astral.sh/uv/${UV_VERSION}/install.sh" | sh && \
-    cp /root/.local/bin/uv /usr/local/bin/uv
+    cp /root/.local/bin/uv /usr/local/bin/uv && \
+    python3.13 -c 'import ssl, urllib.request; print(ssl.OPENSSL_VERSION)'
 COPY docker/scripts/collect-apt-sources.sh \
     docker/scripts/collect-python-sdists.py \
     /usr/local/bin/


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
The docker build for the RL base container is breaking right now. It seems to be the change in how python was installed and ssl handling, though there could be another problem with the causal-conv1d wheel. Testing this and making sure this is the right way.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTPS compatibility for extensions using the bundled Python runtime.
  * Added installation-time verification of SSL functionality and OpenSSL version detection.
  * Improved build reliability for Transformer Engine components by limiting parallel build activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->