### PR TITLE
ci: alert on failed forward merges

### DIFF
--- a/.github/workflows/forward-merge-alert.yaml
+++ b/.github/workflows/forward-merge-alert.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Forward merge alert
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  notify:
+    name: Notify failed forward merge
+    if: >-
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.login == 'rapids-bot[bot]' &&
+      startsWith(github.event.issue.title, 'Forward-merge ') &&
+      startsWith(github.event.comment.body, '**FAILURE** - Unable to forward-merge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack alert
+        env:
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          PR_TITLE: ${{ github.event.issue.title }}
+          PR_URL: ${{ github.event.issue.html_url }}
+          REPOSITORY: ${{ github.repository }}
+          SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK }}
+        run: |
+          text="$(printf '%s\n' \
+            ':warning: *Forward merge needs attention*' \
+            "Repository: ${REPOSITORY}" \
+            "PR: <${PR_URL}|${PR_TITLE}>" \
+            '' \
+            'The bot could not merge automatically and will not retry. Manual recovery is required.' \
+            "<${COMMENT_URL}|View failure details>")"
+          payload="$(jq -n --arg text "${text}" '{text: $text}')"
+          curl --fail-with-body --retry 2 \
+            --header "Content-Type: application/json" \
+            --data "${payload}" \
+            "${SLACK_ALERTS_WEBHOOK}"

--- a/.github/workflows/forward-merge-alert.yaml
+++ b/.github/workflows/forward-merge-alert.yaml
@@ -27,15 +27,17 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK }}
         run: |
+          escaped_pr_title="$(sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' <<<"${PR_TITLE}")"
           text="$(printf '%s\n' \
             ':warning: *Forward merge needs attention*' \
             "Repository: ${REPOSITORY}" \
-            "PR: <${PR_URL}|${PR_TITLE}>" \
+            "PR: <${PR_URL}|${escaped_pr_title}>" \
             '' \
             'The bot could not merge automatically and will not retry. Manual recovery is required.' \
             "<${COMMENT_URL}|View failure details>")"
           payload="$(jq -n --arg text "${text}" '{text: $text}')"
-          curl --fail-with-body --retry 2 \
+          curl --fail-with-body --location --max-redirs 0 \
+            --proto '=https' --connect-timeout 10 --max-time 30 \
             --header "Content-Type: application/json" \
             --data "${payload}" \
             "${SLACK_ALERTS_WEBHOOK}"


### PR DESCRIPTION
## Summary

- notify the existing Slack alerts channel when rapids-bot reports a failed forward merge
- include direct links to the forward-merge PR and failure comment
- keep the workflow event-driven with no polling or GitHub permissions

## Testing

- flox activate --dir tools/actionlint -- actionlint .github/workflows/forward-merge-alert.yaml
- validated Slack JSON encoding with a representative PR title containing quotes

No live Slack notification was sent during testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Slack alerts when automated forward merges fail.
  - Alerts include the relevant pull request title and link.
  - Notifications use connection and transfer time limits to prevent stalled delivery.
  - Removed automatic retry behavior for these alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->