### PR TITLE
fix(agents): run k8s agents from a writable agent root [ASTD-530]

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/environment.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/environment.py
@@ -8,17 +8,27 @@ import os
 import shutil
 import stat
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from nemo_agents_plugin.agent_config import AgentConfig
 
 logger = logging.getLogger(__name__)
 
-#: Where the agent tree is copied when its mounted location cannot be written to.
-RUNTIME_BASE_DIR_NAME = "nemo-agent-runtime"
+#: Prefix for the directory an agent tree is copied to when its mounted location
+#: cannot be written to.
+RUNTIME_BASE_DIR_PREFIX = "nemo-agent-runtime"
 
 
-def resolve_runtime_base_dir(config_path: Path) -> Path:
+@dataclass(frozen=True, slots=True)
+class RuntimeBaseDir:
+    """An agent root the runtime can write to, and whether this process created it."""
+
+    path: Path
+    staged: bool
+
+
+def resolve_runtime_base_dir(config_path: Path) -> RuntimeBaseDir:
     """Return an agent root the runtime can write to, copying the tree out if it cannot.
 
     Fabric resolves everything against the agent root — skills and prompts to
@@ -27,21 +37,32 @@ def resolve_runtime_base_dir(config_path: Path) -> Path:
     root, so the runtime user can read its agent but cannot create anything
     beside it. Docker has no such mount and is unaffected.
 
-    The tree is bounded by the spec-fileset staging limits, so copying it is
-    cheap next to starting a runtime.
+    A staged copy belongs to one process lifecycle: it goes to a fresh directory
+    and :func:`release_runtime_base_dir` removes it at shutdown, so a later
+    runtime can never read skills or prompts left behind by an earlier one. The
+    tree is bounded by the spec-fileset staging limits, so copying it is cheap
+    next to starting a runtime.
     """
     source = config_path.parent
     if os.access(source, os.W_OK):
-        return source
+        return RuntimeBaseDir(path=source, staged=False)
 
-    target = Path(tempfile.gettempdir()) / RUNTIME_BASE_DIR_NAME
+    target = Path(tempfile.mkdtemp(prefix=f"{RUNTIME_BASE_DIR_PREFIX}-"))
     logger.info("Agent root %s is not writable; staging it to %s for the runtime.", source, target)
     shutil.copytree(source, target, dirs_exist_ok=True)
     # copytree carries the source's mode across, so the copy of a read-only mount
     # is read-only too — restore write access on the directories we just made.
     for directory in (target, *(path for path in target.rglob("*") if path.is_dir())):
         directory.chmod(directory.stat().st_mode | stat.S_IRWXU)
-    return target
+    return RuntimeBaseDir(path=target, staged=True)
+
+
+def release_runtime_base_dir(base_dir: RuntimeBaseDir) -> None:
+    """Remove a staged agent root. A root used in place is left alone."""
+    if not base_dir.staged:
+        return
+    shutil.rmtree(base_dir.path, ignore_errors=True)
+    logger.info("Removed staged agent root %s.", base_dir.path)
 
 
 def ensure_local_workspace_dir(agent_config: AgentConfig, base_dir: Path) -> None:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/environment.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/environment.py
@@ -3,9 +3,45 @@
 
 """Prepare Platform-owned environment paths before Fabric runtime startup."""
 
+import logging
+import os
+import shutil
+import stat
+import tempfile
 from pathlib import Path
 
 from nemo_agents_plugin.agent_config import AgentConfig
+
+logger = logging.getLogger(__name__)
+
+#: Where the agent tree is copied when its mounted location cannot be written to.
+RUNTIME_BASE_DIR_NAME = "nemo-agent-runtime"
+
+
+def resolve_runtime_base_dir(config_path: Path) -> Path:
+    """Return an agent root the runtime can write to, copying the tree out if it cannot.
+
+    Fabric resolves everything against the agent root — skills and prompts to
+    read, but also the workspace and artifacts to write. In k8s the agent config
+    arrives on a read-only ConfigMap ``subPath`` whose parent kubelet creates as
+    root, so the runtime user can read its agent but cannot create anything
+    beside it. Docker has no such mount and is unaffected.
+
+    The tree is bounded by the spec-fileset staging limits, so copying it is
+    cheap next to starting a runtime.
+    """
+    source = config_path.parent
+    if os.access(source, os.W_OK):
+        return source
+
+    target = Path(tempfile.gettempdir()) / RUNTIME_BASE_DIR_NAME
+    logger.info("Agent root %s is not writable; staging it to %s for the runtime.", source, target)
+    shutil.copytree(source, target, dirs_exist_ok=True)
+    # copytree carries the source's mode across, so the copy of a read-only mount
+    # is read-only too — restore write access on the directories we just made.
+    for directory in (target, *(path for path in target.rglob("*") if path.is_dir())):
+        directory.chmod(directory.stat().st_mode | stat.S_IRWXU)
+    return target
 
 
 def ensure_local_workspace_dir(agent_config: AgentConfig, base_dir: Path) -> None:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -249,41 +249,43 @@ def create_fabric_serving_app(
         agent_config = load_agent_config(config_path)
         runtime_base_dir = await asyncio.to_thread(resolve_runtime_base_dir, config_path)
         base_dir = runtime_base_dir.path
-        validation_result = await _validate_agent_config(agent_config, base_dir=base_dir)
-        app.state.agent_config = agent_config
-        app.state.base_dir = base_dir
-        app.state.validation_result = validation_result
-        session_registry = FabricSessionRegistry()
-        app.state.session_registry = session_registry
-        session_manager = FabricSessionManager(
-            agent_config,
-            base_dir=base_dir,
-            session_registry=session_registry,
-            max_concurrent_invocations=settings.max_concurrent_invocations,
-        )
-        app.state.session_manager = session_manager
-        cleanup_shutdown = asyncio.Event()
-        cleanup_task = asyncio.create_task(
-            _run_idle_session_cleanup(
-                session_manager,
-                idle_timeout_seconds=settings.idle_session_timeout_seconds,
-                cleanup_interval_seconds=settings.session_cleanup_interval_seconds,
-                shutdown_event=cleanup_shutdown,
-            )
-        )
-        logger.info("Validated Fabric-backed agent config at %s", config_path)
+        # Startup can still fail past this point, and a staged root must not outlive
+        # the process that made it even when the runtime never comes up.
         try:
-            yield
-        finally:
-            cleanup_shutdown.set()
+            validation_result = await _validate_agent_config(agent_config, base_dir=base_dir)
+            app.state.agent_config = agent_config
+            app.state.base_dir = base_dir
+            app.state.validation_result = validation_result
+            session_registry = FabricSessionRegistry()
+            app.state.session_registry = session_registry
+            session_manager = FabricSessionManager(
+                agent_config,
+                base_dir=base_dir,
+                session_registry=session_registry,
+                max_concurrent_invocations=settings.max_concurrent_invocations,
+            )
+            app.state.session_manager = session_manager
+            cleanup_shutdown = asyncio.Event()
+            cleanup_task = asyncio.create_task(
+                _run_idle_session_cleanup(
+                    session_manager,
+                    idle_timeout_seconds=settings.idle_session_timeout_seconds,
+                    cleanup_interval_seconds=settings.session_cleanup_interval_seconds,
+                    shutdown_event=cleanup_shutdown,
+                )
+            )
+            logger.info("Validated Fabric-backed agent config at %s", config_path)
             try:
-                await cleanup_task
+                yield
             finally:
+                cleanup_shutdown.set()
                 try:
+                    await cleanup_task
+                finally:
                     # A staged root is only safe to remove once no runtime can still write to it.
                     await session_manager.close_all_sessions()
-                finally:
-                    await asyncio.to_thread(release_runtime_base_dir, runtime_base_dir)
+        finally:
+            await asyncio.to_thread(release_runtime_base_dir, runtime_base_dir)
 
     app = FastAPI(title="NeMo Agents Fabric Server", lifespan=lifespan)
     runtime_instance_id = str(uuid.uuid4())

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -20,7 +20,7 @@ from typing import Annotated, Any
 from fastapi import FastAPI, Header, HTTPException, Response
 from fastapi.responses import StreamingResponse
 from nemo_agents_plugin.agent_config import AgentConfig, load_agent_config
-from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+from nemo_agents_plugin.fabric.environment import release_runtime_base_dir, resolve_runtime_base_dir
 from nemo_agents_plugin.fabric.runtime import (
     FabricInvocationRequest,
     FabricRuntimeExecutionError,
@@ -247,7 +247,8 @@ def create_fabric_serving_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         agent_config = load_agent_config(config_path)
-        base_dir = await asyncio.to_thread(resolve_runtime_base_dir, config_path)
+        runtime_base_dir = await asyncio.to_thread(resolve_runtime_base_dir, config_path)
+        base_dir = runtime_base_dir.path
         validation_result = await _validate_agent_config(agent_config, base_dir=base_dir)
         app.state.agent_config = agent_config
         app.state.base_dir = base_dir
@@ -278,7 +279,11 @@ def create_fabric_serving_app(
             try:
                 await cleanup_task
             finally:
-                await session_manager.close_all_sessions()
+                try:
+                    # A staged root is only safe to remove once no runtime can still write to it.
+                    await session_manager.close_all_sessions()
+                finally:
+                    await asyncio.to_thread(release_runtime_base_dir, runtime_base_dir)
 
     app = FastAPI(title="NeMo Agents Fabric Server", lifespan=lifespan)
     runtime_instance_id = str(uuid.uuid4())

--- a/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/fabric/server.py
@@ -20,6 +20,7 @@ from typing import Annotated, Any
 from fastapi import FastAPI, Header, HTTPException, Response
 from fastapi.responses import StreamingResponse
 from nemo_agents_plugin.agent_config import AgentConfig, load_agent_config
+from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
 from nemo_agents_plugin.fabric.runtime import (
     FabricInvocationRequest,
     FabricRuntimeExecutionError,
@@ -246,15 +247,16 @@ def create_fabric_serving_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         agent_config = load_agent_config(config_path)
-        validation_result = await _validate_agent_config(agent_config, base_dir=config_path.parent)
+        base_dir = await asyncio.to_thread(resolve_runtime_base_dir, config_path)
+        validation_result = await _validate_agent_config(agent_config, base_dir=base_dir)
         app.state.agent_config = agent_config
-        app.state.base_dir = config_path.parent
+        app.state.base_dir = base_dir
         app.state.validation_result = validation_result
         session_registry = FabricSessionRegistry()
         app.state.session_registry = session_registry
         session_manager = FabricSessionManager(
             agent_config,
-            base_dir=config_path.parent,
+            base_dir=base_dir,
             session_registry=session_registry,
             max_concurrent_invocations=settings.max_concurrent_invocations,
         )

--- a/plugins/nemo-agents/tests/unit/test_environment_resolution.py
+++ b/plugins/nemo-agents/tests/unit/test_environment_resolution.py
@@ -308,45 +308,115 @@ class TestRuntimeBaseDir:
     """Fabric resolves both reads and writes against the agent root, so a root the
     runtime cannot write to breaks session startup rather than config loading."""
 
+    @staticmethod
+    def _unwritable_root(tmp_path: Path, name: str = "mounted") -> Path:
+        mounted = tmp_path / name
+        (mounted / "skills").mkdir(parents=True)
+        (mounted / "agent.yaml").write_text("config_format: nemo-agents-spec-v1\n")
+        (mounted / "skills" / "SKILL.md").write_text(f"# {name}\n")
+        # Mirrors a ConfigMap subPath parent: readable and executable, not writable.
+        mounted.chmod(0o555)
+        return mounted
+
     def test_a_writable_agent_root_is_used_as_is(self, tmp_path: Path) -> None:
         from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
 
         config = tmp_path / "agent.yaml"
         config.write_text("config_format: nemo-agents-spec-v1\n")
 
-        assert resolve_runtime_base_dir(config) == tmp_path
+        base_dir = resolve_runtime_base_dir(config)
+
+        assert base_dir.path == tmp_path
+        assert base_dir.staged is False
 
     def test_an_unwritable_agent_root_is_staged_somewhere_writable(self, tmp_path: Path) -> None:
         from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
 
-        mounted = tmp_path / "mounted"
-        (mounted / "skills").mkdir(parents=True)
-        (mounted / "agent.yaml").write_text("config_format: nemo-agents-spec-v1\n")
-        (mounted / "skills" / "SKILL.md").write_text("# skill\n")
-        # Mirrors a ConfigMap subPath parent: readable and executable, not writable.
-        mounted.chmod(0o555)
+        mounted = self._unwritable_root(tmp_path)
         try:
             base_dir = resolve_runtime_base_dir(mounted / "agent.yaml")
 
-            assert base_dir != mounted
-            assert os.access(base_dir, os.W_OK)
+            assert base_dir.path != mounted
+            assert base_dir.staged is True
+            assert os.access(base_dir.path, os.W_OK)
             # Sibling artifacts must survive the move or skills.paths stops resolving.
-            assert (base_dir / "skills" / "SKILL.md").read_text() == "# skill\n"
-            assert (base_dir / "agent.yaml").exists()
+            assert (base_dir.path / "skills" / "SKILL.md").read_text() == "# mounted\n"
+            assert (base_dir.path / "agent.yaml").exists()
         finally:
             mounted.chmod(0o755)
 
-    def test_staging_is_idempotent_across_restarts(self, tmp_path: Path) -> None:
+    def test_each_lifecycle_stages_to_its_own_directory(self, tmp_path: Path) -> None:
         from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
 
-        mounted = tmp_path / "mounted"
-        mounted.mkdir()
-        (mounted / "agent.yaml").write_text("config_format: nemo-agents-spec-v1\n")
-        mounted.chmod(0o555)
+        mounted = self._unwritable_root(tmp_path)
         try:
             first = resolve_runtime_base_dir(mounted / "agent.yaml")
             second = resolve_runtime_base_dir(mounted / "agent.yaml")
 
-            assert first == second
+            assert first.path != second.path
         finally:
             mounted.chmod(0o755)
+
+    def test_a_staged_root_never_inherits_an_earlier_pass(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import (
+            release_runtime_base_dir,
+            resolve_runtime_base_dir,
+        )
+
+        mounted = self._unwritable_root(tmp_path)
+        try:
+            first = resolve_runtime_base_dir(mounted / "agent.yaml")
+            (first.path / "skills" / "STALE.md").write_text("# dropped skill\n")
+            release_runtime_base_dir(first)
+
+            second = resolve_runtime_base_dir(mounted / "agent.yaml")
+
+            assert not (second.path / "skills" / "STALE.md").exists()
+            assert (second.path / "skills" / "SKILL.md").exists()
+        finally:
+            mounted.chmod(0o755)
+
+    def test_two_agent_roots_stage_to_separate_directories(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+
+        roots = [self._unwritable_root(tmp_path, name) for name in ("first", "second")]
+        try:
+            first = resolve_runtime_base_dir(roots[0] / "agent.yaml")
+            second = resolve_runtime_base_dir(roots[1] / "agent.yaml")
+
+            assert first.path != second.path
+            assert (first.path / "skills" / "SKILL.md").read_text() == "# first\n"
+            assert (second.path / "skills" / "SKILL.md").read_text() == "# second\n"
+        finally:
+            for mounted in roots:
+                mounted.chmod(0o755)
+
+    def test_releasing_a_staged_root_removes_it(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import (
+            release_runtime_base_dir,
+            resolve_runtime_base_dir,
+        )
+
+        mounted = self._unwritable_root(tmp_path)
+        try:
+            base_dir = resolve_runtime_base_dir(mounted / "agent.yaml")
+            release_runtime_base_dir(base_dir)
+
+            assert not base_dir.path.exists()
+        finally:
+            mounted.chmod(0o755)
+
+    def test_releasing_an_in_place_root_leaves_the_agent_alone(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import (
+            release_runtime_base_dir,
+            resolve_runtime_base_dir,
+        )
+
+        config = tmp_path / "agent.yaml"
+        config.write_text("config_format: nemo-agents-spec-v1\n")
+
+        base_dir = resolve_runtime_base_dir(config)
+        release_runtime_base_dir(base_dir)
+
+        assert config.exists()
+        assert tmp_path.exists()

--- a/plugins/nemo-agents/tests/unit/test_environment_resolution.py
+++ b/plugins/nemo-agents/tests/unit/test_environment_resolution.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -15,6 +17,7 @@ from nemo_agents_plugin.entities import (
     AgentEnvironment,
     AgentEnvironmentInline,
     AgentEnvironmentSpec,
+    ComputeResources,
     ComputeSpecInline,
     EnvironmentSpecInline,
     McpFulfillment,
@@ -57,7 +60,7 @@ async def test_resolve_none_returns_empty() -> None:
 async def test_resolve_inline_environment_with_inline_specs() -> None:
     environment = AgentEnvironmentInline(
         environment_spec=EnvironmentSpecInline(env={"FOO": "bar"}),
-        compute_spec=ComputeSpecInline(resources={"limits": {"cpu": "2"}}),
+        compute_spec=ComputeSpecInline(resources=ComputeResources(limits={"cpu": "2"})),
     )
     resolved = await resolve_environment(environment, workspace="default", entity_client=AsyncMock())
     assert resolved.environment_spec is not None
@@ -75,7 +78,7 @@ async def test_resolve_environment_ref_dereferences_all_entities() -> None:
         compute_spec="default/cspec",
     )
     espec = AgentEnvironmentSpec(name="espec", workspace="default", env={"A": "1"})
-    cspec = AgentComputeSpec(name="cspec", workspace="default", resources={"requests": {"cpu": "1"}})
+    cspec = AgentComputeSpec(name="cspec", workspace="default", resources=ComputeResources(requests={"cpu": "1"}))
 
     entity_client = AsyncMock()
     entity_client.get = AsyncMock(side_effect=[env_entity, espec, cspec])
@@ -299,3 +302,51 @@ def test_merge_no_environment_reference_is_identical_to_today() -> None:
     result = merge_environment_spec_into_agent_config(config, None)
     assert result.config == config
     assert result.secrets == {}
+
+
+class TestRuntimeBaseDir:
+    """Fabric resolves both reads and writes against the agent root, so a root the
+    runtime cannot write to breaks session startup rather than config loading."""
+
+    def test_a_writable_agent_root_is_used_as_is(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+
+        config = tmp_path / "agent.yaml"
+        config.write_text("config_format: nemo-agents-spec-v1\n")
+
+        assert resolve_runtime_base_dir(config) == tmp_path
+
+    def test_an_unwritable_agent_root_is_staged_somewhere_writable(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+
+        mounted = tmp_path / "mounted"
+        (mounted / "skills").mkdir(parents=True)
+        (mounted / "agent.yaml").write_text("config_format: nemo-agents-spec-v1\n")
+        (mounted / "skills" / "SKILL.md").write_text("# skill\n")
+        # Mirrors a ConfigMap subPath parent: readable and executable, not writable.
+        mounted.chmod(0o555)
+        try:
+            base_dir = resolve_runtime_base_dir(mounted / "agent.yaml")
+
+            assert base_dir != mounted
+            assert os.access(base_dir, os.W_OK)
+            # Sibling artifacts must survive the move or skills.paths stops resolving.
+            assert (base_dir / "skills" / "SKILL.md").read_text() == "# skill\n"
+            assert (base_dir / "agent.yaml").exists()
+        finally:
+            mounted.chmod(0o755)
+
+    def test_staging_is_idempotent_across_restarts(self, tmp_path: Path) -> None:
+        from nemo_agents_plugin.fabric.environment import resolve_runtime_base_dir
+
+        mounted = tmp_path / "mounted"
+        mounted.mkdir()
+        (mounted / "agent.yaml").write_text("config_format: nemo-agents-spec-v1\n")
+        mounted.chmod(0o555)
+        try:
+            first = resolve_runtime_base_dir(mounted / "agent.yaml")
+            second = resolve_runtime_base_dir(mounted / "agent.yaml")
+
+            assert first == second
+        finally:
+            mounted.chmod(0o755)

--- a/plugins/nemo-agents/tests/unit/test_fabric_server.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_server.py
@@ -140,6 +140,38 @@ def test_shutdown_removes_a_staged_agent_root(
         mounted.chmod(0o755)
 
 
+def test_failed_startup_removes_a_staged_agent_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mounted = tmp_path / "mounted"
+    mounted.mkdir()
+    config_path = _write_agent_config(mounted)
+    mounted.chmod(0o555)
+    staged: list[Path] = []
+    real_resolve = server.resolve_runtime_base_dir
+
+    def record(path: Path) -> Any:
+        base_dir = real_resolve(path)
+        staged.append(base_dir.path)
+        return base_dir
+
+    async def fail(config: AgentConfig, *, base_dir: Path) -> object:
+        raise AgentConfigLoadError("invalid agent")
+
+    monkeypatch.setattr(server, "resolve_runtime_base_dir", record)
+    monkeypatch.setattr(server, "_validate_agent_config", fail)
+    app = create_fabric_serving_app(config_path)
+    try:
+        with pytest.raises(AgentConfigLoadError), TestClient(app):
+            pass
+
+        assert len(staged) == 1
+        assert not staged[0].exists()
+    finally:
+        mounted.chmod(0o755)
+
+
 def test_startup_loads_and_validates_agent_config(
     tmp_path: Path,
     mock_validate_agent_config: list[tuple[AgentConfig, Path]],

--- a/plugins/nemo-agents/tests/unit/test_fabric_server.py
+++ b/plugins/nemo-agents/tests/unit/test_fabric_server.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+from collections.abc import AsyncGenerator
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -20,6 +21,7 @@ from nemo_agents_plugin.fabric import server
 from nemo_agents_plugin.fabric.runtime import (
     FabricRuntimeExecutionError,
     FabricRuntimeResult,
+    FabricRuntimeStream,
     FabricRuntimeTimeoutError,
 )
 from nemo_agents_plugin.fabric.server import SESSION_ID_HEADER, FabricServingSettings, create_fabric_serving_app
@@ -115,6 +117,29 @@ def _sse_line_payload(line: str) -> dict[str, object]:
     return json.loads(line.removeprefix("data: "))
 
 
+def test_shutdown_removes_a_staged_agent_root(
+    tmp_path: Path,
+    mock_validate_agent_config: list[tuple[AgentConfig, Path]],
+) -> None:
+    mounted = tmp_path / "mounted"
+    mounted.mkdir()
+    config_path = _write_agent_config(mounted)
+    mounted.chmod(0o555)
+    app = create_fabric_serving_app(config_path)
+    try:
+        with TestClient(app) as client:
+            assert client.get("/health").status_code == 200
+            staged = Path(app.state.base_dir)
+
+            assert staged != mounted
+            assert (staged / "agent.yaml").exists()
+
+        assert not staged.exists()
+        assert config_path.exists()
+    finally:
+        mounted.chmod(0o755)
+
+
 def test_startup_loads_and_validates_agent_config(
     tmp_path: Path,
     mock_validate_agent_config: list[tuple[AgentConfig, Path]],
@@ -186,6 +211,7 @@ def test_shutdown_stops_all_registered_runtimes(
         async def register_runtime() -> None:
             await registry.register(cast(Any, runtime), session_id="session-1")
 
+        assert client.portal is not None
         client.portal.call(register_runtime)
 
     assert runtime.stop_calls == 1
@@ -521,7 +547,7 @@ async def test_streaming_chat_completion_emits_sse_error_and_closes_stream() -> 
         event
         async for event in server._iter_streaming_chat_completion(
             stream_context,
-            fabric_stream,
+            cast(FabricRuntimeStream, fabric_stream),
             completion_id="chatcmpl-test",
             model="test-model",
         )
@@ -544,14 +570,14 @@ async def test_streaming_chat_completion_closes_stream_on_generator_close() -> N
     stream_context = _FakeStreamContext(fabric_stream)
     events = server._iter_streaming_chat_completion(
         stream_context,
-        fabric_stream,
+        cast(FabricRuntimeStream, fabric_stream),
         completion_id="chatcmpl-test",
         model="test-model",
     )
 
     assert _sse_payload(await events.__anext__())["choices"] == [{"index": 0, "delta": {"role": "assistant"}}]
 
-    await events.aclose()
+    await cast(AsyncGenerator[str], events).aclose()
 
     assert fabric_stream.aclose_calls == 1
     assert stream_context.exit_calls == 1
@@ -563,12 +589,12 @@ async def test_streaming_chat_completion_closes_stream_before_first_event() -> N
     stream_context = _FakeStreamContext(fabric_stream)
     events = server._iter_streaming_chat_completion(
         stream_context,
-        fabric_stream,
+        cast(FabricRuntimeStream, fabric_stream),
         completion_id="chatcmpl-test",
         model="test-model",
     )
 
-    await events.aclose()
+    await cast(AsyncGenerator[str], events).aclose()
 
     assert fabric_stream.aclose_calls == 1
     assert stream_context.exit_calls == 1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## TL;DR

A Fabric agent deployed with `--mode k8s` reaches `running` with a healthy pod, then fails on its **first** chat completion:

```
PermissionError: [Errno 13] Permission denied: '/tmp/nemo/workspace'
  fabric/environment.py  ensure_local_workspace_dir → workspace.mkdir(...)
  fabric/session_manager.py:90  open_session
```

Health probes pass throughout, so the deployment looks fine until somebody uses it. Docker mode is unaffected.

## Cause

Fabric resolves everything against the agent root — skills and prompts to read, but also the workspace and artifacts to write. `base_dir` is derived from where the agent config is mounted, so runtime state is created inside the config mount. In k8s that directory belongs to kubelet:

```
/dev/vdb1 on /tmp/nemo/agent.yaml type ext4 (ro,relatime)   # ConfigMap subPath
drwxr-xr-x root root  /tmp/nemo                             # kubelet-created, 755
uid=1000(agent)                                             # image runtime user
```

The agent can read its config and cannot create anything beside it.

Docker is unaffected for one reason only — nothing mounts over that path, so it is created world-writable. Same image, same code:

| | `/tmp/nemo` | Mounts | First invoke |
|---|---|---|---|
| docker | `drwxrwxrwx` | none | works |
| k8s | `drwxr-xr-x` root | ConfigMap subPath, ro | `PermissionError` |

Docker is the supported path today, which is why this has gone unnoticed.

## Fix

Resolve a writable agent root at startup, copying the tree out of the mount when the mount cannot be written to. A writable mount is used as-is, so docker behaviour is unchanged. The tree is bounded by the spec-fileset staging limits, so the copy is cheap next to starting a runtime.

A staged copy belongs to one process lifecycle: it goes to a fresh directory and is removed once the last runtime has stopped. Nothing is shared between agents, and nothing survives to be read by a later staging pass.

### Notes for reviewers

- **Restoring write permission after the copy is load-bearing, not tidying.** `copytree` carries the source's mode across, so the copy of a read-only mount is itself read-only and the runtime fails exactly as before. My first version had this bug; a test caught it, and that test is included.
- **Fixed in the runtime rather than the k8s compiler.** Mounting an `emptyDir` at each config file's parent would work, but it masks whatever the image has at that path — a config file at `/etc/foo/bar.yaml` would hide the image's `/etc/foo`. The runtime fix has no such blast radius and covers any read-only mount, however it arrives.
- **Cleanup is ordered after `close_all_sessions()`**, not beside it. A staged root is only safe to remove once no runtime can still be writing into it.
- **Release covers startup failure, not just shutdown.** Config validation runs after staging, so a bad agent would otherwise leave a copy behind on every failed start. The test for it fails without the fix.
- **Pre-existing type stubs** in the two touched test modules are typed properly here; `ty` rejects them and would otherwise block committing alongside them.

## Related Issue

ASTD-530

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no user-facing behaviour changes; the fix removes a failure mode rather than adding a knob.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

**Verified on a live `kind` cluster**, not only by tests. Same agent, same cluster, before and after:

| | First `POST /v1/chat/completions` |
|---|---|
| before | `500` — `PermissionError: '/tmp/nemo/workspace'` |
| after | reaches the model call, fails only on a missing credential — the same point docker reaches |

Inside the pod after the fix:

```
Agent root /tmp/nemo is not writable; staging it to /tmp/nemo-agent-runtime-XXXXXXXX for the runtime.

drwxr-xr-x root  root   /tmp/nemo                          # kubelet's mount, untouched
drwxr-xr-x agent agent  /tmp/nemo-agent-runtime-XXXXXXXX
  agent.yaml  artifacts  workspace                         # now creatable
```

| Command | Result |
|---|---|
| `uv run pytest plugins/nemo-agents/tests/unit` | 1503 passed; 2 failed, both `test_port_allocation.py`, which `bind()`s a socket and is blocked by the local sandbox — unrelated and also failing on `main` |
| `uv run ruff check plugins/nemo-agents/` | All checks passed |
| `uv run --frozen ty check` on the changed files | All checks passed |

Verified live before the per-lifecycle change; the staging path moved but the mechanism did not, and the directory-level behaviour is covered by tests.

All pre-commit hooks pass on the commit, including `ty`. Two hooks are blocked in this environment and were skipped for `git push` only, neither related to this change:

- **`uv-lock`** — requires exactly uv 0.9.14 on `PATH`; this machine has 0.9.30. No dependency files are touched here.
- **`helm-docs`** — the binary is not installed locally. No Helm files are touched.

Building an agent image from a source checkout to run this test needed `NEMO_AGENTS_WHEEL` from #1669, which is not merged. That was done on a throwaway local merge; **this branch has no dependency on #1669** and sits directly on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent runtime startup when the configured directory is not writable.
  * Automatically stages runtime files in unique, writable temporary locations while preserving existing agent files.
  * Isolates staged runtime directories between agent roots and startup lifecycles.
  * Cleans up staged runtime directories after shutdown or failed startup without removing original configured directories.
  * Ensures runtime sessions close before temporary resources are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->