### PR TITLE
fix(quickstart): backfill legacy dev secrets config

### DIFF
--- a/packages/nmp_platform_runner/src/nmp/platform_runner/config.py
+++ b/packages/nmp_platform_runner/src/nmp/platform_runner/config.py
@@ -41,6 +41,10 @@ _SCOPE_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _INSTANCES_DIRNAME = "instances"
 _SOCKET_FILENAME = "nemo-platform.sock"
 _LOG_FILENAME = "services.log"
+_QUICKSTART_PLATFORM_CONFIG_FILENAME = "platform-config.yaml"
+_SECRETS_ALLOW_KEY_CREATION_ENV_VAR = "NMP_SECRETS_ALLOW_KEY_CREATION"
+_SECRETS_LOCAL_KEY_CREATION_PATH_ENV_VAR = "NMP_SECRETS_LOCAL_KEY_CREATION_PATH"
+_QUICKSTART_LOCAL_KEY_CREATION_PATH = "/data/nmp-encryption-key.txt"
 
 
 @dataclass
@@ -328,6 +332,7 @@ def apply_run_environment(
     # self-call origin must stay aligned with the resolved base URL. Deployed
     # mode can still override this explicitly by pre-setting the env var.
     env.setdefault("NMP_AUTH_POLICY_DECISION_POINT_BASE_URL", base_url)
+    _apply_quickstart_dev_secrets_defaults(config, env)
     _set_or_clear_env(env, NMP_SERVICES_ENV_VAR, config.services)
     _set_or_clear_env(env, NMP_CONTROLLERS_ENV_VAR, config.controllers)
     _set_or_clear_env(env, NMP_SIDECARS_ENV_VAR, config.sidecars)
@@ -339,6 +344,49 @@ def _set_or_clear_env(env: MutableMapping[str, str], name: str, values: set[str]
         env[name] = ",".join(sorted(values))
     else:
         env.pop(name, None)
+
+
+def _apply_quickstart_dev_secrets_defaults(
+    config: ResolvedRunConfiguration,
+    env: MutableMapping[str, str],
+) -> None:
+    """Backfill quickstart's dev/demo secrets fallback for legacy configs.
+
+    The secrets service deliberately defaults ``allow_key_creation`` to false.
+    Quickstart is the dev/demo exception, and older generated
+    ``platform-config.yaml`` files can omit that field while also omitting a
+    real encryption provider. Keep the backfill tied to quickstart's config file
+    convention so Helm and other named-provider configs continue to fail closed.
+    """
+    if _SECRETS_ALLOW_KEY_CREATION_ENV_VAR in env:
+        return
+    if Path(config.config_path).name != _QUICKSTART_PLATFORM_CONFIG_FILENAME:
+        return
+    try:
+        global_settings = Configuration.get_global_settings_from_file(config.config_path)
+    except (OSError, ValueError):
+        return
+    secrets_settings = global_settings.get("secrets")
+    if isinstance(secrets_settings, dict):
+        if "allow_key_creation" in secrets_settings:
+            return
+        if _has_explicit_secrets_encryption_provider(secrets_settings.get("encryption")):
+            return
+
+    env[_SECRETS_ALLOW_KEY_CREATION_ENV_VAR] = "1"
+    env.setdefault(_SECRETS_LOCAL_KEY_CREATION_PATH_ENV_VAR, _QUICKSTART_LOCAL_KEY_CREATION_PATH)
+
+
+def _has_explicit_secrets_encryption_provider(encryption_settings: object) -> bool:
+    if not isinstance(encryption_settings, dict):
+        return False
+    current_provider = encryption_settings.get("current_provider")
+    if isinstance(current_provider, str) and current_provider.strip():
+        return True
+    providers = encryption_settings.get("providers")
+    if not isinstance(providers, dict):
+        return False
+    return any(isinstance(provider_map, dict) and bool(provider_map) for provider_map in providers.values())
 
 
 def _config_file_base_url_parts(config_path: str) -> tuple[str, str] | None:

--- a/packages/nmp_platform_runner/tests/test_config.py
+++ b/packages/nmp_platform_runner/tests/test_config.py
@@ -313,6 +313,67 @@ auth:
         apply_run_environment(_make_config(sidecars=set()), env=env)
         assert "NMP_SIDECARS" not in env
 
+    def test_quickstart_platform_config_backfills_dev_secret_key_creation(self, tmp_path: Path):
+        config_path = tmp_path / "platform-config.yaml"
+        config_path.write_text("secrets: {}\n", encoding="utf-8")
+
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(config_path=str(config_path)), env=env)
+
+        assert env["NMP_SECRETS_ALLOW_KEY_CREATION"] == "1"
+        assert env["NMP_SECRETS_LOCAL_KEY_CREATION_PATH"] == "/data/nmp-encryption-key.txt"
+
+    def test_quickstart_platform_config_preserves_explicit_secret_key_creation_false(self, tmp_path: Path):
+        config_path = tmp_path / "platform-config.yaml"
+        config_path.write_text("secrets:\n  allow_key_creation: false\n", encoding="utf-8")
+
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(config_path=str(config_path)), env=env)
+
+        assert "NMP_SECRETS_ALLOW_KEY_CREATION" not in env
+        assert "NMP_SECRETS_LOCAL_KEY_CREATION_PATH" not in env
+
+    def test_quickstart_platform_config_preserves_existing_secret_env(self, tmp_path: Path):
+        config_path = tmp_path / "platform-config.yaml"
+        config_path.write_text("secrets: {}\n", encoding="utf-8")
+
+        env: dict[str, str] = {"NMP_SECRETS_ALLOW_KEY_CREATION": "0"}
+        apply_run_environment(_make_config(config_path=str(config_path)), env=env)
+
+        assert env["NMP_SECRETS_ALLOW_KEY_CREATION"] == "0"
+        assert "NMP_SECRETS_LOCAL_KEY_CREATION_PATH" not in env
+
+    def test_quickstart_platform_config_preserves_named_secret_provider(self, tmp_path: Path):
+        config_path = tmp_path / "platform-config.yaml"
+        config_path.write_text(
+            """
+secrets:
+  encryption:
+    current_provider: local_v1
+    providers:
+      secret_key:
+        local_v1:
+          from_env: NMP_SECRETS_DEFAULT_ENCRYPTION_KEY
+""".lstrip(),
+            encoding="utf-8",
+        )
+
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(config_path=str(config_path)), env=env)
+
+        assert "NMP_SECRETS_ALLOW_KEY_CREATION" not in env
+        assert "NMP_SECRETS_LOCAL_KEY_CREATION_PATH" not in env
+
+    def test_non_quickstart_config_does_not_backfill_dev_secret_key_creation(self, tmp_path: Path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("secrets: {}\n", encoding="utf-8")
+
+        env: dict[str, str] = {}
+        apply_run_environment(_make_config(config_path=str(config_path)), env=env)
+
+        assert "NMP_SECRETS_ALLOW_KEY_CREATION" not in env
+        assert "NMP_SECRETS_LOCAL_KEY_CREATION_PATH" not in env
+
 
 class TestApplyRunEnvDeployed:
     """Deployed mode: env vars are pre-set by Helm/k8s. apply_run_environment must NOT overwrite them.


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Backfills the quickstart dev/demo secrets key-creation defaults for legacy `platform-config.yaml` files that omit `secrets.allow_key_creation` and do not configure a real encryption provider. Explicit env values, explicit `allow_key_creation` settings, named provider configs, and non-quickstart config files remain unchanged so deployed/provider configs continue to fail closed.

## Changes
- Adds runner-side quickstart compatibility defaults for `NMP_SECRETS_ALLOW_KEY_CREATION=1` and `/data/nmp-encryption-key.txt` when legacy `platform-config.yaml` has no explicit secrets key-creation or provider configuration.
- Adds unit coverage for the quickstart backfill and the guardrails that preserve explicit false values, existing env overrides, named providers, and non-quickstart configs.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: this is a legacy quickstart compatibility backfill for existing config files and does not change the documented config surface.

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox activate -- uv run pre-commit run -a` — passed.
- `flox activate -- uv run --frozen pytest packages/nmp_platform_runner/tests/test_config.py -q` — 58 passed.
- `flox activate -- uv run --frozen pytest services/core/secrets/tests/test_encryptor.py packages/nemo_platform_ext/tests/quickstart/test_platform_config.py packages/nemo_platform_ext/tests/quickstart/test_container.py::TestCreateEnvironmentGPU::test_explicit_platform_config_secret_env_vars_are_preserved -q` — 11 passed.
- `git diff --check` — passed.
- DCO audit from `contributor-create-pr` skill — passed for `8ae9716c45750cdcd8ac8c670aed2dfe959297a9`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved local quickstart setup by automatically configuring development secret-key creation when no secrets provider is specified.
  * Preserves explicitly configured environment values and supports disabling automatic key creation.

* **Bug Fixes**
  * Prevents development secret settings from being applied to non-quickstart configurations or setups using a named secrets provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->