### PR TITLE
fix(agents): resolve or reject a deployment image at submit time [ASTD-532]

### DIFF
--- a/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
+++ b/plugins/nemo-agents/src/nemo_agents_plugin/api/v2/deployments.py
@@ -108,6 +108,18 @@ async def create_deployment(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    # The runner fails the deployment for this; the answer is already available here.
+    if is_container_deployment_mode(body.deployment_mode) and not (
+        body.image or AgentsConfig.get().deployments.default_image
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"deployment_mode '{body.deployment_mode}' requires a container image. "
+                "Set 'image' on the request, or configure 'deployments.default_image'."
+            ),
+        )
+
     # 3. Resolve deployment-time config. NAT workflows need legacy injection;
     # Platform-owned agent configs stay strict and are translated by the runner.
     resolved_config = _resolve_deployment_config(agent, workspace=workspace)

--- a/plugins/nemo-agents/tests/unit/test_deployments_api.py
+++ b/plugins/nemo-agents/tests/unit/test_deployments_api.py
@@ -178,6 +178,66 @@ class TestCreateDeployment:
         # The controller would have failed this on reconcile; nothing should persist.
         mock_entity_client.create.assert_not_called()
 
+    def test_create_rejects_container_deployment_with_no_resolvable_image(self) -> None:
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={"agent": "fabric-agent", "name": "fabric-dep", "deployment_mode": "docker"},
+        )
+
+        assert resp.status_code == 400
+        assert "requires a container image" in resp.json()["detail"]
+        assert "deployments.default_image" in resp.json()["detail"]
+        mock_entity_client.create.assert_not_called()
+
+    def test_create_allows_container_deployment_without_image_when_a_default_is_configured(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config = AgentsConfig.get()
+        monkeypatch.setattr(config.deployments, "default_image", "registry.example/agent:pinned")
+        monkeypatch.setattr(AgentsConfig, "get", classmethod(lambda cls: config))
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+
+        async def _save_deployment(deployment: AgentDeployment) -> AgentDeployment:
+            deployment._id = f"deployment-{deployment.name}-id"
+            deployment._created_at = NOW
+            return deployment
+
+        mock_entity_client.create = AsyncMock(side_effect=_save_deployment)
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={"agent": "fabric-agent", "name": "fabric-dep", "deployment_mode": "docker"},
+        )
+
+        assert resp.status_code == 201
+        created_deployment: AgentDeployment = mock_entity_client.create.call_args[0][0]
+        assert created_deployment.image == ""
+
+    def test_create_allows_subprocess_deployment_without_an_image(self) -> None:
+        mock_entity_client = AsyncMock()
+        mock_entity_client.get = AsyncMock(return_value=_make_agent())
+
+        async def _save_deployment(deployment: AgentDeployment) -> AgentDeployment:
+            deployment._id = f"deployment-{deployment.name}-id"
+            deployment._created_at = NOW
+            return deployment
+
+        mock_entity_client.create = AsyncMock(side_effect=_save_deployment)
+        client = _test_client(mock_entity_client)
+
+        resp = client.post(
+            "/apis/agents/v2/workspaces/default/deployments",
+            json={"agent": "fabric-agent", "name": "fabric-dep", "deployment_mode": "subprocess"},
+        )
+
+        assert resp.status_code == 201
+
     def test_create_rejects_image_entrypoint_for_subprocess(self) -> None:
         mock_entity_client = AsyncMock()
         mock_entity_client.get = AsyncMock(return_value=_make_agent())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

`agents.deployments.default_image` was only ever read by the deployment runner, so nothing upstream knew whether an image was required. A docker or k8s deployment submitted without one came back **201 with status `pending`** and then failed on the next reconcile — a mistake that was knowable at submit time, reported asynchronously.

This refuses that request at the boundary, and exposes the resolved default so a client can tell "you must supply an image" from "one will be supplied for you".

Before and after, no `default_image` configured:

| | Before | After |
|---|---|---|
| `POST /deployments` with no image, mode `docker` | 201 `pending`, entity created, fails on reconcile | 400, nothing created |
| `GET /deployments/defaults` | — | `{"default_image": ""}` |

An operator who *has* configured `default_image` is unaffected: the request still succeeds with an empty `image`, and the runner still applies the default. That path now works from Studio too, which previously refused to send it.

## Related Issue

ASTD-532

## Changes

- `api/v2/deployments.py`: refuse a container-mode deployment when neither `image` nor `deployments.default_image` resolves. Placed beside the existing `use_image_entrypoint` guard, which validates the same class of thing on the same request.
- `api/v2/deployments.py`: `GET /deployments/defaults`, returning the image a docker/k8s deployment gets when it omits one.
- `schema.py`: `DeploymentDefaults` response model.
- `plugins/nemo-agents/openapi/openapi.yaml`: regenerated.

### Notes for reviewers

- **400, not 422.** The ticket proposed 422, but the guard two lines above this one — `use_image_entrypoint requires deployment_mode 'docker' or 'k8s'` — is a 400 for an equivalent mistake on the same endpoint. Two neighbouring guards disagreeing about the code for the same class of error is worse than either choice. Happy to move both to 422 if that is the preferred direction; I did not want to change existing behaviour by side effect.
- **Route ordering is load-bearing.** `/deployments/{name}` already existed and matches `"defaults"`, so declaring the new route after it would silently turn this into a lookup for a deployment nobody has. It is declared first, with a comment, and `test_defaults_is_not_swallowed_by_the_deployment_name_route` pins it by asserting the entity client is never called. Moving the route below `{name}` fails all three defaults tests.
- **Endpoint shape follows an existing precedent** rather than inventing one: `nemo-iron-swarm` already serves `GET /model-config-defaults` for exactly this — server-side config a form needs in order to pre-fill.
- **The rejection covers the CLI and REST too**, not only Studio. Both previously accepted a request that could not succeed.

### Not included

- **Studio still has its own client-side rule** (`CreateDeploymentModal`, *"Container image is required for Docker and Kubernetes deployments"*). Nothing consumes this endpoint yet; relaxing that rule to match the server is the client half and belongs on a Studio branch.
- **No Python SDK regeneration.** `make update-sdk` produces **no** change for this endpoint — see Verification.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification: the OpenAPI spec is regenerated and carries the endpoint's own description; no prose documents `default_image` today.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
|---|---|
| `uv run pytest plugins/nemo-agents/tests/unit/test_deployments_api.py` | 17 passed |
| `uv run pytest plugins/nemo-agents/tests/unit` | 1530 passed; 2 failed, both `test_port_allocation.py`, which `bind()`s a socket and is blocked by the local sandbox — unrelated, and failing on `main` |
| `uv run ruff check` / `ruff format --check` on changed files | All checks passed |
| `uv run --frozen ty check` on changed files | All checks passed |
| `make refresh-openapi` | endpoint and schema present, +48 lines in the plugin spec |

**Both new behaviours were checked against a deliberately broken build**, so the tests are not decorative:

- Removing the submit-time guard fails `test_create_rejects_container_deployment_with_no_resolvable_image`.
- Moving `/deployments/defaults` below `/deployments/{name}` fails all three defaults tests.

**Why there is no SDK change.** `AGENTS.md` asks for `make update-sdk` when endpoints change, so I ran it. It regenerated **31 files as 1 insertion and 94 deletions, none of them this endpoint** — because Stainless generates the Python SDK from the root `openapi/openapi.yaml`, and agents plugin endpoints are not in it:

```
grep -c "agents/v2/workspaces/{workspace}/deployments" openapi/openapi.yaml                 → 0
grep -c "agents/v2/workspaces/{workspace}/deployments" plugins/nemo-agents/openapi/openapi.yaml → 5
```

The SDK has never covered these endpoints, including the five that already existed. That deletion-only diff is pre-existing drift between the checked-in SDK and current Stainless output, and committing it here would remove unrelated content while adding nothing. I reverted it rather than fold it into this PR. It looks worth its own issue.

Blocked pre-commit hooks, both environmental and neither related to this change:

- **`uv-lock`** — requires exactly uv 0.9.14 on `PATH`; this machine has 0.9.30. No dependency files are touched here.
- **`helm-docs`** — the binary is not installed locally. No Helm files are touched.

`make refresh-openapi` also needs to run outside the macOS sandbox: `uv` panics there with the known `system_configuration::dynamic_store` crash noted in `CLAUDE.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Container-mode deployments now return a clear HTTP 400 error when no container image is provided or configured.
  - Valid deployments continue to use the configured default image when applicable.
  - Invalid deployment requests are rejected before reaching the deployment runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->