### PR TITLE
fix(ci): create the stable GitHub Release for every release scope

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -910,11 +910,13 @@ jobs:
             }
 
   create-github-release:
-    name: Create GitHub Release
+    # Every stable release converges on its version tag and GitHub Release,
+    # regardless of release-scope. Scope only selects artifacts, so subset and
+    # custom runs can finish or retry a release without manual tagging.
+    name: Create or confirm GitHub Release
     needs: [plan-release, poll-final-release]
     if: >-
       needs.plan-release.outputs.release_type == 'stable' &&
-      needs.plan-release.outputs.release_scope == 'all' &&
       needs.plan-release.outputs.dry_run != 'true' &&
       needs.poll-final-release.result == 'success'
     runs-on: ubuntu-latest
@@ -929,7 +931,7 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Create GitHub Release
+      - name: Create or confirm GitHub Release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
@@ -937,6 +939,36 @@ jobs:
           SOURCE_SHA: ${{ needs.plan-release.outputs.source_sha }}
         run: |
           set -euo pipefail
+
+          # An existing version tag must already point at the requested source.
+          tag_sha="$(git rev-parse --verify --quiet "refs/tags/${RELEASE_TAG}^{commit}" || true)"
+          if [[ -n "${tag_sha}" && "${tag_sha}" != "${SOURCE_SHA}" ]]; then
+            echo "::error::Tag ${RELEASE_TAG} points to ${tag_sha}, not the requested source ${SOURCE_SHA}." >&2
+            exit 1
+          fi
+
+          # Only a missing release may fall through to creation. Any other
+          # lookup failure stops the job instead of risking a duplicate.
+          view_err="${RUNNER_TEMP}/gh-release-view.err"
+          if release_json="$(gh release view "${RELEASE_TAG}" --json isDraft 2>"${view_err}")"; then
+            if [[ "$(jq -r '.isDraft' <<< "${release_json}")" == "true" ]]; then
+              echo "::error::A draft GitHub Release for ${RELEASE_TAG} exists. Publish or delete it, then rerun." >&2
+              exit 1
+            fi
+            if [[ -z "${tag_sha}" ]]; then
+              echo "::error::GitHub Release ${RELEASE_TAG} exists but tag ${RELEASE_TAG} is not in the checked-out history." >&2
+              exit 1
+            fi
+            echo "GitHub Release ${RELEASE_TAG} already exists at ${SOURCE_SHA}; nothing to do."
+            exit 0
+          elif ! grep -q "release not found" "${view_err}"; then
+            cat "${view_err}" >&2
+            exit 1
+          fi
+
+          if [[ -n "${tag_sha}" ]]; then
+            echo "Reusing existing tag ${RELEASE_TAG} at ${SOURCE_SHA}."
+          fi
 
           notes_start_tag="$(
             {

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,10 +53,10 @@ and select **Run workflow**. The form shows the allowed custom artifact IDs.
 
 | Input | Use |
 | --- | --- |
-| `release-type` | `nightly` by default. Select `stable` for a full release. |
+| `release-type` | `nightly` by default. Select `stable` for a versioned release. Every successful non-dry-run stable release creates or confirms its Git tag and GitHub Release. |
 | `source-sha` | Required for stable releases. Optional for nightlies; a normal nightly with no SHA uses the current default-branch head. A dry-run nightly with no SHA uses the workflow commit so a branch can be validated. |
 | `version` | Required for stable releases. Enter the `MAJOR.MINOR.PATCH` release version. |
-| `release-scope` | `all` by default. Select `wheels`, `containers`, `helm`, or `custom` for a subset. |
+| `release-scope` | `all` by default. Select `wheels`, `containers`, `helm`, or `custom` for a subset. Scope selects artifacts only; it does not control the stable tag or GitHub Release. |
 | `wheel-ids`, `container-ids` | Comma-separated IDs used only with `release-scope: custom`. Each ID must be in the catalog above; duplicates and empty entries fail validation. |
 | `include-helm` | Includes the Helm chart in a custom release. |
 | `helm-version` | Optional exact SemVer Helm chart version for stable Helm-only releases. The stable release label still comes from `version`. |
@@ -71,6 +71,7 @@ Examples:
 | Scheduled-style nightly | Leave `release-type` as `nightly` and use the default `all` scope. |
 | Stable full release | `release-type: stable`, `source-sha: <40-character SHA>`, `version: <MAJOR.MINOR.PATCH>`, `release-scope: all`. |
 | One container | `release-scope: custom`, `container-ids: nmp-customizer-tasks`. |
+| Stable one-container release or retry | `release-type: stable`, `source-sha: <40-character SHA>`, `version: <MAJOR.MINOR.PATCH>`, `release-scope: custom`, `container-ids: nmp-customizer-tasks`. |
 | Helm-only validation | `release-scope: helm`, `dry-run: true`. |
 | Stable Helm-only chart override | `release-type: stable`, `source-sha: <40-character SHA>`, `version: 0.1.0`, `release-scope: helm`, `helm-version: 0.1.0+helmfix1`. |
 
@@ -97,10 +98,14 @@ America/Los_Angeles.
 6. Waits for every selected final artifact to become available at its configured
    publication destination before continuing. The polling job times out after
    four hours and sends a Slack alert after two hours if it is still waiting.
-7. For a non-dry-run stable release with `release-scope: all`, creates the
-   GitHub release and tag at the selected SHA. GitHub generates the release
-   notes from the previous numeric SemVer tag. Subset releases do not create a
-   GitHub release or tag.
+7. For every non-dry-run stable release, creates or confirms the Git tag and
+   GitHub release at the selected SHA once the selected artifacts are
+   available. This is independent of `release-scope`, so subset and custom runs
+   can finish or retry a release. A rerun is a no-op when the tag and release
+   already match, creates the missing release when only the matching tag
+   exists, and fails when the version tag points to a different SHA or a draft
+   release exists. GitHub generates the release notes from the previous numeric
+   SemVer tag.
 8. After polling succeeds, releases that include the Helm chart dispatch a
    deployment signal to the configured internal release repository. The
    downstream workflow creates a pending GitHub Deployment, and the deployment
@@ -148,7 +153,7 @@ Dry-runs do not poll or send the delayed or final notification.
 
 The workflow summary records the selected wheels and containers. After a live
 release completes, check the selected artifacts at their destination above.
-For a full stable release, also verify that the GitHub tag and generated GitHub
+For a stable release, also verify that the GitHub tag and generated GitHub
 release point to the requested source SHA.
 
 For a stable wheel release, a quick client check is:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary

Stable subset and custom runs (`release-scope: wheels`, `containers`, `helm`, `custom`) published their artifacts but never created the Git tag or GitHub Release, because the `create-github-release` job was gated on `release-scope: all`. The 0.3.0 custom run ([job](https://github.com/NVIDIA-NeMo/nemo-platform/actions/runs/30477833073/job/90703676069)) therefore needed manual tagging. Now `stable` alone is the release intent: every successful non-dry-run stable release creates or confirms its tag and GitHub Release, and `release-scope` only selects artifacts.

Supersedes #976. That review rejected a new `create-github-release` checkbox in favor of an idempotent step, and asked that an existing GitHub Release only count as done when the tag matches the requested SHA. Both are reflected here.

## Changes

- `.github/workflows/release.yaml`: drop the `release_scope == 'all'` gate on `create-github-release`. The step now resolves the tag and release state before acting:

  | Tag | GitHub Release | Result |
  | --- | --- | --- |
  | absent | absent | create tag and release at `source-sha` |
  | at `source-sha` | absent | create release on the existing tag |
  | at `source-sha` | published | no-op, success |
  | at another SHA | any | fail |
  | absent | published | fail (inconsistent state) |
  | any | draft | fail (publish or delete it first) |
  | any | lookup error other than not-found | fail, no create attempted |

- `RELEASING.md`: document that `stable` always tags, that scope selects artifacts only, the rerun semantics above, and a stable single-container retry example.

No new workflow inputs. `release-plan.cjs` is unchanged.

## Type of Change

- [ ] Code change (feature, bug fix, or refactor)
- [ ] Code change with documentation updates
- [ ] Documentation only
- [ ] Contributor tooling or automation
- [x] CI, build, or test infrastructure

## Quality Gates

- [ ] Tests added or updated for changed behavior
- [ ] Existing tests cover changed behavior — justification:
- [x] Tests not applicable — justification: the change is a job `if` and an inline bash step; no `.github/scripts/*.cjs` helper changed. The step was exercised against every row of the table above with a stubbed `gh` and a temporary tagged git repo (see below).
- [x] Documentation updated for user-visible behavior
- [ ] Documentation not applicable — justification:

## Verification

- [x] Pull request title follows the repository's Conventional Commit format
- [x] Every commit includes an appropriate `Signed-off-by:` trailer
- [x] `uv run pre-commit run -a` passes, or any blocked checks are identified below
- [x] Targeted tests pass, or tests are marked not applicable above
- [x] No secrets, API keys, or credentials are included

Targeted validation:

- `actionlint .github/workflows/release.yaml`: clean.
- `git diff --check`: clean.
- Step script extracted with `yq` and run with a stub `gh` on `PATH` against a temp repo tagged `0.1.0`, `0.2.0`: all seven rows of the table behave as listed. Create paths pass `--target <source-sha>` and `--notes-start-tag 0.2.0`.
- `gh release view <missing> --json isDraft` against this repo prints `release not found`, matching the string the step keys on; `gh release view 0.4.0 --json isDraft` returns the field.
- `uv run pre-commit run -a`: all content hooks pass. Three hooks fail for local environment reasons unrelated to the changed files: `helm-docs` (binary not installed), `uv-lock` (local uv 0.11.26 vs pinned 0.9.14), `studio-lint-staged` (`lint-staged` not installed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Management**
  - Stable releases now consistently create or confirm the requested tag and GitHub Release across all release scopes, including subset and custom releases.
  - Existing valid tags and releases are safely reused to prevent duplicates.
  - Release validation now detects source-commit mismatches and rejects draft releases or unexpected lookup errors.

- **Documentation**
  - Updated stable-release guidance, examples, rerun behavior, mismatch handling, and verification steps for all release types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->