### PR TITLE
chore(agents): lift chat tui to shared module

### DIFF
--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py
@@ -134,15 +134,15 @@ def run_chat_tui(
         last_thinking_content = ""
         thinking_displayed = False
 
-        if initial_message:
-            result = _process_user_message(initial_message, send_turn)
-            if result:
-                assistant_message, last_thinking_content = result
-                if record_assistant_message is not None:
-                    record_assistant_message(assistant_message)
+        try:
+            if initial_message:
+                result = _process_user_message(initial_message, send_turn)
+                if result:
+                    assistant_message, last_thinking_content = result
+                    if record_assistant_message is not None:
+                        record_assistant_message(assistant_message)
 
-        while True:
-            try:
+            while True:
                 console.print()
                 user_input = Prompt.ask("[bold cyan]You[/bold cyan]", console=console).strip()
 
@@ -168,8 +168,8 @@ def run_chat_tui(
                     if record_assistant_message is not None:
                         record_assistant_message(assistant_message)
 
-            except (KeyboardInterrupt, EOFError):
-                _exit_gracefully()
+        except (KeyboardInterrupt, EOFError):
+            _exit_gracefully()
 
     finally:
         root_logger.setLevel(initial_level)

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py
@@ -1,0 +1,448 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable terminal UI for OpenAI-compatible streaming chat commands."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sys
+from types import TracebackType
+from typing import Any, Callable, Iterator, Protocol
+
+import click
+from nemo_platform._streaming import SSEDecoder
+from rich.align import Align
+from rich.console import Console
+from rich.live import Live
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.prompt import Prompt
+
+from nemo_platform_ext.cli.core.help_formatter import _get_terminal_width
+
+
+class StreamingBody(Protocol):
+    """Byte-streaming HTTP response returned by an SDK context manager."""
+
+    def iter_bytes(self) -> Iterator[bytes]: ...
+
+
+class StreamingResponse(Protocol):
+    """Context manager returned by generated SDK streaming wrappers."""
+
+    def __enter__(self) -> StreamingBody: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> bool | None: ...
+
+
+SendTurn = Callable[[str], StreamingResponse]
+RecordAssistantMessage = Callable[[str], None]
+
+
+class _StreamingThinkingFilter:
+    """Incrementally strip thinking tags while preserving visible content."""
+
+    def __init__(self) -> None:
+        self._pending = ""
+        self._in_thinking = False
+
+    def feed(self, text: str) -> str:
+        """Return visible text that is safe to print immediately."""
+        if not text:
+            return ""
+
+        data = self._pending + text
+        self._pending = ""
+        visible = ""
+
+        while data:
+            if self._in_thinking:
+                close_index = data.find("</think>")
+                if close_index >= 0:
+                    data = data[close_index + len("</think>") :]
+                    self._in_thinking = False
+                    continue
+
+                pending_length = _partial_tag_suffix_length(data, "</think>")
+                self._pending = data[-pending_length:] if pending_length else ""
+                break
+
+            open_index = data.find("<think>")
+            if open_index >= 0:
+                visible += data[:open_index]
+                data = data[open_index + len("<think>") :]
+                self._in_thinking = True
+                continue
+
+            pending_length = _partial_tag_suffix_length(data, "<think>")
+            visible += data[:-pending_length] if pending_length else data
+            self._pending = data[-pending_length:] if pending_length else ""
+            break
+
+        return visible
+
+    def finish(self) -> str:
+        """Flush any buffered non-thinking text at the end of the stream."""
+        if not self._pending:
+            return ""
+
+        pending = self._pending
+        self._pending = ""
+        if self._in_thinking:
+            logging.debug("Dropping incomplete thinking content at end of streamed chat response")
+            return ""
+
+        return pending
+
+
+USER_PANEL_WIDTH_RATIO = 0.8
+ASSISTANT_PANEL_WIDTH_RATIO = 0.95
+LIVE_REFRESH_RATE = 20
+ANSI_MOVE_UP_CLEAR_LINE = "\033[1A\033[2K"
+THINKING_TAG_PATTERN = r"<think>(.*?)</think>"
+THINKING_UNCLOSED_PATTERN = r"<think>(.*?)$"
+
+terminal_width = _get_terminal_width()
+console = Console(width=terminal_width)
+
+
+def run_chat_tui(
+    *,
+    send_turn: SendTurn,
+    display_info: dict[str, str],
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+    system_message: str | None = None,
+    initial_message: str | None = None,
+    record_assistant_message: RecordAssistantMessage | None = None,
+) -> None:
+    """Run the shared interactive chat UI against a caller-provided transport."""
+    root_logger = logging.getLogger()
+    initial_level = root_logger.level
+    try:
+        root_logger.setLevel(logging.CRITICAL)
+        _print_welcome_header(display_info, temperature, max_tokens, system_message)
+
+        last_thinking_content = ""
+        thinking_displayed = False
+
+        if initial_message:
+            result = _process_user_message(initial_message, send_turn)
+            if result:
+                assistant_message, last_thinking_content = result
+                if record_assistant_message is not None:
+                    record_assistant_message(assistant_message)
+
+        while True:
+            try:
+                console.print()
+                user_input = Prompt.ask("[bold cyan]You[/bold cyan]", console=console).strip()
+
+                if not user_input:
+                    continue
+
+                if user_input.startswith("/"):
+                    _clear_prompt_line()
+                    new_thinking_state = _handle_special_command(
+                        user_input,
+                        last_thinking_content,
+                        thinking_displayed,
+                    )
+                    if new_thinking_state is not None:
+                        thinking_displayed = new_thinking_state
+                    continue
+
+                _clear_prompt_line()
+                result = _process_user_message(user_input, send_turn)
+                if result:
+                    assistant_message, last_thinking_content = result
+                    thinking_displayed = False
+                    if record_assistant_message is not None:
+                        record_assistant_message(assistant_message)
+
+            except (KeyboardInterrupt, EOFError):
+                _exit_gracefully()
+
+    finally:
+        root_logger.setLevel(initial_level)
+
+
+def collect_stream_response(response: StreamingResponse) -> tuple[str, Any | None]:
+    """Collect content chunks from an OpenAI-compatible streaming response."""
+    raw_message = ""
+    usage = None
+
+    for delta in _iter_stream_deltas(response):
+        if delta.get("usage") is not None:
+            usage = delta["usage"]
+
+        content = _stream_delta_content(delta)
+        if content:
+            raw_message += content
+
+    return raw_message, usage
+
+
+def stream_text_response(response: StreamingResponse) -> None:
+    """Stream plain text output while hiding thinking markup."""
+    thinking_filter = _StreamingThinkingFilter()
+
+    for delta in _iter_stream_deltas(response):
+        content = _stream_delta_content(delta)
+        if not content:
+            continue
+
+        visible_content = thinking_filter.feed(content)
+        if visible_content:
+            click.echo(visible_content, nl=False)
+            sys.stdout.flush()
+
+    trailing_content = thinking_filter.finish()
+    if trailing_content:
+        click.echo(trailing_content, nl=False)
+        sys.stdout.flush()
+    click.echo()
+
+
+def parse_thinking(text: str) -> tuple[str, str]:
+    """Return thinking content and visible content parsed from think tags."""
+    matches = re.findall(THINKING_TAG_PATTERN, text, re.DOTALL)
+    regular_content = re.sub(THINKING_TAG_PATTERN, "", text, flags=re.DOTALL)
+    thinking_parts = list(matches)
+
+    unclosed_match = re.search(THINKING_UNCLOSED_PATTERN, regular_content, re.DOTALL)
+    if unclosed_match:
+        thinking_parts.append(unclosed_match.group(1))
+        regular_content = re.sub(THINKING_UNCLOSED_PATTERN, "", regular_content, flags=re.DOTALL)
+
+    if thinking_parts:
+        return "\n\n".join(thinking_parts), regular_content.strip()
+
+    return "", text
+
+
+def _partial_tag_suffix_length(text: str, tag: str) -> int:
+    max_length = min(len(text), len(tag) - 1)
+    for length in range(max_length, 0, -1):
+        if tag.startswith(text[-length:]):
+            return length
+    return 0
+
+
+def _iter_stream_deltas(response: StreamingResponse) -> Iterator[dict[str, Any]]:
+    """Yield parsed OpenAI-compatible streaming delta payloads."""
+    with response as stream:
+        for event in SSEDecoder().iter_bytes(stream.iter_bytes()):
+            if event.event == "error":
+                raise click.ClickException(_format_streaming_error(stream, event.data))
+            if event.event is not None:
+                continue
+            if not event.data:
+                continue
+            if event.data.startswith("[DONE]"):
+                break
+
+            try:
+                yield json.loads(event.data)
+            except json.JSONDecodeError:
+                logging.debug("Failed to parse JSON stream event: %s", event.data)
+
+
+def _format_streaming_error(response: StreamingBody, data: str) -> str:
+    if data:
+        return f"Streaming chat request failed: {data}"
+
+    status_code = getattr(response, "status_code", None)
+    if isinstance(status_code, int):
+        return f"Streaming chat request failed (HTTP {status_code})"
+    return "Streaming chat request failed"
+
+
+def _stream_delta_content(delta: dict[str, Any]) -> str:
+    choices = delta.get("choices", [])
+    if not choices or not isinstance(choices[0], dict):
+        return ""
+
+    chunk_delta = choices[0].get("delta", {})
+    if not isinstance(chunk_delta, dict):
+        return ""
+
+    content = chunk_delta.get("content")
+    return content if isinstance(content, str) else ""
+
+
+def _process_user_message(user_input: str, send_turn: SendTurn) -> tuple[str, str] | None:
+    panel_width = int(terminal_width * USER_PANEL_WIDTH_RATIO)
+    user_panel = Panel(
+        user_input,
+        title="[bold cyan]You[/bold cyan]",
+        title_align="right",
+        border_style="cyan",
+        padding=(0, 1),
+        width=panel_width,
+    )
+    console.print(Align.right(user_panel))
+
+    response = send_turn(user_input)
+    assistant_message, thinking_content = _stream_response(response)
+
+    if assistant_message:
+        return assistant_message, thinking_content
+
+    logging.warning("Received empty response from API")
+    console.print(Panel.fit("⚠ Received empty response from model", border_style="yellow", padding=(0, 1)))
+    return None
+
+
+def _clear_prompt_line() -> None:
+    console.file.write(ANSI_MOVE_UP_CLEAR_LINE)
+    console.file.flush()
+
+
+def _exit_gracefully() -> None:
+    console.print("\n")
+    console.print(Panel.fit("[bold]Chat session ended[/bold]", border_style="dim", padding=(0, 2)))
+    raise click.exceptions.Exit(0)
+
+
+def _handle_special_command(command: str, last_thinking: str, thinking_displayed: bool) -> bool | None:
+    if command in {"/thinking", "/t"}:
+        if not last_thinking:
+            console.print(Panel.fit("No reasoning content in the last response", border_style="yellow", padding=(0, 1)))
+            return None
+
+        if thinking_displayed:
+            console.print(Panel.fit("Reasoning already displayed above", border_style="yellow dim", padding=(0, 1)))
+            return True
+
+        thinking_panel = Panel(
+            Markdown(last_thinking),
+            title="[bold yellow]💭 Reasoning[/bold yellow]",
+            title_align="left",
+            border_style="yellow dim",
+            padding=(0, 1),
+        )
+        console.print(thinking_panel)
+        return True
+
+    if command in {"/help", "/h"}:
+        console.print(
+            Panel(
+                "[cyan]/thinking[/cyan] - Show/hide model reasoning from last response\n"
+                "[cyan]/help[/cyan] - Show this help message\n"
+                "[cyan]Ctrl+C[/cyan] - Exit the chat",
+                title="[bold]Available Commands[/bold]",
+                border_style="blue",
+                padding=(0, 1),
+            )
+        )
+        return None
+
+    console.print(
+        Panel.fit(
+            f"Unknown command: {command}. Type /help for available commands.",
+            border_style="yellow",
+            padding=(0, 1),
+        )
+    )
+    return None
+
+
+def _print_welcome_header(
+    display_info: dict[str, str],
+    temperature: float | None,
+    max_tokens: int | None,
+    system_message: str | None,
+) -> None:
+    config_lines = [f"[cyan]{key}:[/cyan] {value}" for key, value in display_info.items()]
+
+    if temperature is not None:
+        config_lines.append(f"[cyan]Temperature:[/cyan] {temperature}")
+    if max_tokens is not None:
+        config_lines.append(f"[cyan]Max Tokens:[/cyan] {max_tokens}")
+    if system_message:
+        config_lines.append(f"[cyan]System:[/cyan] {system_message}")
+
+    welcome_panel = Panel(
+        "\n".join(config_lines),
+        title="[bold green]🤖 NeMo Platform Chat Session[/bold green]",
+        subtitle="Press Ctrl+C to exit",
+        border_style="green",
+        padding=(1, 2),
+    )
+    console.print(welcome_panel)
+
+
+def _is_inside_thinking_tag(message: str) -> bool:
+    return message.count("<think>") > message.count("</think>")
+
+
+def _create_thinking_preview(message: str) -> str:
+    thinking_match = re.search(THINKING_UNCLOSED_PATTERN, message, re.DOTALL)
+    current_thinking = thinking_match.group(1).strip() if thinking_match else ""
+
+    if not current_thinking:
+        return "[dim]💭 Thinking...[/dim]"
+
+    lines = current_thinking.split("\n")
+    preview = "\n".join(lines[-3:]) if len(lines) > 1 else current_thinking
+    if len(preview) > 150:
+        preview = "..." + preview[-150:]
+    return f"[dim italic]{preview}[/dim italic]"
+
+
+def _extract_display_text(message: str, inside_thinking: bool) -> str:
+    display_text = re.sub(THINKING_TAG_PATTERN, "", message, flags=re.DOTALL)
+    if inside_thinking:
+        display_text = re.sub(THINKING_UNCLOSED_PATTERN, "", display_text, flags=re.DOTALL)
+    return display_text.strip()
+
+
+def _stream_response(response: StreamingResponse) -> tuple[str, str]:
+    full_message = ""
+    panel_width = int(terminal_width * ASSISTANT_PANEL_WIDTH_RATIO)
+
+    with Live("", console=console, refresh_per_second=LIVE_REFRESH_RATE) as live:
+        for delta in _iter_stream_deltas(response):
+            content = _stream_delta_content(delta)
+            if not content:
+                continue
+
+            full_message += content
+            inside_thinking = _is_inside_thinking_tag(full_message)
+            display_text = _extract_display_text(full_message, inside_thinking)
+
+            if inside_thinking and not display_text:
+                thinking_indicator = Panel(
+                    _create_thinking_preview(full_message),
+                    title="[bold yellow dim]💭 Reasoning[/bold yellow dim]",
+                    title_align="left",
+                    border_style="yellow dim",
+                    padding=(0, 1),
+                    width=panel_width,
+                )
+                live.update(Align.left(thinking_indicator))
+            else:
+                response_panel = Panel(
+                    Markdown(display_text) if display_text else "",
+                    title="[bold magenta]Assistant[/bold magenta]",
+                    title_align="left",
+                    border_style="magenta",
+                    padding=(0, 1),
+                    width=panel_width,
+                )
+                live.update(Align.left(response_panel))
+
+    thinking_content, regular_content = parse_thinking(full_message)
+    if thinking_content:
+        console.print("[dim]💭 Reasoning available! Type [dim cyan]/thinking[/] to view it[/]", markup=True)
+
+    return regular_content or full_message, thinking_content

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/use_cases/chat.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/use_cases/chat.py
@@ -349,8 +349,11 @@ def _run_chat_session(
     history: list[ChatMessage] = []
     if system_message:
         history.append({"role": "system", "content": system_message})
+    current_user_input = ""
 
     def send_turn(user_input: str) -> StreamingResponse:
+        nonlocal current_user_input
+        current_user_input = user_input
         return _create_one_shot_response(
             user_input,
             history,
@@ -361,7 +364,12 @@ def _run_chat_session(
         )
 
     def record_assistant_message(assistant_message: str) -> None:
-        history.append({"role": "assistant", "content": assistant_message})
+        history.extend(
+            [
+                {"role": "user", "content": current_user_input},
+                {"role": "assistant", "content": assistant_message},
+            ]
+        )
 
     run_chat_tui(
         send_turn=send_turn,
@@ -383,10 +391,9 @@ def _create_one_shot_response(
     max_tokens: int | None,
 ) -> StreamingResponse:
     """Build and send one chat request."""
-    history.append({"role": "user", "content": user_input})
     body = build_kwargs(
         model=model_for_body,
-        messages=history,
+        messages=[*history, {"role": "user", "content": user_input}],
         stream=True,
         temperature=temperature,
         max_tokens=max_tokens,

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/use_cases/chat.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/use_cases/chat.py
@@ -6,28 +6,24 @@
 from __future__ import annotations
 
 import json
-import logging
-import re
 import select
 import sys
-from types import TracebackType
-from typing import Annotated, Any, Callable, Iterator, Literal, Protocol, Self, TypedDict, cast
+from typing import Annotated, Any, Callable, Literal, TypedDict, cast
 
 import click
 import typer
-from nemo_platform._streaming import SSEDecoder
-from rich.align import Align
-from rich.console import Console
-from rich.live import Live
-from rich.markdown import Markdown
-from rich.panel import Panel
-from rich.prompt import Prompt
 
+from nemo_platform_ext.cli.chat_tui import (
+    StreamingResponse,
+    collect_stream_response,
+    parse_thinking,
+    run_chat_tui,
+    stream_text_response,
+)
 from nemo_platform_ext.cli.core.api import build_kwargs, is_tty
 from nemo_platform_ext.cli.core.autocomplete import autocomplete_model_entity
 from nemo_platform_ext.cli.core.context import CLIContext
 from nemo_platform_ext.cli.core.errors import handle_errors
-from nemo_platform_ext.cli.core.help_formatter import _get_terminal_width
 from nemo_platform_ext.cli.core.stdin_utils import is_stdin_available
 from nemo_platform_ext.ui.prompts import is_interactive
 
@@ -40,103 +36,6 @@ class ChatMessage(TypedDict):
 
 
 ChatOutputFormat = Literal["text", "json", "raw"]
-
-
-class _StreamingResponse(Protocol):
-    """Streaming response interface used by the generated SDK response wrapper."""
-
-    def __enter__(self) -> Self: ...
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc: BaseException | None,
-        traceback: TracebackType | None,
-    ) -> bool | None: ...
-
-    def iter_bytes(self) -> Iterator[bytes]: ...
-
-
-class _StreamingThinkingFilter:
-    """Incrementally strips thinking tags while preserving visible content."""
-
-    def __init__(self) -> None:
-        self._pending = ""
-        self._in_thinking = False
-
-    def feed(self, text: str) -> str:
-        """Return visible text that is safe to print immediately."""
-        if not text:
-            return ""
-
-        data = self._pending + text
-        self._pending = ""
-        visible = ""
-
-        while data:
-            if self._in_thinking:
-                close_index = data.find("</think>")
-                if close_index >= 0:
-                    data = data[close_index + len("</think>") :]
-                    self._in_thinking = False
-                    continue
-
-                pending_length = _partial_tag_suffix_length(data, "</think>")
-                self._pending = data[-pending_length:] if pending_length else ""
-                break
-
-            open_index = data.find("<think>")
-            if open_index >= 0:
-                chunk = data[:open_index]
-                visible += chunk
-                data = data[open_index + len("<think>") :]
-                self._in_thinking = True
-                continue
-
-            pending_length = _partial_tag_suffix_length(data, "<think>")
-            chunk = data[:-pending_length] if pending_length else data
-            visible += chunk
-            self._pending = data[-pending_length:] if pending_length else ""
-            break
-
-        return visible
-
-    def finish(self) -> str:
-        """Flush any buffered non-thinking text at the end of the stream."""
-        if not self._pending:
-            return ""
-
-        pending = self._pending
-        self._pending = ""
-        if self._in_thinking:
-            logging.debug("Dropping incomplete thinking content at end of streamed chat response")
-            return ""
-
-        return pending
-
-
-def _partial_tag_suffix_length(text: str, tag: str) -> int:
-    """Return the length of a text suffix that could start a tag."""
-    max_length = min(len(text), len(tag) - 1)
-    for length in range(max_length, 0, -1):
-        if tag.startswith(text[-length:]):
-            return length
-    return 0
-
-
-# Constants
-USER_PANEL_WIDTH_RATIO = 0.8  # User messages take 80% width to leave right margin
-ASSISTANT_PANEL_WIDTH_RATIO = 0.95  # Assistant uses more space for readability
-LIVE_REFRESH_RATE = 20
-ANSI_MOVE_UP_CLEAR_LINE = "\033[1A\033[2K"
-
-# Regex patterns for thinking tag parsing
-THINKING_TAG_PATTERN = r"<think>(.*?)</think>"  # Matches complete <think>...</think> pairs
-THINKING_UNCLOSED_PATTERN = r"<think>(.*?)$"  # Matches unclosed <think> tag to end of string
-
-# Create console with width limit
-terminal_width = _get_terminal_width()
-console = Console(width=terminal_width)
 
 
 def _parse_model_and_workspace(
@@ -368,7 +267,7 @@ def chat(
                 "No workspace specified. Provide workspace via --workspace flag or configure a default workspace."
             )
 
-        def get_response(body: dict[str, Any]) -> _StreamingResponse:
+        def get_response(body: dict[str, Any]) -> StreamingResponse:
             return client.inference.gateway.provider.with_streaming_response.post(
                 trailing_uri="v1/chat/completions",
                 workspace=resolved_workspace,
@@ -382,7 +281,7 @@ def chat(
         # Model entity routing (default): use OpenAI-compatible gateway
         resolved_workspace, model_entity_id = _parse_model_and_workspace(model, workspace, workspace_from_config)
 
-        def get_response(body: dict[str, Any]) -> _StreamingResponse:
+        def get_response(body: dict[str, Any]) -> StreamingResponse:
             return client.inference.gateway.openai.with_streaming_response.post(
                 trailing_uri="v1/chat/completions",
                 workspace=resolved_workspace,
@@ -417,7 +316,7 @@ def chat(
 def _run_one_shot(
     user_message: str,
     model_for_body: str,
-    get_response_func: Callable[[dict[str, Any]], _StreamingResponse],
+    get_response_func: Callable[[dict[str, Any]], StreamingResponse],
     temperature: float | None,
     max_tokens: int | None,
     system_message: str | None,
@@ -439,88 +338,50 @@ def _run_one_shot(
 
 def _run_chat_session(
     model_for_body: str,
-    get_response_func: Callable[[dict[str, Any]], _StreamingResponse],
+    get_response_func: Callable[[dict[str, Any]], StreamingResponse],
     temperature: float | None,
     max_tokens: int | None,
     system_message: str | None,
     user_message: str | None,
     display_info: dict[str, str],
 ) -> None:
-    """Run an interactive chat session."""
-    root_logger = logging.getLogger()
-    initial_level = root_logger.level
-    try:
-        # Disable logging during the chat session.
-        root_logger.setLevel(logging.CRITICAL)
+    """Run model chat through the shared terminal UI."""
+    history: list[ChatMessage] = []
+    if system_message:
+        history.append({"role": "system", "content": system_message})
 
-        history: list[ChatMessage] = []
-        if system_message:
-            history.append({"role": "system", "content": system_message})
+    def send_turn(user_input: str) -> StreamingResponse:
+        return _create_one_shot_response(
+            user_input,
+            history,
+            model_for_body,
+            get_response_func,
+            temperature,
+            max_tokens,
+        )
 
-        _print_welcome_header(display_info, temperature, max_tokens, system_message)
+    def record_assistant_message(assistant_message: str) -> None:
+        history.append({"role": "assistant", "content": assistant_message})
 
-        last_thinking_content = ""
-        thinking_displayed = False
-
-        # Handle initial user message if provided
-        if user_message:
-            result = _process_user_message(
-                user_message,
-                history,
-                model_for_body,
-                get_response_func,
-                temperature,
-                max_tokens,
-            )
-            if result:
-                _, last_thinking_content = result
-                thinking_displayed = False
-
-        while True:
-            try:
-                console.print()
-                user_input = Prompt.ask("[bold cyan]You[/bold cyan]", console=console).strip()
-
-                if not user_input:
-                    continue
-
-                if user_input.startswith("/"):
-                    _clear_prompt_line()
-                    new_thinking_state = _handle_special_command(user_input, last_thinking_content, thinking_displayed)
-                    if new_thinking_state is not None:
-                        thinking_displayed = new_thinking_state
-                    continue
-
-                _clear_prompt_line()
-
-                result = _process_user_message(
-                    user_input,
-                    history,
-                    model_for_body,
-                    get_response_func,
-                    temperature,
-                    max_tokens,
-                )
-                if result:
-                    _, last_thinking_content = result
-                    thinking_displayed = False
-
-            except (KeyboardInterrupt, EOFError):
-                _exit_gracefully()
-
-    finally:
-        # Restore logging level
-        root_logger.setLevel(initial_level)
+    run_chat_tui(
+        send_turn=send_turn,
+        record_assistant_message=record_assistant_message,
+        display_info=display_info,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        system_message=system_message,
+        initial_message=user_message,
+    )
 
 
 def _create_one_shot_response(
     user_input: str,
     history: list[ChatMessage],
     model_for_body: str,
-    get_response_func: Callable[[dict[str, Any]], _StreamingResponse],
+    get_response_func: Callable[[dict[str, Any]], StreamingResponse],
     temperature: float | None,
     max_tokens: int | None,
-) -> _StreamingResponse:
+) -> StreamingResponse:
     """Build and send one chat request."""
     history.append({"role": "user", "content": user_input})
     body = build_kwargs(
@@ -538,7 +399,7 @@ def _process_one_shot_message(
     user_input: str,
     history: list[ChatMessage],
     model_for_body: str,
-    get_response_func: Callable[[dict[str, Any]], _StreamingResponse],
+    get_response_func: Callable[[dict[str, Any]], StreamingResponse],
     temperature: float | None,
     max_tokens: int | None,
 ) -> dict[str, Any]:
@@ -547,8 +408,8 @@ def _process_one_shot_message(
         user_input, history, model_for_body, get_response_func, temperature, max_tokens
     )
 
-    raw_message, usage = _collect_stream_response(response)
-    thinking_content, regular_content = _parse_thinking(raw_message)
+    raw_message, usage = collect_stream_response(response)
+    thinking_content, regular_content = parse_thinking(raw_message)
     return {
         "content": regular_content,
         "thinking": thinking_content,
@@ -557,79 +418,11 @@ def _process_one_shot_message(
     }
 
 
-def _iter_stream_deltas(response: _StreamingResponse) -> Iterator[dict[str, Any]]:
-    """Yield parsed OpenAI-compatible streaming delta payloads."""
-    with response as stream:
-        for event in SSEDecoder().iter_bytes(stream.iter_bytes()):
-            if event.event == "error":
-                raise click.ClickException(_format_streaming_error(stream, event.data))
-            if event.event is not None:
-                # Match the Stainless Stream behavior: OpenAI chunks are
-                # carried by unnamed data events; named non-error events are skipped.
-                continue
-            if not event.data:
-                continue
-            if event.data.startswith("[DONE]"):
-                break
-
-            try:
-                yield json.loads(event.data)
-            except json.JSONDecodeError:
-                logging.debug(f"Failed to parse JSON stream event: {event.data}")
-
-
-def _format_streaming_error(response: _StreamingResponse, data: str) -> str:
-    """Build a helpful message for an SSE error frame."""
-    if data:
-        return f"Streaming chat request failed: {data}"
-
-    status_code = _stream_status_code(response)
-    if status_code is not None:
-        return f"Streaming chat request failed (HTTP {status_code})"
-    return "Streaming chat request failed"
-
-
-def _stream_status_code(response: _StreamingResponse) -> int | None:
-    """Return the HTTP status code from SDK streaming wrappers when available."""
-    status_code = getattr(response, "status_code", None)
-    return status_code if isinstance(status_code, int) else None
-
-
-def _stream_delta_content(delta: dict[str, Any]) -> str:
-    """Extract text content from a streaming delta payload."""
-    choices = delta.get("choices", [])
-    if not choices or not isinstance(choices[0], dict):
-        return ""
-
-    chunk_delta = choices[0].get("delta", {})
-    if not isinstance(chunk_delta, dict):
-        return ""
-
-    content = chunk_delta.get("content")
-    return content if isinstance(content, str) else ""
-
-
-def _collect_stream_response(response: _StreamingResponse) -> tuple[str, Any | None]:
-    """Collect content chunks from an OpenAI-compatible streaming response."""
-    raw_message = ""
-    usage = None
-
-    for delta in _iter_stream_deltas(response):
-        if delta.get("usage") is not None:
-            usage = delta["usage"]
-
-        content = _stream_delta_content(delta)
-        if content:
-            raw_message += content
-
-    return raw_message, usage
-
-
 def _stream_one_shot_text(
     user_input: str,
     history: list[ChatMessage],
     model_for_body: str,
-    get_response_func: Callable[[dict[str, Any]], _StreamingResponse],
+    get_response_func: Callable[[dict[str, Any]], StreamingResponse],
     temperature: float | None,
     max_tokens: int | None,
 ) -> None:
@@ -637,28 +430,7 @@ def _stream_one_shot_text(
     response = _create_one_shot_response(
         user_input, history, model_for_body, get_response_func, temperature, max_tokens
     )
-    _stream_text_response(response)
-
-
-def _stream_text_response(response: _StreamingResponse) -> None:
-    """Stream text chunks to stdout while hiding thinking markup."""
-    thinking_filter = _StreamingThinkingFilter()
-
-    for delta in _iter_stream_deltas(response):
-        content = _stream_delta_content(delta)
-        if not content:
-            continue
-
-        visible_content = thinking_filter.feed(content)
-        if visible_content:
-            typer.echo(visible_content, nl=False)
-            sys.stdout.flush()
-
-    trailing_content = thinking_filter.finish()
-    if trailing_content:
-        typer.echo(trailing_content, nl=False)
-        sys.stdout.flush()
-    typer.echo()
+    stream_text_response(response)
 
 
 def _print_one_shot_response(
@@ -676,290 +448,3 @@ def _print_one_shot_response(
         return
 
     typer.echo(result["raw"])
-
-
-def _process_user_message(
-    user_input: str,
-    history: list[ChatMessage],
-    model_for_body: str,
-    get_response_func: Callable[[dict[str, Any]], _StreamingResponse],
-    temperature: float | None,
-    max_tokens: int | None,
-) -> tuple[str, str] | None:
-    """Display user message, send to API, stream response.
-
-    Args:
-        user_input: The user's message
-        history: Chat history (will be modified in place)
-        model_for_body: Model identifier for the request body
-        get_response_func: Function to get streaming response
-        temperature: Sampling temperature
-        max_tokens: Max tokens to generate
-
-    Returns:
-        Tuple of (assistant_message, thinking_content) or None if empty response
-    """
-    # Display user message panel
-    panel_width = int(terminal_width * USER_PANEL_WIDTH_RATIO)
-    user_panel = Panel(
-        user_input,
-        title="[bold cyan]You[/bold cyan]",
-        title_align="right",
-        border_style="cyan",
-        padding=(0, 1),
-        width=panel_width,
-    )
-    console.print(Align.right(user_panel))
-
-    # Add to history
-    history.append({"role": "user", "content": user_input})
-
-    # Build request body
-    body = build_kwargs(
-        model=model_for_body,
-        messages=history,
-        stream=True,
-        temperature=temperature,
-        max_tokens=max_tokens,
-    )
-
-    # Make API call
-    response = get_response_func(body)
-
-    # Stream response
-    assistant_message, thinking_content = _stream_response(response)
-
-    if assistant_message:
-        history.append({"role": "assistant", "content": assistant_message})
-        return assistant_message, thinking_content
-    else:
-        logging.warning("Received empty response from API")
-        console.print(Panel.fit("⚠ Received empty response from model", border_style="yellow", padding=(0, 1)))
-        return None
-
-
-def _clear_prompt_line() -> None:
-    """Move cursor up one line and clear it."""
-    console.file.write(ANSI_MOVE_UP_CLEAR_LINE)
-    console.file.flush()
-
-
-def _exit_gracefully() -> None:
-    """Exit the chat session gracefully."""
-    console.print("\n")
-    console.print(Panel.fit("[bold]Chat session ended[/bold]", border_style="dim", padding=(0, 2)))
-    sys.exit(0)
-
-
-def _handle_special_command(command: str, last_thinking: str, thinking_displayed: bool) -> bool | None:
-    """
-    Handle special commands like /thinking, and /help.
-
-    Returns:
-        New thinking_displayed value for /thinking, None otherwise.
-    """
-    if command in {"/thinking", "/t"}:
-        if not last_thinking:
-            console.print(Panel.fit("No reasoning content in the last response", border_style="yellow", padding=(0, 1)))
-            return None
-
-        if thinking_displayed:
-            console.print(Panel.fit("Reasoning already displayed above", border_style="yellow dim", padding=(0, 1)))
-            return True  # Keep the state as displayed
-
-        # Show the thinking content in an expanded panel
-        thinking_panel = Panel(
-            Markdown(last_thinking),
-            title="[bold yellow]💭 Reasoning[/bold yellow]",
-            title_align="left",
-            border_style="yellow dim",
-            padding=(0, 1),
-        )
-        console.print(thinking_panel)
-        return True  # Indicate thinking was shown
-
-    if command in {"/help", "/h"}:
-        console.print(
-            Panel(
-                "[cyan]/thinking[/cyan] - Show/hide model reasoning from last response\n"
-                "[cyan]/help[/cyan] - Show this help message\n"
-                "[cyan]Ctrl+C[/cyan] - Exit the chat",
-                title="[bold]Available Commands[/bold]",
-                border_style="blue",
-                padding=(0, 1),
-            )
-        )
-        return None
-
-    console.print(
-        Panel.fit(
-            f"Unknown command: {command}. Type /help for available commands.", border_style="yellow", padding=(0, 1)
-        )
-    )
-    return None
-
-
-def _print_welcome_header(
-    display_info: dict[str, str],
-    temperature: float | None,
-    max_tokens: int | None,
-    system_message: str | None,
-) -> None:
-    """Print a styled welcome header for the chat session."""
-    config_lines = [f"[cyan]{key}:[/cyan] {value}" for key, value in display_info.items()]
-
-    if temperature is not None:
-        config_lines.append(f"[cyan]Temperature:[/cyan] {temperature}")
-    if max_tokens is not None:
-        config_lines.append(f"[cyan]Max Tokens:[/cyan] {max_tokens}")
-    if system_message:
-        config_lines.append(f"[cyan]System:[/cyan] {system_message}")
-
-    config_text = "\n".join(config_lines)
-
-    welcome_panel = Panel(
-        config_text,
-        title="[bold green]🤖 NeMo Platform Chat Session[/bold green]",
-        subtitle="Press Ctrl+C to exit",
-        border_style="green",
-        padding=(1, 2),
-    )
-
-    console.print(welcome_panel)
-
-
-def _is_inside_thinking_tag(message: str) -> bool:
-    """Check if we're currently inside an unclosed <think> tag."""
-    open_think_count = message.count("<think>")
-    close_think_count = message.count("</think>")
-    return open_think_count > close_think_count
-
-
-def _create_thinking_preview(message: str) -> str:
-    """Create a preview of the current thinking content.
-
-    Args:
-        message: Full message text containing unclosed <think> tag
-
-    Returns:
-        Formatted preview text for display
-    """
-    # Extract current thinking content (inside unclosed <think> tag)
-    thinking_match = re.search(THINKING_UNCLOSED_PATTERN, message, re.DOTALL)
-    current_thinking = thinking_match.group(1).strip() if thinking_match else ""
-
-    if current_thinking:
-        # Get last 150 characters, or last 2-3 lines (whichever is shorter)
-        lines = current_thinking.split("\n")
-        preview = "\n".join(lines[-3:]) if len(lines) > 1 else current_thinking
-        if len(preview) > 150:
-            preview = "..." + preview[-150:]
-        return f"[dim italic]{preview}[/dim italic]"
-    else:
-        return "[dim]💭 Thinking...[/dim]"
-
-
-def _extract_display_text(message: str, inside_thinking: bool) -> str:
-    """Extract content outside of think tags for display.
-
-    Args:
-        message: Full message text
-        inside_thinking: Whether we're currently inside a thinking tag
-
-    Returns:
-        Text to display (with thinking tags removed)
-    """
-    # Remove complete <think>...</think> pairs
-    display_text = re.sub(THINKING_TAG_PATTERN, "", message, flags=re.DOTALL)
-    # Remove any unclosed <think> tag and everything after it
-    if inside_thinking:
-        display_text = re.sub(THINKING_UNCLOSED_PATTERN, "", display_text, flags=re.DOTALL)
-    return display_text.strip()
-
-
-def _stream_response(response: _StreamingResponse) -> tuple[str, str]:
-    """
-    Stream and display the assistant's response with live updates in a panel.
-
-    Parses out <think> tags and shows thinking separately.
-
-    Args:
-        response: Streaming response from the API (StreamingResponse from nemo_platform SDK)
-
-    Returns:
-        Tuple of (complete assistant message, thinking content)
-    """
-    full_message = ""
-    panel_width = int(terminal_width * ASSISTANT_PANEL_WIDTH_RATIO)
-
-    # TODO: this doesn't work well with very long outputs
-    with Live("", console=console, refresh_per_second=LIVE_REFRESH_RATE) as live:
-        for delta in _iter_stream_deltas(response):
-            content = _stream_delta_content(delta)
-            if not content:
-                continue
-
-            full_message += content
-
-            # Check if we're currently inside a <think> tag
-            inside_thinking = _is_inside_thinking_tag(full_message)
-
-            # Extract content outside of think tags for display
-            display_text = _extract_display_text(full_message, inside_thinking)
-
-            # Show thinking indicator if model is currently reasoning
-            if inside_thinking and not display_text:
-                # Show preview of the thinking content
-                thinking_preview = _create_thinking_preview(full_message)
-                thinking_indicator = Panel(
-                    thinking_preview,
-                    title="[bold yellow dim]💭 Reasoning[/bold yellow dim]",
-                    title_align="left",
-                    border_style="yellow dim",
-                    padding=(0, 1),
-                    width=panel_width,
-                )
-                live.update(Align.left(thinking_indicator))
-            else:
-                # Show the main content (regular response)
-                response_panel = Panel(
-                    Markdown(display_text) if display_text else "",
-                    title="[bold magenta]Assistant[/bold magenta]",
-                    title_align="left",
-                    border_style="magenta",
-                    padding=(0, 1),
-                    width=panel_width,
-                )
-                live.update(Align.left(response_panel))
-
-    # Final parse to extract thinking
-    thinking_content, regular_content = _parse_thinking(full_message)
-
-    # Show collapsed thinking hint after streaming if there's thinking content
-    if thinking_content:
-        console.print("[dim]💭 Reasoning available! Type [dim cyan]/thinking[/] to view it[/]", markup=True)
-
-    return regular_content or full_message, thinking_content
-
-
-def _parse_thinking(text: str) -> tuple[str, str]:
-    """
-    Parse out <think> tags from text.
-
-    Returns:
-        Tuple of (thinking_content, regular_content)
-    """
-    # Match <think>...</think> tags (non-greedy)
-    matches = re.findall(THINKING_TAG_PATTERN, text, re.DOTALL)
-    regular_content = re.sub(THINKING_TAG_PATTERN, "", text, flags=re.DOTALL)
-    thinking_parts = list(matches)
-
-    unclosed_match = re.search(THINKING_UNCLOSED_PATTERN, regular_content, re.DOTALL)
-    if unclosed_match:
-        thinking_parts.append(unclosed_match.group(1))
-        regular_content = re.sub(THINKING_UNCLOSED_PATTERN, "", regular_content, flags=re.DOTALL)
-
-    if thinking_parts:
-        return "\n\n".join(thinking_parts), regular_content.strip()
-
-    return "", text

--- a/packages/nemo_platform_ext/tests/cli/commands/use_cases/test_chat.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/use_cases/test_chat.py
@@ -235,7 +235,7 @@ def test_chat_prompt_runs_once_with_plain_text_output(runner: CliRunner) -> None
 
     with (
         patch("nemo_platform_ext.cli.core.context.CLIContext.get_client", return_value=mock_client),
-        patch("nemo_platform_ext.cli.commands.use_cases.chat.Prompt.ask") as mock_prompt,
+        patch("nemo_platform_ext.cli.chat_tui.Prompt.ask") as mock_prompt,
     ):
         result = runner.invoke(
             app,
@@ -367,7 +367,7 @@ def test_chat_interactive_with_prompt_sends_initial_message_then_prompts(runner:
     with (
         patch("nemo_platform_ext.cli.core.context.CLIContext.get_client", return_value=mock_client),
         patch("nemo_platform_ext.cli.commands.use_cases.chat._is_interactive_chat_session", return_value=True),
-        patch("nemo_platform_ext.cli.commands.use_cases.chat.Prompt.ask", side_effect=KeyboardInterrupt) as mock_prompt,
+        patch("nemo_platform_ext.cli.chat_tui.Prompt.ask", side_effect=KeyboardInterrupt) as mock_prompt,
     ):
         result = runner.invoke(app, ["chat", "my-model", "hi", "--interactive"])
 
@@ -377,6 +377,39 @@ def test_chat_interactive_with_prompt_sends_initial_message_then_prompts(runner:
     post = mock_client.inference.gateway.openai.with_streaming_response.post
     post.assert_called_once()
     assert captured_messages == [{"role": "user", "content": "hi"}]
+
+
+def test_chat_interactive_preserves_model_history_across_shared_tui_turns(runner: CliRunner) -> None:
+    """The shared TUI must leave model transcript management with the model-chat command."""
+    responses = [_mock_streaming_response("hello"), _mock_streaming_response("follow-up answer")]
+    mock_client = _mock_client_with_openai_response(responses[0])
+    captured_messages: list[list[dict[str, str]]] = []
+
+    def capture_post(**kwargs):
+        captured_messages.append(deepcopy(kwargs["body"]["messages"]))
+        return responses[len(captured_messages) - 1]
+
+    mock_client.inference.gateway.openai.with_streaming_response.post.side_effect = capture_post
+
+    with (
+        patch("nemo_platform_ext.cli.core.context.CLIContext.get_client", return_value=mock_client),
+        patch("nemo_platform_ext.cli.commands.use_cases.chat._is_interactive_chat_session", return_value=True),
+        patch(
+            "nemo_platform_ext.cli.chat_tui.Prompt.ask",
+            side_effect=["What did I just say?", KeyboardInterrupt],
+        ),
+    ):
+        result = runner.invoke(app, ["chat", "my-model", "hi", "--interactive"])
+
+    assert result.exit_code == 0
+    assert captured_messages == [
+        [{"role": "user", "content": "hi"}],
+        [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "What did I just say?"},
+        ],
+    ]
 
 
 def test_chat_interactive_requires_tty(runner: CliRunner) -> None:

--- a/packages/nemo_platform_ext/tests/cli/commands/use_cases/test_chat.py
+++ b/packages/nemo_platform_ext/tests/cli/commands/use_cases/test_chat.py
@@ -379,6 +379,26 @@ def test_chat_interactive_with_prompt_sends_initial_message_then_prompts(runner:
     assert captured_messages == [{"role": "user", "content": "hi"}]
 
 
+@pytest.mark.parametrize("exception", [KeyboardInterrupt, EOFError])
+def test_chat_interactive_interrupt_during_initial_response_exits_gracefully(
+    runner: CliRunner, exception: type[BaseException]
+) -> None:
+    response = _mock_streaming_response("unused")
+    response.iter_bytes.side_effect = exception
+    mock_client = _mock_client_with_openai_response(response)
+
+    with (
+        patch("nemo_platform_ext.cli.core.context.CLIContext.get_client", return_value=mock_client),
+        patch("nemo_platform_ext.cli.commands.use_cases.chat._is_interactive_chat_session", return_value=True),
+        patch("nemo_platform_ext.cli.chat_tui.Prompt.ask") as mock_prompt,
+    ):
+        result = runner.invoke(app, ["chat", "my-model", "hi", "--interactive"])
+
+    assert result.exit_code == 0
+    assert "Chat session ended" in result.stdout
+    mock_prompt.assert_not_called()
+
+
 def test_chat_interactive_preserves_model_history_across_shared_tui_turns(runner: CliRunner) -> None:
     """The shared TUI must leave model transcript management with the model-chat command."""
     responses = [_mock_streaming_response("hello"), _mock_streaming_response("follow-up answer")]
@@ -409,6 +429,31 @@ def test_chat_interactive_preserves_model_history_across_shared_tui_turns(runner
             {"role": "assistant", "content": "hello"},
             {"role": "user", "content": "What did I just say?"},
         ],
+    ]
+
+
+def test_chat_interactive_discards_user_turn_after_empty_response(runner: CliRunner) -> None:
+    responses = [_mock_streaming_response(), _mock_streaming_response("answer")]
+    mock_client = _mock_client_with_openai_response(responses[0])
+    captured_messages: list[list[dict[str, str]]] = []
+
+    def capture_post(**kwargs):
+        captured_messages.append(deepcopy(kwargs["body"]["messages"]))
+        return responses[len(captured_messages) - 1]
+
+    mock_client.inference.gateway.openai.with_streaming_response.post.side_effect = capture_post
+
+    with (
+        patch("nemo_platform_ext.cli.core.context.CLIContext.get_client", return_value=mock_client),
+        patch("nemo_platform_ext.cli.commands.use_cases.chat._is_interactive_chat_session", return_value=True),
+        patch("nemo_platform_ext.cli.chat_tui.Prompt.ask", side_effect=["second turn", KeyboardInterrupt]),
+    ):
+        result = runner.invoke(app, ["chat", "my-model", "empty turn", "--interactive"])
+
+    assert result.exit_code == 0
+    assert captured_messages == [
+        [{"role": "user", "content": "empty turn"}],
+        [{"role": "user", "content": "second turn"}],
     ]
 
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Extracts the existing `nemo chat` terminal UI and OpenAI-compatible streaming
handling into a reusable CLI module. This is a preparatory refactor for deployed
agent session chat; it does not add session commands or change the current model
chat contract.

## Related Issue

[AIRCORE-951: Add interactive multi-turn CLI for deployed Fabric-backed agents](https://linear.app/nvidia/issue/AIRCORE-951/add-interactive-multi-turn-cli-for-deployed-fabric-backed-agents)

## Changes

- Move the interactive prompt loop, Rich rendering, thinking-tag handling, and
  OpenAI-compatible SSE parsing into `nemo_platform_ext.cli.chat_tui`.
- Define a small transport interface that lets callers supply each streamed turn
  without coupling the TUI to a model or deployment client.
- Keep model request construction, routing, and transcript ownership in the
  existing `nemo chat` command.
- Preserve assistant messages through a callback so model chat continues sending
  the full conversation history on later turns.
- Reuse the extracted stream collection, plain-text streaming, and thinking
  parsing helpers for existing one-shot chat modes.
- Add regression coverage proving interactive model chat retains user and
  assistant history across the shared TUI boundary.

## Design Decisions

- **Keep transport outside the TUI.** The shared module owns terminal behavior and
  OpenAI-compatible response parsing, while each command owns request construction,
  authentication, routing, and conversation state.
- **Keep model transcript replay unchanged.** `nemo chat` still records every user
  and assistant message locally and sends the full history on each model request.
  Future deployment-session chat can reuse the same UI with a different history
  policy without adding session logic to this refactor.
- **Preserve one-shot behavior.** JSON, raw, and plain-text one-shot output continue
  through the existing command path and only reuse the extracted parsing helpers.
- **Keep this PR limited to reuse.** Session creation, discovery, resumption, and
  deployment-gateway wiring remain in the stacked follow-up branch.

## Type of Change

- [x] Code change (refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing model-chat behavior remains covered
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — internal refactor with no command-contract change

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] Branch-scoped pre-commit and pre-push hooks pass
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `.venv/bin/pytest packages/nemo_platform_ext/tests/cli/commands/use_cases/test_chat.py -q` — 34 passed
- `.venv/bin/ruff check --no-cache packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/use_cases/chat.py packages/nemo_platform_ext/tests/cli/commands/use_cases/test_chat.py`
- `.venv/bin/ruff format --check --no-cache packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/use_cases/chat.py packages/nemo_platform_ext/tests/cli/commands/use_cases/test_chat.py`
- `.venv/bin/ty check packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py packages/nemo_platform_ext/src/nemo_platform_ext/cli/commands/use_cases/chat.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable interactive terminal chat experience with streaming responses.
  - Added reasoning display, usage information, error handling, welcome/configuration views, and graceful exits.
  - Preserved conversation history across interactive chat turns.
  - Added optional initial messages and assistant-response recording.

- **Bug Fixes**
  - Improved streamed-response handling and incremental reasoning-markup processing.
  - Added graceful handling for interruptions during the initial response.

- **Tests**
  - Added coverage for conversation history and interruption handling across interactive turns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->