### PR TITLE
perf(plugin): speed up inference middleware imports

### DIFF
--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/.agents/skills/plugin-inference-middleware/SKILL.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/.agents/skills/plugin-inference-middleware/SKILL.md
@@ -34,6 +34,7 @@ from nemo_platform_plugin.inference_middleware import (
     ImmediateResponse,
     InferenceMiddlewareError,
     InferenceMiddlewareUnavailableError,
+    VirtualModel,
 )
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.entities.client import AsyncEntitiesClient
@@ -65,8 +66,8 @@ class MyMiddleware(NemoInferenceMiddleware):
 
     async def on_shutdown(self) -> None: ...
 
-    async def on_virtual_model_upserted(self, virtual_model) -> None: ...
-    async def on_virtual_model_destroyed(self, virtual_model) -> None: ...
+    async def on_virtual_model_upserted(self, virtual_model: VirtualModel) -> None: ...
+    async def on_virtual_model_destroyed(self, virtual_model: VirtualModel) -> None: ...
 
     # ── Config resolution (needed only for config_id support) ──────────
     async def get_middleware_config(self, config_type: str, config_id: str) -> Any:

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/INFERENCE_MIDDLEWARE.md
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/docs/INFERENCE_MIDDLEWARE.md
@@ -43,6 +43,7 @@ from nemo_platform_plugin.inference_middleware import (
     ResponseResult,
     ImmediateResponse,
     InferenceMiddlewareError,
+    VirtualModel,
 )
 
 class MyMiddleware(NemoInferenceMiddleware):
@@ -53,10 +54,10 @@ class MyMiddleware(NemoInferenceMiddleware):
     async def on_shutdown(self) -> None:
         """Release resources on graceful shutdown."""
 
-    async def on_virtual_model_upserted(self, virtual_model) -> None:
+    async def on_virtual_model_upserted(self, virtual_model: VirtualModel) -> None:
         """Pre-warm per-VirtualModel resources (e.g. load a classifier for this VM)."""
 
-    async def on_virtual_model_destroyed(self, virtual_model) -> None:
+    async def on_virtual_model_destroyed(self, virtual_model: VirtualModel) -> None:
         """Release resources held for this VirtualModel."""
 
     async def get_middleware_config(self, config_type: str, config_id: str):

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py
@@ -69,82 +69,10 @@ Example::
 from __future__ import annotations
 
 from abc import ABC
+from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import Enum
-from typing import Any, AsyncIterator, Iterator, Protocol, Self, TypeAlias, Union, runtime_checkable
-
-import anthropic.types as anthropic_types
-import anthropic.types.message_create_params as anthropic_params
-import openai.types.chat as openai_chat_types
-import openai.types.chat.completion_create_params as openai_chat_params
-import openai.types.responses.response_create_params as openai_responses_params
-from nemo_platform_plugin.entity import NemoEntity
-from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperator, LogicalOperation
-from pydantic import BaseModel, Field, ModelWrapValidatorHandler, TypeAdapter, model_validator
-
-TypedResponse: TypeAlias = Union[openai_chat_types.ChatCompletion, anthropic_types.Message]
-OpenAIResponseChunk: TypeAlias = openai_chat_types.ChatCompletionChunk
-AnthropicResponseChunk: TypeAlias = anthropic_types.RawMessageStreamEvent
-TypedResponseChunk: TypeAlias = Union[OpenAIResponseChunk, AnthropicResponseChunk]
-TypedResponseResult: TypeAlias = Union[TypedResponse, AsyncIterator[TypedResponseChunk]]
-
-TypedRequest: TypeAlias = Union[
-    openai_chat_params.CompletionCreateParamsBase,
-    anthropic_params.MessageCreateParamsBase,
-    openai_responses_params.ResponseCreateParamsBase,
-]
-"""Union of the SDK TypedDict param types for each inbound API format.
-
-All three are TypedDicts — plain dicts at runtime. This alias exists for
-static type checking. Plugins that need path-based dispatch should use
-``request.path``, not ``isinstance``, since isinstance on TypedDict types
-just checks ``isinstance(x, dict)``.
-"""
-
-# ---------------------------------------------------------------------------
-# VirtualModel entity and MiddlewareCall schema
-# ---------------------------------------------------------------------------
-
-
-GUARDRAIL_CONFIG_TYPE = "guardrail_config"
-"""``MiddlewareCall.config_type`` discriminator for a stored NeMo Guardrails config.
-
-Mirrors ``GuardrailConfig.__entity_type__`` in the Guardrails service and
-``GUARDRAILS_PLUGIN_CONFIG_TYPE`` in the guardrails middleware plugin.  Declared here so
-:class:`VirtualModel` can derive :attr:`VirtualModel.guardrail_config_ids` without importing
-either of them.
-"""
-
-
-class MiddlewareCall(BaseModel):
-    """One entry in a VirtualModel middleware pipeline.
-
-    Declares which plugin to invoke and how to resolve its configuration.
-    Exactly one of ``config`` (inline dict) or ``config_id`` (entity reference)
-    should be provided. ``config_type`` is always required regardless of which
-    is used — it is the discriminator that tells IGW (and the plugin) which
-    config schema applies.
-
-    Attributes:
-        name: The entry-point key of the plugin to invoke
-            (e.g. ``"nemo-switchyard"``). Must match the plugin's
-            ``nemo.inference_middleware`` entry-point key.
-        config_type: Always required. Maps to the ``entity_type`` of the plugin's
-            config ``NemoEntity`` subclass (e.g. ``"routellm_config"``). Used by
-            IGW to call :meth:`~NemoInferenceMiddleware.validate_middleware_config`
-            with the right discriminator, and by the plugin to dispatch to the
-            correct schema when it supports multiple config types.
-        config: Inline config dict. Mutually exclusive with ``config_id``.
-        config_id: ``"workspace/name"`` reference to a stored config entity.
-            Mutually exclusive with ``config``. IGW resolves this by calling
-            :meth:`~NemoInferenceMiddleware.get_middleware_config` on the plugin.
-    """
-
-    name: str
-    config_type: str
-    config: dict[str, Any] | None = None
-    config_id: str | None = None
+from typing import Any, AsyncIterator, Protocol, TypeAlias, Union, runtime_checkable
 
 
 class BackendFormat(str, Enum):
@@ -152,230 +80,6 @@ class BackendFormat(str, Enum):
 
     OPENAI_CHAT = "OPENAI_CHAT"
     ANTHROPIC_MESSAGES = "ANTHROPIC_MESSAGES"
-
-
-class VirtualModelInferenceConfig(BaseModel):
-    """Inference configuration for one model entity referenced by a VirtualModel."""
-
-    model: str
-    """Model entity reference in ``"workspace/name"`` format."""
-
-    backend_format: BackendFormat | None = Field(
-        default=None,
-        description="Optional backend format override for this VirtualModel entry.",
-        json_schema_extra={"nullable": True},
-    )
-
-
-_AUTOPROVISIONED_DESC = (
-    "Marks this VirtualModel as controller-managed. The Models controller will delete it once no "
-    "ModelProvider serves the matching entity. Setting this manually opts the VirtualModel into "
-    "that cleanup behavior."
-)
-
-
-class VirtualModel(NemoEntity, entity_type="virtual_model"):
-    """Logical inference route.
-
-    Maps a user-facing model name to an optional default model entity and
-    defines ordered middleware pipelines for the request, response, and
-    post-response phases.
-
-    When a caller sets ``model: "workspace/my-virtual-model"`` in an inference
-    request, IGW resolves the ``VirtualModel`` instead of a ``ModelEntity``
-    directly. If ``default_model_entity`` is set, IGW writes it into
-    ``request["model"]`` before the request middleware pipeline runs. Middleware
-    may mutate ``request["model"]`` freely. After the pipeline completes, IGW
-    reads ``request["model"]``, resolves it to a ``ModelProvider`` via the
-    ``ModelCache``, and proxies.
-
-    The ``ModelProviderReconciler`` auto-creates a passthrough ``VirtualModel``
-    for each discovered model (same workspace and name as the ``ModelEntity``,
-    empty middleware lists, ``default_model_entity`` pointing to that entity).
-    All existing inference requests continue to work without changes.
-    """
-
-    default_model_entity: str | None = None
-    """``"workspace/model-entity-name"`` written into ``request["model"]`` before
-    the request middleware pipeline runs. If ``None``, no value is written — a
-    request middleware plugin must handle the backend call itself and return an
-    :class:`InferenceResponse` or ``AsyncIterator``."""
-
-    autoprovisioned: bool = Field(
-        default=False,
-        description=_AUTOPROVISIONED_DESC,
-    )
-    """Whether this VirtualModel was automatically created by the
-    ModelProviderReconciler for a discovered model entity."""
-
-    models: list[VirtualModelInferenceConfig] = Field(default_factory=list)
-    """Model entity references used by this VirtualModel. A per-entry
-    ``backend_format`` overrides the referenced ModelEntity value for requests
-    resolved through this VirtualModel."""
-
-    request_middleware: list[MiddlewareCall] = []
-    """Ordered list of middleware plugins applied before proxying."""
-
-    response_middleware: list[MiddlewareCall] = []
-    """Ordered list of middleware plugins applied after the backend response is
-    received, before returning it to the caller."""
-
-    post_response_middleware: list[MiddlewareCall] = []
-    """Ordered list of middleware plugins invoked after the response has been
-    returned to the caller. Intended for fire-and-forget work (e.g. logging,
-    analytics) that must not block or modify the response."""
-
-    override_proxy: str | None = None
-    """Optional. Names a plugin-provided proxy implementation IGW should use
-    instead of its default ``aiohttp`` proxy. Format: ``"plugin-name.proxy-name"``.
-    If unset, IGW performs the proxy itself."""
-
-    guardrail_config_ids: list[str] = Field(
-        default_factory=list,
-        description=(
-            "System-managed. Guardrail configs applied by this VirtualModel's middleware, as "
-            '"workspace/name" references. Derived from the middleware pipelines on every write and '
-            "ignored if supplied on a create or update body. Filter on it with filter[guardrail_config]."
-        ),
-    )
-    """System-managed. Distinct ``"workspace/name"`` guardrail config references reached by
-    this VirtualModel's middleware pipelines, in first-seen order.
-
-    Derived from the three ``*_middleware`` pipelines and never accepted on a create or update
-    body.  It exists so callers can answer "which VirtualModels use this guardrail config?"
-    with one ``$contains`` predicate against the entity store: the pipelines themselves are
-    arrays of *objects*, and ``$contains`` matches the serialized array as raw text (see
-    ``SQLAlchemyFilterRepository.contains``), so it cannot match a nested field precisely.
-    Flattening the references to an array of scalars is what makes that predicate exact.
-    """
-
-    def middleware_calls(self) -> Iterator[MiddlewareCall]:
-        """Every middleware call across the request, response, and post-response pipelines."""
-        yield from self.request_middleware or []
-        yield from self.response_middleware or []
-        yield from self.post_response_middleware or []
-
-    def references_guardrail_config(self, config_id: str) -> bool:
-        """Whether any middleware call resolves the stored guardrail config ``config_id``.
-
-        Matches on the ``config_type`` discriminator as well as the reference, so a
-        same-named config belonging to another plugin is never mistaken for a guardrail one.
-        """
-        return any(
-            call.config_type == GUARDRAIL_CONFIG_TYPE and call.config_id == config_id
-            for call in self.middleware_calls()
-        )
-
-    def refresh_guardrail_config_ids(self) -> Self:
-        """Recompute :attr:`guardrail_config_ids` from the middleware pipelines, in place."""
-        # dict keys rather than a set: de-duplicates while preserving pipeline order, so the
-        # stored value is stable across writes and diffs cleanly.
-        seen: dict[str, None] = {}
-        for call in self.middleware_calls():
-            if call.config_type == GUARDRAIL_CONFIG_TYPE and call.config_id:
-                seen[call.config_id] = None
-        self.guardrail_config_ids = list(seen)
-        return self
-
-    @model_validator(mode="after")
-    def _sync_guardrail_config_ids(self) -> Self:
-        """Keep the denormalized reference list in step with the pipelines it is derived from.
-
-        Runs on construction and on every entity-store read, so a stored value can never drift
-        from the middleware that produced it.  ``model_copy(update=...)`` is the one path that
-        skips validation — the PATCH handler calls :meth:`refresh_guardrail_config_ids` itself.
-        """
-        return self.refresh_guardrail_config_ids()
-
-    @model_validator(mode="wrap")
-    @classmethod
-    def _hydrate_wire_metadata(
-        cls,
-        value: object,
-        handler: ModelWrapValidatorHandler[Self],
-    ) -> Self:
-        """Retain entity metadata when validating a VirtualModel API response."""
-        model = handler(value)
-        if not isinstance(value, dict):
-            return model
-
-        wire_data = TypeAdapter(dict[str, object]).validate_python(value)
-        optional_string = TypeAdapter(str | None)
-        optional_datetime = TypeAdapter(datetime | None)
-        if "id" in wire_data:
-            model._id = optional_string.validate_python(wire_data["id"])
-        if "created_at" in wire_data:
-            model._created_at = optional_datetime.validate_python(wire_data["created_at"])
-        if "updated_at" in wire_data:
-            model._updated_at = optional_datetime.validate_python(wire_data["updated_at"])
-        if "created_by" in wire_data:
-            model._created_by = optional_string.validate_python(wire_data["created_by"])
-        if "updated_by" in wire_data:
-            model._updated_by = optional_string.validate_python(wire_data["updated_by"])
-        if "parent" in wire_data:
-            model._parent = optional_string.validate_python(wire_data["parent"])
-        return model
-
-
-GUARDRAIL_CONFIG_IDS_FIELD = "data.guardrail_config_ids"
-"""Entity-store path of :attr:`VirtualModel.guardrail_config_ids`."""
-
-_LEGACY_MIDDLEWARE_FIELDS = (
-    "data.request_middleware",
-    "data.response_middleware",
-    "data.post_response_middleware",
-)
-"""Pipelines that ``guardrail_config_ids`` is derived from, scanned directly for rows written
-before that field existed."""
-
-
-def guardrail_config_membership_filter(config_id: str) -> LogicalOperation:
-    """Entity-store predicate for "this VirtualModel applies guardrail config ``config_id``".
-
-    ``config_id`` is a fully qualified ``"workspace/name"`` reference, so this is safe to run
-    across workspaces — a VirtualModel may apply a guardrail config from another workspace.
-
-    VirtualModels written since :attr:`VirtualModel.guardrail_config_ids` was introduced carry the
-    flattened reference list, which ``$contains`` matches exactly.  Rows that predate it have no
-    such key, so they are matched by scanning the middleware pipelines they *do* have.  The OR
-    keeps un-migrated rows queryable with no migration, mirroring how Intake spans both of its
-    evaluation-membership representations (``_group_membership_filter``).
-
-    Those legacy arms are gated on the denormalized field being absent, so they apply only to rows
-    that have not been rewritten since — every other row is matched exactly.  Where they do apply
-    they are a *superset*: ``$contains`` matches an array of objects as raw serialized text (see
-    the entity store's ``SQLAlchemyFilterRepository.contains``), so a middleware call holding this
-    same string in another field also matches, and the ``config_type`` discriminator is invisible
-    to it.  There are no false negatives, so this is safe to narrow with — callers that must be
-    exact should re-check each returned entity with
-    :meth:`VirtualModel.references_guardrail_config`.
-
-    Those legacy arms are meaningful only against the SQL-backed entity store, whose ``$contains``
-    matches serialized text.  ``InMemoryFilterRepository`` implements ``$contains`` as native list
-    membership, so an array of objects never matches there; only the first arm carries over.
-    """
-    return LogicalOperation(
-        operator=FilterOperator.OR,
-        operations=[
-            ComparisonOperation(operator=FilterOperator.CONTAINS, field=GUARDRAIL_CONFIG_IDS_FIELD, value=config_id),
-            LogicalOperation(
-                operator=FilterOperator.AND,
-                operations=[
-                    # `$eq null` matches an absent key as well as an explicit null, which is exactly
-                    # the set of rows written before guardrail_config_ids existed. Gating the fuzzy
-                    # arms on it keeps them off every row that carries the exact list.
-                    ComparisonOperation(operator=FilterOperator.EQ, field=GUARDRAIL_CONFIG_IDS_FIELD, value=None),
-                    LogicalOperation(
-                        operator=FilterOperator.OR,
-                        operations=[
-                            ComparisonOperation(operator=FilterOperator.CONTAINS, field=field, value=config_id)
-                            for field in _LEGACY_MIDDLEWARE_FIELDS
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -388,6 +92,37 @@ ResponseResult = Union[dict[str, Any], AsyncIterator[dict[str, Any]]]
 - ``dict[str, Any]`` — Non-streaming response parsed from the backend.
 - ``AsyncIterator[dict[str, Any]]`` — Streaming response (sequence of chunk dicts).
 """
+
+TypedRequest: TypeAlias = Mapping[str, Any]
+"""Fast-path structural request body type for :attr:`InferenceRequest.typed_body`.
+
+SDK request parameter types are TypedDicts, so they are dict-like at runtime.
+Code that needs the exact SDK TypedDict union can import
+``TypedRequest`` from ``nemo_platform_plugin.inference_middleware_types``.
+"""
+
+
+@runtime_checkable
+class TypedResponse(Protocol):
+    """Fast-path structural response model for :attr:`InferenceResponse.typed_body`.
+
+    The concrete SDK response models live in
+    ``nemo_platform_plugin.inference_middleware_types``. The base middleware
+    interface only needs the shared serialized-model surface.
+    """
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]: ...
+
+
+@runtime_checkable
+class TypedResponseChunk(Protocol):
+    """Fast-path structural streaming chunk model for typed response streams."""
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]: ...
+
+
+TypedResponseResult: TypeAlias = Union[TypedResponse, AsyncIterator[TypedResponseChunk]]
+"""Structural typed response body or typed streaming chunk iterator."""
 
 
 @dataclass
@@ -704,6 +439,81 @@ RequestResult = Union[InferenceRequest, ImmediateResponse]
 # ---------------------------------------------------------------------------
 # Platform entity Protocols
 # ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class MiddlewareCall(Protocol):
+    """Structural middleware pipeline entry passed through VirtualModel hooks."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def config_type(self) -> str: ...
+
+    @property
+    def config(self) -> dict[str, Any] | None: ...
+
+    @property
+    def config_id(self) -> str | None: ...
+
+
+@runtime_checkable
+class VirtualModelInferenceConfig(Protocol):
+    """Structural model entry referenced by a VirtualModel hook payload."""
+
+    @property
+    def model(self) -> str: ...
+
+    @property
+    def backend_format(self) -> BackendFormat | None: ...
+
+
+@runtime_checkable
+class VirtualModel(Protocol):
+    """Structural VirtualModel type passed to middleware lifecycle hooks.
+
+    Middleware plugins should import this type from
+    ``nemo_platform_plugin.inference_middleware``. The concrete Pydantic entity
+    model used by IGW's API layer lives outside this fast import path.
+    """
+
+    @property
+    def id(self) -> str: ...
+
+    @property
+    def workspace(self) -> str: ...
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def default_model_entity(self) -> str | None: ...
+
+    @property
+    def autoprovisioned(self) -> bool: ...
+
+    @property
+    def models(self) -> Sequence[VirtualModelInferenceConfig]: ...
+
+    @property
+    def request_middleware(self) -> Sequence[MiddlewareCall]: ...
+
+    @property
+    def response_middleware(self) -> Sequence[MiddlewareCall]: ...
+
+    @property
+    def post_response_middleware(self) -> Sequence[MiddlewareCall]: ...
+
+    @property
+    def override_proxy(self) -> str | None: ...
+
+    @property
+    def guardrail_config_ids(self) -> Sequence[str]: ...
+
+    def middleware_calls(self) -> Iterator[MiddlewareCall]: ...
+
+    def references_guardrail_config(self, config_id: str) -> bool: ...
 
 
 @runtime_checkable

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware_models.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware_models.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pydantic models used by inference middleware configuration and VirtualModels."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any, Self
+
+from nemo_platform_plugin.entity import NemoEntity
+from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperator, LogicalOperation
+from nemo_platform_plugin.inference_middleware import BackendFormat
+from pydantic import BaseModel, Field, ModelWrapValidatorHandler, TypeAdapter, model_validator
+
+GUARDRAIL_CONFIG_TYPE = "guardrail_config"
+"""``MiddlewareCall.config_type`` discriminator for a stored NeMo Guardrails config.
+
+Mirrors ``GuardrailConfig.__entity_type__`` in the Guardrails service and
+``GUARDRAILS_PLUGIN_CONFIG_TYPE`` in the guardrails middleware plugin.  Declared here so
+:class:`VirtualModel` can derive :attr:`VirtualModel.guardrail_config_ids` without importing
+either of them.
+"""
+
+
+class MiddlewareCall(BaseModel):
+    """One entry in a VirtualModel middleware pipeline.
+
+    Declares which plugin to invoke and how to resolve its configuration.
+    Exactly one of ``config`` (inline dict) or ``config_id`` (entity reference)
+    should be provided. ``config_type`` is always required regardless of which
+    is used — it is the discriminator that tells IGW (and the plugin) which
+    config schema applies.
+
+    Attributes:
+        name: The entry-point key of the plugin to invoke
+            (e.g. ``"nemo-switchyard"``). Must match the plugin's
+            ``nemo.inference_middleware`` entry-point key.
+        config_type: Always required. Maps to the ``entity_type`` of the plugin's
+            config ``NemoEntity`` subclass (e.g. ``"routellm_config"``). Used by
+            IGW to call :meth:`~NemoInferenceMiddleware.validate_middleware_config`
+            with the right discriminator, and by the plugin to dispatch to the
+            correct schema when it supports multiple config types.
+        config: Inline config dict. Mutually exclusive with ``config_id``.
+        config_id: ``"workspace/name"`` reference to a stored config entity.
+            Mutually exclusive with ``config``. IGW resolves this by calling
+            :meth:`~NemoInferenceMiddleware.get_middleware_config` on the plugin.
+    """
+
+    name: str
+    config_type: str
+    config: dict[str, Any] | None = None
+    config_id: str | None = None
+
+    @model_validator(mode="after")
+    def _ensure_exactly_one_config_source(self) -> Self:
+        if (self.config is None) == (self.config_id is None):
+            raise ValueError("Exactly one of config or config_id must be provided")
+        return self
+
+
+class VirtualModelInferenceConfig(BaseModel):
+    """Inference configuration for one model entity referenced by a VirtualModel."""
+
+    model: str
+    """Model entity reference in ``"workspace/name"`` format."""
+
+    backend_format: BackendFormat | None = Field(
+        default=None,
+        description="Optional backend format override for this VirtualModel entry.",
+        json_schema_extra={"nullable": True},
+    )
+
+
+_AUTOPROVISIONED_DESC = (
+    "Marks this VirtualModel as controller-managed. The Models controller will delete it once no "
+    "ModelProvider serves the matching entity. Setting this manually opts the VirtualModel into "
+    "that cleanup behavior."
+)
+
+
+class VirtualModel(NemoEntity, entity_type="virtual_model"):
+    """Logical inference route.
+
+    Maps a user-facing model name to an optional default model entity and
+    defines ordered middleware pipelines for the request, response, and
+    post-response phases.
+
+    When a caller sets ``model: "workspace/my-virtual-model"`` in an inference
+    request, IGW resolves the ``VirtualModel`` instead of a ``ModelEntity``
+    directly. If ``default_model_entity`` is set, IGW writes it into
+    ``request["model"]`` before the request middleware pipeline runs. Middleware
+    may mutate ``request["model"]`` freely. After the pipeline completes, IGW
+    reads ``request["model"]``, resolves it to a ``ModelProvider`` via the
+    ``ModelCache``, and proxies.
+
+    The ``ModelProviderReconciler`` auto-creates a passthrough ``VirtualModel``
+    for each discovered model (same workspace and name as the ``ModelEntity``,
+    empty middleware lists, ``default_model_entity`` pointing to that entity).
+    All existing inference requests continue to work without changes.
+    """
+
+    default_model_entity: str | None = None
+    """``"workspace/model-entity-name"`` written into ``request["model"]`` before
+    the request middleware pipeline runs. If ``None``, no value is written — a
+    request middleware plugin must handle the backend call itself and return an
+    :class:`InferenceResponse` or ``AsyncIterator``."""
+
+    autoprovisioned: bool = Field(
+        default=False,
+        description=_AUTOPROVISIONED_DESC,
+    )
+    """Whether this VirtualModel was automatically created by the
+    ModelProviderReconciler for a discovered model entity."""
+
+    models: list[VirtualModelInferenceConfig] = Field(default_factory=list)
+    """Model entity references used by this VirtualModel. A per-entry
+    ``backend_format`` overrides the referenced ModelEntity value for requests
+    resolved through this VirtualModel."""
+
+    request_middleware: list[MiddlewareCall] = []
+    """Ordered list of middleware plugins applied before proxying."""
+
+    response_middleware: list[MiddlewareCall] = []
+    """Ordered list of middleware plugins applied after the backend response is
+    received, before returning it to the caller."""
+
+    post_response_middleware: list[MiddlewareCall] = []
+    """Ordered list of middleware plugins invoked after the response has been
+    returned to the caller. Intended for fire-and-forget work (e.g. logging,
+    analytics) that must not block or modify the response."""
+
+    override_proxy: str | None = None
+    """Optional. Names a plugin-provided proxy implementation IGW should use
+    instead of its default ``aiohttp`` proxy. Format: ``"plugin-name.proxy-name"``.
+    If unset, IGW performs the proxy itself."""
+
+    guardrail_config_ids: list[str] = Field(
+        default_factory=list,
+        description=(
+            "System-managed. Guardrail configs applied by this VirtualModel's middleware, as "
+            '"workspace/name" references. Derived from the middleware pipelines on every write and '
+            "ignored if supplied on a create or update body. Filter on it with filter[guardrail_config]."
+        ),
+    )
+    """System-managed. Distinct ``"workspace/name"`` guardrail config references reached by
+    this VirtualModel's middleware pipelines, in first-seen order."""
+
+    def middleware_calls(self) -> Iterator[MiddlewareCall]:
+        """Every middleware call across the request, response, and post-response pipelines."""
+        yield from self.request_middleware or []
+        yield from self.response_middleware or []
+        yield from self.post_response_middleware or []
+
+    def references_guardrail_config(self, config_id: str) -> bool:
+        """Whether any middleware call resolves the stored guardrail config ``config_id``."""
+        return any(
+            call.config_type == GUARDRAIL_CONFIG_TYPE and call.config_id == config_id
+            for call in self.middleware_calls()
+        )
+
+    def refresh_guardrail_config_ids(self) -> Self:
+        """Recompute :attr:`guardrail_config_ids` from the middleware pipelines, in place."""
+        seen: dict[str, None] = {}
+        for call in self.middleware_calls():
+            if call.config_type == GUARDRAIL_CONFIG_TYPE and call.config_id:
+                seen[call.config_id] = None
+        self.guardrail_config_ids = list(seen)
+        return self
+
+    @model_validator(mode="after")
+    def _sync_guardrail_config_ids(self) -> Self:
+        """Keep the denormalized reference list in step with the pipelines it is derived from."""
+        return self.refresh_guardrail_config_ids()
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _hydrate_wire_metadata(
+        cls,
+        value: object,
+        handler: ModelWrapValidatorHandler[Self],
+    ) -> Self:
+        """Retain entity metadata when validating a VirtualModel API response."""
+        model = handler(value)
+        if not isinstance(value, dict):
+            return model
+
+        wire_data = TypeAdapter(dict[str, object]).validate_python(value)
+        optional_string = TypeAdapter(str | None)
+        optional_datetime = TypeAdapter(datetime | None)
+        if "id" in wire_data:
+            model._id = optional_string.validate_python(wire_data["id"])
+        if "created_at" in wire_data:
+            model._created_at = optional_datetime.validate_python(wire_data["created_at"])
+        if "updated_at" in wire_data:
+            model._updated_at = optional_datetime.validate_python(wire_data["updated_at"])
+        if "created_by" in wire_data:
+            model._created_by = optional_string.validate_python(wire_data["created_by"])
+        if "updated_by" in wire_data:
+            model._updated_by = optional_string.validate_python(wire_data["updated_by"])
+        if "parent" in wire_data:
+            model._parent = optional_string.validate_python(wire_data["parent"])
+        return model
+
+
+GUARDRAIL_CONFIG_IDS_FIELD = "data.guardrail_config_ids"
+"""Entity-store path of :attr:`VirtualModel.guardrail_config_ids`."""
+
+_LEGACY_MIDDLEWARE_FIELDS = (
+    "data.request_middleware",
+    "data.response_middleware",
+    "data.post_response_middleware",
+)
+"""Pipelines that ``guardrail_config_ids`` is derived from, scanned directly for rows written
+before that field existed."""
+
+
+def guardrail_config_membership_filter(config_id: str) -> LogicalOperation:
+    """Entity-store predicate for "this VirtualModel applies guardrail config ``config_id``"."""
+    return LogicalOperation(
+        operator=FilterOperator.OR,
+        operations=[
+            ComparisonOperation(operator=FilterOperator.CONTAINS, field=GUARDRAIL_CONFIG_IDS_FIELD, value=config_id),
+            LogicalOperation(
+                operator=FilterOperator.AND,
+                operations=[
+                    ComparisonOperation(operator=FilterOperator.EQ, field=GUARDRAIL_CONFIG_IDS_FIELD, value=None),
+                    LogicalOperation(
+                        operator=FilterOperator.OR,
+                        operations=[
+                            ComparisonOperation(operator=FilterOperator.CONTAINS, field=field, value=config_id)
+                            for field in _LEGACY_MIDDLEWARE_FIELDS
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware_types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware_types.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SDK-backed type aliases for inference middleware typed request/response bodies."""
+
+from __future__ import annotations
+
+from typing import AsyncIterator, TypeAlias, Union
+
+import anthropic.types as anthropic_types
+import anthropic.types.message_create_params as anthropic_params
+import openai.types.chat as openai_chat_types
+import openai.types.chat.completion_create_params as openai_chat_params
+import openai.types.responses.response_create_params as openai_responses_params
+
+TypedResponse: TypeAlias = Union[openai_chat_types.ChatCompletion, anthropic_types.Message]
+OpenAIResponseChunk: TypeAlias = openai_chat_types.ChatCompletionChunk
+AnthropicResponseChunk: TypeAlias = anthropic_types.RawMessageStreamEvent
+TypedResponseChunk: TypeAlias = Union[OpenAIResponseChunk, AnthropicResponseChunk]
+TypedResponseResult: TypeAlias = Union[TypedResponse, AsyncIterator[TypedResponseChunk]]
+
+TypedRequest: TypeAlias = Union[
+    openai_chat_params.CompletionCreateParamsBase,
+    anthropic_params.MessageCreateParamsBase,
+    openai_responses_params.ResponseCreateParamsBase,
+]
+"""Union of the SDK TypedDict param types for each inbound API format.
+
+All three are TypedDicts — plain dicts at runtime. This alias exists for
+static type checking. Plugins that need path-based dispatch should use
+``request.path``, not ``isinstance``, since isinstance on TypedDict types
+just checks ``isinstance(x, dict)``.
+"""

--- a/packages/nemo_platform_plugin/src/nemo_platform_plugin/virtual_models/types.py
+++ b/packages/nemo_platform_plugin/src/nemo_platform_plugin/virtual_models/types.py
@@ -3,10 +3,11 @@
 
 """Shared request and query types for Inference Gateway VirtualModel CRUD.
 
-The canonical VirtualModel response and nested middleware types remain in
-``inference_middleware`` because middleware plugins already consume them. This
-module re-exports those types alongside the CRUD request contract used by both
-the Inference Gateway router and the typed client.
+The concrete VirtualModel response and nested middleware models live in
+``inference_middleware_models`` for CRUD/API schema code. Middleware hook code
+imports the lightweight ``VirtualModel`` protocol from ``inference_middleware``.
+This module re-exports the concrete CRUD types alongside the request contract
+used by both the Inference Gateway router and the typed client.
 
 Entity-store filter models remain server-side. Clients pass the public filter
 expression as a string through :class:`ListVirtualModelsQueryParams`.
@@ -16,7 +17,7 @@ from __future__ import annotations
 
 from typing import NotRequired, TypedDict
 
-from nemo_platform_plugin.inference_middleware import (
+from nemo_platform_plugin.inference_middleware_models import (
     _AUTOPROVISIONED_DESC,
     MiddlewareCall,
     VirtualModel,

--- a/packages/nemo_platform_plugin/tests/test_inference_middleware.py
+++ b/packages/nemo_platform_plugin/tests/test_inference_middleware.py
@@ -28,14 +28,12 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareUnavailableError,
     InferenceRequest,
     InferenceResponse,
-    MiddlewareCall,
     ModelProviderInferenceTarget,
     NemoInferenceMiddleware,
     OpenAICompatibleInferenceTarget,
-    TypedResponse,
-    VirtualModel,
-    VirtualModelInferenceConfig,
 )
+from nemo_platform_plugin.inference_middleware_models import MiddlewareCall, VirtualModel, VirtualModelInferenceConfig
+from nemo_platform_plugin.inference_middleware_types import TypedResponse
 from pydantic import TypeAdapter, ValidationError
 
 # ---------------------------------------------------------------------------
@@ -368,10 +366,10 @@ class TestInferenceMiddlewareExceptions:
 
 class TestMiddlewareCall:
     def test_requires_name_and_config_type(self):
-        call = MiddlewareCall(name="nemo-switchyard", config_type="routellm_config")
+        call = MiddlewareCall(name="nemo-switchyard", config_type="routellm_config", config={})
         assert call.name == "nemo-switchyard"
         assert call.config_type == "routellm_config"
-        assert call.config is None
+        assert call.config == {}
         assert call.config_id is None
 
     def test_inline_config(self):
@@ -395,6 +393,28 @@ class TestMiddlewareCall:
     def test_config_type_required(self):
         with pytest.raises(ValidationError):
             MiddlewareCall(name="nemo-switchyard")  # ty: ignore[missing-argument]
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"name": "nemo-switchyard", "config_type": "routellm_config"},
+            {
+                "name": "nemo-switchyard",
+                "config_type": "routellm_config",
+                "config": {},
+                "config_id": "default/router",
+            },
+            {
+                "name": "nemo-switchyard",
+                "config_type": "routellm_config",
+                "config_id": "default/router",
+                "config": {},
+            },
+        ],
+    )
+    def test_requires_exactly_one_config_source(self, payload: dict[str, object]):
+        with pytest.raises(ValidationError, match="Exactly one of config or config_id"):
+            MiddlewareCall.model_validate(payload)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo_platform_plugin/tests/test_inference_middleware_imports.py
+++ b/packages/nemo_platform_plugin/tests/test_inference_middleware_imports.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Import boundary tests for the inference middleware public base interface."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_importing_middleware_base_does_not_load_heavy_sdk_modules() -> None:
+    code = textwrap.dedent(
+        """
+        import sys
+
+        from nemo_platform_plugin.inference_middleware import NemoInferenceMiddleware
+
+        assert NemoInferenceMiddleware.__name__ == "NemoInferenceMiddleware"
+        loaded = {"openai", "anthropic", "pydantic"} & set(sys.modules)
+        assert loaded == set(), loaded
+        """
+    )
+
+    subprocess.run([sys.executable, "-c", code], check=True, capture_output=True, text=True)

--- a/packages/nemo_platform_plugin/tests/virtual_models/test_client.py
+++ b/packages/nemo_platform_plugin/tests/virtual_models/test_client.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import httpx
-from nemo_platform_plugin.inference_middleware import VirtualModel
+from nemo_platform_plugin.inference_middleware_models import VirtualModel
 from nemo_platform_plugin.virtual_models.client import VirtualModelsClient
 from nemo_platform_plugin.virtual_models.types import CreateVirtualModelRequest
 

--- a/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
+++ b/plugins/nemo-guardrails/src/nemo_guardrails_plugin/middleware.py
@@ -699,7 +699,7 @@ class GuardrailsMiddleware(NemoInferenceMiddleware):
         # guardrails have no business there and warming would be wasted.
         return [
             call
-            for call in virtual_model.request_middleware + virtual_model.response_middleware
+            for call in [*virtual_model.request_middleware, *virtual_model.response_middleware]
             if call.name == PLUGIN_NAME
         ]
 

--- a/plugins/nemo-guardrails/tests/unit/test_middleware.py
+++ b/plugins/nemo-guardrails/tests/unit/test_middleware.py
@@ -2188,7 +2188,7 @@ def _make_virtual_model(
     workspace: str = "ws",
     name: str = "vm-1",
 ) -> Any:
-    from nemo_platform_plugin.inference_middleware import MiddlewareCall, VirtualModel
+    from nemo_platform_plugin.inference_middleware_models import MiddlewareCall, VirtualModel
 
     return VirtualModel(
         workspace=workspace,

--- a/plugins/nemo-switchyard/src/nemo_switchyard/_bridge.py
+++ b/plugins/nemo-switchyard/src/nemo_switchyard/_bridge.py
@@ -30,6 +30,7 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareError,
     InferenceRequest,
     InferenceResponse,
+    TypedResponseResult,
 )
 from nemo_switchyard._processors import CTX_PATH_UPDATE
 from nmp.core.inference_gateway.api.typed_response import TypedResponseStream
@@ -100,9 +101,7 @@ def _wrap_streaming(
     return None
 
 
-def _wrap_non_streaming(
-    typed_body: openai_chat_types.ChatCompletion | anthropic_types.Message,
-) -> CompletionChatResponse | AnthropicChatResponse:
+def _wrap_non_streaming(typed_body: TypedResponseResult) -> CompletionChatResponse | AnthropicChatResponse:
     """Wrap a non-streaming pydantic model into the matching Switchyard response wrapper.
 
     The Switchyard response pipeline expects a ``ChatResponse`` as input. This is the

--- a/plugins/nemo-switchyard/src/nemo_switchyard/middleware.py
+++ b/plugins/nemo-switchyard/src/nemo_switchyard/middleware.py
@@ -17,10 +17,8 @@ entries pointing at the same factory — the user is opting into both pipelines.
 from __future__ import annotations
 
 import logging
-from typing import Any, Union, cast
+from typing import Any
 
-import anthropic.types as anthropic_types
-import openai.types.chat as openai_chat_types
 from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareContext,
     InferenceMiddlewareError,
@@ -48,7 +46,7 @@ from switchyard.lib.proxy_context import (
     CTX_PROXY_ACTUAL_MODEL,
     ProxyContext,
 )
-from switchyard.lib.registry import lookup, register, unregister  # noqa: PYI021
+from switchyard.lib.registry import MiddlewareFactory, lookup, register, unregister  # noqa: PYI021
 
 logger = logging.getLogger(__name__)
 
@@ -247,9 +245,7 @@ class SwitchyardMiddleware(NemoInferenceMiddleware):
                 )
                 return response
         else:
-            chat_response = _wrap_non_streaming(
-                cast(Union[openai_chat_types.ChatCompletion, anthropic_types.Message], response.typed_body)
-            )
+            chat_response = _wrap_non_streaming(response.typed_body)
 
         # Phase-tagged lookup: only succeeds if the user listed this config under
         # response_middleware. If they only listed it under request_middleware,
@@ -372,7 +368,12 @@ class SwitchyardMiddleware(NemoInferenceMiddleware):
 
         factory_name = f"nemo-switchyard-{config_type}-{cfg_hash}"
         try:
-            vm_factory = VMFactoryInstance(factory_class, validated_config, factory_name, config_type=config_type)
+            vm_factory: MiddlewareFactory[Any] = VMFactoryInstance(
+                factory_class,
+                validated_config,
+                factory_name,
+                config_type=config_type,
+            )
             register(vm_factory)
             _state.FACTORIES_BY_CONFIG_HASH[cfg_hash] = factory_name
             logger.info(

--- a/plugins/nemo-switchyard/tests/test_comprehensive_coverage.py
+++ b/plugins/nemo-switchyard/tests/test_comprehensive_coverage.py
@@ -17,6 +17,8 @@ from nemo_platform_plugin.inference_middleware import (
     BackendFormat,
     InferenceMiddlewareContext,
     InferenceRequest,
+)
+from nemo_platform_plugin.inference_middleware_models import (
     MiddlewareCall,
     VirtualModel,
     VirtualModelInferenceConfig,
@@ -190,7 +192,7 @@ class TestTranslateFormatRespect:
                 MiddlewareCall(
                     name="nemo-switchyard",
                     config_type="translate",
-                    config=None,
+                    config={},
                 ),
             ],
         )
@@ -213,7 +215,7 @@ class TestTranslateFormatRespect:
                 MiddlewareCall(
                     name="nemo-switchyard",
                     config_type="translate",
-                    config=None,
+                    config={},
                 ),
             ],
         )
@@ -369,7 +371,7 @@ class TestCombinedRandomRoutingAndTranslate:
                 MiddlewareCall(
                     name="nemo-switchyard",
                     config_type="translate",
-                    config=None,
+                    config={},
                 ),
             ],
         )
@@ -557,7 +559,7 @@ class TestConfigValidation:
                 MiddlewareCall(
                     name="nemo-switchyard",
                     config_type="translate",
-                    config=None,  # Uses VM's backend formats
+                    config={},  # Uses VM's backend formats
                 ),
             ],
         )
@@ -616,7 +618,7 @@ class TestCrossFormatTranslation:
                 MiddlewareCall(
                     name="nemo-switchyard",
                     config_type="translate",
-                    config=None,
+                    config={},
                 ),
             ],
         )
@@ -638,7 +640,7 @@ class TestCrossFormatTranslation:
                 MiddlewareCall(
                     name="nemo-switchyard",
                     config_type="translate",
-                    config=None,
+                    config={},
                 ),
             ],
         )
@@ -852,7 +854,7 @@ class TestTypedResultHandling:
                 MiddlewareCall(
                     name="nemo-switchyard",
                     config_type="translate",
-                    config=None,  # Uses VM's backend formats
+                    config={},  # Uses VM's backend formats
                 ),
             ],
         )
@@ -992,7 +994,7 @@ class TestTypedResultHandling:
                 MiddlewareCall(
                     name="nemo-switchyard",
                     config_type="translate",
-                    config=None,
+                    config={},
                 ),
             ],
         )

--- a/plugins/nemo-switchyard/tests/test_e2e_random_routing.py
+++ b/plugins/nemo-switchyard/tests/test_e2e_random_routing.py
@@ -17,6 +17,8 @@ from nemo_platform_plugin.inference_middleware import (
     BackendFormat,
     InferenceMiddlewareContext,
     InferenceRequest,
+)
+from nemo_platform_plugin.inference_middleware_models import (
     MiddlewareCall,
     VirtualModel,
     VirtualModelInferenceConfig,

--- a/plugins/nemo-switchyard/tests/test_e2e_translate.py
+++ b/plugins/nemo-switchyard/tests/test_e2e_translate.py
@@ -17,6 +17,8 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareContext,
     InferenceRequest,
     InferenceResponse,
+)
+from nemo_platform_plugin.inference_middleware_models import (
     MiddlewareCall,
     VirtualModel,
     VirtualModelInferenceConfig,

--- a/plugins/nemo-switchyard/tests/test_factory_lifecycle.py
+++ b/plugins/nemo-switchyard/tests/test_factory_lifecycle.py
@@ -21,6 +21,8 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareContext,
     InferenceRequest,
     InferenceResponse,
+)
+from nemo_platform_plugin.inference_middleware_models import (
     MiddlewareCall,
     VirtualModel,
     VirtualModelInferenceConfig,

--- a/plugins/nemo-switchyard/tests/test_integration.py
+++ b/plugins/nemo-switchyard/tests/test_integration.py
@@ -20,6 +20,8 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareContext,
     InferenceRequest,
     InferenceResponse,
+)
+from nemo_platform_plugin.inference_middleware_models import (
     MiddlewareCall,
     VirtualModel,
     VirtualModelInferenceConfig,

--- a/plugins/nemo-switchyard/tests/test_streaming.py
+++ b/plugins/nemo-switchyard/tests/test_streaming.py
@@ -19,6 +19,8 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareContext,
     InferenceRequest,
     InferenceResponse,
+)
+from nemo_platform_plugin.inference_middleware_models import (
     MiddlewareCall,
     VirtualModel,
     VirtualModelInferenceConfig,

--- a/sdk/python/nemo-platform/pyproject.toml
+++ b/sdk/python/nemo-platform/pyproject.toml
@@ -51,6 +51,7 @@ Homepage = "https://docs.nvidia.com/nemo/microservices/latest/about/index.html"
 aiohttp = ["aiohttp", "httpx_aiohttp>=0.1.9"]
 nemo-evaluator-sdk = [
   "pydantic>=2.10.6",
+  "sandboxed-gym",
   "jinja2>=3.1.6",
   "jsonschema>=4.23.0",
   "jsonpath-ng>=1.7.0",
@@ -65,7 +66,6 @@ nemo-evaluator-sdk = [
   "langchain-nvidia-ai-endpoints>=1.4.3,<2.0.0",
   "nemo-relay>=0.7.2,<0.8",
   "nemo-fabric>=0.2.0,<0.3.0",
-  "sandboxed-gym",
 ]
 
 [project.entry-points."nemo.skills"]

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/middleware_registry.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/middleware_registry.py
@@ -26,14 +26,16 @@ from nemo_platform_plugin.inference_middleware import (
     InferenceMiddlewareError,
     InferenceRequest,
     InferenceResponse,
-    MiddlewareCall,
     MiddlewareConfigNotFoundError,
     ModelProviderInferenceTarget,
     NemoInferenceMiddleware,
     OpenAICompatibleInferenceTarget,
+)
+from nemo_platform_plugin.inference_middleware_models import (
+    MiddlewareCall,
     VirtualModelInferenceConfig,
 )
-from nemo_platform_plugin.inference_middleware import (
+from nemo_platform_plugin.inference_middleware_models import (
     VirtualModel as PluginVirtualModel,
 )
 from nmp.common.config import get_platform_config
@@ -703,7 +705,7 @@ def _sdk_vm_to_plugin_vm(vm: SDKVirtualModel) -> PluginVirtualModel:
             MiddlewareCall(
                 name=c.name or "",
                 config_type=c.config_type or "",
-                config=dict(c.config) if c.config else None,
+                config=dict(c.config) if c.config is not None else None,
                 config_id=c.config_id,
             )
             for c in calls

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/typed_request.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/typed_request.py
@@ -11,7 +11,8 @@ from typing import Any
 import anthropic.types.message_create_params as anthropic_params
 import openai.types.chat.completion_create_params as openai_chat_params
 import openai.types.responses.response_create_params as openai_responses_params
-from nemo_platform_plugin.inference_middleware import InferenceRequest, TypedRequest
+from nemo_platform_plugin.inference_middleware import InferenceRequest
+from nemo_platform_plugin.inference_middleware_types import TypedRequest
 from pydantic import TypeAdapter, ValidationError
 
 logger = logging.getLogger(__name__)

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/typed_response.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/typed_response.py
@@ -12,6 +12,8 @@ import anthropic.types as anthropic_types
 import openai.types.chat as openai_chat_types
 from nemo_platform_plugin.inference_middleware import (
     BackendFormat,
+)
+from nemo_platform_plugin.inference_middleware_types import (
     TypedResponse,
     TypedResponseChunk,
 )

--- a/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/virtual_models.py
+++ b/services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/virtual_models.py
@@ -28,10 +28,12 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from nemo_platform_plugin.filter_ops import ComparisonOperation, FilterOperation, FilterOperator, LogicalOperation
 from nemo_platform_plugin.inference_middleware import (
-    GUARDRAIL_CONFIG_IDS_FIELD,
     InferenceMiddlewareError,
-    MiddlewareCall,
     MiddlewareConfigNotFoundError,
+)
+from nemo_platform_plugin.inference_middleware_models import (
+    GUARDRAIL_CONFIG_IDS_FIELD,
+    MiddlewareCall,
     VirtualModel,
     guardrail_config_membership_filter,
 )

--- a/services/core/inference-gateway/tests/unit/test_middleware_registry.py
+++ b/services/core/inference-gateway/tests/unit/test_middleware_registry.py
@@ -20,7 +20,7 @@ from nemo_platform_plugin.inference_middleware import (
     BackendFormat,
     NemoInferenceMiddleware,
 )
-from nemo_platform_plugin.inference_middleware import (
+from nemo_platform_plugin.inference_middleware_models import (
     VirtualModel as PluginVirtualModel,
 )
 from nmp.core.inference_gateway.api.middleware_registry import (
@@ -642,7 +642,7 @@ class TestNotifyHooks:
         plugin_b = _make_mock_plugin()
         registry = MiddlewareRegistry(plugins={"plugin-a": plugin_a, "plugin-b": plugin_b})
 
-        vm = _make_sdk_vm("ws", "vm", request_middleware=[_make_sdk_call("plugin-a")])
+        vm = _make_sdk_vm("ws", "vm", request_middleware=[_make_sdk_call("plugin-a", config={})])
         await registry.notify_upserted(vm)
 
         plugin_a.on_virtual_model_upserted.assert_awaited_once()
@@ -653,7 +653,7 @@ class TestNotifyHooks:
         plugin_a = _make_mock_plugin()
         registry = MiddlewareRegistry(plugins={"plugin-a": plugin_a})
 
-        vm = _make_sdk_vm("ws", "vm", response_middleware=[_make_sdk_call("plugin-a")])
+        vm = _make_sdk_vm("ws", "vm", response_middleware=[_make_sdk_call("plugin-a", config={})])
         await registry.notify_destroyed(vm)
 
         plugin_a.on_virtual_model_destroyed.assert_awaited_once()
@@ -665,7 +665,7 @@ class TestNotifyHooks:
         plugin.on_virtual_model_upserted = AsyncMock(side_effect=RuntimeError("boom"))
         registry = MiddlewareRegistry(plugins={"my-plugin": plugin})
 
-        vm = _make_sdk_vm("ws", "vm", request_middleware=[_make_sdk_call("my-plugin")])
+        vm = _make_sdk_vm("ws", "vm", request_middleware=[_make_sdk_call("my-plugin", config={})])
         # Should not raise
         await registry.notify_upserted(vm)
         assert "my-plugin" in caplog.text
@@ -675,13 +675,14 @@ class TestNotifyHooks:
         plugin = _make_mock_plugin()
         registry = MiddlewareRegistry(plugins={"my-plugin": plugin})
 
-        vm = _make_sdk_vm("ws", "my-vm", request_middleware=[_make_sdk_call("my-plugin")])
+        vm = _make_sdk_vm("ws", "my-vm", request_middleware=[_make_sdk_call("my-plugin", config={})])
         await registry.notify_upserted(vm)
 
         call_arg = plugin.on_virtual_model_upserted.call_args[0][0]
         assert isinstance(call_arg, PluginVirtualModel)
         assert call_arg.workspace == "ws"
         assert call_arg.name == "my-vm"
+        assert call_arg.request_middleware[0].config == {}
 
 
 # ---------------------------------------------------------------------------

--- a/services/core/inference-gateway/tests/unit/test_virtual_models_router.py
+++ b/services/core/inference-gateway/tests/unit/test_virtual_models_router.py
@@ -223,11 +223,11 @@ class TestCreateVirtualModel:
             client,
             "vm-full",
             default_model_entity="default/llama-70b",
-            request_middleware=[{"name": "nemo-switchyard", "config_type": "routellm_config"}],
+            request_middleware=[{"name": "nemo-switchyard", "config_type": "routellm_config", "config": {}}],
             response_middleware=[
                 {"name": "nemo-guardrails", "config_type": "guardrail_config", "config_id": "default/safe"}
             ],
-            post_response_middleware=[{"name": "nemo-logger", "config_type": "log_config"}],
+            post_response_middleware=[{"name": "nemo-logger", "config_type": "log_config", "config": {}}],
             models=[{"model": "default/claude-sonnet", "backend_format": "ANTHROPIC_MESSAGES"}],
             override_proxy="nemo-switchyard.http-proxy",
         )
@@ -281,7 +281,7 @@ class TestCreateVirtualModel:
             BASE,
             json={
                 "name": "vm-missing-plugin",
-                "request_middleware": [{"name": "missing-plugin", "config_type": "cfg"}],
+                "request_middleware": [{"name": "missing-plugin", "config_type": "cfg", "config": {}}],
             },
         )
 
@@ -319,7 +319,7 @@ class TestCreateVirtualModel:
             BASE,
             json={
                 "name": "vm-plugin-error",
-                "request_middleware": [{"name": "my-plugin", "config_type": "cfg"}],
+                "request_middleware": [{"name": "my-plugin", "config_type": "cfg", "config": {}}],
             },
         )
 
@@ -338,7 +338,7 @@ class TestCreateVirtualModel:
             BASE,
             json={
                 "name": "vm-plugin-server-error",
-                "request_middleware": [{"name": "my-plugin", "config_type": "cfg"}],
+                "request_middleware": [{"name": "my-plugin", "config_type": "cfg", "config": {}}],
             },
         )
 
@@ -636,7 +636,7 @@ class TestUpdateVirtualModel:
         """PATCH replaces middleware lists when provided."""
         _create(client, "vm-mw")
         _install_registry(client, {"nemo-guardrails": _make_plugin()})
-        mw = [{"name": "nemo-guardrails", "config_type": "guardrail_config"}]
+        mw = [{"name": "nemo-guardrails", "config_type": "guardrail_config", "config": {}}]
         resp = client.patch(f"{BASE}/vm-mw", json={"request_middleware": mw})
         assert resp.status_code == 200
         assert resp.json()["request_middleware"][0]["name"] == "nemo-guardrails"
@@ -672,7 +672,7 @@ class TestUpdateVirtualModel:
 
         resp = client.patch(
             f"{BASE}/vm-update-missing-plugin",
-            json={"request_middleware": [{"name": "missing-plugin", "config_type": "cfg"}]},
+            json={"request_middleware": [{"name": "missing-plugin", "config_type": "cfg", "config": {}}]},
         )
 
         assert resp.status_code == 422

--- a/services/guardrails/src/nmp/guardrails/api/v2/configs/endpoints.py
+++ b/services/guardrails/src/nmp/guardrails/api/v2/configs/endpoints.py
@@ -6,7 +6,7 @@
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from nemo_platform_plugin.inference_middleware import VirtualModel, guardrail_config_membership_filter
+from nemo_platform_plugin.inference_middleware_models import VirtualModel, guardrail_config_membership_filter
 from nmp.common.api import ParsedFilter, make_filter_dep
 from nmp.common.api.common import DeleteResponse, GenericSortField, Page, PaginationData
 from nmp.common.api.utils import generate_openapi_extra_params


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Speeds up `from nemo_platform_plugin.inference_middleware import NemoInferenceMiddleware` by removing SDK and Pydantic schema imports from the middleware base module.

Middleware authors keep using the single middleware-facing names from `nemo_platform_plugin.inference_middleware`: `VirtualModel`, `MiddlewareCall`, `VirtualModelInferenceConfig`, `TypedRequest`, and `TypedResponseResult`. The fast base module now exposes lightweight structural protocols/aliases for those hook fields. Code that needs concrete CRUD schemas or exact SDK request/response aliases imports `nemo_platform_plugin.inference_middleware_models` or `nemo_platform_plugin.inference_middleware_types` directly.

## Changes
- Move concrete `VirtualModel`, `MiddlewareCall`, and `VirtualModelInferenceConfig` Pydantic schemas out of `inference_middleware`.
- Move exact SDK typed request/response aliases out of `inference_middleware`.
- Keep lightweight middleware hook protocols under the original public names instead of introducing `*View` names.
- Keep `InferenceRequest.typed_body` and `InferenceResponse.typed_body` annotated with named fast-path aliases instead of raw `Mapping` or `object`.
- Update in-repo API/server/tests that need concrete schemas or exact SDK aliases to import the split modules directly.
- Remove the redundant concrete SDK response guard from Switchyard middleware; `_bridge._wrap_non_streaming` now owns concrete response dispatch and rejection.
- Fix the Guardrails config API to import the concrete `VirtualModel` schema from the split model module, preserving service startup in wheel smoke checks.
- Update middleware docs and the local plugin skill so plugin authors continue importing hook types from `inference_middleware`.
- Add an import-boundary regression test that asserts importing `NemoInferenceMiddleware` does not load `openai`, `anthropic`, or `pydantic`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [x] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates
<!-- Check one tests line and one documentation line. Include the requested justification when a gate is not applicable. -->

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification
<!-- Check an item only when supported by evidence. List exact targeted validation commands and results below. -->

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Rebased on `origin/main` at `887049d8a965416e7d8052b7a2c2435dfbc743e8`.

Targeted validation:

- Cold subprocess import sample for `NemoInferenceMiddleware`: median 7.03 ms; `openai`, `anthropic`, and `pydantic` remained unloaded in all samples.
- `rg -n 'MiddlewareCallView|VirtualModelInferenceConfigView|VirtualModelView' packages/nemo_platform_plugin plugins/nemo-guardrails/src plugins/nemo-switchyard/src plugins/example-plugin/src -g '*.py' -g '*.md'` -> no matches
- `git diff origin/main | rg -n '^\+.*\bcast\(|^\+.*TYPE_CHECKING|^\+.*__getattr__|^\+.*\bgetattr\(|^\+.*MiddlewareCallView|^\+.*VirtualModelView|^\+.*VirtualModelInferenceConfigView|typed_body: object|typed_body: Mapping|isinstance\(response\.typed_body, \(openai_chat_types\.ChatCompletion, anthropic_types\.Message\)'` -> no matches
- `git diff --check` -> passed
- `uv run ruff format --check <changed Python files>` -> 21 files already formatted
- `uv run ruff check <changed Python files>` -> All checks passed
- `uv run --frozen ty check packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware.py packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware_models.py packages/nemo_platform_plugin/src/nemo_platform_plugin/inference_middleware_types.py packages/nemo_platform_plugin/src/nemo_platform_plugin/virtual_models/types.py services/core/inference-gateway/src/nmp/core/inference_gateway/api/middleware_registry.py services/core/inference-gateway/src/nmp/core/inference_gateway/api/typed_request.py services/core/inference-gateway/src/nmp/core/inference_gateway/api/typed_response.py services/core/inference-gateway/src/nmp/core/inference_gateway/api/v2/virtual_models.py` -> All checks passed
- `uv run --frozen ty check plugins/nemo-switchyard/src/nemo_switchyard/middleware.py plugins/nemo-switchyard/src/nemo_switchyard/_bridge.py ...` -> blocked by existing unresolved `switchyard.lib.*` imports in this environment; the type-checkable changed subset above passes.
- `uv run --frozen ty check services/guardrails/src/nmp/guardrails/api/v2/configs/endpoints.py ...` -> blocked by existing diagnostics in that file around `config.data` and nullable registry dependencies; import smoke below passes.
- `uv run python -c "from nmp.guardrails.api.v2.configs.endpoints import _virtual_models_using_config; from nemo_platform_plugin.inference_middleware import NemoInferenceMiddleware; print(_virtual_models_using_config.__name__, NemoInferenceMiddleware.__name__)"` -> `_virtual_models_using_config NemoInferenceMiddleware`
- `uv run --frozen pytest packages/nemo_platform_plugin/tests/test_inference_middleware_imports.py packages/nemo_platform_plugin/tests/test_inference_middleware.py packages/nemo_platform_plugin/tests/virtual_models/test_client.py services/core/inference-gateway/tests/unit/test_typed_response.py services/core/inference-gateway/tests/unit/test_middleware_registry.py services/guardrails/tests/apis/test_configs_api.py plugins/nemo-guardrails/tests/unit/test_middleware.py plugins/nemo-switchyard/tests/test_factory_lifecycle.py plugins/nemo-switchyard/tests/test_bridge.py -q` -> 283 passed, 6 skipped
- `flox activate -- uv run pre-commit run -a` -> Passed
- DCO audit over `origin/main..HEAD` -> passed
