### PR TITLE
fix(studio): Tooltip background is now readable on light mode

### DIFF
--- a/web/packages/common/src/components/charts/ChartTooltip.tsx
+++ b/web/packages/common/src/components/charts/ChartTooltip.tsx
@@ -13,10 +13,7 @@ export const ChartTooltipSurface: FC<{ label?: ReactNode; children?: ReactNode }
   label,
   children,
 }) => (
-  <Stack
-    gap="1"
-    className="bg-component-tooltip border border-component-tooltip shadow-sm rounded-lg p-3"
-  >
+  <Stack gap="1" className="bg-surface-overlay border border-base shadow-sm rounded-lg p-3">
     {label !== undefined && <Text kind="label/semibold/md">{label}</Text>}
     {children}
   </Stack>

--- a/web/packages/studio/src/components/charts/TrainValidationLossLineChart/index.tsx
+++ b/web/packages/studio/src/components/charts/TrainValidationLossLineChart/index.tsx
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { Stack, Text } from '@nvidia/foundations-react-core';
+import {
+  ChartTooltipRow,
+  ChartTooltipSurface,
+} from '@nemo/common/src/components/charts/ChartTooltip';
+import { Text } from '@nvidia/foundations-react-core';
 import { Empty } from '@studio/components/Empty';
 import type { CustomizationMetricValue } from '@studio/types/customization';
 import { type ComponentProps, useMemo } from 'react';
@@ -244,28 +248,24 @@ function CustomTooltip({ active, payload, label }: TooltipProps<number, string>)
   const dataPoint = payload[0]?.payload;
 
   return (
-    <Stack
-      gap="2"
-      className="bg-component-tooltip border border-component-tooltip shadow-sm rounded-lg p-3"
+    <ChartTooltipSurface
+      label={`Step ${label}${dataPoint?.epoch !== undefined ? ` • Epoch ${dataPoint.epoch}` : ''}`}
     >
-      <Text kind="label/semibold/md">
-        Step {label}
-        {dataPoint?.epoch !== undefined ? ` • Epoch ${dataPoint.epoch}` : ''}
-      </Text>
-      <Stack gap="1">
-        <Text kind="body/regular/sm" className="text-accent-blue">
-          Training Loss:{' '}
-          {dataPoint?.trainLoss !== undefined
-            ? `${dataPoint.trainLoss.toFixed(6)}${dataPoint.trainLossInterpolated ? ' (estimated)' : ''}`
-            : '—'}
-        </Text>
-        <Text kind="body/regular/sm" className="text-accent-yellow">
-          Validation Loss:{' '}
-          {dataPoint?.valLoss !== undefined
-            ? `${dataPoint.valLoss.toFixed(6)}${dataPoint.valLossInterpolated ? ' (estimated)' : ''}`
-            : '—'}
-        </Text>
-      </Stack>
-    </Stack>
+      <ChartTooltipRow
+        color="var(--border-color-accent-blue)"
+        label="Training Loss"
+        value={formatLoss(dataPoint?.trainLoss, dataPoint?.trainLossInterpolated)}
+      />
+      <ChartTooltipRow
+        color="var(--border-color-accent-yellow)"
+        label="Validation Loss"
+        value={formatLoss(dataPoint?.valLoss, dataPoint?.valLossInterpolated)}
+      />
+    </ChartTooltipSurface>
   );
 }
+
+const formatLoss = (value: number | undefined, interpolated: boolean | undefined): string => {
+  if (value === undefined) return '—';
+  return `${value.toFixed(6)}${interpolated ? ' (estimated)' : ''}`;
+};


### PR DESCRIPTION

<img width="322" height="187" alt="Screenshot 2026-09-01 at 9 14 14 AM" src="https://github.com/user-attachments/assets/955fcc6d-6164-4fd4-b45a-08515b5e43f9" />

Before

<img width="341" height="348" alt="Screenshot 2026-09-01 at 9 54 56 AM" src="https://github.com/user-attachments/assets/1b7d5da0-a629-427e-8772-f2664995c794" />

After

fix(studio): Tooltip background is now readable on light mode

Signed-off-by: Sean Teramae <steramae@nvidia.com>

fix(studio): Tooltip background is now readable on light mode

Signed-off-by: Sean Teramae <steramae@nvidia.com>

<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
<!-- In 1-3 plain sentences, explain what changes and why. Describe before-and-after behavior when it applies. -->

## Related Issue
<!-- Use Fixes #NNN or Closes #NNN for a related issue. Remove this section if there is none. -->

## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [ ] Targeted tests pass, or tests are marked not applicable above
- [ ] No secrets, API keys, or credentials are included

Targeted validation:

<!-- List each command and result. Explain skipped, blocked, or non-successful checks without marking them as passed. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated chart tooltips with consistent surface and border styling.
  * Improved training and validation loss tooltip presentation, including standardized number formatting, missing-value indicators, and interpolation labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->