### PR TITLE
feat(studio): save an experiment's column layout

### DIFF
--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -12168,9 +12168,11 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and column visibility for the experiment's
-            evaluations table. Omit to preserve the existing layout on update; on
-            create, defaults to an empty layout.
+          description: "Saved column order and column visibility for the experiment's\
+            \ evaluations table. Omit to leave the saved layout unchanged; on create\
+            \ that means no layout is saved. An empty order and hidden pair is itself\
+            \ a saved layout \u2014 one that shows every column \u2014 and is distinct\
+            \ from having none."
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12223,8 +12225,9 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
-            evaluations table. Null when none has been saved.
+          description: Saved column order and column visibility for the experiment's
+            evaluations table. Null when no layout has been saved, which is distinct
+            from a saved layout that hides nothing.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12330,9 +12333,11 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and column visibility for the experiment's
-            evaluations table. Omit to preserve the existing layout on update; on
-            create, defaults to an empty layout.
+          description: "Saved column order and column visibility for the experiment's\
+            \ evaluations table. Omit to leave the saved layout unchanged; on create\
+            \ that means no layout is saved. An empty order and hidden pair is itself\
+            \ a saved layout \u2014 one that shows every column \u2014 and is distinct\
+            \ from having none."
         is_favorite:
           type: boolean
           title: Is Favorite

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -12168,7 +12168,7 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
+          description: Saved column order and column visibility for the experiment's
             evaluations table. Omit to preserve the existing layout on update; on
             create, defaults to an empty layout.
         is_favorite:
@@ -12330,7 +12330,7 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
+          description: Saved column order and column visibility for the experiment's
             evaluations table. Omit to preserve the existing layout on update; on
             create, defaults to an empty layout.
         is_favorite:

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -9906,15 +9906,12 @@ components:
       type: object
       title: ColumnLayout
       description: "A saved table layout for a group's evaluations list: column order\
-        \ and which columns are hidden.\n\nColumn ids are Studio's, not this API's\
-        \ \u2014 the evaluations table builds a column per evaluator and\nper metadata\
-        \ key found in the loaded rows, so the set is workspace- and data-specific\
-        \ and cannot be\nenumerated here. Ids are stored as given and echoed back\
-        \ unvalidated; Studio ignores any that no\nlonger resolve.\n\nVisibility is\
-        \ stored as the *hidden* ids rather than a visible/hidden map for every column,\
-        \ so a\ncolumn that appears later (a new evaluator, a new metadata key) shows\
-        \ up by default instead of\nbeing invisible because a layout saved before\
-        \ it existed never mentioned it."
+        \ and which columns are hidden.\n\nColumn ids are Studio's and cannot be enumerated\
+        \ here \u2014 the table builds a column per evaluator\nand metadata key found\
+        \ in the rows \u2014 so ids are stored and echoed back unvalidated.\n\nVisibility\
+        \ is stored as the *hidden* ids rather than a map over every column, so a\
+        \ column that\nappears later (a new evaluator, a new metadata key) shows up\
+        \ by default."
     ComputeResourceSpec:
       properties:
         cpu:

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -9887,6 +9887,34 @@ components:
       - policy
       title: ClavataRailOptions
       description: Configuration data for the Clavata API
+    ColumnLayout:
+      properties:
+        order:
+          items:
+            type: string
+          type: array
+          title: Order
+          description: 'Column ids in display order. Empty means no saved order: the
+            table falls back to its natural column order.'
+        hidden:
+          items:
+            type: string
+          type: array
+          title: Hidden
+          description: Column ids hidden from the table. Any column not listed is
+            shown.
+      type: object
+      title: ColumnLayout
+      description: "A saved table layout for a group's evaluations list: column order\
+        \ and which columns are hidden.\n\nColumn ids are Studio's, not this API's\
+        \ \u2014 the evaluations table builds a column per evaluator and\nper metadata\
+        \ key found in the loaded rows, so the set is workspace- and data-specific\
+        \ and cannot be\nenumerated here. Ids are stored as given and echoed back\
+        \ unvalidated; Studio ignores any that no\nlonger resolve.\n\nVisibility is\
+        \ stored as the *hidden* ids rather than a visible/hidden map for every column,\
+        \ so a\ncolumn that appears later (a new evaluator, a new metadata key) shows\
+        \ up by default instead of\nbeing invisible because a layout saved before\
+        \ it existed never mentioned it."
     ComputeResourceSpec:
       properties:
         cpu:
@@ -12140,6 +12168,12 @@ components:
           description: Default X/Y metrics for the experiment's Pareto view. Omit
             to preserve the existing value on update; on create, defaults to cost
             vs. latency.
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Omit to preserve the existing layout on update; on
+            create, defaults to an empty layout.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12189,6 +12223,11 @@ components:
           title: Default Sort
         pareto:
           $ref: '#/components/schemas/ParetoConfig'
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Null when none has been saved.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12291,6 +12330,12 @@ components:
           description: Default X/Y metrics for the experiment's Pareto view. Omit
             to preserve the existing value on update; on create, defaults to cost
             vs. latency.
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Omit to preserve the existing layout on update; on
+            create, defaults to an empty layout.
         is_favorite:
           type: boolean
           title: Is Favorite

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -12168,9 +12168,11 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and column visibility for the experiment's
-            evaluations table. Omit to preserve the existing layout on update; on
-            create, defaults to an empty layout.
+          description: "Saved column order and column visibility for the experiment's\
+            \ evaluations table. Omit to leave the saved layout unchanged; on create\
+            \ that means no layout is saved. An empty order and hidden pair is itself\
+            \ a saved layout \u2014 one that shows every column \u2014 and is distinct\
+            \ from having none."
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12223,8 +12225,9 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
-            evaluations table. Null when none has been saved.
+          description: Saved column order and column visibility for the experiment's
+            evaluations table. Null when no layout has been saved, which is distinct
+            from a saved layout that hides nothing.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12330,9 +12333,11 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and column visibility for the experiment's
-            evaluations table. Omit to preserve the existing layout on update; on
-            create, defaults to an empty layout.
+          description: "Saved column order and column visibility for the experiment's\
+            \ evaluations table. Omit to leave the saved layout unchanged; on create\
+            \ that means no layout is saved. An empty order and hidden pair is itself\
+            \ a saved layout \u2014 one that shows every column \u2014 and is distinct\
+            \ from having none."
         is_favorite:
           type: boolean
           title: Is Favorite

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -12168,7 +12168,7 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
+          description: Saved column order and column visibility for the experiment's
             evaluations table. Omit to preserve the existing layout on update; on
             create, defaults to an empty layout.
         is_favorite:
@@ -12330,7 +12330,7 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
+          description: Saved column order and column visibility for the experiment's
             evaluations table. Omit to preserve the existing layout on update; on
             create, defaults to an empty layout.
         is_favorite:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -9906,15 +9906,12 @@ components:
       type: object
       title: ColumnLayout
       description: "A saved table layout for a group's evaluations list: column order\
-        \ and which columns are hidden.\n\nColumn ids are Studio's, not this API's\
-        \ \u2014 the evaluations table builds a column per evaluator and\nper metadata\
-        \ key found in the loaded rows, so the set is workspace- and data-specific\
-        \ and cannot be\nenumerated here. Ids are stored as given and echoed back\
-        \ unvalidated; Studio ignores any that no\nlonger resolve.\n\nVisibility is\
-        \ stored as the *hidden* ids rather than a visible/hidden map for every column,\
-        \ so a\ncolumn that appears later (a new evaluator, a new metadata key) shows\
-        \ up by default instead of\nbeing invisible because a layout saved before\
-        \ it existed never mentioned it."
+        \ and which columns are hidden.\n\nColumn ids are Studio's and cannot be enumerated\
+        \ here \u2014 the table builds a column per evaluator\nand metadata key found\
+        \ in the rows \u2014 so ids are stored and echoed back unvalidated.\n\nVisibility\
+        \ is stored as the *hidden* ids rather than a map over every column, so a\
+        \ column that\nappears later (a new evaluator, a new metadata key) shows up\
+        \ by default."
     ComputeResourceSpec:
       properties:
         cpu:

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -9887,6 +9887,34 @@ components:
       - policy
       title: ClavataRailOptions
       description: Configuration data for the Clavata API
+    ColumnLayout:
+      properties:
+        order:
+          items:
+            type: string
+          type: array
+          title: Order
+          description: 'Column ids in display order. Empty means no saved order: the
+            table falls back to its natural column order.'
+        hidden:
+          items:
+            type: string
+          type: array
+          title: Hidden
+          description: Column ids hidden from the table. Any column not listed is
+            shown.
+      type: object
+      title: ColumnLayout
+      description: "A saved table layout for a group's evaluations list: column order\
+        \ and which columns are hidden.\n\nColumn ids are Studio's, not this API's\
+        \ \u2014 the evaluations table builds a column per evaluator and\nper metadata\
+        \ key found in the loaded rows, so the set is workspace- and data-specific\
+        \ and cannot be\nenumerated here. Ids are stored as given and echoed back\
+        \ unvalidated; Studio ignores any that no\nlonger resolve.\n\nVisibility is\
+        \ stored as the *hidden* ids rather than a visible/hidden map for every column,\
+        \ so a\ncolumn that appears later (a new evaluator, a new metadata key) shows\
+        \ up by default instead of\nbeing invisible because a layout saved before\
+        \ it existed never mentioned it."
     ComputeResourceSpec:
       properties:
         cpu:
@@ -12140,6 +12168,12 @@ components:
           description: Default X/Y metrics for the experiment's Pareto view. Omit
             to preserve the existing value on update; on create, defaults to cost
             vs. latency.
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Omit to preserve the existing layout on update; on
+            create, defaults to an empty layout.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12189,6 +12223,11 @@ components:
           title: Default Sort
         pareto:
           $ref: '#/components/schemas/ParetoConfig'
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Null when none has been saved.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12291,6 +12330,12 @@ components:
           description: Default X/Y metrics for the experiment's Pareto view. Omit
             to preserve the existing value on update; on create, defaults to cost
             vs. latency.
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Omit to preserve the existing layout on update; on
+            create, defaults to an empty layout.
         is_favorite:
           type: boolean
           title: Is Favorite

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -12168,9 +12168,11 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and column visibility for the experiment's
-            evaluations table. Omit to preserve the existing layout on update; on
-            create, defaults to an empty layout.
+          description: "Saved column order and column visibility for the experiment's\
+            \ evaluations table. Omit to leave the saved layout unchanged; on create\
+            \ that means no layout is saved. An empty order and hidden pair is itself\
+            \ a saved layout \u2014 one that shows every column \u2014 and is distinct\
+            \ from having none."
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12223,8 +12225,9 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
-            evaluations table. Null when none has been saved.
+          description: Saved column order and column visibility for the experiment's
+            evaluations table. Null when no layout has been saved, which is distinct
+            from a saved layout that hides nothing.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12330,9 +12333,11 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and column visibility for the experiment's
-            evaluations table. Omit to preserve the existing layout on update; on
-            create, defaults to an empty layout.
+          description: "Saved column order and column visibility for the experiment's\
+            \ evaluations table. Omit to leave the saved layout unchanged; on create\
+            \ that means no layout is saved. An empty order and hidden pair is itself\
+            \ a saved layout \u2014 one that shows every column \u2014 and is distinct\
+            \ from having none."
         is_favorite:
           type: boolean
           title: Is Favorite

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -12168,7 +12168,7 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
+          description: Saved column order and column visibility for the experiment's
             evaluations table. Omit to preserve the existing layout on update; on
             create, defaults to an empty layout.
         is_favorite:
@@ -12330,7 +12330,7 @@ components:
         column_layout:
           allOf:
           - $ref: '#/components/schemas/ColumnLayout'
-          description: Saved column order and hidden columns for the experiment's
+          description: Saved column order and column visibility for the experiment's
             evaluations table. Omit to preserve the existing layout on update; on
             create, defaults to an empty layout.
         is_favorite:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -9906,15 +9906,12 @@ components:
       type: object
       title: ColumnLayout
       description: "A saved table layout for a group's evaluations list: column order\
-        \ and which columns are hidden.\n\nColumn ids are Studio's, not this API's\
-        \ \u2014 the evaluations table builds a column per evaluator and\nper metadata\
-        \ key found in the loaded rows, so the set is workspace- and data-specific\
-        \ and cannot be\nenumerated here. Ids are stored as given and echoed back\
-        \ unvalidated; Studio ignores any that no\nlonger resolve.\n\nVisibility is\
-        \ stored as the *hidden* ids rather than a visible/hidden map for every column,\
-        \ so a\ncolumn that appears later (a new evaluator, a new metadata key) shows\
-        \ up by default instead of\nbeing invisible because a layout saved before\
-        \ it existed never mentioned it."
+        \ and which columns are hidden.\n\nColumn ids are Studio's and cannot be enumerated\
+        \ here \u2014 the table builds a column per evaluator\nand metadata key found\
+        \ in the rows \u2014 so ids are stored and echoed back unvalidated.\n\nVisibility\
+        \ is stored as the *hidden* ids rather than a map over every column, so a\
+        \ column that\nappears later (a new evaluator, a new metadata key) shows up\
+        \ by default."
     ComputeResourceSpec:
       properties:
         cpu:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -9887,6 +9887,34 @@ components:
       - policy
       title: ClavataRailOptions
       description: Configuration data for the Clavata API
+    ColumnLayout:
+      properties:
+        order:
+          items:
+            type: string
+          type: array
+          title: Order
+          description: 'Column ids in display order. Empty means no saved order: the
+            table falls back to its natural column order.'
+        hidden:
+          items:
+            type: string
+          type: array
+          title: Hidden
+          description: Column ids hidden from the table. Any column not listed is
+            shown.
+      type: object
+      title: ColumnLayout
+      description: "A saved table layout for a group's evaluations list: column order\
+        \ and which columns are hidden.\n\nColumn ids are Studio's, not this API's\
+        \ \u2014 the evaluations table builds a column per evaluator and\nper metadata\
+        \ key found in the loaded rows, so the set is workspace- and data-specific\
+        \ and cannot be\nenumerated here. Ids are stored as given and echoed back\
+        \ unvalidated; Studio ignores any that no\nlonger resolve.\n\nVisibility is\
+        \ stored as the *hidden* ids rather than a visible/hidden map for every column,\
+        \ so a\ncolumn that appears later (a new evaluator, a new metadata key) shows\
+        \ up by default instead of\nbeing invisible because a layout saved before\
+        \ it existed never mentioned it."
     ComputeResourceSpec:
       properties:
         cpu:
@@ -12140,6 +12168,12 @@ components:
           description: Default X/Y metrics for the experiment's Pareto view. Omit
             to preserve the existing value on update; on create, defaults to cost
             vs. latency.
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Omit to preserve the existing layout on update; on
+            create, defaults to an empty layout.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12189,6 +12223,11 @@ components:
           title: Default Sort
         pareto:
           $ref: '#/components/schemas/ParetoConfig'
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Null when none has been saved.
         is_favorite:
           type: boolean
           title: Is Favorite
@@ -12291,6 +12330,12 @@ components:
           description: Default X/Y metrics for the experiment's Pareto view. Omit
             to preserve the existing value on update; on create, defaults to cost
             vs. latency.
+        column_layout:
+          allOf:
+          - $ref: '#/components/schemas/ColumnLayout'
+          description: Saved column order and hidden columns for the experiment's
+            evaluations table. Omit to preserve the existing layout on update; on
+            create, defaults to an empty layout.
         is_favorite:
           type: boolean
           title: Is Favorite

--- a/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
@@ -257,8 +257,6 @@ async def update_experiment(
     # clients) must not silently reset customized axes to the cost/latency default.
     if body.pareto is not None:
         existing.pareto = body.pareto
-    # Same reasoning for the saved table layout: an omitted `column_layout` leaves it alone rather
-    # than clearing a layout the user explicitly saved. Sending an empty layout resets it.
     if body.column_layout is not None:
         existing.column_layout = body.column_layout
     # Preserve values written by newer clients when an older client sends a full update without

--- a/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/endpoints.py
@@ -128,6 +128,7 @@ async def create_experiment(
         metadata=body.metadata,
         default_sort=body.default_sort,
         pareto=body.pareto,
+        column_layout=body.column_layout,
         is_favorite=body.is_favorite,
         show_evaluations_over_time=body.show_evaluations_over_time,
     )
@@ -256,6 +257,10 @@ async def update_experiment(
     # clients) must not silently reset customized axes to the cost/latency default.
     if body.pareto is not None:
         existing.pareto = body.pareto
+    # Same reasoning for the saved table layout: an omitted `column_layout` leaves it alone rather
+    # than clearing a layout the user explicitly saved. Sending an empty layout resets it.
+    if body.column_layout is not None:
+        existing.column_layout = body.column_layout
     # Preserve values written by newer clients when an older client sends a full update without
     # fields it does not know about.
     if "is_favorite" in body.model_fields_set:

--- a/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from typing import Annotated, Self
 
 from nmp.common.entities.values import DatetimeFilter, Filter, NumberFilter, map_entity_field
-from nmp.intake.entities.experiments import Experiment, ExperimentGroup, ParetoConfig
+from nmp.intake.entities.experiments import ColumnLayout, Experiment, ExperimentGroup, ParetoConfig
 from nmp.intake.repository.evaluation_session import EvaluationSessionRow
 from nmp.intake.spans.domain import (
     INTAKE_PREVIEW_PAYLOAD_CHAR_LIMIT,
@@ -55,6 +55,13 @@ class ExperimentRequest(BaseModel):
         description=(
             "Default X/Y metrics for the experiment's Pareto view. Omit to preserve the existing value on "
             "update; on create, defaults to cost vs. latency."
+        ),
+    )
+    column_layout: ColumnLayout | None = Field(
+        default=None,
+        description=(
+            "Saved column order and hidden columns for the experiment's evaluations table. Omit to preserve "
+            "the existing layout on update; on create, defaults to an empty layout."
         ),
     )
     is_favorite: bool = Field(
@@ -185,6 +192,13 @@ class ExperimentResponse(BaseModel):
     metadata: dict[str, str] | None = None
     default_sort: str
     pareto: ParetoConfig = Field(default_factory=ParetoConfig)
+    column_layout: ColumnLayout | None = Field(
+        default=None,
+        description=(
+            "Saved column order and hidden columns for the experiment's evaluations table. Null when "
+            "none has been saved."
+        ),
+    )
     is_favorite: bool = Field(default=False, description="Whether this Experiment is marked as a favorite.")
     show_evaluations_over_time: bool = Field(
         default=False,
@@ -213,6 +227,7 @@ class ExperimentResponse(BaseModel):
             metadata=entity.metadata,
             default_sort=entity.default_sort,
             pareto=entity.pareto,
+            column_layout=entity.column_layout,
             is_favorite=entity.is_favorite,
             show_evaluations_over_time=entity.show_evaluations_over_time,
             baseline_evaluation_name=entity.baseline_evaluation_name,

--- a/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
@@ -60,8 +60,8 @@ class ExperimentRequest(BaseModel):
     column_layout: ColumnLayout | None = Field(
         default=None,
         description=(
-            "Saved column order and column visiblity for the experiment's evaluations table. "
-            "the existing layout on update; on create, defaults to an empty layout."
+            "Saved column order and column visibility for the experiment's evaluations table. Omit to "
+            "preserve the existing layout on update; on create, defaults to an empty layout."
         ),
     )
     is_favorite: bool = Field(

--- a/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
@@ -60,7 +60,7 @@ class ExperimentRequest(BaseModel):
     column_layout: ColumnLayout | None = Field(
         default=None,
         description=(
-            "Saved column order and hidden columns for the experiment's evaluations table. Omit to preserve "
+            "Saved column order and column visiblity for the experiment's evaluations table. "
             "the existing layout on update; on create, defaults to an empty layout."
         ),
     )

--- a/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
+++ b/services/intake/src/nmp/intake/api/v2/experiments/schemas.py
@@ -61,7 +61,9 @@ class ExperimentRequest(BaseModel):
         default=None,
         description=(
             "Saved column order and column visibility for the experiment's evaluations table. Omit to "
-            "preserve the existing layout on update; on create, defaults to an empty layout."
+            "leave the saved layout unchanged; on create that means no layout is saved. An empty order "
+            "and hidden pair is itself a saved layout — one that shows every column — and is distinct "
+            "from having none."
         ),
     )
     is_favorite: bool = Field(
@@ -195,8 +197,8 @@ class ExperimentResponse(BaseModel):
     column_layout: ColumnLayout | None = Field(
         default=None,
         description=(
-            "Saved column order and hidden columns for the experiment's evaluations table. Null when "
-            "none has been saved."
+            "Saved column order and column visibility for the experiment's evaluations table. Null when "
+            "no layout has been saved, which is distinct from a saved layout that hides nothing."
         ),
     )
     is_favorite: bool = Field(default=False, description="Whether this Experiment is marked as a favorite.")

--- a/services/intake/src/nmp/intake/entities/experiments.py
+++ b/services/intake/src/nmp/intake/entities/experiments.py
@@ -139,7 +139,7 @@ class ExperimentGroup(EntityBase):
     column_layout: ColumnLayout | None = Field(
         default=None,
         description=(
-            "Saved column order and hidden columns for this group's evaluations table. Null when no "
+            "Saved column order and column visibility for this group's evaluations table. Null when no "
             "layout has been saved, which is distinct from a saved layout that hides nothing: the "
             "client applies its own default hidden columns only in the null case."
         ),

--- a/services/intake/src/nmp/intake/entities/experiments.py
+++ b/services/intake/src/nmp/intake/entities/experiments.py
@@ -59,6 +59,31 @@ class ParetoConfig(BaseModel):
         )
 
 
+class ColumnLayout(BaseModel):
+    """A saved table layout for a group's evaluations list: column order and which columns are hidden.
+
+    Column ids are Studio's, not this API's — the evaluations table builds a column per evaluator and
+    per metadata key found in the loaded rows, so the set is workspace- and data-specific and cannot be
+    enumerated here. Ids are stored as given and echoed back unvalidated; Studio ignores any that no
+    longer resolve.
+
+    Visibility is stored as the *hidden* ids rather than a visible/hidden map for every column, so a
+    column that appears later (a new evaluator, a new metadata key) shows up by default instead of
+    being invisible because a layout saved before it existed never mentioned it.
+    """
+
+    order: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Column ids in display order. Empty means no saved order: the table falls back to its natural column order."
+        ),
+    )
+    hidden: list[str] = Field(
+        default_factory=list,
+        description="Column ids hidden from the table. Any column not listed is shown.",
+    )
+
+
 class ExperimentGroup(EntityBase):
     """A named container of Experiments pursuing a single optimization goal.
 
@@ -113,6 +138,15 @@ class ExperimentGroup(EntityBase):
         """Schema-on-read: groups persisted before this field stored no ``pareto`` (or ``null``);
         coerce anything that isn't a config mapping to the cost-vs-latency default."""
         return value if isinstance(value, dict | ParetoConfig) else ParetoConfig()
+
+    column_layout: ColumnLayout | None = Field(
+        default=None,
+        description=(
+            "Saved column order and hidden columns for this group's evaluations table. Null when no "
+            "layout has been saved, which is distinct from a saved layout that hides nothing: the "
+            "client applies its own default hidden columns only in the null case."
+        ),
+    )
 
     is_favorite: bool = Field(
         default=False,

--- a/services/intake/src/nmp/intake/entities/experiments.py
+++ b/services/intake/src/nmp/intake/entities/experiments.py
@@ -62,14 +62,11 @@ class ParetoConfig(BaseModel):
 class ColumnLayout(BaseModel):
     """A saved table layout for a group's evaluations list: column order and which columns are hidden.
 
-    Column ids are Studio's, not this API's — the evaluations table builds a column per evaluator and
-    per metadata key found in the loaded rows, so the set is workspace- and data-specific and cannot be
-    enumerated here. Ids are stored as given and echoed back unvalidated; Studio ignores any that no
-    longer resolve.
+    Column ids are Studio's and cannot be enumerated here — the table builds a column per evaluator
+    and metadata key found in the rows — so ids are stored and echoed back unvalidated.
 
-    Visibility is stored as the *hidden* ids rather than a visible/hidden map for every column, so a
-    column that appears later (a new evaluator, a new metadata key) shows up by default instead of
-    being invisible because a layout saved before it existed never mentioned it.
+    Visibility is stored as the *hidden* ids rather than a map over every column, so a column that
+    appears later (a new evaluator, a new metadata key) shows up by default.
     """
 
     order: list[str] = Field(

--- a/services/intake/tests/integration/test_experiments_crud.py
+++ b/services/intake/tests/integration/test_experiments_crud.py
@@ -847,3 +847,34 @@ def test_patch_evaluation_dedupes_experiment_ids(client: TestClient) -> None:
     listed = client.get(EXPERIMENTS)
     grp = next(g for g in listed.json()["data"] if g["id"] == group["id"])
     assert grp["evaluation_count"] == 1
+
+
+def test_experiment_group_column_layout_defaults_and_round_trips(client: TestClient) -> None:
+    # Omitting column_layout leaves the table on its natural layout rather than inventing an order.
+    created = client.post(EXPERIMENTS, json={"name": "columns-cfg"})
+    assert created.status_code == 201, created.text
+    assert created.json()["column_layout"] is None
+    assert client.get(f"{EXPERIMENTS}/columns-cfg").json()["column_layout"] is None
+
+    # A saved layout round-trips through PUT, ids echoed back as given.
+    layout = {
+        "order": ["name", "evaluator-llm-judge.answers_question", "created_at"],
+        "hidden": ["created_by", "metadata-run_id"],
+    }
+    updated = client.put(f"{EXPERIMENTS}/columns-cfg", json={"name": "columns-cfg", "column_layout": layout})
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["column_layout"] == layout
+
+    # An update that omits column_layout preserves the saved layout rather than clearing it.
+    preserved = client.put(f"{EXPERIMENTS}/columns-cfg", json={"name": "columns-cfg", "summary": "unrelated edit"})
+    assert preserved.status_code == 200, preserved.text
+    assert preserved.json()["column_layout"] == layout
+
+    # An empty layout is a saved layout, not an absent one: it stays distinguishable from null so the
+    # client knows not to re-apply its default hidden columns over a deliberate "show everything".
+    reset = client.put(
+        f"{EXPERIMENTS}/columns-cfg",
+        json={"name": "columns-cfg", "column_layout": {"order": [], "hidden": []}},
+    )
+    assert reset.status_code == 200, reset.text
+    assert reset.json()["column_layout"] == {"order": [], "hidden": []}

--- a/web/packages/common/plugin-types/plugin.d.ts
+++ b/web/packages/common/plugin-types/plugin.d.ts
@@ -9255,6 +9255,8 @@ interface StudioDataViewToolbarProps<DataType = unknown> {
     table: Table<DataType>;
   }) => ReactNode;
   searchBarProps?: ComponentProps<typeof SearchBar>;
+  /** Rendered before the search bar, at the toolbar's leading edge. */
+  slotStart?: ReactNode;
   /**
    * Additional content rendered inside the toolbar row, after the filter toggle button.
    * Use this to inject view-specific controls such as a sort dropdown.
@@ -9268,7 +9270,7 @@ interface StudioDataViewToolbarProps<DataType = unknown> {
  * Exported so it can be used in non-table views (e.g. card grids) that wrap their content
  * in a headless `DataView.Root` for filter state management.
  */
-export declare function StudioDataViewToolbar<DataType = unknown>({ searchField, showFilters, onToggleFilters, renderBulkActions, searchBarProps, slotEnd }: StudioDataViewToolbarProps<DataType>): import("react/jsx-runtime").JSX.Element | null;
+export declare function StudioDataViewToolbar<DataType = unknown>({ searchField, showFilters, onToggleFilters, renderBulkActions, searchBarProps, slotStart, slotEnd }: StudioDataViewToolbarProps<DataType>): import("react/jsx-runtime").JSX.Element | null;
 //#endregion
 //#region src/components/DataView/StudioDataView.d.ts
 export declare const ROW_SELECTION_COLUMN_SIZE = 50;
@@ -9316,6 +9318,7 @@ interface Props$4<DataType> {
    * Rendered at the trailing end of the toolbar row (after the search bar and filter toggle).
    * Useful for controls like a sort dropdown that belong visually in the toolbar.
    */
+  toolbarSlotStart?: ReactNode;
   toolbarSlotEnd?: ReactNode;
   /**
    * Ref attached to the scrollable container that wraps custom `children`.
@@ -9329,7 +9332,7 @@ interface Props$4<DataType> {
     DataViewSearchBar?: ComponentProps<typeof SearchBar>;
   };
 }
-export declare const StudioDataView: <DataType>({ attributes, children, makeColumns, dataViewState, onRowClick, maxTwoLines, renderBulkActions, scrollContainerRef, searchField, toolbarSlotEnd }: Props$4<DataType>) => import("react/jsx-runtime").JSX.Element;
+export declare const StudioDataView: <DataType>({ attributes, children, makeColumns, dataViewState, onRowClick, maxTwoLines, renderBulkActions, scrollContainerRef, searchField, toolbarSlotStart, toolbarSlotEnd }: Props$4<DataType>) => import("react/jsx-runtime").JSX.Element;
 //#endregion
 //#region src/components/LogViewer/index.d.ts
 interface LogViewerProps {

--- a/web/packages/common/src/components/DataView/StudioDataView.tsx
+++ b/web/packages/common/src/components/DataView/StudioDataView.tsx
@@ -73,6 +73,7 @@ interface Props<DataType> {
    * Rendered at the trailing end of the toolbar row (after the search bar and filter toggle).
    * Useful for controls like a sort dropdown that belong visually in the toolbar.
    */
+  toolbarSlotStart?: ReactNode;
   toolbarSlotEnd?: ReactNode;
   /**
    * Ref attached to the scrollable container that wraps custom `children`.
@@ -103,6 +104,7 @@ export const StudioDataView = <DataType,>({
   renderBulkActions,
   scrollContainerRef,
   searchField,
+  toolbarSlotStart,
   toolbarSlotEnd,
 }: Props<DataType>) => {
   const [showFilters, setShowFilters] = useState(false);
@@ -165,6 +167,7 @@ export const StudioDataView = <DataType,>({
           onToggleFilters={toggleFilters}
           renderBulkActions={renderBulkActions}
           searchBarProps={attributes?.DataViewSearchBar}
+          slotStart={toolbarSlotStart}
           slotEnd={toolbarSlotEnd}
         />
         <Flex className="min-h-0 h-full">

--- a/web/packages/common/src/components/DataView/StudioDataViewToolbar.tsx
+++ b/web/packages/common/src/components/DataView/StudioDataViewToolbar.tsx
@@ -16,6 +16,8 @@ export interface StudioDataViewToolbarProps<DataType = unknown> {
     table: DataView.TanstackTable.Table<DataType>;
   }) => ReactNode;
   searchBarProps?: ComponentProps<typeof DataView.SearchBar>;
+  /** Rendered before the search bar, at the toolbar's leading edge. */
+  slotStart?: ReactNode;
   /**
    * Additional content rendered inside the toolbar row, after the filter toggle button.
    * Use this to inject view-specific controls such as a sort dropdown.
@@ -36,6 +38,7 @@ export function StudioDataViewToolbar<DataType = unknown>({
   onToggleFilters,
   renderBulkActions,
   searchBarProps,
+  slotStart,
   slotEnd,
 }: StudioDataViewToolbarProps<DataType>) {
   const { table } = useInnerDataViewContext();
@@ -43,7 +46,8 @@ export function StudioDataViewToolbar<DataType = unknown>({
   const hasSelectedRows = table.getSelectedRowModel().flatRows.length > 0;
   const hostsBulkActions = Boolean(renderBulkActions) && hasSelectedRows;
 
-  if (!searchField && !hasFilterableColumns && !hostsBulkActions) return null;
+  if (!searchField && !hasFilterableColumns && !hostsBulkActions && !slotStart && !slotEnd)
+    return null;
 
   return (
     <>
@@ -61,6 +65,7 @@ export function StudioDataViewToolbar<DataType = unknown>({
           ) : undefined
         }
       >
+        {slotStart}
         {searchField && (
           <DataView.SearchBar
             placeholder={searchBarProps?.placeholder ?? 'Search...'}

--- a/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
@@ -673,14 +673,10 @@ export const ExperimentDataView: FC<ExperimentDataViewProps> = ({
               </>
             </EditColumnsMenu>
             {/* Only present once the layout differs from the saved one: a permanently visible Save
-                with nothing to save reads as an action the table is waiting on. */}
+                with nothing to save reads as an action the table is waiting on. Left at the default
+                size so it matches the Columns trigger it sits against. */}
             {columnLayout.hasUnsavedLayout && (
-              <Button
-                kind="primary"
-                size="small"
-                disabled={columnLayout.isSaving}
-                onClick={columnLayout.save}
-              >
+              <Button kind="primary" disabled={columnLayout.isSaving} onClick={columnLayout.save}>
                 {columnLayout.isSaving ? 'Saving…' : 'Save columns'}
               </Button>
             )}

--- a/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
@@ -30,6 +30,10 @@ import { AddToGroupModal } from '@studio/components/dataViews/ExperimentDataView
 import '@studio/components/dataViews/ExperimentDataView/ExperimentDataView.css';
 import { MeanValueTooltipCell } from '@studio/components/dataViews/ExperimentDataView/MeanValueTooltipCell';
 import {
+  seedColumnState,
+  useColumnLayout,
+} from '@studio/components/dataViews/ExperimentDataView/useColumnLayout';
+import {
   type EvaluationRow,
   type ListEvaluationsSortParam,
   useExperimentEvaluations,
@@ -41,9 +45,8 @@ import { SubmitEvaluationModal } from '@studio/components/evaluation/SubmitEvalu
 import { useWorkspaceFromPath } from '@studio/hooks/useWorkspaceFromPath';
 import { getEvaluationDetailRoute } from '@studio/routes/utils';
 import { tooltipClassName } from '@studio/styles/common';
-import { useLocalStorage } from '@studio/util/hooks/useLocalStorage';
 import { Columns3, FolderMinus, FolderPlus, Pin, Repeat2 } from 'lucide-react';
-import { type ComponentProps, type FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { type ComponentProps, type FC, useCallback, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 export type { EvaluationRow };
@@ -179,33 +182,32 @@ export const ExperimentDataView: FC<ExperimentDataViewProps> = ({
   // this leaderboard is where you notice a run worth varying.
   const [rerunSource, setRerunSource] = useState<EvaluationRow | null>(null);
 
-  // Persist column order to localStorage, keyed by experiment group ID.
-  const [savedColumnOrder, saveColumnOrder] = useLocalStorage<string[]>(
-    `nemo-studio:experiment-columns:${experimentId}`,
-    []
-  );
-
   // Seed the sort from default_sort so its column header reflects the order on load. Memoized so the
   // reference is stable across renders (until default_sort changes).
   const defaultSort = useMemo(() => seedSortFromDefault(group.default_sort), [group.default_sort]);
+
+  // Seeded once, from the layout saved on the experiment. Keyed by group id at the route level, so a
+  // different experiment remounts this view rather than reusing another's columns.
+  const seededColumns = useMemo(() => seedColumnState(group.column_layout), [group.column_layout]);
 
   const dataViewState = useStudioDataViewState<EvaluationFilter>({
     defaultSort,
     // The evaluations leaderboard supports multi-column sort (shift-click) — score vs. cost etc.
     multiSort: true,
-    columnVisibility: { created_by: false, updated_at: false },
+    columnVisibility: seededColumns.columnVisibility,
     // Keep the pin toggle, row selection, and the row actions menu reachable while horizontally
     // scrolling this wide table.
     columnPinning: { left: ['pin', 'row-selection'], right: ['row-actions'] },
     filterFieldMap: getEvaluationFilterField,
-    columnOrder: savedColumnOrder ?? [],
+    columnOrder: seededColumns.columnOrder,
   });
 
-  // Write column order to localStorage whenever it changes after the first reorder.
-  const { columnOrder } = dataViewState;
-  useEffect(() => {
-    if (columnOrder.state.length > 0) saveColumnOrder(columnOrder.state);
-  }, [columnOrder.state, saveColumnOrder]);
+  const columnLayout = useColumnLayout({
+    workspace,
+    group,
+    columnOrder: dataViewState.columnOrder.state,
+    columnVisibility: dataViewState.columnVisibility.state,
+  });
 
   const page = dataViewState.pagination.state.pageIndex + 1;
   const pageSize = dataViewState.pagination.state.pageSize;
@@ -655,18 +657,34 @@ export const ExperimentDataView: FC<ExperimentDataViewProps> = ({
           </Button>
         )}
         toolbarSlotEnd={
-          <EditColumnsMenu
-            kind="secondary"
-            showChevron={false}
-            // EditColumnsMenu exposes no width control for its dropdown, so this zero-height
-            // spacer sets a min width on the menu (which sizes to its widest child).
-            slotContent={<div aria-hidden className="h-0 w-[230px]" />}
-          >
-            <>
-              <Columns3 />
-              <span className="hide-mobile">Columns</span>
-            </>
-          </EditColumnsMenu>
+          // Held at its natural width so the toolbar's search field absorbs the space instead: the
+          // slot shrinks by default, which clipped the Save button off the end of the toolbar.
+          <div className="flex shrink-0 items-center gap-2">
+            <EditColumnsMenu
+              kind="secondary"
+              showChevron={false}
+              // EditColumnsMenu exposes no width control for its dropdown, so this zero-height
+              // spacer sets a min width on the menu (which sizes to its widest child).
+              slotContent={<div aria-hidden className="h-0 w-[230px]" />}
+            >
+              <>
+                <Columns3 />
+                <span className="hide-mobile">Columns</span>
+              </>
+            </EditColumnsMenu>
+            {/* Only present once the layout differs from the saved one: a permanently visible Save
+                with nothing to save reads as an action the table is waiting on. */}
+            {columnLayout.hasUnsavedLayout && (
+              <Button
+                kind="primary"
+                size="small"
+                disabled={columnLayout.isSaving}
+                onClick={columnLayout.save}
+              >
+                {columnLayout.isSaving ? 'Saving…' : 'Save columns'}
+              </Button>
+            )}
+          </div>
         }
         attributes={{
           DataViewRoot: {

--- a/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
+++ b/web/packages/studio/src/components/dataViews/ExperimentDataView/index.tsx
@@ -186,8 +186,6 @@ export const ExperimentDataView: FC<ExperimentDataViewProps> = ({
   // reference is stable across renders (until default_sort changes).
   const defaultSort = useMemo(() => seedSortFromDefault(group.default_sort), [group.default_sort]);
 
-  // Seeded once, from the layout saved on the experiment. Keyed by group id at the route level, so a
-  // different experiment remounts this view rather than reusing another's columns.
   const seededColumns = useMemo(() => seedColumnState(group.column_layout), [group.column_layout]);
 
   const dataViewState = useStudioDataViewState<EvaluationFilter>({
@@ -656,31 +654,32 @@ export const ExperimentDataView: FC<ExperimentDataViewProps> = ({
             Add to experiment
           </Button>
         )}
-        toolbarSlotEnd={
-          // Held at its natural width so the toolbar's search field absorbs the space instead: the
-          // slot shrinks by default, which clipped the Save button off the end of the toolbar.
-          <div className="flex shrink-0 items-center gap-2">
-            <EditColumnsMenu
-              kind="secondary"
-              showChevron={false}
-              // EditColumnsMenu exposes no width control for its dropdown, so this zero-height
-              // spacer sets a min width on the menu (which sizes to its widest child).
-              slotContent={<div aria-hidden className="h-0 w-[230px]" />}
+        // `shrink-0` so the search field absorbs the width instead of the button being clipped.
+        toolbarSlotStart={
+          columnLayout.hasUnsavedLayout ? (
+            <Button
+              className="shrink-0"
+              kind="primary"
+              disabled={columnLayout.isSaving}
+              onClick={columnLayout.save}
             >
-              <>
-                <Columns3 />
-                <span className="hide-mobile">Columns</span>
-              </>
-            </EditColumnsMenu>
-            {/* Only present once the layout differs from the saved one: a permanently visible Save
-                with nothing to save reads as an action the table is waiting on. Left at the default
-                size so it matches the Columns trigger it sits against. */}
-            {columnLayout.hasUnsavedLayout && (
-              <Button kind="primary" disabled={columnLayout.isSaving} onClick={columnLayout.save}>
-                {columnLayout.isSaving ? 'Saving…' : 'Save columns'}
-              </Button>
-            )}
-          </div>
+              {columnLayout.isSaving ? 'Saving…' : 'Save columns'}
+            </Button>
+          ) : undefined
+        }
+        toolbarSlotEnd={
+          <EditColumnsMenu
+            kind="secondary"
+            showChevron={false}
+            // EditColumnsMenu exposes no width control for its dropdown, so this zero-height
+            // spacer sets a min width on the menu (which sizes to its widest child).
+            slotContent={<div aria-hidden className="h-0 w-[230px]" />}
+          >
+            <>
+              <Columns3 />
+              <span className="hide-mobile">Columns</span>
+            </>
+          </EditColumnsMenu>
         }
         attributes={{
           DataViewRoot: {

--- a/web/packages/studio/src/components/dataViews/ExperimentDataView/useColumnLayout.test.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentDataView/useColumnLayout.test.ts
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  hiddenColumnIds,
+  isLayoutDirty,
+  seedColumnState,
+} from '@studio/components/dataViews/ExperimentDataView/useColumnLayout';
+
+describe('hiddenColumnIds', () => {
+  it('reports only the columns visibility turns off', () => {
+    expect(hiddenColumnIds({ name: true, created_by: false, updated_at: false })).toEqual([
+      'created_by',
+      'updated_at',
+    ]);
+  });
+
+  it('is empty when every recorded column is visible', () => {
+    expect(hiddenColumnIds({ name: true, created_by: true })).toEqual([]);
+  });
+});
+
+describe('seedColumnState', () => {
+  it('applies the built-in hidden columns when nothing has been saved', () => {
+    expect(seedColumnState(undefined)).toEqual({
+      columnOrder: [],
+      columnVisibility: { created_by: false, updated_at: false },
+    });
+  });
+
+  it('treats a saved layout that hides nothing as authoritative', () => {
+    // The distinction that makes `column_layout` nullable: an explicit "show everything" must not be
+    // overwritten by the defaults on the next load.
+    expect(seedColumnState({ order: [], hidden: [] })).toEqual({
+      columnOrder: [],
+      columnVisibility: {},
+    });
+  });
+
+  it('seeds the saved order and hidden columns', () => {
+    expect(seedColumnState({ order: ['name', 'cost_usd'], hidden: ['tokens'] })).toEqual({
+      columnOrder: ['name', 'cost_usd'],
+      columnVisibility: { tokens: false },
+    });
+  });
+});
+
+describe('isLayoutDirty', () => {
+  it('is clean when an untouched table sits on the defaults', () => {
+    // The load-time case: the Save button must not appear before anyone has changed anything.
+    const seeded = seedColumnState(undefined);
+    expect(
+      isLayoutDirty({
+        saved: undefined,
+        columnOrder: seeded.columnOrder,
+        columnVisibility: seeded.columnVisibility,
+      })
+    ).toBe(false);
+  });
+
+  it('is clean when an untouched table sits on its saved layout', () => {
+    const saved = { order: ['name', 'cost_usd'], hidden: ['tokens'] };
+    const seeded = seedColumnState(saved);
+    expect(
+      isLayoutDirty({
+        saved,
+        columnOrder: seeded.columnOrder,
+        columnVisibility: seeded.columnVisibility,
+      })
+    ).toBe(false);
+  });
+
+  it('is dirty once a column is hidden', () => {
+    expect(
+      isLayoutDirty({
+        saved: undefined,
+        columnOrder: [],
+        columnVisibility: { created_by: false, updated_at: false, tokens: false },
+      })
+    ).toBe(true);
+  });
+
+  it('is dirty once a hidden column is shown again', () => {
+    expect(
+      isLayoutDirty({
+        saved: { order: [], hidden: ['tokens'] },
+        columnOrder: [],
+        columnVisibility: { tokens: true },
+      })
+    ).toBe(true);
+  });
+
+  it('is dirty once columns are reordered', () => {
+    expect(
+      isLayoutDirty({
+        saved: { order: ['name', 'cost_usd'], hidden: [] },
+        columnOrder: ['cost_usd', 'name'],
+        columnVisibility: {},
+      })
+    ).toBe(true);
+  });
+
+  it('compares hidden columns as a set, not a sequence', () => {
+    // Visibility is a map, so the ids come out in whatever order they were toggled; that is not a
+    // change worth offering a save for.
+    expect(
+      isLayoutDirty({
+        saved: { order: [], hidden: ['updated_at', 'created_by'] },
+        columnOrder: [],
+        columnVisibility: { created_by: false, updated_at: false },
+      })
+    ).toBe(false);
+  });
+});

--- a/web/packages/studio/src/components/dataViews/ExperimentDataView/useColumnLayout.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentDataView/useColumnLayout.ts
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { useToast } from '@nemo/common/src/providers/toast/useToast';
+import { getGetExperimentQueryKey, useUpdateExperiment } from '@nemo/sdk/generated/platform/api';
+import type { ColumnLayout, ExperimentResponse } from '@nemo/sdk/generated/platform/schema';
+import { useQueryClient } from '@tanstack/react-query';
+
+/**
+ * Columns hidden until someone says otherwise. Applied only when the experiment has no saved layout
+ * at all — once a layout exists it is authoritative, so a deliberate "show everything" is not
+ * quietly re-hidden on the next load.
+ */
+const DEFAULT_HIDDEN_COLUMNS: readonly string[] = ['created_by', 'updated_at'];
+
+/**
+ * The table's `columnVisibility` only records columns someone has toggled; anything absent is
+ * visible. Inverting it back to a plain id list is what makes the saved layout comparable to the
+ * live one, and keeps what we persist independent of how many columns happen to exist.
+ */
+export const hiddenColumnIds = (visibility: Record<string, boolean>): string[] =>
+  Object.entries(visibility)
+    .filter(([, isVisible]) => !isVisible)
+    .map(([id]) => id)
+    .sort();
+
+const toVisibility = (hidden: readonly string[]): Record<string, boolean> =>
+  Object.fromEntries(hidden.map((id) => [id, false]));
+
+/** Order is a sequence, so it compares element-wise; hidden is a set, so it compares sorted. */
+const sameSequence = (a: readonly string[], b: readonly string[]): boolean =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
+
+const sameSet = (a: readonly string[], b: readonly string[]): boolean =>
+  sameSequence([...a].sort(), [...b].sort());
+
+/** The hidden ids a layout implies, falling back to the built-in defaults only when none is saved. */
+const savedHiddenColumns = (layout: ColumnLayout | undefined): readonly string[] =>
+  layout ? (layout.hidden ?? []) : DEFAULT_HIDDEN_COLUMNS;
+
+/**
+ * Seed values for the data view's column state, so the table opens on the experiment's saved layout
+ * instead of flashing the default one and re-arranging once the group loads.
+ */
+export const seedColumnState = (
+  layout: ColumnLayout | undefined
+): { columnOrder: string[]; columnVisibility: Record<string, boolean> } => ({
+  columnOrder: [...(layout?.order ?? [])],
+  columnVisibility: toVisibility(savedHiddenColumns(layout)),
+});
+
+/**
+ * Whether the live column state differs from the saved layout — which is the whole condition for
+ * offering a save. An untouched table sitting on its saved layout must read as clean, including the
+ * case where nothing has ever been saved and the table is on its defaults.
+ */
+export const isLayoutDirty = ({
+  saved,
+  columnOrder,
+  columnVisibility,
+}: {
+  saved: ColumnLayout | undefined;
+  columnOrder: string[];
+  columnVisibility: Record<string, boolean>;
+}): boolean =>
+  !sameSequence(columnOrder, saved?.order ?? []) ||
+  !sameSet(hiddenColumnIds(columnVisibility), savedHiddenColumns(saved));
+
+export interface ExperimentColumnLayout {
+  /** True when the live column order or visibility differs from what is saved on the experiment. */
+  hasUnsavedLayout: boolean;
+  /** Persists the live layout onto the experiment. */
+  save: () => void;
+  isSaving: boolean;
+}
+
+/**
+ * Tracks the evaluations table's column layout against the copy saved on the experiment, and
+ * persists it on request.
+ *
+ * The layout lives on the experiment rather than in browser storage because it describes the
+ * experiment — which of its evaluators are worth a column, and in what order they read — so it
+ * should follow the experiment between browsers and between people looking at the same results.
+ */
+export function useColumnLayout({
+  workspace,
+  group,
+  columnOrder,
+  columnVisibility,
+}: {
+  workspace: string;
+  group: ExperimentResponse;
+  columnOrder: string[];
+  columnVisibility: Record<string, boolean>;
+}): ExperimentColumnLayout {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const { mutate: saveGroup, isPending: isSaving } = useUpdateExperiment({
+    mutation: {
+      onSuccess: () => {
+        toast.success('Saved the column layout for this experiment.');
+        queryClient.invalidateQueries({
+          queryKey: getGetExperimentQueryKey(workspace, group.name),
+        });
+      },
+      onError: () => toast.error('Failed to save the column layout.'),
+    },
+  });
+
+  const currentHidden = hiddenColumnIds(columnVisibility);
+  const hasUnsavedLayout = isLayoutDirty({
+    saved: group.column_layout,
+    columnOrder,
+    columnVisibility,
+  });
+
+  const save = () => {
+    // PUT replaces the whole experiment, and the fields below are written unconditionally by the
+    // API — so they are echoed back as-is. `pareto` and the display flags are guarded server-side by
+    // whether the client sent them, so omitting them preserves what is already saved.
+    saveGroup({
+      workspace,
+      name: group.name,
+      data: {
+        name: group.name,
+        description: group.description,
+        insight_id: group.insight_id,
+        summary: group.summary,
+        metadata: group.metadata,
+        default_sort: group.default_sort,
+        column_layout: { order: columnOrder, hidden: currentHidden },
+      },
+    });
+  };
+
+  return { hasUnsavedLayout, save, isSaving };
+}

--- a/web/packages/studio/src/components/dataViews/ExperimentDataView/useColumnLayout.ts
+++ b/web/packages/studio/src/components/dataViews/ExperimentDataView/useColumnLayout.ts
@@ -6,18 +6,10 @@ import { getGetExperimentQueryKey, useUpdateExperiment } from '@nemo/sdk/generat
 import type { ColumnLayout, ExperimentResponse } from '@nemo/sdk/generated/platform/schema';
 import { useQueryClient } from '@tanstack/react-query';
 
-/**
- * Columns hidden until someone says otherwise. Applied only when the experiment has no saved layout
- * at all — once a layout exists it is authoritative, so a deliberate "show everything" is not
- * quietly re-hidden on the next load.
- */
+/** Applied only when no layout is saved; a saved layout is authoritative, including an empty one. */
 const DEFAULT_HIDDEN_COLUMNS: readonly string[] = ['created_by', 'updated_at'];
 
-/**
- * The table's `columnVisibility` only records columns someone has toggled; anything absent is
- * visible. Inverting it back to a plain id list is what makes the saved layout comparable to the
- * live one, and keeps what we persist independent of how many columns happen to exist.
- */
+/** `columnVisibility` only records toggled columns; anything absent is visible. */
 export const hiddenColumnIds = (visibility: Record<string, boolean>): string[] =>
   Object.entries(visibility)
     .filter(([, isVisible]) => !isVisible)
@@ -27,21 +19,15 @@ export const hiddenColumnIds = (visibility: Record<string, boolean>): string[] =
 const toVisibility = (hidden: readonly string[]): Record<string, boolean> =>
   Object.fromEntries(hidden.map((id) => [id, false]));
 
-/** Order is a sequence, so it compares element-wise; hidden is a set, so it compares sorted. */
 const sameSequence = (a: readonly string[], b: readonly string[]): boolean =>
   a.length === b.length && a.every((value, index) => value === b[index]);
 
 const sameSet = (a: readonly string[], b: readonly string[]): boolean =>
   sameSequence([...a].sort(), [...b].sort());
 
-/** The hidden ids a layout implies, falling back to the built-in defaults only when none is saved. */
 const savedHiddenColumns = (layout: ColumnLayout | undefined): readonly string[] =>
   layout ? (layout.hidden ?? []) : DEFAULT_HIDDEN_COLUMNS;
 
-/**
- * Seed values for the data view's column state, so the table opens on the experiment's saved layout
- * instead of flashing the default one and re-arranging once the group loads.
- */
 export const seedColumnState = (
   layout: ColumnLayout | undefined
 ): { columnOrder: string[]; columnVisibility: Record<string, boolean> } => ({
@@ -49,11 +35,6 @@ export const seedColumnState = (
   columnVisibility: toVisibility(savedHiddenColumns(layout)),
 });
 
-/**
- * Whether the live column state differs from the saved layout — which is the whole condition for
- * offering a save. An untouched table sitting on its saved layout must read as clean, including the
- * case where nothing has ever been saved and the table is on its defaults.
- */
 export const isLayoutDirty = ({
   saved,
   columnOrder,
@@ -75,12 +56,10 @@ export interface ExperimentColumnLayout {
 }
 
 /**
- * Tracks the evaluations table's column layout against the copy saved on the experiment, and
- * persists it on request.
+ * Tracks the evaluations table's column layout against the copy saved on the experiment.
  *
- * The layout lives on the experiment rather than in browser storage because it describes the
- * experiment — which of its evaluators are worth a column, and in what order they read — so it
- * should follow the experiment between browsers and between people looking at the same results.
+ * The layout lives on the experiment, not in browser storage, so it follows the experiment between
+ * browsers and between people looking at the same results.
  */
 export function useColumnLayout({
   workspace,
@@ -116,9 +95,8 @@ export function useColumnLayout({
   });
 
   const save = () => {
-    // PUT replaces the whole experiment, and the fields below are written unconditionally by the
-    // API — so they are echoed back as-is. `pareto` and the display flags are guarded server-side by
-    // whether the client sent them, so omitting them preserves what is already saved.
+    // PUT replaces the whole experiment: the fields below are written unconditionally by the API and
+    // must be echoed back, while omitted ones (`pareto`, the display flags) are preserved server-side.
     saveGroup({
       workspace,
       name: group.name,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

The evaluations table's column order lived in `localStorage`, so it followed the browser rather than the experiment it describes — which of an experiment's evaluators are worth a column, and in what order they read, is a property of the experiment, not of the machine looking at it. Column visibility was not persisted at all. Both now live on the experiment: a **Save columns** button appears at the toolbar's leading edge once the live layout differs from the saved one, and disappears again once it matches.

## Changes

- `ExperimentGroup` gains `column_layout` (`order` + `hidden`). The entity store is schema-on-read, so **no migration is required**. Update follows the existing `pareto` convention: an omitted `column_layout` preserves what is saved rather than clearing it.
- The field is **nullable** so "never saved" stays distinct from "saved with nothing hidden". The client applies its own default hidden columns only in the null case, so a deliberate "show everything" survives a reload instead of being re-hidden — and the Save button does not appear on a freshly loaded page.
- Visibility is stored as the **hidden ids** rather than a map over every column, so a column that appears later (a new evaluator, a new metadata key) shows up by default instead of being invisible because a layout saved before it existed never mentioned it.
- Studio seeds column order and visibility from the experiment and persists them through the existing `PUT /experiments/{name}`.
- `StudioDataViewToolbar` gains a `slotStart` (surfaced as `toolbarSlotStart` on `StudioDataView`), rendered before the search bar. This is additive and optional; existing callers are unaffected.
- Regenerated `openapi/` and the web SDK.

### Behavior change worth calling out

This replaces the `localStorage` column-order persistence (`nemo-studio:experiment-columns:<id>`). Anyone holding a local layout will see it reset once to the experiment's saved (initially absent) layout. Keeping both stores seemed worse than picking one.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: no documented surface changes; the field is described in the OpenAPI schema it ships with.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation, all run after rebasing onto `origin/main`:

- `uv run pre-commit run --files <changed files>` — passed (ruff, ruff format, **ty**, copyright headers, UI lint-staged, merge-conflict check). The full `-a` run was **not** performed locally, so that box is left unchecked; CI runs the complete gate.
- `uv run --frozen pytest services/intake/tests/integration/test_experiments_crud.py -k "column_layout or pareto"` — 3 passed. Covers the null default, the PUT round-trip, preservation on an update that omits the field, and that an empty layout stays distinguishable from null.
- `pnpm --filter="...[origin/main]" run --parallel --if-present test:ci` — `@nemo/common` 1518 passed (122 files), `studio` 3358 passed (346 files). Includes 11 new `useColumnLayout` cases (load-time clean state, hide/show, reorder, hidden-compared-as-a-set).
- `pnpm --filter="...[origin/main]" run --parallel --if-present typecheck`, `pnpm lint`, `pnpm format` — clean.
- Regenerated `openapi/` and the web SDK on the rebased base and confirmed the only remaining diff is this change; re-running the generator is stable.
- Manually exercised against a local platform: reordering and hiding columns reveals the button, saving persists, and a reload comes back on the saved layout. The stored layout round-trips through the API.

Not done: the Stainless **Python** SDK was not regenerated — `make update-sdk` requires `STAINLESS_API_KEY`, which this environment does not have. The OpenAPI spec and web SDK are committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experiment evaluation-table column order and hidden columns can now be saved and restored.
  * Added a toolbar action to save unsaved column-layout changes, with saving status and success/error feedback.
  * Saved layouts persist through experiment creation and updates and appear in experiment details.
  * New experiments start without a saved layout; an explicitly saved empty layout is preserved separately.
  * Added support for custom content at the start of data-view toolbars.
* **Tests**
  * Added coverage for layout defaults, persistence, visibility changes, ordering, and unsaved-state detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->