### PR TITLE
fix(intake): validate the evaluation OTLP spans name, as ATIF ingest does

### DIFF
--- a/plugins/nemo-experimentalist/examples/smoke-agent/scripts/record_traces.py
+++ b/plugins/nemo-experimentalist/examples/smoke-agent/scripts/record_traces.py
@@ -26,7 +26,7 @@ from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor_nat
     HarborNativeOutcomeEvaluator,
 )
 from nemo_experimentalist_plugin.experimentalist.otlp import jsonl_to_protobuf, read_trace_id
-from nemo_platform import AsyncNeMoPlatform, NotFoundError
+from nemo_platform import AsyncNeMoPlatform, ConflictError, NotFoundError
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.workspaces.client import AsyncWorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
@@ -35,6 +35,24 @@ AGENT_NAME = "smoke-agent"
 AGENT_VERSION = "1.0.0"
 POLL_ATTEMPTS = 30
 POLL_DELAY_SECONDS = 2.0
+
+
+async def _ensure_evaluation(client: AsyncNeMoPlatform, *, workspace: str, name: str) -> None:
+    """Register the Evaluation these spans name, or Intake drops them."""
+    try:
+        group = await client.experiments.create(workspace=workspace, name=name)
+    except ConflictError:
+        group = await client.experiments.retrieve(name, workspace=workspace)
+    try:
+        await client.evaluations.create(
+            workspace=workspace,
+            name=name,
+            experiment_ids=[group.id],
+            dataset_name=name,
+            dataset_version="v1",
+        )
+    except ConflictError:
+        pass
 
 
 async def _upload_trials(
@@ -111,6 +129,7 @@ async def run(args: argparse.Namespace) -> dict[str, str]:
                 body=CreateWorkspaceRequest(name=args.workspace, description="smoke-agent traces for Insights"),
             )
         ).data()
+        await _ensure_evaluation(client, workspace=args.workspace, name=args.group)
         options = HarborEvaluatorConfig(
             job_name=f"smoke-{args.group}-{args.split}-record",
             jobs_dir=Path("results"),

--- a/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
+++ b/plugins/nemo-experimentalist/examples/tau3-nooa-agent/record_tau_airline_traces.py
@@ -24,7 +24,7 @@ from nemo_experimentalist_plugin.experimentalist.components.evaluator.harbor_nat
     HarborNativeOutcomeEvaluator,
 )
 from nemo_experimentalist_plugin.experimentalist.otlp import jsonl_to_protobuf, read_trace_id
-from nemo_platform import AsyncNeMoPlatform, NotFoundError
+from nemo_platform import AsyncNeMoPlatform, ConflictError, NotFoundError
 from nemo_platform_plugin.client.adapter import client_from_platform
 from nemo_platform_plugin.workspaces.client import AsyncWorkspacesClient
 from nemo_platform_plugin.workspaces.types import CreateWorkspaceRequest
@@ -131,6 +131,24 @@ def _write_upload_summary(
     return summary_path
 
 
+async def _ensure_evaluation(client: AsyncNeMoPlatform, *, workspace: str, name: str) -> None:
+    """Register the Evaluation these spans name, or Intake drops them."""
+    try:
+        group = await client.experiments.create(workspace=workspace, name=name)
+    except ConflictError:
+        group = await client.experiments.retrieve(name, workspace=workspace)
+    try:
+        await client.evaluations.create(
+            workspace=workspace,
+            name=name,
+            experiment_ids=[group.id],
+            dataset_name=name,
+            dataset_version="v1",
+        )
+    except ConflictError:
+        pass
+
+
 async def _upload_trials(
     client: AsyncNeMoPlatform,
     trials: list[TrialResult],
@@ -229,6 +247,7 @@ async def run(args: argparse.Namespace) -> Path:
                     ),
                 )
             ).data()
+            await _ensure_evaluation(client, workspace=args.workspace, name=evaluation_name)
             trace_ids = await _upload_trials(
                 client,
                 uploadable_trials,
@@ -271,6 +290,7 @@ async def run(args: argparse.Namespace) -> Path:
                 body=CreateWorkspaceRequest(name=args.workspace, description="Tau3 Airline agent traces for Insights"),
             )
         ).data()
+        await _ensure_evaluation(client, workspace=args.workspace, name=evaluation_name)
         run_dir.mkdir(parents=True)
 
         options = HarborEvaluatorConfig(

--- a/plugins/nemo-experimentalist/tests/integration/test_persist_trial_to_intake.py
+++ b/plugins/nemo-experimentalist/tests/integration/test_persist_trial_to_intake.py
@@ -66,14 +66,28 @@ def _otlp_trace(tmp_path: Path, span_name: str) -> tuple[ResourceRef, str]:
     return ref, trace_id
 
 
+async def _ensure_evaluation(platform: AsyncNeMoPlatform, name: str) -> None:
+    """Register the Evaluation these spans name, or Intake drops them."""
+    group = await platform.experiments.create(workspace=WORKSPACE, name=name)
+    await platform.evaluations.create(
+        workspace=WORKSPACE,
+        name=name,
+        experiment_ids=[group.id],
+        dataset_name=name,
+        dataset_version="v1",
+    )
+
+
 async def test_persist_trial_uploads_a_local_otlp_trace_and_repoints_it(
     platform: AsyncNeMoPlatform, tmp_path: Path
 ) -> None:
     backend = LocalExperimentalistBackend(client=platform, path=tmp_path / "backend")
     trace, trace_id = _otlp_trace(tmp_path, "it-span")
     trial = TrialResult(id="trial-it", task_id="case-it", status="completed", trace=trace)
+    evaluation_name = f"exp-it-{uuid4().hex}"
+    await _ensure_evaluation(platform, evaluation_name)
 
-    await backend._persist_trial(trial, workspace=WORKSPACE, evaluation_name="exp-it", agent_attrs={})
+    await backend._persist_trial(trial, workspace=WORKSPACE, evaluation_name=evaluation_name, agent_attrs={})
 
     # The span reached ClickHouse through the typed SDK and is readable back through it.
     spans = await platform.intake.spans.list(workspace=WORKSPACE, filter={"trace_id": trace_id})
@@ -93,6 +107,7 @@ async def test_persist_trial_stamps_evaluation_identity_onto_the_uploaded_spans(
     trial = TrialResult(id="trial-attrs", task_id="case-attrs", status="completed", trace=trace)
     # Unique for the same reason the ids are: this is the value the read filters on.
     evaluation_name = f"exp-attrs-{uuid4().hex}"
+    await _ensure_evaluation(platform, evaluation_name)
 
     await backend._persist_trial(trial, workspace=WORKSPACE, evaluation_name=evaluation_name, agent_attrs={})
 

--- a/plugins/nemo-insights/evaluation/adapters.py
+++ b/plugins/nemo-insights/evaluation/adapters.py
@@ -179,26 +179,25 @@ class BenchmarkAdapter:
         version = policy_version(policy)
         tasks = load_tasks(data_dir, domain)
         agent_llm = str(cfg["agent_llm"])
-        # Register this run as an Experiment on the oracle workspace (where the UI
-        # reads it). The realistic side needs only the span tag, not the entity.
-        if oracle_workspace is not None:
-            group_id = ensure_experiment_group(base_url, oracle_workspace, base)
+        experiment_metadata = {
+            "agent_llm": agent_llm,
+            "user_llm": str(cfg.get("user_llm", "")),
+            "num_trials": cfg.get("num_trials"),
+            "seed": cfg.get("seed"),
+            "task_split_name": cfg.get("task_split_name"),
+            "num_tasks": cfg.get("num_tasks"),
+            "created_at": created_at,
+        }
+        for tagged_workspace in [realistic_workspace] + ([oracle_workspace] if oracle_workspace else []):
+            group_id = ensure_experiment_group(base_url, tagged_workspace, base)
             create_experiment(
                 base_url,
-                oracle_workspace,
+                tagged_workspace,
                 name=run_id,
                 experiment_group_id=group_id,
                 dataset_name=dataset_name,
                 dataset_version=version,
-                metadata={
-                    "agent_llm": agent_llm,
-                    "user_llm": str(cfg.get("user_llm", "")),
-                    "num_trials": cfg.get("num_trials"),
-                    "seed": cfg.get("seed"),
-                    "task_split_name": cfg.get("task_split_name"),
-                    "num_tasks": cfg.get("num_tasks"),
-                    "created_at": created_at,
-                },
+                metadata=experiment_metadata,
             )
         session_ids: set[str] = set()
         client = httpx.Client(timeout=30.0)

--- a/plugins/nemo-insights/tests/evaluation/test_adapters.py
+++ b/plugins/nemo-insights/tests/evaluation/test_adapters.py
@@ -333,7 +333,10 @@ async def test_benchmark_produce_records_run_without_analyzing(monkeypatch, tmp_
     assert record["dataset_name"] == "tau2:airline"
     assert created == ["tau2-airline", "tau2-airline-oracle"]  # both stable workspaces ensured
     # Experiment entity created on the ORACLE workspace only.
-    assert experiments == [("tau2-airline-oracle", record["experiment_id"], "tau2:airline", record["dataset_version"])]
+    assert experiments == [
+        ("tau2-airline", record["experiment_id"], "tau2:airline", record["dataset_version"]),
+        ("tau2-airline-oracle", record["experiment_id"], "tau2:airline", record["dataset_version"]),
+    ]
     assert len(exported) == 4  # 2 sims x 2 workspaces
     # Every exported span is tagged with the run id.
     for _ws, _sid, spans in exported:
@@ -513,4 +516,4 @@ async def test_benchmark_produce_realistic_only_when_rewards_disabled(monkeypatc
     assert len(exported) == 2  # 2 sims x 1 workspace
     assert all(ws == record["realistic_workspace"] for ws, _, _ in exported)
     assert evals == []  # no oracle → no reward rows
-    assert experiments == []  # no oracle workspace → no Experiment entity
+    assert experiments == [("tau2-airline", record["experiment_id"], "tau2:airline", record["dataset_version"])]

--- a/services/intake/src/nmp/intake/spans/ingest/otlp.py
+++ b/services/intake/src/nmp/intake/spans/ingest/otlp.py
@@ -4,9 +4,11 @@
 """OTLP/HTTP trace ingest for ClickHouse-backed Intake spans."""
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from nmp.common.entities.client import EntityClient
+from nmp.common.service.dependencies import get_entity_client
 from nmp.intake.config import IntakeConfig
 from nmp.intake.spans.api.dependencies import DenormalizerDep, SpansServiceDep, require_workspace_access
 from nmp.intake.spans.domain import (
@@ -14,12 +16,15 @@ from nmp.intake.spans.domain import (
     SpanStatus,
     TraceBatch,
 )
+from nmp.intake.spans.ingest.evaluation_context import EvaluationContext
+from nmp.intake.spans.ingest.evaluation_context_validation import validate_evaluation_context
 from nmp.intake.spans.span_attribute_catalog import SpanAttributeField, spec_for_field
 from nmp.intake.spans.span_semantic_attributes import SpanSemanticAttributes
 from nmp.intake.spans.storage import json_dumps_preserve, normalize_span_kind, stable_id, utc_now
 from pydantic import BaseModel, Field
 
 router = APIRouter(dependencies=[Depends(require_workspace_access)])
+EntityClientDep = Annotated[EntityClient, Depends(get_entity_client)]
 API_TAG = "Ingest"
 
 # Bag key the evaluation id lands under on a built span (from the attribute catalog). The ingest loop
@@ -79,6 +84,7 @@ async def ingest_otlp_traces(
     workspace: str,
     request: Request,
     service: SpansServiceDep,
+    entity_client: EntityClientDep,
     denormalizer: DenormalizerDep,
     content_length: int | None = Header(default=None),
 ) -> IngestResponse:
@@ -128,6 +134,22 @@ async def ingest_otlp_traces(
                 evaluation_name = span_domain.attributes_string.get(_EVALUATION_NAME_BAG_KEY)
                 if evaluation_name:
                     evaluation_names.add(evaluation_name)
+
+    rejected_names: set[str] = set()
+    for evaluation_name in sorted(evaluation_names):
+        try:
+            await validate_evaluation_context(
+                workspace=workspace,
+                context=EvaluationContext(evaluation_name=evaluation_name),
+                entity_client=entity_client,
+            )
+        except HTTPException as exc:
+            rejected_names.add(evaluation_name)
+            errors.append(f"evaluation {evaluation_name!r}: {exc.detail}")
+    if rejected_names:
+        # One entry per evaluation, not per span: thousands of spans can share one bad name.
+        evaluation_names -= rejected_names
+        spans = [span for span in spans if span.attributes_string.get(_EVALUATION_NAME_BAG_KEY) not in rejected_names]
 
     await service.ingest_batch(TraceBatch(spans=spans))
     # A single OTLP batch can carry spans for several evaluations (associated via the

--- a/services/intake/tests/integration/spans/test_otlp_ingest_evaluation_context.py
+++ b/services/intake/tests/integration/spans/test_otlp_ingest_evaluation_context.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OTLP ingest validates the evaluation its spans name, as ATIF ingest does."""
+
+from fastapi.testclient import TestClient
+
+OTLP_INGEST = "/apis/intake/v2/workspaces/default/ingest/otlp/v1/traces"
+EVALUATIONS = "/apis/intake/v2/workspaces/default/evaluations"
+EXPERIMENTS = "/apis/intake/v2/workspaces/default/experiments"
+
+
+def _create_evaluation(client: TestClient, name: str) -> None:
+    group = client.post(EXPERIMENTS, json={"name": "otlp-context-group"})
+    if group.status_code == 409:
+        group = client.get(f"{EXPERIMENTS}/otlp-context-group")
+    group.raise_for_status()
+    created = client.post(
+        EVALUATIONS,
+        json={
+            "name": name,
+            "experiment_group_id": group.json()["id"],
+            "dataset_name": "otlp-context-dataset",
+            "dataset_version": "v1",
+        },
+    )
+    assert created.status_code == 201, created.text
+
+
+def _post(client: TestClient, body: bytes):
+    return client.post(OTLP_INGEST, content=body, headers={"Content-Type": "application/x-protobuf"})
+
+
+def _span(evaluation_name: str, *, name: str = "agent-run", span_id: str | None = None) -> dict[str, object]:
+    span: dict[str, object] = {"name": name, "attributes": {"nemo.evaluation.name": evaluation_name}}
+    if span_id is not None:
+        span["span_id"] = span_id
+    return span
+
+
+def test_otlp_ingest_reports_an_unknown_evaluation_in_the_error_list(client: TestClient, make_otlp_request) -> None:
+    response = _post(client, make_otlp_request([_span("otlp-missing-evaluation")]))
+
+    assert response.status_code == 200, response.text
+    assert response.json()["errors"] == [
+        "evaluation 'otlp-missing-evaluation': Evaluation 'otlp-missing-evaluation' must be created "
+        "before it can be logged."
+    ]
+
+
+def test_otlp_ingest_stores_nothing_when_the_evaluation_is_unknown(client: TestClient, make_otlp_request) -> None:
+    # The check has to precede the write, or the rejected spans are already stored.
+    session_id = "otlp-rejected-session"
+    body = make_otlp_request(
+        [
+            {
+                "name": "agent-run",
+                "attributes": {
+                    "nemo.evaluation.name": "otlp-missing-evaluation-2",
+                    "gen_ai.conversation.id": session_id,
+                },
+            }
+        ],
+        trace_id="a" * 31 + "2",
+    )
+
+    assert _post(client, body).status_code == 200
+
+    stored = client.get(
+        "/apis/intake/v2/workspaces/default/spans",
+        params={"filter[session_id]": session_id, "filter[source]": "otel"},
+    )
+    assert stored.status_code == 200, stored.text
+    assert stored.json()["data"] == []
+
+
+def test_otlp_ingest_accepts_spans_naming_an_existing_evaluation(client: TestClient, make_otlp_request) -> None:
+    _create_evaluation(client, "otlp-known-evaluation")
+
+    response = _post(client, make_otlp_request([_span("otlp-known-evaluation")], trace_id="b" * 31 + "3"))
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"errors": []}
+
+
+def test_otlp_ingest_without_an_evaluation_name_is_unaffected(client: TestClient, make_otlp_request) -> None:
+    body = make_otlp_request([{"name": "plain-span"}], trace_id="c" * 31 + "4")
+
+    response = _post(client, body)
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {"errors": []}
+
+
+def test_spans_for_a_known_evaluation_survive_a_sibling_naming_a_missing_one(
+    client: TestClient, make_otlp_request
+) -> None:
+    # This endpoint reports problems and stores the rest rather than failing the request.
+    _create_evaluation(client, "otlp-batch-known")
+    body = make_otlp_request(
+        [
+            {
+                "name": "known",
+                "span_id": f"{1:016x}",
+                "attributes": {"nemo.evaluation.name": "otlp-batch-known", "gen_ai.conversation.id": "batch-known"},
+            },
+            {
+                "name": "missing",
+                "span_id": f"{2:016x}",
+                "attributes": {"nemo.evaluation.name": "otlp-batch-missing", "gen_ai.conversation.id": "batch-missing"},
+            },
+        ],
+        trace_id="d" * 31 + "5",
+    )
+
+    response = _post(client, body)
+
+    assert response.status_code == 200, response.text
+    assert response.json()["errors"] == [
+        "evaluation 'otlp-batch-missing': Evaluation 'otlp-batch-missing' must be created before it can be logged."
+    ]
+    kept = client.get(
+        "/apis/intake/v2/workspaces/default/spans",
+        params={"filter[session_id]": "batch-known", "filter[source]": "otel"},
+    )
+    assert [span["name"] for span in kept.json()["data"]] == ["known"]
+    dropped = client.get(
+        "/apis/intake/v2/workspaces/default/spans",
+        params={"filter[session_id]": "batch-missing", "filter[source]": "otel"},
+    )
+    assert dropped.json()["data"] == []
+
+
+def test_otlp_ingest_rejects_a_deleted_evaluation(client: TestClient, make_otlp_request) -> None:
+    _create_evaluation(client, "otlp-deleted-evaluation")
+    deleted = client.delete(f"{EVALUATIONS}/otlp-deleted-evaluation")
+    assert deleted.status_code == 204, deleted.text
+
+    response = _post(client, make_otlp_request([_span("otlp-deleted-evaluation")], trace_id="e" * 31 + "6"))
+
+    assert response.status_code == 200, response.text
+    assert "deleted" in response.json()["errors"][0].lower()

--- a/services/intake/tests/integration/spans/test_traces_read.py
+++ b/services/intake/tests/integration/spans/test_traces_read.py
@@ -9,7 +9,26 @@ from decimal import Decimal
 from fastapi.testclient import TestClient
 
 
+def _create_evaluation(client: TestClient, name: str) -> None:
+    """Create the Evaluation the spans below name; ingest rejects one that resolves to nothing."""
+    group = client.post("/apis/intake/v2/workspaces/default/experiments", json={"name": "trace-read-group"})
+    if group.status_code == 409:
+        group = client.get("/apis/intake/v2/workspaces/default/experiments/trace-read-group")
+    group.raise_for_status()
+    created = client.post(
+        "/apis/intake/v2/workspaces/default/evaluations",
+        json={
+            "name": name,
+            "experiment_group_id": group.json()["id"],
+            "dataset_name": "trace-read-dataset",
+            "dataset_version": "v1",
+        },
+    )
+    assert created.status_code == 201, created.text
+
+
 def test_traces_read_returns_core_trace_summary(client: TestClient, make_otlp_request):
+    _create_evaluation(client, "experiment-a")
     base_ns = int(datetime.now(timezone.utc).replace(microsecond=0).timestamp() * 1_000_000_000)
     input_text = "i" * 350
     output_text = "o" * 350


### PR DESCRIPTION
## Summary

Intake's ATIF ingest validates the evaluation a payload names, refusing one that resolves to no `Evaluation` or to a deleted one. Its OTLP ingest read the same `nemo.evaluation.name` attribute purely to mark the denormalizer dirty and never checked it — so the identical mistake failed loudly on one endpoint and succeeded silently on the other, leaving spans (and evaluator results written against them) associated with an evaluation that does not exist.

This adds the same `validate_evaluation_context` call to the OTLP endpoint.

## Related Issue

None. Found while making Evaluator publish OTLP traces (AALGO-569 in Linear), which is the first evaluator caller of this endpoint and so the first to walk through the gap. Raised here rather than worked around client-side, since the check belongs next to its ATIF sibling.

## Changes

- `ingest_otlp_traces` takes an `EntityClientDep` and calls `validate_evaluation_context` once per distinct evaluation name in the batch, **before** `ingest_batch`.
- A name that fails validation is reported in the response `errors` list and its spans are dropped; spans naming a valid evaluation in the same batch are still stored, and the request still returns 200.
- New `test_otlp_ingest_evaluation_context.py` (6 tests): unknown evaluation reported in `errors`; nothing stored for it; known evaluation accepted; spans naming no evaluation unaffected; a known evaluation's spans surviving a sibling that names a missing one; deleted evaluation reported.
- `test_traces_read` now creates the evaluation its spans name — see the behaviour change below.

### Design calls

**Validated before the write, not after.** Rejecting afterwards would leave spans pointing at a nonexistent evaluation, which is precisely the state the ATIF endpoint refuses to create.

**Reported, not fatal.** This is where it deliberately diverges from ATIF. One OTLP export can carry spans for several evaluations — the handler already collects them into a set for the denormalizer — and the endpoint is already best-effort per span, returning 200 with an `errors` list for spans it could not convert. Failing the whole request would let one stale name discard the valid telemetry batched alongside it, which is a worse outcome than the one being fixed. So a rejected name follows the shape the endpoint already has: its spans are dropped, the reason is named in `errors`, and its siblings are unaffected.

This is not a silent partial store. The rejection is named per evaluation in the response, and a caller that treats a non-empty `errors` list as failure still fails loudly — the Evaluator publisher in #1725 does exactly that.

**Deduplicated via the existing set**, so the entity lookup is once per distinct name, not once per span.

## ⚠️ Behaviour change — the main thing to review

**An OTLP producer that names an Evaluation it never created previously had those spans stored. They are now dropped, and the reason is returned in `errors`.**

This is not hypothetical: `test_traces_read` was exactly such a producer, stamping the legacy `nemo.experiment.id: "experiment-a"` with no such Evaluation, and it failed against this change. I updated it to create the evaluation, because the alternative — dropping the attribute — would have gutted what that test exists to prove (that the legacy key normalizes and the trace still associates). But it is evidence that this behaviour was reachable and relied upon.

Three producers in this repo tagged spans with an Evaluation they never created, and so would have lost those spans under the new check. Each now registers the Evaluation it names:

- the Insights benchmark registered its Experiment only in the oracle workspace while tagging and posting realistic spans to another — Intake resolves the tag per workspace, so the realistic side needs it too;
- the smoke-agent and tau3 recording examples created only a workspace.

**So the question for the Intake team is whether dropping is what you want, or whether these should be rejected outright (400, as ATIF does) or accepted with a warning.** I have no visibility into who posts to this endpoint outside this repo. If producers in the wild stamp evaluation names without creating the Evaluation first, this silently loses their telemetry where it previously stored it — the `errors` list is the only signal, and a producer that ignores it will not notice.

## Type of Change

- [x] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [ ] CI, build, or test infrastructure

## Quality Gates

- [x] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [ ] Tests not applicable — justification:
- [ ] Documentation updated for user-visible behavior
- [x] Documentation not applicable — justification:

The endpoint's response shape is unchanged; it now names a rejected evaluation in the `errors` list it already returns. If the team wants this called out in API docs, say so and I will add it.

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [ ] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

| Command | Result |
| -- | -- |
| `pytest services/intake/tests` (real ClickHouse via testcontainers) | **559 passed** |
| `pytest .../test_otlp_ingest_evaluation_context.py` | **6 passed** |
| `tools/lint/lint-python-types.sh` | All checks passed |
| `uv run ruff check services/intake` | All checks passed |
| `uv run ruff format --check services/intake` | clean |

**The new tests have teeth**: deleting the validation loop turns **4 of the 6** red — the unknown-evaluation report, the nothing-stored check, the surviving-sibling case, and the deleted-evaluation case. The `test_traces_read` regression was confirmed as caused by this change by running that test with and without the diff — it passes without, fails with.

`pre-commit run -a` was not run in this worktree; the individual hooks that matter here (`ty`, ruff check, ruff format) were run directly and pass. Flagging rather than claiming the aggregate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Trace ingestion now validates evaluation references before storing spans.
  - Spans linked to valid evaluations continue processing, while spans referencing unknown or deleted evaluations are excluded and reported.
  - Benchmark runs now register experiments in both realistic and oracle workspaces.
  - Trace-recording examples automatically create or reuse the required experiments and evaluations before uploading traces.

- **Bug Fixes**
  - Improved handling of mixed batches containing both valid and invalid evaluation references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
