### PR TITLE
perf(discovery): defer NemoInferenceMiddleware import behind TYPE_CHECKING

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/discovery.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/discovery.py
@@ -51,7 +51,7 @@ import logging
 import os
 from functools import cache
 from importlib.metadata import EntryPoint, entry_points
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from nemo_platform_plugin.cli import NemoCLI
 from nemo_platform_plugin.controller import NemoController
@@ -60,13 +60,18 @@ from nemo_platform_plugin.customization_contributor import (
     CustomizationContributorDiscoveryError,
 )
 from nemo_platform_plugin.function import NemoFunction
-from nemo_platform_plugin.inference_middleware import NemoInferenceMiddleware
 from nemo_platform_plugin.interface import PluginManifest
 from nemo_platform_plugin.job import NemoJob
 from nemo_platform_plugin.sandbox import SandboxImageProfile
 from nemo_platform_plugin.sdk import NemoPluginSDKResources
 from nemo_platform_plugin.seed import NemoSeedJob
 from nemo_platform_plugin.service import NemoService
+
+if TYPE_CHECKING:
+    # Deferred: pulls in anthropic + openai (~750ms), and every nemo CLI
+    # invocation imports this module. discover_inference_middleware()
+    # re-imports it locally at runtime.
+    from nemo_platform_plugin.inference_middleware import NemoInferenceMiddleware
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- `nemo_platform_plugin.discovery` is imported unconditionally by every `nemo` CLI invocation, but its module-level `NemoInferenceMiddleware` import transitively pulled in the full `anthropic` + `openai` SDKs (~750ms of import time), paid even by commands that never touch inference middleware discovery.
- `discover_inference_middleware()` already re-imports `NemoInferenceMiddleware` locally at call time for the actual runtime `cast(...)` — the module-level import only existed so its return-type annotation would resolve for `ty`/pyright. Moved it behind `TYPE_CHECKING` instead, which static type checkers still resolve.
- Scoped narrowly to this one class (the only genuinely heavy import in this file's discovery surface); the other typed wrappers (`NemoCLI`, `NemoJob`, etc.) are cheap and left untouched.

This is a deliberate, narrow exception to the repo's usual "no `TYPE_CHECKING`-gated imports" convention (`AGENTS.md`), justified by the size of the anthropic/openai SDKs and the fact that this module is on the hot path for every CLI command.

## Test plan
- [x] `uv run --frozen ty check packages/nemo_platform_plugin/src/nemo_platform_plugin/discovery.py` — passes
- [x] `uv run ruff check` / `ruff format --check` on the changed file — pass
- [x] `uv run pre-commit run --files packages/nemo_platform_plugin/src/nemo_platform_plugin/discovery.py` — all hooks pass
- [x] `uv run --frozen pytest packages/nemo_platform_plugin/tests plugins/nemo-customizer/tests -q` — 1362 passed
- [x] `python -X importtime .venv/bin/nemo --help`: 0 `anthropic`/`openai` imports (previously ~750ms); wall time for `nemo --help` dropped from ~1.3s+ to ~0.6-0.9s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup reliability by preventing unnecessary middleware loading during discovery.
  * Inference middleware continues to load when needed, with no changes to public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->