### PR TITLE
chore(customizer): update RL commit ref

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -128,7 +128,7 @@ variable "NEMO_RL_REPO" {
 # RL pins Gym as a git submodule (-> soluwalana/Gym over https), so Gym rides in with the RL git ADD
 # - no separate Gym pin needed.
 variable "NEMO_RL_REF" {
-  default = "ccb125c216d5d12aa471be6ce7f14e28cd67ff07" # soluwalana/RL nmp/customizer
+  default = "874f94737d5358680607735e339a8c06c01495f7" # soluwalana/RL nmp/customizer
 }
 variable "RL_BASE_CONTEXT" {
   default = ""


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

**Issue:**

When we strat the Gym servers, it creates the virtual env at expected path /`opt/gym_venvs/...`, but then does not install the deps in that venv, but instead uses the abs path defined by `UV_PYTHON1 and fails with permission denied error
```
(math_with_judge_simple_agent) Using CPython 3.13.15 interpreter at: /opt/cpython/bin/python3.13
(math_with_judge_simple_agent) Creating virtual environment with seed packages at: /opt/gym_venvs/responses_api_agents/simple_agent/.venv
(math_with_judge_simple_agent)  + pip==26.2.1
(math_with_judge_simple_agent) Activate with: source /opt/gym_venvs/responses_api_agents/simple_agent/.venv/bin/activate
....
(math_with_judge_simple_agent) Using Python 3.13.15 environment at: /opt/cpython
.....
(math_with_judge_simple_agent) Prepared 173 packages in 3.81s
(math_with_judge_simple_agent) error: Failed to install: httpx-0.28.1-py3-none-any.whl (httpx==0.28.1)
(math_with_judge_simple_agent)   Caused by: Failed to create directory `/opt/cpython/lib/python3.13/site-packages/httpx`
(math_with_judge_simple_agent)   Caused by: failed to create directory `/opt/cpython/lib/python3.13/site-packages/httpx`: Permission denied (os error 13)
```

The fix is to make gym env install deps in the same venev it created, and I found a flag that we can set in Gym code to do that here - https://github.com/soluwalana/Gym/blob/nmp/customizer/nemo_gym/cli/setup_command.py#L122

The fix was implemented and merged in [RL fork](https://github.com/soluwalana/RL), this PR just updates the RL commit ref

**Fix worked:**

Logs from the sandbox pod

```
All 3 / 3 servers ready! Polling every 60s

####################################################################################################
#
# Server Instances
#
####################################################################################################

[1] policy_model (responses_api_models/vllm_model)
{
    'config_path': 'policy_model',
    'dir_path': '/tmp/gym-src/Gym/responses_api_models/vllm_model',
    'entrypoint': 'app.py',
    'host': '127.0.0.1',
    'name': 'vllm_model',
    'pid': 1334,
    'port': 5321,
    'process_name': 'policy_model',
    'server_type': 'responses_api_models',
    'url': 'http://127.0.0.1:5321',
}
[2] math_with_judge (resources_servers/math_with_judge)
{
    'config_path': 'math_with_judge',
    'dir_path': '/job/environment/resources_servers/math_with_judge',
    'entrypoint': 'app.py',
    'host': '127.0.0.1',
    'name': 'math_with_judge',
    'pid': 1351,
    'port': 5500,
    'process_name': 'math_with_judge',
    'server_type': 'resources_servers',
    'url': 'http://127.0.0.1:5500',
}
[3] math_with_judge_simple_agent (responses_api_agents/simple_agent)
{
    'config_path': 'math_with_judge_simple_agent',
    'dir_path': '/tmp/gym-src/Gym/responses_api_agents/simple_agent',
    'entrypoint': 'app.py',
    'host': '127.0.0.1',
    'name': 'simple_agent',
    'pid': 1365,
    'port': 5061,
    'process_name': 'math_with_judge_simple_agent',
    'server_type': 'responses_api_agents',
    'url': 'http://127.0.0.1:5061',
}
####################################################################################################
```

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

* Updated the NeMo-RL base image to a newer pinned version for improved build consistency and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->