### PR TITLE
feat(evaluator): publish the OTLP trace to Intake when a trial has one

### DIFF
--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/evidence.py
@@ -19,10 +19,12 @@ from pathlib import Path
 from typing import Any, Literal, TypeAlias, overload
 from urllib.parse import urlparse
 
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 from pydantic import BaseModel, ConfigDict, Field, JsonValue, PrivateAttr, model_validator
 
 from nemo_evaluator_sdk.values.atif import FinalMetrics, Step, ToolCall, Trajectory
 from nemo_evaluator_sdk.values.otlp import (
+    export_request_from_resource_spans,
     resource_spans_from_request,
     resource_spans_from_text,
     validate_resource_spans,
@@ -374,6 +376,18 @@ class OTLPTraceHandle:
     def __init__(self, descriptor: EvidenceDescriptor) -> None:
         self._descriptor = descriptor
         self._resource_spans: list[dict[str, Any]] | None = None
+        self._export_request: ExportTraceServiceRequest | None = None
+
+    async def export_request(self) -> ExportTraceServiceRequest:
+        """Return the trace as the typed OTLP request, parsed once.
+
+        Serializing this is what OTLP ingest accepts, so a consumer that publishes and one
+        that reads share a representation instead of re-encoding between two.
+        """
+        if self._export_request is None:
+            resource_spans = await self.resource_spans()
+            self._export_request = await asyncio.to_thread(export_request_from_resource_spans, resource_spans)
+        return self._export_request
 
     async def resource_spans(self) -> list[dict[str, Any]]:
         """Return concatenated OTLP ``resourceSpans``, loading and validating once.

--- a/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/otlp.py
+++ b/packages/nemo_evaluator_sdk/src/nemo_evaluator_sdk/values/otlp.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 
 import json
 from base64 import b64encode
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from copy import deepcopy
-from typing import Any, cast
+from typing import Any, TypeAlias, cast
 
 from google.protobuf import json_format
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
-from opentelemetry.proto.trace.v1.trace_pb2 import Span
+from opentelemetry.proto.trace.v1.trace_pb2 import Span, Status
 
 _MESSAGE_ATTRIBUTE_KEY = "gen_ai.output.messages"
 _SPAN_KIND_ATTRIBUTE = "openinference.span.kind"
@@ -42,6 +42,9 @@ FINAL_OUTPUT_ATTRIBUTE_KEYS = (
 # know about is ineligible: a tool result and a judge's score are both recorded in the same
 # `output.value` attribute an answer uses, and scoring one as the model's answer is silent.
 ANSWER_SPAN_KINDS = frozenset({"AGENT", "CHAIN", "LLM"})
+
+#: Attribute value types OTLP's ``AnyValue`` carries that a caller here needs to write.
+AttributeValue: TypeAlias = str | int | float | bool
 
 
 def validate_resource_spans(value: Any) -> list[dict[str, Any]]:
@@ -291,6 +294,101 @@ def _loads(text: str) -> Any:
         return json.loads(text)
     except RecursionError as error:
         raise ValueError("OTLP JSON is nested too deeply to parse") from error
+
+
+def set_span_attributes(request: ExportTraceServiceRequest, attributes: Mapping[str, AttributeValue]) -> None:
+    """Set attributes on every span of a trace, replacing any the producer set.
+
+    Span attributes are written rather than resource attributes because Intake merges the two
+    layers as ``{**resource, **span}``. A producer that publishes one of these keys itself
+    would win from the resource layer and silently redirect whatever the value identifies.
+    """
+    for span in _spans(request):
+        _set_attributes(span, attributes)
+
+
+def set_root_span_attributes(request: ExportTraceServiceRequest, attributes: Mapping[str, AttributeValue]) -> None:
+    """Set attributes on the trace's root span alone, if it has exactly one.
+
+    Totals for a whole run belong on the one span that represents it. Writing them to every
+    span would have any rollup that sums across a trace count them once per span.
+    """
+    root = _root_span(request)
+    if root is not None:
+        _set_attributes(root, attributes)
+
+
+def set_root_span_error(request: ExportTraceServiceRequest, *, message: str | None = None) -> None:
+    """Mark the trace's root span as failed, if it has exactly one.
+
+    Intake reads span status, not attributes, to decide a span failed.
+    """
+    root = _root_span(request)
+    if root is None:
+        return
+    root.status.code = Status.STATUS_CODE_ERROR
+    if message is not None:
+        root.status.message = message
+
+
+def fill_missing_start_times(request: ExportTraceServiceRequest, *, start_time_unix_nano: int) -> None:
+    """Give spans without a start time one, so re-publishing the same trace replaces it.
+
+    Intake stores a span with no start time against its own ingest clock, and start time is
+    part of the key its spans table replaces on — so an absent one makes every publish a new
+    row rather than a replacement of the last.
+    """
+    for span in _spans(request):
+        if not span.start_time_unix_nano:
+            span.start_time_unix_nano = start_time_unix_nano
+
+
+def _root_span(request: ExportTraceServiceRequest) -> Span | None:
+    """The single parentless span of a trace, or ``None`` when there is not exactly one."""
+    roots = [span for span in _spans(request) if not span.parent_span_id]
+    return roots[0] if len(roots) == 1 else None
+
+
+def _spans(request: ExportTraceServiceRequest) -> Iterator[Span]:
+    """Yield every span in the request, in resource and scope order."""
+    for resource_span in request.resource_spans:
+        for scope_span in resource_span.scope_spans:
+            yield from scope_span.spans
+
+
+def _set_attributes(span: Span, attributes: Mapping[str, AttributeValue]) -> None:
+    """Write attributes onto one span, replacing keys it already carries."""
+    existing = {attribute.key: attribute for attribute in span.attributes}
+    for key, value in attributes.items():
+        attribute = existing.get(key)
+        if attribute is None:
+            attribute = span.attributes.add()
+            attribute.key = key
+        if isinstance(value, bool):
+            attribute.value.bool_value = value
+        elif isinstance(value, int):
+            attribute.value.int_value = value
+        elif isinstance(value, float):
+            attribute.value.double_value = value
+        else:
+            attribute.value.string_value = value
+
+
+def root_span_id(request: ExportTraceServiceRequest) -> str | None:
+    """Return the hex id of the trace's root span, or ``None`` when it has no single root.
+
+    A trace with several roots has no one span that stands for the whole run, so there is
+    nothing to attach a trial-level score to.
+    """
+    roots = [span for span in _spans(request) if not span.parent_span_id]
+    if len(roots) != 1:
+        return None
+    span_id = bytes(roots[0].span_id)
+    # Intake requires a present, non-zero id and drops the span otherwise, which would leave
+    # anything scored against this id pointing at a span that was never stored.
+    if not any(span_id):
+        return None
+    return span_id.hex()
 
 
 # Byte lengths of the OTLP id fields, which decide whether a string is hex for that field.

--- a/packages/nemo_evaluator_sdk/tests/values/test_otlp.py
+++ b/packages/nemo_evaluator_sdk/tests/values/test_otlp.py
@@ -9,6 +9,8 @@ from nemo_evaluator_sdk.values.otlp import (
     export_request_from_resource_spans,
     final_output_text,
     resource_spans_from_text,
+    root_span_id,
+    set_span_attributes,
     span_text_strings,
 )
 
@@ -346,3 +348,68 @@ def test_a_span_declaring_no_kind_is_not_eligible() -> None:
 
 def test_span_kind_is_matched_case_insensitively() -> None:
     assert _answer(_span("a" * 16, end=5, kind="agent", **{"output.value": "answer"})) == "answer"
+
+
+def test_root_span_id_is_the_span_without_a_parent() -> None:
+    request = _parsed(
+        {"traceId": _HEX_TRACE_ID, "spanId": _HEX_SPAN_ID, "name": "root"},
+        {"traceId": _HEX_TRACE_ID, "spanId": "aabbccddeeff0011", "parentSpanId": _HEX_SPAN_ID, "name": "child"},
+    )
+
+    assert root_span_id(request) == _HEX_SPAN_ID
+
+
+@pytest.mark.parametrize(
+    "spans",
+    [
+        pytest.param([], id="no spans"),
+        pytest.param(
+            [
+                {"traceId": _HEX_TRACE_ID, "spanId": _HEX_SPAN_ID, "name": "a"},
+                {"traceId": _HEX_TRACE_ID, "spanId": "aabbccddeeff0011", "name": "b"},
+            ],
+            id="two roots",
+        ),
+        pytest.param(
+            [{"traceId": _HEX_TRACE_ID, "spanId": "0000000000000000", "name": "zero id"}],
+            id="all-zero root id",
+        ),
+    ],
+)
+def test_no_scorable_root_span(spans: list[dict[str, Any]]) -> None:
+    # A trial-level score needs one span standing for the whole run, and Intake drops a span
+    # whose id is absent or all zero, so scoring against it would point at nothing stored.
+    assert root_span_id(_parsed(*spans)) is None
+
+
+def test_set_span_attributes_overrides_what_the_producer_wrote() -> None:
+    request = _parsed(
+        {
+            "traceId": _HEX_TRACE_ID,
+            "spanId": _HEX_SPAN_ID,
+            "name": "root",
+            "attributes": [{"key": "gen_ai.conversation.id", "value": {"stringValue": "producer-own"}}],
+        },
+        {"traceId": _HEX_TRACE_ID, "spanId": "aabbccddeeff0011", "parentSpanId": _HEX_SPAN_ID, "name": "child"},
+    )
+
+    set_span_attributes(request, {"gen_ai.conversation.id": "run:trial", "nemo.evaluation.name": "exp"})
+
+    for span in request.resource_spans[0].scope_spans[0].spans:
+        attributes = {attribute.key: attribute.value.string_value for attribute in span.attributes}
+        assert attributes["gen_ai.conversation.id"] == "run:trial"
+        assert attributes["nemo.evaluation.name"] == "exp"
+
+
+def test_each_attribute_value_type_maps_to_its_any_value_field() -> None:
+    # bool is an int subclass, so an ordering slip would write it to int_value instead.
+    request = _parsed({"traceId": _HEX_TRACE_ID, "spanId": _HEX_SPAN_ID, "name": "root"})
+
+    set_span_attributes(request, {"s": "text", "i": 7, "f": 1.5, "b": True})
+
+    values = {a.key: a.value for a in request.resource_spans[0].scope_spans[0].spans[0].attributes}
+    assert values["s"].string_value == "text"
+    assert values["i"].int_value == 7
+    assert values["f"].double_value == pytest.approx(1.5)
+    assert values["b"].bool_value is True
+    assert values["b"].WhichOneof("value") == "bool_value"

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -73,15 +73,6 @@ _SESSION_ID_ATTRIBUTE = "gen_ai.conversation.id"
 _EVALUATION_NAME_ATTRIBUTE = "nemo.evaluation.name"
 _TEST_CASE_NAME_ATTRIBUTE = "nemo.test_case.name"
 
-# Trial-level totals, which Intake reads as numbers. ATIF carried these as ``final_metrics``;
-# under OTLP they go on the root span, which is the span that stands for the whole trial.
-_MEASUREMENT_ATTRIBUTES = {
-    "prompt_tokens": "gen_ai.usage.input_tokens",
-    "completion_tokens": "gen_ai.usage.output_tokens",
-    "cache_read_tokens": "gen_ai.usage.cached_tokens",
-    "cost_usd": "gen_ai.usage.cost",
-}
-
 
 def session_id_for(run_id: str, trial_id: str) -> str:
     """Return the stable, adapter-minted session id for a trial.
@@ -201,9 +192,15 @@ async def otlp_ingest_for_trial(
 
 def _trial_totals(trial: AgentEvalTrial, measurements: TrialMeasurements) -> dict[str, str | int | float]:
     """The trial-level totals and error that ATIF conveyed outside the step list."""
+    # Read as numbers by Intake. ATIF carried these as ``final_metrics``; under OTLP they go on
+    # the root span, which is the span that stands for the whole trial.
     totals: dict[str, str | int | float] = {}
-    for field, attribute in _MEASUREMENT_ATTRIBUTES.items():
-        value = getattr(measurements, field)
+    for value, attribute in (
+        (measurements.prompt_tokens, "gen_ai.usage.input_tokens"),
+        (measurements.completion_tokens, "gen_ai.usage.output_tokens"),
+        (measurements.cache_read_tokens, "gen_ai.usage.cached_tokens"),
+        (measurements.cost_usd, "gen_ai.usage.cost"),
+    ):
         if value is not None:
             totals[attribute] = value
     if trial.error is not None:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/mapping.py
@@ -36,9 +36,17 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal, cast
 
+from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
-from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_ATIF, EVIDENCE_TRACE
+from nemo_evaluator_sdk.values.evidence import EVIDENCE_FORMAT_ATIF, EVIDENCE_FORMAT_OTLP, EVIDENCE_TRACE
+from nemo_evaluator_sdk.values.otlp import (
+    fill_missing_start_times,
+    root_span_id,
+    set_root_span_attributes,
+    set_root_span_error,
+    set_span_attributes,
+)
 from nemo_platform.types.intake.evaluation_context_param import EvaluationContextParam
 from nemo_platform.types.intake.evaluator_result_create_params import EvaluatorResultCreateParams
 from nemo_platform.types.intake.evaluator_result_data_type import EvaluatorResultDataType
@@ -58,6 +66,21 @@ ATIF_SCHEMA_VERSION: Literal["ATIF-v1.7"] = "ATIF-v1.7"
 #: Default ``agent.version`` when the run target carries none. Neither Model nor
 #: Agent has a version field today, and ATIF requires one (design doc §3.9 #6).
 DEFAULT_AGENT_VERSION = "unknown"
+
+# Span attribute keys Intake reads identity back from; see its span attribute catalog. The
+# session id has two accepted keys and this is the one that wins.
+_SESSION_ID_ATTRIBUTE = "gen_ai.conversation.id"
+_EVALUATION_NAME_ATTRIBUTE = "nemo.evaluation.name"
+_TEST_CASE_NAME_ATTRIBUTE = "nemo.test_case.name"
+
+# Trial-level totals, which Intake reads as numbers. ATIF carried these as ``final_metrics``;
+# under OTLP they go on the root span, which is the span that stands for the whole trial.
+_MEASUREMENT_ATTRIBUTES = {
+    "prompt_tokens": "gen_ai.usage.input_tokens",
+    "completion_tokens": "gen_ai.usage.output_tokens",
+    "cache_read_tokens": "gen_ai.usage.cached_tokens",
+    "cost_usd": "gen_ai.usage.cost",
+}
 
 
 def session_id_for(run_id: str, trial_id: str) -> str:
@@ -117,6 +140,77 @@ async def atif_steps_from_trial(trial: AgentEvalTrial, *, started_at: datetime) 
         dumped.setdefault("timestamp", started_at.isoformat())
         payload.append(cast(AtifStepParam, dumped))
     return payload
+
+
+async def otlp_ingest_for_trial(
+    trial: AgentEvalTrial,
+    *,
+    session_id: str,
+    evaluation_name: str,
+    measurements: TrialMeasurements,
+    started_at: datetime,
+) -> tuple[bytes, str] | None:
+    """Return the trial's OTLP payload stamped with evaluation identity, and its root span id.
+
+    ``None`` when the trial has no readable OTLP trace, or when its spans have no single root
+    carrying a usable id: a trial-level score needs one span standing for the whole run.
+
+    ``started_at`` fills in any span that recorded no start time of its own, because Intake
+    otherwise stores it against the ingest clock and start time is part of the key its spans
+    table replaces on — so a re-publish would insert rather than replace.
+
+    Identity is written onto spans rather than resource attributes because Intake merges the
+    layers as ``{**resource, **span}``. An agent that records its own ``gen_ai.conversation.id``
+    would otherwise win, and the session id is what Intake's ``ReplacingMergeTree`` is keyed on,
+    so a re-publish would insert duplicates instead of replacing.
+    """
+    evidence = trial.evidence
+    if evidence is None:
+        return None
+    try:
+        handle = await evidence.trace(EVIDENCE_TRACE, format=EVIDENCE_FORMAT_OTLP)
+    except KeyError:
+        return None
+    try:
+        request = await handle.export_request()
+    except (OSError, ValueError) as error:
+        logger.warning("Ignoring unreadable OTLP trace for trial %s: %s", trial.id, error)
+        return None
+
+    span_id = root_span_id(request)
+    if span_id is None:
+        logger.warning(
+            "Ignoring OTLP trace for trial %s: it has no single root span with a usable id to score.", trial.id
+        )
+        return None
+
+    set_span_attributes(
+        request,
+        {
+            _SESSION_ID_ATTRIBUTE: session_id,
+            _EVALUATION_NAME_ATTRIBUTE: evaluation_name,
+            _TEST_CASE_NAME_ATTRIBUTE: trial.task_id,
+        },
+    )
+    set_root_span_attributes(request, _trial_totals(trial, measurements))
+    if trial.error is not None:
+        set_root_span_error(request, message=trial.error.message)
+    fill_missing_start_times(request, start_time_unix_nano=int(started_at.timestamp() * 1_000_000_000))
+    return request.SerializeToString(), span_id
+
+
+def _trial_totals(trial: AgentEvalTrial, measurements: TrialMeasurements) -> dict[str, str | int | float]:
+    """The trial-level totals and error that ATIF conveyed outside the step list."""
+    totals: dict[str, str | int | float] = {}
+    for field, attribute in _MEASUREMENT_ATTRIBUTES.items():
+        value = getattr(measurements, field)
+        if value is not None:
+            totals[attribute] = value
+    if trial.error is not None:
+        totals["exception.type"] = trial.error.type
+        if trial.error.message is not None:
+            totals["exception.message"] = trial.error.message
+    return totals
 
 
 def trial_to_atif_ingest(

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
@@ -209,6 +209,28 @@ async def publish_to_intake(
                 body["workspace"] = resolved_workspace
                 return body
 
+            session_id = mapping.session_id_for(result.run_id, trial.id)
+            otlp = await mapping.otlp_ingest_for_trial(
+                trial,
+                session_id=session_id,
+                evaluation_name=experiment_id,
+                measurements=measurements,
+                started_at=started_at,
+            )
+            if otlp is not None:
+                payload, span_id = otlp
+                response = await platform.intake.ingest.otlp.v1.traces.create(
+                    body=payload, workspace=resolved_workspace
+                )
+                # OTLP ingest answers 200 with a per-span error list, so a partly-stored trace is
+                # invisible unless the body is read — including the case where the span the scores
+                # are about to reference is the one that was dropped.
+                if response.errors:
+                    raise PublishError(
+                        f"Intake rejected {len(response.errors)} span(s) of trial {trial.id!r}: {response.errors}"
+                    )
+                return await _publish_scores(trial, session_id=session_id, span_id=span_id)
+
             recorded_steps = await mapping.atif_steps_from_trial(trial, started_at=started_at)
             try:
                 await platform.intake.ingest.atif.create(**build_body(recorded_steps))
@@ -227,24 +249,27 @@ async def publish_to_intake(
                 )
                 await platform.intake.ingest.atif.create(**build_body(None))
 
-            session_id = mapping.session_id_for(result.run_id, trial.id)
+            # ATIF span ids are minted by Intake from its own identity scheme, so unlike the
+            # OTLP path this one has to read the id back rather than know it locally.
             span_id = await _resolve_root_span_id(platform, workspace=resolved_workspace, session_id=session_id)
+            return await _publish_scores(trial, session_id=session_id, span_id=span_id)
 
-            written = 0
-            for score in scores_by_trial.get(trial.id, []):
-                rows, omitted = mapping.score_to_evaluator_results(score, session_id=session_id, span_id=span_id)
-                for row in rows:
-                    row["workspace"] = resolved_workspace
-                    await platform.intake.evaluator_results.create(**row)
-                    written += 1
-                skipped.extend(SkippedScore(trial_id=trial.id, name=item.name, reason=item.reason) for item in omitted)
+    async def _publish_scores(trial: AgentEvalTrial, *, session_id: str, span_id: str) -> PublishedTrial:
+        written = 0
+        for score in scores_by_trial.get(trial.id, []):
+            rows, omitted = mapping.score_to_evaluator_results(score, session_id=session_id, span_id=span_id)
+            for row in rows:
+                row["workspace"] = resolved_workspace
+                await platform.intake.evaluator_results.create(**row)
+                written += 1
+            skipped.extend(SkippedScore(trial_id=trial.id, name=item.name, reason=item.reason) for item in omitted)
 
-            return PublishedTrial(
-                trial_id=trial.id,
-                session_id=session_id,
-                span_id=span_id,
-                evaluator_result_count=written,
-            )
+        return PublishedTrial(
+            trial_id=trial.id,
+            session_id=session_id,
+            span_id=span_id,
+            evaluator_result_count=written,
+        )
 
     outcomes = await asyncio.gather(*(_publish_trial(trial) for trial in result.trials), return_exceptions=True)
 

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
@@ -29,7 +29,7 @@ from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial
-from nemo_platform import AsyncNeMoPlatform, UnprocessableEntityError
+from nemo_platform import AsyncNeMoPlatform, NotFoundError, UnprocessableEntityError
 from nemo_platform.types.intake.ingest.atif_create_params import AtifCreateParams
 from nemo_platform.types.intake.ingest.atif_final_metrics_param import AtifFinalMetricsParam
 from nemo_platform.types.intake.ingest.atif_step_param import AtifStepParam
@@ -154,8 +154,10 @@ async def publish_to_intake(
     already landed replaces its rows instead of duplicating them, which is what makes
     a worker retry after a partial publish safe.
 
-    ``experiment_id`` must reference an Experiment that already exists — ATIF ingest
-    rejects unknown experiments with HTTP 400. Creating the Experiment/group is a
+    ``experiment_id`` must reference an evaluation that already exists and is not
+    deleted; it is checked once up front. ATIF ingest enforces this server-side, but
+    OTLP ingest does not, so nothing else would stop the primary path from writing
+    spans against an evaluation that cannot hold them. Creating the evaluation is a
     separate, caller-side step via the platform Experiments SDK.
 
     Agent identity (``agent_name``/``agent_version``/``model_name``) is taken as
@@ -174,6 +176,14 @@ async def publish_to_intake(
             f"Cannot publish run {result.run_id!r}: metadata.started_at is unset, and publishing "
             "without it would write trajectories that duplicate on re-publish."
         )
+
+    try:
+        await platform.evaluations.retrieve(experiment_id, workspace=resolved_workspace)
+    except NotFoundError as error:
+        raise PublishError(
+            f"Cannot publish run {result.run_id!r}: evaluation {experiment_id!r} does not exist in "
+            f"workspace {resolved_workspace!r}, or has been deleted."
+        ) from error
 
     scores_by_trial: dict[str, list[AgentEvalTaskScore]] = defaultdict(list)
     for score in result.scores:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/intake/publish.py
@@ -136,9 +136,9 @@ async def publish_to_intake(
 ) -> PublishReport:
     """Publish a completed ``AgentEvalResult`` to Intake under an existing Experiment.
 
-    For each trial: POST the ATIF trajectory, resolve its root span, then POST one
-    evaluator-result per metric output. Trials are published concurrently up to
-    ``max_concurrency``.
+    For each trial: POST its OTLP trace when it has one, else fall back to the ATIF
+    trajectory, then POST one evaluator-result per metric output against the trial's
+    root span. Trials are published concurrently up to ``max_concurrency``.
 
     Publishing is **not atomic** and Intake has no rollback, so a per-trial failure
     must not abort the others: every trial that can land does, and the failures are
@@ -182,76 +182,81 @@ async def publish_to_intake(
     semaphore = asyncio.Semaphore(max_concurrency)
     skipped: list[SkippedScore] = []
 
+    async def _publish_otlp(trial: AgentEvalTrial, *, measurements: TrialMeasurements, session_id: str) -> str | None:
+        """Publish the trial's OTLP trace and return its root span id, or ``None`` when it has none."""
+        otlp = await mapping.otlp_ingest_for_trial(
+            trial,
+            session_id=session_id,
+            evaluation_name=experiment_id,
+            measurements=measurements,
+            started_at=started_at,
+        )
+        if otlp is None:
+            return None
+        payload, span_id = otlp
+        response = await platform.intake.ingest.otlp.v1.traces.create(body=payload, workspace=resolved_workspace)
+        # OTLP ingest answers 200 with a per-span error list, so a partly-stored trace is
+        # invisible unless the body is read — including the case where the span the scores
+        # are about to reference is the one that was dropped.
+        if response.errors:
+            raise PublishError(
+                f"Intake rejected {len(response.errors)} span(s) of trial {trial.id!r}: {response.errors}"
+            )
+        return span_id
+
+    async def _publish_atif(trial: AgentEvalTrial, *, measurements: TrialMeasurements, session_id: str) -> str:
+        """Publish the trial's ATIF trajectory and return the root span id Intake minted for it."""
+        # A recorded runtime gives the trajectory a real end so Intake's latency rollup sees the
+        # trial's wall-clock duration instead of 0; absent → no window, latency stays unmeasured.
+        ended_at = (
+            started_at + timedelta(seconds=measurements.runtime_sec) if measurements.runtime_sec is not None else None
+        )
+
+        def build_body(steps: Sequence[AtifStepParam] | None) -> AtifCreateParams:
+            body = mapping.trial_to_atif_ingest(
+                trial,
+                run_id=result.run_id,
+                evaluation_name=experiment_id,
+                agent_name=agent_name,
+                started_at=started_at,
+                agent_version=agent_version,
+                model_name=model_name,
+                final_metrics=_token_final_metrics(measurements),
+                ended_at=ended_at,
+                steps=steps,
+            )
+            body["workspace"] = resolved_workspace
+            return body
+
+        recorded_steps = await mapping.atif_steps_from_trial(trial, started_at=started_at)
+        try:
+            await platform.intake.ingest.atif.create(**build_body(recorded_steps))
+        except UnprocessableEntityError as error:
+            # The SDK's ATIF read model accepts shapes ingest does not, so a trajectory that
+            # parsed locally can still be refused. Losing the trial's scores over a trace
+            # detail is the wrong trade — fall back to the single-step trajectory a runner
+            # with no trace would have sent. Guard on emptiness rather than ``is None``: with no
+            # steps to drop, the retry would resend the body ingest just refused.
+            if not recorded_steps:
+                raise
+            logger.warning(
+                "Intake rejected the recorded trajectory for trial %s (%s); publishing its final output instead.",
+                trial.id,
+                error,
+            )
+            await platform.intake.ingest.atif.create(**build_body(None))
+
+        # ATIF span ids are minted by Intake from its own identity scheme, so unlike the
+        # OTLP path this one has to read the id back rather than know it locally.
+        return await _resolve_root_span_id(platform, workspace=resolved_workspace, session_id=session_id)
+
     async def _publish_trial(trial: AgentEvalTrial) -> PublishedTrial:
         async with semaphore:
             measurements = TrialMeasurements.from_metadata(trial.metadata)
-            # A recorded runtime gives the trajectory a real end so Intake's latency rollup sees the
-            # trial's wall-clock duration instead of 0; absent → no window, latency stays unmeasured.
-            ended_at = (
-                started_at + timedelta(seconds=measurements.runtime_sec)
-                if measurements.runtime_sec is not None
-                else None
-            )
-
-            def build_body(steps: Sequence[AtifStepParam] | None) -> AtifCreateParams:
-                body = mapping.trial_to_atif_ingest(
-                    trial,
-                    run_id=result.run_id,
-                    evaluation_name=experiment_id,
-                    agent_name=agent_name,
-                    started_at=started_at,
-                    agent_version=agent_version,
-                    model_name=model_name,
-                    final_metrics=_token_final_metrics(measurements),
-                    ended_at=ended_at,
-                    steps=steps,
-                )
-                body["workspace"] = resolved_workspace
-                return body
-
             session_id = mapping.session_id_for(result.run_id, trial.id)
-            otlp = await mapping.otlp_ingest_for_trial(
-                trial,
-                session_id=session_id,
-                evaluation_name=experiment_id,
-                measurements=measurements,
-                started_at=started_at,
-            )
-            if otlp is not None:
-                payload, span_id = otlp
-                response = await platform.intake.ingest.otlp.v1.traces.create(
-                    body=payload, workspace=resolved_workspace
-                )
-                # OTLP ingest answers 200 with a per-span error list, so a partly-stored trace is
-                # invisible unless the body is read — including the case where the span the scores
-                # are about to reference is the one that was dropped.
-                if response.errors:
-                    raise PublishError(
-                        f"Intake rejected {len(response.errors)} span(s) of trial {trial.id!r}: {response.errors}"
-                    )
-                return await _publish_scores(trial, session_id=session_id, span_id=span_id)
-
-            recorded_steps = await mapping.atif_steps_from_trial(trial, started_at=started_at)
-            try:
-                await platform.intake.ingest.atif.create(**build_body(recorded_steps))
-            except UnprocessableEntityError as error:
-                # The SDK's ATIF read model accepts shapes ingest does not, so a trajectory that
-                # parsed locally can still be refused. Losing the trial's scores over a trace
-                # detail is the wrong trade — fall back to the single-step trajectory a runner
-                # with no trace would have sent. Guard on emptiness rather than ``is None``: with no
-                # steps to drop, the retry would resend the body ingest just refused.
-                if not recorded_steps:
-                    raise
-                logger.warning(
-                    "Intake rejected the recorded trajectory for trial %s (%s); publishing its final output instead.",
-                    trial.id,
-                    error,
-                )
-                await platform.intake.ingest.atif.create(**build_body(None))
-
-            # ATIF span ids are minted by Intake from its own identity scheme, so unlike the
-            # OTLP path this one has to read the id back rather than know it locally.
-            span_id = await _resolve_root_span_id(platform, workspace=resolved_workspace, session_id=session_id)
+            span_id = await _publish_otlp(trial, measurements=measurements, session_id=session_id)
+            if span_id is None:
+                span_id = await _publish_atif(trial, measurements=measurements, session_id=session_id)
             return await _publish_scores(trial, session_id=session_id, span_id=span_id)
 
     async def _publish_scores(trial: AgentEvalTrial, *, session_id: str, span_id: str) -> PublishedTrial:

--- a/plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py
+++ b/plugins/nemo-evaluator/src/nemo_evaluator/jobs/publication.py
@@ -154,10 +154,9 @@ async def _publish(
     # Measured before the publish so the two durations stay disjoint — for a result that carries only
     # a start time, reading this afterwards would fold the whole publish into the run's own length.
     eval_duration_sec = _eval_duration_sec(result)
-    # The Evaluation must pre-exist — ATIF ingest rejects an unknown one per trial, so without this
-    # a typo would surface as N failed writes after a partial publish instead of one clear stop.
-    # This reads the entity store, so it says nothing about whether Intake's span storage is up;
-    # that surfaces on the first ingest below, and re-publish is idempotent, so it needs no probe.
+    # Read for the entity itself, which ``_record_durations`` stamps onto below. This reads the
+    # entity store, so it says nothing about whether Intake's span storage is up; that surfaces on
+    # the first ingest, and re-publish is idempotent, so it needs no probe.
     evaluation = await platform.evaluations.retrieve(spec.evaluation_id, workspace=workspace)
     publish_started = time.monotonic()
     report = await publish_to_intake(

--- a/plugins/nemo-evaluator/tests/intake/test_publish.py
+++ b/plugins/nemo-evaluator/tests/intake/test_publish.py
@@ -22,7 +22,7 @@ from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEval
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput, TrialError
 from nemo_evaluator_sdk.metrics.protocol import MetricOutput
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
-from nemo_platform import AsyncNeMoPlatform, UnprocessableEntityError
+from nemo_platform import AsyncNeMoPlatform, NotFoundError, UnprocessableEntityError
 
 # --- fakes ------------------------------------------------------------------
 
@@ -77,6 +77,24 @@ class _FakeTraces:
         return _gen()
 
 
+class _FakeEvaluations:
+    """Resolves the run's evaluation, or 404s the way ingest does for a missing or deleted one."""
+
+    def __init__(self, calls: list[dict[str, Any]], *, missing: bool = False) -> None:
+        self._calls = calls
+        self._missing = missing
+
+    async def retrieve(self, name: str, *, workspace: str) -> object:
+        self._calls.append({"name": name, "workspace": workspace})
+        if self._missing:
+            raise NotFoundError(
+                "evaluation not found",
+                response=httpx.Response(404, request=httpx.Request("GET", "http://intake/evaluations")),
+                body=None,
+            )
+        return SimpleNamespace(name=name)
+
+
 class _FakeClient:
     def __init__(
         self,
@@ -87,8 +105,11 @@ class _FakeClient:
         fail_eval_session: str | None = None,
         atif: Any | None = None,
         otlp_errors: list[str] | None = None,
+        evaluation_missing: bool = False,
     ) -> None:
         self.workspace = workspace
+        self.evaluation_calls: list[dict[str, Any]] = []
+        self.evaluations = _FakeEvaluations(self.evaluation_calls, missing=evaluation_missing)
         self.atif_calls: list[dict[str, Any]] = []
         self.otlp_calls: list[dict[str, Any]] = []
         self.eval_calls: list[dict[str, Any]] = []
@@ -205,6 +226,22 @@ async def test_publishes_trajectory_and_scores() -> None:
         "span:run-1:t-1",
         3,
     )
+
+
+async def test_an_unknown_evaluation_fails_the_run_before_any_trial_is_written() -> None:
+    # OTLP ingest does not check the evaluation exists the way ATIF ingest does, so without this
+    # guard the primary path would write spans against an evaluation that cannot hold them.
+    result = _result(
+        trials=[_trial("t-1")],
+        scores=[_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])],
+    )
+    client = _FakeClient(evaluation_missing=True)
+
+    with pytest.raises(PublishError, match="does not exist"):
+        await publish_to_intake(result, platform=cast(AsyncNeMoPlatform, client), experiment_id="exp-1")
+
+    assert client.evaluation_calls == [{"name": "exp-1", "workspace": "default"}]
+    assert (client.otlp_calls, client.atif_calls, client.eval_calls) == ([], [], [])
 
 
 async def test_multiple_trials_each_get_their_own_session_and_span() -> None:

--- a/plugins/nemo-evaluator/tests/intake/test_publish.py
+++ b/plugins/nemo-evaluator/tests/intake/test_publish.py
@@ -19,7 +19,7 @@ from nemo_evaluator.intake.publish import PublishError, _token_final_metrics, pu
 from nemo_evaluator_sdk.agent_eval.metrics import TrialMeasurements
 from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSummary, RunMetadata
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
-from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
+from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput, TrialError
 from nemo_evaluator_sdk.metrics.protocol import MetricOutput
 from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 from nemo_platform import AsyncNeMoPlatform, UnprocessableEntityError
@@ -36,6 +36,16 @@ class _FakeAtif:
         if self._fail:
             raise RuntimeError("atif ingest 400")
         self._calls.append(kwargs)
+
+
+class _FakeOtlpTraces:
+    def __init__(self, calls: list[dict[str, Any]], *, errors: list[str] | None = None) -> None:
+        self._calls = calls
+        self._errors = errors or []
+
+    async def create(self, **kwargs: Any) -> object:
+        self._calls.append(kwargs)
+        return SimpleNamespace(errors=list(self._errors))
 
 
 class _FakeEvaluatorResults:
@@ -76,12 +86,17 @@ class _FakeClient:
         atif_fail: bool = False,
         fail_eval_session: str | None = None,
         atif: Any | None = None,
+        otlp_errors: list[str] | None = None,
     ) -> None:
         self.workspace = workspace
         self.atif_calls: list[dict[str, Any]] = []
+        self.otlp_calls: list[dict[str, Any]] = []
         self.eval_calls: list[dict[str, Any]] = []
         self.intake = SimpleNamespace(
-            ingest=SimpleNamespace(atif=atif or _FakeAtif(self.atif_calls, fail=atif_fail)),
+            ingest=SimpleNamespace(
+                atif=atif or _FakeAtif(self.atif_calls, fail=atif_fail),
+                otlp=SimpleNamespace(v1=SimpleNamespace(traces=_FakeOtlpTraces(self.otlp_calls, errors=otlp_errors))),
+            ),
             evaluator_results=_FakeEvaluatorResults(self.eval_calls, fail_session=fail_eval_session),
             traces=_FakeTraces(root_span_id=root_span_id),
         )
@@ -362,3 +377,210 @@ async def test_a_rejected_trajectory_falls_back_instead_of_failing_the_trial(tmp
     # The rich attempt is refused, the single-step retry lands, and the trial still publishes.
     assert [len(call["steps"]) for call in calls] == [2, 1]
     assert report.trial_count == 1
+
+
+# --- OTLP publish path ------------------------------------------------------
+
+_OTLP_TRACE_ID = "0123456789abcdef0123456789abcdef"
+_OTLP_SPAN_ID = "0102030405060708"
+
+
+def _otlp_trial(trial_id: str = "t-1", *, span_id: str = _OTLP_SPAN_ID, extra_spans: list[dict] | None = None):
+    from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
+
+    spans = [{"traceId": _OTLP_TRACE_ID, "spanId": span_id, "name": "agent run"}, *(extra_spans or [])]
+    trace = EvidenceDescriptor(
+        kind="trace", format="otlp", data={"resourceSpans": [{"scopeSpans": [{"spans": spans}]}]}
+    )
+    trial = _trial(trial_id)
+    return trial.model_copy(update={"evidence": CandidateEvidence(descriptors={"trace": trace})})
+
+
+async def test_a_trial_with_an_otlp_trace_publishes_otlp_and_skips_atif() -> None:
+    client = _client()
+
+    report = await publish_to_intake(
+        _result([_otlp_trial()], [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])]),
+        platform=client,
+        experiment_id="exp-1",
+        agent_name="a",
+    )
+
+    assert len(client.otlp_calls) == 1
+    assert client.atif_calls == [], "the OTLP trace is the trial's trajectory; ATIF must not also be sent"
+    assert client.otlp_calls[0]["workspace"] == "default"
+    assert isinstance(client.otlp_calls[0]["body"], bytes)
+    # The root span id comes off the payload, not from an Intake round trip.
+    assert report.published_trials[0].span_id == _OTLP_SPAN_ID
+
+
+async def test_the_published_otlp_payload_carries_the_stamped_identity() -> None:
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+    client = _client()
+
+    await publish_to_intake(
+        _result([_otlp_trial()], [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])]),
+        platform=client,
+        experiment_id="exp-1",
+        agent_name="a",
+    )
+
+    sent = ExportTraceServiceRequest()
+    sent.ParseFromString(client.otlp_calls[0]["body"])
+    span = sent.resource_spans[0].scope_spans[0].spans[0]
+    attributes = {attribute.key: attribute.value.string_value for attribute in span.attributes}
+    assert attributes["gen_ai.conversation.id"] == "run-1:t-1"
+    assert attributes["nemo.evaluation.name"] == "exp-1"
+    assert attributes["nemo.test_case.name"] == "task-1"
+    # The producer's ids survive the hex/base64 round trip, or scores attach to nothing.
+    assert span.span_id.hex() == _OTLP_SPAN_ID
+    assert span.trace_id.hex() == _OTLP_TRACE_ID
+
+
+async def test_a_trial_without_an_otlp_trace_still_publishes_atif() -> None:
+    client = _client()
+
+    await publish_to_intake(
+        _result([_trial("t-1")], [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])]),
+        platform=client,
+        experiment_id="exp-1",
+        agent_name="a",
+    )
+
+    assert client.otlp_calls == []
+    assert len(client.atif_calls) == 1
+
+
+async def test_an_otlp_trace_with_no_single_root_falls_back_to_atif() -> None:
+    # Nothing stands for the whole run, so there is no span to attach a trial score to.
+    second_root = {"traceId": _OTLP_TRACE_ID, "spanId": "aabbccddeeff0011", "name": "other root"}
+    client = _client()
+
+    await publish_to_intake(
+        _result(
+            [_otlp_trial(extra_spans=[second_root])],
+            [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])],
+        ),
+        platform=client,
+        experiment_id="exp-1",
+        agent_name="a",
+    )
+
+    assert client.otlp_calls == []
+    assert len(client.atif_calls) == 1
+
+
+async def test_trial_totals_land_on_the_root_span_only() -> None:
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+    child = {"traceId": _OTLP_TRACE_ID, "spanId": "aabbccddeeff0011", "parentSpanId": _OTLP_SPAN_ID, "name": "child"}
+    trial = _otlp_trial(extra_spans=[child]).model_copy(
+        update={
+            "metadata": {"prompt_tokens": 120, "completion_tokens": 45, "cache_read_tokens": 30, "cost_usd": 0.134},
+            "error": TrialError(type="Timeout", message="agent exceeded its budget"),
+        }
+    )
+    client = _client()
+
+    await publish_to_intake(
+        _result([trial], [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])]),
+        platform=client,
+        experiment_id="exp-1",
+        agent_name="a",
+    )
+
+    sent = ExportTraceServiceRequest()
+    sent.ParseFromString(client.otlp_calls[0]["body"])
+    spans = {span.name: span for span in sent.resource_spans[0].scope_spans[0].spans}
+    root = {attribute.key: attribute.value for attribute in spans["agent run"].attributes}
+    assert root["gen_ai.usage.input_tokens"].int_value == 120
+    assert root["gen_ai.usage.output_tokens"].int_value == 45
+    assert root["gen_ai.usage.cached_tokens"].int_value == 30
+    assert root["gen_ai.usage.cost"].double_value == pytest.approx(0.134)
+    assert root["exception.type"].string_value == "Timeout"
+    assert root["exception.message"].string_value == "agent exceeded its budget"
+
+    # A rollup that sums across the trace would double-count these if every span carried them.
+    child_keys = {attribute.key for attribute in spans["child"].attributes}
+    assert not child_keys & {"gen_ai.usage.input_tokens", "gen_ai.usage.cost", "exception.type"}
+    # Identity, by contrast, is on every span so any of them resolves back to the trial.
+    assert "gen_ai.conversation.id" in child_keys
+
+
+async def test_a_root_span_with_no_usable_id_falls_back_to_atif() -> None:
+    # Intake drops a span whose id is absent or all zero, so scoring against that id would
+    # point at a span it never stored.
+    client = _client()
+
+    await publish_to_intake(
+        _result(
+            [_otlp_trial(span_id="0000000000000000")],
+            [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])],
+        ),
+        platform=client,
+        experiment_id="exp-1",
+        agent_name="a",
+    )
+
+    assert client.otlp_calls == []
+    assert len(client.atif_calls) == 1
+
+
+async def test_a_span_without_a_start_time_is_given_the_runs() -> None:
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+
+    # Intake stores a span with no start time against its own ingest clock, and start time is
+    # part of the key it replaces on, so a re-publish would insert instead of replacing.
+    client = _client()
+
+    await publish_to_intake(
+        _result([_otlp_trial()], [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])]),
+        platform=client,
+        experiment_id="exp-1",
+        agent_name="a",
+    )
+
+    sent = ExportTraceServiceRequest()
+    sent.ParseFromString(client.otlp_calls[0]["body"])
+    assert sent.resource_spans[0].scope_spans[0].spans[0].start_time_unix_nano == int(
+        STARTED_AT.timestamp() * 1_000_000_000
+    )
+
+
+async def test_a_failed_trial_marks_its_root_span_failed() -> None:
+    from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+    from opentelemetry.proto.trace.v1.trace_pb2 import Status
+
+    # Status is a span field, not an attribute; recorded only as text the trace reads as a success.
+    trial = _otlp_trial().model_copy(update={"error": TrialError(type="Timeout", message="over budget")})
+    client = _client()
+
+    await publish_to_intake(
+        _result([trial], [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])]),
+        platform=client,
+        experiment_id="exp-1",
+        agent_name="a",
+    )
+
+    sent = ExportTraceServiceRequest()
+    sent.ParseFromString(client.otlp_calls[0]["body"])
+    status = sent.resource_spans[0].scope_spans[0].spans[0].status
+    assert status.code == Status.STATUS_CODE_ERROR
+    assert status.message == "over budget"
+
+
+async def test_a_partly_rejected_otlp_batch_fails_the_trial_instead_of_scoring_it() -> None:
+    # Ingest answers 200 with a per-span error list, so a dropped span is invisible unless the
+    # body is read -- including when the dropped span is the one the scores reference.
+    client = _client(otlp_errors=["span 0102030405060708: parent_span_id must not be all zero"])
+
+    with pytest.raises(PublishError, match="Intake rejected 1 span"):
+        await publish_to_intake(
+            _result([_otlp_trial()], [_score("t-1", "accuracy", [MetricOutput(name="score", value=1.0)])]),
+            platform=client,
+            experiment_id="exp-1",
+            agent_name="a",
+        )
+
+    assert client.eval_calls == [], "scores must not attach to a trace Intake only partly stored"

--- a/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
+++ b/plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py
@@ -40,6 +40,7 @@ from nemo_evaluator_sdk.agent_eval.results import AgentEvalResult, AgentEvalSumm
 from nemo_evaluator_sdk.agent_eval.scores import AgentEvalScoreStatus, AgentEvalTaskScore
 from nemo_evaluator_sdk.agent_eval.trials import AgentEvalTrial, AgentEvalTrialStatus, AgentOutput
 from nemo_evaluator_sdk.metrics.protocol import MetricOutput
+from nemo_evaluator_sdk.values.evidence import CandidateEvidence, EvidenceDescriptor
 from nemo_evaluator_sdk.values.results import AggregatedMetricResult, EvaluationResult, RowScore
 from nemo_platform import AsyncNeMoPlatform
 from nemo_platform.types.intake.trace_filter_param import TraceFilterParam
@@ -56,11 +57,17 @@ NAN_EXPERIMENT_NAME = "intake-it-nan-exp"
 NAN_RUN_ID = "intake-it-nan-run"
 IDEMPOTENCY_EXPERIMENT_NAME = "intake-it-idempotency-exp"
 IDEMPOTENCY_RUN_ID = "intake-it-idempotency-run"
+OTLP_EXPERIMENT_NAME = "intake-it-otlp-exp"
+OTLP_RUN_ID = "intake-it-otlp-run"
+OTLP_TRACE_ID = "0123456789abcdef0123456789abcdef"
+OTLP_ROOT_SPAN_ID = "0102030405060708"
 ROW_EXPERIMENT_NAME = "intake-it-row-exp"
 ROW_RUN_ID = "intake-it-row-run"
 #: Recent, not fixed: a trajectory's start_time is a real timestamp, and Intake's trace queries
 #: only look back a bounded window — a hardcoded past date ingests fine but reads back empty.
 STARTED_AT = datetime.now(UTC) - timedelta(minutes=5)
+#: Fixed for the process so a re-publish writes the same ReplacingMergeTree key.
+_OTLP_START_NANOS = time.time_ns()
 
 
 def _docker_available() -> bool:
@@ -528,3 +535,122 @@ async def test_row_result_publishes_and_is_idempotent(platform_base_url: str) ->
 
         rows = await client.intake.spans.evaluator_results.list(second.published_trials[0].span_id, workspace=WORKSPACE)
         assert [row.name for row in rows] == ["exact_match.score"]
+
+
+def _otlp_result() -> AgentEvalResult:
+    """One trial whose trace is OTLP, so publish takes the OTLP path instead of ATIF.
+
+    Span times are minted once at import and reused by every publish in a run: Intake's
+    spans table is a ReplacingMergeTree keyed partly on ``start_time``, so a per-publish
+    clock would make a re-publish insert rather than replace. They are recent because that
+    table is also TTL'd on ``start_time``, and a fixed past timestamp would be dropped on
+    write while ingest still reported success.
+    """
+    span = {
+        "traceId": OTLP_TRACE_ID,
+        "spanId": OTLP_ROOT_SPAN_ID,
+        "name": "agent run",
+        "startTimeUnixNano": str(_OTLP_START_NANOS),
+        "endTimeUnixNano": str(_OTLP_START_NANOS + 5_000_000),
+        "attributes": [{"key": "output.value", "value": {"stringValue": "answer"}}],
+    }
+    trace = EvidenceDescriptor(
+        kind="trace", format="otlp", data={"resourceSpans": [{"scopeSpans": [{"spans": [span]}]}]}
+    )
+    return AgentEvalResult(
+        run_id=OTLP_RUN_ID,
+        tasks=[],
+        trials=[
+            AgentEvalTrial(
+                id="trial-1",
+                task_id="task-1",
+                status=AgentEvalTrialStatus.COMPLETED,
+                output=AgentOutput(output_text="answer"),
+                evidence=CandidateEvidence(descriptors={"trace": trace}),
+            )
+        ],
+        scores=[
+            AgentEvalTaskScore(
+                id="score-1",
+                run_id=OTLP_RUN_ID,
+                task_id="task-1",
+                trial_id="trial-1",
+                metric_type="accuracy",
+                status=AgentEvalScoreStatus.COMPLETED,
+                outputs=[MetricOutput(name="score", value=1.0)],
+            )
+        ],
+        summary=AgentEvalSummary(),
+        metadata=RunMetadata(started_at=STARTED_AT),
+    )
+
+
+async def test_publishing_a_trial_with_an_otlp_trace_lands_its_spans(platform_base_url: str) -> None:
+    async with AsyncNeMoPlatform(base_url=platform_base_url, max_retries=2) as client:
+        group = await client.experiments.create(workspace=WORKSPACE, name=GROUP_NAME, exist_ok=True)
+        await client.evaluations.create(
+            workspace=WORKSPACE,
+            name=OTLP_EXPERIMENT_NAME,
+            experiment_ids=[group.id],
+            dataset_name="intake-it-otlp-dataset",
+            dataset_version="v1",
+            exist_ok=True,
+        )
+
+        report = await publish_to_intake(
+            _otlp_result(),
+            platform=client,
+            experiment_id=OTLP_EXPERIMENT_NAME,
+            workspace=WORKSPACE,
+            agent_name="intake-it-agent",
+        )
+
+        published = report.published_trials[0]
+        # The span id is the producer's own, read off the payload rather than queried back.
+        assert published.span_id == OTLP_ROOT_SPAN_ID
+        assert published.session_id == f"{OTLP_RUN_ID}:trial-1"
+
+        # The stamped session id is what Intake indexed the spans under.
+        spans = await client.intake.spans.list(workspace=WORKSPACE, filter={"session_id": published.session_id})
+        assert [span.name for span in spans.data] == ["agent run"]
+
+        rows = await client.intake.spans.evaluator_results.list(published.span_id, workspace=WORKSPACE)
+        assert [row.name for row in rows] == ["accuracy.score"]
+
+
+async def test_republishing_an_otlp_result_replaces_rather_than_duplicates(platform_base_url: str) -> None:
+    # The session id we stamp is part of the ReplacingMergeTree key, so getting it wrong or
+    # letting it vary per publish inserts a second uncollapsible row instead of replacing.
+    async with AsyncNeMoPlatform(base_url=platform_base_url, max_retries=2) as client:
+        group = await client.experiments.create(workspace=WORKSPACE, name=GROUP_NAME, exist_ok=True)
+        await client.evaluations.create(
+            workspace=WORKSPACE,
+            name=OTLP_EXPERIMENT_NAME,
+            experiment_ids=[group.id],
+            dataset_name="intake-it-otlp-dataset",
+            dataset_version="v1",
+            exist_ok=True,
+        )
+
+        async def publish() -> PublishReport:
+            return await publish_to_intake(
+                _otlp_result(),
+                platform=client,
+                experiment_id=OTLP_EXPERIMENT_NAME,
+                workspace=WORKSPACE,
+                agent_name="intake-it-agent",
+            )
+
+        first = await publish()
+        second = await publish()
+
+        assert first.published_trials[0].session_id == second.published_trials[0].session_id
+        assert first.published_trials[0].span_id == second.published_trials[0].span_id
+
+        session_id = second.published_trials[0].session_id
+        trace_filter: TraceFilterParam = {"session_id": session_id}
+        traces = [trace async for trace in client.intake.traces.list(workspace=WORKSPACE, filter=trace_filter)]
+        assert len(traces) == 1, "re-publish duplicated the OTLP trace instead of replacing it"
+
+        spans = await client.intake.spans.list(workspace=WORKSPACE, filter={"session_id": session_id})
+        assert len(spans.data) == 1, "re-publish duplicated the span instead of replacing it"

--- a/plugins/nemo-evaluator/tests/jobs/test_publication.py
+++ b/plugins/nemo-evaluator/tests/jobs/test_publication.py
@@ -336,7 +336,9 @@ def test_publishes_and_reports_what_landed() -> None:
     assert outcome.trial_count == 1
     assert outcome.evaluator_result_count == 1
     assert outcome.error is None
-    assert client.evaluations.retrieved == ["eval-1"]
+    # Twice: this path needs the entity to stamp durations onto, and ``publish_to_intake``
+    # re-checks for itself because it is public and cannot assume its caller did.
+    assert client.evaluations.retrieved == ["eval-1", "eval-1"]
 
 
 def test_durations_are_stamped_without_dropping_existing_metadata() -> None:


### PR DESCRIPTION
## Summary

A trial's OTLP trace is now what gets published to Intake, carrying the span tree, per-call detail and timing that ATIF's turn shape flattens. Runners whose agent emits no OTLP keep publishing ATIF exactly as before — this adds a path rather than replacing one.

**Stacked on #1717.** Review that one first; this PR's diff is only the publish work.

## Related Issue

AALGO-569 (Linear), "PR 4" in its sequencing table. Not a GitHub issue, so no `Fixes` keyword.

## Changes

- **`mapping.otlp_ingest_for_trial`** reads the trial's OTLP trace as a typed `ExportTraceServiceRequest`, stamps identity and trial totals, and returns the serialized payload plus its root span id. Returns `None` — falling back to ATIF — when the trial has no readable OTLP trace or no single scorable root span.
- **`publish.py`** sends that payload via `intake.ingest.otlp.v1.traces.create(body=…)` (landed in #1680) and scores against the locally-read span id.
- **`values/otlp.py`** gains `set_span_attributes`, `set_root_span_attributes`, `set_root_span_error`, `fill_missing_start_times`, and `root_span_id`.
- **`OTLPTraceHandle.export_request()`** returns, now that it has a caller.

### Design calls

**Identity goes on span attributes, not resource attributes.** Intake merges the layers as `{**resource, **span}`, so an agent recording its own `gen_ai.conversation.id` would win from the resource layer and take the session id with it. That id is part of the key Intake's `ReplacingMergeTree` replaces on, so losing it turns a re-publish into duplicate rows.

**`_resolve_root_span_id` stays, for the ATIF path only.** ATIF span ids are minted inside Intake via `stable_id(workspace, session_id, *identity, "trajectory", prefix="span")` and cannot be known locally without replicating that scheme. Deleting it outright would have broken score attachment for exactly the ATIF-only runners this PR keeps supporting. Note this corrects AALGO-569, which justifies removing the round trip with "OTLP span IDs are producer-chosen, so Evaluator already knows the id" — untrue for Harbor, where the *agent under test* writes the trace. The real reason is that the root span id is readable from the payload we are about to publish.

**Four things the OTLP path must carry that the agent's spans do not**, each found by review rather than by a failing test:

1. Trial token and cost totals, which ATIF sent as `final_metrics`. On the **root span alone**, so a rollup summing across a trace cannot count them once per span.
2. The trial's error, as **span status** — Intake reads status, not attributes, to decide a span failed. Recorded only as `exception.type`, a failed trial read as successful.
3. A start time for any span lacking one. Intake stores such a span against its own ingest clock (`_nanos_to_datetime(...) or ingested_at`), and start time is in the replace key, so re-publish would insert instead of replacing.
4. A check of the per-span error list ingest returns **with its 200**. A dropped span is otherwise invisible — including when the dropped span is the one about to be scored.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification:

`publish_to_intake` is an internal publish path with no user-facing configuration or CLI surface; which encoding a trial publishes is a property of what the runner produced, not something a user selects. The user-facing trace-format documentation was updated in #1717.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
| -- | -- |
| `pytest plugins/nemo-evaluator/tests/integration/test_publish_to_intake.py` (real ClickHouse + platform) | **6 passed** |
| `pytest packages/nemo_evaluator_sdk/tests plugins/nemo-evaluator/tests` | **2706 passed, 51 skipped** |
| `tools/lint/lint-python-types.sh` (CI's type gate) | All checks passed |
| `uv run ruff check packages plugins` | All checks passed |
| `uv run ruff format --check packages plugins` | 2192 files already formatted |

### The integration test was run, not just written

The idempotency claim is the one unit doubles cannot reach, so it is covered end to end against real ClickHouse: publish twice, assert **one** trace and **one** span. To confirm the assertion has teeth, `session_id_for` was mutated to append a per-call uuid — the exact "unstable session id" failure the `ReplacingMergeTree` key is vulnerable to — and the test went red. Code restored and re-verified.

The four ATIF integration tests pass alongside the two new OTLP ones, so the fallback path is unregressed.

### `pre-commit run -a` — one hook blocked, unrelated to this change

**`uv-lock`** requires uv 0.9.14; this shell has 0.9.30. No dependency changed in this PR, and the sibling **`uv-lock-check` (drift) passed**, confirming `uv.lock` is untouched. Every other hook passed, including `ty`, ruff, copyright headers, config-reference docs, helm-docs, and the plugin/`nmp-common` boundary check.

## Known gap, not addressed here

Intake's ATIF ingest endpoint calls `validate_evaluation_context`; its OTLP endpoint has no equivalent. So a nonexistent evaluation name now publishes successfully where the ATIF path would have failed. This PR is the first evaluator caller to exercise that endpoint and so the first to expose the gap, but the fix belongs in Intake alongside its ATIF sibling — a client-side check here would duplicate a server responsibility and need removing later. Worth its own ticket.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for publishing OTLP traces from evaluation trials.
  * Preserved trace and span identities, timestamps, usage totals, errors, and evaluation metadata.
  * Added validation for root spans and malformed trace data.
  * Added fallback to the existing ATIF publishing path when OTLP evidence is unavailable.
  * Re-publishing results now avoids creating duplicate traces or spans.

* **Bug Fixes**
  * Unknown evaluations are rejected before trial data is written.
  * Trial and per-span ingestion errors are surfaced during publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->