### PR TITLE
fix(entities): hide pending-deletion workspaces from the list API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,7 @@ Check for an existing instance before starting (`lsof -iTCP:8080 -sTCP:LISTEN` o
 
 ```bash
 tmux -f /exec-daemon/tmux.portal.conf new-session -d -s nemo-platform -c /workspace -- \
-  'export NMP_BASE_URL=http://localhost:8080 && uv run nemo services run --service-group all --port 8080'
+  'export NMP_BASE_URL=http://localhost:8080 && uv run nemo services run --service-group all --controller-group all --port 8080'
 ```
 
 Wait for readiness: `curl -sf http://localhost:8080/health/ready` → `{"status":"ready"}`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,7 +308,7 @@ nemo services run --services jobs --controllers jobs
 # Run a predefined service group
 nemo services run --service-group core  # Infrastructure only
 nemo services run --service-group api   # Application services
-nemo services run --service-group all   # Everything
+nemo services run --service-group all --controller-group all  # All services and controllers
 ```
 
 The platform binds to `127.0.0.1:8080` by default. You can customize the host and port:

--- a/openapi/ga/individual/platform.openapi.yaml
+++ b/openapi/ga/individual/platform.openapi.yaml
@@ -656,6 +656,11 @@ paths:
       description: 'List all workspaces with pagination.
 
 
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the
+
+        list matches GET/DELETE, which treat those workspaces as not found.
+
+
         When authentication is enabled, only workspaces the principal has access to
 
         are returned. Service principals and platform admins have access to all workspaces.

--- a/openapi/ga/openapi.yaml
+++ b/openapi/ga/openapi.yaml
@@ -656,6 +656,11 @@ paths:
       description: 'List all workspaces with pagination.
 
 
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the
+
+        list matches GET/DELETE, which treat those workspaces as not found.
+
+
         When authentication is enabled, only workspaces the principal has access to
 
         are returned. Service principals and platform admins have access to all workspaces.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -656,6 +656,11 @@ paths:
       description: 'List all workspaces with pagination.
 
 
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the
+
+        list matches GET/DELETE, which treat those workspaces as not found.
+
+
         When authentication is enabled, only workspaces the principal has access to
 
         are returned. Service principals and platform admins have access to all workspaces.

--- a/packages/nmp_platform/config/local.yaml
+++ b/packages/nmp_platform/config/local.yaml
@@ -7,7 +7,7 @@
 #   export NMP_BASE_URL=http://127.0.0.1:8080
 #   uv run nemo services run --host 127.0.0.1 --port 8080
 #
-# Use default service set (omit --services) or --service-group all. Then:
+# Use default service set (omit --services) or --service-group all --controller-group all. Then:
 #   nemo auth login --unsigned-token
 #   uv run nemo-platform run task --task nmp.platform_seed
 

--- a/packages/nmp_platform_runner/tests/test_config.py
+++ b/packages/nmp_platform_runner/tests/test_config.py
@@ -164,6 +164,14 @@ def test_no_arguments_defaults_to_all_services_and_default_controllers():
     assert resolved.controllers.issuperset({"jobs", "models", "entities"})
 
 
+def test_service_group_all_does_not_start_controllers():
+    """Helm API pods use --service-group=all with no controllers; do not auto-start them."""
+    resolved = resolve(service_group="all")
+
+    assert "entities" in resolved.services
+    assert resolved.controllers == set()
+
+
 def test_service_group_core_resolves_core_services_only():
     resolved = resolve(service_group="core")
 

--- a/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
+++ b/sdk/python/nemo-platform/.nmpcontext/openapi.yaml
@@ -659,6 +659,11 @@ paths:
       description: 'List all workspaces with pagination.
 
 
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the
+
+        list matches GET/DELETE, which treat those workspaces as not found.
+
+
         When authentication is enabled, only workspaces the principal has access to
 
         are returned. Service principals and platform admins have access to all workspaces.

--- a/services/core/entities/src/nmp/core/entities/api/v2/workspaces/endpoints.py
+++ b/services/core/entities/src/nmp/core/entities/api/v2/workspaces/endpoints.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Query, status
 from nmp.common.api.common import DeleteResponse, GenericSortField, Page, PaginationData
-from nmp.common.api.filter import ComparisonOperation, FilterOperator
+from nmp.common.api.filter import ComparisonOperation, FilterOperation, FilterOperator, LogicalOperation
 from nmp.common.auth.models import Principal
 from nmp.core.entities.api.dependencies import AuthClientDep, EntityRepository, WorkspaceRepository
 from nmp.core.entities.api.v2.utils import (
@@ -49,6 +49,22 @@ from sqlalchemy.exc import IntegrityError
 router = APIRouter()
 API_TAG = "Entity Store"
 logger = logging.getLogger(__name__)
+
+_ACTIVE_WORKSPACE_FILTER = ComparisonOperation(
+    operator=FilterOperator.EQ,
+    field="deletion_stage",
+    value=None,
+)
+
+
+def _exclude_deleting_workspaces(filter_op: FilterOperation | None) -> FilterOperation:
+    """AND the caller filter with deletion_stage IS NULL so list matches GET/DELETE."""
+    if filter_op is None:
+        return _ACTIVE_WORKSPACE_FILTER
+    return LogicalOperation(
+        operator=FilterOperator.AND,
+        operations=[filter_op, _ACTIVE_WORKSPACE_FILTER],
+    )
 
 
 def _principal_for_role_binding(principal: Principal) -> str | None:
@@ -265,6 +281,9 @@ async def create_workspace(
     description=textwrap.dedent("""
         List all workspaces with pagination.
 
+        Workspaces marked for deletion (non-null deletion_stage) are omitted so the
+        list matches GET/DELETE, which treat those workspaces as not found.
+
         When authentication is enabled, only workspaces the principal has access to
         are returned. Service principals and platform admins have access to all workspaces.
 
@@ -291,8 +310,7 @@ async def list_workspaces(
     # Get accessible workspaces for access control
     accessible_workspaces = await get_accessible_workspaces(entity_repository)
 
-    # Build combined filter for workspace access and user's filter
-    combined_filter = add_workspace_filtering(accessible_workspaces, filter, field="name")
+    combined_filter = _exclude_deleting_workspaces(add_workspace_filtering(accessible_workspaces, filter, field="name"))
 
     workspaces, total = await repository.list_workspaces(
         page=page,

--- a/services/core/entities/tests/integration/test_workspace_deletion.py
+++ b/services/core/entities/tests/integration/test_workspace_deletion.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import AsyncClient
+from nmp.common.api.filter import ComparisonOperation, FilterOperator
 from nmp.common.auth import get_auth_client
 from nmp.common.auth.client import AuthClient
 from nmp.common.auth.models import Principal
@@ -250,3 +251,113 @@ class TestWorkspaceDeletionBehavior:
         finally:
             # Clean up override
             app.dependency_overrides.clear()
+
+
+def _workspace_names_and_total(list_response) -> tuple[set[str], int]:
+    body = list_response.json()
+    names = {ws["name"] for ws in body["data"]}
+    return names, body["pagination"]["total_results"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestWorkspaceListExcludesDeleting:
+    """List must not return workspaces the single-entity GET path already treats as gone."""
+
+    async def test_list_excludes_pending_workspace_after_delete(self, client: AsyncClient):
+        workspace_name = "list-hide-pending"
+        created = await client.post(
+            "/apis/entities/v2/workspaces",
+            json={"name": workspace_name, "description": "Pending deletion list test"},
+        )
+        assert created.status_code == 201
+
+        listed_before = await client.get("/apis/entities/v2/workspaces", params={"page_size": 100})
+        assert listed_before.status_code == 200
+        names_before, total_before = _workspace_names_and_total(listed_before)
+        assert workspace_name in names_before
+
+        deleted = await client.delete(f"/apis/entities/v2/workspaces/{workspace_name}")
+        assert deleted.status_code == 200
+
+        listed_after = await client.get("/apis/entities/v2/workspaces", params={"page_size": 100})
+        assert listed_after.status_code == 200
+        names_after, total_after = _workspace_names_and_total(listed_after)
+        assert workspace_name not in names_after
+        assert total_after == total_before - 1
+
+        get_response = await client.get(f"/apis/entities/v2/workspaces/{workspace_name}")
+        assert get_response.status_code == 404
+
+    async def test_list_still_shows_live_sibling_after_delete(self, client: AsyncClient):
+        keep_name = "list-keep-sibling"
+        delete_name = "list-delete-sibling"
+        for name in (keep_name, delete_name):
+            created = await client.post(
+                "/apis/entities/v2/workspaces",
+                json={"name": name, "description": "Sibling list test"},
+            )
+            assert created.status_code == 201
+
+        deleted = await client.delete(f"/apis/entities/v2/workspaces/{delete_name}")
+        assert deleted.status_code == 200
+
+        listed = await client.get("/apis/entities/v2/workspaces", params={"page_size": 100})
+        assert listed.status_code == 200
+        names, _ = _workspace_names_and_total(listed)
+        assert keep_name in names
+        assert delete_name not in names
+
+    async def test_cleanup_filter_still_finds_pending_workspace(self, client: AsyncClient, repos):
+        workspace_name = "cleanup-filter-pending"
+        created = await client.post(
+            "/apis/entities/v2/workspaces",
+            json={"name": workspace_name, "description": "Cleanup query contract"},
+        )
+        assert created.status_code == 201
+
+        deleted = await client.delete(f"/apis/entities/v2/workspaces/{workspace_name}")
+        assert deleted.status_code == 200
+
+        workspace_repo: WorkspaceRepositoryInterface = repos["workspace"]
+        pending, _ = await workspace_repo.list_workspaces(
+            filter_op=ComparisonOperation(
+                operator=FilterOperator.EQ,
+                field="deletion_stage",
+                value=WorkspaceDeletionStage.PENDING,
+            ),
+            page_size=1,
+        )
+        assert any(ws.name == workspace_name for ws in pending)
+
+    @pytest.mark.parametrize(
+        "stage",
+        [WorkspaceDeletionStage.DELETING, WorkspaceDeletionStage.FAILED],
+    )
+    async def test_list_excludes_deleting_and_failed_workspaces(
+        self,
+        client: AsyncClient,
+        repos,
+        stage: WorkspaceDeletionStage,
+    ):
+        workspace_name = f"list-hide-{stage.value}"
+        created = await client.post(
+            "/apis/entities/v2/workspaces",
+            json={"name": workspace_name, "description": f"{stage.value} list test"},
+        )
+        assert created.status_code == 201
+
+        workspace_repo: WorkspaceRepositoryInterface = repos["workspace"]
+        marked = await workspace_repo.mark_workspace_for_deletion(
+            name=workspace_name,
+            deletion_stage=stage,
+        )
+        assert marked is True
+
+        listed = await client.get("/apis/entities/v2/workspaces", params={"page_size": 100})
+        assert listed.status_code == 200
+        names, _ = _workspace_names_and_total(listed)
+        assert workspace_name not in names
+
+        get_response = await client.get(f"/apis/entities/v2/workspaces/{workspace_name}")
+        assert get_response.status_code == 404


### PR DESCRIPTION
## Summary

- `GET /apis/entities/v2/workspaces` now omits workspaces with a non-null `deletion_stage` (`deletion_stage IS NULL`) so list matches GET/DELETE-by-name (those already 404 while cleanup is in progress). Fixes the Studio contradiction in NVBug 6709050.
- Integration tests cover: pending hidden after DELETE, live sibling still listed, DELETING/FAILED omitted, and the cleanup repo query with `EQ pending` still finds candidates.
- Guardrail: `--service-group all` still starts **zero** controllers.

## Docs vs runner (intentional)

We **did not** change the platform runner so that `--service-group all` auto-starts controllers. Helm API pods pass `--service-group=all` and must keep running with no controllers.

Instead, local/dev docs (`AGENTS.md`, `CONTRIBUTING.md`, `packages/nmp_platform/config/local.yaml`) now tell you to add **`--controller-group all`** when you actually want controllers (including WorkspaceCleanup):

```
nemo services run --service-group all --controller-group all
```

A runner config test locks the Helm-safe behavior: `--service-group all` ⇒ empty controller set.

## Test plan

- [x] Entities workspace-deletion integration tests
- [x] Runner config test: `--service-group all` does not start controllers
- [x] Pod smoke (nemo-dev-blue / tbray-dev): after DELETE, workspace is gone from list immediately, GET 404, live sibling remains, logs show `Processing workspace deletion` / `Entities controller started`
- [ ] Full row delete in that pod still 404s listing deployments (inference/deployments plugin not in this smoke service set). That is an env gap, not the list-filter bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace listings now omit workspaces pending deletion, being deleted, or marked as failed.
  - Deleted workspaces remain unavailable through direct retrieval, returning a not-found response.
  - Active sibling workspaces continue to appear normally.

- **Documentation**
  - Local development instructions now show how to start all service and controller groups together.
  - Workspace API documentation clarifies that deleting workspaces are excluded from listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->