### PR TITLE
fix(studio): align filter for fine-tunable models on fine-tune form and base models list

### DIFF
--- a/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
@@ -6,6 +6,7 @@ import { ControlledTextInput } from '@nemo/common/src/components/form/Controlled
 import { ModelSelectV2, type ModelSelection } from '@nemo/common/src/components/ModelSelectV2';
 import { FormField, Stack } from '@nvidia/foundations-react-core';
 import { FormSection } from '@studio/components/NewCustomizationForm/FormSection';
+import { canFineTuneModel } from '@studio/hooks/useModelCustomizationEligibility';
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import {
   MODEL_FIELD_BY_BACKEND,
@@ -28,7 +29,11 @@ export const ModelSelectionSection = () => {
   });
 
   const [open, setOpen] = useState(false);
-  const modelSearch = useModelSearch({ workspace, enabled: open });
+  const modelSearch = useModelSearch({
+    workspace,
+    enabled: open,
+    include: canFineTuneModel,
+  });
 
   const selectedValue: ModelSelection | null = modelField.value
     ? { model: modelField.value as string }

--- a/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
+++ b/web/packages/studio/src/components/NewCustomizationForm/ModelSelectionSection.tsx
@@ -58,6 +58,7 @@ export const ModelSelectionSection = () => {
             onValueChange={handleModelChange}
             onOpenChange={setOpen}
             disabled={disabled}
+            emptyMessage="No fine-tunable models found"
             hideAdapters
             fullWidth
           />

--- a/web/packages/studio/src/hooks/useModelCustomizationEligibility/index.ts
+++ b/web/packages/studio/src/hooks/useModelCustomizationEligibility/index.ts
@@ -5,6 +5,14 @@ import type { ModelEntity } from '@nemo/sdk/generated/platform/schema';
 import { useModelChatAvailability } from '@studio/hooks/useModelChatAvailability';
 import { useModelLoraEnabled } from '@studio/hooks/useModelLoraEnabled';
 
+/**
+ * Whether a model can be fine-tuned: it needs a fileset holding the base weights.
+ * All three customization backends require one at job-compile time and reject the
+ * job with a 422 otherwise, so this is also what the base-model pickers filter on.
+ */
+export const canFineTuneModel = (model: ModelEntity | null | undefined): boolean =>
+  Boolean(model?.fileset);
+
 export interface ModelCustomizationEligibility {
   canFineTune: boolean;
   canPromptTune: boolean;
@@ -26,7 +34,7 @@ export interface ModelCustomizationEligibility {
 export const useModelCustomizationEligibility = (
   model: ModelEntity | undefined
 ): ModelCustomizationEligibility => {
-  const canFineTune = Boolean(model?.fileset);
+  const canFineTune = canFineTuneModel(model);
 
   const { isChatAvailable, isLoading: isChatLoading } = useModelChatAvailability(model);
   const { isLoraEnabled, isLoading: isLoraLoading } = useModelLoraEnabled(model);


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Fixes https://nvbugspro.nvidia.com/bug/6702315

**the Base Model detail-panel check is the source of truth.**

This is settled by the compiler contract, not a product decision.

All three customization backends require the base model to have a fileset before a job can be built:

- `services/automodel/src/nmp/automodel/app/jobs/compiler.py:110` — `_require_fileset_for_download`
- `services/unsloth/src/nmp/unsloth/app/jobs/compiler.py:130` — `_require_fileset`
- `services/rl/src/nmp/rl/app/jobs/compiler.py:109` — `_require_fileset`

Each raises `PlatformJobCompilationError`, which `packages/nemo_platform_plugin/src/nemo_platform_plugin/jobs/api_factory.py:738` maps to HTTP 422. Fine-tuning a fileset-less model is therefore impossible as shipped, so there is no permissive path for the wizard to be deliberately supporting.

**Correction to the [Impact] section:** the failure is not late or unclear. Compilation runs synchronously inside the create-job POST, so an ineligible base model is rejected immediately with:

```
Failed to compile automodel job spec: Model 'default/adept-fuyu-8b' has no fileset. Attach a platform FileSet (workspace/name) with model weights before running training.
```

The defect is that the wizard offers the choice at all, not that the failure surfaces late.

**One clarification on "apply the same gating."** The detail-panel button is gated on `canCustomize = canFineTune || canPromptTune`. Only the `canFineTune` half (`Boolean(model.fileset)`) applies to the fine-tuning wizard; reusing the full `canCustomize` would still admit fileset-less models that happen to have a LoRA-enabled deployment, and those still fail with 422.

**Fix:** `Boolean(model.fileset)` is now a single exported predicate, `canFineTuneModel`, in `useModelCustomizationEligibility`. The hook derives `canFineTune` from it and the wizard's base-model picker passes it as `useModelSearch`'s `include`, so the detail panel and the picker cannot diverge again. `fileset` is already present on models-list responses, so this costs no additional requests. This also brings the fine-tuning wizard in line with the prompt-tuning form, which already filters its picker (`QUERY_PROMPT_TUNEABLE_MODELS`).


## Changes
<!-- List the concrete changes included in this pull request. -->

## Type of Change

- [x] Code change (feature, bug fix, or refactor)

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x ] Tests not applicable — justification: canFineTune filter shared on both screens




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model selection now shows only models eligible for fine-tuning.
  * Added a clear empty-state message when no eligible models match the search.

* **Bug Fixes**
  * Improved model eligibility handling to consistently identify models that support fine-tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->