### PR TITLE
feat(agents): add deployment-backed sessions chat functionality

### DIFF
--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -5823,6 +5823,11 @@ nemo agents [OPTIONS] [COMMAND] [ARGS]...
 * `environments`: Manage agent environments.
 * `compute-specs`: Manage agent compute specs.
 
+*Deployed agent interaction (requires running cluster):*
+
+* `chat`: Chat interactively with a new or existing deployed-agent...
+* `sessions`: Discover and manage persisted deployed-agent sessions.
+
 *Jobs:*
 
 * `analyze`: Analyze a batch of eval-suite results (clusters,...
@@ -6517,6 +6522,122 @@ nemo agents compute-specs delete [OPTIONS] NAME
 **Arguments:**
 
 * `<NAME>`: Compute-spec name.
+
+**Options:**
+
+* `--workspace, -w`: [default: default]
+* `--base-url`: Platform base URL. Resolution order: (1) this --base-url flag or NEMO_BASE_URL; (2) shared CLI config (`nemo config set --base-url`) or NMP_BASE_URL; (3) http://localhost:8080 (default). [env: NEMO_BASE_URL=]
+* `--yes, -y`: Skip confirmation prompt.
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+#### nemo agents chat
+
+Chat interactively with a new or existing deployed-agent session.
+
+**Usage:**
+
+```shell
+nemo agents chat [OPTIONS]
+```
+
+**Options:**
+
+* `--input, -i`: Optional first message to send before prompting for the next turn.
+* `--agent-deployment, -d`: Deployment to start a new persisted session against.
+* `--session, -s`: Name of an existing persisted session to resume.
+* `--session-name`: Name for a new session; valid only with --agent-deployment.
+* `--workspace, -w`: [default: default]
+* `--base-url`: Platform base URL. Resolution order: (1) this --base-url flag or NEMO_BASE_URL; (2) shared CLI config (`nemo config set --base-url`) or NMP_BASE_URL; (3) http://localhost:8080 (default). [env: NEMO_BASE_URL=]
+* `--timeout, -t <FLOAT RANGE>`: Request timeout in seconds for each streamed agent turn. [default: 300] [env: NEMO_AGENTS_INVOKE_TIMEOUT=]
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+#### nemo agents sessions
+
+Discover and manage persisted deployed-agent sessions.
+
+**Usage:**
+
+```shell
+nemo agents sessions [OPTIONS] COMMAND [ARGS]...
+```
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Commands:**
+
+* `list`: List persisted sessions, newest first.
+* `get`: Get a persisted session by name.
+* `close`: Close a session and release its deployed runtime.
+
+##### nemo agents sessions list
+
+List persisted sessions, newest first.
+
+**Usage:**
+
+```shell
+nemo agents sessions list [OPTIONS]
+```
+
+**Options:**
+
+* `--agent-deployment, -d`: Limit results to sessions bound to this deployment.
+* `--workspace, -w`: [default: default]
+* `--base-url`: Platform base URL. Resolution order: (1) this --base-url flag or NEMO_BASE_URL; (2) shared CLI config (`nemo config set --base-url`) or NMP_BASE_URL; (3) http://localhost:8080 (default). [env: NEMO_BASE_URL=]
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+**Output Options:**
+
+* `--format, --output-format, -o, -f <CHOICE>`: Output format for the list of sessions. [possible values: table, json, yaml, csv, markdown, raw]
+* `--no-truncate`: Don't truncate long values in table/markdown/csv output.
+
+##### nemo agents sessions get
+
+Get a persisted session by name.
+
+**Usage:**
+
+```shell
+nemo agents sessions get [OPTIONS] NAME
+```
+
+**Arguments:**
+
+* `<NAME>`: Session name.
+
+**Options:**
+
+* `--workspace, -w`: [default: default]
+* `--base-url`: Platform base URL. Resolution order: (1) this --base-url flag or NEMO_BASE_URL; (2) shared CLI config (`nemo config set --base-url`) or NMP_BASE_URL; (3) http://localhost:8080 (default). [env: NEMO_BASE_URL=]
+
+**Help:**
+
+* `--help, -h`: Show this message and exit.
+
+##### nemo agents sessions close
+
+Close a session and release its deployed runtime.
+
+**Usage:**
+
+```shell
+nemo agents sessions close [OPTIONS] NAME
+```
+
+**Arguments:**
+
+* `<NAME>`: Session name.
 
 **Options:**
 

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py
@@ -9,8 +9,9 @@ import json
 import logging
 import re
 import sys
+from enum import Enum
 from types import TracebackType
-from typing import Any, Callable, Iterator, Literal, Protocol
+from typing import Any, Callable, Iterator, Protocol
 
 import click
 from nemo_platform._streaming import SSEDecoder
@@ -22,6 +23,18 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 
 from nemo_platform_ext.cli.core.help_formatter import _get_terminal_width
+
+
+class ExitAction(Enum):
+    """Presentation text for leaving a chat TUI."""
+
+    EXIT = ("exit", "Exit the chat", "Chat session ended")
+    DETACH = ("detach", "Detach from the session", "Session detached")
+
+    def __init__(self, verb: str, help_text: str, successful_exit_text: str) -> None:
+        self.verb = verb
+        self.help_text = help_text
+        self.successful_exit_text = successful_exit_text
 
 
 class StreamingBody(Protocol):
@@ -123,7 +136,7 @@ def run_chat_tui(
     system_message: str | None = None,
     initial_message: str | None = None,
     record_assistant_message: RecordAssistantMessage | None = None,
-    exit_action: Literal["exit", "detach"] = "exit",
+    exit_action: ExitAction = ExitAction.EXIT,
 ) -> None:
     """Run the shared interactive chat UI against a caller-provided transport."""
     root_logger = logging.getLogger()
@@ -309,10 +322,9 @@ def _clear_prompt_line() -> None:
     console.file.flush()
 
 
-def _exit_gracefully(exit_action: Literal["exit", "detach"]) -> None:
+def _exit_gracefully(exit_action: ExitAction) -> None:
     console.print("\n")
-    message = "Session detached" if exit_action == "detach" else "Chat session ended"
-    console.print(Panel.fit(f"[bold]{message}[/bold]", border_style="dim", padding=(0, 2)))
+    console.print(Panel.fit(f"[bold]{exit_action.successful_exit_text}[/bold]", border_style="dim", padding=(0, 2)))
     raise click.exceptions.Exit(0)
 
 
@@ -320,7 +332,7 @@ def _handle_special_command(
     command: str,
     last_thinking: str,
     thinking_displayed: bool,
-    exit_action: Literal["exit", "detach"],
+    exit_action: ExitAction,
 ) -> bool | None:
     if command in {"/thinking", "/t"}:
         if not last_thinking:
@@ -342,12 +354,11 @@ def _handle_special_command(
         return True
 
     if command in {"/help", "/h"}:
-        exit_help = "Detach from the session" if exit_action == "detach" else "Exit the chat"
         console.print(
             Panel(
                 "[cyan]/thinking[/cyan] - Show/hide model reasoning from last response\n"
                 "[cyan]/help[/cyan] - Show this help message\n"
-                f"[cyan]Ctrl+C[/cyan] - {exit_help}",
+                f"[cyan]Ctrl+C[/cyan] - {exit_action.help_text}",
                 title="[bold]Available Commands[/bold]",
                 border_style="blue",
                 padding=(0, 1),
@@ -370,7 +381,7 @@ def _print_welcome_header(
     temperature: float | None,
     max_tokens: int | None,
     system_message: str | None,
-    exit_action: Literal["exit", "detach"],
+    exit_action: ExitAction,
 ) -> None:
     config_lines = [f"[cyan]{key}:[/cyan] {value}" for key, value in display_info.items()]
 
@@ -384,7 +395,7 @@ def _print_welcome_header(
     welcome_panel = Panel(
         "\n".join(config_lines),
         title="[bold green]🤖 NeMo Platform Chat Session[/bold green]",
-        subtitle=f"Press Ctrl+C to {exit_action}",
+        subtitle=f"Press Ctrl+C to {exit_action.verb}",
         border_style="green",
         padding=(1, 2),
     )

--- a/packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py
+++ b/packages/nemo_platform_ext/src/nemo_platform_ext/cli/chat_tui.py
@@ -10,7 +10,7 @@ import logging
 import re
 import sys
 from types import TracebackType
-from typing import Any, Callable, Iterator, Protocol
+from typing import Any, Callable, Iterator, Literal, Protocol
 
 import click
 from nemo_platform._streaming import SSEDecoder
@@ -123,13 +123,14 @@ def run_chat_tui(
     system_message: str | None = None,
     initial_message: str | None = None,
     record_assistant_message: RecordAssistantMessage | None = None,
+    exit_action: Literal["exit", "detach"] = "exit",
 ) -> None:
     """Run the shared interactive chat UI against a caller-provided transport."""
     root_logger = logging.getLogger()
     initial_level = root_logger.level
     try:
         root_logger.setLevel(logging.CRITICAL)
-        _print_welcome_header(display_info, temperature, max_tokens, system_message)
+        _print_welcome_header(display_info, temperature, max_tokens, system_message, exit_action)
 
         last_thinking_content = ""
         thinking_displayed = False
@@ -155,6 +156,7 @@ def run_chat_tui(
                         user_input,
                         last_thinking_content,
                         thinking_displayed,
+                        exit_action,
                     )
                     if new_thinking_state is not None:
                         thinking_displayed = new_thinking_state
@@ -169,7 +171,7 @@ def run_chat_tui(
                         record_assistant_message(assistant_message)
 
         except (KeyboardInterrupt, EOFError):
-            _exit_gracefully()
+            _exit_gracefully(exit_action)
 
     finally:
         root_logger.setLevel(initial_level)
@@ -307,13 +309,19 @@ def _clear_prompt_line() -> None:
     console.file.flush()
 
 
-def _exit_gracefully() -> None:
+def _exit_gracefully(exit_action: Literal["exit", "detach"]) -> None:
     console.print("\n")
-    console.print(Panel.fit("[bold]Chat session ended[/bold]", border_style="dim", padding=(0, 2)))
+    message = "Session detached" if exit_action == "detach" else "Chat session ended"
+    console.print(Panel.fit(f"[bold]{message}[/bold]", border_style="dim", padding=(0, 2)))
     raise click.exceptions.Exit(0)
 
 
-def _handle_special_command(command: str, last_thinking: str, thinking_displayed: bool) -> bool | None:
+def _handle_special_command(
+    command: str,
+    last_thinking: str,
+    thinking_displayed: bool,
+    exit_action: Literal["exit", "detach"],
+) -> bool | None:
     if command in {"/thinking", "/t"}:
         if not last_thinking:
             console.print(Panel.fit("No reasoning content in the last response", border_style="yellow", padding=(0, 1)))
@@ -334,11 +342,12 @@ def _handle_special_command(command: str, last_thinking: str, thinking_displayed
         return True
 
     if command in {"/help", "/h"}:
+        exit_help = "Detach from the session" if exit_action == "detach" else "Exit the chat"
         console.print(
             Panel(
                 "[cyan]/thinking[/cyan] - Show/hide model reasoning from last response\n"
                 "[cyan]/help[/cyan] - Show this help message\n"
-                "[cyan]Ctrl+C[/cyan] - Exit the chat",
+                f"[cyan]Ctrl+C[/cyan] - {exit_help}",
                 title="[bold]Available Commands[/bold]",
                 border_style="blue",
                 padding=(0, 1),
@@ -361,6 +370,7 @@ def _print_welcome_header(
     temperature: float | None,
     max_tokens: int | None,
     system_message: str | None,
+    exit_action: Literal["exit", "detach"],
 ) -> None:
     config_lines = [f"[cyan]{key}:[/cyan] {value}" for key, value in display_info.items()]
 
@@ -374,7 +384,7 @@ def _print_welcome_header(
     welcome_panel = Panel(
         "\n".join(config_lines),
         title="[bold green]🤖 NeMo Platform Chat Session[/bold green]",
-        subtitle="Press Ctrl+C to exit",
+        subtitle=f"Press Ctrl+C to {exit_action}",
         border_style="green",
         padding=(1, 2),
     )

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -44,6 +44,7 @@ import re
 import sys
 import tempfile
 import time
+from contextlib import closing
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -83,8 +84,10 @@ from nemo_agents_plugin.entities import (
 )
 from nemo_agents_plugin.leaderboard.cli import register_leaderboard_commands
 from nemo_agents_plugin.session_lifecycle import session_expiration_is_due
+from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 from nemo_agents_plugin.usage.cli import register_usage_commands
 from nemo_platform import NeMoPlatform
+from nemo_platform_ext.cli.chat_tui import StreamingResponse, run_chat_tui
 from nemo_platform_ext.cli.core.api import is_tty
 from nemo_platform_ext.cli.core.formatters import Column, format_output
 from nemo_platform_ext.cli.core.help_formatter import NmpGroup
@@ -2205,8 +2208,48 @@ def _run_resolved_session_chat(
     timeout: float,
 ) -> None:
     """Run the shared TUI for an already-resolved session."""
-    typer.echo("Error: Session chat transport is not implemented yet.", err=True)
-    raise typer.Exit(code=1)
+    url = (
+        f"{base_url.rstrip('/')}/apis/agents/v2/workspaces/{workspace}"
+        f"/deployments/{deployment.name}/-/v1/chat/completions"
+    )
+    headers = {**_resolve_context_headers(), SESSION_ID_HEADER: session_id}
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+
+            def send_turn(user_input: str) -> StreamingResponse:
+                request = client.build_request(
+                    "POST",
+                    url,
+                    headers=headers,
+                    json={"messages": [{"role": "user", "content": user_input}], "stream": True},
+                )
+                response = client.send(request, stream=True)
+                try:
+                    response.raise_for_status()
+                except httpx.HTTPStatusError:
+                    response.read()
+                    response.close()
+                    raise
+                return cast(StreamingResponse, closing(response))
+
+            run_chat_tui(
+                send_turn=send_turn,
+                display_info={"Deployment": deployment.name, "Session": session.name},
+                initial_message=input,
+            )
+    except httpx.TimeoutException as exc:
+        typer.echo(
+            f"Error: session chat request timed out after {timeout:.0f}s. Use --timeout to increase it.",
+            err=True,
+        )
+        raise typer.Exit(code=1) from exc
+    except httpx.HTTPStatusError as exc:
+        print_http_status_error(exc, action="chat with deployed agent")
+        raise typer.Exit(code=1)
+    except httpx.RequestError as exc:
+        print_http_request_error(exc, action="chat with deployed agent")
+        raise typer.Exit(code=1)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -88,7 +88,7 @@ from nemo_agents_plugin.session_lifecycle import session_expiration_is_due
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
 from nemo_agents_plugin.usage.cli import register_usage_commands
 from nemo_platform import NeMoPlatform
-from nemo_platform_ext.cli.chat_tui import StreamingResponse, run_chat_tui
+from nemo_platform_ext.cli.chat_tui import ExitAction, StreamingResponse, run_chat_tui
 from nemo_platform_ext.cli.core.api import is_tty
 from nemo_platform_ext.cli.core.formatters import Column, format_output
 from nemo_platform_ext.cli.core.help_formatter import NmpGroup
@@ -1003,7 +1003,8 @@ def _register_platform_commands(app: typer.Typer) -> None:
                 base_url,
                 f"/apis/agents/v2/workspaces/{workspace}/deployments/{agent_deployment}",
             )
-            path += f"?{urlencode({'filter[deployment_id]': deployment['id']})}"
+            deployment_id = _require_deployment_id(deployment, agent_deployment)
+            path += f"?{urlencode({'filter[deployment_id]': deployment_id})}"
 
         resp = _api_request("GET", base_url, path)
         _print_list_response(
@@ -2250,7 +2251,7 @@ def _run_resolved_session_chat(
                 send_turn=send_turn,
                 display_info=display_info,
                 initial_message=input,
-                exit_action="detach",
+                exit_action=ExitAction.DETACH,
             )
     except httpx.TimeoutException as exc:
         typer.echo(
@@ -2271,6 +2272,18 @@ def _run_resolved_session_chat(
 # ---------------------------------------------------------------------------
 
 
+def _require_deployment_id(response: Any, deployment_name: str) -> str:
+    """Return a valid deployment ID or exit with the standard response error."""
+    try:
+        deployment_id = response["id"]
+        if not isinstance(deployment_id, str) or not deployment_id:
+            raise ValueError
+        return deployment_id
+    except (KeyError, TypeError, ValueError):
+        typer.echo(f"Error: Deployment '{deployment_name}' returned an invalid response.", err=True)
+        raise typer.Exit(code=1)
+
+
 def _create_session_for_deployment(
     *,
     base_url: str,
@@ -2284,10 +2297,8 @@ def _create_session_for_deployment(
         base_url,
         f"/apis/agents/v2/workspaces/{workspace}/deployments/{deployment_name}",
     )
+    deployment_id = _require_deployment_id(deployment_response, deployment_name)
     try:
-        deployment_id = deployment_response["id"]
-        if not isinstance(deployment_id, str) or not deployment_id:
-            raise ValueError
         deployment = AgentDeployment.model_validate(deployment_response)
     except (KeyError, TypeError, ValueError):
         typer.echo(f"Error: Deployment '{deployment_name}' returned an invalid response.", err=True)

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -45,7 +45,7 @@ import sys
 import tempfile
 import time
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from pkgutil import resolve_name
 from typing import Any, ClassVar, Literal, Optional, cast
@@ -78,9 +78,11 @@ from nemo_agents_plugin.entities import (
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
     AgentDeployment,
     AgentSession,
+    SessionStatus,
     ethos_fileset_name,
 )
 from nemo_agents_plugin.leaderboard.cli import register_leaderboard_commands
+from nemo_agents_plugin.session_lifecycle import session_expiration_is_due
 from nemo_agents_plugin.usage.cli import register_usage_commands
 from nemo_platform import NeMoPlatform
 from nemo_platform_ext.cli.core.api import is_tty
@@ -99,6 +101,7 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_WORKSPACE = "default"
 _LIST_OUTPUT_FORMAT = Literal["table", "json", "yaml", "csv", "markdown", "raw"]
+_DEPLOYMENT_RESOLUTION_PAGE_SIZE = 100
 
 _AGENT_LIST_COLUMNS = [
     Column("name"),
@@ -986,22 +989,19 @@ def _register_platform_commands(app: typer.Typer) -> None:
     ) -> None:
         """List persisted sessions, newest first."""
         base_url = _resolve_base_url(base_url)
-        deployment_id = None
+        path = f"/apis/agents/v2/workspaces/{workspace}/sessions"
         if agent_deployment is not None:
             if not agent_deployment.strip():
                 typer.echo("Error: --agent-deployment must not be empty.", err=True)
                 raise typer.Exit(code=2)
-            deployment_id = _get_deployment_id(
-                base_url=base_url,
-                workspace=workspace,
-                deployment_name=agent_deployment,
+            deployment = _api_request(
+                "GET",
+                base_url,
+                f"/apis/agents/v2/workspaces/{workspace}/deployments/{agent_deployment}",
             )
+            path += f"?{urlencode({'filter[deployment_id]': deployment['id']})}"
 
-        resp = _api_request(
-            "GET",
-            base_url,
-            _sessions_list_path(workspace=workspace, deployment_id=deployment_id),
-        )
+        resp = _api_request("GET", base_url, path)
         _print_list_response(
             ctx,
             resp,
@@ -1031,10 +1031,7 @@ def _register_platform_commands(app: typer.Typer) -> None:
         """Close a session and release its deployed runtime."""
         base_url = _resolve_base_url(base_url)
         if not yes:
-            typer.confirm(
-                f"Close session '{name}'? It cannot be resumed after it is closed.",
-                abort=True,
-            )
+            typer.confirm(f"Close session '{name}'? It cannot be resumed after it is closed.", abort=True)
         _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/sessions/{name}/close")
         typer.echo(f"Session '{name}' closed.")
 
@@ -2178,8 +2175,21 @@ def _platform_session_chat(
         return
 
     if session is not None:
-        typer.echo("Error: Existing session resumption is not implemented yet.", err=True)
-        raise typer.Exit(code=1)
+        deployment, resolved_session, session_id = _resolve_existing_session(
+            base_url=base_url,
+            workspace=workspace,
+            session_name=session,
+        )
+        _run_resolved_session_chat(
+            base_url=base_url,
+            workspace=workspace,
+            deployment=deployment,
+            session=resolved_session,
+            session_id=session_id,
+            input=input,
+            timeout=timeout,
+        )
+        return
     typer.echo("Error: Provide exactly one of --agent-deployment or --session.", err=True)
     raise typer.Exit(code=2)
 
@@ -2204,28 +2214,6 @@ def _run_resolved_session_chat(
 # ---------------------------------------------------------------------------
 
 
-def _sessions_list_path(*, workspace: str, deployment_id: str | None = None) -> str:
-    """Build the session-list path with the API's deep-object deployment filter."""
-    path = f"/apis/agents/v2/workspaces/{workspace}/sessions"
-    if deployment_id is None:
-        return path
-    return f"{path}?{urlencode({'filter[deployment_id]': deployment_id})}"
-
-
-def _get_deployment_id(*, base_url: str, workspace: str, deployment_name: str) -> str:
-    """Resolve a deployment's entity ID for APIs that filter by immutable ID."""
-    deployment = _api_request(
-        "GET",
-        base_url,
-        f"/apis/agents/v2/workspaces/{workspace}/deployments/{deployment_name}",
-    )
-    deployment_id = deployment.get("id") if isinstance(deployment, dict) else None
-    if not isinstance(deployment_id, str) or not deployment_id:
-        typer.echo(f"Error: Deployment '{deployment_name}' response did not include a valid ID.", err=True)
-        raise typer.Exit(code=1)
-    return deployment_id
-
-
 def _create_session_for_deployment(
     *,
     base_url: str,
@@ -2239,17 +2227,13 @@ def _create_session_for_deployment(
         base_url,
         f"/apis/agents/v2/workspaces/{workspace}/deployments/{deployment_name}",
     )
-    deployment_id = deployment_response.get("id") if isinstance(deployment_response, dict) else None
-    if not isinstance(deployment_id, str) or not deployment_id:
-        typer.echo(f"Error: Deployment '{deployment_name}' response did not include a valid ID.", err=True)
-        raise typer.Exit(code=1)
     try:
+        deployment_id = deployment_response["id"]
+        if not isinstance(deployment_id, str) or not deployment_id:
+            raise ValueError
         deployment = AgentDeployment.model_validate(deployment_response)
-    except ValidationError:
+    except (KeyError, TypeError, ValueError):
         typer.echo(f"Error: Deployment '{deployment_name}' returned an invalid response.", err=True)
-        raise typer.Exit(code=1)
-    if deployment.name != deployment_name or deployment.workspace != workspace:
-        typer.echo(f"Error: Deployment '{deployment_name}' returned mismatched identity metadata.", err=True)
         raise typer.Exit(code=1)
 
     config_format = deployment.config.get("config_format")
@@ -2276,23 +2260,99 @@ def _create_session_for_deployment(
         f"/apis/agents/v2/workspaces/{workspace}/sessions",
         json_body=payload,
     )
-    session_id = response.get("id") if isinstance(response, dict) else None
-    if not isinstance(session_id, str) or not session_id:
-        typer.echo("Error: Session creation response did not include a valid ID.", err=True)
-        raise typer.Exit(code=1)
     try:
+        session_id = response["id"]
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError
         created_session = AgentSession.model_validate(response)
-    except ValidationError:
+    except (KeyError, TypeError, ValueError):
         typer.echo("Error: Session creation returned an invalid response.", err=True)
-        raise typer.Exit(code=1)
-    if created_session.workspace != workspace or created_session.deployment_id != deployment_id:
-        typer.echo("Error: Session creation returned mismatched deployment or workspace metadata.", err=True)
-        raise typer.Exit(code=1)
-    if session_name is not None and created_session.name != session_name:
-        typer.echo("Error: Session creation returned a different name than requested.", err=True)
         raise typer.Exit(code=1)
 
     return deployment, created_session, session_id
+
+
+def _resolve_existing_session(
+    *,
+    base_url: str,
+    workspace: str,
+    session_name: str,
+) -> tuple[AgentDeployment, AgentSession, str]:
+    """Resolve a resumable persisted session and its bound deployment."""
+    response = _api_request(
+        "GET",
+        base_url,
+        f"/apis/agents/v2/workspaces/{workspace}/sessions/{session_name}",
+    )
+    try:
+        session_id = response["id"]
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError
+        resolved_session = AgentSession.model_validate(response)
+    except (KeyError, TypeError, ValueError):
+        typer.echo(f"Error: Session '{session_name}' returned an invalid response.", err=True)
+        raise typer.Exit(code=1)
+    if resolved_session.status is not SessionStatus.ACTIVE:
+        typer.echo(
+            f"Error: Session '{session_name}' is {resolved_session.status.value} and cannot be resumed.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if session_expiration_is_due(resolved_session, at=datetime.now(UTC)):
+        typer.echo(f"Error: Session '{session_name}' is expired and cannot be resumed.", err=True)
+        raise typer.Exit(code=1)
+
+    deployment = _resolve_deployment_by_id(
+        base_url=base_url,
+        workspace=workspace,
+        deployment_id=resolved_session.deployment_id,
+        session_name=session_name,
+    )
+    return deployment, resolved_session, session_id
+
+
+def _resolve_deployment_by_id(
+    *,
+    base_url: str,
+    workspace: str,
+    deployment_id: str,
+    session_name: str,
+) -> AgentDeployment:
+    """Find a session's bound deployment through the paginated list API."""
+    page = 1
+    while True:
+        query = urlencode({"page": page, "page_size": _DEPLOYMENT_RESOLUTION_PAGE_SIZE})
+        response = _api_request(
+            "GET",
+            base_url,
+            f"/apis/agents/v2/workspaces/{workspace}/deployments?{query}",
+        )
+        for candidate in _unwrap_list(response):
+            if candidate.get("id") != deployment_id:
+                continue
+            try:
+                deployment = AgentDeployment.model_validate(candidate)
+            except ValidationError:
+                typer.echo(
+                    f"Error: Deployment ID '{deployment_id}' for session '{session_name}' "
+                    "returned an invalid response.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+            return deployment
+
+        pagination = response.get("pagination") if isinstance(response, dict) else None
+        total_pages = pagination.get("total_pages") if isinstance(pagination, dict) else None
+        if not isinstance(total_pages, int) or page >= total_pages:
+            break
+        page += 1
+
+    typer.echo(
+        f"Error: Session '{session_name}' references deployment ID '{deployment_id}', "
+        f"but no matching deployment exists in workspace '{workspace}'.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
 
 
 def _unwrap_list(resp: Any) -> list[dict[str, Any]]:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -51,7 +51,6 @@ from pkgutil import resolve_name
 from typing import Any, ClassVar, Literal, Optional, cast
 from urllib.parse import urlencode
 
-import click
 import httpx
 import typer
 import yaml
@@ -67,6 +66,7 @@ from nemo_agents_plugin.cli_context import (
 from nemo_agents_plugin.cli_context import (
     resolve_context_headers as _resolve_context_headers,
 )
+from nemo_agents_plugin.deployment_routing import is_deployment_routable
 from nemo_agents_plugin.entities import (
     AGENT_SPEC_FILENAME,
     CONTAINER_DEPLOYMENT_MODES,
@@ -76,6 +76,8 @@ from nemo_agents_plugin.entities import (
     MAX_ETHOS_STAGED_FILES,
     NAT_WORKFLOW_CONFIG_FORMAT,
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
+    AgentDeployment,
+    AgentSession,
     ethos_fileset_name,
 )
 from nemo_agents_plugin.leaderboard.cli import register_leaderboard_commands
@@ -91,11 +93,13 @@ from nemo_platform_plugin.cli_progress import request_progress
 from nemo_platform_plugin.discovery import AGENT_CLI_GROUP, discover_entry_points
 from nemo_platform_plugin.job import NemoJob
 from typer.main import get_command as _typer_get_command
+from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_WORKSPACE = "default"
 _LIST_OUTPUT_FORMAT = Literal["table", "json", "yaml", "csv", "markdown", "raw"]
+
 _AGENT_LIST_COLUMNS = [
     Column("name"),
     Column("workspace"),
@@ -929,9 +933,12 @@ def _register_platform_commands(app: typer.Typer) -> None:
             input=input,
         )
         if not _is_interactive_session_chat():
-            raise click.UsageError(
-                "Agent chat requires an interactive terminal. Use `nemo agents invoke` for one-shot or scripted input."
+            typer.echo(
+                "Error: Agent chat requires an interactive terminal. "
+                "Use `nemo agents invoke` for one-shot or scripted input.",
+                err=True,
             )
+            raise typer.Exit(code=2)
 
         _platform_session_chat(
             base_url=_resolve_base_url(base_url),
@@ -982,7 +989,8 @@ def _register_platform_commands(app: typer.Typer) -> None:
         deployment_id = None
         if agent_deployment is not None:
             if not agent_deployment.strip():
-                raise click.UsageError("--agent-deployment must not be empty.")
+                typer.echo("Error: --agent-deployment must not be empty.", err=True)
+                raise typer.Exit(code=2)
             deployment_id = _get_deployment_id(
                 base_url=base_url,
                 workspace=workspace,
@@ -2035,7 +2043,6 @@ def _local_fabric_invoke(config: dict[str, Any], inputs: list[Any], *, base_dir:
     from nemo_agents_plugin.fabric.invocation import invoke_agent_config_once
     from nemo_agents_plugin.fabric.runtime import FabricRuntimeExecutionError
     from nemo_agents_plugin.fabric.translator import FabricTranslationError
-    from pydantic import ValidationError
 
     try:
         agent_config = AgentConfig.model_validate(config)
@@ -2121,18 +2128,24 @@ def _validate_session_chat_options(
 ) -> None:
     """Validate the mutually exclusive new-session and resume selectors."""
     if agent_deployment is not None and not agent_deployment.strip():
-        raise click.UsageError("--agent-deployment must not be empty.")
+        typer.echo("Error: --agent-deployment must not be empty.", err=True)
+        raise typer.Exit(code=2)
     if session is not None and not session.strip():
-        raise click.UsageError("--session must not be empty.")
+        typer.echo("Error: --session must not be empty.", err=True)
+        raise typer.Exit(code=2)
     if session_name is not None and not session_name.strip():
-        raise click.UsageError("--session-name must not be empty.")
+        typer.echo("Error: --session-name must not be empty.", err=True)
+        raise typer.Exit(code=2)
     if input is not None and not input.strip():
-        raise click.UsageError("--input must not be empty.")
+        typer.echo("Error: --input must not be empty.", err=True)
+        raise typer.Exit(code=2)
 
     if (agent_deployment is None) == (session is None):
-        raise click.UsageError("Provide exactly one of --agent-deployment or --session.")
+        typer.echo("Error: Provide exactly one of --agent-deployment or --session.", err=True)
+        raise typer.Exit(code=2)
     if session_name is not None and agent_deployment is None:
-        raise click.UsageError("--session-name can only be used with --agent-deployment.")
+        typer.echo("Error: --session-name can only be used with --agent-deployment.", err=True)
+        raise typer.Exit(code=2)
 
 
 def _platform_session_chat(
@@ -2145,13 +2158,45 @@ def _platform_session_chat(
     input: str | None,
     timeout: float,
 ) -> None:
-    """Run deployed-agent session chat after command validation.
+    """Resolve a new or existing persisted session, then enter its chat transport."""
+    if agent_deployment is not None:
+        deployment, created_session, session_id = _create_session_for_deployment(
+            base_url=base_url,
+            workspace=workspace,
+            deployment_name=agent_deployment,
+            session_name=session_name,
+        )
+        _run_resolved_session_chat(
+            base_url=base_url,
+            workspace=workspace,
+            deployment=deployment,
+            session=created_session,
+            session_id=session_id,
+            input=input,
+            timeout=timeout,
+        )
+        return
 
-    Session creation, resumption, and gateway transport are implemented by
-    the subsequent session-chat steps; this boundary keeps their behavior
-    separate from the public CLI contract.
-    """
-    raise click.ClickException("Session chat execution is not implemented yet.")
+    if session is not None:
+        typer.echo("Error: Existing session resumption is not implemented yet.", err=True)
+        raise typer.Exit(code=1)
+    typer.echo("Error: Provide exactly one of --agent-deployment or --session.", err=True)
+    raise typer.Exit(code=2)
+
+
+def _run_resolved_session_chat(
+    *,
+    base_url: str,
+    workspace: str,
+    deployment: AgentDeployment,
+    session: AgentSession,
+    session_id: str,
+    input: str | None,
+    timeout: float,
+) -> None:
+    """Run the shared TUI for an already-resolved session."""
+    typer.echo("Error: Session chat transport is not implemented yet.", err=True)
+    raise typer.Exit(code=1)
 
 
 # ---------------------------------------------------------------------------
@@ -2176,8 +2221,78 @@ def _get_deployment_id(*, base_url: str, workspace: str, deployment_name: str) -
     )
     deployment_id = deployment.get("id") if isinstance(deployment, dict) else None
     if not isinstance(deployment_id, str) or not deployment_id:
-        raise click.ClickException(f"Deployment '{deployment_name}' response did not include a valid ID.")
+        typer.echo(f"Error: Deployment '{deployment_name}' response did not include a valid ID.", err=True)
+        raise typer.Exit(code=1)
     return deployment_id
+
+
+def _create_session_for_deployment(
+    *,
+    base_url: str,
+    workspace: str,
+    deployment_name: str,
+    session_name: str | None,
+) -> tuple[AgentDeployment, AgentSession, str]:
+    """Validate a Fabric deployment and create its persisted Platform session."""
+    deployment_response = _api_request(
+        "GET",
+        base_url,
+        f"/apis/agents/v2/workspaces/{workspace}/deployments/{deployment_name}",
+    )
+    deployment_id = deployment_response.get("id") if isinstance(deployment_response, dict) else None
+    if not isinstance(deployment_id, str) or not deployment_id:
+        typer.echo(f"Error: Deployment '{deployment_name}' response did not include a valid ID.", err=True)
+        raise typer.Exit(code=1)
+    try:
+        deployment = AgentDeployment.model_validate(deployment_response)
+    except ValidationError:
+        typer.echo(f"Error: Deployment '{deployment_name}' returned an invalid response.", err=True)
+        raise typer.Exit(code=1)
+    if deployment.name != deployment_name or deployment.workspace != workspace:
+        typer.echo(f"Error: Deployment '{deployment_name}' returned mismatched identity metadata.", err=True)
+        raise typer.Exit(code=1)
+
+    config_format = deployment.config.get("config_format")
+    if config_format != NEMO_AGENTS_SPEC_CONFIG_FORMAT:
+        typer.echo(
+            f"Error: Deployment '{deployment.name}' is not Fabric-backed (config_format={config_format!r}).",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+    if not is_deployment_routable(deployment):
+        typer.echo(
+            f"Error: Deployment '{deployment.name}' is not routable "
+            f"(mode='{deployment.deployment_mode}', status='{deployment.status}').",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    payload = {"deployment_id": deployment_id}
+    if session_name is not None:
+        payload["name"] = session_name
+    response = _api_request(
+        "POST",
+        base_url,
+        f"/apis/agents/v2/workspaces/{workspace}/sessions",
+        json_body=payload,
+    )
+    session_id = response.get("id") if isinstance(response, dict) else None
+    if not isinstance(session_id, str) or not session_id:
+        typer.echo("Error: Session creation response did not include a valid ID.", err=True)
+        raise typer.Exit(code=1)
+    try:
+        created_session = AgentSession.model_validate(response)
+    except ValidationError:
+        typer.echo("Error: Session creation returned an invalid response.", err=True)
+        raise typer.Exit(code=1)
+    if created_session.workspace != workspace or created_session.deployment_id != deployment_id:
+        typer.echo("Error: Session creation returned mismatched deployment or workspace metadata.", err=True)
+        raise typer.Exit(code=1)
+    if session_name is not None and created_session.name != session_name:
+        typer.echo("Error: Session creation returned a different name than requested.", err=True)
+        raise typer.Exit(code=1)
+
+    return deployment, created_session, session_id
 
 
 def _unwrap_list(resp: Any) -> list[dict[str, Any]]:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -27,6 +27,7 @@ group at startup. Numeric optimize is likewise auto-injected from
 - ``get``          — get an agent by name
 - ``delete``       — delete an agent
 - ``deploy``       — create a deployment for an agent (waits for ``running`` by default)
+- ``chat``         — open an interactive new or existing deployed-agent session
 - ``undeploy``     — stop and remove a deployment
 - ``logs``         — print or tail the local deployment log file
 - ``deployments``  — sub-group: list / get / delete deployments
@@ -78,8 +79,10 @@ from nemo_agents_plugin.entities import (
 from nemo_agents_plugin.leaderboard.cli import register_leaderboard_commands
 from nemo_agents_plugin.usage.cli import register_usage_commands
 from nemo_platform import NeMoPlatform
+from nemo_platform_ext.cli.core.api import is_tty
 from nemo_platform_ext.cli.core.formatters import Column, format_output
 from nemo_platform_ext.cli.core.help_formatter import NmpGroup
+from nemo_platform_ext.ui.prompts import is_interactive
 from nemo_platform_plugin.cli import NemoCLI
 from nemo_platform_plugin.cli_errors import print_http_request_error, print_http_status_error
 from nemo_platform_plugin.cli_progress import request_progress
@@ -871,6 +874,64 @@ def _package_render_only(
 
 def _register_platform_commands(app: typer.Typer) -> None:
     """Register Agent Resources commands (require a running cluster) onto *app*."""
+
+    @app.command(rich_help_panel="Deployed agent interaction (requires running cluster)")
+    def chat(
+        input: Optional[str] = typer.Option(
+            None,
+            "--input",
+            "-i",
+            help="Optional first message to send before prompting for the next turn.",
+        ),
+        agent_deployment: Optional[str] = typer.Option(
+            None,
+            "--agent-deployment",
+            "-d",
+            help="Deployment to start a new persisted session against.",
+        ),
+        session: Optional[str] = typer.Option(
+            None,
+            "--session",
+            "-s",
+            help="Name of an existing persisted session to resume.",
+        ),
+        session_name: Optional[str] = typer.Option(
+            None,
+            "--session-name",
+            help="Name for a new session; valid only with --agent-deployment.",
+        ),
+        workspace: str = typer.Option(_DEFAULT_WORKSPACE, "--workspace", "-w"),
+        base_url: BaseUrlOption = None,
+        timeout: float = typer.Option(
+            300,
+            "--timeout",
+            "-t",
+            min=0.001,
+            envvar="NEMO_AGENTS_INVOKE_TIMEOUT",
+            help="Request timeout in seconds for each streamed agent turn.",
+        ),
+    ) -> None:
+        """Chat interactively with a new or existing deployed-agent session."""
+        _validate_session_chat_options(
+            agent_deployment=agent_deployment,
+            session=session,
+            session_name=session_name,
+            input=input,
+        )
+        if not _is_interactive_session_chat():
+            raise click.UsageError(
+                "Agent chat requires an interactive terminal. Use `nemo agents invoke` for one-shot or scripted input."
+            )
+
+        _platform_session_chat(
+            base_url=_resolve_base_url(base_url),
+            workspace=workspace,
+            agent_deployment=agent_deployment,
+            session=session,
+            session_name=session_name,
+            input=input,
+            timeout=timeout,
+        )
 
     @app.command(rich_help_panel="Agent Resources (requires running cluster)")
     def create(
@@ -1947,6 +2008,53 @@ def _platform_invoke(
         except httpx.RequestError as exc:
             print_http_request_error(exc, action="invoke agent")
             raise typer.Exit(code=1)
+
+
+def _is_interactive_session_chat() -> bool:
+    """Return whether the process can safely run the agent chat TUI."""
+    return is_interactive() and is_tty()
+
+
+def _validate_session_chat_options(
+    *,
+    agent_deployment: str | None,
+    session: str | None,
+    session_name: str | None,
+    input: str | None,
+) -> None:
+    """Validate the mutually exclusive new-session and resume selectors."""
+    if agent_deployment is not None and not agent_deployment.strip():
+        raise click.UsageError("--agent-deployment must not be empty.")
+    if session is not None and not session.strip():
+        raise click.UsageError("--session must not be empty.")
+    if session_name is not None and not session_name.strip():
+        raise click.UsageError("--session-name must not be empty.")
+    if input is not None and not input.strip():
+        raise click.UsageError("--input must not be empty.")
+
+    if (agent_deployment is None) == (session is None):
+        raise click.UsageError("Provide exactly one of --agent-deployment or --session.")
+    if session_name is not None and agent_deployment is None:
+        raise click.UsageError("--session-name can only be used with --agent-deployment.")
+
+
+def _platform_session_chat(
+    *,
+    base_url: str,
+    workspace: str,
+    agent_deployment: str | None,
+    session: str | None,
+    session_name: str | None,
+    input: str | None,
+    timeout: float,
+) -> None:
+    """Run deployed-agent session chat after command validation.
+
+    Session creation, resumption, and gateway transport are implemented by
+    the subsequent session-chat steps; this boundary keeps their behavior
+    separate from the public CLI contract.
+    """
+    raise click.ClickException("Session chat execution is not implemented yet.")
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -2183,25 +2183,22 @@ def _platform_session_chat(
         )
         return
 
-    if session is not None:
-        deployment, resolved_session, session_id = _resolve_existing_session(
-            base_url=base_url,
-            workspace=workspace,
-            session_name=session,
-        )
-        typer.echo("Resuming runtime context; prior messages are not redisplayed.")
-        _run_resolved_session_chat(
-            base_url=base_url,
-            workspace=workspace,
-            deployment=deployment,
-            session=resolved_session,
-            session_id=session_id,
-            input=input,
-            timeout=timeout,
-        )
-        return
-    typer.echo("Error: Provide exactly one of --agent-deployment or --session.", err=True)
-    raise typer.Exit(code=2)
+    assert session is not None
+    deployment, resolved_session, session_id = _resolve_existing_session(
+        base_url=base_url,
+        workspace=workspace,
+        session_name=session,
+    )
+    typer.echo("Resuming runtime context; prior messages are not redisplayed.")
+    _run_resolved_session_chat(
+        base_url=base_url,
+        workspace=workspace,
+        deployment=deployment,
+        session=resolved_session,
+        session_id=session_id,
+        input=input,
+        timeout=timeout,
+    )
 
 
 def _run_resolved_session_chat(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -52,6 +52,7 @@ from pkgutil import resolve_name
 from typing import Any, ClassVar, Literal, Optional, cast
 from urllib.parse import urlencode
 
+import click
 import httpx
 import typer
 import yaml
@@ -97,8 +98,8 @@ from nemo_platform_plugin.cli_errors import print_http_request_error, print_http
 from nemo_platform_plugin.cli_progress import request_progress
 from nemo_platform_plugin.discovery import AGENT_CLI_GROUP, discover_entry_points
 from nemo_platform_plugin.job import NemoJob
-from typer.main import get_command as _typer_get_command
 from pydantic import ValidationError
+from typer.main import get_command as _typer_get_command
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -28,6 +28,7 @@ group at startup. Numeric optimize is likewise auto-injected from
 - ``delete``       — delete an agent
 - ``deploy``       — create a deployment for an agent (waits for ``running`` by default)
 - ``chat``         — open an interactive new or existing deployed-agent session
+- ``sessions``     — sub-group: list / get / close persisted sessions
 - ``undeploy``     — stop and remove a deployment
 - ``logs``         — print or tail the local deployment log file
 - ``deployments``  — sub-group: list / get / delete deployments
@@ -48,6 +49,7 @@ from datetime import datetime
 from pathlib import Path
 from pkgutil import resolve_name
 from typing import Any, ClassVar, Literal, Optional, cast
+from urllib.parse import urlencode
 
 import click
 import httpx
@@ -107,6 +109,14 @@ _DEPLOYMENT_LIST_COLUMNS = [
     Column("workspace"),
     Column("status"),
     Column("endpoint"),
+    Column("created_at"),
+]
+_SESSION_LIST_COLUMNS = [
+    Column("name"),
+    Column("status"),
+    Column("deployment_id"),
+    Column("last_active_at"),
+    Column("expires_at"),
     Column("created_at"),
 ]
 _ENVIRONMENT_LIST_COLUMNS = [
@@ -932,6 +942,93 @@ def _register_platform_commands(app: typer.Typer) -> None:
             input=input,
             timeout=timeout,
         )
+
+    sessions_app = typer.Typer(
+        name="sessions",
+        help="Discover and manage persisted deployed-agent sessions.",
+        no_args_is_help=True,
+    )
+    app.add_typer(sessions_app, rich_help_panel="Deployed agent interaction (requires running cluster)")
+
+    @sessions_app.command(name="list")
+    def sessions_list(
+        ctx: typer.Context,
+        agent_deployment: Optional[str] = typer.Option(
+            None,
+            "--agent-deployment",
+            "-d",
+            help="Limit results to sessions bound to this deployment.",
+        ),
+        workspace: str = typer.Option(_DEFAULT_WORKSPACE, "--workspace", "-w"),
+        base_url: BaseUrlOption = None,
+        output_format: Optional[_LIST_OUTPUT_FORMAT] = typer.Option(
+            None,
+            "--format",
+            "--output-format",
+            "-o",
+            "-f",
+            help="Output format for the list of sessions.",
+            rich_help_panel="Output Options",
+        ),
+        no_truncate: Optional[bool] = typer.Option(
+            None,
+            "--no-truncate",
+            help="Don't truncate long values in table/markdown/csv output.",
+            rich_help_panel="Output Options",
+        ),
+    ) -> None:
+        """List persisted sessions, newest first."""
+        base_url = _resolve_base_url(base_url)
+        deployment_id = None
+        if agent_deployment is not None:
+            if not agent_deployment.strip():
+                raise click.UsageError("--agent-deployment must not be empty.")
+            deployment_id = _get_deployment_id(
+                base_url=base_url,
+                workspace=workspace,
+                deployment_name=agent_deployment,
+            )
+
+        resp = _api_request(
+            "GET",
+            base_url,
+            _sessions_list_path(workspace=workspace, deployment_id=deployment_id),
+        )
+        _print_list_response(
+            ctx,
+            resp,
+            default_columns=_SESSION_LIST_COLUMNS,
+            output_format=output_format,
+            no_truncate=no_truncate,
+        )
+
+    @sessions_app.command(name="get")
+    def sessions_get(
+        name: str = typer.Argument(..., help="Session name."),
+        workspace: str = typer.Option(_DEFAULT_WORKSPACE, "--workspace", "-w"),
+        base_url: BaseUrlOption = None,
+    ) -> None:
+        """Get a persisted session by name."""
+        base_url = _resolve_base_url(base_url)
+        resp = _api_request("GET", base_url, f"/apis/agents/v2/workspaces/{workspace}/sessions/{name}")
+        typer.echo(json.dumps(resp, indent=2))
+
+    @sessions_app.command(name="close")
+    def sessions_close(
+        name: str = typer.Argument(..., help="Session name."),
+        workspace: str = typer.Option(_DEFAULT_WORKSPACE, "--workspace", "-w"),
+        base_url: BaseUrlOption = None,
+        yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    ) -> None:
+        """Close a session and release its deployed runtime."""
+        base_url = _resolve_base_url(base_url)
+        if not yes:
+            typer.confirm(
+                f"Close session '{name}'? It cannot be resumed after it is closed.",
+                abort=True,
+            )
+        _api_request("POST", base_url, f"/apis/agents/v2/workspaces/{workspace}/sessions/{name}/close")
+        typer.echo(f"Session '{name}' closed.")
 
     @app.command(rich_help_panel="Agent Resources (requires running cluster)")
     def create(
@@ -2060,6 +2157,27 @@ def _platform_session_chat(
 # ---------------------------------------------------------------------------
 # Platform API helpers
 # ---------------------------------------------------------------------------
+
+
+def _sessions_list_path(*, workspace: str, deployment_id: str | None = None) -> str:
+    """Build the session-list path with the API's deep-object deployment filter."""
+    path = f"/apis/agents/v2/workspaces/{workspace}/sessions"
+    if deployment_id is None:
+        return path
+    return f"{path}?{urlencode({'filter[deployment_id]': deployment_id})}"
+
+
+def _get_deployment_id(*, base_url: str, workspace: str, deployment_name: str) -> str:
+    """Resolve a deployment's entity ID for APIs that filter by immutable ID."""
+    deployment = _api_request(
+        "GET",
+        base_url,
+        f"/apis/agents/v2/workspaces/{workspace}/deployments/{deployment_name}",
+    )
+    deployment_id = deployment.get("id") if isinstance(deployment, dict) else None
+    if not isinstance(deployment_id, str) or not deployment_id:
+        raise click.ClickException(f"Deployment '{deployment_name}' response did not include a valid ID.")
+    return deployment_id
 
 
 def _unwrap_list(resp: Any) -> list[dict[str, Any]]:

--- a/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/cli.py
@@ -2166,6 +2166,10 @@ def _platform_session_chat(
             deployment_name=agent_deployment,
             session_name=session_name,
         )
+        typer.echo(
+            f"Session '{created_session.name}' created. Resume with:\n"
+            f"  nemo agents chat --session {created_session.name} --workspace {workspace} --base-url {base_url}"
+        )
         _run_resolved_session_chat(
             base_url=base_url,
             workspace=workspace,
@@ -2183,6 +2187,7 @@ def _platform_session_chat(
             workspace=workspace,
             session_name=session,
         )
+        typer.echo("Resuming runtime context; prior messages are not redisplayed.")
         _run_resolved_session_chat(
             base_url=base_url,
             workspace=workspace,
@@ -2213,6 +2218,13 @@ def _run_resolved_session_chat(
         f"/deployments/{deployment.name}/-/v1/chat/completions"
     )
     headers = {**_resolve_context_headers(), SESSION_ID_HEADER: session_id}
+    display_info = {
+        "Deployment": deployment.name,
+        "Session": session.name,
+        "Status": session.status.value,
+    }
+    if session.expires_at is not None:
+        display_info["Expires"] = session.expires_at.isoformat()
 
     try:
         with httpx.Client(timeout=timeout) as client:
@@ -2235,8 +2247,9 @@ def _run_resolved_session_chat(
 
             run_chat_tui(
                 send_turn=send_turn,
-                display_info={"Deployment": deployment.name, "Session": session.name},
+                display_info=display_info,
                 initial_message=input,
+                exit_action="detach",
             )
     except httpx.TimeoutException as exc:
         typer.echo(

--- a/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/runner/controller.py
@@ -677,6 +677,8 @@ class AgentDeploymentController(NemoController):
         healthy = bool(dep.endpoint) and await backend.health_check(dep.endpoint)
 
         if healthy:
+            if info is not None:
+                info.status = "running"
             dep.status = "running"
             self._starting_since.pop((dep.workspace, dep.name), None)
             await self._observe_runtime_instance(dep)

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import call, patch
 
@@ -16,6 +17,7 @@ from nemo_agents_plugin.entities import (
     AgentDeployment,
     AgentSession,
     DeploymentStatus,
+    SessionStatus,
 )
 from typer.testing import CliRunner
 
@@ -29,6 +31,7 @@ def _deployment_response(
     config_format: str = NEMO_AGENTS_SPEC_CONFIG_FORMAT,
     status: DeploymentStatus = "running",
     endpoint: str = "http://127.0.0.1:9001",
+    deployment_id: str = "deployment-id",
 ) -> dict[str, Any]:
     response = AgentDeployment(
         name=name,
@@ -38,7 +41,7 @@ def _deployment_response(
         status=status,
         endpoint=endpoint,
     ).model_dump(mode="json")
-    response["id"] = "deployment-id"
+    response["id"] = deployment_id
     return response
 
 
@@ -47,14 +50,35 @@ def _session_response(
     name: str = "debug-auth",
     workspace: str = "default",
     deployment_id: str = "deployment-id",
+    status: SessionStatus = SessionStatus.ACTIVE,
+    expires_at: datetime | None = None,
 ) -> dict[str, Any]:
     response = AgentSession(
         name=name,
         workspace=workspace,
         deployment_id=deployment_id,
+        status=status,
+        expires_at=expires_at,
     ).model_dump(mode="json")
     response["id"] = "session-id"
     return response
+
+
+def _deployment_page(
+    *deployments: dict[str, Any],
+    page: int = 1,
+    total_pages: int = 1,
+) -> dict[str, Any]:
+    return {
+        "data": list(deployments),
+        "pagination": {
+            "page": page,
+            "page_size": 100,
+            "current_page_size": len(deployments),
+            "total_pages": total_pages,
+            "total_results": len(deployments),
+        },
+    }
 
 
 def test_session_chat_help_describes_new_and_resumed_sessions() -> None:
@@ -245,6 +269,156 @@ def test_session_chat_preserves_api_generated_session_name() -> None:
     assert run_chat.call_args.kwargs["session_id"] == "session-id"
 
 
+def test_session_chat_resumes_active_session_and_passes_values_to_transport() -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            side_effect=[
+                _session_response(),
+                _deployment_page(_deployment_response()),
+            ],
+        ) as api_request,
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(
+            AgentsCLI().get_cli(),
+            ["chat", "--session", "debug-auth", "--input", "Continue debugging", "--timeout", "42"],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert api_request.call_args_list == [
+        call(
+            "GET",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/sessions/debug-auth",
+        ),
+        call(
+            "GET",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/deployments?page=1&page_size=100",
+        ),
+    ]
+    run_chat.assert_called_once()
+    run_kwargs = run_chat.call_args.kwargs
+    assert run_kwargs["base_url"] == "http://localhost:8080"
+    assert run_kwargs["workspace"] == "default"
+    assert run_kwargs["input"] == "Continue debugging"
+    assert run_kwargs["timeout"] == 42.0
+    assert run_kwargs["deployment"].name == "fabric-deployment"
+    assert run_kwargs["session"].name == "debug-auth"
+    assert run_kwargs["session_id"] == "session-id"
+
+
+def test_session_chat_pages_until_it_finds_the_session_deployment() -> None:
+    target_id = "target-deployment-id"
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            side_effect=[
+                _session_response(deployment_id=target_id),
+                _deployment_page(
+                    _deployment_response(name="unrelated", deployment_id="unrelated-id"),
+                    page=1,
+                    total_pages=2,
+                ),
+                _deployment_page(
+                    _deployment_response(deployment_id=target_id),
+                    page=2,
+                    total_pages=2,
+                ),
+            ],
+        ) as api_request,
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
+
+    assert result.exit_code == 0, result.stderr
+    assert api_request.call_args_list[-2:] == [
+        call(
+            "GET",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/deployments?page=1&page_size=100",
+        ),
+        call(
+            "GET",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/deployments?page=2&page_size=100",
+        ),
+    ]
+    assert run_chat.call_args.kwargs["deployment"].name == "fabric-deployment"
+    assert run_chat.call_args.kwargs["session_id"] == "session-id"
+
+
+@pytest.mark.parametrize("status", [SessionStatus.CLOSED, SessionStatus.EXPIRED, SessionStatus.LOST])
+def test_session_chat_rejects_terminal_session_before_deployment_lookup(status: SessionStatus) -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            return_value=_session_response(status=status),
+        ) as api_request,
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
+
+    assert result.exit_code == 1
+    assert f"is {status.value} and cannot be resumed" in result.stderr
+    api_request.assert_called_once()
+    run_chat.assert_not_called()
+
+
+def test_session_chat_rejects_active_session_past_its_expiration_deadline() -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            return_value=_session_response(expires_at=datetime(2000, 1, 1, tzinfo=UTC)),
+        ) as api_request,
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
+
+    assert result.exit_code == 1
+    assert "is expired and cannot be resumed" in result.stderr
+    api_request.assert_called_once()
+    run_chat.assert_not_called()
+
+
+def test_session_chat_rejects_session_whose_deployment_no_longer_exists() -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            side_effect=[_session_response(), _deployment_page()],
+        ),
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
+
+    assert result.exit_code == 1
+    assert "references deployment ID 'deployment-id'" in result.stderr
+    assert "no matching deployment exists" in result.stderr
+    run_chat.assert_not_called()
+
+
+def test_session_chat_rejects_invalid_session_lookup_response() -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            return_value={"name": "debug-auth", "deployment_id": "deployment-id"},
+        ),
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
+
+    assert result.exit_code == 1
+    assert "returned an invalid response" in result.stderr
+    run_chat.assert_not_called()
+
+
 def test_session_chat_rejects_non_fabric_deployment_before_session_creation() -> None:
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
@@ -295,23 +469,15 @@ def test_session_chat_rejects_unroutable_deployment_before_session_creation(
     run_chat.assert_not_called()
 
 
-@pytest.mark.parametrize(
-    ("session_response", "message"),
-    [
-        ({"name": "debug-auth", "deployment_id": "deployment-id"}, "did not include a valid ID"),
-        (_session_response(deployment_id="other-deployment-id"), "mismatched deployment or workspace"),
-        (_session_response(name="different-name"), "different name than requested"),
-    ],
-)
-def test_session_chat_rejects_invalid_session_creation_response(
-    session_response: dict[str, Any],
-    message: str,
-) -> None:
+def test_session_chat_rejects_invalid_session_creation_response() -> None:
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
         patch(
             "nemo_agents_plugin.cli._api_request",
-            side_effect=[_deployment_response(), session_response],
+            side_effect=[
+                _deployment_response(),
+                {"name": "debug-auth", "deployment_id": "deployment-id"},
+            ],
         ),
         patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
     ):
@@ -327,5 +493,5 @@ def test_session_chat_rejects_invalid_session_creation_response(
         )
 
     assert result.exit_code == 1
-    assert message in result.stderr
+    assert "returned an invalid response" in result.stderr
     run_chat.assert_not_called()

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -532,6 +532,32 @@ def test_session_chat_interrupt_detaches_without_closing(exception: type[BaseExc
     ]
 
 
+def test_session_chat_interrupt_during_initial_turn_detaches_without_closing() -> None:
+    def interrupt(_: httpx.Request) -> httpx.Response:
+        raise KeyboardInterrupt
+
+    real_client = httpx.Client
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            side_effect=[_session_response(), _deployment_page(_deployment_response())],
+        ) as api_request,
+        patch(
+            "nemo_agents_plugin.cli.httpx.Client",
+            side_effect=lambda **kwargs: real_client(transport=httpx.MockTransport(interrupt), **kwargs),
+        ),
+    ):
+        result = runner.invoke(
+            AgentsCLI().get_cli(),
+            ["chat", "--session", "debug-auth", "--input", "first turn"],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert "Session detached" in result.stdout
+    assert [request.args[0] for request in api_request.call_args_list] == ["GET", "GET"]
+
+
 def test_session_chat_rejects_non_fabric_deployment_before_session_creation() -> None:
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -223,6 +223,10 @@ def test_session_chat_creates_named_session_and_passes_values_to_transport() -> 
         )
 
     assert result.exit_code == 0, result.stderr
+    assert (
+        "Session 'debug-auth' created. Resume with:\n"
+        "  nemo agents chat --session debug-auth --workspace default --base-url http://localhost:8080" in result.stdout
+    )
     assert api_request.call_args_list == [
         call(
             "GET",
@@ -291,6 +295,7 @@ def test_session_chat_resumes_active_session_and_passes_values_to_transport() ->
         )
 
     assert result.exit_code == 0, result.stderr
+    assert "Resuming runtime context; prior messages are not redisplayed." in result.stdout
     assert api_request.call_args_list == [
         call(
             "GET",
@@ -425,6 +430,7 @@ def test_session_chat_rejects_invalid_session_lookup_response() -> None:
 
 def test_resolved_session_chat_streams_each_current_turn_with_session_and_auth_headers() -> None:
     requests: list[httpx.Request] = []
+    expires_at = datetime(2026, 9, 1, 18, 30, tzinfo=UTC)
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
@@ -440,8 +446,14 @@ def test_resolved_session_chat_streams_each_current_turn_with_session_and_auth_h
     transport = httpx.MockTransport(handler)
 
     def exercise_tui(**kwargs: Any) -> None:
-        assert kwargs["display_info"] == {"Deployment": "fabric-deployment", "Session": "debug-auth"}
+        assert kwargs["display_info"] == {
+            "Deployment": "fabric-deployment",
+            "Session": "debug-auth",
+            "Status": "active",
+            "Expires": expires_at.isoformat(),
+        }
         assert kwargs["initial_message"] == "first turn"
+        assert kwargs["exit_action"] == "detach"
         for user_input in (kwargs["initial_message"], "second turn"):
             response_text, usage = collect_stream_response(kwargs["send_turn"](user_input))
             assert response_text == f"reply:{user_input}"
@@ -459,7 +471,7 @@ def test_resolved_session_chat_streams_each_current_turn_with_session_and_auth_h
             base_url="http://platform.test/",
             workspace="team-a",
             deployment=AgentDeployment.model_validate(_deployment_response()),
-            session=AgentSession.model_validate(_session_response()),
+            session=AgentSession.model_validate(_session_response(expires_at=expires_at)),
             session_id="session-id",
             input="first turn",
             timeout=42,
@@ -473,6 +485,30 @@ def test_resolved_session_chat_streams_each_current_turn_with_session_and_auth_h
     ]
     assert all(request.headers[SESSION_ID_HEADER] == "session-id" for request in requests)
     assert all(request.headers["Authorization"] == "Bearer token" for request in requests)
+
+
+@pytest.mark.parametrize("exception", [KeyboardInterrupt, EOFError])
+def test_session_chat_interrupt_detaches_without_closing(exception: type[BaseException]) -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            side_effect=[_session_response(), _deployment_page(_deployment_response())],
+        ) as api_request,
+        patch("nemo_platform_ext.cli.chat_tui.Prompt.ask", side_effect=exception),
+    ):
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
+
+    assert result.exit_code == 0, result.stderr
+    assert "Session detached" in result.stdout
+    assert api_request.call_args_list == [
+        call("GET", "http://localhost:8080", "/apis/agents/v2/workspaces/default/sessions/debug-auth"),
+        call(
+            "GET",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/deployments?page=1&page_size=100",
+        ),
+    ]
 
 
 def test_session_chat_rejects_non_fabric_deployment_before_session_creation() -> None:

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -5,13 +5,56 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from typing import Any
+from unittest.mock import call, patch
 
 import pytest
 from nemo_agents_plugin.cli import AgentsCLI
+from nemo_agents_plugin.entities import (
+    NAT_WORKFLOW_CONFIG_FORMAT,
+    NEMO_AGENTS_SPEC_CONFIG_FORMAT,
+    AgentDeployment,
+    AgentSession,
+    DeploymentStatus,
+)
 from typer.testing import CliRunner
 
 runner = CliRunner()
+
+
+def _deployment_response(
+    *,
+    name: str = "fabric-deployment",
+    workspace: str = "default",
+    config_format: str = NEMO_AGENTS_SPEC_CONFIG_FORMAT,
+    status: DeploymentStatus = "running",
+    endpoint: str = "http://127.0.0.1:9001",
+) -> dict[str, Any]:
+    response = AgentDeployment(
+        name=name,
+        workspace=workspace,
+        agent="fabric-agent",
+        config={"config_format": config_format},
+        status=status,
+        endpoint=endpoint,
+    ).model_dump(mode="json")
+    response["id"] = "deployment-id"
+    return response
+
+
+def _session_response(
+    *,
+    name: str = "debug-auth",
+    workspace: str = "default",
+    deployment_id: str = "deployment-id",
+) -> dict[str, Any]:
+    response = AgentSession(
+        name=name,
+        workspace=workspace,
+        deployment_id=deployment_id,
+    ).model_dump(mode="json")
+    response["id"] = "session-id"
+    return response
 
 
 def test_session_chat_help_describes_new_and_resumed_sessions() -> None:
@@ -124,3 +167,165 @@ def test_session_chat_requires_an_interactive_terminal() -> None:
     assert "Agent chat requires an interactive terminal" in result.stderr
     assert "nemo agents invoke" in result.stderr
     session_chat.assert_not_called()
+
+
+def test_session_chat_creates_named_session_and_passes_values_to_transport() -> None:
+    app = AgentsCLI().get_cli()
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            side_effect=[_deployment_response(), _session_response()],
+        ) as api_request,
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "chat",
+                "--agent-deployment",
+                "fabric-deployment",
+                "--session-name",
+                "debug-auth",
+                "--input",
+                "Help me debug this",
+                "--timeout",
+                "42",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert api_request.call_args_list == [
+        call(
+            "GET",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/deployments/fabric-deployment",
+        ),
+        call(
+            "POST",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/sessions",
+            json_body={"deployment_id": "deployment-id", "name": "debug-auth"},
+        ),
+    ]
+    run_chat.assert_called_once()
+    run_kwargs = run_chat.call_args.kwargs
+    assert run_kwargs["base_url"] == "http://localhost:8080"
+    assert run_kwargs["workspace"] == "default"
+    assert run_kwargs["input"] == "Help me debug this"
+    assert run_kwargs["timeout"] == 42.0
+    assert run_kwargs["deployment"].name == "fabric-deployment"
+    assert run_kwargs["session"].name == "debug-auth"
+    assert run_kwargs["session_id"] == "session-id"
+
+
+def test_session_chat_preserves_api_generated_session_name() -> None:
+    generated_name = "fabric-deployment-a1b2c3d4"
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            side_effect=[_deployment_response(), _session_response(name=generated_name)],
+        ) as api_request,
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(
+            AgentsCLI().get_cli(),
+            ["chat", "--agent-deployment", "fabric-deployment"],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    assert api_request.call_args_list[1] == call(
+        "POST",
+        "http://localhost:8080",
+        "/apis/agents/v2/workspaces/default/sessions",
+        json_body={"deployment_id": "deployment-id"},
+    )
+    assert run_chat.call_args.kwargs["session"].name == generated_name
+    assert run_chat.call_args.kwargs["session_id"] == "session-id"
+
+
+def test_session_chat_rejects_non_fabric_deployment_before_session_creation() -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            return_value=_deployment_response(config_format=NAT_WORKFLOW_CONFIG_FORMAT),
+        ) as api_request,
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(
+            AgentsCLI().get_cli(),
+            ["chat", "--agent-deployment", "fabric-deployment"],
+        )
+
+    assert result.exit_code == 1
+    assert "is not Fabric-backed" in result.stderr
+    api_request.assert_called_once()
+    run_chat.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("status", "endpoint"),
+    [
+        ("starting", "http://127.0.0.1:9001"),
+        ("running", ""),
+    ],
+)
+def test_session_chat_rejects_unroutable_deployment_before_session_creation(
+    status: DeploymentStatus,
+    endpoint: str,
+) -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            return_value=_deployment_response(status=status, endpoint=endpoint),
+        ) as api_request,
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(
+            AgentsCLI().get_cli(),
+            ["chat", "--agent-deployment", "fabric-deployment"],
+        )
+
+    assert result.exit_code == 1
+    assert "is not routable" in result.stderr
+    api_request.assert_called_once()
+    run_chat.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("session_response", "message"),
+    [
+        ({"name": "debug-auth", "deployment_id": "deployment-id"}, "did not include a valid ID"),
+        (_session_response(deployment_id="other-deployment-id"), "mismatched deployment or workspace"),
+        (_session_response(name="different-name"), "different name than requested"),
+    ],
+)
+def test_session_chat_rejects_invalid_session_creation_response(
+    session_response: dict[str, Any],
+    message: str,
+) -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli._api_request",
+            side_effect=[_deployment_response(), session_response],
+        ),
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(
+            AgentsCLI().get_cli(),
+            [
+                "chat",
+                "--agent-deployment",
+                "fabric-deployment",
+                "--session-name",
+                "debug-auth",
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert message in result.stderr
+    run_chat.assert_not_called()

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -378,6 +378,27 @@ def test_session_chat_rejects_terminal_session_before_deployment_lookup(status: 
     run_chat.assert_not_called()
 
 
+def test_session_chat_reports_missing_session() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, request=request, json={"detail": "Session 'missing' not found."})
+
+    real_client = httpx.Client
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch(
+            "nemo_agents_plugin.cli.httpx.Client",
+            side_effect=lambda **kwargs: real_client(transport=httpx.MockTransport(handler), **kwargs),
+        ),
+        patch("nemo_agents_plugin.cli._run_resolved_session_chat") as run_chat,
+    ):
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "missing"])
+
+    assert result.exit_code == 1
+    assert "Session 'missing' not found. (HTTP 404 Not Found)" in result.stderr
+    assert "/apis/agents/v2/workspaces/default/sessions/missing" in result.stderr
+    run_chat.assert_not_called()
+
+
 def test_session_chat_rejects_active_session_past_its_expiration_deadline() -> None:
     with (
         patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -22,7 +22,7 @@ from nemo_agents_plugin.entities import (
     SessionStatus,
 )
 from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
-from nemo_platform_ext.cli.chat_tui import collect_stream_response
+from nemo_platform_ext.cli.chat_tui import ExitAction, collect_stream_response
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -474,7 +474,7 @@ def test_resolved_session_chat_streams_each_current_turn_with_session_and_auth_h
             "Expires": expires_at.isoformat(),
         }
         assert kwargs["initial_message"] == "first turn"
-        assert kwargs["exit_action"] == "detach"
+        assert kwargs["exit_action"] is ExitAction.DETACH
         for user_input in (kwargs["initial_message"], "second turn"):
             response_text, usage = collect_stream_response(kwargs["send_turn"](user_input))
             assert response_text == f"reply:{user_input}"

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -5,12 +5,14 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import call, patch
 
+import httpx
 import pytest
-from nemo_agents_plugin.cli import AgentsCLI
+from nemo_agents_plugin.cli import AgentsCLI, _run_resolved_session_chat
 from nemo_agents_plugin.entities import (
     NAT_WORKFLOW_CONFIG_FORMAT,
     NEMO_AGENTS_SPEC_CONFIG_FORMAT,
@@ -19,6 +21,8 @@ from nemo_agents_plugin.entities import (
     DeploymentStatus,
     SessionStatus,
 )
+from nemo_agents_plugin.session_protocol import SESSION_ID_HEADER
+from nemo_platform_ext.cli.chat_tui import collect_stream_response
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -417,6 +421,58 @@ def test_session_chat_rejects_invalid_session_lookup_response() -> None:
     assert result.exit_code == 1
     assert "returned an invalid response" in result.stderr
     run_chat.assert_not_called()
+
+
+def test_resolved_session_chat_streams_each_current_turn_with_session_and_auth_headers() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        user_input = json.loads(request.content)["messages"][0]["content"]
+        chunk = {"choices": [{"delta": {"content": f"reply:{user_input}"}}]}
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content=f"data: {json.dumps(chunk)}\n\ndata: [DONE]\n\n".encode(),
+        )
+
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+
+    def exercise_tui(**kwargs: Any) -> None:
+        assert kwargs["display_info"] == {"Deployment": "fabric-deployment", "Session": "debug-auth"}
+        assert kwargs["initial_message"] == "first turn"
+        for user_input in (kwargs["initial_message"], "second turn"):
+            response_text, usage = collect_stream_response(kwargs["send_turn"](user_input))
+            assert response_text == f"reply:{user_input}"
+            assert usage is None
+
+    with (
+        patch("nemo_agents_plugin.cli._resolve_context_headers", return_value={"Authorization": "Bearer token"}),
+        patch(
+            "nemo_agents_plugin.cli.httpx.Client",
+            side_effect=lambda **kwargs: real_client(transport=transport, **kwargs),
+        ),
+        patch("nemo_agents_plugin.cli.run_chat_tui", side_effect=exercise_tui),
+    ):
+        _run_resolved_session_chat(
+            base_url="http://platform.test/",
+            workspace="team-a",
+            deployment=AgentDeployment.model_validate(_deployment_response()),
+            session=AgentSession.model_validate(_session_response()),
+            session_id="session-id",
+            input="first turn",
+            timeout=42,
+        )
+
+    expected_path = "/apis/agents/v2/workspaces/team-a/deployments/fabric-deployment/-/v1/chat/completions"
+    assert [request.url.path for request in requests] == [expected_path, expected_path]
+    assert [json.loads(request.content) for request in requests] == [
+        {"messages": [{"role": "user", "content": "first turn"}], "stream": True},
+        {"messages": [{"role": "user", "content": "second turn"}], "stream": True},
+    ]
+    assert all(request.headers[SESSION_ID_HEADER] == "session-id" for request in requests)
+    assert all(request.headers["Authorization"] == "Bearer token" for request in requests)
 
 
 def test_session_chat_rejects_non_fabric_deployment_before_session_creation() -> None:

--- a/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_session_chat.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI contract tests for ``nemo agents chat``."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from nemo_agents_plugin.cli import AgentsCLI
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_session_chat_help_describes_new_and_resumed_sessions() -> None:
+    result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--help"])
+
+    assert result.exit_code == 0
+    assert "Chat interactively with a new or existing deployed-agent session" in result.stdout
+    assert "--input" in result.stdout
+    assert "--agent-deployment" in result.stdout
+    assert "--session" in result.stdout
+    assert "--session-name" in result.stdout
+    assert "--workspace" in result.stdout
+    assert "--base-url" in result.stdout
+    assert "--timeout" in result.stdout
+    assert "--interactive" not in result.stdout
+
+
+def test_session_chat_accepts_new_named_session_options() -> None:
+    app = AgentsCLI().get_cli()
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch("nemo_agents_plugin.cli._platform_session_chat") as session_chat,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "chat",
+                "--agent-deployment",
+                "fabric-deployment",
+                "--session-name",
+                "debug-auth",
+                "--input",
+                "Help me debug this",
+                "--workspace",
+                "team-a",
+                "--base-url",
+                "http://platform.test",
+                "--timeout",
+                "42",
+            ],
+        )
+
+    assert result.exit_code == 0, result.stderr
+    session_chat.assert_called_once_with(
+        base_url="http://platform.test",
+        workspace="team-a",
+        agent_deployment="fabric-deployment",
+        session=None,
+        session_name="debug-auth",
+        input="Help me debug this",
+        timeout=42.0,
+    )
+
+
+def test_session_chat_accepts_existing_session_without_initial_input() -> None:
+    app = AgentsCLI().get_cli()
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=True),
+        patch("nemo_agents_plugin.cli._platform_session_chat") as session_chat,
+    ):
+        result = runner.invoke(app, ["chat", "--session", "debug-auth"])
+
+    assert result.exit_code == 0, result.stderr
+    session_chat.assert_called_once_with(
+        base_url="http://localhost:8080",
+        workspace="default",
+        agent_deployment=None,
+        session="debug-auth",
+        session_name=None,
+        input=None,
+        timeout=300.0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("arguments", "message"),
+    [
+        ([], "Provide exactly one of --agent-deployment or --session"),
+        (
+            ["--agent-deployment", "fabric-deployment", "--session", "debug-auth"],
+            "Provide exactly one of --agent-deployment or --session",
+        ),
+        (
+            ["--session", "debug-auth", "--session-name", "replacement"],
+            "--session-name can only be used with --agent-deployment",
+        ),
+        (["--agent-deployment", ""], "--agent-deployment must not be empty"),
+        (["--session", ""], "--session must not be empty"),
+        (["--agent-deployment", "fabric-deployment", "--session-name", ""], "--session-name must not be empty"),
+        (["--agent-deployment", "fabric-deployment", "--input", ""], "--input must not be empty"),
+    ],
+)
+def test_session_chat_rejects_invalid_selector_combinations(arguments: list[str], message: str) -> None:
+    with patch("nemo_agents_plugin.cli._platform_session_chat") as session_chat:
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", *arguments])
+
+    assert result.exit_code == 2
+    assert message in result.stderr
+    session_chat.assert_not_called()
+
+
+def test_session_chat_requires_an_interactive_terminal() -> None:
+    with (
+        patch("nemo_agents_plugin.cli._is_interactive_session_chat", return_value=False),
+        patch("nemo_agents_plugin.cli._platform_session_chat") as session_chat,
+    ):
+        result = runner.invoke(AgentsCLI().get_cli(), ["chat", "--session", "debug-auth"])
+
+    assert result.exit_code == 2
+    assert "Agent chat requires an interactive terminal" in result.stderr
+    assert "nemo agents invoke" in result.stderr
+    session_chat.assert_not_called()

--- a/plugins/nemo-agents/tests/unit/test_cli_sessions.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_sessions.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``nemo agents sessions`` management commands."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import call, patch
+
+import pytest
+from nemo_agents_plugin.cli import AgentsCLI
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def app():
+    return AgentsCLI().get_cli()
+
+
+def _sessions_response() -> dict[str, Any]:
+    return {
+        "data": [
+            {
+                "id": "session-id",
+                "name": "debug-auth",
+                "workspace": "default",
+                "status": "active",
+                "deployment_id": "deployment-id",
+                "first_active_at": "2026-09-01T15:00:00Z",
+                "last_active_at": "2026-09-01T15:05:00Z",
+                "expires_at": "2026-09-01T16:05:00Z",
+                "created_at": "2026-09-01T14:59:00Z",
+            }
+        ],
+        "pagination": {
+            "current_page": 1,
+            "current_page_size": 1,
+            "total_pages": 1,
+            "total_results": 1,
+        },
+        "sort": "-created_at",
+        "filter": {},
+    }
+
+
+def test_sessions_help_exposes_management_scope_without_pagination_or_delete(app) -> None:
+    result = runner.invoke(app, ["sessions", "--help"])
+
+    assert result.exit_code == 0
+    assert "list" in result.stdout
+    assert "get" in result.stdout
+    assert "close" in result.stdout
+    assert "delete" not in result.stdout
+
+    list_help = runner.invoke(app, ["sessions", "list", "--help"])
+    assert list_help.exit_code == 0
+    assert "--agent-deployment" in list_help.stdout
+    assert "--format" in list_help.stdout
+    assert "--no-truncate" in list_help.stdout
+    assert "--page" not in list_help.stdout
+    assert "--page-size" not in list_help.stdout
+
+
+def test_sessions_list_defaults_to_newest_first_api_table(app) -> None:
+    response = _sessions_response()
+    with patch("nemo_agents_plugin.cli._api_request", return_value=response) as api_request:
+        result = runner.invoke(app, ["sessions", "list", "--base-url", "http://test"])
+
+    assert result.exit_code == 0, result.output
+    api_request.assert_called_once_with(
+        "GET",
+        "http://test",
+        "/apis/agents/v2/workspaces/default/sessions",
+    )
+    assert "debug-auth" in result.stdout
+    assert "active" in result.stdout
+    assert "deployment_id" in result.stdout
+    assert "last_active_at" in result.stdout
+    assert "expires_at" in result.stdout
+    assert '"data"' not in result.stdout
+
+
+@pytest.mark.parametrize("output_format", ["json", "yaml", "csv", "markdown", "raw"])
+def test_sessions_list_supports_existing_output_formats(app, output_format: str) -> None:
+    response = _sessions_response()
+    with patch("nemo_agents_plugin.cli._api_request", return_value=response):
+        result = runner.invoke(app, ["sessions", "list", "--format", output_format])
+
+    assert result.exit_code == 0, result.output
+    assert "debug-auth" in result.stdout
+    if output_format == "json":
+        assert json.loads(result.stdout) == response
+
+
+def test_sessions_list_filters_by_deployment_name(app) -> None:
+    response = _sessions_response()
+    with patch(
+        "nemo_agents_plugin.cli._api_request",
+        side_effect=[{"id": "deployment-id", "name": "fabric-deployment"}, response],
+    ) as api_request:
+        result = runner.invoke(
+            app,
+            ["sessions", "list", "--agent-deployment", "fabric-deployment", "--format", "json"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert api_request.call_args_list == [
+        call(
+            "GET",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/deployments/fabric-deployment",
+        ),
+        call(
+            "GET",
+            "http://localhost:8080",
+            "/apis/agents/v2/workspaces/default/sessions?filter%5Bdeployment_id%5D=deployment-id",
+        ),
+    ]
+
+
+def test_sessions_list_rejects_empty_deployment_filter(app) -> None:
+    with patch("nemo_agents_plugin.cli._api_request") as api_request:
+        result = runner.invoke(app, ["sessions", "list", "--agent-deployment", ""])
+
+    assert result.exit_code == 2
+    assert "--agent-deployment must not be empty" in result.stderr
+    api_request.assert_not_called()
+
+
+def test_sessions_list_rejects_deployment_response_without_id(app) -> None:
+    with patch("nemo_agents_plugin.cli._api_request", return_value={"name": "fabric-deployment"}) as api_request:
+        result = runner.invoke(app, ["sessions", "list", "--agent-deployment", "fabric-deployment"])
+
+    assert result.exit_code == 1
+    assert "did not include a valid ID" in result.stderr
+    api_request.assert_called_once()
+
+
+def test_sessions_get_prints_full_session_json(app) -> None:
+    session = _sessions_response()["data"][0]
+    with patch("nemo_agents_plugin.cli._api_request", return_value=session) as api_request:
+        result = runner.invoke(app, ["sessions", "get", "debug-auth", "--base-url", "http://test"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == session
+    api_request.assert_called_once_with(
+        "GET",
+        "http://test",
+        "/apis/agents/v2/workspaces/default/sessions/debug-auth",
+    )
+
+
+def test_sessions_close_requires_confirmation(app) -> None:
+    with patch("nemo_agents_plugin.cli._api_request") as api_request:
+        result = runner.invoke(app, ["sessions", "close", "debug-auth"], input="n\n")
+
+    assert result.exit_code == 1
+    assert "cannot be resumed" in result.stdout
+    api_request.assert_not_called()
+
+
+def test_sessions_close_accepts_yes_and_calls_close_endpoint(app) -> None:
+    with patch(
+        "nemo_agents_plugin.cli._api_request", return_value={"name": "debug-auth", "status": "closed"}
+    ) as api_request:
+        result = runner.invoke(
+            app,
+            ["sessions", "close", "debug-auth", "--yes", "--workspace", "team-a", "--base-url", "http://test"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Session 'debug-auth' closed." in result.stdout
+    api_request.assert_called_once_with(
+        "POST",
+        "http://test",
+        "/apis/agents/v2/workspaces/team-a/sessions/debug-auth/close",
+    )

--- a/plugins/nemo-agents/tests/unit/test_cli_sessions.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_sessions.py
@@ -51,18 +51,16 @@ def test_sessions_help_exposes_management_scope_without_pagination_or_delete(app
     result = runner.invoke(app, ["sessions", "--help"])
 
     assert result.exit_code == 0
-    assert "list" in result.stdout
-    assert "get" in result.stdout
-    assert "close" in result.stdout
+    for command in ("list", "get", "close"):
+        assert command in result.stdout
     assert "delete" not in result.stdout
 
     list_help = runner.invoke(app, ["sessions", "list", "--help"])
     assert list_help.exit_code == 0
-    assert "--agent-deployment" in list_help.stdout
-    assert "--format" in list_help.stdout
-    assert "--no-truncate" in list_help.stdout
-    assert "--page" not in list_help.stdout
-    assert "--page-size" not in list_help.stdout
+    for option in ("--agent-deployment", "--format", "--no-truncate"):
+        assert option in list_help.stdout
+    for option in ("--page", "--page-size"):
+        assert option not in list_help.stdout
 
 
 def test_sessions_list_defaults_to_newest_first_api_table(app) -> None:
@@ -129,15 +127,6 @@ def test_sessions_list_rejects_empty_deployment_filter(app) -> None:
     assert result.exit_code == 2
     assert "--agent-deployment must not be empty" in result.stderr
     api_request.assert_not_called()
-
-
-def test_sessions_list_rejects_deployment_response_without_id(app) -> None:
-    with patch("nemo_agents_plugin.cli._api_request", return_value={"name": "fabric-deployment"}) as api_request:
-        result = runner.invoke(app, ["sessions", "list", "--agent-deployment", "fabric-deployment"])
-
-    assert result.exit_code == 1
-    assert "did not include a valid ID" in result.stderr
-    api_request.assert_called_once()
 
 
 def test_sessions_get_prints_full_session_json(app) -> None:

--- a/plugins/nemo-agents/tests/unit/test_cli_sessions.py
+++ b/plugins/nemo-agents/tests/unit/test_cli_sessions.py
@@ -120,6 +120,20 @@ def test_sessions_list_filters_by_deployment_name(app) -> None:
     ]
 
 
+@pytest.mark.parametrize("deployment", [None, {}, {"id": None}, {"id": ""}, {"id": 123}])
+def test_sessions_list_rejects_invalid_deployment_response(app, deployment: Any) -> None:
+    with patch("nemo_agents_plugin.cli._api_request", return_value=deployment) as api_request:
+        result = runner.invoke(app, ["sessions", "list", "--agent-deployment", "fabric-deployment"])
+
+    assert result.exit_code == 1
+    assert "Deployment 'fabric-deployment' returned an invalid response" in result.stderr
+    api_request.assert_called_once_with(
+        "GET",
+        "http://localhost:8080",
+        "/apis/agents/v2/workspaces/default/deployments/fabric-deployment",
+    )
+
+
 def test_sessions_list_rejects_empty_deployment_filter(app) -> None:
     with patch("nemo_agents_plugin.cli._api_request") as api_request:
         result = runner.invoke(app, ["sessions", "list", "--agent-deployment", ""])

--- a/plugins/nemo-agents/tests/unit/test_runner_controller.py
+++ b/plugins/nemo-agents/tests/unit/test_runner_controller.py
@@ -642,7 +642,8 @@ async def test_check_health_marks_failed_when_subprocess_exited() -> None:
 async def test_check_health_marks_running_when_healthy() -> None:
     """Backward behaviour: a healthy process flips to ``running``."""
     ctrl, backend = _make_controller()
-    backend.get_deployment_status = AsyncMock(return_value=DeploymentInfo(name="dep-1", status="starting"))
+    info = DeploymentInfo(name="dep-1", status="starting")
+    backend.get_deployment_status = AsyncMock(return_value=info)
     backend.health_check = AsyncMock(return_value=True)
     dep = AgentDeployment(
         name="dep-1",
@@ -656,6 +657,12 @@ async def test_check_health_marks_running_when_healthy() -> None:
     await ctrl._check_health(dep)
 
     assert dep.status == "running"
+    assert info.status == "running"
+
+    ctrl._reconcile_deployment_sessions_after_restart = AsyncMock()  # type: ignore[method-assign]
+    ctrl._observe_runtime_instance = AsyncMock()  # type: ignore[method-assign]
+    await ctrl._verify_running(dep)
+    ctrl._reconcile_deployment_sessions_after_restart.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary

Adds an interactive multi-turn CLI for persisted sessions on deployed
Fabric-backed agents. Users can create, discover, resume, inspect, and close
sessions while the deployment runtime—not the CLI—retains conversation context.

This PR is stacked on `sessions-cli-1/mmogallapalli`, which extracts the reusable
chat TUI. The TUI refactor is therefore excluded from this PR's functional scope.

## Related Issue

[AIRCORE-951: Add interactive multi-turn CLI for deployed Fabric-backed agents](https://linear.app/nvidia/issue/AIRCORE-951/add-interactive-multi-turn-cli-for-deployed-fabric-backed-agents)

## Changes

- Add `nemo agents chat` with two mutually exclusive flows:
  - `--agent-deployment/-d` creates a new persisted session.
  - `--session/-s` resumes an existing session by name.
- Support `--session-name` for explicit naming and preserve API-generated names
  when it is omitted.
- Support an optional first turn through `--input/-i` while keeping chat
  interactive; reject non-interactive terminals and direct scripted callers to
  `nemo agents invoke`.
- Add `nemo agents sessions list|get|close`:
  - list sessions newest-first, optionally filtered by deployment;
  - reuse table, JSON, YAML, CSV, Markdown, and raw output formats;
  - close with confirmation unless `--yes/-y` is supplied;
  - omit deletion and user-facing pagination.
- Validate new-session deployments as Fabric-backed and routable before creating
  the session with the deployment entity ID.
- Resolve resumed sessions by name, reject closed, expired, or lost sessions, and
  find their immutable deployment binding through the existing paginated
  deployment-list API.
- Stream each turn through the deployment's `/v1/chat/completions` gateway route
  with `X-Nemo-Session-Id` and the existing authentication headers.
- Send only the current user turn; persisted Fabric runtime state owns the
  conversation instead of a replayed CLI transcript.
- Show deployment, session, status, and expiration metadata in the shared TUI.
- Print a reusable resume command after session creation and explain that resumed
  runtime context does not redisplay earlier messages.
- Treat Ctrl+C and EOF as detach operations that leave the persisted session
  active, including interruptions during the optional initial streamed turn.
- Synchronize healthy subprocess backend state to `running` so controller
  reconciliation does not falsely mark active sessions as `lost`.
- Add CLI regression coverage for the command contract, management operations,
  creation, resumption, deployment resolution, streaming, authentication,
  current-turn-only requests, terminal session errors, missing sessions, and
  detach behavior.

## Design Decisions

- **Use the deployment gateway.** Session chat continues through the deployment's
  existing OpenAI-compatible gateway route and identifies the persisted session
  with `X-Nemo-Session-Id`; no session-specific gateway is introduced.
- **Keep runtime context server-side.** The CLI sends only the current user turn.
  Fabric owns multi-turn state, so resuming does not require local transcript
  persistence or replay.
- **Resolve the immutable deployment binding through existing APIs.** Resumption
  reads `AgentSession.deployment_id` and internally walks the deployment list in
  pages of 100 until it finds the matching entity. No deployment-by-ID endpoint
  or user-facing pagination options are added.
- **Separate detach from close.** Leaving the TUI never closes the session.
  Lifecycle termination remains an explicit `nemo agents sessions close` action.
- **Keep management intentionally small.** The CLI exposes list, get, and close;
  permanent deletion remains API-only and outside this ticket.
- **Defer user documentation.** General session-chat documentation will be added
  separately rather than attaching the workflow to an unrelated example in this
  PR.

## Type of Change

- [x] Code change (feature)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [x] Existing model-chat and Agents CLI behavior remains covered
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation deferred to separate follow-up work

## Verification

- [ ] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] Branch-scoped pre-commit and pre-push hooks pass
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `.venv/bin/pytest plugins/nemo-agents/tests/unit/test_cli_sessions.py plugins/nemo-agents/tests/unit/test_cli_session_chat.py -q` — 42 passed
- `.venv/bin/pytest plugins/nemo-agents/tests/unit plugins/nemo-agents/tests/test_authz.py -q` — 1,546 passed
- Focused and full-source Ruff linting and formatting passed.
- Changed-file `ty` type checking passed.
- `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to chat with deployed agents and resume persisted sessions.
  * Added session management commands to list, view, and close sessions.
  * Added support for detaching from interactive chat sessions.
  * Added CLI reference documentation for agent chat and session management.

* **Bug Fixes**
  * Deployment status now correctly reports as running after a successful health check.
  * Improved validation of deployment and session information when managing sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->