### PR TITLE
refactor(experimentalist): upload Intake traces through the typed SDK

### DIFF
--- a/plugins/nemo-experimentalist/examples/smoke-agent/scripts/record_traces.py
+++ b/plugins/nemo-experimentalist/examples/smoke-agent/scripts/record_traces.py
@@ -33,7 +33,6 @@ from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
 
 AGENT_NAME = "smoke-agent"
 AGENT_VERSION = "1.0.0"
-INGEST_PATH = "/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
 POLL_ATTEMPTS = 30
 POLL_DELAY_SECONDS = 2.0
 
@@ -46,7 +45,6 @@ async def _upload_trials(
     group: str,
 ) -> dict[str, str]:
     """Upload each trial's trace; return {task_id: trace_id}."""
-    url = INGEST_PATH.format(workspace=workspace)
     trace_ids: dict[str, str] = {}
 
     for trial in trials:
@@ -68,12 +66,7 @@ async def _upload_trials(
         if not payloads:
             raise RuntimeError(f"Trial {trial.id} produced an empty trace")
         for payload in payloads:
-            await client.post(
-                url,
-                cast_to=object,
-                content=payload,
-                options={"headers": {"Content-Type": "application/x-protobuf"}},
-            )
+            await client.intake.ingest.otlp.v1.traces.create(body=payload, workspace=workspace)
         # Every recording run uses one attempt per task.  Keep the task id here
         # so the caller can put precisely the failing task traces in an Insight.
         trace_ids[trial.task_id] = trace_id

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
@@ -142,7 +142,6 @@ async def _upload_trials(
     model: str,
 ) -> dict[str, str]:
     trace_ids: dict[str, str] = {}
-    url = f"/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
 
     for trial in trials:
         if trial.trace is None:
@@ -164,12 +163,7 @@ async def _upload_trials(
         if not payloads:
             raise RuntimeError(f"Trial {trial.id} produced an empty agent execution trace")
         for payload in payloads:
-            await client.post(
-                url,
-                cast_to=object,
-                content=payload,
-                options={"headers": {"Content-Type": "application/x-protobuf"}},
-            )
+            await client.intake.ingest.otlp.v1.traces.create(body=payload, workspace=workspace)
         trace_ids[trial.id] = trace_id
 
     return trace_ids

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/atif.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/atif.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from nemo_experimentalist_plugin.entities import ResourceRef
+from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParams
 
 # ATIF carries agent identity on the trajectory; the Experimentalist carries it as
 # OTLP-style span attributes. This maps one onto the other.
@@ -54,7 +55,7 @@ def build_ingest_payload(
     evaluation_name: str,
     task_id: str,
     agent_attrs: dict[str, str],
-) -> dict[str, Any]:
+) -> AtifCreateParams:
     """Load a trajectory and stamp evaluation identity onto it for Intake ingest.
 
     Agent fields the producer already set are left alone; ``agent_attrs`` only
@@ -71,7 +72,7 @@ def build_ingest_payload(
         agent_attrs(dict[str, str]): OTLP-style agent attributes used as fallbacks.
 
     Returns:
-        dict[str, Any]: The ATIF ingest request body.
+        AtifCreateParams: The ATIF ingest request body.
     """
     trajectory = _load(ref)
     trajectory["evaluation_context"] = {
@@ -79,10 +80,18 @@ def build_ingest_payload(
         "test_case_name": task_id,
     }
     agent = trajectory.get("agent")
-    if not isinstance(agent, dict):
+    if agent is None:
         agent = {}
+    elif not isinstance(agent, dict):
+        raise ValueError(f"ATIF trajectory agent is not an object: {ref.uri}")
     for field, attr in _AGENT_FIELD_BY_ATTR:
         if not agent.get(field) and attr in agent_attrs:
             agent[field] = agent_attrs[attr]
     trajectory["agent"] = agent
-    return trajectory
+    # The trajectory is unvalidated JSON, so this cast is an assertion, not a proof: the
+    # checks cover only the keys AtifCreateParams marks required. Intake validates the rest.
+    if not isinstance(trajectory.get("schema_version"), str):
+        raise ValueError(f"ATIF trajectory has no schema_version: {ref.uri}")
+    if not all(isinstance(agent.get(field), str) for field in ("name", "version")):
+        raise ValueError(f"ATIF trajectory has no agent name and version: {ref.uri}")
+    return cast(AtifCreateParams, trajectory)

--- a/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/src/nemo_experimentalist_plugin/experimentalist/experimentalist_backend.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 import uuid
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterable
 from pathlib import Path
 from typing import Any, TypeVar, cast
 from urllib.parse import urlparse
@@ -55,6 +55,28 @@ logger = logging.getLogger(__name__)
 _ModelT = TypeVar("_ModelT", bound=BaseModel)
 
 
+async def _ingest_otlp(
+    client: AsyncNeMoPlatform,
+    payloads: Iterable[bytes],
+    *,
+    workspace: str,
+    trial_id: str,
+) -> None:
+    """Send OTLP payloads to Intake, failing if it could not map every span.
+
+    Intake answers 200 with a per-span error list, so a partial ingest is invisible
+    unless the response body is read. Raising keeps the caller from repointing the
+    trial at a trace that never fully landed; ``persist_evaluation`` catches this per
+    trial, so the run continues.
+    """
+    for payload in payloads:
+        response = await client.intake.ingest.otlp.v1.traces.create(body=payload, workspace=workspace)
+        if response.errors:
+            raise RuntimeError(
+                f"Intake rejected {len(response.errors)} span(s) for trial {trial_id}: {response.errors}"
+            )
+
+
 async def _upload_trace_otlp(
     client: AsyncNeMoPlatform,
     workspace: str,
@@ -74,14 +96,9 @@ async def _upload_trace_otlp(
         "nemo.trial.id": trial_id,
         **(extra_attrs or {}),
     }
-    url = f"/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
-    for payload in jsonl_to_protobuf(path, extra_resource_attrs=attrs):
-        await client.post(
-            url,
-            cast_to=object,
-            content=payload,
-            options={"headers": {"Content-Type": "application/x-protobuf"}},
-        )
+    await _ingest_otlp(
+        client, jsonl_to_protobuf(path, extra_resource_attrs=attrs), workspace=workspace, trial_id=trial_id
+    )
 
 
 async def _upload_trace_atif(
@@ -106,8 +123,8 @@ async def _upload_trace_atif(
         task_id=task_id,
         agent_attrs=extra_attrs or {},
     )
-    url = f"/apis/intake/v2/workspaces/{workspace}/ingest/atif"
-    await client.post(url, cast_to=object, body=payload)
+    payload["workspace"] = workspace
+    await client.intake.ingest.atif.create(**payload)
 
 
 _BASELINE_AGENT_LABEL = "agent-0"
@@ -742,14 +759,7 @@ class LocalExperimentalistBackend(ExperimentalistBackend):
                     "nemo.trial.id": trial.id,
                     **agent_attrs,
                 }
-                url = f"/apis/intake/v2/workspaces/{workspace}/ingest/otlp/v1/traces"
-                for payload in spans_to_protobuf(rows, attrs):
-                    await self.client.post(
-                        url,
-                        cast_to=object,
-                        content=payload,
-                        options={"headers": {"Content-Type": "application/x-protobuf"}},
-                    )
+                await _ingest_otlp(self.client, spans_to_protobuf(rows, attrs), workspace=workspace, trial_id=trial.id)
                 trace = await self._retrieve_trace_with_retry(trace_id, workspace=workspace)
         else:
             trace_format = str(trial.trace.metadata.get("trace_format", "otlp"))

--- a/plugins/nemo-experimentalist/tests/integration/conftest.py
+++ b/plugins/nemo-experimentalist/tests/integration/conftest.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A real Intake service, ClickHouse-backed, reachable through the platform SDK."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from importlib.util import find_spec
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from nemo_platform import AsyncNeMoPlatform
+from nmp.intake.config import ClickHouseConfig, IntakeConfig
+from nmp.intake.service import IntakeService
+from nmp.intake.spans.clickhouse_client import ClickHouseSettings, ClickHouseSpanClient, bootstrap_schema
+from nmp.testing import create_test_client
+
+CLICKHOUSE_VERSION = (
+    (Path(__file__).resolve().parents[4] / "services" / "intake" / ".clickhouse-version")
+    .read_text(encoding="utf-8")
+    .strip()
+)
+
+
+def _docker_available() -> bool:
+    if find_spec("docker") is None:
+        return False
+    from docker.errors import DockerException
+
+    import docker
+
+    try:
+        client = docker.from_env()
+        try:
+            client.ping()
+        finally:
+            client.close()
+        return True
+    except (DockerException, OSError):
+        return False
+
+
+@pytest.fixture(scope="session")
+def clickhouse_settings() -> Iterator[ClickHouseSettings]:
+    if not _docker_available():
+        pytest.skip("Docker is not available; Intake is ClickHouse-backed")
+
+    from testcontainers.clickhouse import ClickHouseContainer
+
+    with ClickHouseContainer(
+        f"clickhouse/clickhouse-server:{CLICKHOUSE_VERSION}", username="test", password="test", dbname="default"
+    ) as container:
+        settings = ClickHouseSettings(
+            url=f"http://{container.get_container_host_ip()}:{container.get_exposed_port(8123)}",
+            user=container.username,
+            password=container.password,
+            database=f"experimentalist_it_{uuid4().hex}",
+        )
+        client = ClickHouseSpanClient(settings)
+        asyncio.run(bootstrap_schema(client))
+        try:
+            yield settings
+        finally:
+            asyncio.run(client.close())
+
+
+@pytest.fixture
+def platform(clickhouse_settings: ClickHouseSettings) -> Iterator[AsyncNeMoPlatform]:
+    config = IntakeConfig(
+        clickhouse_config=ClickHouseConfig(
+            url=clickhouse_settings.url,
+            user=clickhouse_settings.user,
+            password=clickhouse_settings.password,
+            database=clickhouse_settings.database,
+        )
+    )
+    with create_test_client(
+        IntakeService, client_type=AsyncNeMoPlatform, service_configs={IntakeService: config}
+    ) as client:
+        yield client

--- a/plugins/nemo-experimentalist/tests/integration/test_persist_trial_to_intake.py
+++ b/plugins/nemo-experimentalist/tests/integration/test_persist_trial_to_intake.py
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration test: `_persist_trial` against a real Intake service and ClickHouse.
+
+The unit tests for these paths drive hand-written doubles, so they would keep passing if
+the generated SDK method were renamed or changed shape. This exercises the whole chain —
+backend, typed SDK, Intake, ClickHouse — and reads the trace back through the SDK.
+
+Run directly::
+
+    uv run pytest plugins/nemo-experimentalist/tests/integration/test_persist_trial_to_intake.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from nemo_experimentalist_plugin.entities import ResourceRef, TrialResult
+from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import LocalExperimentalistBackend
+from nemo_platform import AsyncNeMoPlatform
+
+pytestmark = pytest.mark.integration
+
+WORKSPACE = "default"
+
+
+def _otlp_trace(tmp_path: Path, span_name: str) -> tuple[ResourceRef, str]:
+    """One OTLP span on disk, in the jsonl shape the experimentalist's recorders emit.
+
+    Ids are minted per call: the ClickHouse database is shared across the session with no
+    truncation between tests, so fixed ids would make each test's reads depend on which
+    others had already run.
+    """
+    trace_id = uuid4().hex
+    span_id = uuid4().hex[:16]
+    # Intake's spans table is TTL'd at 90 days on start_time, so a fixed past timestamp
+    # would be dropped on write and the ingest would look successful but store nothing.
+    now_ns = time.time_ns()
+    line = {
+        "resourceSpans": [
+            {
+                "scopeSpans": [
+                    {
+                        "spans": [
+                            {
+                                "traceId": trace_id,
+                                "spanId": span_id,
+                                "name": span_name,
+                                "startTimeUnixNano": str(now_ns),
+                                "endTimeUnixNano": str(now_ns + 5_000_000),
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    path = tmp_path / f"trace-{trace_id}.jsonl"
+    path.write_text(json.dumps(line) + "\n", encoding="utf-8")
+    ref = ResourceRef(uri=f"file://{path}", description="", metadata={"trace_format": "otlp"})
+    return ref, trace_id
+
+
+async def test_persist_trial_uploads_a_local_otlp_trace_and_repoints_it(
+    platform: AsyncNeMoPlatform, tmp_path: Path
+) -> None:
+    backend = LocalExperimentalistBackend(client=platform, path=tmp_path / "backend")
+    trace, trace_id = _otlp_trace(tmp_path, "it-span")
+    trial = TrialResult(id="trial-it", task_id="case-it", status="completed", trace=trace)
+
+    await backend._persist_trial(trial, workspace=WORKSPACE, evaluation_name="exp-it", agent_attrs={})
+
+    # The span reached ClickHouse through the typed SDK and is readable back through it.
+    spans = await platform.intake.spans.list(workspace=WORKSPACE, filter={"trace_id": trace_id})
+    assert [span.name for span in spans.data] == ["it-span"]
+
+    # The trial now points at Intake, with the local file kept for reference.
+    assert trial.trace is not None
+    assert trial.trace.uri == f"intake://traces/{trace_id}"
+    assert str(trial.trace.metadata["local_uri"]).startswith("file://")
+
+
+async def test_persist_trial_stamps_evaluation_identity_onto_the_uploaded_spans(
+    platform: AsyncNeMoPlatform, tmp_path: Path
+) -> None:
+    backend = LocalExperimentalistBackend(client=platform, path=tmp_path / "backend")
+    trace, _ = _otlp_trace(tmp_path, "s")
+    trial = TrialResult(id="trial-attrs", task_id="case-attrs", status="completed", trace=trace)
+    # Unique for the same reason the ids are: this is the value the read filters on.
+    evaluation_name = f"exp-attrs-{uuid4().hex}"
+
+    await backend._persist_trial(trial, workspace=WORKSPACE, evaluation_name=evaluation_name, agent_attrs={})
+
+    # evaluation_name is the attribute Intake indexes and the experiments rollup groups on,
+    # so it has to survive the round trip rather than merely be sent.
+    spans = await platform.intake.spans.list(workspace=WORKSPACE, filter={"evaluation_name": evaluation_name})
+    assert [span.name for span in spans.data] == ["s"]

--- a/plugins/nemo-experimentalist/tests/test_atif.py
+++ b/plugins/nemo-experimentalist/tests/test_atif.py
@@ -92,6 +92,45 @@ def test_build_ingest_payload_preserves_producer_fields(tmp_path):
     assert payload["steps"] == [{"step_id": 1, "source": "user", "message": "hi"}]
 
 
+def test_build_ingest_payload_raises_when_schema_version_is_absent(tmp_path):
+    ref = _ref(tmp_path, _trajectory(schema_version=None))
+    with pytest.raises(ValueError, match="no schema_version"):
+        build_ingest_payload(ref, evaluation_name="exp-1", task_id="case-a", agent_attrs={})
+
+
+@pytest.mark.parametrize(
+    "agent",
+    [
+        pytest.param({}, id="empty"),
+        pytest.param({"name": "Codeact"}, id="no-version"),
+        pytest.param({"version": "1.0"}, id="no-name"),
+    ],
+)
+def test_build_ingest_payload_raises_when_agent_identity_is_absent(tmp_path, agent):
+    # Without these the cast would claim a shape the payload does not have.
+    ref = _ref(tmp_path, _trajectory(agent=agent))
+    with pytest.raises(ValueError, match="no agent name and version"):
+        build_ingest_payload(ref, evaluation_name="exp-1", task_id="case-a", agent_attrs={})
+
+
+def test_build_ingest_payload_names_the_agent_type_when_it_is_not_an_object(tmp_path):
+    # "no name and version" would send a producer looking for missing fields rather than
+    # a wrong type.
+    ref = _ref(tmp_path, _trajectory(agent="Codeact"))
+    with pytest.raises(ValueError, match="agent is not an object"):
+        build_ingest_payload(ref, evaluation_name="exp-1", task_id="case-a", agent_attrs={})
+
+
+def test_build_ingest_payload_accepts_blank_agent_identity(tmp_path):
+    # Intake types agent name and version as plain str, so blank is valid; the guard
+    # checks presence, not content, and must not be stricter than the server.
+    ref = _ref(tmp_path, _trajectory(agent={"name": "", "version": ""}))
+
+    payload = build_ingest_payload(ref, evaluation_name="exp-1", task_id="case-a", agent_attrs={})
+
+    assert payload["agent"] == {"name": "", "version": ""}
+
+
 def test_build_ingest_payload_fills_only_blank_agent_fields(tmp_path):
     # Producer set name and version; model_name is absent.
     payload = build_ingest_payload(

--- a/plugins/nemo-experimentalist/tests/test_experimentalist_backend.py
+++ b/plugins/nemo-experimentalist/tests/test_experimentalist_backend.py
@@ -11,8 +11,10 @@ boundary mocked.
 
 import asyncio
 import json
+import logging
 import traceback
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import httpx
@@ -377,17 +379,6 @@ async def test_persist_result_preserves_generated_optimization_report(tmp_path: 
 # ---------------------------------------------------------------------------
 
 
-class _RecordingClient:
-    """Captures posts so the payload and URL can be asserted directly."""
-
-    def __init__(self) -> None:
-        self.posts: list[dict] = []
-
-    async def post(self, url, *, cast_to, body=None, content=None, options=None):
-        self.posts.append({"url": url, "body": body, "content": content, "options": options})
-        return {}
-
-
 def _atif_ref(tmp_path, session_id="sess-1"):
     from nemo_experimentalist_plugin.entities import ResourceRef
 
@@ -406,10 +397,178 @@ def _atif_ref(tmp_path, session_id="sess-1"):
     return ResourceRef(uri=f"file://{path}", description="", metadata={"trace_format": "atif"})
 
 
-async def test_upload_trace_atif_posts_to_the_atif_ingest_endpoint(tmp_path):
+class _RecordingResource:
+    def __init__(self, result: object = None) -> None:
+        self.calls: list[dict] = []
+        self._result = result
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._result
+
+
+class _RecordingIntakeClient:
+    """Exposes only the ingest chains the trace uploads reach through."""
+
+    def __init__(self) -> None:
+        self.traces = _RecordingResource(SimpleNamespace(errors=[]))
+        self.atif = _RecordingResource()
+        self.intake = SimpleNamespace(
+            ingest=SimpleNamespace(
+                otlp=SimpleNamespace(v1=SimpleNamespace(traces=self.traces)),
+                atif=self.atif,
+            )
+        )
+
+
+def _otlp_ref(tmp_path):
+    from nemo_experimentalist_plugin.entities import ResourceRef
+
+    path = tmp_path / "trace.jsonl"
+    path.write_text(
+        json.dumps({"resourceSpans": [{"scopeSpans": [{"spans": [{"traceId": "f" * 32, "spanId": "a" * 16}]}]}]})
+        + "\n",
+        encoding="utf-8",
+    )
+    return ResourceRef(uri=f"file://{path}", description="", metadata={"trace_format": "otlp"})
+
+
+async def test_upload_trace_otlp_sends_protobuf_through_the_typed_sdk_method(tmp_path):
+    from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import _upload_trace_otlp
+
+    client = _RecordingIntakeClient()
+    await _upload_trace_otlp(
+        cast(Any, client),
+        "ws-1",
+        _otlp_ref(tmp_path),
+        evaluation_name="exp-1",
+        trial_id="trial-1",
+        task_id="case-a",
+    )
+
+    assert len(client.traces.calls) == 1
+    call = client.traces.calls[0]
+    assert call["workspace"] == "ws-1"
+    assert isinstance(call["body"], bytes)
+    assert b"exp-1" in call["body"]
+
+
+async def test_ingest_otlp_sends_every_payload_and_stays_quiet_when_intake_accepts(caplog):
+    from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import _ingest_otlp
+
+    client = _RecordingIntakeClient()
+
+    with caplog.at_level(logging.WARNING):
+        await _ingest_otlp(cast(Any, client), [b"one", b"two"], workspace="ws-1", trial_id="trial-1")
+
+    assert [call["body"] for call in client.traces.calls] == [b"one", b"two"]
+    assert all(call["workspace"] == "ws-1" for call in client.traces.calls)
+    assert caplog.text == ""
+
+
+async def test_upload_trace_otlp_raises_when_intake_rejects_spans(tmp_path):
+    from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import _upload_trace_otlp
+
+    client = _RecordingIntakeClient()
+    client.traces._result = SimpleNamespace(errors=["span 00a1: bad trace_id"])
+
+    with pytest.raises(RuntimeError, match="bad trace_id"):
+        await _upload_trace_otlp(
+            cast(Any, client),
+            "ws-1",
+            _otlp_ref(tmp_path),
+            evaluation_name="exp-1",
+            trial_id="trial-1",
+            task_id="case-a",
+        )
+
+
+async def test_persist_trial_leaves_the_local_trace_ref_when_ingest_is_rejected(tmp_path):
+    """A partial ingest must not repoint the trial at a trace that never fully landed."""
+    from nemo_experimentalist_plugin.entities import TrialResult
+
+    client = _RecordingIntakeClient()
+    client.traces._result = SimpleNamespace(errors=["span 00a1: bad trace_id"])
+    backend = LocalExperimentalistBackend(client=cast(Any, client), path=tmp_path / "backend")
+    ref = _otlp_ref(tmp_path)
+    trial = TrialResult(id="trial-9", task_id="case-z", status="completed", trace=ref)
+
+    with pytest.raises(RuntimeError):
+        await backend._persist_trial(trial, workspace="ws-1", evaluation_name="exp-1", agent_attrs={})
+
+    assert trial.trace is not None and trial.trace.uri == ref.uri
+
+
+async def _completed(value):
+    return value
+
+
+class _SpanRow:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def model_dump(self, **_kwargs):
+        return self._payload
+
+
+class _ReingestClient(_RecordingIntakeClient):
+    """Adds the span listing `_persist_trial` reads before it re-ingests."""
+
+    def __init__(self, rows: list[dict]) -> None:
+        super().__init__()
+        self.list_calls: list[dict] = []
+        self.intake.spans = SimpleNamespace(list=self._list)
+        self._rows = rows
+
+    def _list(self, **kwargs):
+        self.list_calls.append(kwargs)
+
+        async def _iter():
+            for row in self._rows:
+                yield _SpanRow(row)
+
+        return _iter()
+
+
+async def test_persist_trial_reingests_intake_traces_with_evaluation_attributes(tmp_path, monkeypatch):
+    from nemo_experimentalist_plugin.entities import ResourceRef, TrialResult
+
+    row = {
+        "span_id": "00000000000000a1",
+        "trace_id": "f" * 32,
+        "name": "root",
+        "started_at": "2026-08-14T00:00:00Z",
+    }
+    client = _ReingestClient([row])
+    backend = LocalExperimentalistBackend(client=cast(Any, client), path=tmp_path / "backend")
+    # The trace already exists in Intake but carries no evaluation context, which is the
+    # condition that triggers the re-ingest.
+    monkeypatch.setattr(
+        LocalExperimentalistBackend,
+        "_retrieve_trace_with_retry",
+        lambda self, trace_id, **kwargs: _completed(SimpleNamespace(evaluation_context=None)),
+    )
+    trial = TrialResult(
+        id="trial-9",
+        task_id="case-z",
+        status="completed",
+        trace=ResourceRef(uri="intake://traces/abc123", description="", metadata={}),
+    )
+
+    await backend._persist_trial(trial, workspace="ws-1", evaluation_name="exp-1", agent_attrs={})
+
+    assert client.list_calls[0]["workspace"] == "ws-1"
+    assert client.list_calls[0]["filter"] == {"trace_id": "abc123"}
+    assert len(client.traces.calls) == 1
+    body = client.traces.calls[0]["body"]
+    assert client.traces.calls[0]["workspace"] == "ws-1"
+    assert b"exp-1" in body and b"case-z" in body and b"trial-9" in body
+
+
+async def test_upload_trace_atif_sends_evaluation_context_and_agent_identity(tmp_path):
     from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import _upload_trace_atif
 
-    client = _RecordingClient()
+    client = _RecordingIntakeClient()
     await _upload_trace_atif(
         cast(Any, client),
         "ws-1",
@@ -419,23 +578,24 @@ async def test_upload_trace_atif_posts_to_the_atif_ingest_endpoint(tmp_path):
         extra_attrs={"gen_ai.request.model": "gpt-5-mini"},
     )
 
-    assert len(client.posts) == 1
-    post = client.posts[0]
-    assert post["url"] == "/apis/intake/v2/workspaces/ws-1/ingest/atif"
-    assert post["body"]["evaluation_context"] == {
+    assert len(client.atif.calls) == 1
+    call = client.atif.calls[0]
+    assert call["workspace"] == "ws-1"
+    assert call["evaluation_context"] == {
         "evaluation_name": "exp-1",
         "test_case_name": "case-a",
     }
-    assert post["body"]["agent"]["model_name"] == "gpt-5-mini"
+    assert call["agent"]["model_name"] == "gpt-5-mini"
 
 
-async def test_upload_trace_atif_sends_json_not_protobuf(tmp_path):
+async def test_upload_trace_atif_sends_a_trajectory_not_bytes(tmp_path):
     from nemo_experimentalist_plugin.experimentalist.experimentalist_backend import _upload_trace_atif
 
-    client = _RecordingClient()
+    client = _RecordingIntakeClient()
     await _upload_trace_atif(cast(Any, client), "ws-1", _atif_ref(tmp_path), evaluation_name="exp-1", task_id="case-a")
-    assert client.posts[0]["content"] is None
-    assert client.posts[0]["body"] is not None
+
+    assert client.traces.calls == []
+    assert client.atif.calls[0]["schema_version"].startswith("ATIF-")
 
 
 @pytest.mark.parametrize("bad_id", ["../run", "a/b", "..", ".", "nested/../../run"])


### PR DESCRIPTION
## Summary

Every Intake trace upload in `nemo-experimentalist` hand-built the route and set `Content-Type` itself, calling the SDK's low-level `client.post`. That was not a style choice — the generated `intake.ingest.otlp.v1.traces.create()` had no body parameter, so there was no typed method to call. #1680 gives it one, so the workaround can go: from both production paths and from the two example recorders that were the copy-paste source for it.

Two behaviour changes ride along, both described below: ingest errors are no longer discarded, and the ATIF payload is typed.

**Stacked on #1680** — based on `intake-otlp-protobuf-request-body/schapman`, not `main`. The typed method only exists there. Review #1680 first; GitHub will retarget this to `main` when it merges.

## Related Issue

Relates to AALGO-569 (Linear). No GitHub issue.

## Changes

- `experimentalist_backend.py`: new `_ingest_otlp` helper shared by both OTLP upload paths — `_upload_trace_otlp` and the `_persist_trial` re-ingest branch. `_upload_trace_atif` moves to `intake.ingest.atif.create(**payload)`.
- `atif.py`: `build_ingest_payload` returns the SDK's `AtifCreateParams` instead of `dict[str, Any]`, guarded on the keys the TypedDict marks required.
- `examples/smoke-agent/scripts/record_traces.py`, `examples/tau3-nooa-agent/record_tau_airline_traces.py`: same conversion. Removes the `INGEST_PATH` constant and both inline URLs.
- Tests: first coverage for `_upload_trace_otlp` and for the `_persist_trial` re-ingest branch; ATIF tests moved onto the typed call; the now-dead `_RecordingClient` double deleted.
- `tests/integration/`: the plugin's first integration coverage of the Intake upload path — a real ClickHouse-backed Intake service driven through a real platform client, reading the trace back through the SDK. Marked `integration`, so it is excluded from the unit suite and skips cleanly without Docker.

After this, `grep` for `/apis/intake` or `client.post(` across the whole plugin returns nothing.

### Behaviour change 1 — ingest errors are no longer discarded

Intake answers **HTTP 200 with a per-span error list**, so a partial ingest was invisible. `_persist_trial` would then repoint the trial at `intake://traces/<id>` and downstream scoring would consume a trace that never fully landed.

`_ingest_otlp` raises instead. `persist_evaluation` already wraps `_persist_trial` in a per-trial `except Exception`, so the run still continues — it just no longer records a trace reference it cannot honour, because the raise happens *before* the reference is rewritten.

**The trade-off**: a trial with a rejected span now records no metrics, where before it recorded metrics attached to a stale root span. No-data over wrong-data, but worth a reviewer's eye.

The two examples deliberately keep ignoring the response — examples should not carry production error semantics, and this matches their previous `cast_to=object` behaviour.

### Behaviour change 2 — typed ATIF payload

`AtifCreateParams` restored type checking at the call site, which immediately caught a latent bug: `workspace` was being passed both explicitly *and* through `**payload`, which raises `TypeError: got multiple values for keyword argument` whenever a trajectory carries a `workspace` key. Fixed by setting it into the payload, matching `nemo-evaluator`.

The cast is an assertion over unvalidated JSON from disk, so it is guarded on the required keys only. Validating `schema_version` against its `Literal` set, or agent extra/nested fields, would reimplement Intake's model here and drift from it; Intake owns that and answers 422.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: internal upload plumbing; no user-facing API, CLI, or config surface changes.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `pytest plugins/nemo-experimentalist/tests/` — **1026 passed, 51 skipped, 3 deselected** (unit suite; integration deselected)
- `pytest plugins/nemo-experimentalist/tests/integration/ -q` — **2 passed** against real Intake + ClickHouse
- `ruff check` / `ruff format --check` on the plugin — pass
- `ty check` on both changed source files — pass. Plugin-wide `ty` reports 52 diagnostics **both before and after** this change (verified against the parent commit in a scratch worktree); all are pre-existing, in `strategies/evolutionary.py` and elsewhere.
- **Mutation-checked** — every behaviour change broken on purpose with the matching test confirmed red: wrong workspace on the OTLP call; upload removed entirely; wrong workspace on the ATIF call; the `response.errors` check swallowed; the `schema_version` guard dropped; the agent guard dropped; the non-dict-agent branch reverted to silent coercion; the truthiness over-reach re-added; `nemo.evaluation.name` dropped from the re-ingest attrs; the re-ingest span filter changed from `trace_id` to `span_id`.
- Real SDK signatures verified by introspection rather than assumed: `traces.create(body, *, workspace, ...)` returns `IngestResponse`; `atif.create(*, workspace, agent, schema_version, ...)` returns `None`.
- The integration tests are mutation-checked too: sending an empty body fails both; a wrong `evaluation_name` fails the attribute test only.

**`uv run pre-commit run -a` — two hooks fail for environmental reasons, left unchecked rather than claimed:**

- **Helm Docs** — `helm-docs` not installed locally; this diff touches no `k8s/` or `helm/` files.
- **Run uv lock with platform uv** — pins uv 0.9.14, local is 0.9.30; this diff changes no dependency, and the sibling `Check for uv.lock drift` hook **passed**.

## Notes for reviewers

- The converted **example** paths are verified by type-checking and by being identical to the production change, **not by execution**: `test_smoke_agent_assets` only runs `record_traces.py --help`, the E2E suite skips without `--run-e2e`, and the Tau3 recorder has no coverage.
- The `_persist_trial` **re-ingest** branch (`intake://` URIs) is covered by a unit test of its wiring — span query filter, stamped attributes, emitted payload — not by the integration test, which exercises the local-upload branch.
- `tests/integration/` makes a plugin test import a service (`nmp.intake`). That inverts the usual direction, but matches existing precedent in `nemo-evaluator`, `nemo-agents`, and `example-plugin`, which all have `tests/integration/` importing `nmp.*`. The deps resolve through the shared workspace venv and are not declared in the plugin's `pyproject.toml`.
- Worth knowing for anyone writing Intake tests: the spans table is `TTL toDate(start_time) + INTERVAL 90 DAY`, so a span with an old timestamp is **silently dropped on write** — the ingest returns 200 with an empty `errors` list and stores nothing. The fixture uses `time.time_ns()` for that reason.
- `_ingest_otlp` posts payloads serially. That is inherited, and fine: the 4 MiB chunker means the list is almost always length one, and serial gives fail-fast against the new raise.
