### PR TITLE
ci: dispatch release branch updates

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -5,7 +5,7 @@ name: Dispatch
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/*"]
 
 permissions:
   contents: read
@@ -26,6 +26,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          jq -n --arg ref "${GITHUB_SHA}" \
-            '{event_type: "ci-passed", client_payload: {ref: $ref}}' \
+          event_type="ci-passed"
+          release_version=""
+          if [[ "${GITHUB_REF_NAME}" == release/* ]]; then
+            event_type="release-branch-updated"
+            release_version="${GITHUB_REF_NAME#release/}"
+          fi
+
+          jq -n \
+            --arg event_type "${event_type}" \
+            --arg ref "${GITHUB_SHA}" \
+            --arg branch "${GITHUB_REF_NAME}" \
+            --arg version "${release_version}" \
+            '{
+              event_type: $event_type,
+              client_payload: {
+                ref: $ref,
+                branch: $branch,
+                version: $version
+              }
+            }' \
           | gh api -X POST "/repos/${DISPATCH_REPO}/dispatches" --input -


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Extends the dispatch workflow on `release/0.5` to react to `release/*` pushes. Release branches emit a branch-specific event with the exact commit ref, branch, and derived version, while the existing `main` behavior remains unchanged.

## Changes
- watch `release/*` in the dispatch workflow
- emit `release-branch-updated` for release branch pushes
- include `ref`, `branch`, and `version` in the dispatch payload
- preserve the existing `ci-passed` event for `main`

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: workflow-only trigger and payload change validated with repository hooks and actionlint
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing behavior or interface changes

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `flox activate -- uv run pre-commit run -a` — passed
- `flox activate --dir tools/actionlint -- actionlint .github/workflows/dispatch.yaml` — passed
- `git diff --check` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated workflows now run when changes are pushed to the main branch or release branches.
  * Workflow notifications now include the commit reference, branch, and release version.
  * Release branch updates emit a dedicated release notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->