### PR TITLE
ci: use release webhook for forward merge alerts

### DIFF
--- a/.github/workflows/forward-merge-alert.yaml
+++ b/.github/workflows/forward-merge-alert.yaml
@@ -25,7 +25,7 @@ jobs:
           PR_TITLE: ${{ github.event.issue.title }}
           PR_URL: ${{ github.event.issue.html_url }}
           REPOSITORY: ${{ github.repository }}
-          SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK }}
+          SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}
         run: |
           escaped_pr_title="$(sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' <<<"${PR_TITLE}")"
           text="$(printf '%s\n' \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- markdownlint-disable MD041 -->
## Summary
Use the release-specific Slack webhook secret for failed forward-merge alerts instead of the general alerts webhook.

## Changes
- Map the forward-merge alert webhook environment variable to `secrets.SLACK_RELEASE_WEBHOOK`.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [x] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: This is a one-line GitHub Actions secret mapping change.
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: The change is internal workflow configuration.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `git diff --check origin/main...HEAD` passed.
- Verified exactly one `SLACK_ALERTS_WEBHOOK: ${{ secrets.SLACK_RELEASE_WEBHOOK }}` mapping and no remaining `secrets.SLACK_ALERTS_WEBHOOK` reference in the workflow.
- DCO audit passed for commit `769cd75edcd717e72e1f0ec7f7cabd712b717a7e`.
- `uv run pre-commit run -a` could not run because `uv` is not installed in the Cloud Agent environment.
- YAML parser validation could not run because the environment does not include Ruby; GitHub CI remains the workflow syntax authority.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://nvidia.slack.com/archives/C068SNN705R/p1788366817949909?thread_ts=1788366817.949909&cid=C068SNN705R)

<div><a href="https://cursor.com/agents/bc-cee659bc-b145-5189-83b8-0809521b0696?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cee659bc-b145-5189-83b8-0809521b0696&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated failed forward-merge Slack alerts to use the release notification channel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->