### PR TITLE
feat(auth): implement access keys rotate

### DIFF
--- a/docs/auth/authentication/using-authentication.mdx
+++ b/docs/auth/authentication/using-authentication.mdx
@@ -134,23 +134,35 @@ Pass `--expires-in <seconds>` to request a specific finite lifetime. Pass
 `--expires-in none` only for deployments where the administrator has explicitly
 allowed unlimited keys.
 
-List keys, temporarily suspend and restore one, or permanently revoke one by its stable `jti`:
+List keys, temporarily suspend and restore one, rotate one, or permanently revoke one by
+its stable `jti`:
 
 ```bash
 nemo auth access-keys list
 nemo auth access-keys list --page 2 --page-size 100
 nemo auth access-keys suspend ak_0123456789abcdef0123456789abcdef
 nemo auth access-keys unsuspend ak_0123456789abcdef0123456789abcdef
+nemo auth access-keys rotate ak_0123456789abcdef0123456789abcdef
 nemo auth access-keys revoke ak_0123456789abcdef0123456789abcdef
 ```
 
-The list includes each key's `ACTIVE`, `EXPIRED`, `SUSPENDED`, or `REVOKED` status
-plus its description, issuer, audiences, creation time, and expiration time. Suspension
-and revocation take effect on subsequent authenticated platform requests. Use suspension
-to temporarily block a key, such as while investigating suspected misuse, without
-permanently revoking it. An unexpired suspended key can be restored with `unsuspend`. If
-the key expires while suspended, `unsuspend` is a no-op and reports `EXPIRED`. A revoked
-key cannot be restored. Rotation is not implemented.
+The list includes each key's `ACTIVE`, `EXPIRED`, `SUSPENDED`, `ROTATING`, or `REVOKED`
+status plus its description, issuer, audiences, creation time, expiration time, and last
+authentication time. Suspension and revocation take effect on subsequent authenticated
+platform requests. Use suspension to temporarily block a key, such as while investigating
+suspected misuse, without permanently revoking it. An unexpired suspended key can be
+restored with `unsuspend`. If the key expires while suspended, `unsuspend` is a no-op and
+reports `EXPIRED`. A revoked key cannot be restored.
+
+`rotate` mints a successor key with the same name, description, and lifetime
+characteristics, prints its token once, and transitions the original key to `ROTATING`.
+The rotated-out key keeps authenticating for a dual-active grace period (configurable via
+`auth.access_keys.rotation_grace_period_seconds`, 48 hours by default) so you can update
+configuration or secret stores to the new key without downtime, then call `revoke` on the
+old `jti` once traffic has moved over — check its last authentication time in `list` to
+confirm no recent traffic before revoking. If you don't revoke it manually, it is treated
+as revoked automatically once the grace period elapses. A key must be `ACTIVE` to rotate;
+a suspended, already-rotating, expired, or revoked key must be resolved first.
 
 ### Token Inspection
 

--- a/docs/auth/deployment/configuration.mdx
+++ b/docs/auth/deployment/configuration.mdx
@@ -116,6 +116,7 @@ auth:
    audience: "nemo-platform-access-key"
    default_expires_in_seconds: 2592000
    max_expires_in_seconds: 2592000
+   rotation_grace_period_seconds: 172800
 ```
 
 Equivalent environment overrides:
@@ -130,6 +131,7 @@ NMP_AUTH_ACCESS_KEYS__ACCEPTED_FORMATS=jwt
 NMP_AUTH_ACCESS_KEYS__AUDIENCE=nemo-platform-access-key
 NMP_AUTH_ACCESS_KEYS__DEFAULT_EXPIRES_IN_SECONDS=2592000
 NMP_AUTH_ACCESS_KEYS__MAX_EXPIRES_IN_SECONDS=2592000
+NMP_AUTH_ACCESS_KEYS__ROTATION_GRACE_PERIOD_SECONDS=172800
 ```
 
 List-valued env vars for accepted Scoped Access Key formats are written as
@@ -159,6 +161,13 @@ With a finite `max_expires_in_seconds` and `default_expires_in_seconds: null`,
 callers must provide a finite `expires_in_seconds`. When
 `max_expires_in_seconds` is `null`, callers may still provide a finite
 `expires_in_seconds`, and the auth service honors that finite lifetime.
+
+`POST /apis/auth/v2/access-keys/{jti}/rotate` mints a successor key and puts the
+rotated-out key into a `ROTATING` state that still authenticates for
+`auth.access_keys.rotation_grace_period_seconds` (48 hours by default), so
+deployments can cut over configuration before the old key is finalized. Call
+`DELETE /apis/auth/v2/access-keys/{jti}` on the old key to finalize rotation
+immediately, or let it lapse automatically once the grace period elapses.
 
 The issuer defaults to `<platform.base_url>/apis/auth` when
 `auth.token_signing.issuer` is unset. Use an externally reachable issuer URL

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -283,6 +283,7 @@ nemo auth access-keys [OPTIONS] COMMAND [ARGS]...
 * `revoke`: Revoke a Scoped Access Key owned by the currently...
 * `suspend`: Temporarily suspend a Scoped Access Key owned by the...
 * `unsuspend`: Restore a suspended Scoped Access Key owned by the...
+* `rotate`: Mint a successor Scoped Access Key and start the old...
 
 ##### nemo auth access-keys create
 
@@ -378,6 +379,32 @@ nemo auth access-keys unsuspend [OPTIONS] JTI
 **Arguments:**
 
 * `<JTI>`: Stable ID of the Scoped Access Key to unsuspend.
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+##### nemo auth access-keys rotate
+
+Mint a successor Scoped Access Key and start the old key's rotation grace period.
+
+The old key (jti) keeps working for its rotation grace period so you can cut
+configuration over to the new key without downtime, then revoke the old key once
+traffic has moved, or let it expire automatically at the end of the grace period.
+
+**Usage:**
+
+```shell
+nemo auth access-keys rotate [OPTIONS] JTI
+```
+
+**Arguments:**
+
+* `<JTI>`: Stable ID of the Scoped Access Key to rotate.
+
+**Options:**
+
+* `--grace-period-seconds <INTEGER RANGE>`: Grace period in seconds for the rotated-out key. Defaults to the server's `rotation_grace_period_seconds` config (default 48h) when omitted, and is capped by `max_rotation_grace_period_seconds`.
 
 **Help:**
 

--- a/docs/set-up/config-reference.mdx
+++ b/docs/set-up/config-reference.mdx
@@ -170,6 +170,10 @@ auth:
     default_expires_in_seconds: 2592000
     # Maximum finite lifetime accepted when creating Scoped Access Keys. Set to null to allow explicit no-expiration requests. | default: 2592000
     max_expires_in_seconds: 2592000
+    # Default grace period in seconds for a rotated-out Scoped Access Key, used when grace_period_seconds is omitted from POST /v2/access-keys/{jti}/rotate. The key remains usable for this long after rotation before it is treated as revoked. Gives callers a dual-active window to cut over to the newly issued key. | default: 172800
+    rotation_grace_period_seconds: 172800
+    # Maximum grace period accepted when a caller explicitly requests grace_period_seconds on POST /v2/access-keys/{jti}/rotate. Set to null to allow any explicitly requested grace period. | default: 2592000
+    max_rotation_grace_period_seconds: 2592000
   # Port to run the service on | default: 8000
   port: 8000
   # Refresh interval for policy data in seconds | default: 30

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -333,6 +333,66 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/auth/v2/access-keys/{jti}/rotate:
+    post:
+      tags:
+      - Scoped Access Keys
+      summary: Rotate Access Key
+      operationId: rotate_access_key_apis_auth_v2_access_keys__jti__rotate_post
+      parameters:
+      - name: jti
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: ^ak_[0-9a-f]{32}$
+          description: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+          title: Jti
+        description: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/AccessKeyRotateRequest'
+              default: {}
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyRotateResponse'
+        '400':
+          description: Scoped Access Key rotation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '404':
+          description: Scoped Access Keys are not enabled or the key was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '409':
+          description: Invalid or concurrent access-key state transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '501':
+          description: Not Implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyNotImplementedErrorResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/auth/v2/access-keys/{jti}/suspend:
     post:
       tags:
@@ -8322,6 +8382,7 @@ components:
           - EXPIRED
           - REVOKED
           - SUSPENDED
+          - ROTATING
           title: Status
         issuer:
           type: string
@@ -8340,6 +8401,19 @@ components:
           title: Created At
         expires_at:
           title: Expires At
+          nullable: true
+          type: string
+          format: date-time
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+        last_used_at:
+          title: Last Used At
+          description: Timestamp of the most recent successful authentication with
+            this Scoped Access Key.
           nullable: true
           type: string
           format: date-time
@@ -8431,6 +8505,7 @@ components:
           - EXPIRED
           - REVOKED
           - SUSPENDED
+          - ROTATING
           title: Status
         issuer:
           type: string
@@ -8449,6 +8524,19 @@ components:
           title: Created At
         expires_at:
           title: Expires At
+          nullable: true
+          type: string
+          format: date-time
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+        last_used_at:
+          title: Last Used At
+          description: Timestamp of the most recent successful authentication with
+            this Scoped Access Key.
           nullable: true
           type: string
           format: date-time
@@ -8488,6 +8576,68 @@ components:
       - revoked
       title: AccessKeyRevokeResponse
       description: Response returned after a Scoped Access Key revoke request.
+    AccessKeyRotateRequest:
+      properties:
+        grace_period_seconds:
+          title: Grace Period Seconds
+          description: Grace period in seconds for the rotated-out key. Omit to use
+            auth.access_keys.rotation_grace_period_seconds. Subject to auth.access_keys.max_rotation_grace_period_seconds.
+          nullable: true
+          type: integer
+          minimum: 1.0
+      type: object
+      title: AccessKeyRotateRequest
+      description: Request body for rotating a Scoped Access Key.
+    AccessKeyRotateResponse:
+      properties:
+        new_key:
+          allOf:
+          - $ref: '#/components/schemas/AccessKeyCreateResponse'
+          description: Newly minted successor Scoped Access Key. Its raw token is
+            returned only once.
+        previous_jti:
+          type: string
+          title: Previous Jti
+          description: Stable JWT ID of the Scoped Access Key that was rotated out.
+        previous_status:
+          type: string
+          enum:
+          - ACTIVE
+          - EXPIRED
+          - REVOKED
+          - SUSPENDED
+          - ROTATING
+          title: Previous Status
+          description: Effective status of the rotated-out key immediately after this
+            request. Normally ROTATING, but may already read as REVOKED or EXPIRED
+            if reconciling this request's outcome was itself delayed past the grace
+            deadline or a concurrent revoke.
+        grace_period_seconds:
+          type: integer
+          title: Grace Period Seconds
+          description: Seconds the rotated-out key remains usable before it is treated
+            as revoked.
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+      type: object
+      required:
+      - new_key
+      - previous_jti
+      - previous_status
+      - grace_period_seconds
+      title: AccessKeyRotateResponse
+      description: 'Response returned after rotating a Scoped Access Key.
+
+
+        The rotated-out key (``previous_jti``) remains usable for ``grace_period_seconds``
+
+        (the dual-active grace period) so callers can cut traffic over to ``new_key``
+
+        before the old key is treated as revoked.'
     AccessKeyStatusChangeResponse:
       properties:
         jti:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -333,6 +333,66 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/auth/v2/access-keys/{jti}/rotate:
+    post:
+      tags:
+      - Scoped Access Keys
+      summary: Rotate Access Key
+      operationId: rotate_access_key_apis_auth_v2_access_keys__jti__rotate_post
+      parameters:
+      - name: jti
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: ^ak_[0-9a-f]{32}$
+          description: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+          title: Jti
+        description: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/AccessKeyRotateRequest'
+              default: {}
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyRotateResponse'
+        '400':
+          description: Scoped Access Key rotation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '404':
+          description: Scoped Access Keys are not enabled or the key was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '409':
+          description: Invalid or concurrent access-key state transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '501':
+          description: Not Implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyNotImplementedErrorResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/auth/v2/access-keys/{jti}/suspend:
     post:
       tags:
@@ -8322,6 +8382,7 @@ components:
           - EXPIRED
           - REVOKED
           - SUSPENDED
+          - ROTATING
           title: Status
         issuer:
           type: string
@@ -8340,6 +8401,19 @@ components:
           title: Created At
         expires_at:
           title: Expires At
+          nullable: true
+          type: string
+          format: date-time
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+        last_used_at:
+          title: Last Used At
+          description: Timestamp of the most recent successful authentication with
+            this Scoped Access Key.
           nullable: true
           type: string
           format: date-time
@@ -8431,6 +8505,7 @@ components:
           - EXPIRED
           - REVOKED
           - SUSPENDED
+          - ROTATING
           title: Status
         issuer:
           type: string
@@ -8449,6 +8524,19 @@ components:
           title: Created At
         expires_at:
           title: Expires At
+          nullable: true
+          type: string
+          format: date-time
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+        last_used_at:
+          title: Last Used At
+          description: Timestamp of the most recent successful authentication with
+            this Scoped Access Key.
           nullable: true
           type: string
           format: date-time
@@ -8488,6 +8576,68 @@ components:
       - revoked
       title: AccessKeyRevokeResponse
       description: Response returned after a Scoped Access Key revoke request.
+    AccessKeyRotateRequest:
+      properties:
+        grace_period_seconds:
+          title: Grace Period Seconds
+          description: Grace period in seconds for the rotated-out key. Omit to use
+            auth.access_keys.rotation_grace_period_seconds. Subject to auth.access_keys.max_rotation_grace_period_seconds.
+          nullable: true
+          type: integer
+          minimum: 1.0
+      type: object
+      title: AccessKeyRotateRequest
+      description: Request body for rotating a Scoped Access Key.
+    AccessKeyRotateResponse:
+      properties:
+        new_key:
+          allOf:
+          - $ref: '#/components/schemas/AccessKeyCreateResponse'
+          description: Newly minted successor Scoped Access Key. Its raw token is
+            returned only once.
+        previous_jti:
+          type: string
+          title: Previous Jti
+          description: Stable JWT ID of the Scoped Access Key that was rotated out.
+        previous_status:
+          type: string
+          enum:
+          - ACTIVE
+          - EXPIRED
+          - REVOKED
+          - SUSPENDED
+          - ROTATING
+          title: Previous Status
+          description: Effective status of the rotated-out key immediately after this
+            request. Normally ROTATING, but may already read as REVOKED or EXPIRED
+            if reconciling this request's outcome was itself delayed past the grace
+            deadline or a concurrent revoke.
+        grace_period_seconds:
+          type: integer
+          title: Grace Period Seconds
+          description: Seconds the rotated-out key remains usable before it is treated
+            as revoked.
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+      type: object
+      required:
+      - new_key
+      - previous_jti
+      - previous_status
+      - grace_period_seconds
+      title: AccessKeyRotateResponse
+      description: 'Response returned after rotating a Scoped Access Key.
+
+
+        The rotated-out key (``previous_jti``) remains usable for ``grace_period_seconds``
+
+        (the dual-active grace period) so callers can cut traffic over to ``new_key``
+
+        before the old key is treated as revoked.'
     AccessKeyStatusChangeResponse:
       properties:
         jti:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -333,6 +333,66 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/auth/v2/access-keys/{jti}/rotate:
+    post:
+      tags:
+      - Scoped Access Keys
+      summary: Rotate Access Key
+      operationId: rotate_access_key_apis_auth_v2_access_keys__jti__rotate_post
+      parameters:
+      - name: jti
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: ^ak_[0-9a-f]{32}$
+          description: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+          title: Jti
+        description: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/AccessKeyRotateRequest'
+              default: {}
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyRotateResponse'
+        '400':
+          description: Scoped Access Key rotation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '404':
+          description: Scoped Access Keys are not enabled or the key was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '409':
+          description: Invalid or concurrent access-key state transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '501':
+          description: Not Implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyNotImplementedErrorResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/auth/v2/access-keys/{jti}/suspend:
     post:
       tags:
@@ -8322,6 +8382,7 @@ components:
           - EXPIRED
           - REVOKED
           - SUSPENDED
+          - ROTATING
           title: Status
         issuer:
           type: string
@@ -8340,6 +8401,19 @@ components:
           title: Created At
         expires_at:
           title: Expires At
+          nullable: true
+          type: string
+          format: date-time
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+        last_used_at:
+          title: Last Used At
+          description: Timestamp of the most recent successful authentication with
+            this Scoped Access Key.
           nullable: true
           type: string
           format: date-time
@@ -8431,6 +8505,7 @@ components:
           - EXPIRED
           - REVOKED
           - SUSPENDED
+          - ROTATING
           title: Status
         issuer:
           type: string
@@ -8449,6 +8524,19 @@ components:
           title: Created At
         expires_at:
           title: Expires At
+          nullable: true
+          type: string
+          format: date-time
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+        last_used_at:
+          title: Last Used At
+          description: Timestamp of the most recent successful authentication with
+            this Scoped Access Key.
           nullable: true
           type: string
           format: date-time
@@ -8488,6 +8576,68 @@ components:
       - revoked
       title: AccessKeyRevokeResponse
       description: Response returned after a Scoped Access Key revoke request.
+    AccessKeyRotateRequest:
+      properties:
+        grace_period_seconds:
+          title: Grace Period Seconds
+          description: Grace period in seconds for the rotated-out key. Omit to use
+            auth.access_keys.rotation_grace_period_seconds. Subject to auth.access_keys.max_rotation_grace_period_seconds.
+          nullable: true
+          type: integer
+          minimum: 1.0
+      type: object
+      title: AccessKeyRotateRequest
+      description: Request body for rotating a Scoped Access Key.
+    AccessKeyRotateResponse:
+      properties:
+        new_key:
+          allOf:
+          - $ref: '#/components/schemas/AccessKeyCreateResponse'
+          description: Newly minted successor Scoped Access Key. Its raw token is
+            returned only once.
+        previous_jti:
+          type: string
+          title: Previous Jti
+          description: Stable JWT ID of the Scoped Access Key that was rotated out.
+        previous_status:
+          type: string
+          enum:
+          - ACTIVE
+          - EXPIRED
+          - REVOKED
+          - SUSPENDED
+          - ROTATING
+          title: Previous Status
+          description: Effective status of the rotated-out key immediately after this
+            request. Normally ROTATING, but may already read as REVOKED or EXPIRED
+            if reconciling this request's outcome was itself delayed past the grace
+            deadline or a concurrent revoke.
+        grace_period_seconds:
+          type: integer
+          title: Grace Period Seconds
+          description: Seconds the rotated-out key remains usable before it is treated
+            as revoked.
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+      type: object
+      required:
+      - new_key
+      - previous_jti
+      - previous_status
+      - grace_period_seconds
+      title: AccessKeyRotateResponse
+      description: 'Response returned after rotating a Scoped Access Key.
+
+
+        The rotated-out key (``previous_jti``) remains usable for ``grace_period_seconds``
+
+        (the dual-active grace period) so callers can cut traffic over to ``new_key``
+
+        before the old key is treated as revoked.'
     AccessKeyStatusChangeResponse:
       properties:
         jti:

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/auth.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/auth.py
@@ -922,6 +922,8 @@ def list_access_keys(
             Column("audiences", None),
             Column("created_at", None),
             Column("expires_at", None),
+            Column("last_used_at", None),
+            Column("grace_period_expires_at", None),
         ],
         timestamp_format=state.get_timestamp_format(),
     )
@@ -987,6 +989,58 @@ def unsuspend_access_key(
         typer.echo(f"Unsuspended Scoped Access Key {jti}.")
     else:
         typer.echo(f"Scoped Access Key {jti} was already {result.status.lower()}.")
+
+
+@access_keys_app.command("rotate")
+@handle_errors
+def rotate_access_key(
+    ctx: typer.Context,
+    jti: Annotated[str, typer.Argument(help="Stable ID of the Scoped Access Key to rotate.")],
+    grace_period_seconds: Annotated[
+        int | None,
+        typer.Option(
+            "--grace-period-seconds",
+            min=1,
+            help=(
+                "Grace period in seconds for the rotated-out key. Defaults to the server's "
+                "`rotation_grace_period_seconds` config (default 48h) when omitted, and is "
+                "capped by `max_rotation_grace_period_seconds`."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """Mint a successor Scoped Access Key and start the old key's rotation grace period.
+
+    The old key (jti) keeps working for its rotation grace period so you can cut
+    configuration over to the new key without downtime, then revoke the old key once
+    traffic has moved, or let it expire automatically at the end of the grace period.
+    """
+    try:
+        result = _access_key_issuer(ctx).rotate(jti, grace_period_seconds=grace_period_seconds)
+    except AccessKeyFeatureDisabledError as exc:
+        _raise_access_key_disabled(exc)
+    except AccessKeyOperationNotImplementedError as exc:
+        _raise_access_key_not_implemented(exc)
+    typer.echo(result.new_key.token)
+    if result.previous_status == "ROTATING":
+        if result.grace_period_expires_at is not None:
+            typer.echo(
+                f"Rotated Scoped Access Key {jti}; it remains usable until "
+                f"{result.grace_period_expires_at.isoformat()} "
+                f"(grace period {result.grace_period_seconds}s).",
+                err=True,
+            )
+        else:
+            typer.echo(
+                f"Rotated Scoped Access Key {jti}; it remains usable for a "
+                f"grace period of {result.grace_period_seconds}s.",
+                err=True,
+            )
+    else:
+        typer.echo(
+            f"Rotated Scoped Access Key {jti}; it is now {result.previous_status} and is no longer usable.",
+            err=True,
+        )
 
 
 @app.command("status")

--- a/packages/nemo_platform_ext/tests/cli/commands/test_auth.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/test_auth.py
@@ -20,6 +20,8 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyListResponse,
     AccessKeyMetadataResponse,
     AccessKeyRevokeResponse,
+    AccessKeyRotateRequest,
+    AccessKeyRotateResponse,
     AccessKeyStatusChangeResponse,
 )
 from nemo_platform_plugin.client.constants import WORKLOAD_IDENTITY_TOKEN_FILE_ENVVAR
@@ -529,8 +531,10 @@ def test_auth_access_keys_list_outputs_owned_keys(monkeypatch: pytest.MonkeyPatc
                 name="ci-build",
                 principal="alice@example.com",
                 created_at=datetime(2026, 7, 28, 12, 0, tzinfo=UTC),
+                last_used_at=datetime(2026, 7, 28, 12, 30, tzinfo=UTC),
+                grace_period_expires_at=datetime(2026, 7, 28, 13, 0, tzinfo=UTC),
                 description="CI automation",
-                status="ACTIVE",
+                status="ROTATING",
                 issuer="https://platform.example.com/apis/auth",
                 audiences=["nemo-platform-access-key"],
             )
@@ -548,7 +552,9 @@ def test_auth_access_keys_list_outputs_owned_keys(monkeypatch: pytest.MonkeyPatc
     assert '"jti": "ak_example"' in result.output
     assert '"name": "ci-build"' in result.output
     assert '"description": "CI automation"' in result.output
-    assert '"status": "ACTIVE"' in result.output
+    assert '"status": "ROTATING"' in result.output
+    assert '"last_used_at": "2026-07-28T12:30:00Z"' in result.output
+    assert '"grace_period_expires_at": "2026-07-28T13:00:00Z"' in result.output
     fake_access_keys_client.list_access_keys.assert_called_once_with(query_params={"page": 1, "page_size": 100})
 
 
@@ -561,8 +567,10 @@ def test_auth_access_keys_list_table_includes_key_name(monkeypatch: pytest.Monke
                 name="ci-build",
                 principal="alice@example.com",
                 created_at=datetime(2026, 7, 28, 12, 0, tzinfo=UTC),
+                last_used_at=datetime(2026, 7, 28, 12, 30, tzinfo=UTC),
+                grace_period_expires_at=datetime(2026, 7, 28, 13, 0, tzinfo=UTC),
                 description="CI automation",
-                status="ACTIVE",
+                status="ROTATING",
                 issuer="https://platform.example.com/apis/auth",
                 audiences=["nemo-platform-access-key"],
             )
@@ -580,7 +588,11 @@ def test_auth_access_keys_list_table_includes_key_name(monkeypatch: pytest.Monke
     assert "ak_example" in result.output
     assert "ci-build" in result.output
     assert "CI automation" in result.output
-    assert "ACTIVE" in result.output
+    assert "ROTATING" in result.output
+    assert "last_used_at" in result.output
+    assert "grace_period_expires_at" in result.output
+    assert "2026-07-28T12:30:00Z" in result.output
+    assert "2026-07-28T13:00:00Z" in result.output
     fake_access_keys_client.list_access_keys.assert_called_once_with(query_params={"page": 1, "page_size": 100})
 
 
@@ -702,6 +714,158 @@ def test_auth_access_keys_unsuspend_noop_reports_expired_status(monkeypatch: pyt
     assert "Scoped Access Key ak_example was already expired." in result.output
 
 
+def test_auth_access_keys_rotate_prints_new_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_access_keys_client = MagicMock()
+    fake_access_keys_client.rotate_access_key.return_value.data.return_value = AccessKeyRotateResponse(
+        new_key=AccessKeyCreateResponse(
+            jti="ak_successor",
+            name="ci-intake",
+            token="signed.jwt.token",
+            token_type="Bearer",
+            principal="alice@example.com",
+            created_at=datetime(2026, 7, 28, 12, 0, tzinfo=UTC),
+            expires_at=None,
+            description=None,
+            status="ACTIVE",
+            issuer="https://platform.example.com/apis/auth",
+            audiences=["nemo-platform-access-key"],
+        ),
+        previous_jti="ak_example",
+        previous_status="ROTATING",
+        grace_period_seconds=3600,
+    )
+    monkeypatch.setattr("nemo_platform_ext.cli.core.context.CLIContext.get_client", lambda _self: MagicMock())
+    monkeypatch.setattr(
+        "nemo_platform_ext.cli.commands.auth.client_from_platform",
+        lambda _platform, _client_cls: fake_access_keys_client,
+    )
+
+    result = runner.invoke(app, ["auth", "access-keys", "rotate", "ak_example"])
+
+    assert_exit_code(result, 0)
+    assert "signed.jwt.token" in result.output
+    assert "Rotated Scoped Access Key ak_example; it remains usable for a grace period of 3600s." in result.output
+    assert "no longer usable" not in result.output
+    fake_access_keys_client.rotate_access_key.assert_called_once_with(jti="ak_example", body=AccessKeyRotateRequest())
+
+
+def test_auth_access_keys_rotate_passes_explicit_grace_period_seconds(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_access_keys_client = MagicMock()
+    fake_access_keys_client.rotate_access_key.return_value.data.return_value = AccessKeyRotateResponse(
+        new_key=AccessKeyCreateResponse(
+            jti="ak_successor",
+            name="ci-intake",
+            token="signed.jwt.token",
+            token_type="Bearer",
+            principal="alice@example.com",
+            created_at=datetime(2026, 7, 28, 12, 0, tzinfo=UTC),
+            expires_at=None,
+            description=None,
+            status="ACTIVE",
+            issuer="https://platform.example.com/apis/auth",
+            audiences=["nemo-platform-access-key"],
+        ),
+        previous_jti="ak_example",
+        previous_status="ROTATING",
+        grace_period_seconds=3600,
+    )
+    monkeypatch.setattr("nemo_platform_ext.cli.core.context.CLIContext.get_client", lambda _self: MagicMock())
+    monkeypatch.setattr(
+        "nemo_platform_ext.cli.commands.auth.client_from_platform",
+        lambda _platform, _client_cls: fake_access_keys_client,
+    )
+
+    result = runner.invoke(app, ["auth", "access-keys", "rotate", "ak_example", "--grace-period-seconds", "3600"])
+
+    assert_exit_code(result, 0)
+    fake_access_keys_client.rotate_access_key.assert_called_once_with(
+        jti="ak_example", body=AccessKeyRotateRequest(grace_period_seconds=3600)
+    )
+
+
+def test_auth_access_keys_rotate_reports_grace_period_expiration(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_access_keys_client = MagicMock()
+    fake_access_keys_client.rotate_access_key.return_value.data.return_value = AccessKeyRotateResponse(
+        new_key=AccessKeyCreateResponse(
+            jti="ak_successor",
+            name="ci-intake",
+            token="signed.jwt.token",
+            token_type="Bearer",
+            principal="alice@example.com",
+            created_at=datetime(2026, 7, 28, 12, 0, tzinfo=UTC),
+            expires_at=None,
+            description=None,
+            status="ACTIVE",
+            issuer="https://platform.example.com/apis/auth",
+            audiences=["nemo-platform-access-key"],
+        ),
+        previous_jti="ak_example",
+        previous_status="ROTATING",
+        grace_period_seconds=3600,
+        grace_period_expires_at=datetime(2026, 7, 28, 13, 0, tzinfo=UTC),
+    )
+    monkeypatch.setattr("nemo_platform_ext.cli.core.context.CLIContext.get_client", lambda _self: MagicMock())
+    monkeypatch.setattr(
+        "nemo_platform_ext.cli.commands.auth.client_from_platform",
+        lambda _platform, _client_cls: fake_access_keys_client,
+    )
+
+    result = runner.invoke(app, ["auth", "access-keys", "rotate", "ak_example"])
+
+    assert_exit_code(result, 0)
+    assert (
+        "Rotated Scoped Access Key ak_example; it remains usable until "
+        "2026-07-28T13:00:00+00:00 (grace period 3600s)." in result.output
+    )
+
+
+def test_auth_access_keys_rotate_reports_revoked_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_access_keys_client = MagicMock()
+    fake_access_keys_client.rotate_access_key.return_value.data.return_value = AccessKeyRotateResponse(
+        new_key=AccessKeyCreateResponse(
+            jti="ak_successor",
+            name="ci-intake",
+            token="signed.jwt.token",
+            token_type="Bearer",
+            principal="alice@example.com",
+            created_at=datetime(2026, 7, 28, 12, 0, tzinfo=UTC),
+            expires_at=None,
+            description=None,
+            status="ACTIVE",
+            issuer="https://platform.example.com/apis/auth",
+            audiences=["nemo-platform-access-key"],
+        ),
+        previous_jti="ak_example",
+        previous_status="REVOKED",
+        grace_period_seconds=3600,
+    )
+    monkeypatch.setattr("nemo_platform_ext.cli.core.context.CLIContext.get_client", lambda _self: MagicMock())
+    monkeypatch.setattr(
+        "nemo_platform_ext.cli.commands.auth.client_from_platform",
+        lambda _platform, _client_cls: fake_access_keys_client,
+    )
+
+    result = runner.invoke(app, ["auth", "access-keys", "rotate", "ak_example"])
+
+    assert_exit_code(result, 0)
+    assert "Rotated Scoped Access Key ak_example; it is now REVOKED and is no longer usable." in result.output
+
+
+def test_auth_access_keys_rotate_reports_missing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_access_keys_client = MagicMock()
+    fake_access_keys_client.rotate_access_key.side_effect = _access_key_not_found_error("ak_unknown")
+    monkeypatch.setattr("nemo_platform_ext.cli.core.context.CLIContext.get_client", lambda _self: MagicMock())
+    monkeypatch.setattr(
+        "nemo_platform_ext.cli.commands.auth.client_from_platform",
+        lambda _platform, _client_cls: fake_access_keys_client,
+    )
+
+    result = runner.invoke(app, ["auth", "access-keys", "rotate", "ak_unknown"])
+
+    assert_exit_code(result, 3)
+    assert "Not found: (404) Scoped Access Key ak_unknown was not found" in result.output
+
+
 def test_auth_access_keys_help_exposes_lifecycle_commands() -> None:
     result = runner.invoke(app, ["auth", "access-keys", "--help"])
 
@@ -711,6 +875,7 @@ def test_auth_access_keys_help_exposes_lifecycle_commands() -> None:
     assert "revoke" in result.output
     assert "suspend" in result.output
     assert "unsuspend" in result.output
+    assert "rotate" in result.output
 
     create_help = runner.invoke(app, ["auth", "access-keys", "create", "--help"])
     assert_exit_code(create_help, 0)

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/client.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/client.py
@@ -14,6 +14,8 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyCreateResponse,
     AccessKeyListResponse,
     AccessKeyRevokeResponse,
+    AccessKeyRotateRequest,
+    AccessKeyRotateResponse,
     AccessKeyStatusChangeResponse,
 )
 from nemo_platform_plugin.client.client import AsyncNemoClient, NemoClient
@@ -27,6 +29,7 @@ class _AccessKeyMethods:
     revoke_access_key = method(endpoints.revoke_access_key)
     suspend_access_key = method(endpoints.suspend_access_key)
     unsuspend_access_key = method(endpoints.unsuspend_access_key)
+    rotate_access_key = method(endpoints.rotate_access_key)
 
 
 class AccessKeysClient(_AccessKeyMethods, NemoClient):
@@ -74,6 +77,14 @@ class AccessKeyIssuerClient(AccessKeyIssuer):
     def unsuspend(self, jti: str) -> AccessKeyStatusChangeResponse:
         try:
             return self._client.unsuspend_access_key(jti=jti).data()
+        except NemoHTTPError as exc:
+            _raise_known_domain_error_from_http(exc)
+            raise
+
+    def rotate(self, jti: str, *, grace_period_seconds: int | None = None) -> AccessKeyRotateResponse:
+        try:
+            body = AccessKeyRotateRequest(grace_period_seconds=grace_period_seconds)
+            return self._client.rotate_access_key(jti=jti, body=body).data()
         except NemoHTTPError as exc:
             _raise_known_domain_error_from_http(exc)
             raise

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/endpoints.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/endpoints.py
@@ -11,6 +11,8 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyListQueryParams,
     AccessKeyListResponse,
     AccessKeyRevokeResponse,
+    AccessKeyRotateRequest,
+    AccessKeyRotateResponse,
     AccessKeyStatusChangeResponse,
 )
 from nemo_platform_plugin.client.endpoint import delete, get, post
@@ -39,3 +41,8 @@ def suspend_access_key(*, jti: str) -> AccessKeyStatusChangeResponse: ...
 @post("/apis/auth/v2/access-keys/{jti}/unsuspend")
 @abstractmethod
 def unsuspend_access_key(*, jti: str) -> AccessKeyStatusChangeResponse: ...
+
+
+@post("/apis/auth/v2/access-keys/{jti}/rotate")
+@abstractmethod
+def rotate_access_key(*, jti: str, body: AccessKeyRotateRequest) -> AccessKeyRotateResponse: ...

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/issuer.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/issuer.py
@@ -10,6 +10,7 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyCreateResponse,
     AccessKeyListResponse,
     AccessKeyRevokeResponse,
+    AccessKeyRotateResponse,
     AccessKeyStatusChangeResponse,
 )
 
@@ -34,3 +35,5 @@ class AccessKeyIssuer(Protocol):
     def suspend(self, jti: str) -> AccessKeyStatusChangeResponse: ...
 
     def unsuspend(self, jti: str) -> AccessKeyStatusChangeResponse: ...
+
+    def rotate(self, jti: str, *, grace_period_seconds: int | None = None) -> AccessKeyRotateResponse: ...

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/auth/access_keys/types.py
@@ -8,7 +8,7 @@ from typing import Literal, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
-AccessKeyStatus = Literal["ACTIVE", "EXPIRED", "REVOKED", "SUSPENDED"]
+AccessKeyStatus = Literal["ACTIVE", "EXPIRED", "REVOKED", "SUSPENDED", "ROTATING"]
 AccessKeyReversibleStatus = Literal["ACTIVE", "EXPIRED", "SUSPENDED"]
 AccessKeyEntityType = Literal["USER", "SERVICE_ACCOUNT"]
 
@@ -60,6 +60,21 @@ class AccessKeyCreateRequest(BaseModel):
     )
 
 
+class AccessKeyRotateRequest(BaseModel):
+    """Request body for rotating a Scoped Access Key."""
+
+    grace_period_seconds: int | None = Field(
+        default=None,
+        ge=1,
+        json_schema_extra={"nullable": True},
+        description=(
+            "Grace period in seconds for the rotated-out key. Omit to use "
+            "auth.access_keys.rotation_grace_period_seconds. Subject to "
+            "auth.access_keys.max_rotation_grace_period_seconds."
+        ),
+    )
+
+
 class AccessKeyMetadataResponse(BaseModel):
     """Metadata for a Scoped Access Key."""
 
@@ -87,6 +102,16 @@ class AccessKeyMetadataResponse(BaseModel):
     )
     created_at: datetime
     expires_at: datetime | None = Field(default=None, json_schema_extra={"nullable": True})
+    grace_period_expires_at: datetime | None = Field(
+        default=None,
+        json_schema_extra={"nullable": True},
+        description="Timestamp when the rotated-out key's grace period expires.",
+    )
+    last_used_at: datetime | None = Field(
+        default=None,
+        json_schema_extra={"nullable": True},
+        description="Timestamp of the most recent successful authentication with this Scoped Access Key.",
+    )
 
 
 class AccessKeyCreateResponse(AccessKeyMetadataResponse):
@@ -121,6 +146,35 @@ class AccessKeyStatusChangeResponse(BaseModel):
         description="Resulting effective status of the key, including expiration."
     )
     changed: bool = Field(description="True when this request changed the key's persistent status.")
+
+
+class AccessKeyRotateResponse(BaseModel):
+    """Response returned after rotating a Scoped Access Key.
+
+    The rotated-out key (``previous_jti``) remains usable for ``grace_period_seconds``
+    (the dual-active grace period) so callers can cut traffic over to ``new_key``
+    before the old key is treated as revoked.
+    """
+
+    new_key: AccessKeyCreateResponse = Field(
+        description="Newly minted successor Scoped Access Key. Its raw token is returned only once."
+    )
+    previous_jti: str = Field(description="Stable JWT ID of the Scoped Access Key that was rotated out.")
+    previous_status: AccessKeyStatus = Field(
+        description=(
+            "Effective status of the rotated-out key immediately after this request. Normally "
+            "ROTATING, but may already read as REVOKED or EXPIRED if reconciling this request's "
+            "outcome was itself delayed past the grace deadline or a concurrent revoke."
+        )
+    )
+    grace_period_seconds: int = Field(
+        description="Seconds the rotated-out key remains usable before it is treated as revoked."
+    )
+    grace_period_expires_at: datetime | None = Field(
+        default=None,
+        json_schema_extra={"nullable": True},
+        description="Timestamp when the rotated-out key's grace period expires.",
+    )
 
 
 class AccessKeyNotImplementedErrorResponse(BaseModel):

--- a/packages/nemo_platform_plugin/tests/auth/access_keys/test_client.py
+++ b/packages/nemo_platform_plugin/tests/auth/access_keys/test_client.py
@@ -16,6 +16,8 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyCreateRequest,
     AccessKeyCreateResponse,
     AccessKeyRevokeResponse,
+    AccessKeyRotateRequest,
+    AccessKeyRotateResponse,
     AccessKeyStatusChangeResponse,
 )
 from nemo_platform_plugin.client.errors import NemoHTTPError
@@ -28,6 +30,7 @@ class _AccessKeysClientStub:
         self.revoke_access_key = MagicMock()
         self.suspend_access_key = MagicMock()
         self.unsuspend_access_key = MagicMock()
+        self.rotate_access_key = MagicMock()
 
     def as_client(self) -> AccessKeysClient:
         return cast(AccessKeysClient, self)
@@ -83,6 +86,47 @@ def test_access_key_issuer_client_suspends_and_unsuspends_by_jti() -> None:
     assert issuer.unsuspend("ak_example").changed
     client.suspend_access_key.assert_called_once_with(jti="ak_example")
     client.unsuspend_access_key.assert_called_once_with(jti="ak_example")
+
+
+def test_access_key_issuer_client_rotates_by_jti() -> None:
+    client = _AccessKeysClientStub()
+    rotated = AccessKeyRotateResponse(
+        new_key=AccessKeyCreateResponse(
+            jti="ak_successor",
+            name=None,
+            token="signed.jwt.token",
+            token_type="Bearer",
+            principal="alice@example.com",
+            created_at=datetime(2026, 7, 28, 12, 0, tzinfo=UTC),
+            expires_at=None,
+            description=None,
+            status="ACTIVE",
+            issuer="https://platform.example.com/apis/auth",
+            audiences=["nemo-platform-access-key"],
+        ),
+        previous_jti="ak_example",
+        previous_status="ROTATING",
+        grace_period_seconds=3600,
+    )
+    client.rotate_access_key.return_value.data.return_value = rotated
+
+    issuer = AccessKeyIssuerClient(client.as_client())
+    result = issuer.rotate("ak_example")
+
+    assert result == rotated
+    client.rotate_access_key.assert_called_once_with(jti="ak_example", body=AccessKeyRotateRequest())
+
+
+def test_access_key_issuer_client_rotates_with_explicit_grace_period() -> None:
+    client = _AccessKeysClientStub()
+    client.rotate_access_key.return_value.data.return_value = None
+
+    issuer = AccessKeyIssuerClient(client.as_client())
+    issuer.rotate("ak_example", grace_period_seconds=3600)
+
+    client.rotate_access_key.assert_called_once_with(
+        jti="ak_example", body=AccessKeyRotateRequest(grace_period_seconds=3600)
+    )
 
 
 def test_access_key_issuer_client_lists_requested_page() -> None:

--- a/packages/nemo_platform_plugin/tests/auth/access_keys/test_endpoints.py
+++ b/packages/nemo_platform_plugin/tests/auth/access_keys/test_endpoints.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from nemo_platform_plugin.auth.access_keys import endpoints
-from nemo_platform_plugin.auth.access_keys.types import AccessKeyCreateRequest
+from nemo_platform_plugin.auth.access_keys.types import AccessKeyCreateRequest, AccessKeyRotateRequest
 from nemo_platform_plugin.client.types import PreparedRequest
 
 
@@ -53,3 +53,18 @@ def test_unsuspend_access_key_endpoint_uses_jti_path_param() -> None:
     assert prepared.method == "POST"
     assert prepared.path_template == "/apis/auth/v2/access-keys/{jti}/unsuspend"
     assert prepared.path_params == {"jti": "ak_example"}
+
+
+def test_rotate_access_key_endpoint_uses_jti_path_param() -> None:
+    prepared = endpoints.rotate_access_key(jti="ak_example", body=AccessKeyRotateRequest())
+
+    assert prepared.method == "POST"
+    assert prepared.path_template == "/apis/auth/v2/access-keys/{jti}/rotate"
+    assert prepared.path_params == {"jti": "ak_example"}
+
+
+def test_rotate_access_key_endpoint_sends_grace_period_seconds() -> None:
+    prepared = endpoints.rotate_access_key(jti="ak_example", body=AccessKeyRotateRequest(grace_period_seconds=3600))
+
+    assert prepared.content_type == "application/json"
+    assert prepared.content == b'{"grace_period_seconds":3600}'

--- a/packages/nmp_common/src/nmp/common/auth/access_keys.py
+++ b/packages/nmp_common/src/nmp/common/auth/access_keys.py
@@ -25,6 +25,7 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyEntityType,
     AccessKeyListResponse,
     AccessKeyRevokeResponse,
+    AccessKeyRotateResponse,
     AccessKeyStatus,
     AccessKeyStatusChangeResponse,
 )
@@ -273,6 +274,10 @@ class AccessKeyIssuerService(AccessKeyIssuer):
     def unsuspend(self, jti: str) -> AccessKeyStatusChangeResponse:
         self._ensure_enabled()
         raise AccessKeyOperationNotImplementedError(f"Scoped Access Key unsuspension for {jti} is not implemented.")
+
+    def rotate(self, jti: str, *, grace_period_seconds: int | None = None) -> AccessKeyRotateResponse:  # noqa: ARG002
+        self._ensure_enabled()
+        raise AccessKeyOperationNotImplementedError(f"Scoped Access Key rotation for {jti} is not implemented.")
 
 
 def _create_access_key_token(

--- a/packages/nmp_common/src/nmp/common/config/base.py
+++ b/packages/nmp_common/src/nmp/common/config/base.py
@@ -319,6 +319,25 @@ class AccessKeyConfig(BaseSettings):
             "Set to null to allow explicit no-expiration requests."
         ),
     )
+    rotation_grace_period_seconds: int = Field(
+        default=48 * 60 * 60,
+        ge=1,
+        description=(
+            "Default grace period in seconds for a rotated-out Scoped Access Key, used when "
+            "grace_period_seconds is omitted from POST /v2/access-keys/{jti}/rotate. The key "
+            "remains usable for this long after rotation before it is treated as revoked. "
+            "Gives callers a dual-active window to cut over to the newly issued key."
+        ),
+    )
+    max_rotation_grace_period_seconds: int | None = Field(
+        default=30 * 24 * 60 * 60,
+        ge=1,
+        description=(
+            "Maximum grace period accepted when a caller explicitly requests grace_period_seconds "
+            "on POST /v2/access-keys/{jti}/rotate. Set to null to allow any explicitly requested "
+            "grace period."
+        ),
+    )
 
     @staticmethod
     def _parse_nullable_expiry(value: Any) -> Any:

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -336,6 +336,66 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /apis/auth/v2/access-keys/{jti}/rotate:
+    post:
+      tags:
+      - Scoped Access Keys
+      summary: Rotate Access Key
+      operationId: rotate_access_key_apis_auth_v2_access_keys__jti__rotate_post
+      parameters:
+      - name: jti
+        in: path
+        required: true
+        schema:
+          type: string
+          pattern: ^ak_[0-9a-f]{32}$
+          description: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+          title: Jti
+        description: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/AccessKeyRotateRequest'
+              default: {}
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyRotateResponse'
+        '400':
+          description: Scoped Access Key rotation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '404':
+          description: Scoped Access Keys are not enabled or the key was not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '409':
+          description: Invalid or concurrent access-key state transition
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyErrorResponse'
+        '501':
+          description: Not Implemented
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccessKeyNotImplementedErrorResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /apis/auth/v2/access-keys/{jti}/suspend:
     post:
       tags:
@@ -8325,6 +8385,7 @@ components:
           - EXPIRED
           - REVOKED
           - SUSPENDED
+          - ROTATING
           title: Status
         issuer:
           type: string
@@ -8343,6 +8404,19 @@ components:
           title: Created At
         expires_at:
           title: Expires At
+          nullable: true
+          type: string
+          format: date-time
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+        last_used_at:
+          title: Last Used At
+          description: Timestamp of the most recent successful authentication with
+            this Scoped Access Key.
           nullable: true
           type: string
           format: date-time
@@ -8434,6 +8508,7 @@ components:
           - EXPIRED
           - REVOKED
           - SUSPENDED
+          - ROTATING
           title: Status
         issuer:
           type: string
@@ -8452,6 +8527,19 @@ components:
           title: Created At
         expires_at:
           title: Expires At
+          nullable: true
+          type: string
+          format: date-time
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+        last_used_at:
+          title: Last Used At
+          description: Timestamp of the most recent successful authentication with
+            this Scoped Access Key.
           nullable: true
           type: string
           format: date-time
@@ -8491,6 +8579,68 @@ components:
       - revoked
       title: AccessKeyRevokeResponse
       description: Response returned after a Scoped Access Key revoke request.
+    AccessKeyRotateRequest:
+      properties:
+        grace_period_seconds:
+          title: Grace Period Seconds
+          description: Grace period in seconds for the rotated-out key. Omit to use
+            auth.access_keys.rotation_grace_period_seconds. Subject to auth.access_keys.max_rotation_grace_period_seconds.
+          nullable: true
+          type: integer
+          minimum: 1.0
+      type: object
+      title: AccessKeyRotateRequest
+      description: Request body for rotating a Scoped Access Key.
+    AccessKeyRotateResponse:
+      properties:
+        new_key:
+          allOf:
+          - $ref: '#/components/schemas/AccessKeyCreateResponse'
+          description: Newly minted successor Scoped Access Key. Its raw token is
+            returned only once.
+        previous_jti:
+          type: string
+          title: Previous Jti
+          description: Stable JWT ID of the Scoped Access Key that was rotated out.
+        previous_status:
+          type: string
+          enum:
+          - ACTIVE
+          - EXPIRED
+          - REVOKED
+          - SUSPENDED
+          - ROTATING
+          title: Previous Status
+          description: Effective status of the rotated-out key immediately after this
+            request. Normally ROTATING, but may already read as REVOKED or EXPIRED
+            if reconciling this request's outcome was itself delayed past the grace
+            deadline or a concurrent revoke.
+        grace_period_seconds:
+          type: integer
+          title: Grace Period Seconds
+          description: Seconds the rotated-out key remains usable before it is treated
+            as revoked.
+        grace_period_expires_at:
+          title: Grace Period Expires At
+          description: Timestamp when the rotated-out key's grace period expires.
+          nullable: true
+          type: string
+          format: date-time
+      type: object
+      required:
+      - new_key
+      - previous_jti
+      - previous_status
+      - grace_period_seconds
+      title: AccessKeyRotateResponse
+      description: 'Response returned after rotating a Scoped Access Key.
+
+
+        The rotated-out key (``previous_jti``) remains usable for ``grace_period_seconds``
+
+        (the dual-active grace period) so callers can cut traffic over to ``new_key``
+
+        before the old key is treated as revoked.'
     AccessKeyStatusChangeResponse:
       properties:
         jti:

--- a/sdk/python/nemo-platform/.nmpcontext/stainless.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/stainless.yaml
@@ -985,6 +985,8 @@ resources:
       access_key_metadata_response: AccessKeyMetadataResponse
       access_key_not_implemented_error_response: AccessKeyNotImplementedErrorResponse
       access_key_revoke_response: AccessKeyRevokeResponse
+      access_key_rotate_request: AccessKeyRotateRequest
+      access_key_rotate_response: AccessKeyRotateResponse
       access_key_status_change_response: AccessKeyStatusChangeResponse
     methods:
       list: get /apis/auth/v2/access-keys
@@ -992,3 +994,4 @@ resources:
       delete: delete /apis/auth/v2/access-keys/{jti}
       suspend: post /apis/auth/v2/access-keys/{jti}/suspend
       unsuspend: post /apis/auth/v2/access-keys/{jti}/unsuspend
+      rotate: post /apis/auth/v2/access-keys/{jti}/rotate

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/access_keys/access_keys.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/access_keys/access_keys.py
@@ -32,10 +32,11 @@ from ..._response import (
     async_to_streamed_response_wrapper,
 )
 from ..._base_client import make_request_options
-from ...types.access_keys import access_key_list_params, access_key_create_params
+from ...types.access_keys import access_key_list_params, access_key_create_params, access_key_rotate_params
 from ...types.access_keys.access_key_list_response import AccessKeyListResponse
 from ...types.access_keys.access_key_create_response import AccessKeyCreateResponse
 from ...types.access_keys.access_key_revoke_response import AccessKeyRevokeResponse
+from ...types.access_keys.access_key_rotate_response import AccessKeyRotateResponse
 from ...types.access_keys.access_key_status_change_response import AccessKeyStatusChangeResponse
 
 __all__ = ["AccessKeysResource", "AsyncAccessKeysResource"]
@@ -196,6 +197,49 @@ class AccessKeysResource(SyncAPIResource):
                 extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
             ),
             cast_to=AccessKeyRevokeResponse,
+        )
+
+    def rotate(
+        self,
+        jti: str,
+        *,
+        grace_period_seconds: Optional[int] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> AccessKeyRotateResponse:
+        """
+        Rotate Access Key
+
+        Args:
+          jti: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+
+          grace_period_seconds: Grace period in seconds for the rotated-out key. Omit to use
+              auth.access_keys.rotation_grace_period_seconds. Subject to
+              auth.access_keys.max_rotation_grace_period_seconds.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not jti:
+            raise ValueError(f"Expected a non-empty value for `jti` but received {jti!r}")
+        return self._post(
+            path_template("/apis/auth/v2/access-keys/{jti}/rotate", jti=jti),
+            body=maybe_transform(
+                {"grace_period_seconds": grace_period_seconds}, access_key_rotate_params.AccessKeyRotateParams
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=AccessKeyRotateResponse,
         )
 
     def suspend(
@@ -426,6 +470,49 @@ class AsyncAccessKeysResource(AsyncAPIResource):
             cast_to=AccessKeyRevokeResponse,
         )
 
+    async def rotate(
+        self,
+        jti: str,
+        *,
+        grace_period_seconds: Optional[int] | Omit = omit,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = not_given,
+    ) -> AccessKeyRotateResponse:
+        """
+        Rotate Access Key
+
+        Args:
+          jti: Stable JWT ID of the Scoped Access Key for the lifecycle operation.
+
+          grace_period_seconds: Grace period in seconds for the rotated-out key. Omit to use
+              auth.access_keys.rotation_grace_period_seconds. Subject to
+              auth.access_keys.max_rotation_grace_period_seconds.
+
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        if not jti:
+            raise ValueError(f"Expected a non-empty value for `jti` but received {jti!r}")
+        return await self._post(
+            path_template("/apis/auth/v2/access-keys/{jti}/rotate", jti=jti),
+            body=await async_maybe_transform(
+                {"grace_period_seconds": grace_period_seconds}, access_key_rotate_params.AccessKeyRotateParams
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=AccessKeyRotateResponse,
+        )
+
     async def suspend(
         self,
         jti: str,
@@ -510,6 +597,9 @@ class AccessKeysResourceWithRawResponse:
         self.delete = to_raw_response_wrapper(
             access_keys.delete,
         )
+        self.rotate = to_raw_response_wrapper(
+            access_keys.rotate,
+        )
         self.suspend = to_raw_response_wrapper(
             access_keys.suspend,
         )
@@ -530,6 +620,9 @@ class AsyncAccessKeysResourceWithRawResponse:
         )
         self.delete = async_to_raw_response_wrapper(
             access_keys.delete,
+        )
+        self.rotate = async_to_raw_response_wrapper(
+            access_keys.rotate,
         )
         self.suspend = async_to_raw_response_wrapper(
             access_keys.suspend,
@@ -552,6 +645,9 @@ class AccessKeysResourceWithStreamingResponse:
         self.delete = to_streamed_response_wrapper(
             access_keys.delete,
         )
+        self.rotate = to_streamed_response_wrapper(
+            access_keys.rotate,
+        )
         self.suspend = to_streamed_response_wrapper(
             access_keys.suspend,
         )
@@ -572,6 +668,9 @@ class AsyncAccessKeysResourceWithStreamingResponse:
         )
         self.delete = async_to_streamed_response_wrapper(
             access_keys.delete,
+        )
+        self.rotate = async_to_streamed_response_wrapper(
+            access_keys.rotate,
         )
         self.suspend = async_to_streamed_response_wrapper(
             access_keys.suspend,

--- a/sdk/python/nemo-platform/src/nemo_platform/resources/access_keys/api.md
+++ b/sdk/python/nemo-platform/src/nemo_platform/resources/access_keys/api.md
@@ -14,6 +14,8 @@ from nemo_platform.types.access_keys import (
     AccessKeyMetadataResponse,
     AccessKeyNotImplementedErrorResponse,
     AccessKeyRevokeResponse,
+    AccessKeyRotateRequest,
+    AccessKeyRotateResponse,
     AccessKeyStatusChangeResponse,
 )
 ```
@@ -23,5 +25,6 @@ Methods:
 - <code title="post /apis/auth/v2/access-keys">client.access_keys.<a href="./src/nemo_platform/resources/access_keys/access_keys.py">create</a>(\*\*<a href="src/nemo_platform/types/access_keys/access_key_create_params.py">params</a>) -> <a href="./src/nemo_platform/types/access_keys/access_key_create_response.py">AccessKeyCreateResponse</a></code>
 - <code title="get /apis/auth/v2/access-keys">client.access_keys.<a href="./src/nemo_platform/resources/access_keys/access_keys.py">list</a>(\*\*<a href="src/nemo_platform/types/access_keys/access_key_list_params.py">params</a>) -> <a href="./src/nemo_platform/types/access_keys/access_key_list_response.py">AccessKeyListResponse</a></code>
 - <code title="delete /apis/auth/v2/access-keys/{jti}">client.access_keys.<a href="./src/nemo_platform/resources/access_keys/access_keys.py">delete</a>(jti) -> <a href="./src/nemo_platform/types/access_keys/access_key_revoke_response.py">AccessKeyRevokeResponse</a></code>
+- <code title="post /apis/auth/v2/access-keys/{jti}/rotate">client.access_keys.<a href="./src/nemo_platform/resources/access_keys/access_keys.py">rotate</a>(jti, \*\*<a href="src/nemo_platform/types/access_keys/access_key_rotate_params.py">params</a>) -> <a href="./src/nemo_platform/types/access_keys/access_key_rotate_response.py">AccessKeyRotateResponse</a></code>
 - <code title="post /apis/auth/v2/access-keys/{jti}/suspend">client.access_keys.<a href="./src/nemo_platform/resources/access_keys/access_keys.py">suspend</a>(jti) -> <a href="./src/nemo_platform/types/access_keys/access_key_status_change_response.py">AccessKeyStatusChangeResponse</a></code>
 - <code title="post /apis/auth/v2/access-keys/{jti}/unsuspend">client.access_keys.<a href="./src/nemo_platform/resources/access_keys/access_keys.py">unsuspend</a>(jti) -> <a href="./src/nemo_platform/types/access_keys/access_key_status_change_response.py">AccessKeyStatusChangeResponse</a></code>

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/__init__.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/__init__.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 from .access_key_list_params import AccessKeyListParams as AccessKeyListParams
 from .access_key_create_params import AccessKeyCreateParams as AccessKeyCreateParams
 from .access_key_list_response import AccessKeyListResponse as AccessKeyListResponse
+from .access_key_rotate_params import AccessKeyRotateParams as AccessKeyRotateParams
 from .access_key_create_response import AccessKeyCreateResponse as AccessKeyCreateResponse
 from .access_key_revoke_response import AccessKeyRevokeResponse as AccessKeyRevokeResponse
+from .access_key_rotate_response import AccessKeyRotateResponse as AccessKeyRotateResponse
 from .access_key_metadata_response import AccessKeyMetadataResponse as AccessKeyMetadataResponse
 from .access_key_status_change_response import AccessKeyStatusChangeResponse as AccessKeyStatusChangeResponse

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_create_response.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_create_response.py
@@ -43,7 +43,7 @@ class AccessKeyCreateResponse(BaseModel):
     principal: str
     """Principal ID stamped into the token."""
 
-    status: Literal["ACTIVE", "EXPIRED", "REVOKED", "SUSPENDED"]
+    status: Literal["ACTIVE", "EXPIRED", "REVOKED", "SUSPENDED", "ROTATING"]
 
     token_type: Literal["Bearer"]
 
@@ -54,6 +54,15 @@ class AccessKeyCreateResponse(BaseModel):
     """Whether the key is bound to a user or a non-human service account."""
 
     expires_at: Optional[datetime] = None
+
+    grace_period_expires_at: Optional[datetime] = None
+    """Timestamp when the rotated-out key's grace period expires."""
+
+    last_used_at: Optional[datetime] = None
+    """
+    Timestamp of the most recent successful authentication with this Scoped Access
+    Key.
+    """
 
     name: Optional[str] = None
     """Optional human-readable Scoped Access Key label."""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_metadata_response.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_metadata_response.py
@@ -41,7 +41,7 @@ class AccessKeyMetadataResponse(BaseModel):
     principal: str
     """Principal ID stamped into the token."""
 
-    status: Literal["ACTIVE", "EXPIRED", "REVOKED", "SUSPENDED"]
+    status: Literal["ACTIVE", "EXPIRED", "REVOKED", "SUSPENDED", "ROTATING"]
 
     description: Optional[str] = None
     """Human-readable description of the Scoped Access Key."""
@@ -50,6 +50,15 @@ class AccessKeyMetadataResponse(BaseModel):
     """Whether the key is bound to a user or a non-human service account."""
 
     expires_at: Optional[datetime] = None
+
+    grace_period_expires_at: Optional[datetime] = None
+    """Timestamp when the rotated-out key's grace period expires."""
+
+    last_used_at: Optional[datetime] = None
+    """
+    Timestamp of the most recent successful authentication with this Scoped Access
+    Key.
+    """
 
     name: Optional[str] = None
     """Optional human-readable Scoped Access Key label."""

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_rotate_params.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_rotate_params.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Optional
+from typing_extensions import TypedDict
+
+__all__ = ["AccessKeyRotateParams"]
+
+
+class AccessKeyRotateParams(TypedDict, total=False):
+    grace_period_seconds: Optional[int]
+    """Grace period in seconds for the rotated-out key.
+
+    Omit to use auth.access_keys.rotation_grace_period_seconds. Subject to
+    auth.access_keys.max_rotation_grace_period_seconds.
+    """

--- a/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_rotate_response.py
+++ b/sdk/python/nemo-platform/src/nemo_platform/types/access_keys/access_key_rotate_response.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Optional
+from datetime import datetime
+from typing_extensions import Literal
+
+from ..._models import BaseModel
+from .access_key_create_response import AccessKeyCreateResponse
+
+__all__ = ["AccessKeyRotateResponse"]
+
+
+class AccessKeyRotateResponse(BaseModel):
+    """Response returned after rotating a Scoped Access Key.
+
+    The rotated-out key (``previous_jti``) remains usable for ``grace_period_seconds``
+    (the dual-active grace period) so callers can cut traffic over to ``new_key``
+    before the old key is treated as revoked.
+    """
+
+    grace_period_seconds: int
+    """Seconds the rotated-out key remains usable before it is treated as revoked."""
+
+    new_key: AccessKeyCreateResponse
+    """Create response. The token value is returned only once."""
+
+    previous_jti: str
+    """Stable JWT ID of the Scoped Access Key that was rotated out."""
+
+    previous_status: Literal["ACTIVE", "EXPIRED", "REVOKED", "SUSPENDED", "ROTATING"]
+    """Effective status of the rotated-out key immediately after this request.
+
+    Normally ROTATING, but may already read as REVOKED or EXPIRED if reconciling
+    this request's outcome was itself delayed past the grace deadline or a
+    concurrent revoke.
+    """
+
+    grace_period_expires_at: Optional[datetime] = None
+    """Timestamp when the rotated-out key's grace period expires."""

--- a/sdk/python/nemo-platform/tests/api_resources/test_access_keys.py
+++ b/sdk/python/nemo-platform/tests/api_resources/test_access_keys.py
@@ -28,6 +28,7 @@ from nemo_platform.types.access_keys import (
     AccessKeyListResponse,
     AccessKeyCreateResponse,
     AccessKeyRevokeResponse,
+    AccessKeyRotateResponse,
     AccessKeyStatusChangeResponse,
 )
 
@@ -152,6 +153,57 @@ class TestAccessKeys:
     def test_path_params_delete(self, client: NeMoPlatform) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `jti` but received ''"):
             client.access_keys.with_raw_response.delete(
+                "",
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_rotate(self, client: NeMoPlatform) -> None:
+        access_key = client.access_keys.rotate(
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
+        )
+        assert_matches_type(AccessKeyRotateResponse, access_key, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_method_rotate_with_all_params(self, client: NeMoPlatform) -> None:
+        access_key = client.access_keys.rotate(
+            jti="ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
+            grace_period_seconds=1,
+        )
+        assert_matches_type(AccessKeyRotateResponse, access_key, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_raw_response_rotate(self, client: NeMoPlatform) -> None:
+        response = client.access_keys.with_raw_response.rotate(
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        access_key = response.parse()
+        assert_matches_type(AccessKeyRotateResponse, access_key, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_streaming_response_rotate(self, client: NeMoPlatform) -> None:
+        with client.access_keys.with_streaming_response.rotate(
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            access_key = response.parse()
+            assert_matches_type(AccessKeyRotateResponse, access_key, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    def test_path_params_rotate(self, client: NeMoPlatform) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `jti` but received ''"):
+            client.access_keys.with_raw_response.rotate(
                 "",
             )
 
@@ -360,6 +412,57 @@ class TestAsyncAccessKeys:
     async def test_path_params_delete(self, async_client: AsyncNeMoPlatform) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `jti` but received ''"):
             await async_client.access_keys.with_raw_response.delete(
+                "",
+            )
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_rotate(self, async_client: AsyncNeMoPlatform) -> None:
+        access_key = await async_client.access_keys.rotate(
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
+        )
+        assert_matches_type(AccessKeyRotateResponse, access_key, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_method_rotate_with_all_params(self, async_client: AsyncNeMoPlatform) -> None:
+        access_key = await async_client.access_keys.rotate(
+            jti="ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
+            grace_period_seconds=1,
+        )
+        assert_matches_type(AccessKeyRotateResponse, access_key, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_raw_response_rotate(self, async_client: AsyncNeMoPlatform) -> None:
+        response = await async_client.access_keys.with_raw_response.rotate(
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        access_key = await response.parse()
+        assert_matches_type(AccessKeyRotateResponse, access_key, path=["response"])
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_streaming_response_rotate(self, async_client: AsyncNeMoPlatform) -> None:
+        async with async_client.access_keys.with_streaming_response.rotate(
+            "ak_ecc2efdd09bd231a9ad9bd2aada37aa7",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            access_key = await response.parse()
+            assert_matches_type(AccessKeyRotateResponse, access_key, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(reason="Mock server tests are disabled")
+    @parametrize
+    async def test_path_params_rotate(self, async_client: AsyncNeMoPlatform) -> None:
+        with pytest.raises(ValueError, match=r"Expected a non-empty value for `jti` but received ''"):
+            await async_client.access_keys.with_raw_response.rotate(
                 "",
             )
 

--- a/sdk/stainless.yaml
+++ b/sdk/stainless.yaml
@@ -985,6 +985,8 @@ resources:
       access_key_metadata_response: AccessKeyMetadataResponse
       access_key_not_implemented_error_response: AccessKeyNotImplementedErrorResponse
       access_key_revoke_response: AccessKeyRevokeResponse
+      access_key_rotate_request: AccessKeyRotateRequest
+      access_key_rotate_response: AccessKeyRotateResponse
       access_key_status_change_response: AccessKeyStatusChangeResponse
     methods:
       list: get /apis/auth/v2/access-keys
@@ -992,3 +994,4 @@ resources:
       delete: delete /apis/auth/v2/access-keys/{jti}
       suspend: post /apis/auth/v2/access-keys/{jti}/suspend
       unsuspend: post /apis/auth/v2/access-keys/{jti}/unsuspend
+      rotate: post /apis/auth/v2/access-keys/{jti}/rotate

--- a/services/core/auth/src/nmp/core/auth/api/v2/access_keys/endpoints.py
+++ b/services/core/auth/src/nmp/core/auth/api/v2/access_keys/endpoints.py
@@ -89,6 +89,15 @@ _ACCESS_KEY_SUSPENSION_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
     409: _ACCESS_KEY_STATE_CONFLICT_ERROR_RESPONSE,
     501: _ACCESS_KEY_NOT_IMPLEMENTED_ERROR_RESPONSE,
 }
+_ACCESS_KEY_ROTATE_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    400: {
+        "description": "Scoped Access Key rotation error",
+        "model": schemas.AccessKeyErrorResponse,
+    },
+    404: _ACCESS_KEY_DISABLED_OR_NOT_FOUND_ERROR_RESPONSE,
+    409: _ACCESS_KEY_STATE_CONFLICT_ERROR_RESPONSE,
+    501: _ACCESS_KEY_NOT_IMPLEMENTED_ERROR_RESPONSE,
+}
 
 
 async def _is_platform_admin(auth_client: AuthClient) -> bool:
@@ -242,3 +251,29 @@ async def unsuspend_access_key(
     issuer: PersistentAccessKeyIssuer = Depends(get_access_key_issuer),
 ) -> schemas.AccessKeyStatusChangeResponse | JSONResponse:
     return await _change_suspension_status(jti, issuer.unsuspend_async)
+
+
+@router.post(
+    "/v2/access-keys/{jti}/rotate",
+    response_model=schemas.AccessKeyRotateResponse,
+    responses=_ACCESS_KEY_ROTATE_ERROR_RESPONSES,
+)
+async def rotate_access_key(
+    jti: _AccessKeyJTI,
+    request: schemas.AccessKeyRotateRequest = schemas.AccessKeyRotateRequest(),
+    issuer: PersistentAccessKeyIssuer = Depends(get_access_key_issuer),
+) -> schemas.AccessKeyRotateResponse | JSONResponse:
+    try:
+        return await issuer.rotate_async(jti, grace_period_seconds=request.grace_period_seconds)
+    except AccessKeyFeatureDisabledError:
+        return _disabled_response()
+    except AccessKeyOperationNotImplementedError as exc:
+        raise _not_implemented(exc) from exc
+    except AccessKeyValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except AccessKeyNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except AccessKeyStateConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except EntityConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Concurrent update conflict; retry.") from exc

--- a/services/core/auth/src/nmp/core/auth/api/v2/access_keys/schemas.py
+++ b/services/core/auth/src/nmp/core/auth/api/v2/access_keys/schemas.py
@@ -12,6 +12,8 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyNotImplementedErrorResponse as AccessKeyNotImplementedErrorResponse,
 )
 from nemo_platform_plugin.auth.access_keys.types import AccessKeyRevokeResponse as AccessKeyRevokeResponse
+from nemo_platform_plugin.auth.access_keys.types import AccessKeyRotateRequest as AccessKeyRotateRequest
+from nemo_platform_plugin.auth.access_keys.types import AccessKeyRotateResponse as AccessKeyRotateResponse
 from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyStatusChangeResponse as AccessKeyStatusChangeResponse,
 )

--- a/services/core/auth/src/nmp/core/auth/app/access_keys.py
+++ b/services/core/auth/src/nmp/core/auth/app/access_keys.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
-from typing import Literal
+from typing import Literal, TypeVar
 
 from fastapi import Depends, HTTPException
 from nemo_platform_plugin.auth.access_keys.issuer import AccessKeyFeatureDisabledError
@@ -18,11 +18,13 @@ from nemo_platform_plugin.auth.access_keys.types import (
     AccessKeyListResponse,
     AccessKeyMetadataResponse,
     AccessKeyReversibleStatus,
+    AccessKeyRotateResponse,
     AccessKeyStatus,
 )
 from nmp.common.api.filter import ComparisonOperation, FilterOperator, LogicalOperation
 from nmp.common.auth.access_keys import (
     LEGACY_ACCESS_KEY_METADATA_VERSION,
+    SERVICE_ACCOUNT_PRINCIPAL_PREFIX,
     AccessKeyIssuerService,
     AccessKeyValidationError,
 )
@@ -35,6 +37,26 @@ from nmp.core.auth.entities import AccessKeyEntity
 
 ACCESS_KEY_WORKSPACE = "system"
 logger = logging.getLogger(__name__)
+
+# Bounds retries of a lifecycle mutation's optimistic-lock update against version
+# bumps from concurrent, unrelated writes (chiefly is_active's last_used_at updates
+# on every authenticated request) that don't actually conflict with the mutation
+# itself. A key with real traffic is exactly the case these operations exist to serve.
+_MUTATION_MAX_ATTEMPTS = 3
+
+# Coarsens last_used_at writes in is_active: a key with active traffic doesn't need a
+# store write on every single authenticated request, just often enough to tell a caller
+# their traffic has moved off a rotated-out key.
+_LAST_USED_AT_RESOLUTION = timedelta(minutes=5)
+
+_MutationResultT = TypeVar("_MutationResultT")
+
+
+class _Retry:
+    """Sentinel a `_retry_on_conflict` conflict handler returns to request another attempt."""
+
+
+_RETRY = _Retry()
 
 # Service-bound keys are machine-to-machine credentials owned by the platform, not
 # by the creating individual (AIRCORE-986). Every lifecycle operation therefore
@@ -95,6 +117,16 @@ class AccessKeyRegistry:
             )
         )
 
+    async def discard_unreturned(self, jti: str) -> None:
+        try:
+            await self._entity_client.delete(
+                AccessKeyEntity,
+                name=jti,
+                workspace=ACCESS_KEY_WORKSPACE,
+            )
+        except EntityNotFoundError:
+            pass
+
     async def list_for_principal(
         self, principal: str, *, page: int, page_size: int, include_service_accounts: bool = False
     ) -> AccessKeyListResponse:
@@ -134,6 +166,32 @@ class AccessKeyRegistry:
             has_more=page < result.pagination.total_pages,
         )
 
+    async def _retry_on_conflict(
+        self,
+        do_attempt: Callable[[], Awaitable[_MutationResultT]],
+        handle_conflict: Callable[[], Awaitable[_MutationResultT | _Retry]],
+    ) -> _MutationResultT:
+        """Run `do_attempt`, retrying up to `_MUTATION_MAX_ATTEMPTS` times on
+        `EntityConflictError`.
+
+        `EntityClient.update` uses db_version optimistic locking, so every conflict
+        is handed to `handle_conflict`, which re-reads the current record and either
+        returns a final result (an early outcome, or re-raising a state error) or the
+        `_RETRY` sentinel to try `do_attempt` again against the fresh state — the
+        conflict may be from an unrelated concurrent write (e.g. is_active's
+        last_used_at update) rather than a real state clash.
+        """
+        for attempt in range(_MUTATION_MAX_ATTEMPTS):
+            try:
+                return await do_attempt()
+            except EntityConflictError:
+                outcome = await handle_conflict()
+                if not isinstance(outcome, _Retry):
+                    return outcome
+                if attempt == _MUTATION_MAX_ATTEMPTS - 1:
+                    raise
+        raise AssertionError("unreachable: loop always returns or raises")
+
     async def revoke(self, jti: str, principal: str, *, admin_override: AdminOverride | None = None) -> bool:
         # Note: unlike is_active, revoke has no backfill path for legacy v1 keys that have
         # never authenticated after migration. Without the original JWT claims we cannot
@@ -142,22 +200,24 @@ class AccessKeyRegistry:
         record = await self._get_owned(jti, principal, admin_override=admin_override)
         if record.status == "REVOKED":
             return False
-        updated = record.model_copy(update={"status": "REVOKED"})
-        try:
-            await self._entity_client.update(updated)
-        except EntityConflictError:
-            # EntityClient.update uses db_version optimistic locking. Re-read to
-            # determine whether a concurrent revoke won the race.
+
+        async def do_attempt() -> bool:
+            await self._entity_client.update(record.model_copy(update={"status": "REVOKED"}))
+            return True
+
+        async def handle_conflict() -> bool | _Retry:
+            nonlocal record
             try:
-                current = await self._get_owned(jti, principal, admin_override=admin_override)
+                record = await self._get_owned(jti, principal, admin_override=admin_override)
             except AccessKeyNotFoundError:
                 # The key was concurrently hard-deleted between our update and this
                 # read. Treat as already-revoked (idempotent outcome).
                 return False
-            if current.status == "REVOKED":
+            if record.status == "REVOKED":
                 return False
-            raise
-        return True
+            return _RETRY
+
+        return await self._retry_on_conflict(do_attempt, handle_conflict)
 
     async def suspend(
         self, jti: str, principal: str, *, admin_override: AdminOverride | None = None
@@ -181,6 +241,7 @@ class AccessKeyRegistry:
         completed_action = "suspended" if suspended else "unsuspended"
         admin_override = _memoize_admin_override(admin_override)
         record = await self._get_owned(jti, principal, admin_override=admin_override)
+        self._ensure_not_rotating(jti, record, action=completed_action)
         if record.status == "REVOKED":
             raise AccessKeyStateConflictError(f"Revoked Scoped Access Key {jti} cannot be {completed_action}")
         effective_status = self._reversible_status(record)
@@ -188,20 +249,112 @@ class AccessKeyRegistry:
             return False, effective_status
         if record.status == target_status:
             return False, effective_status
-        updated = record.model_copy(update={"status": target_status})
-        try:
+
+        async def do_attempt() -> tuple[bool, AccessKeyReversibleStatus]:
+            updated = record.model_copy(update={"status": target_status})
             await self._entity_client.update(updated)
-        except EntityConflictError:
-            # EntityClient.update uses db_version optimistic locking. Re-read to
-            # determine whether a concurrent update won the race.
-            current = await self._get_owned(jti, principal, admin_override=admin_override)
-            if current.status == "REVOKED":
+            return True, self._reversible_status(updated)
+
+        async def handle_conflict() -> tuple[bool, AccessKeyReversibleStatus] | _Retry:
+            nonlocal record
+            record = await self._get_owned(jti, principal, admin_override=admin_override)
+            self._ensure_not_rotating(jti, record, action=completed_action)
+            if record.status == "REVOKED":
                 raise AccessKeyStateConflictError(f"Revoked Scoped Access Key {jti} cannot be {completed_action}")
-            current_status = self._reversible_status(current)
-            if current_status == "EXPIRED" or current.status == target_status:
+            current_status = self._reversible_status(record)
+            if current_status == "EXPIRED" or record.status == target_status:
                 return False, current_status
+            return _RETRY
+
+        return await self._retry_on_conflict(do_attempt, handle_conflict)
+
+    async def get_rotatable(
+        self, jti: str, principal: str, *, admin_override: AdminOverride | None = None
+    ) -> AccessKeyEntity:
+        """Return `jti`'s current record if it is eligible to be rotated, else raise.
+
+        Read-only: callers mint the successor key from the returned record's
+        attributes, then call `begin_rotation` to transition this record to ROTATING.
+        """
+        record = await self._get_owned(jti, principal, admin_override=admin_override)
+        self._ensure_rotatable(jti, record)
+        return record
+
+    async def get_status(
+        self, jti: str, principal: str, *, admin_override: AdminOverride | None = None
+    ) -> AccessKeyEntity:
+        """Return an owned key record without requiring a particular lifecycle state."""
+        return await self._get_owned(jti, principal, admin_override=admin_override)
+
+    async def begin_rotation(
+        self,
+        jti: str,
+        principal: str,
+        *,
+        grace_period_seconds: int,
+        successor_jti: str,
+        admin_override: AdminOverride | None = None,
+    ) -> AccessKeyEntity:
+        admin_override = _memoize_admin_override(admin_override)
+        try:
+            record = await self._get_owned(jti, principal, admin_override=admin_override)
+        except Exception as exc:
+            # No update has been attempted in this rotation iteration yet.
+            exc.__dict__["write_attempted"] = False
             raise
-        return True, self._reversible_status(updated)
+        self._ensure_rotatable(jti, record)
+
+        async def do_attempt() -> AccessKeyEntity:
+            # Recomputed each attempt so a retry's deadline reflects the current
+            # time, and capped by the old key's own natural expiry so the reported
+            # deadline is never later than the instant the key would die anyway
+            # (natural expiry always takes precedence over rotation grace).
+            grace_period_expires_at = datetime.now(tz=UTC) + timedelta(seconds=grace_period_seconds)
+            if record.expires_at is not None and record.expires_at < grace_period_expires_at:
+                grace_period_expires_at = record.expires_at
+            updated = record.model_copy(
+                update={
+                    "status": "ROTATING",
+                    "grace_period_expires_at": grace_period_expires_at,
+                    "rotation_successor_jti": successor_jti,
+                }
+            )
+            await self._entity_client.update(updated)
+            return updated
+
+        async def handle_conflict() -> AccessKeyEntity | _Retry:
+            nonlocal record
+            # Re-read so a caller that already validated get_rotatable sees a precise
+            # reason if a concurrent lifecycle change (e.g. a revoke) won the race,
+            # rather than a bare conflict. If the record is still rotatable, the
+            # conflict was from an unrelated concurrent write (e.g. is_active's
+            # last_used_at update) — retry against the fresh db_version instead of
+            # failing the rotation.
+            try:
+                record = await self._get_owned(jti, principal, admin_override=admin_override)
+            except Exception as exc:
+                # The conflict proves the preceding update was rejected, so this
+                # re-read can also fail only before a rotation write commits.
+                exc.__dict__["write_attempted"] = False
+                raise
+            self._ensure_rotatable(jti, record)
+            return _RETRY
+
+        return await self._retry_on_conflict(do_attempt, handle_conflict)
+
+    @staticmethod
+    def _ensure_rotatable(jti: str, record: AccessKeyEntity) -> None:
+        if record.status != "ACTIVE":
+            raise AccessKeyStateConflictError(
+                f"Scoped Access Key {jti} must be ACTIVE to rotate (current status: {record.status})"
+            )
+        if AccessKeyRegistry._status(record) == "EXPIRED":
+            raise AccessKeyStateConflictError(f"Expired Scoped Access Key {jti} cannot be rotated")
+
+    @staticmethod
+    def _ensure_not_rotating(jti: str, record: AccessKeyEntity, *, action: str) -> None:
+        if record.status == "ROTATING":
+            raise AccessKeyStateConflictError(f"Scoped Access Key {jti} is being rotated and cannot be {action}")
 
     async def is_active(self, jti: str, principal: str, *, claims: TokenClaims | None = None) -> bool:
         try:
@@ -212,7 +365,65 @@ class AccessKeyRegistry:
             record = await self._backfill_legacy_record(jti, principal, claims)
             if record is None:
                 return False
-        return self._status(record, leeway_seconds=30) == "ACTIVE"
+        effective_status = self._status(record, leeway_seconds=30)
+        # ROTATING keys skip the coalescing resolution and get a write on every
+        # authenticated request: last_used_at is the caller's signal for confirming
+        # traffic has moved off a rotated-out key before revoking it, and that key
+        # only exists for the bounded grace window, so a stale-by-up-to-5-minutes
+        # timestamp right after cutover could read as "no more traffic" when there
+        # still is some, prompting a premature revoke.
+        if effective_status in {"ACTIVE", "ROTATING"} and (
+            effective_status == "ROTATING"
+            or record.last_used_at is None
+            or datetime.now(tz=UTC) - record.last_used_at >= _LAST_USED_AT_RESOLUTION
+        ):
+            current_record = record
+
+            async def do_attempt() -> bool:
+                await self._entity_client.update(
+                    current_record.model_copy(update={"last_used_at": datetime.now(tz=UTC)})
+                )
+                return True
+
+            async def handle_conflict() -> bool | _Retry:
+                nonlocal current_record, effective_status
+                try:
+                    current_record = await self._get_for_subject(jti, principal)
+                except Exception:
+                    logger.warning(
+                        "Failed to refresh Scoped Access Key after a concurrent last-used timestamp update",
+                        extra={"access_key_jti": jti, "actor_principal": principal},
+                        exc_info=True,
+                    )
+                    return False
+                effective_status = self._status(current_record, leeway_seconds=30)
+                if effective_status not in {"ACTIVE", "ROTATING"}:
+                    return False
+                if (
+                    effective_status != "ROTATING"
+                    and current_record.last_used_at is not None
+                    and datetime.now(tz=UTC) - current_record.last_used_at < _LAST_USED_AT_RESOLUTION
+                ):
+                    return False
+                return _RETRY
+
+            try:
+                await self._retry_on_conflict(do_attempt, handle_conflict)
+            except EntityConflictError:
+                logger.warning(
+                    "Failed to update last-used timestamp for Scoped Access Key due to concurrent updates",
+                    extra={"access_key_jti": jti, "actor_principal": principal},
+                    exc_info=True,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to update last-used timestamp for Scoped Access Key",
+                    extra={"access_key_jti": jti, "actor_principal": principal},
+                    exc_info=True,
+                )
+        # ROTATING keys stay usable through their grace period so callers can cut
+        # over to the successor key without downtime (dual-active rotation).
+        return effective_status in ("ACTIVE", "ROTATING")
 
     async def _get_for_subject(self, jti: str, principal: str) -> AccessKeyEntity:
         record = await self._get(jti)
@@ -246,6 +457,7 @@ class AccessKeyRegistry:
 
     @staticmethod
     def _metadata(record: AccessKeyEntity) -> AccessKeyMetadataResponse:
+        effective_status = AccessKeyRegistry._status(record)
         return AccessKeyMetadataResponse(
             jti=record.name,
             name=record.key_name,
@@ -254,11 +466,13 @@ class AccessKeyRegistry:
             entity_type=record.entity_type,
             # Report lifecycle status against the published expiration instant.
             # Clock-skew leeway applies only while authenticating the JWT.
-            status=AccessKeyRegistry._status(record),
+            status=effective_status,
             issuer=record.issuer,
             audiences=list(dict.fromkeys(record.audiences)),
             created_at=record.issued_at,
             expires_at=record.expires_at,
+            grace_period_expires_at=record.grace_period_expires_at if effective_status == "ROTATING" else None,
+            last_used_at=record.last_used_at,
         )
 
     @staticmethod
@@ -269,6 +483,18 @@ class AccessKeyRegistry:
             seconds=leeway_seconds
         ):
             return "EXPIRED"
+        if record.status == "ROTATING":
+            # Finalization is lazy, mirroring how natural expiry above is derived at
+            # read time rather than written by a background job: once grace_period_expires_at
+            # passes, the rotated-out key is reported (and authenticates) as REVOKED.
+            # leeway_seconds is clock-skew tolerance for validating a JWT's own `exp`
+            # claim against the issuing server's clock; the rotation grace deadline is
+            # a server-side-only comparison, so it must not get the same extension —
+            # otherwise a key could keep authenticating past the deadline metadata
+            # already reports as REVOKED.
+            if record.grace_period_expires_at is not None and datetime.now(tz=UTC) >= record.grace_period_expires_at:
+                return "REVOKED"
+            return "ROTATING"
         if record.status == "SUSPENDED":
             return "SUSPENDED"
         return "ACTIVE"
@@ -276,8 +502,11 @@ class AccessKeyRegistry:
     @staticmethod
     def _reversible_status(record: AccessKeyEntity) -> AccessKeyReversibleStatus:
         effective_status = AccessKeyRegistry._status(record)
-        if effective_status == "REVOKED":
-            raise AssertionError("A reversible access-key transition cannot produce REVOKED status")
+        if effective_status in ("REVOKED", "ROTATING"):
+            # Callers must guard with _ensure_not_rotating (and never pass a REVOKED
+            # record) before reaching here; both are lifecycle states that suspend/
+            # unsuspend explicitly reject earlier, not states this helper should report.
+            raise AssertionError(f"A reversible access-key transition cannot produce {effective_status} status")
         return effective_status
 
     async def _backfill_legacy_record(
@@ -290,7 +519,7 @@ class AccessKeyRegistry:
         if record is None:
             return None
         try:
-            await self._entity_client.create(record)
+            created = await self._entity_client.create(record)
         except EntityConflictError:
             try:
                 return await self._get_for_subject(jti, principal)
@@ -304,11 +533,7 @@ class AccessKeyRegistry:
                 "access_key_jti": jti,
             },
         )
-        # Return the locally-constructed record rather than re-fetching. The
-        # immediate caller (is_active) only reads status and expires_at,
-        # both of which are set locally. If this method is extended to use
-        # server-assigned fields (e.g. db_version), re-fetch here instead.
-        return record
+        return created
 
     @classmethod
     def _record_from_validated_claims(
@@ -488,6 +713,181 @@ class PersistentAccessKeyIssuer:
         )
         self._log_suspension(jti, changed=unsuspended, action="unsuspend")
         return unsuspended, effective_status
+
+    async def _discard_orphaned_successor(self, new_key_jti: str, *, context: str) -> None:
+        try:
+            await self._registry.discard_unreturned(new_key_jti)
+        except Exception:
+            logger.warning(
+                f"Failed to discard {context}",
+                extra={"access_key_jti": new_key_jti, "actor_principal": self.principal},
+                exc_info=True,
+            )
+
+    async def rotate_async(self, jti: str, *, grace_period_seconds: int | None = None) -> AccessKeyRotateResponse:
+        self._ensure_enabled()
+        max_grace_period_seconds = self._config.access_keys.max_rotation_grace_period_seconds
+        if grace_period_seconds is not None and (
+            max_grace_period_seconds is not None and grace_period_seconds > max_grace_period_seconds
+        ):
+            raise AccessKeyValidationError(
+                f"grace_period_seconds ({grace_period_seconds}) exceeds "
+                f"auth.access_keys.max_rotation_grace_period_seconds ({max_grace_period_seconds})"
+            )
+        # Read-validate before minting: fail fast on an ineligible key (already
+        # revoked/suspended/rotating/expired) instead of issuing a successor JWT we'd
+        # then have to discard.
+        old_record = await self._registry.get_rotatable(jti, self.principal, admin_override=self._admin_override)
+        allow_service_account = old_record.entity_type == "SERVICE_ACCOUNT"
+        if allow_service_account:
+            # Mirrors create_async's defense-in-depth re-check: don't rely solely on
+            # the caller having verified PlatformAdmin status upstream (see AdminOverride).
+            if not await self.is_platform_admin():
+                raise AccessKeyValidationError("Service-bound Scoped Access Keys require PlatformAdmin")
+            service_account_id = (old_record.subject_principal or "").removeprefix(SERVICE_ACCOUNT_PRINCIPAL_PREFIX)
+        else:
+            service_account_id = None
+        # Preserve the original key's lifetime characteristic (finite duration, restarted
+        # from now, or explicitly non-expiring) rather than the caller's current default.
+        expires_in_seconds = (
+            int((old_record.expires_at - old_record.issued_at).total_seconds())
+            if old_record.expires_at is not None
+            else None
+        )
+        # The preserved lifetime (or non-expiring None) can violate a max_expires_in_seconds
+        # policy that has since tightened relative to when the old key was issued. Clamp it
+        # to the current maximum rather than let an otherwise-eligible rotation fail outright.
+        max_expires_in_seconds = self._config.access_keys.max_expires_in_seconds
+        if max_expires_in_seconds is not None and (
+            expires_in_seconds is None or expires_in_seconds > max_expires_in_seconds
+        ):
+            expires_in_seconds = max_expires_in_seconds
+        request = AccessKeyCreateRequest(
+            name=old_record.key_name,
+            description=old_record.description,
+            service_account_id=service_account_id,
+            expires_in_seconds=expires_in_seconds,
+        )
+        new_key = await self._issuer.create_async(request, allow_service_account=allow_service_account)
+        try:
+            await self._registry.add(new_key, owner_principal=self.principal)
+        except Exception:
+            try:
+                await self._registry.get_status(
+                    new_key.jti,
+                    self.principal,
+                    admin_override=self._admin_override,
+                )
+            except AccessKeyNotFoundError:
+                pass
+            except Exception:
+                logger.warning(
+                    "Could not reconcile whether the rotated Scoped Access Key lifecycle record was persisted",
+                    extra={"access_key_jti": new_key.jti, "actor_principal": self.principal},
+                    exc_info=True,
+                )
+            else:
+                await self._discard_orphaned_successor(
+                    new_key.jti,
+                    context="unreturned successor Scoped Access Key after an ambiguous persistence failure",
+                )
+            logger.warning(
+                "Failed to persist rotated Scoped Access Key lifecycle record; "
+                "the signed JWT will not be returned to the caller",
+                extra={"access_key_jti": new_key.jti, "actor_principal": self.principal},
+                exc_info=True,
+            )
+            raise
+        if grace_period_seconds is None:
+            grace_period_seconds = self._config.access_keys.rotation_grace_period_seconds
+        try:
+            rotated_record = await self._registry.begin_rotation(
+                jti,
+                self.principal,
+                grace_period_seconds=grace_period_seconds,
+                successor_jti=new_key.jti,
+                admin_override=self._admin_override,
+            )
+        except (AccessKeyStateConflictError, EntityConflictError, AccessKeyNotFoundError):
+            await self._discard_orphaned_successor(
+                new_key.jti, context="orphaned successor Scoped Access Key after a failed rotation"
+            )
+            raise
+        except Exception as rotation_error:
+            if not getattr(rotation_error, "write_attempted", True):
+                # begin_rotation identified a deterministic pre-write failure. A
+                # concurrent winner may still make the old key look ROTATING, but
+                # this request's successor was never paired with that transition.
+                await self._discard_orphaned_successor(
+                    new_key.jti, context="orphaned successor Scoped Access Key after a failed rotation"
+                )
+                raise
+            try:
+                reconciled_record = await self._registry.get_status(
+                    jti,
+                    self.principal,
+                    admin_override=self._admin_override,
+                )
+            except Exception:
+                logger.warning(
+                    "Could not reconcile Scoped Access Key state after rotation failed; keeping the successor",
+                    extra={
+                        "access_key_jti": jti,
+                        "access_key_new_jti": new_key.jti,
+                        "actor_principal": self.principal,
+                    },
+                    exc_info=True,
+                )
+                raise rotation_error from None
+            if reconciled_record.rotation_successor_jti == new_key.jti:
+                # Confirmed: this request's write committed, however the record now
+                # reads. Normally that's still ROTATING, but if reconciliation was
+                # itself delayed (e.g. past the grace deadline, or a subsequent
+                # manual revoke landed first), _status() may already report
+                # REVOKED/EXPIRED -- report that faithfully rather than discarding
+                # a successor this request is confirmed to own.
+                rotated_record = reconciled_record
+            else:
+                # This request's own transition never took effect: the old key is
+                # either still ACTIVE (the write never committed), or it moved on
+                # paired with a different successor (a concurrent request's
+                # rotation committed instead) -- either way, this request's
+                # successor must be discarded rather than misattributed as a
+                # success it didn't cause.
+                await self._discard_orphaned_successor(
+                    new_key.jti, context="orphaned successor Scoped Access Key after a failed rotation"
+                )
+                raise rotation_error from None
+        previous_status = AccessKeyRegistry._status(rotated_record)
+        effective_grace_period_expires_at = (
+            rotated_record.grace_period_expires_at if previous_status == "ROTATING" else None
+        )
+        logger.info(
+            "Scoped Access Key rotated",
+            extra={
+                "audit_event": "access_key.rotated",
+                "actor_principal": self.principal,
+                "access_key_jti": jti,
+                "access_key_new_jti": new_key.jti,
+            },
+        )
+        # rotated_record.grace_period_expires_at is already capped by the old key's
+        # natural expiry (see begin_rotation), so derive the reported remaining
+        # seconds from it rather than echoing the configured grace_period_seconds
+        # verbatim -- otherwise a key expiring sooner than the configured grace
+        # period would be reported as remaining usable far longer than it actually is.
+        effective_grace_period_seconds = 0
+        if effective_grace_period_expires_at is not None:
+            effective_grace_period_seconds = max(
+                0, int((effective_grace_period_expires_at - datetime.now(tz=UTC)).total_seconds())
+            )
+        return AccessKeyRotateResponse(
+            new_key=new_key,
+            previous_jti=jti,
+            previous_status=previous_status,
+            grace_period_seconds=effective_grace_period_seconds,
+            grace_period_expires_at=effective_grace_period_expires_at,
+        )
 
     def _log_suspension(
         self,

--- a/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
+++ b/services/core/auth/src/nmp/core/auth/assets/static-authz.yaml
@@ -468,6 +468,10 @@ authz:
       post:
         permissions: []
         scopes: []
+    /apis/auth/v2/access-keys/{jti}/rotate:
+      post:
+        permissions: []
+        scopes: []
     /apis/auth/v2/iam/opa-bundle.tar.gz:
       get:
         permissions:

--- a/services/core/auth/src/nmp/core/auth/entities/entities.py
+++ b/services/core/auth/src/nmp/core/auth/entities/entities.py
@@ -56,7 +56,16 @@ class AccessKeyEntity(EntityBase):
     audiences: list[str]
     issued_at: datetime
     expires_at: datetime | None = None
-    status: Literal["ACTIVE", "REVOKED", "SUSPENDED"] = "ACTIVE"
+    last_used_at: datetime | None = None
+    status: Literal["ACTIVE", "REVOKED", "SUSPENDED", "ROTATING"] = "ACTIVE"
+    # Set when status == "ROTATING": the instant after which this rotated-out key is
+    # treated as revoked. Unused for every other status.
+    grace_period_expires_at: datetime | None = None
+    # Set when status == "ROTATING": the jti of the successor key minted for this
+    # rotation. Lets an ambiguous begin_rotation outcome be attributed to the request
+    # that actually committed it, rather than to a differently-raced concurrent
+    # request that happened to also see this key as ROTATING.
+    rotation_successor_jti: str | None = None
 
     @model_validator(mode="before")
     @classmethod

--- a/services/core/auth/tests/integration/test_scoped_access_keys.py
+++ b/services/core/auth/tests/integration/test_scoped_access_keys.py
@@ -271,6 +271,77 @@ def test_scoped_access_key_created_by_auth_service_authenticates_platform_reques
             client.delete(f"{WORKSPACES_PATH}/{workspace}", headers=SERVICE_HEADERS)
 
 
+def test_rotated_access_key_keeps_working_during_grace_period_and_new_key_authenticates(tmp_path: Path) -> None:
+    private_key_file = tmp_path / "rotate-access-key-private.pem"
+    _write_private_key(private_key_file)
+    shared_config, service_config = _auth_configs(str(private_key_file))
+    user = f"rotate-user-{uuid.uuid4().hex[:8]}@example.com"
+    user_headers = {
+        "X-NMP-Principal-Id": user,
+        "X-NMP-Principal-Email": user,
+    }
+
+    with create_test_client(
+        client_type=TestClient,
+        auth_enabled=True,
+        service_configs={AuthConfig: shared_config, AuthServiceConfig: service_config},
+    ) as client:
+        created = client.post(
+            ACCESS_KEYS_PATH,
+            json={"name": "rotate-smoke"},
+            headers=user_headers,
+        )
+        assert created.status_code == 200, created.text
+        old_key = created.json()["token"]
+        old_jti = created.json()["jti"]
+
+        rotated = client.post(f"{ACCESS_KEYS_PATH}/{old_jti}/rotate", headers=user_headers)
+        assert rotated.status_code == 200, rotated.text
+        rotated_body = rotated.json()
+        assert rotated_body["previous_jti"] == old_jti
+        assert rotated_body["previous_status"] == "ROTATING"
+        new_key = rotated_body["new_key"]["token"]
+        new_jti = rotated_body["new_key"]["jti"]
+        assert new_jti != old_jti
+
+        jwks = {"keys": [public_jwk_from_private_key_pem(shared_config)]}
+
+        async def validate_with_local_jwks(config: AuthConfig, token: str) -> TokenClaims | None:
+            return await validate_access_key_token(config, token, jwks_override=jwks)
+
+        def authenticate_with_access_key(token: str) -> Response:
+            with patch("nmp.common.auth.access_keys.validate_access_key_token", validate_with_local_jwks):
+                return client.get(
+                    "/apis/auth/authenticate",
+                    headers={"Authorization": f"Bearer {token}"},
+                )
+
+        # Dual-active grace period: both the rotated-out key and its successor
+        # authenticate until the old key is finalized (revoked or grace expires).
+        old_key_response = authenticate_with_access_key(old_key)
+        new_key_response = authenticate_with_access_key(new_key)
+        assert old_key_response.status_code == 200, old_key_response.text
+        assert new_key_response.status_code == 200, new_key_response.text
+
+        listing = {key["jti"]: key for key in client.get(ACCESS_KEYS_PATH, headers=user_headers).json()["data"]}
+        assert listing[old_jti]["status"] == "ROTATING"
+        assert listing[new_jti]["status"] == "ACTIVE"
+
+        # Cannot rotate an already-rotating key; must finalize (revoke) first.
+        second_rotate = client.post(f"{ACCESS_KEYS_PATH}/{old_jti}/rotate", headers=user_headers)
+        assert second_rotate.status_code == 409, second_rotate.text
+
+        finalize = client.delete(f"{ACCESS_KEYS_PATH}/{old_jti}", headers=user_headers)
+        assert finalize.status_code == 200, finalize.text
+
+        finalized_old_key_response = _wait_for_authorization_response(
+            lambda: authenticate_with_access_key(old_key),
+            expected_status_code=401,
+        )
+        assert finalized_old_key_response.status_code == 401, finalized_old_key_response.text
+        assert authenticate_with_access_key(new_key).status_code == 200
+
+
 def test_platform_admin_creates_service_bound_key_with_independent_identity(tmp_path: Path) -> None:
     private_key_file = tmp_path / "service-access-key-private.pem"
     _write_private_key(private_key_file)

--- a/services/core/auth/tests/test_access_key_registry.py
+++ b/services/core/auth/tests/test_access_key_registry.py
@@ -42,6 +42,13 @@ def _suspended_record() -> AccessKeyEntity:
     return _record(jti="ak_suspended").model_copy(update={"status": "SUSPENDED"})
 
 
+def _rotating_record(*, grace_period_expires_at: datetime | None = None) -> AccessKeyEntity:
+    grace_period_expires_at = grace_period_expires_at or datetime.now(tz=UTC) + timedelta(days=2)
+    return _record(jti="ak_rotating").model_copy(
+        update={"status": "ROTATING", "grace_period_expires_at": grace_period_expires_at}
+    )
+
+
 def _expired_record() -> AccessKeyEntity:
     return _record(jti="ak_expired").model_copy(update={"expires_at": datetime(2000, 1, 1, tzinfo=UTC)})
 
@@ -160,6 +167,31 @@ async def test_registry_separates_service_key_owner_from_token_subject() -> None
     assert saved.principal == "admin@example.com"
     assert saved.subject_principal == "service-account:otel-collector"
     assert saved.entity_type == "SERVICE_ACCOUNT"
+
+
+@pytest.mark.asyncio
+async def test_registry_discards_unreturned_key() -> None:
+    entity_client = AsyncMock()
+    registry = AccessKeyRegistry(entity_client)
+
+    await registry.discard_unreturned("ak_orphaned")
+
+    entity_client.delete.assert_awaited_once_with(
+        AccessKeyEntity,
+        name="ak_orphaned",
+        workspace="system",
+    )
+
+
+@pytest.mark.asyncio
+async def test_registry_discard_unreturned_is_idempotent_when_record_is_missing() -> None:
+    entity_client = AsyncMock()
+    entity_client.delete.side_effect = EntityNotFoundError("missing")
+    registry = AccessKeyRegistry(entity_client)
+
+    await registry.discard_unreturned("ak_missing")
+
+    entity_client.delete.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -319,6 +351,126 @@ async def test_registry_can_newly_revoke_expired_key() -> None:
 
 
 @pytest.mark.asyncio
+async def test_registry_active_authentication_updates_last_used_at() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record()
+    registry = AccessKeyRegistry(entity_client)
+
+    assert await registry.is_active("ak_example", "alice@example.com")
+
+    updated = entity_client.update.await_args.args[0]
+    assert updated.last_used_at is not None
+    assert updated.last_used_at.tzinfo is UTC
+
+
+@pytest.mark.asyncio
+async def test_registry_rotating_authentication_updates_last_used_at() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record(jti="ak_rotating").model_copy(
+        update={
+            "status": "ROTATING",
+            "grace_period_expires_at": datetime.now(tz=UTC) + timedelta(minutes=5),
+        }
+    )
+    registry = AccessKeyRegistry(entity_client)
+
+    assert await registry.is_active("ak_rotating", "alice@example.com")
+
+    updated = entity_client.update.await_args.args[0]
+    assert updated.last_used_at is not None
+
+
+@pytest.mark.asyncio
+async def test_registry_rotating_authentication_bypasses_last_used_at_coalescing() -> None:
+    # ROTATING keys skip the 5-minute coalescing window: last_used_at is the signal
+    # callers rely on to confirm traffic has moved off a rotated-out key before
+    # revoking it, so it must reflect every authenticated request during the
+    # bounded grace window, not just one every 5 minutes.
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record(jti="ak_rotating").model_copy(
+        update={
+            "status": "ROTATING",
+            "grace_period_expires_at": datetime.now(tz=UTC) + timedelta(minutes=5),
+            "last_used_at": datetime.now(tz=UTC) - timedelta(seconds=5),
+        }
+    )
+    registry = AccessKeyRegistry(entity_client)
+
+    assert await registry.is_active("ak_rotating", "alice@example.com")
+
+    entity_client.update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_registry_last_used_at_update_retries_transient_conflict() -> None:
+    stale, fresh = _record(), _record()
+    stale._db_version = 1
+    fresh._db_version = 2
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [stale, fresh]
+    entity_client.update.side_effect = [EntityConflictError("entity version changed"), None]
+    registry = AccessKeyRegistry(entity_client)
+
+    assert await registry.is_active("ak_example", "alice@example.com")
+
+    assert entity_client.get.await_count == 2
+    assert entity_client.update.await_count == 2
+    first_attempt, second_attempt = (call.args[0] for call in entity_client.update.await_args_list)
+    assert first_attempt.db_version == 1
+    assert second_attempt.db_version == 2
+    assert first_attempt.last_used_at is not None
+    assert second_attempt.last_used_at is not None
+    assert second_attempt.last_used_at >= first_attempt.last_used_at
+
+
+@pytest.mark.asyncio
+async def test_registry_last_used_at_update_stops_when_conflict_reveals_revocation() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [_record(), _record(revoked=True)]
+    entity_client.update.side_effect = EntityConflictError("entity version changed")
+    registry = AccessKeyRegistry(entity_client)
+
+    assert not await registry.is_active("ak_example", "alice@example.com")
+
+    assert entity_client.get.await_count == 2
+    entity_client.update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "record",
+    [
+        _record(revoked=True),
+        _suspended_record(),
+        _expired_record(),
+        _record(principal="bob@example.com"),
+    ],
+)
+async def test_registry_rejected_authentication_does_not_update_last_used_at(record: AccessKeyEntity) -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = record
+    registry = AccessKeyRegistry(entity_client)
+
+    assert not await registry.is_active(record.name, "alice@example.com")
+
+    entity_client.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "failure",
+    [EntityConflictError("entity version changed"), RuntimeError("storage unavailable")],
+)
+async def test_registry_last_used_at_update_failure_does_not_reject_authentication(failure: Exception) -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record()
+    entity_client.update.side_effect = failure
+    registry = AccessKeyRegistry(entity_client)
+
+    assert await registry.is_active("ak_example", "alice@example.com")
+
+
+@pytest.mark.asyncio
 async def test_registry_reports_revoked_key_as_inactive() -> None:
     entity_client = AsyncMock()
     entity_client.get.return_value = _record(revoked=True)
@@ -442,6 +594,7 @@ async def test_registry_is_active_for_service_bound_key_checks_subject_not_owner
 async def test_registry_backfills_missing_legacy_access_key_from_validated_claims() -> None:
     entity_client = AsyncMock()
     entity_client.get.side_effect = EntityNotFoundError("missing")
+    entity_client.create.side_effect = lambda record: record
     registry = AccessKeyRegistry(entity_client)
     claims = TokenClaims(
         subject="alice@example.com",
@@ -522,17 +675,39 @@ async def test_registry_revoke_transitions_suspended_key_to_revoked() -> None:
 
 
 @pytest.mark.asyncio
-async def test_registry_concurrent_revoke_retries_when_key_is_only_suspended() -> None:
+async def test_registry_revoke_retries_transient_conflict_when_key_is_only_suspended() -> None:
+    # A conflict from something unrelated (e.g. is_active's last_used_at update landing
+    # between our read and update) shouldn't fail the revoke outright: since the key is
+    # merely suspended (not revoked) on re-read, revoke should retry and succeed.
+    stale, fresh = _record(), _suspended_record()
+    stale._db_version = 1
+    fresh._db_version = 2
     entity_client = AsyncMock()
-    entity_client.get.side_effect = [_record(), _suspended_record()]
+    entity_client.get.side_effect = [stale, fresh]
+    entity_client.update.side_effect = [EntityConflictError("entity version changed"), None]
+    registry = AccessKeyRegistry(entity_client)
+
+    assert await registry.revoke("ak_suspended", "alice@example.com")
+
+    assert entity_client.get.await_count == 2
+    assert entity_client.update.await_count == 2
+    first_attempt, second_attempt = (call.args[0] for call in entity_client.update.await_args_list)
+    assert first_attempt.db_version == 1
+    assert second_attempt.db_version == 2
+
+
+@pytest.mark.asyncio
+async def test_registry_revoke_gives_up_after_persistent_conflict_when_key_is_only_suspended() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [_record(), *([_suspended_record()] * 3)]
     entity_client.update.side_effect = EntityConflictError("entity version changed")
     registry = AccessKeyRegistry(entity_client)
 
     with pytest.raises(EntityConflictError, match="entity version changed"):
         await registry.revoke("ak_suspended", "alice@example.com")
 
-    assert entity_client.get.await_count == 2
-    entity_client.update.assert_awaited_once()
+    assert entity_client.get.await_count == 4
+    assert entity_client.update.await_count == 3
 
 
 @pytest.mark.asyncio
@@ -637,6 +812,44 @@ async def test_registry_concurrent_suspension_transition_rejects_revocation() ->
 
 
 @pytest.mark.asyncio
+async def test_registry_suspend_retries_transient_conflict_from_unrelated_write() -> None:
+    # A conflict from something unrelated (e.g. is_active's last_used_at update landing
+    # between our read and update) shouldn't fail the suspension outright: since the
+    # key is still eligible on re-read, suspend should retry and succeed.
+    stale, fresh = _record(), _record()
+    stale._db_version = 1
+    fresh._db_version = 2
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [stale, fresh]
+    entity_client.update.side_effect = [EntityConflictError("entity version changed"), None]
+    registry = AccessKeyRegistry(entity_client)
+
+    changed, effective_status = await registry.suspend("ak_example", "alice@example.com")
+
+    assert changed
+    assert effective_status == "SUSPENDED"
+    assert entity_client.get.await_count == 2
+    assert entity_client.update.await_count == 2
+    first_attempt, second_attempt = (call.args[0] for call in entity_client.update.await_args_list)
+    assert first_attempt.db_version == 1
+    assert second_attempt.db_version == 2
+
+
+@pytest.mark.asyncio
+async def test_registry_suspend_gives_up_after_persistent_conflict() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [_record() for _ in range(4)]
+    entity_client.update.side_effect = EntityConflictError("entity version changed")
+    registry = AccessKeyRegistry(entity_client)
+
+    with pytest.raises(EntityConflictError, match="entity version changed"):
+        await registry.suspend("ak_example", "alice@example.com")
+
+    assert entity_client.get.await_count == 4
+    assert entity_client.update.await_count == 3
+
+
+@pytest.mark.asyncio
 async def test_registry_rejects_missing_current_access_key_record() -> None:
     entity_client = AsyncMock()
     entity_client.get.side_effect = EntityNotFoundError("missing")
@@ -661,3 +874,209 @@ async def test_registry_rejects_missing_current_access_key_record() -> None:
 
     assert not await registry.is_active("ak_current", "alice@example.com", claims=claims)
     entity_client.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_registry_reports_rotating_key_as_active_during_grace_period() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _rotating_record(grace_period_expires_at=datetime(2999, 1, 1, tzinfo=UTC))
+    registry = AccessKeyRegistry(entity_client)
+
+    assert await registry.is_active("ak_rotating", "alice@example.com")
+
+
+@pytest.mark.asyncio
+async def test_registry_reports_rotated_key_as_inactive_after_grace_period() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _rotating_record(grace_period_expires_at=datetime(2000, 1, 1, tzinfo=UTC))
+    registry = AccessKeyRegistry(entity_client)
+
+    assert not await registry.is_active("ak_rotating", "alice@example.com")
+
+
+@pytest.mark.asyncio
+async def test_registry_is_active_does_not_extend_grace_deadline_by_auth_leeway() -> None:
+    # is_active's 30s clock-skew leeway is meant only for validating a JWT's own exp
+    # claim, not the server-side-only rotation grace deadline. A key just past its
+    # grace deadline must be rejected immediately, not for another 30 seconds.
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _rotating_record(
+        grace_period_expires_at=datetime.now(tz=UTC) - timedelta(seconds=5)
+    )
+    registry = AccessKeyRegistry(entity_client)
+
+    assert not await registry.is_active("ak_rotating", "alice@example.com")
+
+
+@pytest.mark.asyncio
+async def test_registry_reports_rotating_key_status_in_listing() -> None:
+    entity_client = AsyncMock()
+    entity_client.list.return_value = SimpleNamespace(
+        data=[_rotating_record(grace_period_expires_at=datetime(2999, 1, 1, tzinfo=UTC))],
+        pagination=SimpleNamespace(total_pages=1),
+    )
+    registry = AccessKeyRegistry(entity_client)
+
+    result = await registry.list_for_principal("alice@example.com", page=1, page_size=100)
+
+    assert result.data[0].status == "ROTATING"
+
+
+def test_registry_metadata_exposes_grace_expiry_for_rotating_key() -> None:
+    grace_period_expires_at = datetime(2999, 1, 1, tzinfo=UTC)
+
+    metadata = AccessKeyRegistry._metadata(_rotating_record(grace_period_expires_at=grace_period_expires_at))
+
+    assert metadata.grace_period_expires_at == grace_period_expires_at
+
+
+@pytest.mark.parametrize("status", ["ACTIVE", "REVOKED", "SUSPENDED"])
+def test_registry_metadata_hides_stale_grace_expiry_when_not_rotating(status: str) -> None:
+    record = _record().model_copy(
+        update={
+            "status": status,
+            "grace_period_expires_at": datetime(2999, 1, 1, tzinfo=UTC),
+        }
+    )
+
+    metadata = AccessKeyRegistry._metadata(record)
+
+    assert metadata.grace_period_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_registry_get_rotatable_returns_active_record() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record()
+    registry = AccessKeyRegistry(entity_client)
+
+    record = await registry.get_rotatable("ak_example", "alice@example.com")
+
+    assert record.name == "ak_example"
+    entity_client.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "record",
+    [_suspended_record(), _record(revoked=True), _rotating_record(), _expired_record()],
+    ids=["suspended", "revoked", "rotating", "expired"],
+)
+async def test_registry_get_rotatable_rejects_non_active_key(record: AccessKeyEntity) -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = record
+    registry = AccessKeyRegistry(entity_client)
+
+    with pytest.raises(AccessKeyStateConflictError):
+        await registry.get_rotatable(record.name, record.principal)
+
+
+@pytest.mark.asyncio
+async def test_registry_begin_rotation_transitions_active_key_to_rotating() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = _record()
+    registry = AccessKeyRegistry(entity_client)
+
+    result = await registry.begin_rotation(
+        "ak_example", "alice@example.com", grace_period_seconds=3600, successor_jti="ak_successor"
+    )
+
+    assert isinstance(result, AccessKeyEntity)
+    assert result.status == "ROTATING"
+    assert result.grace_period_expires_at is not None
+    assert result.grace_period_expires_at > datetime.now(tz=UTC)
+    assert result.rotation_successor_jti == "ak_successor"
+    updated = entity_client.update.await_args.args[0]
+    assert result is updated
+    assert updated.status == "ROTATING"
+    assert updated.grace_period_expires_at == result.grace_period_expires_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "record",
+    [_suspended_record(), _record(revoked=True), _rotating_record(), _expired_record()],
+    ids=["suspended", "revoked", "rotating", "expired"],
+)
+async def test_registry_begin_rotation_rejects_non_active_key(record: AccessKeyEntity) -> None:
+    entity_client = AsyncMock()
+    entity_client.get.return_value = record
+    registry = AccessKeyRegistry(entity_client)
+
+    with pytest.raises(AccessKeyStateConflictError):
+        await registry.begin_rotation(
+            record.name, record.principal, grace_period_seconds=3600, successor_jti="ak_successor"
+        )
+
+    entity_client.update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_registry_begin_rotation_caps_grace_deadline_at_natural_expiry() -> None:
+    # Natural expiry always takes precedence over rotation grace (AIRCORE-985): a key
+    # expiring sooner than the configured grace period must not have its reported
+    # deadline pushed out past that natural expiry.
+    soon_expiring = _record().model_copy(update={"expires_at": datetime.now(tz=UTC) + timedelta(minutes=10)})
+    entity_client = AsyncMock()
+    entity_client.get.return_value = soon_expiring
+    registry = AccessKeyRegistry(entity_client)
+
+    result = await registry.begin_rotation(
+        "ak_example", "alice@example.com", grace_period_seconds=3600, successor_jti="ak_successor"
+    )
+
+    assert result.grace_period_expires_at == soon_expiring.expires_at
+
+
+@pytest.mark.asyncio
+async def test_registry_begin_rotation_retries_transient_conflict_from_unrelated_write() -> None:
+    # A conflict from something unrelated (e.g. is_active's last_used_at update landing
+    # between our read and update) shouldn't fail the rotation outright: since the
+    # record is still rotatable on re-read, begin_rotation should retry and succeed.
+    stale, fresh = _record(), _record()
+    stale._db_version = 1
+    fresh._db_version = 2
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [stale, fresh]
+    entity_client.update.side_effect = [EntityConflictError("entity version changed"), None]
+    registry = AccessKeyRegistry(entity_client)
+
+    result = await registry.begin_rotation(
+        "ak_example", "alice@example.com", grace_period_seconds=3600, successor_jti="ak_successor"
+    )
+
+    assert result.status == "ROTATING"
+    assert entity_client.get.await_count == 2
+    assert entity_client.update.await_count == 2
+    first_attempt, second_attempt = (call.args[0] for call in entity_client.update.await_args_list)
+    assert first_attempt.db_version == 1
+    assert second_attempt.db_version == 2
+
+
+@pytest.mark.asyncio
+async def test_registry_begin_rotation_gives_up_after_persistent_conflict() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [_record() for _ in range(4)]
+    entity_client.update.side_effect = EntityConflictError("entity version changed")
+    registry = AccessKeyRegistry(entity_client)
+
+    with pytest.raises(EntityConflictError):
+        await registry.begin_rotation(
+            "ak_example", "alice@example.com", grace_period_seconds=3600, successor_jti="ak_successor"
+        )
+
+    assert entity_client.get.await_count == 4
+    assert entity_client.update.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_registry_begin_rotation_concurrent_conflict_surfaces_state_conflict_when_no_longer_rotatable() -> None:
+    entity_client = AsyncMock()
+    entity_client.get.side_effect = [_record(), _record(revoked=True)]
+    entity_client.update.side_effect = EntityConflictError("entity version changed")
+    registry = AccessKeyRegistry(entity_client)
+
+    with pytest.raises(AccessKeyStateConflictError):
+        await registry.begin_rotation(
+            "ak_example", "alice@example.com", grace_period_seconds=3600, successor_jti="ak_successor"
+        )

--- a/services/core/auth/tests/test_access_keys.py
+++ b/services/core/auth/tests/test_access_keys.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import logging
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
@@ -15,6 +17,7 @@ from nmp.common.auth.dependencies import auth_client_context
 from nmp.common.auth.models import Principal
 from nmp.common.config import AuthConfig
 from nmp.common.config.base import AccessKeyConfig, TokenSigningConfig
+from nmp.common.entities import EntityConflictError
 from nmp.core.auth.api.v2.access_keys.endpoints import get_access_key_issuer, router
 from nmp.core.auth.app.access_keys import AccessKeyNotFoundError, AccessKeyStateConflictError, get_access_key_registry
 
@@ -25,16 +28,41 @@ class InMemoryAccessKeyRegistry:
         self.owners = {}
         self.revoked = set()
         self.suspended = set()
+        # jti -> grace_period_expires_at for keys rotated out via begin_rotation.
+        self.rotating = {}
+        # jti -> the successor key jti recorded by whichever begin_rotation call
+        # actually committed the ACTIVE -> ROTATING transition.
+        self.rotating_successor = {}
+        self.begin_rotation_error = None
+        self.begin_rotation_pre_write_error = None
+        self.begin_rotation_commits_before_error = False
+        self.mark_rotating_before_begin_rotation_error = False
+        # Lets a test simulate a *different*, concurrently-racing request's successor
+        # having won the transition, rather than this request's own successor_jti.
+        self.begin_rotation_successor_override = None
+        # Lets a test simulate get_status reconciling to a status that already moved
+        # on past ROTATING (e.g. the grace period elapsed, or a manual revoke landed)
+        # by the time reconciliation runs, independent of self.rotating's own deadline.
+        self.get_status_status_override = None
+        self.add_error = None
+        self.add_commits_before_error = False
+        self.discarded = set()
 
     async def add(self, key, *, owner_principal=None):
+        if self.add_error is not None and not self.add_commits_before_error:
+            raise self.add_error
         self.keys[key.jti] = key
         self.owners[key.jti] = owner_principal or key.principal
+        if self.add_error is not None:
+            raise self.add_error
 
     def _status(self, jti, key):
         if jti in self.revoked:
             return "REVOKED"
         if key.expires_at is not None and key.expires_at <= datetime.now(tz=UTC) - timedelta(seconds=30):
             return "EXPIRED"
+        if jti in self.rotating:
+            return "REVOKED" if datetime.now(tz=UTC) >= self.rotating[jti] else "ROTATING"
         if jti in self.suspended:
             return "SUSPENDED"
         return key.status
@@ -69,7 +97,13 @@ class InMemoryAccessKeyRegistry:
         return AccessKeyListResponse(
             data=[
                 AccessKeyMetadataResponse.model_validate(
-                    key.model_dump(exclude={"token", "token_type"}) | {"status": self._status(jti, key)}
+                    key.model_dump(exclude={"token", "token_type"})
+                    | {
+                        "status": self._status(jti, key),
+                        "grace_period_expires_at": (
+                            self.rotating.get(jti) if self._status(jti, key) == "ROTATING" else None
+                        ),
+                    }
                 )
                 for jti, key in selected
             ],
@@ -111,7 +145,82 @@ class InMemoryAccessKeyRegistry:
 
     async def is_active(self, jti, principal, **kwargs):
         key = self.keys.get(jti)
-        return key is not None and key.principal == principal and self._status(jti, key) == "ACTIVE"
+        return key is not None and key.principal == principal and self._status(jti, key) in ("ACTIVE", "ROTATING")
+
+    def _ensure_rotatable(self, jti, key):
+        if jti in self.revoked or jti in self.suspended or jti in self.rotating:
+            raise AccessKeyStateConflictError(f"Scoped Access Key {jti} must be ACTIVE to rotate")
+        if key.expires_at is not None and key.expires_at <= datetime.now(tz=UTC):
+            raise AccessKeyStateConflictError(f"Expired Scoped Access Key {jti} cannot be rotated")
+
+    def _as_entity_view(self, jti, key):
+        # AccessKeyRegistry.get_rotatable returns an AccessKeyEntity-shaped record
+        # (key_name/issued_at/subject_principal, not name/created_at/principal-as-subject).
+        # This fake stores raw AccessKeyCreateResponse objects, so translate field names
+        # for rotate_async's state reads, which rely on the entity shape.
+        owner = self.owners[jti]
+        return SimpleNamespace(
+            key_name=key.name,
+            description=key.description,
+            principal=owner,
+            subject_principal=key.principal if key.principal != owner else None,
+            entity_type=key.entity_type,
+            issued_at=key.created_at,
+            expires_at=key.expires_at,
+            status=self._status(jti, key),
+            grace_period_expires_at=self.rotating.get(jti),
+            rotation_successor_jti=self.rotating_successor.get(jti),
+        )
+
+    async def get_rotatable(self, jti, principal, *, admin_override=None):
+        key = await self._may_manage(jti, principal, admin_override=admin_override)
+        if key is None:
+            raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
+        self._ensure_rotatable(jti, key)
+        return self._as_entity_view(jti, key)
+
+    async def get_status(self, jti, principal, *, admin_override=None):
+        key = await self._may_manage(jti, principal, admin_override=admin_override)
+        if key is None:
+            raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
+        view = self._as_entity_view(jti, key)
+        if self.get_status_status_override is not None:
+            view = SimpleNamespace(**{**vars(view), "status": self.get_status_status_override})
+        return view
+
+    async def discard_unreturned(self, jti):
+        self.keys.pop(jti, None)
+        self.owners.pop(jti, None)
+        self.revoked.discard(jti)
+        self.suspended.discard(jti)
+        self.rotating.pop(jti, None)
+        self.rotating_successor.pop(jti, None)
+        self.discarded.add(jti)
+
+    async def begin_rotation(self, jti, principal, *, grace_period_seconds, successor_jti, admin_override=None):
+        recorded_successor_jti = self.begin_rotation_successor_override or successor_jti
+        if self.begin_rotation_pre_write_error is not None:
+            error = self.begin_rotation_pre_write_error
+            error.__dict__["write_attempted"] = False
+            if self.mark_rotating_before_begin_rotation_error:
+                self.rotating[jti] = datetime.now(tz=UTC) + timedelta(seconds=grace_period_seconds)
+                self.rotating_successor[jti] = recorded_successor_jti
+            raise error
+        key = await self._may_manage(jti, principal, admin_override=admin_override)
+        if key is None:
+            raise AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
+        self._ensure_rotatable(jti, key)
+        if self.begin_rotation_error is not None:
+            if self.mark_rotating_before_begin_rotation_error:
+                self.rotating[jti] = datetime.now(tz=UTC) + timedelta(seconds=grace_period_seconds)
+                self.rotating_successor[jti] = recorded_successor_jti
+            if self.begin_rotation_commits_before_error:
+                self.rotating[jti] = datetime.now(tz=UTC) + timedelta(seconds=grace_period_seconds)
+                self.rotating_successor[jti] = recorded_successor_jti
+            raise self.begin_rotation_error
+        self.rotating[jti] = datetime.now(tz=UTC) + timedelta(seconds=grace_period_seconds)
+        self.rotating_successor[jti] = successor_jti
+        return self._as_entity_view(jti, key)
 
 
 @pytest.fixture
@@ -352,6 +461,55 @@ def test_platform_admin_can_revoke_service_key_created_by_a_different_admin(clie
     assert revoked.json()["revoked"] is True
 
 
+def test_platform_admin_rotates_service_key_and_preserves_binding_and_expiration(client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True):
+        created = client.post(
+            "/v2/access-keys",
+            json={
+                "name": "otel",
+                "service_account_id": "otel-collector",
+                "expires_in_seconds": 3600,
+            },
+        ).json()
+
+        other_admin_token = auth_client_context.set(
+            AuthClient(
+                principal=Principal(id="bob@example.com", email="bob@example.com"),
+                config=AuthConfig(enabled=True, access_keys=AccessKeyConfig(enabled=True)),
+            )
+        )
+        try:
+            rotated = client.post(f"/v2/access-keys/{created['jti']}/rotate")
+        finally:
+            auth_client_context.reset(other_admin_token)
+
+    assert rotated.status_code == 200
+    new_key = rotated.json()["new_key"]
+    assert new_key["principal"] == "service-account:otel-collector"
+    assert new_key["entity_type"] == "SERVICE_ACCOUNT"
+
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    persisted_successor = registry.keys[new_key["jti"]]
+    assert persisted_successor.principal == "service-account:otel-collector"
+    assert persisted_successor.entity_type == "SERVICE_ACCOUNT"
+    old_key = registry.keys[created["jti"]]
+    assert old_key.expires_at - old_key.created_at == timedelta(seconds=3600)
+    assert persisted_successor.expires_at - persisted_successor.created_at == timedelta(seconds=3600)
+
+
+def test_service_key_creator_cannot_rotate_after_losing_platform_admin(client):
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True):
+        created = client.post(
+            "/v2/access-keys",
+            json={"name": "otel", "service_account_id": "otel-collector"},
+        ).json()
+
+    with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=False):
+        rotated = client.post(f"/v2/access-keys/{created['jti']}/rotate")
+
+    assert rotated.status_code == 404
+
+
 def test_platform_admin_cannot_revoke_another_admins_personal_access_key(client):
     with patch.object(AuthClient, "has_role", new_callable=AsyncMock, return_value=True):
         created = client.post("/v2/access-keys", json={"name": "personal"}).json()
@@ -453,6 +611,129 @@ def test_create_access_key_allows_unnamed_tokens(client):
     assert body["jti"].startswith("ak_")
     assert body["name"] is None
     assert body["token"].count(".") == 2
+
+
+def test_rotate_discards_successor_when_begin_rotation_fails(client):
+    created = client.post("/v2/access-keys", json={"name": "ci-intake"}).json()
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.begin_rotation_error = AccessKeyStateConflictError("simulated rotation race")
+
+    response = client.post(f"/v2/access-keys/{created['jti']}/rotate")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "simulated rotation race"
+    assert len(registry.discarded) == 1
+    successor_jti = next(iter(registry.discarded))
+    assert successor_jti not in registry.keys
+
+
+def test_rotate_discards_successor_when_concurrent_rotation_wins(client):
+    created = client.post("/v2/access-keys", json={"name": "ci-intake"}).json()
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.mark_rotating_before_begin_rotation_error = True
+    registry.begin_rotation_error = AccessKeyStateConflictError("simulated concurrent rotation")
+
+    response = client.post(f"/v2/access-keys/{created['jti']}/rotate")
+
+    assert response.status_code == 409
+    assert len(registry.discarded) == 1
+    successor_jti = next(iter(registry.discarded))
+    assert successor_jti not in registry.keys
+    assert created["jti"] in registry.rotating
+
+
+def test_rotate_keeps_successor_when_begin_rotation_committed_before_raising(client):
+    created = client.post("/v2/access-keys", json={"name": "ci-intake"}).json()
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.begin_rotation_commits_before_error = True
+    registry.begin_rotation_error = RuntimeError("simulated post-commit transport failure")
+
+    response = client.post(f"/v2/access-keys/{created['jti']}/rotate")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["previous_status"] == "ROTATING"
+    assert body["grace_period_expires_at"] is not None
+    assert body["new_key"]["jti"] in registry.keys
+    assert registry.discarded == set()
+    listing = {entry["jti"]: entry for entry in client.get("/v2/access-keys").json()["data"]}
+    assert listing[created["jti"]]["grace_period_expires_at"] == body["grace_period_expires_at"]
+
+
+def test_rotate_discards_successor_when_ambiguous_failure_reconciles_to_a_different_concurrent_winner(client):
+    # An ambiguous begin_rotation failure that reconciles to ROTATING must only be
+    # treated as *this* request's success if it's paired with *this* request's own
+    # successor. Here the reconciled record is ROTATING but for a different
+    # (concurrently-raced) successor, so this request's own successor must be
+    # discarded rather than misattributed as the one that committed.
+    created = client.post("/v2/access-keys", json={"name": "ci-intake"}).json()
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.begin_rotation_commits_before_error = True
+    registry.begin_rotation_successor_override = "ak_" + "9" * 32
+    registry.begin_rotation_error = RuntimeError("simulated post-commit transport failure")
+
+    with pytest.raises(RuntimeError, match="simulated post-commit transport failure"):
+        client.post(f"/v2/access-keys/{created['jti']}/rotate")
+
+    assert len(registry.discarded) == 1
+    successor_jti = next(iter(registry.discarded))
+    assert successor_jti not in registry.keys
+    assert registry.rotating_successor[created["jti"]] == "ak_" + "9" * 32
+
+
+def test_rotate_reports_success_when_reconciliation_finds_own_successor_already_finalized(client):
+    # An ambiguous begin_rotation failure that reconciles to a *matching* successor
+    # confirms this request's write committed, even if the record has since moved
+    # on past ROTATING (e.g. reconciliation itself was delayed past the grace
+    # deadline, or a manual revoke landed first) -- report the real status rather
+    # than discarding a successor this request is confirmed to own.
+    created = client.post("/v2/access-keys", json={"name": "ci-intake"}).json()
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.begin_rotation_commits_before_error = True
+    registry.begin_rotation_error = RuntimeError("simulated post-commit transport failure")
+    registry.get_status_status_override = "REVOKED"
+
+    response = client.post(f"/v2/access-keys/{created['jti']}/rotate")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["previous_status"] == "REVOKED"
+    assert body["grace_period_seconds"] == 0
+    assert body["grace_period_expires_at"] is None
+    assert body["new_key"]["jti"] in registry.keys
+    assert registry.discarded == set()
+
+
+def test_rotate_discards_persisted_successor_when_add_raises_after_commit(client):
+    created = client.post("/v2/access-keys", json={"name": "ci-intake"}).json()
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.add_commits_before_error = True
+    registry.add_error = RuntimeError("simulated post-commit persistence failure")
+
+    with pytest.raises(RuntimeError, match="simulated post-commit persistence failure"):
+        client.post(f"/v2/access-keys/{created['jti']}/rotate")
+
+    assert len(registry.discarded) == 1
+    successor_jti = next(iter(registry.discarded))
+    assert successor_jti not in registry.keys
+    assert created["jti"] in registry.keys
+
+
+def test_rotate_discards_successor_for_pre_write_read_failure_even_if_old_key_is_rotating(client):
+    created = client.post("/v2/access-keys", json={"name": "ci-intake"}).json()
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    error = RuntimeError("simulated transport failure during pre-write read")
+    registry.begin_rotation_pre_write_error = error
+    registry.mark_rotating_before_begin_rotation_error = True
+
+    with pytest.raises(RuntimeError, match="simulated transport failure during pre-write read") as exc_info:
+        client.post(f"/v2/access-keys/{created['jti']}/rotate")
+
+    assert exc_info.value is error
+    assert created["jti"] in registry.rotating
+    assert len(registry.discarded) == 1
+    successor_jti = next(iter(registry.discarded))
+    assert successor_jti not in registry.keys
 
 
 def test_create_access_key_defaults_expiration_when_omitted(client):
@@ -611,6 +892,8 @@ def test_access_key_lifecycle_openapi_documents_error_responses(client):
     assert metadata_schema["properties"]["description"]["nullable"] is True
     assert metadata_schema["properties"]["audiences"]["uniqueItems"] is True
     assert metadata_schema["properties"]["expires_at"]["nullable"] is True
+    assert metadata_schema["properties"]["grace_period_expires_at"]["nullable"] is True
+    assert metadata_schema["properties"]["last_used_at"]["nullable"] is True
     create_response_schema = openapi["components"]["schemas"]["AccessKeyCreateResponse"]
     assert create_response_schema["properties"]["audiences"]["uniqueItems"] is True
     list_schema = openapi["components"]["schemas"]["AccessKeyListResponse"]
@@ -622,6 +905,7 @@ def test_access_key_lifecycle_openapi_documents_error_responses(client):
         "EXPIRED",
         "REVOKED",
         "SUSPENDED",
+        "ROTATING",
     ]
     status_change_schema = openapi["components"]["schemas"]["AccessKeyStatusChangeResponse"]
     assert set(status_change_schema["required"]) == {"jti", "status", "changed"}
@@ -676,6 +960,21 @@ def test_access_key_lifecycle_openapi_documents_error_responses(client):
             "$ref": "#/components/schemas/AccessKeyErrorResponse"
         }
 
+    rotate_responses = openapi["paths"]["/v2/access-keys/{jti}/rotate"]["post"]["responses"]
+    assert rotate_responses["200"]["content"]["application/json"]["schema"] == {
+        "$ref": "#/components/schemas/AccessKeyRotateResponse"
+    }
+    assert rotate_responses["400"]["description"] == "Scoped Access Key rotation error"
+    assert rotate_responses["409"]["description"] == "Invalid or concurrent access-key state transition"
+    rotate_schema = openapi["components"]["schemas"]["AccessKeyRotateResponse"]
+    assert rotate_schema["properties"]["grace_period_expires_at"]["nullable"] is True
+    assert set(rotate_schema["required"]) == {
+        "new_key",
+        "previous_jti",
+        "previous_status",
+        "grace_period_seconds",
+    }
+
     revoke_operation = openapi["paths"]["/v2/access-keys/{jti}"]["delete"]
     jti_parameter = next(parameter for parameter in revoke_operation["parameters"] if parameter["name"] == "jti")
     assert jti_parameter["schema"]["pattern"] == "^ak_[0-9a-f]{32}$"
@@ -715,6 +1014,8 @@ def test_list_access_keys_returns_current_principals_persisted_keys(client):
             "entity_type": "USER",
             "created_at": created["created_at"],
             "expires_at": created["expires_at"],
+            "grace_period_expires_at": None,
+            "last_used_at": None,
             "description": "CI intake automation",
             "status": "ACTIVE",
             "issuer": "http://testserver/apis/auth",
@@ -851,3 +1152,180 @@ def test_suspension_action_returns_not_found_for_unknown_key(client, action):
 
     assert response.status_code == 404
     assert response.json()["detail"] == f"Scoped Access Key {unknown_jti} was not found"
+
+
+def test_rotate_access_key_mints_successor_and_starts_grace_period(client):
+    created = client.post("/v2/access-keys", json={"name": "ci-intake", "description": "CI intake automation"}).json()
+    jti = created["jti"]
+
+    response = client.post(f"/v2/access-keys/{jti}/rotate")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["previous_jti"] == jti
+    assert body["previous_status"] == "ROTATING"
+    assert body["grace_period_seconds"] > 0
+    assert body["grace_period_expires_at"] is not None
+    new_key = body["new_key"]
+    assert new_key["jti"] != jti
+    assert new_key["jti"].startswith("ak_")
+    assert new_key["token"].count(".") == 2
+    assert new_key["name"] == "ci-intake"
+    assert new_key["description"] == "CI intake automation"
+
+    listing = {entry["jti"]: entry for entry in client.get("/v2/access-keys").json()["data"]}
+    assert listing[jti]["status"] == "ROTATING"
+    assert listing[jti]["grace_period_expires_at"] == body["grace_period_expires_at"]
+    assert listing[new_key["jti"]]["status"] == "ACTIVE"
+    assert listing[new_key["jti"]]["grace_period_expires_at"] is None
+
+
+def test_rotate_access_key_accepts_explicit_grace_period_seconds(client):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+
+    response = client.post(f"/v2/access-keys/{jti}/rotate", json={"grace_period_seconds": 3600})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["grace_period_seconds"] <= 3600
+    assert body["grace_period_seconds"] > 0
+
+
+def test_rotate_access_key_rejects_grace_period_seconds_above_configured_max(client):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+    max_grace_period_seconds = AccessKeyConfig().max_rotation_grace_period_seconds
+
+    response = client.post(
+        f"/v2/access-keys/{jti}/rotate",
+        json={"grace_period_seconds": max_grace_period_seconds + 1},
+    )
+
+    assert response.status_code == 400
+    assert "max_rotation_grace_period_seconds" in response.json()["detail"]
+
+
+def test_rotate_discards_successor_when_begin_rotation_exhausts_conflicts_and_concurrent_winner_is_visible(
+    client,
+):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.mark_rotating_before_begin_rotation_error = True
+    registry.begin_rotation_error = EntityConflictError("entity version changed")
+
+    response = client.post(f"/v2/access-keys/{jti}/rotate")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Concurrent update conflict; retry."
+    assert len(registry.discarded) == 1
+    discarded_jti = next(iter(registry.discarded))
+    assert discarded_jti not in registry.keys
+    assert jti in registry.rotating
+
+
+def test_rotated_out_key_stays_active_for_auth_during_grace_period(client):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+
+    client.post(f"/v2/access-keys/{jti}/rotate")
+
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    assert asyncio.run(registry.is_active(jti, "alice@example.com"))
+
+
+def test_rotated_out_key_becomes_revoked_after_grace_period_elapses(client):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+
+    client.post(f"/v2/access-keys/{jti}/rotate")
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.rotating[jti] = datetime.now(tz=UTC) - timedelta(seconds=1)
+
+    assert not asyncio.run(registry.is_active(jti, "alice@example.com"))
+    listing = {entry["jti"]: entry for entry in client.get("/v2/access-keys").json()["data"]}
+    assert listing[jti]["status"] == "REVOKED"
+
+
+def test_rotated_out_key_can_still_be_manually_revoked(client):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+    client.post(f"/v2/access-keys/{jti}/rotate")
+
+    response = client.delete(f"/v2/access-keys/{jti}")
+
+    assert response.status_code == 200
+    assert response.json() == {"jti": jti, "revoked": True}
+
+
+def test_already_rotating_access_key_cannot_be_rotated_again(client):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+    client.post(f"/v2/access-keys/{jti}/rotate")
+
+    response = client.post(f"/v2/access-keys/{jti}/rotate")
+
+    assert response.status_code == 409
+    assert f"Scoped Access Key {jti} must be ACTIVE to rotate" in response.json()["detail"]
+
+
+@pytest.mark.parametrize("action", ["suspend", "revoke"])
+def test_non_active_access_key_cannot_be_rotated(client, action):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+    method = client.delete if action == "revoke" else client.post
+    path = f"/v2/access-keys/{jti}" if action == "revoke" else f"/v2/access-keys/{jti}/{action}"
+    assert method(path).status_code == 200
+
+    response = client.post(f"/v2/access-keys/{jti}/rotate")
+
+    assert response.status_code == 409
+
+
+def test_rotate_access_key_returns_not_found_for_unknown_key(client):
+    unknown_jti = "ak_" + "0" * 32
+
+    response = client.post(f"/v2/access-keys/{unknown_jti}/rotate")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Scoped Access Key {unknown_jti} was not found"
+
+
+def test_rotate_access_key_discards_successor_when_begin_rotation_reports_not_found(client):
+    created = client.post("/v2/access-keys", json={}).json()
+    jti = created["jti"]
+    registry = client.app.dependency_overrides[get_access_key_registry]()
+    registry.begin_rotation_error = AccessKeyNotFoundError(f"Scoped Access Key {jti} was not found")
+
+    response = client.post(f"/v2/access-keys/{jti}/rotate")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == f"Scoped Access Key {jti} was not found"
+    assert len(registry.discarded) == 1
+    assert registry.discarded.isdisjoint(registry.keys)
+    assert set(registry.keys) == {jti}
+
+
+def test_rotate_access_key_is_disabled_by_default(disabled_client):
+    response = disabled_client.post(f"/v2/access-keys/ak_{'a' * 32}/rotate")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "detail": "Scoped Access Keys are not enabled",
+        "code": "access_keys_disabled",
+    }
+
+
+def test_rotate_and_new_key_emit_actor_aware_audit_logs(client, caplog):
+    created = client.post("/v2/access-keys", json={"name": "ci-intake"}).json()
+    jti = created["jti"]
+
+    with caplog.at_level(logging.INFO, logger="nmp.core.auth.app.access_keys"):
+        response = client.post(f"/v2/access-keys/{jti}/rotate")
+
+    new_jti = response.json()["new_key"]["jti"]
+    events = {record.audit_event: record for record in caplog.records if hasattr(record, "audit_event")}
+    assert events["access_key.rotated"].actor_principal == "alice@example.com"
+    assert events["access_key.rotated"].access_key_jti == jti
+    assert events["access_key.rotated"].access_key_new_jti == new_jti


### PR DESCRIPTION
## Summary
Implements zero-downtime rotation for Scoped Access Keys (`POST /apis/auth/v2/access-keys/{jti}/rotate`): mints a successor key, transitions the old key to a `ROTATING` grace period, and auto-revokes it once the grace period elapses (or lets the caller revoke it manually after confirming traffic moved over).

## Related Issue
Closes [AIRCORE-985](https://linear.app/nvidia/issue/AIRCORE-985/implement-access-keys-rotate)

## Changes
- New `rotate` lifecycle operation (`AccessKeyRegistry.get_rotatable`/`begin_rotation`, `PersistentAccessKeyIssuer.rotate_async`), CLI command (`nemo auth access-keys rotate`), SDK method, and OpenAPI schema (`AccessKeyRotateResponse`).
- New `ROTATING` key status with a configurable `rotation_grace_period_seconds` (default 48h) during which the rotated-out key still authenticates.
- New `grace_expires_at` field, exposed on the metadata and rotate responses, giving callers the authoritative deadline for when a `ROTATING` key will be treated as revoked. It's intentionally a separate field from the key's existing `expires_at` (its original, unrelated natural-expiry deadline) rather than reusing/overwriting it: `expires_at` still governs independently (a key that would naturally expire *before* its grace period ends still dies on schedule, never gets its life extended by rotation), status reporting still distinguishes `EXPIRED` from `ROTATING`/`REVOKED`, and the key's originally-configured lifetime stays intact for audit purposes. `grace_expires_at` is only ever populated while a key is `ROTATING`; it's `null` otherwise.
- Phase-aware, concurrency-safe rollback: a failed rotation only discards the just-minted successor when the old key's transition is positively confirmed to not have committed (including under concurrent-rotation races, exhausted optimistic-lock retries, and pre-write lookup failures) — never leaving an orphaned successor, and never mistaking a *different* concurrent request's success for its own.
- `last_used_at` tracking on every successful authentication (best-effort, retried against transient conflicts, non-blocking on write failure), surfaced in the key metadata response and as CLI list columns (alongside the new `grace_expires_at`), so callers can verify traffic moved off a rotated-out key before revoking it.
- Bounded retry against transient optimistic-lock conflicts (`_MUTATION_MAX_ATTEMPTS = 3`) in `begin_rotation`, `revoke`, and suspend/unsuspend, since `last_used_at` writes now bump a key's version on every authenticated request.
- Docs: CLI reference, `using-authentication.mdx`, config reference, deployment config.

## Type of Change

- [x] Code change with documentation updates

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Documentation updated for user-visible behavior — CLI/config docs regenerated via `make refresh-openapi`/`make lint-fix`; `using-authentication.mdx` hand-updated for rotation and `last_used_at`.

## Verification

- [ ] Pull request title follows the repository's Conventional Commit format
- [ ] Every commit includes an appropriate `Signed-off-by:` trailer — not verified; nothing was committed during this review pass.
- [ ] `uv run pre-commit run -a` passes — not run; targeted `ruff check`/`ruff format --check`/`ty check` on all changed Python files passed instead.
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:
- `uv run --frozen pytest services/core/auth/tests/test_access_keys.py services/core/auth/tests/test_access_key_registry.py services/core/auth/tests/integration/test_scoped_access_keys.py packages/nemo_platform_ext/tests/cli/commands/test_auth.py packages/nemo_platform_plugin/tests/auth/access_keys` — 213 passed
- Full `services/core/auth/tests/`, `nemo_platform_ext`, `nemo_platform_plugin` suites — 3696 passed, 8 pre-existing unrelated skips
- `uv run ruff check` / `uv run ruff format --check` on all touched files — clean
- `uv run --frozen ty check` on all touched source files — clean (one pre-existing, unrelated diagnostic confirmed present at the branch's fork point)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Scoped Access Key rotation through the API, CLI, and client libraries.
  * Rotated keys remain usable during a configurable grace period before automatic or manual revocation.
  * Added `ROTATING` status, last-use timestamps, and grace-period expiration details to key listings and responses.
  * Added a default 48-hour rotation grace period.
  * Rotation is available for active keys; other key states must be resolved first.
* **Documentation**
  * Documented rotation commands, API usage, lifecycle behavior, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->