### PR TITLE
feat(Studio): Add missing GRPO to Customizer form inputs

### DIFF
--- a/web/packages/common/src/components/SliderWithTextInput/index.tsx
+++ b/web/packages/common/src/components/SliderWithTextInput/index.tsx
@@ -24,7 +24,8 @@ type SliderProps = ComponentProps<typeof Slider>;
 
 export type SliderWithTextInputProps = {
   field: FieldValues;
-  defaultValue: number;
+  defaultValue?: number;
+  unsetPlaceholder?: string;
   max: number;
   min: number;
   step?: number;
@@ -45,6 +46,7 @@ export type SliderWithTextInputProps = {
 export const SliderWithTextInput = ({
   field,
   defaultValue,
+  unsetPlaceholder,
   formFieldProps,
   max,
   min,
@@ -95,7 +97,8 @@ export const SliderWithTextInput = ({
   const handleReset = () => {
     setDraftValue(null);
     field.onChange(defaultValue);
-    attributes?.Slider?.onValueChange?.(defaultValue);
+    // Nothing numeric to forward when the field resets to unset.
+    if (defaultValue !== undefined) attributes?.Slider?.onValueChange?.(defaultValue);
   };
   const fallback = defaultValue ?? min;
   const isFieldValueNumber = typeof field.value === 'number' && !Number.isNaN(field.value);
@@ -167,6 +170,7 @@ export const SliderWithTextInput = ({
         status={fieldStatus}
         aria-label="Slider value"
         value={textInputValue}
+        placeholder={unsetPlaceholder}
         max={max.toString()}
         min={min.toString()}
         step={step?.toString()}

--- a/web/packages/studio/src/components/NewCustomizationForm/ControlledStringListInput.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ControlledStringListInput.tsx
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import type { UseControllerComponentProps } from '@nemo/common/src/types';
+import { FormField, TextInput } from '@nvidia/foundations-react-core';
+import { useController } from 'react-hook-form';
+
+interface Props extends UseControllerComponentProps {
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Edits a `string[]` field as one comma separated line — LoRA module lists and W&B tags
+ * are both far easier to type that way than as repeated inputs.
+ *
+ * Blank yields `[]`, which the submit mapper turns into "send nothing" so the backend
+ * keeps its own default rather than receiving an empty list as a filter.
+ */
+export const ControlledStringListInput = ({
+  useControllerProps,
+  formFieldProps,
+  placeholder,
+  disabled,
+}: Props) => {
+  const {
+    field: { value, onChange, onBlur, disabled: fieldDisabled },
+  } = useController(useControllerProps);
+
+  return (
+    <FormField {...formFieldProps}>
+      <TextInput
+        value={((value as string[] | undefined) ?? []).join(', ')}
+        placeholder={placeholder}
+        disabled={disabled || fieldDisabled}
+        onValueChange={(next: string) =>
+          onChange(
+            next
+              .split(',')
+              .map((part) => part.trim())
+              .filter(Boolean)
+          )
+        }
+        onBlur={onBlur}
+      />
+    </FormField>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/ControlledStringListInput.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ControlledStringListInput.tsx
@@ -30,7 +30,7 @@ export const ControlledStringListInput = ({
   return (
     <FormField {...formFieldProps}>
       <TextInput
-        value={((value as string[] | undefined) ?? []).join(', ')}
+        value={Array.isArray(value) ? (value as string[]).join(', ') : ''}
         placeholder={placeholder}
         disabled={disabled || fieldDisabled}
         onValueChange={(next: string) =>

--- a/web/packages/studio/src/components/NewCustomizationForm/FormSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/FormSection.tsx
@@ -1,21 +1,54 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Stack, Text } from '@nvidia/foundations-react-core';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionRoot,
+  AccordionTrigger,
+  Stack,
+  Text,
+} from '@nvidia/foundations-react-core';
 import type { FC, ReactNode } from 'react';
 
 interface FormSectionProps {
   title: string;
   description?: ReactNode;
+  collapsible?: boolean;
   children: ReactNode;
 }
 
-export const FormSection: FC<FormSectionProps> = ({ title, description, children }) => (
-  <Stack gap="density-md">
-    <Stack gap="density-sm" className="pb-density-xl">
-      <Text kind="body/bold/lg">{title}</Text>
-      {description && <Text kind="body/regular/md">{description}</Text>}
+export const FormSection: FC<FormSectionProps> = ({
+  title,
+  description,
+  collapsible = false,
+  children,
+}) => {
+  if (collapsible) {
+    return (
+      <AccordionRoot multiple>
+        <AccordionItem value={title} className="border-b-0">
+          <AccordionTrigger>
+            <Text kind="body/bold/lg">{title}</Text>
+          </AccordionTrigger>
+          <AccordionContent>
+            <Stack gap="density-md" className="pt-density-md">
+              {description && <Text kind="body/regular/md">{description}</Text>}
+              {children}
+            </Stack>
+          </AccordionContent>
+        </AccordionItem>
+      </AccordionRoot>
+    );
+  }
+
+  return (
+    <Stack gap="density-md">
+      <Stack gap="density-sm" className="pb-density-xl">
+        <Text kind="body/bold/lg">{title}</Text>
+        {description && <Text kind="body/regular/md">{description}</Text>}
+      </Stack>
+      {children}
     </Stack>
-    {children}
-  </Stack>
-);
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GeneralParametersSection.tsx
@@ -184,7 +184,7 @@ export const GeneralParametersSection = () => {
                     }}
                     defaultValue={1.0}
                     min={0.01}
-                    max={10}
+                    max={1000}
                     step={0.01}
                     disabled={disabled}
                   />

--- a/web/packages/studio/src/components/NewCustomizationForm/GrpoAdvancedSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GrpoAdvancedSection.tsx
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledSelect } from '@nemo/common/src/components/form/ControlledSelect';
+import { ControlledSliderWithTextInput } from '@nemo/common/src/components/form/ControlledSliderWithTextInput';
+import { ControlledSwitch } from '@nemo/common/src/components/form/ControlledSwitch';
+import {
+  BatchingStrategy,
+  PolicyBackend,
+  RlGRPOTrainingTruncatedImportanceSamplingType,
+} from '@nemo/sdk/generated/customizer/schema';
+import { Divider, FormField, Stack, TextInput } from '@nvidia/foundations-react-core';
+import { ControlledJsonInput } from '@studio/components/NewCustomizationForm/ControlledJsonInput';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useFormContext } from 'react-hook-form';
+
+const POLICY_BACKEND_ITEMS = [
+  { value: PolicyBackend.automodel, label: 'Automodel' },
+  { value: PolicyBackend.dtensor, label: 'DTensor' },
+];
+
+const BATCHING_STRATEGY_ITEMS = [
+  { value: BatchingStrategy.dynamic, label: 'Dynamic' },
+  { value: BatchingStrategy.static, label: 'Static' },
+  { value: BatchingStrategy.sequence_packing, label: 'Sequence Packing' },
+];
+
+const TIS_TYPE_ITEMS = [
+  { value: RlGRPOTrainingTruncatedImportanceSamplingType.tis, label: 'TIS' },
+  { value: RlGRPOTrainingTruncatedImportanceSamplingType.icepop, label: 'IcePop' },
+  { value: RlGRPOTrainingTruncatedImportanceSamplingType['seq-mask-tis'], label: 'Seq-Mask-TIS' },
+];
+
+/**
+ * GRPO knobs the backend leaves off by default. Their sliders omit `defaultValue`, so ↺
+ * clears the field back to unset and the feature stays off rather than resetting to a
+ * number the user never chose.
+ */
+export const GrpoAdvancedSection = () => {
+  const { control, watch, setValue, formState } = useFormContext<CustomizationFormFields>();
+  const disabled = formState.isSubmitting;
+  const executionProfile = watch('rl.training.execution_profile');
+
+  return (
+    <>
+      <Divider />
+      <FormSection
+        collapsible
+        title="Policy Update"
+        description="How the policy update is computed and bounded. Leave a field blank to keep the backend default."
+      >
+        <Stack gap="density-md">
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'rl.training.ref_policy_kl_penalty', control }}
+            formFieldProps={{
+              slotLabel: 'KL Penalty',
+              slotInfo:
+                'KL penalty coefficient against the reference policy. Higher values keep the model closer to the reference.',
+            }}
+            defaultValue={0.0}
+            min={0}
+            max={1}
+            step={0.01}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.ratio_clip_min', control }}
+            formFieldProps={{
+              slotLabel: 'Clip Min',
+              slotInfo: 'Lower bound for PPO-style importance ratio clipping.',
+            }}
+            defaultValue={0.2}
+            min={0}
+            max={1}
+            step={0.01}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.ratio_clip_max', control }}
+            formFieldProps={{
+              slotLabel: 'Clip Max',
+              slotInfo: 'Upper bound for PPO-style importance ratio clipping.',
+            }}
+            defaultValue={0.28}
+            min={0}
+            max={2}
+            step={0.01}
+            disabled={disabled}
+          />
+          <ControlledSwitch
+            useControllerProps={{ name: 'grpo.use_leave_one_out_baseline', control }}
+            formFieldProps={{
+              slotLabel: 'Leave-One-Out Baseline',
+              slotInfo:
+                'Compare each rollout against the mean of the other rollouts in its group rather than against the group mean including itself.',
+            }}
+            disabled={disabled}
+          />
+          <ControlledSwitch
+            useControllerProps={{ name: 'grpo.use_importance_sampling_correction', control }}
+            formFieldProps={{
+              slotLabel: 'Importance Sampling Correction',
+              slotInfo:
+                'Reweight each token by how much more or less likely the training policy is to produce it than the policy that generated the rollout.',
+            }}
+            disabled={disabled}
+          />
+          <ControlledSwitch
+            useControllerProps={{ name: 'grpo.use_on_policy_kl_approximation', control }}
+            formFieldProps={{
+              slotLabel: 'On-Policy KL Approximation',
+              slotInfo:
+                'Estimate the KL term against the policy that generated the rollouts rather than the one currently training.',
+            }}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.ratio_clip_c', control }}
+            formFieldProps={{
+              slotLabel: 'Dual-Clip Bound',
+              slotInfo:
+                'Second safety limit on how far one update can move the model. Must be above 1. Unset disables dual clipping.',
+            }}
+            unsetPlaceholder="Off"
+            min={1.01}
+            max={20}
+            step={0.01}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.advantage_clip_low', control }}
+            formFieldProps={{
+              slotLabel: 'Advantage Clip Low',
+              slotInfo:
+                'Lower bound applied to advantages after normalization. Must be below the high bound.',
+            }}
+            unsetPlaceholder="Off"
+            min={-20}
+            max={20}
+            step={0.1}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.advantage_clip_high', control }}
+            formFieldProps={{
+              slotLabel: 'Advantage Clip High',
+              slotInfo: 'Upper bound applied to advantages after normalization.',
+            }}
+            unsetPlaceholder="Off"
+            min={-20}
+            max={20}
+            step={0.1}
+            disabled={disabled}
+          />
+          <ControlledSelect
+            useControllerProps={{ name: 'grpo.truncated_importance_sampling_type', control }}
+            formFieldProps={{
+              slotLabel: 'Truncated Importance Sampling',
+              slotInfo:
+                'Bound the rollout-vs-training importance weights so a policy that has drifted cannot blow up an update. Leave unselected to disable.',
+            }}
+            items={TIS_TYPE_ITEMS}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.truncated_importance_sampling_ratio', control }}
+            formFieldProps={{
+              slotLabel: 'TIS Ratio (Upper)',
+              slotInfo: 'Upper bound on the importance weight.',
+            }}
+            unsetPlaceholder="Off"
+            min={0.01}
+            max={20}
+            step={0.01}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{
+              name: 'grpo.truncated_importance_sampling_ratio_min',
+              control,
+            }}
+            formFieldProps={{
+              slotLabel: 'TIS Ratio (Lower)',
+              slotInfo: 'Lower bound on the importance weight.',
+            }}
+            unsetPlaceholder="Off"
+            min={0}
+            max={20}
+            step={0.01}
+            disabled={disabled}
+          />
+        </Stack>
+      </FormSection>
+
+      <Divider />
+      <FormSection
+        collapsible
+        title="Execution & Overrides"
+        description="Which trainer and rollout engine run the job, and model-specific configuration."
+      >
+        <Stack gap="density-md">
+          <FormField
+            slotLabel="Execution Profile"
+            slotInfo="Operator-configured GPU profile for the training step, e.g. h100. Leave blank to use the service default."
+          >
+            <TextInput
+              value={executionProfile ?? ''}
+              placeholder="Service default"
+              disabled={disabled}
+              onValueChange={(next: string) =>
+                setValue('rl.training.execution_profile', next, { shouldValidate: true })
+              }
+            />
+          </FormField>
+          <ControlledSelect
+            useControllerProps={{ name: 'grpo.policy_backend', control }}
+            formFieldProps={{
+              slotLabel: 'Policy Backend',
+              slotInfo:
+                'NeMo-RL policy worker that trains the model. Automodel is the only backend supporting LoRA, expert parallelism and automodel kwargs.',
+            }}
+            items={POLICY_BACKEND_ITEMS}
+            disabled={disabled}
+          />
+          <ControlledSelect
+            useControllerProps={{ name: 'grpo.batching_strategy', control }}
+            formFieldProps={{
+              slotLabel: 'Batching Strategy',
+              slotInfo: 'How rollouts are grouped into training micro-batches.',
+            }}
+            items={BATCHING_STRATEGY_ITEMS}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.sequence_length_round', control }}
+            formFieldProps={{
+              slotLabel: 'Sequence Length Round',
+              slotInfo: 'Round bucketed micro-batch sequence lengths up to a multiple of this.',
+            }}
+            defaultValue={64}
+            min={1}
+            max={1024}
+            step={1}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.train_mb_tokens', control }}
+            formFieldProps={{
+              slotLabel: 'Train Micro-Batch Tokens',
+              slotInfo:
+                'Token budget per training micro-batch, read by the dynamic and sequence_packing strategies.',
+            }}
+            unsetPlaceholder="Auto"
+            min={1}
+            max={131072}
+            step={128}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.vllm_tensor_parallel_size', control }}
+            formFieldProps={{
+              slotLabel: 'vLLM Tensor Parallel Size',
+              slotInfo:
+                "Tensor parallel size for the vLLM rollout engine, independent of the policy's.",
+            }}
+            unsetPlaceholder="Auto"
+            min={1}
+            max={64}
+            step={1}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.vllm_gpu_memory_utilization', control }}
+            formFieldProps={{
+              slotLabel: 'vLLM GPU Memory Utilization',
+              slotInfo: 'Fraction of each GPU vLLM reserves for weights plus KV cache.',
+            }}
+            defaultValue={0.5}
+            min={0.05}
+            max={1}
+            step={0.05}
+            disabled={disabled}
+          />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.router_aux_loss_coef', control }}
+            formFieldProps={{
+              slotLabel: 'Router Aux Loss Coefficient',
+              slotInfo:
+                'MoE router auxiliary-loss coefficient, applied as a top-level HuggingFace config override.',
+            }}
+            unsetPlaceholder="Off"
+            min={0}
+            max={1}
+            step={0.001}
+            disabled={disabled}
+          />
+          <ControlledJsonInput
+            useControllerProps={{ name: 'grpo.hf_config_overrides', control }}
+            formFieldProps={{
+              slotLabel: 'HF Config Overrides (JSON)',
+              slotInfo:
+                'Passed to the training model as HuggingFace config kwargs and to vLLM as hf_overrides. Nested keys are supported, e.g. {"text_config": {"router_aux_loss_coef": 0.0}} for Qwen3.5.',
+            }}
+            placeholder='{"text_config": {"router_aux_loss_coef": 0.0}}'
+            disabled={disabled}
+          />
+          <ControlledJsonInput
+            useControllerProps={{ name: 'grpo.automodel_kwargs', control }}
+            formFieldProps={{
+              slotLabel: 'Automodel Kwargs (JSON)',
+              slotInfo:
+                'Selects the low-level compute kernels for mixture-of-experts models. Requires the automodel policy backend.',
+            }}
+            placeholder="{}"
+            disabled={disabled}
+          />
+        </Stack>
+      </FormSection>
+    </>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/GrpoParametersSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/GrpoParametersSection.tsx
@@ -17,7 +17,9 @@ import {
   Text,
 } from '@nvidia/foundations-react-core';
 import { OPTIMIZER_TYPE_ITEMS } from '@studio/components/NewCustomizationForm/constants';
+import { ControlledStringListInput } from '@studio/components/NewCustomizationForm/ControlledStringListInput';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import { GrpoAdvancedSection } from '@studio/components/NewCustomizationForm/GrpoAdvancedSection';
 import type { CustomizationFormFields } from '@studio/util/forms/customization';
 import { useFormContext } from 'react-hook-form';
 
@@ -39,11 +41,12 @@ export const GrpoParametersSection = () => {
   const { control, watch, setValue, formState } = useFormContext<CustomizationFormFields>();
   const disabled = formState.isSubmitting;
   const finetuningType = watch('grpo.finetuning_type');
+  const useDynamicSampling = watch('grpo.use_dynamic_sampling');
   const isLora = finetuningType === RlGRPOTrainingFinetuningType.lora;
 
   return (
     <>
-      <FormSection title="Rollout & Reward">
+      <FormSection title="Rollout & Sampling">
         <Stack gap="density-lg">
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'rl.training.max_seq_length', control }}
@@ -131,11 +134,195 @@ export const GrpoParametersSection = () => {
             step={128}
             disabled={disabled}
           />
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'grpo.top_k', control }}
+            formFieldProps={{
+              slotLabel: 'Top-K Sampling',
+              slotInfo:
+                'Restrict rollout sampling to the k most likely tokens at each step. Unset samples from the full distribution.',
+            }}
+            unsetPlaceholder="Off"
+            min={1}
+            max={1000}
+            step={1}
+            disabled={disabled}
+          />
+          <ControlledSwitch
+            useControllerProps={{ name: 'grpo.use_dynamic_sampling', control }}
+            formFieldProps={{
+              slotLabel: 'Dynamic Sampling',
+              labelPosition: 'left',
+              slotInfo:
+                'Discard prompt groups whose rewards all match, since a group with no spread teaches nothing, and keep generating until the step is full.',
+            }}
+            disabled={disabled}
+          />
+          {useDynamicSampling && (
+            <Stack gap="density-md" className="pl-density-lg">
+              <ControlledSliderWithTextInput
+                useControllerProps={{ name: 'grpo.batch_multiplier', control }}
+                formFieldProps={{
+                  slotLabel: 'Batch Multiplier',
+                  slotInfo:
+                    'Over-generate each step by this factor so dynamic sampling has candidates to filter. Only settable while dynamic sampling is on.',
+                }}
+                defaultValue={1}
+                min={1}
+                max={8}
+                step={0.1}
+                disabled={disabled}
+              />
+              <ControlledSliderWithTextInput
+                useControllerProps={{ name: 'grpo.dynamic_sampling_max_gen_batches', control }}
+                formFieldProps={{
+                  slotLabel: 'Max Generation Batches',
+                  slotInfo:
+                    'How many generation batches one step may consume trying to fill itself before the run fails.',
+                }}
+                defaultValue={10}
+                min={1}
+                max={100}
+                step={1}
+                disabled={disabled}
+              />
+            </Stack>
+          )}
+        </Stack>
+      </FormSection>
+      <Divider />
+      <FormSection title="Reward" description="How environment scores become the training signal.">
+        <Stack gap="density-lg">
+          <ControlledSwitch
+            useControllerProps={{ name: 'grpo.normalize_rewards', control }}
+            formFieldProps={{
+              slotLabel: 'Normalize Rewards',
+              labelPosition: 'left',
+              slotInfo: 'Normalize rewards within each prompt group before computing advantages.',
+            }}
+            disabled={disabled}
+          />
+          <AccordionRoot multiple>
+            <AccordionItem value="grpo-reward" className="border-b-0">
+              <AccordionTrigger>
+                <Text kind="label/bold/md">Reward Scaling & Shaping</Text>
+              </AccordionTrigger>
+              <AccordionContent>
+                <Stack gap="density-md" className="pt-density-md">
+                  <Text kind="body/regular/sm" color="secondary">
+                    Rescaling maps rewards onto a new range, so a wrong answer can be penalised
+                    rather than merely less rewarded. Leave all four blank for no rescaling; set any
+                    one and the rest fall back to the shown defaults.
+                  </Text>
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'grpo.reward_scaling.source_min', control }}
+                    formFieldProps={{ slotLabel: 'Scale Source Min' }}
+                    unsetPlaceholder="0"
+                    min={-10}
+                    max={10}
+                    step={0.1}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'grpo.reward_scaling.source_max', control }}
+                    formFieldProps={{ slotLabel: 'Scale Source Max' }}
+                    unsetPlaceholder="1"
+                    min={-10}
+                    max={10}
+                    step={0.1}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'grpo.reward_scaling.target_min', control }}
+                    formFieldProps={{ slotLabel: 'Scale Target Min' }}
+                    unsetPlaceholder="0"
+                    min={-10}
+                    max={10}
+                    step={0.1}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{ name: 'grpo.reward_scaling.target_max', control }}
+                    formFieldProps={{ slotLabel: 'Scale Target Max' }}
+                    unsetPlaceholder="1"
+                    min={-10}
+                    max={10}
+                    step={0.1}
+                    disabled={disabled}
+                  />
+                  <Divider />
+                  <Text kind="body/regular/sm" color="secondary">
+                    Shaping softens the penalty for responses cut off at the length limit instead of
+                    scoring them a flat zero.
+                  </Text>
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{
+                      name: 'grpo.reward_shaping.overlong_buffer_length',
+                      control,
+                    }}
+                    formFieldProps={{ slotLabel: 'Overlong Buffer Length' }}
+                    unsetPlaceholder="Off"
+                    min={1}
+                    max={16384}
+                    step={128}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{
+                      name: 'grpo.reward_shaping.overlong_buffer_penalty',
+                      control,
+                    }}
+                    formFieldProps={{ slotLabel: 'Overlong Buffer Penalty' }}
+                    unsetPlaceholder="Off"
+                    min={0}
+                    max={10}
+                    step={0.1}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{
+                      name: 'grpo.reward_shaping.max_response_length',
+                      control,
+                    }}
+                    formFieldProps={{ slotLabel: 'Max Response Length' }}
+                    unsetPlaceholder="Off"
+                    min={1}
+                    max={131072}
+                    step={128}
+                    disabled={disabled}
+                  />
+                  <ControlledSliderWithTextInput
+                    useControllerProps={{
+                      name: 'grpo.reward_shaping.stop_properly_penalty_coef',
+                      control,
+                    }}
+                    formFieldProps={{ slotLabel: 'Improper Stop Penalty' }}
+                    unsetPlaceholder="Off"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    disabled={disabled}
+                  />
+                </Stack>
+              </AccordionContent>
+            </AccordionItem>
+          </AccordionRoot>
         </Stack>
       </FormSection>
       <Divider />
       <FormSection title="Training Parameters">
         <Stack gap="density-lg">
+          <ControlledSliderWithTextInput
+            useControllerProps={{ name: 'rl.training.epochs', control }}
+            formFieldProps={{
+              slotLabel: 'Epochs',
+              slotInfo: 'Passes through the dataset. Max Steps overrides this when both are set.',
+            }}
+            defaultValue={1}
+            min={1}
+            max={100}
+            step={1}
+            disabled={disabled}
+          />
           <ControlledSliderWithTextInput
             useControllerProps={{ name: 'rl.training.learning_rate', control }}
             formFieldProps={{ slotLabel: 'Learning Rate' }}
@@ -143,19 +330,6 @@ export const GrpoParametersSection = () => {
             min={1e-6}
             max={1e-3}
             step={1e-6}
-            disabled={disabled}
-          />
-          <ControlledSliderWithTextInput
-            useControllerProps={{ name: 'rl.training.ref_policy_kl_penalty', control }}
-            formFieldProps={{
-              slotLabel: 'KL Penalty',
-              slotInfo:
-                'KL penalty coefficient against the reference policy. Higher values keep the model closer to the reference.',
-            }}
-            defaultValue={0.0}
-            min={0}
-            max={1}
-            step={0.01}
             disabled={disabled}
           />
           <ControlledSliderWithTextInput
@@ -211,40 +385,6 @@ export const GrpoParametersSection = () => {
                     min={0}
                     max={1}
                     step={0.01}
-                    disabled={disabled}
-                  />
-                  <ControlledSliderWithTextInput
-                    useControllerProps={{ name: 'grpo.ratio_clip_min', control }}
-                    formFieldProps={{
-                      slotLabel: 'Clip Min',
-                      slotInfo: 'Lower bound for PPO-style importance ratio clipping.',
-                    }}
-                    defaultValue={0.2}
-                    min={0}
-                    max={1}
-                    step={0.01}
-                    disabled={disabled}
-                  />
-                  <ControlledSliderWithTextInput
-                    useControllerProps={{ name: 'grpo.ratio_clip_max', control }}
-                    formFieldProps={{
-                      slotLabel: 'Clip Max',
-                      slotInfo: 'Upper bound for PPO-style importance ratio clipping.',
-                    }}
-                    defaultValue={0.28}
-                    min={0}
-                    max={2}
-                    step={0.01}
-                    disabled={disabled}
-                  />
-                  <ControlledSwitch
-                    useControllerProps={{ name: 'grpo.normalize_rewards', control }}
-                    formFieldProps={{
-                      slotLabel: 'Normalize Rewards',
-                      labelPosition: 'left',
-                      slotInfo:
-                        'Normalize rewards within each prompt group before computing advantages.',
-                    }}
                     disabled={disabled}
                   />
                   <ControlledSliderWithTextInput
@@ -338,7 +478,7 @@ export const GrpoParametersSection = () => {
                     }}
                     defaultValue={1.0}
                     min={0.01}
-                    max={10}
+                    max={1000}
                     step={0.01}
                     disabled={disabled}
                   />
@@ -445,6 +585,26 @@ export const GrpoParametersSection = () => {
                 step={0.01}
                 disabled={disabled}
               />
+              <ControlledStringListInput
+                useControllerProps={{ name: 'grpo.lora.target_modules', control }}
+                formFieldProps={{
+                  slotLabel: 'Target Modules',
+                  slotInfo:
+                    'Modules to attach adapters to, comma separated. Leave blank for the backend default.',
+                }}
+                placeholder="q_proj, k_proj, v_proj"
+                disabled={disabled}
+              />
+              <ControlledStringListInput
+                useControllerProps={{ name: 'grpo.lora.exclude_modules', control }}
+                formFieldProps={{
+                  slotLabel: 'Exclude Modules',
+                  slotInfo:
+                    'Modules to skip, comma separated. Supports glob patterns, e.g. *out_proj*.',
+                }}
+                placeholder="*out_proj*"
+                disabled={disabled}
+              />
               <ControlledSwitch
                 useControllerProps={{ name: 'grpo.lora.use_triton', control }}
                 formFieldProps={{
@@ -459,6 +619,7 @@ export const GrpoParametersSection = () => {
           )}
         </Stack>
       </FormSection>
+      <GrpoAdvancedSection />
     </>
   );
 };

--- a/web/packages/studio/src/components/NewCustomizationForm/RlIntegrationsSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/RlIntegrationsSection.tsx
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ControlledTextInput } from '@nemo/common/src/components/form/ControlledTextInput';
+import { Stack, Text } from '@nvidia/foundations-react-core';
+import { ControlledStringListInput } from '@studio/components/NewCustomizationForm/ControlledStringListInput';
+import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import type { CustomizationFormFields } from '@studio/util/forms/customization';
+import { useFormContext } from 'react-hook-form';
+
+/**
+ * Experiment-tracking configuration for RL jobs. Everything here is optional — a blank
+ * field is stripped on submit so the job ships without the integration rather than with
+ * an empty one.
+ */
+export const RlIntegrationsSection = () => {
+  const { control, formState } = useFormContext<CustomizationFormFields>();
+  const disabled = formState.isSubmitting;
+
+  return (
+    <FormSection
+      collapsible
+      title="Experiment Tracking"
+      description="Optional. Stream metrics to Weights & Biases or MLflow while the job runs."
+    >
+      <Stack gap="density-md">
+        <Text kind="label/bold/sm">Weights &amp; Biases</Text>
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.wandb.project', control }}
+          formFieldProps={{ slotLabel: 'Project' }}
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.wandb.name', control }}
+          formFieldProps={{ slotLabel: 'Run Name' }}
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.wandb.entity', control }}
+          formFieldProps={{ slotLabel: 'Entity' }}
+          disabled={disabled}
+        />
+        <ControlledStringListInput
+          useControllerProps={{ name: 'rl.integrations.wandb.tags', control }}
+          formFieldProps={{
+            slotLabel: 'Tags',
+            slotInfo: 'Comma separated labels attached to the W&B run.',
+          }}
+          placeholder="grpo, recipe-aligned"
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.wandb.notes', control }}
+          formFieldProps={{ slotLabel: 'Notes' }}
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.wandb.base_url', control }}
+          formFieldProps={{
+            slotLabel: 'Base URL',
+            slotInfo: 'Only needed for a self-hosted W&B instance.',
+          }}
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.wandb.api_key_secret', control }}
+          formFieldProps={{
+            slotLabel: 'API Key Secret',
+            slotInfo:
+              "Name of a stored secret holding the W&B API key, as 'secret-name' or 'workspace/secret-name'. The key itself is never entered here.",
+          }}
+          placeholder="wandb-api-key"
+          disabled={disabled}
+        />
+
+        <Text kind="label/bold/sm">MLflow</Text>
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.mlflow.experiment_name', control }}
+          formFieldProps={{ slotLabel: 'Experiment Name' }}
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.mlflow.name', control }}
+          formFieldProps={{ slotLabel: 'Run Name' }}
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.mlflow.description', control }}
+          formFieldProps={{ slotLabel: 'Description' }}
+          disabled={disabled}
+        />
+        <ControlledTextInput
+          useControllerProps={{ name: 'rl.integrations.mlflow.tracking_uri', control }}
+          formFieldProps={{ slotLabel: 'Tracking URI' }}
+          disabled={disabled}
+        />
+      </Stack>
+    </FormSection>
+  );
+};

--- a/web/packages/studio/src/components/NewCustomizationForm/index.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/index.tsx
@@ -29,6 +29,7 @@ import { GrpoParametersSection } from '@studio/components/NewCustomizationForm/G
 import { LoraParametersSection } from '@studio/components/NewCustomizationForm/LoraParametersSection';
 import { ModelSelectionSection } from '@studio/components/NewCustomizationForm/ModelSelectionSection';
 import { RewardEnvironmentSection } from '@studio/components/NewCustomizationForm/RewardEnvironmentSection';
+import { RlIntegrationsSection } from '@studio/components/NewCustomizationForm/RlIntegrationsSection';
 import { TrainingMethodSection } from '@studio/components/NewCustomizationForm/TrainingMethodSection';
 import { getWorkspaceCustomizationJobDetailsRoute } from '@studio/routes/utils';
 import {
@@ -228,6 +229,12 @@ export const NewCustomizationForm: FC<NewCustomizationFormProps> = ({
                       <>
                         <Divider />
                         <DpoParametersSection />
+                      </>
+                    )}
+                    {backend === 'rl' && (
+                      <>
+                        <Divider />
+                        <RlIntegrationsSection />
                       </>
                     )}
                     <Divider />

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -407,60 +407,16 @@ export const customizationFormSchema = z
       spec = rlSpecSchema;
       value = data.rl;
       const grpo = data.grpo as Partial<GrpoFormFields> | undefined;
-      if (grpo?.trainingType === 'grpo') {
-        if (!grpo.environmentFileset) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'A reward environment fileset is required for GRPO training',
-            path: ['grpo', 'environmentFileset'],
-          });
-        }
-        // Mirrors the backend's _generation_length_fits_context validator: max_seq_length
-        // is the whole prompt + generation budget, so a larger generation cap is
-        // unsatisfiable and the job is rejected at submit.
-        const maxSeqLength = (data.rl as RlJobInput | undefined)?.training?.max_seq_length;
-        if (
-          grpo.max_new_tokens != null &&
-          maxSeqLength != null &&
-          grpo.max_new_tokens > maxSeqLength
-        ) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `Max new tokens cannot exceed the max sequence length (${maxSeqLength}), which is the total prompt + generation budget`,
-            path: ['grpo', 'max_new_tokens'],
-          });
-        }
-        // Mirrors _advantage_clip_range_is_usable: reversed or equal bounds clamp every
-        // advantage to one value, which zeroes the gradient with nothing in the logs.
-        const { advantage_clip_low: low, advantage_clip_high: high } = grpo;
-        if (low != null && high != null && low >= high) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Advantage clip low must be below advantage clip high',
-            path: ['grpo', 'advantage_clip_low'],
-          });
-        }
-        // Mirrors _batch_multiplier_requires_dynamic_sampling. The payload already omits
-        // the multiplier when dynamic sampling is off, so this only fires if both are on
-        // screen and inconsistent.
-        if (!grpo.use_dynamic_sampling && grpo.batch_multiplier !== 1) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Batch multiplier requires dynamic sampling to be enabled',
-            path: ['grpo', 'batch_multiplier'],
-          });
-        }
-        // Only automodel implements LoRA, expert parallelism and automodel_kwargs.
-        if (
-          grpo.policy_backend === PolicyBackend.dtensor &&
-          grpo.finetuning_type === RlGRPOTrainingFinetuningType.lora
-        ) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'LoRA requires the automodel policy backend',
-            path: ['grpo', 'policy_backend'],
-          });
-        }
+      if (grpo?.trainingType === 'grpo' && !grpo.environmentFileset) {
+        // Form-completeness only. Every other GRPO rule (generation length, advantage
+        // clip range, policy-backend conflicts, truncated importance sampling, HF
+        // override collisions) is enforced by the backend, which reports it with a
+        // precise message; mirroring them here just creates two sources of truth.
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'A reward environment fileset is required for GRPO training',
+          path: ['grpo', 'environmentFileset'],
+        });
       }
     }
     const result = spec.safeParse(value);

--- a/web/packages/studio/src/util/forms/customization.ts
+++ b/web/packages/studio/src/util/forms/customization.ts
@@ -5,7 +5,9 @@ import { generateDefaultName } from '@nemo/common/src/utils/generateDefaultName'
 import {
   type AutomodelJobInput,
   type AutomodelJobsJobRequest,
+  BatchingStrategy,
   OptimizerType,
+  PolicyBackend,
   RlGRPOTrainingFinetuningType,
   type RlDPOTraining,
   type RlGRPOTraining,
@@ -34,7 +36,8 @@ import { z } from 'zod';
  */
 export type GrpoLoraFields = Required<
   Pick<RlLoRAParams, 'rank' | 'alpha' | 'dropout' | 'use_triton'>
->;
+> &
+  Pick<RlLoRAParams, 'target_modules' | 'exclude_modules'>;
 
 /**
  * GRPO-only hyperparameters, kept in their own namespace because `rl.training` holds
@@ -54,6 +57,16 @@ export interface GrpoFormFields extends Required<
     | 'temperature'
     | 'val_at_start'
     | 'overlong_filtering'
+    | 'use_dynamic_sampling'
+    | 'batch_multiplier'
+    | 'dynamic_sampling_max_gen_batches'
+    | 'use_leave_one_out_baseline'
+    | 'use_importance_sampling_correction'
+    | 'use_on_policy_kl_approximation'
+    | 'policy_backend'
+    | 'batching_strategy'
+    | 'sequence_length_round'
+    | 'vllm_gpu_memory_utilization'
   >
 > {
   /** 'grpo' shows the GRPO form sections; 'dpo' shows DPO sections. Maps to training.type on submit. */
@@ -70,6 +83,26 @@ export interface GrpoFormFields extends Required<
   max_new_tokens: RlGRPOTraining['max_new_tokens'];
   /** LoRA hyperparameters; only sent when finetuning_type is 'lora'. */
   lora: GrpoLoraFields;
+  /**
+   * Fields the backend leaves unset by default. They stay optional here so an untouched
+   * control sends nothing and the backend keeps its own behaviour, rather than the form
+   * switching a feature on with a value the user never chose.
+   */
+  ratio_clip_c: RlGRPOTraining['ratio_clip_c'];
+  advantage_clip_low: RlGRPOTraining['advantage_clip_low'];
+  advantage_clip_high: RlGRPOTraining['advantage_clip_high'];
+  truncated_importance_sampling_type: RlGRPOTraining['truncated_importance_sampling_type'];
+  truncated_importance_sampling_ratio: RlGRPOTraining['truncated_importance_sampling_ratio'];
+  truncated_importance_sampling_ratio_min: RlGRPOTraining['truncated_importance_sampling_ratio_min'];
+  top_k: RlGRPOTraining['top_k'];
+  train_mb_tokens: RlGRPOTraining['train_mb_tokens'];
+  router_aux_loss_coef: RlGRPOTraining['router_aux_loss_coef'];
+  vllm_tensor_parallel_size: RlGRPOTraining['vllm_tensor_parallel_size'];
+  reward_scaling: RlGRPOTraining['reward_scaling'];
+  reward_shaping: RlGRPOTraining['reward_shaping'];
+  /** Free-form passthrough dicts, edited via ControlledJsonInput. */
+  hf_config_overrides: RlGRPOTraining['hf_config_overrides'];
+  automodel_kwargs: RlGRPOTraining['automodel_kwargs'];
 }
 
 export interface CustomizationFormFields {
@@ -287,6 +320,32 @@ export const FORM_DEFAULTS: CustomizationFormFields = {
     max_new_tokens: 2048,
     finetuning_type: RlGRPOTrainingFinetuningType.all_weights,
     lora: { rank: 16, alpha: 32, dropout: 0, use_triton: true },
+    use_dynamic_sampling: false,
+    batch_multiplier: 1.0,
+    dynamic_sampling_max_gen_batches: 10,
+    use_leave_one_out_baseline: true,
+    use_importance_sampling_correction: true,
+    use_on_policy_kl_approximation: true,
+    policy_backend: PolicyBackend.automodel,
+    batching_strategy: BatchingStrategy.dynamic,
+    sequence_length_round: 64,
+    vllm_gpu_memory_utilization: 0.5,
+    // Left unset: the backend treats absence as "feature off", so seeding any number
+    // here would silently enable it. Their controls reset to empty rather than to a value.
+    ratio_clip_c: undefined,
+    advantage_clip_low: undefined,
+    advantage_clip_high: undefined,
+    truncated_importance_sampling_type: undefined,
+    truncated_importance_sampling_ratio: undefined,
+    truncated_importance_sampling_ratio_min: undefined,
+    top_k: undefined,
+    train_mb_tokens: undefined,
+    router_aux_loss_coef: undefined,
+    vllm_tensor_parallel_size: undefined,
+    reward_scaling: undefined,
+    reward_shaping: undefined,
+    hf_config_overrides: undefined,
+    automodel_kwargs: undefined,
   },
 };
 
@@ -371,6 +430,37 @@ export const customizationFormSchema = z
             path: ['grpo', 'max_new_tokens'],
           });
         }
+        // Mirrors _advantage_clip_range_is_usable: reversed or equal bounds clamp every
+        // advantage to one value, which zeroes the gradient with nothing in the logs.
+        const { advantage_clip_low: low, advantage_clip_high: high } = grpo;
+        if (low != null && high != null && low >= high) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Advantage clip low must be below advantage clip high',
+            path: ['grpo', 'advantage_clip_low'],
+          });
+        }
+        // Mirrors _batch_multiplier_requires_dynamic_sampling. The payload already omits
+        // the multiplier when dynamic sampling is off, so this only fires if both are on
+        // screen and inconsistent.
+        if (!grpo.use_dynamic_sampling && grpo.batch_multiplier !== 1) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Batch multiplier requires dynamic sampling to be enabled',
+            path: ['grpo', 'batch_multiplier'],
+          });
+        }
+        // Only automodel implements LoRA, expert parallelism and automodel_kwargs.
+        if (
+          grpo.policy_backend === PolicyBackend.dtensor &&
+          grpo.finetuning_type === RlGRPOTrainingFinetuningType.lora
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'LoRA requires the automodel policy backend',
+            path: ['grpo', 'policy_backend'],
+          });
+        }
       }
     }
     const result = spec.safeParse(value);
@@ -401,6 +491,29 @@ export const formToAutomodelCreate = (f: CustomizationFormFields): AutomodelJobs
   };
 };
 
+/**
+ * Blank text fields mean "no integration", not "an integration named empty string". Drop
+ * empty values, then drop a provider whose fields are all empty, then the whole block.
+ */
+const cleanIntegrations = (
+  integrations: RlJobInput['integrations']
+): RlJobInput['integrations'] => {
+  if (!integrations) return undefined;
+  const prune = <T extends object>(obj: T | undefined | null): T | undefined => {
+    if (!obj) return undefined;
+    const kept = Object.entries(obj).filter(([, v]) =>
+      typeof v === 'string' ? v.trim() !== '' : Array.isArray(v) ? v.length > 0 : v != null
+    );
+    return kept.length > 0 ? (Object.fromEntries(kept) as T) : undefined;
+  };
+  const wandb = prune(integrations.wandb);
+  const mlflow = prune(integrations.mlflow);
+  return wandb || mlflow ? { ...(wandb && { wandb }), ...(mlflow && { mlflow }) } : undefined;
+};
+
+/** An empty list is not a filter — send nothing so the backend keeps its own default. */
+const emptyToUndefined = (v: string[] | undefined | null) => (v && v.length > 0 ? v : undefined);
+
 export const formToRlCreate = (f: CustomizationFormFields): RlJobsJobRequest => {
   if (f.grpo.trainingType === 'grpo') {
     const t = f.rl.training;
@@ -412,6 +525,7 @@ export const formToRlCreate = (f: CustomizationFormFields): RlJobsJobRequest => 
         model: f.rl.model,
         dataset: f.rl.dataset,
         environment: f.grpo.environmentFileset || undefined,
+        integrations: cleanIntegrations(f.rl.integrations),
         training: {
           type: 'grpo',
           optimizer_type: t.optimizer_type,
@@ -434,7 +548,13 @@ export const formToRlCreate = (f: CustomizationFormFields): RlJobsJobRequest => 
           parallelism: t.parallelism,
           max_grad_norm: t.max_grad_norm,
           finetuning_type: f.grpo.finetuning_type,
-          lora: isLora ? f.grpo.lora : undefined,
+          lora: isLora
+            ? {
+                ...f.grpo.lora,
+                target_modules: emptyToUndefined(f.grpo.lora.target_modules),
+                exclude_modules: emptyToUndefined(f.grpo.lora.exclude_modules),
+              }
+            : undefined,
           num_generations_per_prompt: f.grpo.num_generations_per_prompt,
           num_prompts_per_step: f.grpo.num_prompts_per_step,
           overlong_filtering: f.grpo.overlong_filtering,
@@ -446,6 +566,36 @@ export const formToRlCreate = (f: CustomizationFormFields): RlJobsJobRequest => 
           ref_policy_kl_penalty: t.ref_policy_kl_penalty,
           ratio_clip_min: f.grpo.ratio_clip_min,
           ratio_clip_max: f.grpo.ratio_clip_max,
+          epochs: t.epochs,
+          execution_profile: t.execution_profile || undefined,
+          ratio_clip_c: f.grpo.ratio_clip_c,
+          advantage_clip_low: f.grpo.advantage_clip_low,
+          advantage_clip_high: f.grpo.advantage_clip_high,
+          use_dynamic_sampling: f.grpo.use_dynamic_sampling,
+          // The backend rejects a multiplier other than 1.0 unless dynamic sampling is on,
+          // so the two always travel together.
+          batch_multiplier: f.grpo.use_dynamic_sampling ? f.grpo.batch_multiplier : undefined,
+          dynamic_sampling_max_gen_batches: f.grpo.use_dynamic_sampling
+            ? f.grpo.dynamic_sampling_max_gen_batches
+            : undefined,
+          use_leave_one_out_baseline: f.grpo.use_leave_one_out_baseline,
+          use_importance_sampling_correction: f.grpo.use_importance_sampling_correction,
+          use_on_policy_kl_approximation: f.grpo.use_on_policy_kl_approximation,
+          truncated_importance_sampling_type: f.grpo.truncated_importance_sampling_type,
+          truncated_importance_sampling_ratio: f.grpo.truncated_importance_sampling_ratio,
+          truncated_importance_sampling_ratio_min: f.grpo.truncated_importance_sampling_ratio_min,
+          reward_scaling: f.grpo.reward_scaling,
+          reward_shaping: f.grpo.reward_shaping,
+          policy_backend: f.grpo.policy_backend,
+          batching_strategy: f.grpo.batching_strategy,
+          sequence_length_round: f.grpo.sequence_length_round,
+          top_k: f.grpo.top_k,
+          train_mb_tokens: f.grpo.train_mb_tokens,
+          router_aux_loss_coef: f.grpo.router_aux_loss_coef,
+          vllm_tensor_parallel_size: f.grpo.vllm_tensor_parallel_size,
+          vllm_gpu_memory_utilization: f.grpo.vllm_gpu_memory_utilization,
+          hf_config_overrides: f.grpo.hf_config_overrides,
+          automodel_kwargs: f.grpo.automodel_kwargs,
         },
         output: { name: f.outputName || undefined },
       },
@@ -463,6 +613,7 @@ export const formToRlCreate = (f: CustomizationFormFields): RlJobsJobRequest => 
     spec: {
       model: f.rl.model,
       dataset: f.rl.dataset,
+      integrations: cleanIntegrations(f.rl.integrations),
       training: {
         type: 'dpo' as const,
         optimizer_type: dpo.optimizer_type,
@@ -490,6 +641,7 @@ export const formToRlCreate = (f: CustomizationFormFields): RlJobsJobRequest => 
         sft_loss_weight: dpo.sft_loss_weight,
         preference_average_log_probs: dpo.preference_average_log_probs,
         sft_average_log_probs: dpo.sft_average_log_probs,
+        execution_profile: dpo.execution_profile || undefined,
       },
       output: { name: f.outputName || undefined },
     },
@@ -565,6 +717,36 @@ export const jobToFormFields = (job: CustomizationJob): CustomizationFormFields 
           max_new_tokens: grpo.max_new_tokens ?? defaults.max_new_tokens,
           finetuning_type: grpo.finetuning_type ?? defaults.finetuning_type,
           lora: grpo.lora ? { ...defaults.lora, ...grpo.lora } : defaults.lora,
+          use_dynamic_sampling: grpo.use_dynamic_sampling ?? defaults.use_dynamic_sampling,
+          batch_multiplier: grpo.batch_multiplier ?? defaults.batch_multiplier,
+          dynamic_sampling_max_gen_batches:
+            grpo.dynamic_sampling_max_gen_batches ?? defaults.dynamic_sampling_max_gen_batches,
+          use_leave_one_out_baseline:
+            grpo.use_leave_one_out_baseline ?? defaults.use_leave_one_out_baseline,
+          use_importance_sampling_correction:
+            grpo.use_importance_sampling_correction ?? defaults.use_importance_sampling_correction,
+          use_on_policy_kl_approximation:
+            grpo.use_on_policy_kl_approximation ?? defaults.use_on_policy_kl_approximation,
+          policy_backend: grpo.policy_backend ?? defaults.policy_backend,
+          batching_strategy: grpo.batching_strategy ?? defaults.batching_strategy,
+          sequence_length_round: grpo.sequence_length_round ?? defaults.sequence_length_round,
+          vllm_gpu_memory_utilization:
+            grpo.vllm_gpu_memory_utilization ?? defaults.vllm_gpu_memory_utilization,
+          // No `??` fallback: these are unset by default, and absence is meaningful.
+          ratio_clip_c: grpo.ratio_clip_c,
+          advantage_clip_low: grpo.advantage_clip_low,
+          advantage_clip_high: grpo.advantage_clip_high,
+          truncated_importance_sampling_type: grpo.truncated_importance_sampling_type,
+          truncated_importance_sampling_ratio: grpo.truncated_importance_sampling_ratio,
+          truncated_importance_sampling_ratio_min: grpo.truncated_importance_sampling_ratio_min,
+          top_k: grpo.top_k,
+          train_mb_tokens: grpo.train_mb_tokens,
+          router_aux_loss_coef: grpo.router_aux_loss_coef,
+          vllm_tensor_parallel_size: grpo.vllm_tensor_parallel_size,
+          reward_scaling: grpo.reward_scaling,
+          reward_shaping: grpo.reward_shaping,
+          hf_config_overrides: grpo.hf_config_overrides,
+          automodel_kwargs: grpo.automodel_kwargs,
         }),
       },
     };


### PR DESCRIPTION
https://linear.app/nvidia/issue/ASTD-522/missing-inputs-in-ui-for-grpo-job

<img width="1211" height="677" alt="image" src="https://github.com/user-attachments/assets/3b52e57f-fe62-437b-a194-316fd358c170" />
<img width="1080" height="822" alt="image" src="https://github.com/user-attachments/assets/269dd499-1b09-4357-968a-cdb809ee158d" />

Added parameters

Rollout & Sampling

- top_k — restrict rollout sampling to the k most likely tokens (default: unset)
- use_dynamic_sampling — discard prompt groups with no reward spread (default: false)
- batch_multiplier — over-generate so dynamic sampling has candidates to filter (default: 1.0)
- dynamic_sampling_max_gen_batches — generation batches one step may consume before failing (default: 10)

Reward

- reward_scaling — source_min, source_max, target_min, target_max
- reward_shaping — overlong_buffer_length, overlong_buffer_penalty, max_response_length, stop_properly_penalty_coef

Policy Update

- use_leave_one_out_baseline — score each rollout against its siblings (default: true)
- use_importance_sampling_correction — reweight tokens by training-vs-rollout policy likelihood (default: true)
- use_on_policy_kl_approximation — estimate KL against the generating policy (default: true)
- ratio_clip_c — dual-clip bound (default: unset)
- advantage_clip_low / advantage_clip_high — bounds on normalized advantages (default: unset)
- truncated_importance_sampling_type — tis / icepop / seq-mask-tis (default: unset)
- truncated_importance_sampling_ratio / truncated_importance_sampling_ratio_min — importance weight bounds (default: unset)

Execution & Overrides

- policy_backend — automodel / dtensor (default: automodel)
- batching_strategy — dynamic / static / sequence_packing (default: dynamic)
- sequence_length_round — round micro-batch sequence lengths to a multiple (default: 64)
- train_mb_tokens — token budget per training micro-batch (default: unset)
- vllm_tensor_parallel_size — TP size for the rollout engine (default: unset)
- vllm_gpu_memory_utilization — GPU fraction reserved by vLLM (default: 0.5)
- router_aux_loss_coef — MoE router auxiliary-loss coefficient (default: unset)
- hf_config_overrides — JSON passthrough to HF config / vLLM hf_overrides (default: unset)
- automodel_kwargs — JSON passthrough selecting MoE compute kernels (default: unset)

Previously-missing basics

- epochs — GRPO had no control; DPO already did
- execution_profile — added to both DPO and GRPO
- target_modules / exclude_modules — LoRA module lists

Top-level (both DPO and GRPO)

- integrations.wandb — project, name, entity, tags, notes, b
- integrations.mlflow — experiment_name, name, description, tracking_uri


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Expanded GRPO configuration with rollout, sampling, reward, batching, model, backend, and validation options.
  * Added optional reinforcement-learning experiment tracking for Weights & Biases and MLflow.
  * Added editable LoRA target and excluded module lists.
  * Added collapsible form sections and clearer placeholders for unset values.
* **Bug Fixes**
  * Improved handling of unset values, reset fields, and empty configuration entries.
  * Job replay now restores expanded GRPO settings more reliably.
  * Increased the RL validation interval limit to 1,000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->